### PR TITLE
builtins: support custom bases log function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -666,6 +666,10 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="ln"></a><code>ln(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the natural log of <code>val</code>.</p>
 </span></td></tr>
+<tr><td><a name="log"></a><code>log(b: <a href="decimal.html">decimal</a>, x: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base <code>b</code> log of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><a name="log"></a><code>log(b: <a href="float.html">float</a>, x: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base <code>b</code> log of <code>val</code>.</p>
+</span></td></tr>
 <tr><td><a name="log"></a><code>log(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
 </span></td></tr>
 <tr><td><a name="log"></a><code>log(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -730,6 +730,28 @@ SELECT log(10.0::float), log(100.000::decimal)
 ----
 1 2.0000000000000000000
 
+query R
+SELECT log(2.0::float, 4.0::float)
+----
+2
+
+query R
+SELECT log(2.0::decimal, 4.0::decimal)
+----
+2.0000000000000000000
+
+query error cannot take logarithm of a negative number
+SELECT log(2.0::float, -10.0::float)
+
+query error cannot take logarithm of zero
+SELECT log(2.0::float, 0.0::float)
+
+query error cannot take logarithm of a negative number
+SELECT log(2.0::decimal, -10.0::decimal)
+
+query error cannot take logarithm of zero
+SELECT log(2.0::decimal, 0.0::decimal)
+
 query error cannot take logarithm of a negative number
 SELECT log(-100.000::decimal)
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2187,7 +2187,49 @@ may increase either contention or retry errors, or both.`,
 		floatOverload1(func(x float64) (tree.Datum, error) {
 			return tree.NewDFloat(tree.DFloat(math.Log10(x))), nil
 		}, "Calculates the base 10 log of `val`."),
+		floatOverload2("b", "x", func(b, x float64) (tree.Datum, error) {
+			switch {
+			case x < 0.0:
+				return nil, errLogOfNegNumber
+			case x == 0.0:
+				return nil, errLogOfZero
+			}
+			switch {
+			case b < 0.0:
+				return nil, errLogOfNegNumber
+			case b == 0.0:
+				return nil, errLogOfZero
+			}
+			return tree.NewDFloat(tree.DFloat(math.Log10(x) / math.Log10(b))), nil
+		}, "Calculates the base `b` log of `val`."),
 		decimalLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
+		decimalOverload2("b", "x", func(b, x *apd.Decimal) (tree.Datum, error) {
+			switch x.Sign() {
+			case -1:
+				return nil, errLogOfNegNumber
+			case 0:
+				return nil, errLogOfZero
+			}
+			switch b.Sign() {
+			case -1:
+				return nil, errLogOfNegNumber
+			case 0:
+				return nil, errLogOfZero
+			}
+
+			top := new(apd.Decimal)
+			if _, err := tree.IntermediateCtx.Ln(top, x); err != nil {
+				return nil, err
+			}
+			bot := new(apd.Decimal)
+			if _, err := tree.IntermediateCtx.Ln(bot, b); err != nil {
+				return nil, err
+			}
+
+			dd := &tree.DDecimal{}
+			_, err := tree.DecimalCtx.Quo(&dd.Decimal, top, bot)
+			return dd, err
+		}, "Calculates the base `b` log of `val`."),
 	),
 
 	"mod": makeBuiltin(defProps(),


### PR DESCRIPTION
Fixes: #41837 

Release note (sql change): This PR introduces a newly added `log`
builtin for any base, e.g. log(2.0, 4.0).