### PR TITLE
storage/engine: fix RocksDBCache memory leak

### DIFF
--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -83,6 +83,7 @@ func NewRocksDBTempEngine(
 		ExtraOptions:    storeSpec.ExtraOptions,
 	}
 	rocksDBCache := NewRocksDBCache(0)
+	defer rocksDBCache.Release()
 	db, err := NewRocksDB(cfg, rocksDBCache)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
NewRocksDBTempEngine creates RocksDBCache and not release that. The result was a memory leak, not only DBCache but also its shared pointer(`std::shared_ptr<rocksdb::Cache> rep`).

Release note: None