### PR TITLE
pkg: Beginning refactor of hiding primary index behind a Getter method

### DIFF
--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -86,8 +86,8 @@ func TestShowBackup(t *testing.T) {
 
 	details1Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details1")
 	details2Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details2")
-	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details1Desc, details1Desc.PrimaryIndex.ID))
-	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details2Desc, details2Desc.PrimaryIndex.ID))
+	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details1Desc, details1Desc.PrimaryIdx().ID))
+	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details2Desc, details2Desc.PrimaryIdx().ID))
 
 	sqlDB.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
 		{"/Table/54/1", "/Table/54/2", string(details1Key), string(details1Key.PrefixEnd())},

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -275,7 +275,7 @@ func TestAvroSchema(t *testing.T) {
 				`{"type":["null","long"],"name":"_u0001f366_","default":null,`+
 				`"__crdb__":"🍦 INT8 NOT NULL"}]}`,
 			tableSchema.codec.Schema())
-		indexSchema, err := indexToAvroSchema(tableDesc, &tableDesc.PrimaryIndex)
+		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.PrimaryIdx())
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -123,8 +123,8 @@ func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
 
 func (e *jsonEncoder) encodeKeyRaw(row encodeRow) ([]interface{}, error) {
 	colIdxByID := row.tableDesc.ColumnIdxMap()
-	jsonEntries := make([]interface{}, len(row.tableDesc.PrimaryIndex.ColumnIDs))
-	for i, colID := range row.tableDesc.PrimaryIndex.ColumnIDs {
+	jsonEntries := make([]interface{}, len(row.tableDesc.PrimaryIdx().ColumnIDs))
+	for i, colID := range row.tableDesc.PrimaryIdx().ColumnIDs {
 		idx, ok := colIdxByID[colID]
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
@@ -285,7 +285,7 @@ func (e *confluentAvroEncoder) EncodeKey(row encodeRow) ([]byte, error) {
 	registered, ok := e.keyCache[cacheKey]
 	if !ok {
 		var err error
-		registered.schema, err = indexToAvroSchema(row.tableDesc, &row.tableDesc.PrimaryIndex)
+		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.PrimaryIdx())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -63,7 +63,7 @@ func (c *rowFetcherCache) TableDescForKey(
 		}
 
 		// Skip over the column data.
-		for ; skippedCols < len(tableDesc.PrimaryIndex.ColumnIDs); skippedCols++ {
+		for ; skippedCols < len(tableDesc.PrimaryIdx().ColumnIDs); skippedCols++ {
 			l, err := encoding.PeekLength(remaining)
 			if err != nil {
 				return nil, err
@@ -102,7 +102,7 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 		row.FetcherTableArgs{
 			Spans:            tableDesc.AllIndexSpans(),
 			Desc:             tableDesc,
-			Index:            &tableDesc.PrimaryIndex,
+			Index:            tableDesc.PrimaryIdx(),
 			ColIdxMap:        colIdxMap,
 			IsSecondaryIndex: false,
 			Cols:             tableDesc.Columns,

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1319,7 +1319,7 @@ func TestRepartitioning(t *testing.T) {
 				}
 
 				var repartition bytes.Buffer
-				if testIndex.ID == test.new.parsed.tableDesc.PrimaryIndex.ID {
+				if testIndex.ID == test.new.parsed.tableDesc.PrimaryIdx().ID {
 					fmt.Fprintf(&repartition, `ALTER TABLE %s `, test.new.parsed.tableName)
 				} else {
 					fmt.Fprintf(&repartition, `ALTER INDEX %s@%s `, test.new.parsed.tableName, testIndex.Name)

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -178,7 +178,7 @@ func BenchmarkImport(b *testing.B) {
 					if tableDesc == nil || tableDesc.ParentID == keys.SystemDatabaseID {
 						b.Fatalf("bad table descriptor: %+v", tableDesc)
 					}
-					oldStartKey = sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+					oldStartKey = sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 					newDesc := *tableDesc
 					newDesc.ID = id
 					newDescBytes, err := protoutil.Marshal(sqlbase.WrapDescriptor(&newDesc))

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -170,7 +170,7 @@ func (kr *KeyRewriter) RewriteKey(key []byte, isFromSpan bool) ([]byte, bool, er
 		return key, true, nil
 	}
 	// We do not support interleaved secondary indexes.
-	if idx.ID != desc.PrimaryIndex.ID {
+	if idx.ID != desc.PrimaryIdx().ID {
 		return nil, false, errors.New("restoring interleaved secondary indexes not supported")
 	}
 	colIDs, _ := idx.FullColumnIDs()

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -76,7 +76,7 @@ func TestKeyRewriter(t *testing.T) {
 	}
 
 	t.Run("normal", func(t *testing.T) {
-		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
+		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIdx().ID)
 		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
@@ -94,7 +94,7 @@ func TestKeyRewriter(t *testing.T) {
 	})
 
 	t.Run("prefix end", func(t *testing.T) {
-		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)).PrefixEnd()
+		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIdx().ID)).PrefixEnd()
 		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
@@ -123,7 +123,7 @@ func TestKeyRewriter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
+		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIdx().ID)
 		newKey, ok, err := newKr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -44,7 +44,7 @@ func (s *Server) refreshSettings() {
 		{
 			types := []types.T{tbl.Columns[0].Type}
 			nameRow := make([]sqlbase.EncDatum, 1)
-			_, matches, err := sqlbase.DecodeIndexKey(tbl, &tbl.PrimaryIndex, types, nameRow, nil, kv.Key)
+			_, matches, err := sqlbase.DecodeIndexKey(tbl, tbl.PrimaryIdx(), types, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -356,7 +356,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 			}
 
-			if n.tableDesc.PrimaryIndex.ContainsColumnID(col.ID) {
+			if n.tableDesc.PrimaryIdx().ContainsColumnID(col.ID) {
 				return pgerror.Newf(pgcode.InvalidColumnReference,
 					"column %q is referenced by the primary key", col.Name)
 			}
@@ -391,7 +391,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					}
 				}
 				for _, id := range idx.ExtraColumnIDs {
-					if n.tableDesc.PrimaryIndex.ContainsColumnID(id) {
+					if n.tableDesc.PrimaryIdx().ContainsColumnID(id) {
 						// All secondary indices necessary contain the PK
 						// columns, too. (See the comments on the definition of
 						// IndexDescriptor). The presence of a PK column in the
@@ -589,23 +589,23 @@ func (n *alterTableNode) startExec(params runParams) error {
 			partitioning, err := CreatePartitioning(
 				params.ctx, params.p.ExecCfg().Settings,
 				params.EvalContext(),
-				n.tableDesc, &n.tableDesc.PrimaryIndex, t.PartitionBy)
+				n.tableDesc, n.tableDesc.PrimaryIdx(), t.PartitionBy)
 			if err != nil {
 				return err
 			}
 			descriptorChanged = !proto.Equal(
-				&n.tableDesc.PrimaryIndex.Partitioning,
+				&n.tableDesc.PrimaryIdx().Partitioning,
 				&partitioning,
 			)
 			err = deleteRemovedPartitionZoneConfigs(
 				params.ctx, params.p.txn,
-				n.tableDesc.TableDesc(), &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning,
+				n.tableDesc.TableDesc(), n.tableDesc.PrimaryIdx(), &n.tableDesc.PrimaryIdx().Partitioning,
 				&partitioning, params.extendedEvalCtx.ExecCfg,
 			)
 			if err != nil {
 				return err
 			}
-			n.tableDesc.PrimaryIndex.Partitioning = partitioning
+			n.tableDesc.PrimaryIdx().Partitioning = partitioning
 
 		case *tree.AlterTableSetAudit:
 			var err error

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -115,7 +115,7 @@ func (cb *ColumnBackfiller) Init(
 
 	tableArgs := row.FetcherTableArgs{
 		Desc:            desc,
-		Index:           &desc.PrimaryIndex,
+		Index:           desc.PrimaryIdx(),
 		ColIdxMap:       desc.ColumnIdxMap(),
 		Cols:            desc.Columns,
 		ValNeededForCol: valNeededForCol,
@@ -351,7 +351,7 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 
 	tableArgs := row.FetcherTableArgs{
 		Desc:            desc,
-		Index:           &desc.PrimaryIndex,
+		Index:           desc.PrimaryIdx(),
 		ColIdxMap:       ib.colIdxMap,
 		Cols:            cols,
 		ValNeededForCol: valNeededForCol,

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -88,7 +88,7 @@ func matchFullUnacceptableKeyQuery(
 		srcNotNullClause[i] = fmt.Sprintf("%s IS NOT NULL", srcCols[i])
 	}
 
-	for _, id := range srcTbl.PrimaryIndex.ColumnIDs {
+	for _, id := range srcTbl.PrimaryIdx().ColumnIDs {
 		alreadyPresent := false
 		for _, otherID := range fk.OriginColumnIDs {
 			if id == otherID {
@@ -151,7 +151,7 @@ func nonMatchingRowQuery(
 		return "", nil, err
 	}
 	// Get primary key columns not included in the FK
-	for _, pkColID := range srcTbl.PrimaryIndex.ColumnIDs {
+	for _, pkColID := range srcTbl.PrimaryIdx().ColumnIDs {
 		found := false
 		for _, id := range fk.OriginColumnIDs {
 			if pkColID == id {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1250,7 +1250,7 @@ CREATE TABLE crdb_internal.create_statements (
 					if err != nil {
 						return err
 					}
-					allIdx := append(table.Indexes, table.PrimaryIndex)
+					allIdx := append(table.Indexes, *table.PrimaryIdx())
 					if err := showAlterStatementWithInterleave(ctx, tn, contextName, lCtx, allIdx, table, alterStmts, validateStmts); err != nil {
 						return err
 					}
@@ -1276,7 +1276,7 @@ CREATE TABLE crdb_internal.create_statements (
 							break
 						}
 					}
-					hasPartitions = hasPartitions || table.PrimaryIndex.Partitioning.NumColumns != 0
+					hasPartitions = hasPartitions || table.PrimaryIdx().Partitioning.NumColumns != 0
 					if hasPartitions {
 						stmt += "\n-- Warning: Partitioned table with no zone configurations."
 					}
@@ -1480,10 +1480,10 @@ CREATE TABLE crdb_internal.table_indexes (
 				if err := addRow(
 					tableID,
 					tableName,
-					tree.NewDInt(tree.DInt(table.PrimaryIndex.ID)),
-					tree.NewDString(table.PrimaryIndex.Name),
+					tree.NewDInt(tree.DInt(table.PrimaryIdx().ID)),
+					tree.NewDString(table.PrimaryIdx().Name),
 					primary,
-					tree.MakeDBool(tree.DBool(table.PrimaryIndex.Unique)),
+					tree.MakeDBool(tree.DBool(table.PrimaryIdx().Unique)),
 				); err != nil {
 					return err
 				}
@@ -1605,7 +1605,7 @@ CREATE TABLE crdb_internal.index_columns (
 					return nil
 				}
 
-				if err := reportIndex(&table.PrimaryIndex); err != nil {
+				if err := reportIndex(table.PrimaryIdx()); err != nil {
 					return err
 				}
 				for i := range table.Indexes {
@@ -1684,7 +1684,7 @@ CREATE TABLE crdb_internal.backward_dependencies (
 				}
 
 				// Record the backward references of the primary index.
-				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+				if err := reportIdxDeps(table.PrimaryIdx()); err != nil {
 					return err
 				}
 
@@ -1822,7 +1822,7 @@ CREATE TABLE crdb_internal.forward_dependencies (
 				}
 
 				// Record the backward references of the primary index.
-				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+				if err := reportIdxDeps(table.PrimaryIdx()); err != nil {
 					return err
 				}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -92,7 +92,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	// Guard against creating a non-partitioned index on a partitioned table,
 	// which is undesirable in most cases.
 	if params.SessionData().SafeUpdates && n.n.PartitionBy == nil &&
-		n.tableDesc.PrimaryIndex.Partitioning.NumColumns > 0 {
+		n.tableDesc.PrimaryIdx().Partitioning.NumColumns > 0 {
 		return pgerror.DangerousStatementf("non-partitioned index on partitioned table")
 	}
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -277,7 +277,7 @@ func createStatsDefaultColumns(
 	var requestedCols util.FastIntSet
 
 	// Add a column for the primary key.
-	pkCol := desc.PrimaryIndex.ColumnIDs[0]
+	pkCol := desc.PrimaryIdx().ColumnIDs[0]
 	colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
 		ColumnIDs:    []sqlbase.ColumnID{pkCol},
 		HasHistogram: true,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -454,8 +454,8 @@ func ResolveFK(
 	targetColNames := d.ToCols
 	// If no columns are specified, attempt to default to PK.
 	if len(targetColNames) == 0 {
-		targetColNames = make(tree.NameList, len(target.PrimaryIndex.ColumnNames))
-		for i, n := range target.PrimaryIndex.ColumnNames {
+		targetColNames = make(tree.NameList, len(target.PrimaryIdx().ColumnNames))
+		for i, n := range target.PrimaryIdx().ColumnNames {
 			targetColNames[i] = tree.Name(n)
 		}
 	}
@@ -709,11 +709,11 @@ func addInterleave(
 	if err != nil {
 		return err
 	}
-	parentIndex := parentTable.PrimaryIndex
+	parentIndex := parentTable.PrimaryIdx()
 
 	// typeOfIndex is used to give more informative error messages.
 	var typeOfIndex string
-	if index.ID == desc.PrimaryIndex.ID {
+	if index.ID == desc.PrimaryIdx().ID {
 		typeOfIndex = "primary key"
 	} else {
 		typeOfIndex = "index"
@@ -1193,18 +1193,18 @@ func MakeTableDesc(
 	}
 
 	if n.Interleave != nil {
-		if err := addInterleave(ctx, txn, vt, &desc, &desc.PrimaryIndex, n.Interleave); err != nil {
+		if err := addInterleave(ctx, txn, vt, &desc, desc.PrimaryIdx(), n.Interleave); err != nil {
 			return desc, err
 		}
 	}
 
 	if n.PartitionBy != nil {
 		partitioning, err := CreatePartitioning(
-			ctx, st, evalCtx, &desc, &desc.PrimaryIndex, n.PartitionBy)
+			ctx, st, evalCtx, &desc, desc.PrimaryIdx(), n.PartitionBy)
 		if err != nil {
 			return desc, err
 		}
-		desc.PrimaryIndex.Partitioning = partitioning
+		desc.PrimaryIdx().Partitioning = partitioning
 	}
 
 	// With all structural elements in place and IDs allocated, we can resolve the

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -257,7 +257,7 @@ func canDeleteFastInterleaved(table *ImmutableTableDescriptor, fkTables row.FkTa
 		for _, idx := range tableDesc.AllNonDropIndexes() {
 			// Don't allow any secondary indexes
 			// TODO(emmanuel): identify the cases where secondary indexes can still work with the fast path and allow them
-			if idx.ID != tableDesc.PrimaryIndex.ID {
+			if idx.ID != tableDesc.PrimaryIdx().ID {
 				return false
 			}
 

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -158,7 +158,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		false, false, false, &params.p.alloc,
 		row.FetcherTableArgs{
 			Desc:  d.desc,
-			Index: &d.desc.PrimaryIndex,
+			Index: d.desc.PrimaryIdx(),
 		}); err != nil {
 		return err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -850,7 +850,7 @@ func (dsp *DistSQLPlanner) nodeVersionIsCompatible(
 }
 
 func getIndexIdx(n *scanNode) (uint32, error) {
-	if n.index.ID == n.desc.PrimaryIndex.ID {
+	if n.index.ID == n.desc.PrimaryIdx().ID {
 		return 0, nil
 	}
 	for i := range n.desc.Indexes {

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -624,7 +624,7 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 	// required" error.
 	zoneConfig := zonepb.ZoneConfig{
 		Subzones: []zonepb.Subzone{
-			{IndexID: uint32(tableDesc.PrimaryIndex.ID), Config: s.(*server.TestServer).Cfg.DefaultZoneConfig},
+			{IndexID: uint32(tableDesc.PrimaryIdx().ID), Config: s.(*server.TestServer).Cfg.DefaultZoneConfig},
 			{IndexID: uint32(indexDesc.ID), Config: s.(*server.TestServer).Cfg.DefaultZoneConfig},
 		},
 	}

--- a/pkg/sql/execinfra/joinreader.go
+++ b/pkg/sql/execinfra/joinreader.go
@@ -356,7 +356,7 @@ func (jr *JoinReader) maybeSplitSpanIntoSeparateFamilies(span roachpb.Span) roac
 	// - our table has more than the default family
 	// - we have all the columns of the index
 	if len(jr.neededFamilies) > 0 &&
-		jr.index.ID == jr.desc.PrimaryIndex.ID &&
+		jr.index.ID == jr.desc.PrimaryIdx().ID &&
 		len(jr.lookupCols) == len(jr.index.ColumnIDs) &&
 		len(jr.neededFamilies) < len(jr.desc.Families) {
 		return sqlbase.SplitSpanIntoSeparateFamilies(span, jr.neededFamilies)

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1138,7 +1138,7 @@ CREATE TABLE information_schema.statistics (
 					}
 					if hasImplicitCols {
 						implicitCols = make(map[string]struct{})
-						for _, col := range table.PrimaryIndex.ColumnNames {
+						for _, col := range table.PrimaryIdx().ColumnNames {
 							implicitCols[col] = struct{}{}
 						}
 					}
@@ -1612,7 +1612,7 @@ func forEachIndexInTable(
 	table *sqlbase.TableDescriptor, fn func(*sqlbase.IndexDescriptor) error,
 ) error {
 	if table.IsPhysicalTable() {
-		if err := fn(&table.PrimaryIndex); err != nil {
+		if err := fn(table.PrimaryIdx()); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -46,7 +46,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	scan.reqOrdering = ordering
 
 	scan.spans, err = spansFromConstraint(
-		desc, &desc.PrimaryIndex, nil /* constraint */, exec.ColumnOrdinalSet{}, false /* forDelete */)
+		desc, desc.PrimaryIdx(), nil /* constraint */, exec.ColumnOrdinalSet{}, false /* forDelete */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -540,7 +540,7 @@ func newOptTable(
 	for i := range ot.indexes {
 		var idxDesc *sqlbase.IndexDescriptor
 		if i == 0 {
-			idxDesc = &desc.PrimaryIndex
+			idxDesc = desc.PrimaryIdx()
 		} else {
 			idxDesc = &ot.desc.DeletableIndexes()[i-1]
 		}
@@ -834,7 +834,7 @@ func (oi *optIndex) init(
 	oi.desc = desc
 	oi.zone = zone
 	oi.indexOrdinal = indexOrdinal
-	if desc == &tab.desc.PrimaryIndex {
+	if desc == tab.desc.PrimaryIdx() {
 		// Although the primary index contains all columns in the table, the index
 		// descriptor does not contain columns that are not explicitly part of the
 		// primary key. Retrieve those columns from the table descriptor.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -98,7 +98,7 @@ func (ef *execFactory) ConstructScan(
 		return newZeroNode(scan.resultColumns), nil
 	}
 	scan.index = indexDesc
-	scan.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
+	scan.isSecondaryIndex = (indexDesc != tabDesc.PrimaryIdx())
 	scan.hardLimit = hardLimit
 	scan.reverse = reverse
 	scan.maxResults = maxResults
@@ -603,7 +603,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	}
 
 	tableScan.index = indexDesc
-	tableScan.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
+	tableScan.isSecondaryIndex = (indexDesc != tabDesc.PrimaryIdx())
 
 	n := &lookupJoinNode{
 		input:        input.(planNode),
@@ -653,7 +653,7 @@ func (ef *execFactory) constructScanForZigzag(
 	}
 
 	scan.index = indexDesc
-	scan.isSecondaryIndex = (indexDesc.ID != tableDesc.PrimaryIndex.ID)
+	scan.isSecondaryIndex = (indexDesc.ID != tableDesc.PrimaryIdx().ID)
 
 	return scan, nil
 }
@@ -1776,7 +1776,7 @@ func (ef *execFactory) ConstructDeleteRange(
 	allowAutoCommit bool,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
-	indexDesc := &tabDesc.PrimaryIndex
+	indexDesc := tabDesc.PrimaryIdx()
 
 	// Setting the "forDelete" flag includes all column families in case where a
 	// single record is deleted.

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -161,9 +161,9 @@ func appendSpansFromConstraintSpan(
 	// deletions to ensure that the entire row is deleted.
 	if !forDelete &&
 		needed.Len() > 0 &&
-		index.ID == tableDesc.PrimaryIndex.ID &&
+		index.ID == tableDesc.PrimaryIdx().ID &&
 		len(tableDesc.Families) > 1 &&
-		cs.StartKey().Length() == len(tableDesc.PrimaryIndex.ColumnIDs) &&
+		cs.StartKey().Length() == len(tableDesc.PrimaryIdx().ColumnIDs) &&
 		s.Key.Equal(s.EndKey) {
 		neededFamilyIDs := sqlbase.NeededColumnFamilyIDs(tableDesc.ColumnIdxMap(), tableDesc.Families, needed)
 		if len(neededFamilyIDs) < len(tableDesc.Families) {

--- a/pkg/sql/partition_test.go
+++ b/pkg/sql/partition_test.go
@@ -44,7 +44,7 @@ func TestRemovePartitioningOSS(t *testing.T) {
 	tableKey := sqlbase.MakeDescMetadataKey(tableDesc.ID)
 
 	// Hack in partitions. Doing this properly requires a CCL binary.
-	tableDesc.PrimaryIndex.Partitioning = sqlbase.PartitioningDescriptor{
+	tableDesc.PrimaryIdx().Partitioning = sqlbase.PartitioningDescriptor{
 		NumColumns: 1,
 		Range: []sqlbase.PartitioningDescriptor_Range{{
 			Name:          "p1",
@@ -85,7 +85,7 @@ func TestRemovePartitioningOSS(t *testing.T) {
 	zoneConfig := zonepb.ZoneConfig{
 		Subzones: []zonepb.Subzone{
 			{
-				IndexID:       uint32(tableDesc.PrimaryIndex.ID),
+				IndexID:       uint32(tableDesc.PrimaryIdx().ID),
 				PartitionName: "p1",
 				Config:        s.(*server.TestServer).Cfg.DefaultZoneConfig,
 			},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1394,7 +1394,7 @@ CREATE TABLE pg_catalog.pg_index (
 						tableOid,                       // indrelid
 						tree.NewDInt(tree.DInt(len(index.ColumnNames))),                                          // indnatts
 						tree.MakeDBool(tree.DBool(index.Unique)),                                                 // indisunique
-						tree.MakeDBool(tree.DBool(table.IsPhysicalTable() && index.ID == table.PrimaryIndex.ID)), // indisprimary
+						tree.MakeDBool(tree.DBool(table.IsPhysicalTable() && index.ID == table.PrimaryIdx().ID)), // indisprimary
 						tree.DBoolFalse,                          // indisexclusion
 						tree.MakeDBool(tree.DBool(index.Unique)), // indimmediate
 						tree.DBoolFalse,                          // indisclustered

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -54,7 +54,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	it := resolver.NewSpanResolverIterator(txn)
 
 	tableDesc := sqlbase.GetTableDescriptor(db, "test", "t")
-	primIdxValDirs := sqlbase.IndexKeyValDirs(&tableDesc.PrimaryIndex)
+	primIdxValDirs := sqlbase.IndexKeyValDirs(tableDesc.PrimaryIdx())
 
 	span := tableDesc.PrimaryIndexSpan()
 

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -304,12 +304,12 @@ func spanForPKValues(
 ) (roachpb.Span, error) {
 	return spanForIndexValues(
 		table,
-		&table.PrimaryIndex,
-		len(table.PrimaryIndex.ColumnIDs),
+		table.PrimaryIdx(),
+		len(table.PrimaryIdx().ColumnIDs),
 		sqlbase.ForeignKeyReference_SIMPLE, /* primary key lookup can always use MATCH SIMPLE */
 		fetchColIDtoRowIndex,
 		values,
-		sqlbase.MakeIndexKeyPrefix(table.TableDesc(), table.PrimaryIndex.ID),
+		sqlbase.MakeIndexKeyPrefix(table.TableDesc(), table.PrimaryIdx().ID),
 	)
 }
 
@@ -357,7 +357,7 @@ func (c *cascader) addIndexPKRowFetcher(
 
 	// Create a new row fetcher. Only the primary key columns are required.
 	var colDesc []sqlbase.ColumnDescriptor
-	for _, id := range table.PrimaryIndex.ColumnIDs {
+	for _, id := range table.PrimaryIdx().ColumnIDs {
 		cDesc, err := table.FindColumnByID(id)
 		if err != nil {
 			return Fetcher{}, err
@@ -366,7 +366,7 @@ func (c *cascader) addIndexPKRowFetcher(
 	}
 	var valNeededForCol util.FastIntSet
 	valNeededForCol.AddRange(0, len(colDesc)-1)
-	isSecondary := table.PrimaryIndex.ID != index.ID
+	isSecondary := table.PrimaryIdx().ID != index.ID
 	var rowFetcher Fetcher
 	if err := rowFetcher.Init(
 		false, /* reverse */
@@ -424,7 +424,7 @@ func (c *cascader) addRowDeleter(
 	valNeededForCol.AddRange(0, len(rowDeleter.FetchCols)-1)
 	tableArgs := FetcherTableArgs{
 		Desc:             table,
-		Index:            &table.PrimaryIndex,
+		Index:            table.PrimaryIdx(),
 		ColIdxMap:        rowDeleter.FetchColIDtoRowIndex,
 		IsSecondaryIndex: false,
 		Cols:             rowDeleter.FetchCols,
@@ -485,7 +485,7 @@ func (c *cascader) addRowUpdater(
 	valNeededForCol.AddRange(0, len(rowUpdater.FetchCols)-1)
 	tableArgs := FetcherTableArgs{
 		Desc:             table,
-		Index:            &table.PrimaryIndex,
+		Index:            table.PrimaryIdx(),
 		ColIdxMap:        rowUpdater.FetchColIDtoRowIndex,
 		IsSecondaryIndex: false,
 		Cols:             rowUpdater.FetchCols,

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -88,7 +88,7 @@ func makeRowDeleterWithoutCascader(
 		}
 		return nil
 	}
-	for _, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+	for _, colID := range tableDesc.PrimaryIdx().ColumnIDs {
 		if err := maybeAddCol(colID); err != nil {
 			return Deleter{}, err
 		}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -104,7 +104,7 @@ func NewUniquenessConstraintViolationError(
 		Desc:             tableDesc,
 		Index:            index,
 		ColIdxMap:        colIdxMap,
-		IsSecondaryIndex: indexID != tableDesc.PrimaryIndex.ID,
+		IsSecondaryIndex: indexID != tableDesc.PrimaryIdx().ID,
 		Cols:             cols,
 		ValNeededForCol:  valNeededForCol,
 	}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1207,7 +1207,7 @@ func (rf *Fetcher) NextRowWithErrors(ctx context.Context) (sqlbase.EncDatumRow, 
 		rf.rowReadyTable.decodedRow[i] = row[i].Datum
 	}
 
-	if index.ID == table.PrimaryIndex.ID {
+	if index.ID == table.PrimaryIdx().ID {
 		err = rf.checkPrimaryIndexDatumEncodings(ctx)
 	} else {
 		err = rf.checkSecondaryIndexDatumEncodings(ctx)

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -97,7 +97,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		args = append(args, row.FetcherTableArgs{
 			Spans:            desc.AllIndexSpans(),
 			Desc:             desc,
-			Index:            &desc.PrimaryIndex,
+			Index:            desc.PrimaryIdx(),
 			ColIdxMap:        colIdxMap,
 			IsSecondaryIndex: false,
 			Cols:             desc.Columns,

--- a/pkg/sql/row/fk_existence_base.go
+++ b/pkg/sql/row/fk_existence_base.go
@@ -144,7 +144,7 @@ func makeFkExistenceCheckBaseHelper(
 		Desc:             searchTable,
 		Index:            searchIdx,
 		ColIdxMap:        searchTable.ColumnIdxMap(),
-		IsSecondaryIndex: searchIdx.ID != searchTable.PrimaryIndex.ID,
+		IsSecondaryIndex: searchIdx.ID != searchTable.PrimaryIdx().ID,
 		Cols:             searchTable.Columns,
 	}
 	rf := &Fetcher{}

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -43,7 +43,7 @@ func newRowHelper(
 
 	// Pre-compute the encoding directions of the index key values for
 	// pretty-printing in traces.
-	rh.primIndexValDirs = sqlbase.IndexKeyValDirs(&rh.TableDesc.PrimaryIndex)
+	rh.primIndexValDirs = sqlbase.IndexKeyValDirs(rh.TableDesc.PrimaryIdx())
 
 	rh.secIndexValDirs = make([][]encoding.Direction, len(rh.Indexes))
 	for i := range rh.Indexes {
@@ -61,10 +61,10 @@ func (rh *rowHelper) encodeIndexes(
 ) (primaryIndexKey []byte, secondaryIndexEntries []sqlbase.IndexEntry, err error) {
 	if rh.primaryIndexKeyPrefix == nil {
 		rh.primaryIndexKeyPrefix = sqlbase.MakeIndexKeyPrefix(rh.TableDesc.TableDesc(),
-			rh.TableDesc.PrimaryIndex.ID)
+			rh.TableDesc.PrimaryIdx().ID)
 	}
 	primaryIndexKey, _, err = sqlbase.EncodeIndexKey(
-		rh.TableDesc.TableDesc(), &rh.TableDesc.PrimaryIndex, colIDtoRowIndex, values, rh.primaryIndexKeyPrefix)
+		rh.TableDesc.TableDesc(), rh.TableDesc.PrimaryIdx(), colIDtoRowIndex, values, rh.primaryIndexKeyPrefix)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +102,7 @@ func (rh *rowHelper) skipColumnInPK(
 ) (bool, error) {
 	if rh.primaryIndexCols == nil {
 		rh.primaryIndexCols = make(map[sqlbase.ColumnID]struct{})
-		for _, colID := range rh.TableDesc.PrimaryIndex.ColumnIDs {
+		for _, colID := range rh.TableDesc.PrimaryIdx().ColumnIDs {
 			rh.primaryIndexCols[colID] = struct{}{}
 		}
 	}

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -54,9 +54,9 @@ func MakeInserter(
 		marshaled:             make([]roachpb.Value, len(insertCols)),
 	}
 
-	for i, col := range tableDesc.PrimaryIndex.ColumnIDs {
+	for i, col := range tableDesc.PrimaryIdx().ColumnIDs {
 		if _, ok := ri.InsertColIDtoRowIndex[col]; !ok {
-			return Inserter{}, fmt.Errorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
+			return Inserter{}, fmt.Errorf("missing %q primary key column", tableDesc.PrimaryIdx().ColumnNames[i])
 		}
 	}
 

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -118,8 +118,8 @@ func makeUpdaterWithoutCascader(
 ) (Updater, error) {
 	updateColIDtoRowIndex := ColIDtoRowIndexFromCols(updateCols)
 
-	primaryIndexCols := make(map[sqlbase.ColumnID]struct{}, len(tableDesc.PrimaryIndex.ColumnIDs))
-	for _, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+	primaryIndexCols := make(map[sqlbase.ColumnID]struct{}, len(tableDesc.PrimaryIdx().ColumnIDs))
+	for _, colID := range tableDesc.PrimaryIdx().ColumnIDs {
 		primaryIndexCols[colID] = struct{}{}
 	}
 
@@ -223,7 +223,7 @@ func makeUpdaterWithoutCascader(
 
 		// Fetch all columns in the primary key so that we can construct the
 		// keys when writing out the new kvs to the primary index.
-		for _, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+		for _, colID := range tableDesc.PrimaryIdx().ColumnIDs {
 			if err := maybeAddCol(colID); err != nil {
 				return Updater{}, err
 			}
@@ -364,7 +364,7 @@ func (ru *Updater) UpdateRow(
 		}
 
 		if ru.Fks.checker != nil {
-			ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIndex.ID, ru.Helper.TableDesc.PrimaryIndex.Type)
+			ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIdx().ID, ru.Helper.TableDesc.PrimaryIdx().Type)
 			for i := range ru.Helper.Indexes {
 				if !bytes.Equal(newSecondaryIndexEntries[i].Key, oldSecondaryIndexEntries[i].Key) {
 					ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID, ru.Helper.Indexes[i].Type)

--- a/pkg/sql/rowexec/index_skip_table_reader_test.go
+++ b/pkg/sql/rowexec/index_skip_table_reader_test.go
@@ -168,7 +168,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 
 	makeIndexSpan := func(td *sqlbase.TableDescriptor, start, end int) execinfrapb.TableReaderSpan {
 		var span roachpb.Span
-		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(td, td.PrimaryIndex.ID))
+		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(td, td.PrimaryIdx().ID))
 		span.Key = append(prefix, encoding.EncodeVarintAscending(nil, int64(start))...)
 		span.EndKey = append(span.EndKey, prefix...)
 		span.EndKey = append(span.EndKey, encoding.EncodeVarintAscending(nil, int64(end))...)

--- a/pkg/sql/rowexec/interleaved_reader_joiner_test.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner_test.go
@@ -35,7 +35,7 @@ import (
 // min and max are inclusive bounds on the root table's ID.
 // If min and/or max is -1, then no bound is used for that endpoint.
 func makeSpanWithRootBound(desc *sqlbase.TableDescriptor, min int, max int) roachpb.Span {
-	keyPrefix := sqlbase.MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID)
+	keyPrefix := sqlbase.MakeIndexKeyPrefix(desc, desc.PrimaryIdx().ID)
 
 	startKey := roachpb.Key(append([]byte(nil), keyPrefix...))
 	if min != -1 {

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -146,7 +146,7 @@ func (tr *scrubTableReader) generateScrubErrorRow(
 	details := make(map[string]interface{})
 	var index *sqlbase.IndexDescriptor
 	if tr.indexIdx == 0 {
-		index = &tr.tableDesc.PrimaryIndex
+		index = tr.tableDesc.PrimaryIdx()
 	} else {
 		index = &tr.tableDesc.Indexes[tr.indexIdx-1]
 	}
@@ -197,7 +197,7 @@ func (tr *scrubTableReader) prettyPrimaryKeyValues(
 	}
 	var primaryKeyValues bytes.Buffer
 	primaryKeyValues.WriteByte('(')
-	for i, id := range table.PrimaryIndex.ColumnIDs {
+	for i, id := range table.PrimaryIdx().ColumnIDs {
 		if i > 0 {
 			primaryKeyValues.WriteByte(',')
 		}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -398,7 +398,7 @@ func (z *zigzagJoiner) setupInfo(
 	info.eqColumns = spec.EqColumns[side].Columns
 	indexID := spec.IndexIds[side]
 	if indexID == 0 {
-		info.index = &info.table.PrimaryIndex
+		info.index = info.table.PrimaryIdx()
 	} else {
 		info.index = &info.table.Indexes[indexID-1]
 	}
@@ -646,8 +646,8 @@ func (zi *zigzagJoinerInfo) eqOrdering() (sqlbase.ColumnOrdering, error) {
 			if err != nil {
 				return nil, err
 			}
-		} else if idx := findColumnID(zi.table.PrimaryIndex.ColumnIDs, colID); idx != -1 {
-			direction, err = zi.table.PrimaryIndex.ColumnDirections[idx].ToEncodingDirection()
+		} else if idx := findColumnID(zi.table.PrimaryIdx().ColumnIDs, colID); idx != -1 {
+			direction, err = zi.table.PrimaryIdx().ColumnDirections[idx].ToEncodingDirection()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -276,8 +276,8 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 	if indexFlags.Index != "" {
 		// Search index by name.
 		indexName := string(indexFlags.Index)
-		if indexName == n.desc.PrimaryIndex.Name {
-			n.specifiedIndex = &n.desc.PrimaryIndex
+		if indexName == n.desc.PrimaryIdx().Name {
+			n.specifiedIndex = n.desc.PrimaryIdx()
 		} else {
 			for i := range n.desc.Indexes {
 				if indexName == n.desc.Indexes[i].Name {
@@ -291,8 +291,8 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 		}
 	} else if indexFlags.IndexID != 0 {
 		// Search index by ID.
-		if n.desc.PrimaryIndex.ID == sqlbase.IndexID(indexFlags.IndexID) {
-			n.specifiedIndex = &n.desc.PrimaryIndex
+		if n.desc.PrimaryIdx().ID == sqlbase.IndexID(indexFlags.IndexID) {
+			n.specifiedIndex = n.desc.PrimaryIdx()
 		} else {
 			for i := range n.desc.Indexes {
 				if n.desc.Indexes[i].ID == sqlbase.IndexID(indexFlags.IndexID) {
@@ -370,7 +370,7 @@ func (n *scanNode) initCols() error {
 // Initializes the column structures.
 func (n *scanNode) initDescDefaults(planDeps planDependencies, colCfg scanColumnsConfig) error {
 	n.colCfg = colCfg
-	n.index = &n.desc.PrimaryIndex
+	n.index = n.desc.PrimaryIdx()
 
 	if err := n.initCols(); err != nil {
 		return err

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -264,7 +264,7 @@ func (n *scrubNode) startScrubTable(
 func getPrimaryColIdxs(
 	tableDesc *sqlbase.ImmutableTableDescriptor, columns []*sqlbase.ColumnDescriptor,
 ) (primaryColIdxs []int, err error) {
-	for i, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+	for i, colID := range tableDesc.PrimaryIdx().ColumnIDs {
 		rowIdx := -1
 		for idx, col := range columns {
 			if col.ID == colID {
@@ -276,7 +276,7 @@ func getPrimaryColIdxs(
 			return nil, errors.Errorf(
 				"could not find primary index column in projection: columnID=%d columnName=%s",
 				colID,
-				tableDesc.PrimaryIndex.ColumnNames[i])
+				tableDesc.PrimaryIdx().ColumnNames[i])
 		}
 		primaryColIdxs = append(primaryColIdxs, rowIdx)
 	}
@@ -323,7 +323,7 @@ func pairwiseOp(left []string, right []string, op string) []string {
 func createPhysicalCheckOperations(
 	tableDesc *sqlbase.ImmutableTableDescriptor, tableName *tree.TableName,
 ) (checks []checkOperation) {
-	checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, &tableDesc.PrimaryIndex))
+	checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, tableDesc.PrimaryIdx()))
 	for i := range tableDesc.Indexes {
 		checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, &tableDesc.Indexes[i]))
 	}

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -110,7 +110,7 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 	// Get primary key columns not included in the FK.
 	var colIDs []sqlbase.ColumnID
 	colIDs = append(colIDs, o.constraint.FK.OriginColumnIDs...)
-	for _, pkColID := range o.tableDesc.PrimaryIndex.ColumnIDs {
+	for _, pkColID := range o.tableDesc.PrimaryIdx().ColumnIDs {
 		found := false
 		for _, id := range o.constraint.FK.OriginColumnIDs {
 			if pkColID == id {
@@ -144,8 +144,8 @@ func (o *sqlForeignKeyCheckOperation) Next(params runParams) (tree.Datums, error
 
 	// Collect the primary index values for generating the primary key
 	// pretty string.
-	primaryKeyDatums := make(tree.Datums, 0, len(o.tableDesc.PrimaryIndex.ColumnIDs))
-	for _, id := range o.tableDesc.PrimaryIndex.ColumnIDs {
+	primaryKeyDatums := make(tree.Datums, 0, len(o.tableDesc.PrimaryIdx().ColumnIDs))
+	for _, id := range o.tableDesc.PrimaryIdx().ColumnIDs {
 		idx := o.colIDToRowIdx[id]
 		primaryKeyDatums = append(primaryKeyDatums, row[idx])
 	}
@@ -160,7 +160,7 @@ func (o *sqlForeignKeyCheckOperation) Next(params runParams) (tree.Datums, error
 		}
 		rowDetails[col.Name] = row[idx].String()
 	}
-	for _, id := range o.tableDesc.PrimaryIndex.ColumnIDs {
+	for _, id := range o.tableDesc.PrimaryIdx().ColumnIDs {
 		found := false
 		for _, fkID := range o.constraint.FK.OriginColumnIDs {
 			if id == fkID {

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -81,7 +81,7 @@ func (o *indexCheckOperation) Start(params runParams) error {
 
 	var pkColumns, otherColumns []*sqlbase.ColumnDescriptor
 
-	for _, colID := range o.tableDesc.PrimaryIndex.ColumnIDs {
+	for _, colID := range o.tableDesc.PrimaryIdx().ColumnIDs {
 		col := &o.tableDesc.Columns[colToIdx[colID]]
 		pkColumns = append(pkColumns, col)
 		colToIdx[colID] = -1

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -73,7 +73,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 
 	// Collect all of the columns being scanned.
-	if o.indexDesc.ID == o.tableDesc.PrimaryIndex.ID {
+	if o.indexDesc.ID == o.tableDesc.PrimaryIdx().ID {
 		for i := range o.tableDesc.Columns {
 			columnIDs = append(columnIDs, tree.ColumnID(o.tableDesc.Columns[i].ID))
 		}

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -342,9 +342,9 @@ INSERT INTO t.test VALUES (10, 2);
 
 	// Create the primary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(2)}
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, &tableDesc.PrimaryIdx(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -578,9 +578,9 @@ INSERT INTO t.test VALUES (217, 314);
 	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, &tableDesc.PrimaryIdx(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -659,9 +659,9 @@ INSERT INTO t.test VALUES (217, 314, 1337);
 	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, &tableDesc.PrimaryIdx(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -762,9 +762,9 @@ CREATE TABLE t.test (
 	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.PrimaryIdx(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -865,9 +865,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v1 INT, v2 INT);
 	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.PrimaryIdx(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3007,7 +3007,7 @@ may increase either contention or retry errors, or both.`,
 					colMap[tableDesc.Columns[i].ID] = i
 				}
 
-				if indexDesc.ID == tableDesc.PrimaryIndex.ID {
+				if indexDesc.ID == tableDesc.PrimaryIdx().ID {
 					keyPrefix := tableDesc.IndexSpan(indexDesc.ID).Key
 					res, _, err := sqlbase.EncodeIndexKey(tableDesc, indexDesc, colMap, datums, keyPrefix)
 					if err != nil {

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -68,7 +68,7 @@ func ShowCreateTable(
 		}
 		f.WriteString("\n\t")
 		f.WriteString(col.SQLString())
-		if desc.IsPhysicalTable() && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
+		if desc.IsPhysicalTable() && desc.PrimaryIdx().ColumnIDs[0] == col.ID {
 			// Only set primaryKeyIsOnVisibleColumn to true if the primary key
 			// is on a visible column (not rowid).
 			primaryKeyIsOnVisibleColumn = true
@@ -76,7 +76,7 @@ func ShowCreateTable(
 	}
 	if primaryKeyIsOnVisibleColumn {
 		f.WriteString(",\n\tCONSTRAINT ")
-		formatQuoteNames(&f.Buffer, desc.PrimaryIndex.Name)
+		formatQuoteNames(&f.Buffer, desc.PrimaryIdx().Name)
 		f.WriteString(" ")
 		f.WriteString(desc.PrimaryKeyString())
 	}
@@ -99,7 +99,7 @@ func ShowCreateTable(
 			f.WriteString(fkCtx.String())
 		}
 	}
-	allIdx := append(desc.Indexes, desc.PrimaryIndex)
+	allIdx := append(desc.Indexes, *desc.PrimaryIdx())
 	for i := range allIdx {
 		idx := &allIdx[i]
 		// Only add indexes to the create_statement column, and not to the
@@ -115,7 +115,7 @@ func ShowCreateTable(
 			// clauses as well.
 			includeInterleaveClause = true
 		}
-		if idx.ID != desc.PrimaryIndex.ID && includeInterleaveClause {
+		if idx.ID != desc.PrimaryIdx().ID && includeInterleaveClause {
 			// Showing the primary index is handled above.
 			f.WriteString(",\n\t")
 			f.WriteString(idx.SQLString(&sqlbase.AnonymousTable))
@@ -141,11 +141,11 @@ func ShowCreateTable(
 	showFamilyClause(desc, f)
 	showConstraintClause(desc, f)
 
-	if err := showCreateInterleave(&desc.PrimaryIndex, &f.Buffer, dbPrefix, lCtx); err != nil {
+	if err := showCreateInterleave(desc.PrimaryIdx(), &f.Buffer, dbPrefix, lCtx); err != nil {
 		return "", err
 	}
 	if err := ShowCreatePartitioning(
-		a, desc, &desc.PrimaryIndex, &desc.PrimaryIndex.Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
+		a, desc, desc.PrimaryIdx(), &desc.PrimaryIdx().Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
 	); err != nil {
 		return "", err
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -100,7 +100,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 		}
 	}
 
-	if index.ID == n.tableDesc.PrimaryIndex.ID {
+	if index.ID == n.tableDesc.PrimaryIdx().ID {
 		for i := range n.tableDesc.Columns {
 			addColumn(&n.tableDesc.Columns[i])
 		}

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -434,7 +434,7 @@ func DecodeIndexKeyPrefix(
 	// TODO(dan): This whole operation is n^2 because of the interleaves
 	// bookkeeping. We could improve it to n with a prefix tree of components.
 
-	interleaves := append([]IndexDescriptor{desc.PrimaryIndex}, desc.Indexes...)
+	interleaves := append([]IndexDescriptor{*desc.PrimaryIdx()}, desc.Indexes...)
 
 	for component := 0; ; component++ {
 		var tableID ID
@@ -611,7 +611,7 @@ func ExtractIndexKey(
 	if err != nil {
 		return nil, err
 	}
-	if indexID == tableDesc.PrimaryIndex.ID {
+	if indexID == tableDesc.PrimaryIdx().ID {
 		return entry.Key, nil
 	}
 
@@ -677,7 +677,7 @@ func ExtractIndexKey(
 	for i, columnID := range index.ExtraColumnIDs {
 		colMap[columnID] = i + len(index.ColumnIDs)
 	}
-	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIdx().ID)
 
 	decodedValues := make([]tree.Datum, len(values)+len(extraValues))
 	for i, value := range values {
@@ -695,7 +695,7 @@ func ExtractIndexKey(
 		decodedValues[len(values)+i] = value.Datum
 	}
 	indexKey, _, err := EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colMap, decodedValues, indexKeyPrefix)
+		tableDesc, tableDesc.PrimaryIdx(), colMap, decodedValues, indexKeyPrefix)
 	return indexKey, err
 }
 
@@ -1168,7 +1168,7 @@ func AdjustEndKeyForInterleave(
 	// adjust the sibling key such that we add or remove child (the current
 	// index's) rows from our span.
 
-	if index.ID != table.PrimaryIndex.ID || len(keyTokens) < nIndexTokens {
+	if index.ID != table.PrimaryIdx().ID || len(keyTokens) < nIndexTokens {
 		// Case 1: secondary index, parent key or partial child key:
 		// Secondary indexes cannot have interleaved rows.
 		// We cannot adjust or tighten parent keys with respect to a

--- a/pkg/sql/sqlbase/keys.go
+++ b/pkg/sql/sqlbase/keys.go
@@ -23,7 +23,7 @@ import (
 // specified parentID.
 func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(NamespaceTable.ID))
-	k = encoding.EncodeUvarintAscending(k, uint64(NamespaceTable.PrimaryIndex.ID))
+	k = encoding.EncodeUvarintAscending(k, uint64(NamespaceTable.PrimaryIdx().ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(parentID))
 	if name != "" {
 		k = encoding.EncodeBytesAscending(k, []byte(name))

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -316,7 +316,7 @@ func (desc *TableDescriptor) collectConstraintInfo(
 	// Indexes provide PK, Unique and FK constraints.
 	indexes := desc.AllNonDropIndexes()
 	for _, index := range indexes {
-		if index.ID == desc.PrimaryIndex.ID {
+		if index.ID == desc.PrimaryIdx().ID {
 			if _, ok := info[index.Name]; ok {
 				return nil, pgerror.Newf(pgcode.DuplicateObject,
 					"duplicate constraint name: %q", index.Name)
@@ -424,8 +424,8 @@ func FindFKReferencedIndex(
 ) (*IndexDescriptor, error) {
 	// Search for a unique index on the referenced table that matches our foreign
 	// key columns.
-	if ColumnIDs(referencedTable.PrimaryIndex.ColumnIDs).HasPrefix(referencedColIDs) {
-		return &referencedTable.PrimaryIndex, nil
+	if ColumnIDs(referencedTable.PrimaryIdx().ColumnIDs).HasPrefix(referencedColIDs) {
+		return referencedTable.PrimaryIdx(), nil
 	}
 	// If the PK doesn't match, find the index corresponding to the referenced column.
 	for _, idx := range referencedTable.Indexes {
@@ -447,8 +447,8 @@ func FindFKOriginIndex(
 ) (*IndexDescriptor, error) {
 	// Search for an index on the origin table that matches our foreign
 	// key columns.
-	if ColumnIDs(originTable.PrimaryIndex.ColumnIDs).HasPrefix(originColIDs) {
-		return &originTable.PrimaryIndex, nil
+	if ColumnIDs(originTable.PrimaryIdx().ColumnIDs).HasPrefix(originColIDs) {
+		return originTable.PrimaryIdx(), nil
 	}
 	// If the PK doesn't match, find the index corresponding to the origin column.
 	for _, idx := range originTable.Indexes {

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -658,7 +658,7 @@ func RandEncDatumRowsOfTypes(rng *rand.Rand, numRows int, types []types.T) EncDa
 //  - int (converts to DInt)
 //  - string (converts to DString)
 func TestingMakePrimaryIndexKey(desc *TableDescriptor, vals ...interface{}) (roachpb.Key, error) {
-	index := &desc.PrimaryIndex
+	index := desc.PrimaryIdx()
 	if len(vals) > len(index.ColumnIDs) {
 		return nil, errors.Errorf("got %d values, PK has %d columns", len(vals), len(index.ColumnIDs))
 	}

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -55,7 +55,7 @@ CREATE INDEX bc ON test.t(b, c);
 			cID = c.ID
 		}
 	}
-	pkID := tableDesc.PrimaryIndex.ID
+	pkID := tableDesc.PrimaryIdx().ID
 	secID := tableDesc.Indexes[0].ID
 
 	// Retrieve the numeric descriptors.

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -278,8 +278,8 @@ func TestMakeTableDescIndexes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%d (%s): %v", i, d.sql, err)
 		}
-		if !reflect.DeepEqual(d.primary, schema.PrimaryIndex) {
-			t.Fatalf("%d (%s): primary mismatch: expected %+v, but got %+v", i, d.sql, d.primary, schema.PrimaryIndex)
+		if !reflect.DeepEqual(d.primary, schema.PrimaryIdx()) {
+			t.Fatalf("%d (%s): primary mismatch: expected %+v, but got %+v", i, d.sql, d.primary, schema.PrimaryIdx())
 		}
 		if !reflect.DeepEqual(d.indexes, append([]sqlbase.IndexDescriptor{}, schema.Indexes...)) {
 			t.Fatalf("%d (%s): index mismatch: expected %+v, but got %+v", i, d.sql, d.indexes, schema.Indexes)

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -156,7 +156,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	var rf row.Fetcher
 	tableArgs := row.FetcherTableArgs{
 		Desc:            td.rd.Helper.TableDesc,
-		Index:           &td.rd.Helper.TableDesc.PrimaryIndex,
+		Index:           td.rd.Helper.TableDesc.PrimaryIdx(),
 		ColIdxMap:       td.rd.FetchColIDtoRowIndex,
 		Cols:            td.rd.FetchCols,
 		ValNeededForCol: valNeededForCol,
@@ -268,7 +268,7 @@ func (td *tableDeleter) deleteIndexScan(
 	var rf row.Fetcher
 	tableArgs := row.FetcherTableArgs{
 		Desc:            td.rd.Helper.TableDesc,
-		Index:           &td.rd.Helper.TableDesc.PrimaryIndex,
+		Index:           td.rd.Helper.TableDesc.PrimaryIdx(),
 		ColIdxMap:       td.rd.FetchColIDtoRowIndex,
 		Cols:            td.rd.FetchCols,
 		ValNeededForCol: valNeededForCol,

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -131,7 +131,7 @@ func (tu *strictTableUpserter) getConflictingRows(
 
 		// Get the primary key of the insert row.
 		upsertRowPKBytes, _, err := sqlbase.EncodeIndexKey(
-			tableDesc.TableDesc(), &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
+			tableDesc.TableDesc(), tableDesc.PrimaryIdx(), tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -118,7 +118,7 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 		return err
 	}
 	indexName := ""
-	if n.index.ID != n.tableDesc.PrimaryIndex.ID {
+	if n.index.ID != n.tableDesc.PrimaryIdx().ID {
 		indexName = n.index.Name
 	}
 	ranges, err := params.p.ExtendedEvalContext().InternalExecutor.Query(

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -559,7 +559,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			v.observer.attr(name, "from", n.desc.Name)
 		}
 		if v.observer.spans != nil {
-			v.observer.spans(name, "spans", &n.desc.PrimaryIndex, n.spans)
+			v.observer.spans(name, "spans", n.desc.PrimaryIdx(), n.spans)
 		}
 
 	case *serializeNode:

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -296,7 +296,7 @@ func resolveSubzone(
 	indexName := string(zs.TableOrIndex.Index)
 	var index *sqlbase.IndexDescriptor
 	if indexName == "" {
-		index = &table.PrimaryIndex
+		index = table.PrimaryIdx()
 		indexName = index.Name
 	} else {
 		var err error


### PR DESCRIPTION
This change is necessary to allow easy change of a table's primary
index. Most likely the representation for table descriptors will change,
and accessing the primary index of a table will be more than just
looking up one field on the descriptor. This change gates primary index
access behind a getter method so that minimum code is needed to change
the primary key representation in the future.

The problem of dealing with writes to the PrimaryIndex field can be addressed once a new representation has been decided.

This PR can also wait until a new representation for the TableDescriptors has been decided upon.

Unsolved questions:
* Is there a way to enforce that the PrimaryIndex field of the table
descriptor is not accessed directly anymore?
* Can we ensure that the compiler doesn't translate the calling of the
getter method into a double dereference (rather than just indexing into
the struct)? I'm worried about slowdown.
* How can I make proto not generate a getter for PrimaryIndex? I only
see options to turn on/off getters for the whole struct.

Release note: none