### PR TITLE
storage/engine: add pebbleReadOnly

### DIFF
--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -992,44 +992,47 @@ func TestBatchDistinct(t *testing.T) {
 func TestWriteOnlyBatchDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := PutProto(e, mvccKey("c"), &roachpb.Value{}); err != nil {
-		t.Fatal(err)
-	}
+			if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := PutProto(e, mvccKey("c"), &roachpb.Value{}); err != nil {
+				t.Fatal(err)
+			}
 
-	b := e.NewWriteOnlyBatch()
-	defer b.Close()
+			b := e.NewWriteOnlyBatch()
+			defer b.Close()
 
-	distinct := b.Distinct()
-	defer distinct.Close()
+			distinct := b.Distinct()
+			defer distinct.Close()
 
-	// Verify that reads on the distinct batch go to the underlying engine, not
-	// to the write-only batch.
-	iter := distinct.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-	iter.Seek(mvccKey("a"))
-	if ok, err := iter.Valid(); !ok {
-		t.Fatalf("expected iterator to be valid, err=%v", err)
-	}
-	if string(iter.Key().Key) != "b" {
-		t.Fatalf("expected b, but got %s", iter.Key())
-	}
+			// Verify that reads on the distinct batch go to the underlying engine, not
+			// to the write-only batch.
+			iter := distinct.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			iter.Seek(mvccKey("a"))
+			if ok, err := iter.Valid(); !ok {
+				t.Fatalf("expected iterator to be valid, err=%v", err)
+			}
+			if string(iter.Key().Key) != "b" {
+				t.Fatalf("expected b, but got %s", iter.Key())
+			}
+			iter.Close()
 
-	if v, err := distinct.Get(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	} else if string(v) != "b" {
-		t.Fatalf("expected b, but got %s", v)
-	}
+			if v, err := distinct.Get(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			} else if string(v) != "b" {
+				t.Fatalf("expected b, but got %s", v)
+			}
 
-	val := &roachpb.Value{}
-	if _, _, _, err := distinct.GetProto(mvccKey("c"), val); err != nil {
-		t.Fatal(err)
+			val := &roachpb.Value{}
+			if _, _, _, err := distinct.GetProto(mvccKey("c"), val); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -47,90 +47,92 @@ func mvccKey(k interface{}) MVCCKey {
 }
 
 func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch) error) {
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	var b Batch
-	if writeOnly {
-		b = e.NewWriteOnlyBatch()
-	} else {
-		b = e.NewBatch()
-	}
-	defer b.Close()
+			var b Batch
+			if writeOnly {
+				b = e.NewWriteOnlyBatch()
+			} else {
+				b = e.NewBatch()
+			}
+			defer b.Close()
 
-	if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	// Write an engine value to be deleted.
-	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Clear(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	}
-	// Write an engine value to be merged.
-	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
-		t.Fatal(err)
-	}
-	// Write a key with an empty value.
-	if err := b.Put(mvccKey("e"), nil); err != nil {
-		t.Fatal(err)
-	}
-	// Write an engine value to be single deleted.
-	if err := e.Put(mvccKey("d"), []byte("before")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.SingleClear(mvccKey("d")); err != nil {
-		t.Fatal(err)
-	}
+			if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			// Write an engine value to be deleted.
+			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Clear(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			}
+			// Write an engine value to be merged.
+			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
+				t.Fatal(err)
+			}
+			// Write a key with an empty value.
+			if err := b.Put(mvccKey("e"), nil); err != nil {
+				t.Fatal(err)
+			}
+			// Write an engine value to be single deleted.
+			if err := e.Put(mvccKey("d"), []byte("before")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.SingleClear(mvccKey("d")); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check all keys are in initial state (nothing from batch has gone
-	// through to engine until commit).
-	expValues := []MVCCKeyValue{
-		{Key: mvccKey("b"), Value: []byte("value")},
-		{Key: mvccKey("c"), Value: appender("foo")},
-		{Key: mvccKey("d"), Value: []byte("before")},
-	}
-	kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expValues, kvs) {
-		t.Fatalf("%v != %v", kvs, expValues)
-	}
+			// Check all keys are in initial state (nothing from batch has gone
+			// through to engine until commit).
+			expValues := []MVCCKeyValue{
+				{Key: mvccKey("b"), Value: []byte("value")},
+				{Key: mvccKey("c"), Value: appender("foo")},
+				{Key: mvccKey("d"), Value: []byte("before")},
+			}
+			kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expValues, kvs) {
+				t.Fatalf("%v != %v", kvs, expValues)
+			}
 
-	// Now, merged values should be:
-	expValues = []MVCCKeyValue{
-		{Key: mvccKey("a"), Value: []byte("value")},
-		{Key: mvccKey("c"), Value: appender("foobar")},
-		{Key: mvccKey("e"), Value: []byte{}},
-	}
-	if !writeOnly {
-		// Scan values from batch directly.
-		kvs, err = Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(expValues, kvs) {
-			t.Errorf("%v != %v", kvs, expValues)
-		}
-	}
+			// Now, merged values should be:
+			expValues = []MVCCKeyValue{
+				{Key: mvccKey("a"), Value: []byte("value")},
+				{Key: mvccKey("c"), Value: appender("foobar")},
+				{Key: mvccKey("e"), Value: []byte{}},
+			}
+			if !writeOnly {
+				// Scan values from batch directly.
+				kvs, err = Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(expValues, kvs) {
+					t.Errorf("%v != %v", kvs, expValues)
+				}
+			}
 
-	// Commit batch and verify direct engine scan yields correct values.
-	if err := commit(e, b); err != nil {
-		t.Fatal(err)
-	}
-	kvs, err = Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expValues, kvs) {
-		t.Errorf("%v != %v", kvs, expValues)
+			// Commit batch and verify direct engine scan yields correct values.
+			if err := commit(e, b); err != nil {
+				t.Fatal(err)
+			}
+			kvs, err = Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expValues, kvs) {
+				t.Errorf("%v != %v", kvs, expValues)
+			}
+		})
 	}
 }
 
@@ -168,92 +170,99 @@ func shouldNotPanic(t *testing.T, f func(), funcName string) {
 // as "not implemented". Also basic iterating functionality is verified.
 func TestReadOnlyBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewReadOnly()
-	if b.Closed() {
-		t.Fatal("read-only is expectedly found to be closed")
-	}
-	a := mvccKey("a")
-	getVal := &roachpb.Value{}
-	successTestCases := []func(){
-		func() { _, _ = b.Get(a) },
-		func() { _, _, _, _ = b.GetProto(a, getVal) },
-		func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
-		func() { b.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}).Close() },
-		func() {
-			b.NewIterator(IterOptions{
-				MinTimestampHint: hlc.MinTimestamp,
-				MaxTimestampHint: hlc.MaxTimestamp,
-				UpperBound:       roachpb.KeyMax,
-			}).Close()
-		},
-	}
-	defer func() {
-		b.Close()
-		if !b.Closed() {
-			t.Fatal("even after calling Close, a read-only should not be closed")
-		}
-		shouldPanic(t, func() { b.Close() }, "Close", "closing an already-closed rocksDBReadOnly")
-		for i, f := range successTestCases {
-			shouldPanic(t, f, string(i), "using a closed rocksDBReadOnly")
-		}
-	}()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	for i, f := range successTestCases {
-		shouldNotPanic(t, f, string(i))
-	}
+			b := e.NewReadOnly()
+			if b.Closed() {
+				t.Fatal("read-only is expectedly found to be closed")
+			}
+			a := mvccKey("a")
+			getVal := &roachpb.Value{}
+			successTestCases := []func(){
+				func() { _, _ = b.Get(a) },
+				func() { _, _, _, _ = b.GetProto(a, getVal) },
+				func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
+				func() { b.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}).Close() },
+				func() {
+					b.NewIterator(IterOptions{
+						MinTimestampHint: hlc.MinTimestamp,
+						MaxTimestampHint: hlc.MaxTimestamp,
+						UpperBound:       roachpb.KeyMax,
+					}).Close()
+				},
+			}
+			defer func() {
+				b.Close()
+				if !b.Closed() {
+					t.Fatal("even after calling Close, a read-only should not be closed")
+				}
+				name := "rocksDBReadOnly"
+				if engineImpl.name == "pebble" {
+					name = "pebbleReadOnly"
+				}
+				shouldPanic(t, func() { b.Close() }, "Close", "closing an already-closed "+name)
+				for i, f := range successTestCases {
+					shouldPanic(t, f, string(i), "using a closed "+name)
+				}
+			}()
 
-	// For a read-only ReadWriter, all Writer methods should panic.
-	failureTestCases := []func(){
-		func() { _ = b.ApplyBatchRepr(nil, false) },
-		func() { _ = b.Clear(a) },
-		func() { _ = b.SingleClear(a) },
-		func() { _ = b.ClearRange(a, a) },
-		func() { _ = b.Merge(a, nil) },
-		func() { _ = b.Put(a, nil) },
-	}
-	for i, f := range failureTestCases {
-		shouldPanic(t, f, string(i), "not implemented")
-	}
+			for i, f := range successTestCases {
+				shouldNotPanic(t, f, string(i))
+			}
 
-	if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Clear(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Merge(mvccKey("c"), appender("bar")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Put(mvccKey("d"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SingleClear(mvccKey("d")); err != nil {
-		t.Fatal(err)
-	}
+			// For a read-only ReadWriter, all Writer methods should panic.
+			failureTestCases := []func(){
+				func() { _ = b.ApplyBatchRepr(nil, false) },
+				func() { _ = b.Clear(a) },
+				func() { _ = b.SingleClear(a) },
+				func() { _ = b.ClearRange(a, a) },
+				func() { _ = b.Merge(a, nil) },
+				func() { _ = b.Put(a, nil) },
+			}
+			for i, f := range failureTestCases {
+				shouldPanic(t, f, string(i), "not implemented")
+			}
 
-	// Now, merged values should be:
-	expValues := []MVCCKeyValue{
-		{Key: mvccKey("a"), Value: []byte("value")},
-		{Key: mvccKey("c"), Value: appender("foobar")},
-	}
+			if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Clear(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Merge(mvccKey("c"), appender("bar")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Put(mvccKey("d"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.SingleClear(mvccKey("d")); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expValues, kvs) {
-		t.Errorf("%v != %v", kvs, expValues)
+			// Now, merged values should be:
+			expValues := []MVCCKeyValue{
+				{Key: mvccKey("a"), Value: []byte("value")},
+				{Key: mvccKey("c"), Value: appender("foobar")},
+			}
+
+			kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expValues, kvs) {
+				t.Errorf("%v != %v", kvs, expValues)
+			}
+		})
 	}
 }
 
@@ -328,117 +337,123 @@ func TestWriteBatchBasics(t *testing.T) {
 // b2.ApplyBatchRepr(b1.Repr()).Repr() to not equal a noop.
 func TestApplyBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	// Failure to represent the absorbed Batch again.
-	{
-		b1 := e.NewBatch()
-		defer b1.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-		if err := b1.Put(mvccKey("lost"), []byte("update")); err != nil {
-			t.Fatal(err)
-		}
+			// Failure to represent the absorbed Batch again.
+			{
+				b1 := e.NewBatch()
+				defer b1.Close()
 
-		repr1 := b1.Repr()
+				if err := b1.Put(mvccKey("lost"), []byte("update")); err != nil {
+					t.Fatal(err)
+				}
 
-		b2 := e.NewBatch()
-		defer b2.Close()
-		if err := b2.ApplyBatchRepr(repr1, false /* sync */); err != nil {
-			t.Fatal(err)
-		}
-		repr2 := b2.Repr()
+				repr1 := b1.Repr()
 
-		if !reflect.DeepEqual(repr1, repr2) {
-			t.Fatalf("old batch represents to:\n%q\nrestored batch to:\n%q", repr1, repr2)
-		}
-	}
+				b2 := e.NewBatch()
+				defer b2.Close()
+				if err := b2.ApplyBatchRepr(repr1, false /* sync */); err != nil {
+					t.Fatal(err)
+				}
+				repr2 := b2.Repr()
 
-	// Failure to commit what was absorbed.
-	{
-		b3 := e.NewBatch()
-		defer b3.Close()
+				if !reflect.DeepEqual(repr1, repr2) {
+					t.Fatalf("old batch represents to:\n%q\nrestored batch to:\n%q", repr1, repr2)
+				}
+			}
 
-		key := mvccKey("phantom")
-		val := []byte("phantom")
+			// Failure to commit what was absorbed.
+			{
+				b3 := e.NewBatch()
+				defer b3.Close()
 
-		if err := b3.Put(key, val); err != nil {
-			t.Fatal(err)
-		}
+				key := mvccKey("phantom")
+				val := []byte("phantom")
 
-		repr := b3.Repr()
+				if err := b3.Put(key, val); err != nil {
+					t.Fatal(err)
+				}
 
-		b4 := e.NewBatch()
-		defer b4.Close()
-		if err := b4.ApplyBatchRepr(repr, false /* sync */); err != nil {
-			t.Fatal(err)
-		}
-		// Intentionally don't call Repr() because the expected user wouldn't.
-		if err := b4.Commit(false /* sync */); err != nil {
-			t.Fatal(err)
-		}
+				repr := b3.Repr()
 
-		if b, err := e.Get(key); err != nil {
-			t.Fatal(err)
-		} else if !reflect.DeepEqual(b, val) {
-			t.Fatalf("read %q from engine, expected %q", b, val)
-		}
+				b4 := e.NewBatch()
+				defer b4.Close()
+				if err := b4.ApplyBatchRepr(repr, false /* sync */); err != nil {
+					t.Fatal(err)
+				}
+				// Intentionally don't call Repr() because the expected user wouldn't.
+				if err := b4.Commit(false /* sync */); err != nil {
+					t.Fatal(err)
+				}
+
+				if b, err := e.Get(key); err != nil {
+					t.Fatal(err)
+				} else if !reflect.DeepEqual(b, val) {
+					t.Fatalf("read %q from engine, expected %q", b, val)
+				}
+			}
+		})
 	}
 }
 
 func TestBatchGet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	// Write initial values, then write to batch.
-	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
-		t.Fatal(err)
-	}
-	// Write batch values.
-	if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Clear(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Put(mvccKey("d"), []byte("before")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.SingleClear(mvccKey("d")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Put(mvccKey("d"), []byte("after")); err != nil {
-		t.Fatal(err)
-	}
+			b := e.NewBatch()
+			defer b.Close()
 
-	expValues := []MVCCKeyValue{
-		{Key: mvccKey("a"), Value: []byte("value")},
-		{Key: mvccKey("b"), Value: nil},
-		{Key: mvccKey("c"), Value: appender("foobar")},
-		{Key: mvccKey("d"), Value: []byte("after")},
-	}
-	for i, expKV := range expValues {
-		kv, err := b.Get(expKV.Key)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(kv, expKV.Value) {
-			t.Errorf("%d: expected \"value\", got %q", i, kv)
-		}
+			// Write initial values, then write to batch.
+			if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+				t.Fatal(err)
+			}
+			// Write batch values.
+			if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Clear(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Put(mvccKey("d"), []byte("before")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.SingleClear(mvccKey("d")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Put(mvccKey("d"), []byte("after")); err != nil {
+				t.Fatal(err)
+			}
+
+			expValues := []MVCCKeyValue{
+				{Key: mvccKey("a"), Value: []byte("value")},
+				{Key: mvccKey("b"), Value: nil},
+				{Key: mvccKey("c"), Value: appender("foobar")},
+				{Key: mvccKey("d"), Value: []byte("after")},
+			}
+			for i, expKV := range expValues {
+				kv, err := b.Get(expKV.Key)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(kv, expKV.Value) {
+					t.Errorf("%d: expected \"value\", got %q", i, kv)
+				}
+			}
+		})
 	}
 }
 
@@ -455,199 +470,208 @@ func compareMergedValues(t *testing.T, result, expected []byte) bool {
 
 func TestBatchMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	// Write batch put, delete & merge.
-	if err := b.Put(mvccKey("a"), appender("a-value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Clear(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Merge(mvccKey("c"), appender("c-value")); err != nil {
-		t.Fatal(err)
-	}
+			b := e.NewBatch()
+			defer b.Close()
 
-	// Now, merge to all three keys.
-	if err := b.Merge(mvccKey("a"), appender("append")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Merge(mvccKey("b"), appender("append")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Merge(mvccKey("c"), appender("append")); err != nil {
-		t.Fatal(err)
-	}
+			// Write batch put, delete & merge.
+			if err := b.Put(mvccKey("a"), appender("a-value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Clear(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Merge(mvccKey("c"), appender("c-value")); err != nil {
+				t.Fatal(err)
+			}
 
-	// Verify values.
-	val, err := b.Get(mvccKey("a"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !compareMergedValues(t, val, appender("a-valueappend")) {
-		t.Error("mismatch of \"a\"")
-	}
+			// Now, merge to all three keys.
+			if err := b.Merge(mvccKey("a"), appender("append")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Merge(mvccKey("b"), appender("append")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Merge(mvccKey("c"), appender("append")); err != nil {
+				t.Fatal(err)
+			}
 
-	val, err = b.Get(mvccKey("b"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !compareMergedValues(t, val, appender("append")) {
-		t.Error("mismatch of \"b\"")
-	}
+			// Verify values.
+			val, err := b.Get(mvccKey("a"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compareMergedValues(t, val, appender("a-valueappend")) {
+				t.Error("mismatch of \"a\"")
+			}
 
-	val, err = b.Get(mvccKey("c"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !compareMergedValues(t, val, appender("c-valueappend")) {
-		t.Error("mismatch of \"c\"")
+			val, err = b.Get(mvccKey("b"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compareMergedValues(t, val, appender("append")) {
+				t.Error("mismatch of \"b\"")
+			}
+
+			val, err = b.Get(mvccKey("c"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compareMergedValues(t, val, appender("c-valueappend")) {
+				t.Error("mismatch of \"c\"")
+			}
+		})
 	}
 }
 
 func TestBatchProto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	val := roachpb.MakeValueFromString("value")
-	if _, _, err := PutProto(b, mvccKey("proto"), &val); err != nil {
-		t.Fatal(err)
-	}
-	getVal := &roachpb.Value{}
-	ok, keySize, valSize, err := b.GetProto(mvccKey("proto"), getVal)
-	if !ok || err != nil {
-		t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
-	}
-	if keySize != 6 {
-		t.Errorf("expected key size 6; got %d", keySize)
-	}
-	data, err := protoutil.Marshal(&val)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if valSize != int64(len(data)) {
-		t.Errorf("expected value size %d; got %d", len(data), valSize)
-	}
-	if !proto.Equal(getVal, &val) {
-		t.Errorf("expected %v; got %v", &val, getVal)
-	}
-	// Before commit, proto will not be available via engine.
-	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
-		t.Fatalf("expected GetProto to fail ok=%t: %+v", ok, err)
-	}
-	// Commit and verify the proto can be read directly from the engine.
-	if err := b.Commit(false /* sync */); err != nil {
-		t.Fatal(err)
-	}
-	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
-		t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
-	}
-	if !proto.Equal(getVal, &val) {
-		t.Errorf("expected %v; got %v", &val, getVal)
+			b := e.NewBatch()
+			defer b.Close()
+
+			val := roachpb.MakeValueFromString("value")
+			if _, _, err := PutProto(b, mvccKey("proto"), &val); err != nil {
+				t.Fatal(err)
+			}
+			getVal := &roachpb.Value{}
+			ok, keySize, valSize, err := b.GetProto(mvccKey("proto"), getVal)
+			if !ok || err != nil {
+				t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
+			}
+			if keySize != 6 {
+				t.Errorf("expected key size 6; got %d", keySize)
+			}
+			data, err := protoutil.Marshal(&val)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if valSize != int64(len(data)) {
+				t.Errorf("expected value size %d; got %d", len(data), valSize)
+			}
+			if !proto.Equal(getVal, &val) {
+				t.Errorf("expected %v; got %v", &val, getVal)
+			}
+			// Before commit, proto will not be available via engine.
+			if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
+				t.Fatalf("expected GetProto to fail ok=%t: %+v", ok, err)
+			}
+			// Commit and verify the proto can be read directly from the engine.
+			if err := b.Commit(false /* sync */); err != nil {
+				t.Fatal(err)
+			}
+			if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
+				t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
+			}
+			if !proto.Equal(getVal, &val) {
+				t.Errorf("expected %v; got %v", &val, getVal)
+			}
+		})
 	}
 }
 
 func TestBatchScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	existingVals := []MVCCKeyValue{
-		{Key: mvccKey("a"), Value: []byte("1")},
-		{Key: mvccKey("b"), Value: []byte("2")},
-		{Key: mvccKey("c"), Value: []byte("3")},
-		{Key: mvccKey("d"), Value: []byte("4")},
-		{Key: mvccKey("e"), Value: []byte("5")},
-		{Key: mvccKey("f"), Value: []byte("6")},
-		{Key: mvccKey("g"), Value: []byte("7")},
-		{Key: mvccKey("h"), Value: []byte("8")},
-		{Key: mvccKey("i"), Value: []byte("9")},
-		{Key: mvccKey("j"), Value: []byte("10")},
-		{Key: mvccKey("k"), Value: []byte("11")},
-		{Key: mvccKey("l"), Value: []byte("12")},
-		{Key: mvccKey("m"), Value: []byte("13")},
-	}
-	for _, kv := range existingVals {
-		if err := e.Put(kv.Key, kv.Value); err != nil {
-			t.Fatal(err)
-		}
-	}
+			b := e.NewBatch()
+			defer b.Close()
 
-	batchVals := []MVCCKeyValue{
-		{Key: mvccKey("a"), Value: []byte("b1")},
-		{Key: mvccKey("bb"), Value: []byte("b2")},
-		{Key: mvccKey("c"), Value: []byte("b3")},
-		{Key: mvccKey("dd"), Value: []byte("b4")},
-		{Key: mvccKey("e"), Value: []byte("b5")},
-		{Key: mvccKey("ff"), Value: []byte("b6")},
-		{Key: mvccKey("g"), Value: []byte("b7")},
-		{Key: mvccKey("hh"), Value: []byte("b8")},
-		{Key: mvccKey("i"), Value: []byte("b9")},
-		{Key: mvccKey("jj"), Value: []byte("b10")},
-	}
-	for _, kv := range batchVals {
-		if err := b.Put(kv.Key, kv.Value); err != nil {
-			t.Fatal(err)
-		}
-	}
+			existingVals := []MVCCKeyValue{
+				{Key: mvccKey("a"), Value: []byte("1")},
+				{Key: mvccKey("b"), Value: []byte("2")},
+				{Key: mvccKey("c"), Value: []byte("3")},
+				{Key: mvccKey("d"), Value: []byte("4")},
+				{Key: mvccKey("e"), Value: []byte("5")},
+				{Key: mvccKey("f"), Value: []byte("6")},
+				{Key: mvccKey("g"), Value: []byte("7")},
+				{Key: mvccKey("h"), Value: []byte("8")},
+				{Key: mvccKey("i"), Value: []byte("9")},
+				{Key: mvccKey("j"), Value: []byte("10")},
+				{Key: mvccKey("k"), Value: []byte("11")},
+				{Key: mvccKey("l"), Value: []byte("12")},
+				{Key: mvccKey("m"), Value: []byte("13")},
+			}
+			for _, kv := range existingVals {
+				if err := e.Put(kv.Key, kv.Value); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	scans := []struct {
-		start, end MVCCKey
-		max        int64
-	}{
-		// Full monty.
-		{start: mvccKey("a"), end: mvccKey("z"), max: 0},
-		// Select ~half.
-		{start: mvccKey("a"), end: mvccKey("z"), max: 9},
-		// Select one.
-		{start: mvccKey("a"), end: mvccKey("z"), max: 1},
-		// Select half by end key.
-		{start: mvccKey("a"), end: mvccKey("f0"), max: 0},
-		// Start at half and select rest.
-		{start: mvccKey("f"), end: mvccKey("z"), max: 0},
-		// Start at last and select max=10.
-		{start: mvccKey("m"), end: mvccKey("z"), max: 10},
-	}
+			batchVals := []MVCCKeyValue{
+				{Key: mvccKey("a"), Value: []byte("b1")},
+				{Key: mvccKey("bb"), Value: []byte("b2")},
+				{Key: mvccKey("c"), Value: []byte("b3")},
+				{Key: mvccKey("dd"), Value: []byte("b4")},
+				{Key: mvccKey("e"), Value: []byte("b5")},
+				{Key: mvccKey("ff"), Value: []byte("b6")},
+				{Key: mvccKey("g"), Value: []byte("b7")},
+				{Key: mvccKey("hh"), Value: []byte("b8")},
+				{Key: mvccKey("i"), Value: []byte("b9")},
+				{Key: mvccKey("jj"), Value: []byte("b10")},
+			}
+			for _, kv := range batchVals {
+				if err := b.Put(kv.Key, kv.Value); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// Scan each case using the batch and store the results.
-	results := map[int][]MVCCKeyValue{}
-	for i, scan := range scans {
-		kvs, err := Scan(b, scan.start, scan.end, scan.max)
-		if err != nil {
-			t.Fatal(err)
-		}
-		results[i] = kvs
-	}
+			scans := []struct {
+				start, end MVCCKey
+				max        int64
+			}{
+				// Full monty.
+				{start: mvccKey("a"), end: mvccKey("z"), max: 0},
+				// Select ~half.
+				{start: mvccKey("a"), end: mvccKey("z"), max: 9},
+				// Select one.
+				{start: mvccKey("a"), end: mvccKey("z"), max: 1},
+				// Select half by end key.
+				{start: mvccKey("a"), end: mvccKey("f0"), max: 0},
+				// Start at half and select rest.
+				{start: mvccKey("f"), end: mvccKey("z"), max: 0},
+				// Start at last and select max=10.
+				{start: mvccKey("m"), end: mvccKey("z"), max: 10},
+			}
 
-	// Now, commit batch and re-scan using engine direct to compare results.
-	if err := b.Commit(false /* sync */); err != nil {
-		t.Fatal(err)
-	}
-	for i, scan := range scans {
-		kvs, err := Scan(e, scan.start, scan.end, scan.max)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(kvs, results[i]) {
-			t.Errorf("%d: expected %v; got %v", i, results[i], kvs)
-		}
+			// Scan each case using the batch and store the results.
+			results := map[int][]MVCCKeyValue{}
+			for i, scan := range scans {
+				kvs, err := Scan(b, scan.start, scan.end, scan.max)
+				if err != nil {
+					t.Fatal(err)
+				}
+				results[i] = kvs
+			}
+
+			// Now, commit batch and re-scan using engine direct to compare results.
+			if err := b.Commit(false /* sync */); err != nil {
+				t.Fatal(err)
+			}
+			for i, scan := range scans {
+				kvs, err := Scan(e, scan.start, scan.end, scan.max)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(kvs, results[i]) {
+					t.Errorf("%d: expected %v; got %v", i, results[i], kvs)
+				}
+			}
+		})
 	}
 }
 
@@ -655,27 +679,30 @@ func TestBatchScan(t *testing.T) {
 // a single deleted value returns nothing.
 func TestBatchScanWithDelete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	// Write initial value, then delete via batch.
-	if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Clear(mvccKey("a")); err != nil {
-		t.Fatal(err)
-	}
-	kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 0 {
-		t.Errorf("expected empty scan with batch-deleted value; got %v", kvs)
+			b := e.NewBatch()
+			defer b.Close()
+
+			// Write initial value, then delete via batch.
+			if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Clear(mvccKey("a")); err != nil {
+				t.Fatal(err)
+			}
+			kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 0 {
+				t.Errorf("expected empty scan with batch-deleted value; got %v", kvs)
+			}
+		})
 	}
 }
 
@@ -684,32 +711,35 @@ func TestBatchScanWithDelete(t *testing.T) {
 // max on a scan is still reached.
 func TestBatchScanMaxWithDeleted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	// Write two values.
-	if err := e.Put(mvccKey("a"), []byte("value1")); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.Put(mvccKey("b"), []byte("value2")); err != nil {
-		t.Fatal(err)
-	}
-	// Now, delete "a" in batch.
-	if err := b.Clear(mvccKey("a")); err != nil {
-		t.Fatal(err)
-	}
-	// A scan with max=1 should scan "b".
-	kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 || !bytes.Equal(kvs[0].Key.Key, []byte("b")) {
-		t.Errorf("expected scan of \"b\"; got %v", kvs)
+			b := e.NewBatch()
+			defer b.Close()
+
+			// Write two values.
+			if err := e.Put(mvccKey("a"), []byte("value1")); err != nil {
+				t.Fatal(err)
+			}
+			if err := e.Put(mvccKey("b"), []byte("value2")); err != nil {
+				t.Fatal(err)
+			}
+			// Now, delete "a" in batch.
+			if err := b.Clear(mvccKey("a")); err != nil {
+				t.Fatal(err)
+			}
+			// A scan with max=1 should scan "b".
+			kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 || !bytes.Equal(kvs[0].Key.Key, []byte("b")) {
+				t.Errorf("expected scan of \"b\"; got %v", kvs)
+			}
+		})
 	}
 }
 
@@ -719,36 +749,39 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 // batches, but worth verifying.
 func TestBatchConcurrency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
 
-	b := e.NewBatch()
-	defer b.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	// Write a merge to the batch.
-	if err := b.Merge(mvccKey("a"), appender("bar")); err != nil {
-		t.Fatal(err)
-	}
-	val, err := b.Get(mvccKey("a"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !compareMergedValues(t, val, appender("bar")) {
-		t.Error("mismatch of \"a\"")
-	}
-	// Write an engine value.
-	if err := e.Put(mvccKey("a"), appender("foo")); err != nil {
-		t.Fatal(err)
-	}
-	// Now, read again and verify that the merge happens on top of the mod.
-	val, err = b.Get(mvccKey("a"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(val, appender("foobar")) {
-		t.Error("mismatch of \"a\"")
+			b := e.NewBatch()
+			defer b.Close()
+
+			// Write a merge to the batch.
+			if err := b.Merge(mvccKey("a"), appender("bar")); err != nil {
+				t.Fatal(err)
+			}
+			val, err := b.Get(mvccKey("a"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compareMergedValues(t, val, appender("bar")) {
+				t.Error("mismatch of \"a\"")
+			}
+			// Write an engine value.
+			if err := e.Put(mvccKey("a"), appender("foo")); err != nil {
+				t.Fatal(err)
+			}
+			// Now, read again and verify that the merge happens on top of the mod.
+			val, err = b.Get(mvccKey("a"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(val, appender("foobar")) {
+				t.Error("mismatch of \"a\"")
+			}
+		})
 	}
 }
 
@@ -885,107 +918,125 @@ func TestBatchBuilderStress(t *testing.T) {
 func TestBatchDistinctAfterApplyBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	wb := func() []byte {
-		batch := e.NewBatch()
-		defer batch.Close()
+			wb := func() []byte {
+				batch := e.NewBatch()
+				defer batch.Close()
 
-		if err := batch.Put(mvccKey("batchkey"), []byte("b")); err != nil {
-			t.Fatal(err)
-		}
+				if err := batch.Put(mvccKey("batchkey"), []byte("b")); err != nil {
+					t.Fatal(err)
+				}
 
-		return batch.Repr()
-	}()
+				return batch.Repr()
+			}()
 
-	batch := e.NewBatch()
-	defer batch.Close()
+			batch := e.NewBatch()
+			defer batch.Close()
 
-	assert.NoError(t, batch.ApplyBatchRepr(wb, false /* sync */))
+			assert.NoError(t, batch.ApplyBatchRepr(wb, false /* sync */))
 
-	distinct := batch.Distinct()
-	defer distinct.Close()
+			distinct := batch.Distinct()
+			defer distinct.Close()
 
-	// The distinct batch can see the earlier write to the batch.
-	v, err := distinct.Get(mvccKey("batchkey"))
-	if err != nil {
-		t.Fatal(err)
+			// The distinct batch can see the earlier write to the batch.
+			v, err := distinct.Get(mvccKey("batchkey"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, []byte("b"), v)
+		})
 	}
-	assert.Equal(t, []byte("b"), v)
 }
 
 func TestBatchDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
-		t.Fatal(err)
-	}
+			if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
+				t.Fatal(err)
+			}
 
-	batch := e.NewBatch()
-	defer batch.Close()
+			batch := e.NewBatch()
+			defer batch.Close()
 
-	if err := batch.Put(mvccKey("a"), []byte("a")); err != nil {
-		t.Fatal(err)
-	}
-	if err := batch.Clear(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	}
+			if err := batch.Put(mvccKey("a"), []byte("a")); err != nil {
+				t.Fatal(err)
+			}
+			if err := batch.Clear(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			}
 
-	// The original batch can see the writes to the batch.
-	if v, err := batch.Get(mvccKey("a")); err != nil {
-		t.Fatal(err)
-	} else if string(v) != "a" {
-		t.Fatalf("expected a, but got %s", v)
-	}
+			// The original batch can see the writes to the batch.
+			if v, err := batch.Get(mvccKey("a")); err != nil {
+				t.Fatal(err)
+			} else if string(v) != "a" {
+				t.Fatalf("expected a, but got %s", v)
+			}
 
-	// The distinct batch will see previous writes to the batch.
-	distinct := batch.Distinct()
-	if v, err := distinct.Get(mvccKey("a")); err != nil {
-		t.Fatal(err)
-	} else if string(v) != "a" {
-		t.Fatalf("expected a, but got %s", v)
-	}
-	if v, err := distinct.Get(mvccKey("b")); err != nil {
-		t.Fatal(err)
-	} else if v != nil {
-		t.Fatalf("expected nothing, but got %s", v)
-	}
+			// The distinct batch will see previous writes to the batch.
+			distinct := batch.Distinct()
+			if v, err := distinct.Get(mvccKey("a")); err != nil {
+				t.Fatal(err)
+			} else if string(v) != "a" {
+				t.Fatalf("expected a, but got %s", v)
+			}
+			if v, err := distinct.Get(mvccKey("b")); err != nil {
+				t.Fatal(err)
+			} else if v != nil {
+				t.Fatalf("expected nothing, but got %s", v)
+			}
 
-	// Similarly, for distinct batch iterators we will see previous writes to the
-	// batch.
-	iter := distinct.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-	iter.Seek(mvccKey("a"))
-	if ok, err := iter.Valid(); !ok {
-		t.Fatalf("expected iterator to be valid; err=%v", err)
-	}
-	if string(iter.Key().Key) != "a" {
-		t.Fatalf("expected a, but got %s", iter.Key())
-	}
+			// Similarly, for distinct batch iterators we will see previous writes to the
+			// batch.
+			iter := distinct.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			iter.Seek(mvccKey("a"))
+			if ok, err := iter.Valid(); !ok {
+				t.Fatalf("expected iterator to be valid; err=%v", err)
+			}
+			if string(iter.Key().Key) != "a" {
+				t.Fatalf("expected a, but got %s", iter.Key())
+			}
+			iter.Close()
 
-	// Writes to the distinct batch are not readable by the distinct batch.
-	if err := distinct.Put(mvccKey("c"), []byte("c")); err != nil {
-		t.Fatal(err)
-	}
-	if v, err := distinct.Get(mvccKey("c")); err != nil {
-		t.Fatal(err)
-	} else if v != nil {
-		t.Fatalf("expected nothing, but got %s", v)
-	}
-	distinct.Close()
+			if err := distinct.Put(mvccKey("c"), []byte("c")); err != nil {
+				t.Fatal(err)
+			}
+			if v, err := distinct.Get(mvccKey("c")); err != nil {
+				t.Fatal(err)
+			} else {
+				switch engineImpl.name {
+				case "pebble":
+					// With Pebble, writes to the distinct batch are readable by the
+					// distinct batch. This semantic difference is due to not buffering
+					// writes in a builder.
+					if v == nil {
+						t.Fatalf("expected success, but got %s", v)
+					}
+				default:
+					// Writes to the distinct batch are not readable by the distinct
+					// batch.
+					if v != nil {
+						t.Fatalf("expected nothing, but got %s", v)
+					}
+				}
+			}
+			distinct.Close()
 
-	// Writes to the distinct batch are reflected in the original batch.
-	if v, err := batch.Get(mvccKey("c")); err != nil {
-		t.Fatal(err)
-	} else if string(v) != "c" {
-		t.Fatalf("expected c, but got %s", v)
+			// Writes to the distinct batch are reflected in the original batch.
+			if v, err := batch.Get(mvccKey("c")); err != nil {
+				t.Fatal(err)
+			} else if string(v) != "c" {
+				t.Fatalf("expected c, but got %s", v)
+			}
+		})
 	}
 }
 
@@ -1039,119 +1090,139 @@ func TestWriteOnlyBatchDistinct(t *testing.T) {
 func TestBatchDistinctPanics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	batch := e.NewBatch()
-	defer batch.Close()
+			batch := e.NewBatch()
+			defer batch.Close()
 
-	distinct := batch.Distinct()
-	defer distinct.Close()
+			distinct := batch.Distinct()
+			defer distinct.Close()
 
-	// The various Reader and Writer methods on the original batch should panic
-	// while the distinct batch is open.
-	a := mvccKey("a")
-	testCases := []func(){
-		func() { _ = batch.Put(a, nil) },
-		func() { _ = batch.Merge(a, nil) },
-		func() { _ = batch.Clear(a) },
-		func() { _ = batch.SingleClear(a) },
-		func() { _ = batch.ApplyBatchRepr(nil, false) },
-		func() { _, _ = batch.Get(a) },
-		func() { _, _, _, _ = batch.GetProto(a, nil) },
-		func() { _ = batch.Iterate(a, a, nil) },
-		func() { _ = batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}) },
-	}
-	for i, f := range testCases {
-		func() {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Fatalf("%d: test did not panic", i)
-				} else if r != "distinct batch open" {
-					t.Fatalf("%d: unexpected panic: %v", i, r)
-				}
-			}()
-			f()
-		}()
+			// The various Reader and Writer methods on the original batch should panic
+			// while the distinct batch is open.
+			a := mvccKey("a")
+			testCases := []func(){
+				func() { _ = batch.Put(a, nil) },
+				func() { _ = batch.Merge(a, nil) },
+				func() { _ = batch.Clear(a) },
+				func() { _ = batch.SingleClear(a) },
+				func() { _ = batch.ApplyBatchRepr(nil, false) },
+				func() { _, _ = batch.Get(a) },
+				func() { _, _, _, _ = batch.GetProto(a, nil) },
+				func() { _ = batch.Iterate(a, a, nil) },
+				func() { _ = batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}) },
+			}
+			for i, f := range testCases {
+				func() {
+					defer func() {
+						if r := recover(); r == nil {
+							t.Fatalf("%d: test did not panic", i)
+						} else if r != "distinct batch open" {
+							t.Fatalf("%d: unexpected panic: %v", i, r)
+						}
+					}()
+					f()
+				}()
+			}
+		})
 	}
 }
 
 func TestBatchIteration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	defer e.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	b := e.NewBatch()
-	defer b.Close()
+			b := e.NewBatch()
+			defer b.Close()
 
-	k1 := MakeMVCCMetadataKey(roachpb.Key("c"))
-	k2 := MakeMVCCMetadataKey(roachpb.Key("d"))
-	k3 := MakeMVCCMetadataKey(roachpb.Key("e"))
-	v1 := []byte("value1")
-	v2 := []byte("value2")
+			k1 := MakeMVCCMetadataKey(roachpb.Key("c"))
+			k2 := MakeMVCCMetadataKey(roachpb.Key("d"))
+			k3 := MakeMVCCMetadataKey(roachpb.Key("e"))
+			v1 := []byte("value1")
+			v2 := []byte("value2")
 
-	if err := b.Put(k1, v1); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Put(k2, v2); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Put(k3, []byte("doesn't matter")); err != nil {
-		t.Fatal(err)
-	}
+			if err := b.Put(k1, v1); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Put(k2, v2); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Put(k3, []byte("doesn't matter")); err != nil {
+				t.Fatal(err)
+			}
 
-	iter := b.NewIterator(IterOptions{UpperBound: k3.Key})
-	defer iter.Close()
+			iter := b.NewIterator(IterOptions{UpperBound: k3.Key})
+			defer iter.Close()
 
-	// Forward iteration
-	iter.Seek(k1)
-	if ok, err := iter.Valid(); !ok {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(iter.Key(), k1) {
-		t.Fatalf("expected %s, got %s", k1, iter.Key())
-	}
-	if !reflect.DeepEqual(iter.Value(), v1) {
-		t.Fatalf("expected %s, got %s", v1, iter.Value())
-	}
-	iter.Next()
-	if ok, err := iter.Valid(); !ok {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(iter.Key(), k2) {
-		t.Fatalf("expected %s, got %s", k2, iter.Key())
-	}
-	if !reflect.DeepEqual(iter.Value(), v2) {
-		t.Fatalf("expected %s, got %s", v2, iter.Value())
-	}
-	iter.Next()
-	if ok, err := iter.Valid(); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatalf("expected invalid, got valid at key %s", iter.Key())
-	}
+			// Forward iteration
+			iter.Seek(k1)
+			if ok, err := iter.Valid(); !ok {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(iter.Key(), k1) {
+				t.Fatalf("expected %s, got %s", k1, iter.Key())
+			}
+			if !reflect.DeepEqual(iter.Value(), v1) {
+				t.Fatalf("expected %s, got %s", v1, iter.Value())
+			}
+			iter.Next()
+			if ok, err := iter.Valid(); !ok {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(iter.Key(), k2) {
+				t.Fatalf("expected %s, got %s", k2, iter.Key())
+			}
+			if !reflect.DeepEqual(iter.Value(), v2) {
+				t.Fatalf("expected %s, got %s", v2, iter.Value())
+			}
+			iter.Next()
+			if ok, err := iter.Valid(); err != nil {
+				t.Fatal(err)
+			} else if ok {
+				t.Fatalf("expected invalid, got valid at key %s", iter.Key())
+			}
 
-	// SeekReverse works, but reverse iteration is not supported.
-	iter.SeekReverse(k2)
-	if ok, err := iter.Valid(); !ok {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(iter.Key(), k2) {
-		t.Fatalf("expected %s, got %s", k2, iter.Key())
-	}
-	if !reflect.DeepEqual(iter.Value(), v2) {
-		t.Fatalf("expected %s, got %s", v2, iter.Value())
-	}
-	iter.Prev()
-	if ok, err := iter.Valid(); ok {
-		t.Fatalf("expected invalid, got valid at key %s", iter.Key())
-	} else if !testutils.IsError(err, "Prev\\(\\) not supported") {
-		t.Fatalf("expected 'Prev() not supported', got %s", err)
+			// SeekReverse works.
+			iter.SeekReverse(k2)
+			if ok, err := iter.Valid(); !ok {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(iter.Key(), k2) {
+				t.Fatalf("expected %s, got %s", k2, iter.Key())
+			}
+			if !reflect.DeepEqual(iter.Value(), v2) {
+				t.Fatalf("expected %s, got %s", v2, iter.Value())
+			}
+			iter.Prev()
+
+			switch engineImpl.name {
+			case "pebble":
+				// Reverse iteration in batches works on Pebble.
+				if ok, err := iter.Valid(); !ok || err != nil {
+					t.Fatalf("expected success, but got invalid: %v", err)
+				}
+				if !reflect.DeepEqual(iter.Key(), k1) {
+					t.Fatalf("expected %s, got %s", k1, iter.Key())
+				}
+				if !reflect.DeepEqual(iter.Value(), v1) {
+					t.Fatalf("expected %s, got %s", v1, iter.Value())
+				}
+			default:
+				// Reverse iteration in batches is not supported with RocksDB.
+				if ok, err := iter.Valid(); ok {
+					t.Fatalf("expected invalid, got valid at key %s", iter.Key())
+				} else if !testutils.IsError(err, "Prev\\(\\) not supported") {
+					t.Fatalf("expected 'Prev() not supported', got %s", err)
+				}
+			}
+		})
 	}
 }
 
@@ -1160,51 +1231,53 @@ func TestBatchIteration(t *testing.T) {
 func TestBatchCombine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
-	stopper.AddCloser(e)
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	var n uint32
-	const count = 10000
+			var n uint32
+			const count = 10000
 
-	errs := make(chan error, 10)
-	for i := 0; i < cap(errs); i++ {
-		go func() {
-			for {
-				v := atomic.AddUint32(&n, 1) - 1
-				if v >= count {
-					break
-				}
-				k := fmt.Sprint(v)
+			errs := make(chan error, 10)
+			for i := 0; i < cap(errs); i++ {
+				go func() {
+					for {
+						v := atomic.AddUint32(&n, 1) - 1
+						if v >= count {
+							break
+						}
+						k := fmt.Sprint(v)
 
-				b := e.NewWriteOnlyBatch()
-				if err := b.Put(mvccKey(k), []byte(k)); err != nil {
-					errs <- errors.Wrap(err, "put failed")
-					return
-				}
-				if err := b.Commit(false); err != nil {
-					errs <- errors.Wrap(err, "commit failed")
-					return
-				}
+						b := e.NewWriteOnlyBatch()
+						if err := b.Put(mvccKey(k), []byte(k)); err != nil {
+							errs <- errors.Wrap(err, "put failed")
+							return
+						}
+						if err := b.Commit(false); err != nil {
+							errs <- errors.Wrap(err, "commit failed")
+							return
+						}
 
-				// Verify we can read the key we just wrote immediately.
-				if v, err := e.Get(mvccKey(k)); err != nil {
-					errs <- errors.Wrap(err, "get failed")
-					return
-				} else if string(v) != k {
-					errs <- errors.Errorf("read %q from engine, expected %q", v, k)
-					return
+						// Verify we can read the key we just wrote immediately.
+						if v, err := e.Get(mvccKey(k)); err != nil {
+							errs <- errors.Wrap(err, "get failed")
+							return
+						} else if string(v) != k {
+							errs <- errors.Errorf("read %q from engine, expected %q", v, k)
+							return
+						}
+					}
+					errs <- nil
+				}()
+			}
+
+			for i := 0; i < cap(errs); i++ {
+				if err := <-errs; err != nil {
+					t.Error(err)
 				}
 			}
-			errs <- nil
-		}()
-	}
-
-	for i := 0; i < cap(errs); i++ {
-		if err := <-errs; err != nil {
-			t.Error(err)
-		}
+		})
 	}
 }
 

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -168,6 +168,8 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 				t.Fatalf("iterator unexpectedly valid: %v -> %v",
 					iter.UnsafeKey(), iter.UnsafeValue())
 			}
+
+			iter.Close()
 		}
 
 		// Higher-level failure mode. Mostly for documentation.

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -156,8 +156,7 @@ type Pebble struct {
 	attrs  roachpb.Attributes
 
 	// Relevant options copied over from pebble.Options.
-	fs       vfs.FS
-	readOnly bool
+	fs vfs.FS
 }
 
 var _ WithSSTables = &Pebble{}
@@ -179,22 +178,15 @@ func NewPebble(path string, cfg *pebble.Options) (*Pebble, error) {
 	}
 
 	return &Pebble{
-		db:       db,
-		path:     path,
-		fs:       cfg.FS,
-		readOnly: cfg.ReadOnly,
+		db:   db,
+		path: path,
+		fs:   cfg.FS,
 	}, nil
 }
 
 // Close implements the Engine interface.
 func (p *Pebble) Close() {
 	p.closed = true
-
-	if p.readOnly {
-		// Don't close the underlying handle; the non-ReadOnly instance will handle
-		// that.
-		return
-	}
 	_ = p.db.Close()
 }
 
@@ -280,9 +272,6 @@ func (p *Pebble) NewIterator(opts IterOptions) Iterator {
 
 // ApplyBatchRepr implements the Engine interface.
 func (p *Pebble) ApplyBatchRepr(repr []byte, sync bool) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	// batch.SetRepr takes ownership of the underlying slice, so make a copy.
 	reprCopy := make([]byte, len(repr))
 	copy(reprCopy, repr)
@@ -301,34 +290,22 @@ func (p *Pebble) ApplyBatchRepr(repr []byte, sync bool) error {
 
 // Clear implements the Engine interface.
 func (p *Pebble) Clear(key MVCCKey) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	if len(key.Key) == 0 {
 		return emptyKeyError()
 	}
-
 	return p.db.Delete(EncodeKey(key), pebble.Sync)
 }
 
 // SingleClear implements the Engine interface.
 func (p *Pebble) SingleClear(key MVCCKey) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	if len(key.Key) == 0 {
 		return emptyKeyError()
 	}
-
 	return p.db.SingleDelete(EncodeKey(key), pebble.Sync)
 }
 
 // ClearRange implements the Engine interface.
 func (p *Pebble) ClearRange(start, end MVCCKey) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
-
 	bufStart := EncodeKey(start)
 	bufEnd := EncodeKey(end)
 	return p.db.DeleteRange(bufStart, bufEnd, pebble.Sync)
@@ -336,10 +313,6 @@ func (p *Pebble) ClearRange(start, end MVCCKey) error {
 
 // ClearIterRange implements the Engine interface.
 func (p *Pebble) ClearIterRange(iter Iterator, start, end MVCCKey) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
-
 	// Write all the tombstones in one batch.
 	batch := p.NewWriteOnlyBatch()
 	defer batch.Close()
@@ -352,25 +325,17 @@ func (p *Pebble) ClearIterRange(iter Iterator, start, end MVCCKey) error {
 
 // Merge implements the Engine interface.
 func (p *Pebble) Merge(key MVCCKey, value []byte) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	if len(key.Key) == 0 {
 		return emptyKeyError()
 	}
-
 	return p.db.Merge(EncodeKey(key), value, pebble.Sync)
 }
 
 // Put implements the Engine interface.
 func (p *Pebble) Put(key MVCCKey, value []byte) error {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	if len(key.Key) == 0 {
 		return emptyKeyError()
 	}
-
 	return p.db.Set(EncodeKey(key), value, pebble.Sync)
 }
 
@@ -427,28 +392,18 @@ func (p *Pebble) GetAuxiliaryDir() string {
 
 // NewBatch implements the Engine interface.
 func (p *Pebble) NewBatch() Batch {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	return newPebbleBatch(p.db, p.db.NewIndexedBatch())
 }
 
 // NewReadOnly implements the Engine interface.
 func (p *Pebble) NewReadOnly() ReadWriter {
-	peb := &Pebble{
-		db:       p.db,
-		path:     p.path,
-		readOnly: true,
-		fs:       p.fs,
+	return &pebbleReadOnly{
+		parent: p,
 	}
-	return peb
 }
 
 // NewWriteOnlyBatch implements the Engine interface.
 func (p *Pebble) NewWriteOnlyBatch() Batch {
-	if p.readOnly {
-		panic("write operation called on read-only pebble instance")
-	}
 	return newPebbleBatch(p.db, p.db.NewBatch())
 }
 
@@ -570,6 +525,113 @@ func (p *Pebble) GetSSTables() (sstables SSTableInfos) {
 		}
 	}
 	return sstables
+}
+
+type pebbleReadOnly struct {
+	parent *Pebble
+	iter   pebbleIterator
+	closed bool
+}
+
+var _ ReadWriter = &pebbleReadOnly{}
+
+func (p *pebbleReadOnly) Close() {
+	if p.closed {
+		panic("closing an already-closed pebbleReadOnly")
+	}
+	p.closed = true
+	p.iter.destroy()
+}
+
+func (p *pebbleReadOnly) Closed() bool {
+	return p.closed
+}
+
+func (p *pebbleReadOnly) Get(key MVCCKey) ([]byte, error) {
+	if p.closed {
+		panic("using a closed pebbleReadOnly")
+	}
+	return p.parent.Get(key)
+}
+
+func (p *pebbleReadOnly) GetProto(
+	key MVCCKey, msg protoutil.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
+	if p.closed {
+		panic("using a closed pebbleReadOnly")
+	}
+	return p.parent.GetProto(key, msg)
+}
+
+func (p *pebbleReadOnly) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	if p.closed {
+		panic("using a closed pebbleReadOnly")
+	}
+	return p.parent.Iterate(start, end, f)
+}
+
+func (p *pebbleReadOnly) NewIterator(opts IterOptions) Iterator {
+	if p.closed {
+		panic("using a closed pebbleReadOnly")
+	}
+
+	if opts.MinTimestampHint != (hlc.Timestamp{}) {
+		// Iterators that specify timestamp bounds cannot be cached.
+		return newPebbleIterator(p.parent.db, opts)
+	}
+
+	if p.iter.inuse {
+		panic("iterator already in use")
+	}
+	p.iter.inuse = true
+	p.iter.reusable = true
+
+	if p.iter.iter != nil {
+		p.iter.setOptions(opts)
+	} else {
+		p.iter.init(p.parent.db, opts)
+	}
+	return &p.iter
+}
+
+// Writer methods are not implemented for pebbleReadOnly. Ideally, the code
+// could be refactored so that a Reader could be supplied to evaluateBatch
+
+// Writer is the write interface to an engine's data.
+func (p *pebbleReadOnly) ApplyBatchRepr(repr []byte, sync bool) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) Clear(key MVCCKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) SingleClear(key MVCCKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ClearRange(start, end MVCCKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) Merge(key MVCCKey, value []byte) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) Put(key MVCCKey, value []byte) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) LogData(data []byte) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+	panic("not implemented")
 }
 
 // pebbleSnapshot represents a snapshot created using Pebble.NewSnapshot().

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -23,7 +23,7 @@ type pebbleBatch struct {
 	db           *pebble.DB
 	batch        *pebble.Batch
 	buf          []byte
-	iter         pebbleBatchIterator
+	iter         pebbleIterator
 	closed       bool
 	isDistinct   bool
 	distinctOpen bool
@@ -45,23 +45,20 @@ func newPebbleBatch(db *pebble.DB, batch *pebble.Batch) *pebbleBatch {
 		db:    db,
 		batch: batch,
 		buf:   pb.buf,
-		iter: pebbleBatchIterator{
-			pebbleIterator: pebbleIterator{
-				lowerBoundBuf: pb.iter.lowerBoundBuf,
-				upperBoundBuf: pb.iter.upperBoundBuf,
-			},
+		iter: pebbleIterator{
+			lowerBoundBuf: pb.iter.lowerBoundBuf,
+			upperBoundBuf: pb.iter.upperBoundBuf,
 		},
 	}
-
 	return pb
 }
 
 // Close implements the Batch interface.
 func (p *pebbleBatch) Close() {
-	if p.iter.iter != nil {
-		_ = p.iter.iter.Close()
-		p.iter.destroy()
+	if p.closed {
+		panic("closing an already-closed pebbleBatch")
 	}
+	p.closed = true
 	if !p.isDistinct {
 		_ = p.batch.Close()
 		p.batch = nil
@@ -69,7 +66,7 @@ func (p *pebbleBatch) Close() {
 		p.parentBatch.distinctOpen = false
 		p.isDistinct = false
 	}
-	p.closed = true
+	p.iter.destroy()
 	pebbleBatchPool.Put(p)
 }
 
@@ -80,17 +77,22 @@ func (p *pebbleBatch) Closed() bool {
 
 // Get implements the Batch interface.
 func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
-	if !p.batch.Indexed() {
-		panic("write-only batch")
-	}
-	if p.distinctOpen {
-		panic("distinct batch open")
+	r := pebble.Reader(p.batch)
+	if !p.isDistinct {
+		if !p.batch.Indexed() {
+			panic("write-only batch")
+		}
+		if p.distinctOpen {
+			panic("distinct batch open")
+		}
+	} else if !p.batch.Indexed() {
+		r = p.db
 	}
 	if len(key.Key) == 0 {
 		return nil, emptyKeyError()
 	}
 	p.buf = EncodeKeyToBuf(p.buf[:0], key)
-	ret, err := p.batch.Get(p.buf)
+	ret, err := r.Get(p.buf)
 	if err == pebble.ErrNotFound || len(ret) == 0 {
 		return nil, nil
 	}
@@ -101,17 +103,22 @@ func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
 func (p *pebbleBatch) GetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
-	if !p.batch.Indexed() {
-		panic("write-only batch")
-	}
-	if p.distinctOpen {
-		panic("distinct batch open")
+	r := pebble.Reader(p.batch)
+	if !p.isDistinct {
+		if !p.batch.Indexed() {
+			panic("write-only batch")
+		}
+		if p.distinctOpen {
+			panic("distinct batch open")
+		}
+	} else if !p.batch.Indexed() {
+		r = p.db
 	}
 	if len(key.Key) == 0 {
 		return false, 0, 0, emptyKeyError()
 	}
 	p.buf = EncodeKeyToBuf(p.buf[:0], key)
-	val, err := p.batch.Get(p.buf)
+	val, err := r.Get(p.buf)
 	if err != nil || val == nil {
 		return false, 0, 0, err
 	}
@@ -126,6 +133,9 @@ func (p *pebbleBatch) GetProto(
 func (p *pebbleBatch) Iterate(
 	start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error),
 ) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
 	return iterateOnReader(p, start, end, f)
 }
 
@@ -144,31 +154,22 @@ func (p *pebbleBatch) NewIterator(opts IterOptions) Iterator {
 
 	if opts.MinTimestampHint != (hlc.Timestamp{}) {
 		// Iterators that specify timestamp bounds cannot be cached.
-		iter := &pebbleBatchIterator{batch: p}
-		iter.init(p.batch, opts)
-		return iter
+		return newPebbleIterator(p.batch, opts)
 	}
 
-	// Use the cached iterator.
-	//
-	// TODO(itsbilal): Investigate if it's equally or more efficient to just call
-	// newPebbleIterator with p.batch as the handle, instead of caching an
-	// iterator in pebbleBatch. This would clean up some of the oddities around
-	// pebbleBatchIterator.Close() (which doesn't close the underlying pebble
-	// Iterator), vs pebbleIterator.Close(), and the way memory is managed for
-	// the two iterators.
-	if p.iter.batch != nil {
+	if p.iter.inuse {
 		panic("iterator already in use")
-	} else if p.iter.iter != nil {
-		_ = p.iter.iter.Close()
 	}
+	p.iter.inuse = true
+	p.iter.reusable = true
 
-	if p.batch.Indexed() {
+	if p.iter.iter != nil {
+		p.iter.setOptions(opts)
+	} else if p.batch.Indexed() {
 		p.iter.init(p.batch, opts)
 	} else {
 		p.iter.init(p.db, opts)
 	}
-	p.iter.batch = p
 	return &p.iter
 }
 
@@ -348,35 +349,4 @@ func (p *pebbleBatch) Repr() []byte {
 	reprCopy := make([]byte, len(p.batch.Repr()))
 	copy(reprCopy, repr)
 	return reprCopy
-}
-
-// pebbleBatchIterator extends pebbleIterator and is meant to be embedded inside
-// a pebbleBatch.
-type pebbleBatchIterator struct {
-	pebbleIterator
-	batch *pebbleBatch
-}
-
-// Close implements the Iterator interface. There are two notable differences
-// from pebbleIterator.Close: 1. don't close the underlying p.iter (this is done
-// when the batch is closed), and 2. don't release the pebbleIterator back into
-// pebbleIterPool, since this memory is managed by pebbleBatch instead.
-func (p *pebbleBatchIterator) Close() {
-	if p.batch == nil {
-		panic("closing idle iterator")
-	}
-	p.batch = nil
-}
-
-// destroy resets all fields in a pebbleBatchIterator, while holding onto
-// some buffers to reduce allocations down the line. Assumes the underlying
-// pebble.Iterator has been closed already.
-func (p *pebbleBatchIterator) destroy() {
-	*p = pebbleBatchIterator{
-		pebbleIterator: pebbleIterator{
-			lowerBoundBuf: p.lowerBoundBuf,
-			upperBoundBuf: p.upperBoundBuf,
-		},
-		batch: nil,
-	}
 }

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -11,7 +11,6 @@
 package engine
 
 import (
-	"C"
 	"bytes"
 	"math"
 	"sync"

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1023,8 +1023,8 @@ func (r *rocksDBReadOnly) NewIterator(opts IterOptions) Iterator {
 	return iter
 }
 
-// Writer methods are not implemented for rocksDBReadOnly. Ideally, the code could be refactored so that
-// a Reader could be supplied to evaluateBatch
+// Writer methods are not implemented for rocksDBReadOnly. Ideally, the code
+// could be refactored so that a Reader could be supplied to evaluateBatch
 
 // Writer is the write interface to an engine's data.
 func (r *rocksDBReadOnly) ApplyBatchRepr(repr []byte, sync bool) error {
@@ -1433,6 +1433,12 @@ func (r *distinctBatch) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOp
 }
 
 func (r *distinctBatch) close() {
+	if r.prefixIter.inuse {
+		panic("iterator still inuse")
+	}
+	if r.normalIter.inuse {
+		panic("iterator still inuse")
+	}
 	if i := &r.prefixIter.rocksDBIterator; i.iter != nil {
 		i.destroy()
 	}
@@ -1615,6 +1621,12 @@ func (r *rocksDBBatch) Close() {
 		panic("this batch was already closed")
 	}
 	r.distinct.close()
+	if r.prefixIter.batch != nil {
+		panic("iterator still inuse")
+	}
+	if r.normalIter.batch != nil {
+		panic("iterator still inuse")
+	}
 	if i := &r.prefixIter.iter; i.iter != nil {
 		i.destroy()
 	}


### PR DESCRIPTION
Reimplement `Pebble.ReadOnly` with a specific `pebbleReadOnly`
implementation. This removes a lot of `if p.readOnly` checks from
`Pebble`, and also allows for `pebbleReadOnly.NewIterator` to use a
reusable iterator. This brings the behavior in line with
`rocksDBReadOnly`.

Added `pebbleIterator.{reusable,inuse,setOptions}`. Replaced
`pebbleBatchIterator` with a `pebbleIterator` marked as reusable.

Release note: None