### PR TITLE
opt: track FK fallback in MutationPrivate

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -69,7 +69,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	checkOrds := ordinalSetFromColList(ins.CheckCols)
 	returnOrds := ordinalSetFromColList(ins.ReturnCols)
 	// If we planned FK checks, disable the execution code for FK checks.
-	disableExecFKs := len(ins.Checks) > 0
+	disableExecFKs := !ins.FKFallback
 	node, err := b.factory.ConstructInsert(
 		input.root,
 		tab,
@@ -142,7 +142,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 		}
 	}
 
-	disableExecFKs := len(upd.Checks) > 0
+	disableExecFKs := !upd.FKFallback
 	node, err := b.factory.ConstructUpdate(
 		input.root,
 		tab,
@@ -263,7 +263,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	tab := md.Table(del.Table)
 	fetchColOrds := ordinalSetFromColList(del.FetchCols)
 	returnColOrds := ordinalSetFromColList(del.ReturnCols)
-	disableExecFKs := len(del.Checks) > 0
+	disableExecFKs := !del.FKFallback
 	node, err := b.factory.ConstructDelete(
 		input.root,
 		tab,

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -368,7 +368,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			}
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
-			f.formatMutationWithID(tp, t.WithID)
+			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
 	case *UpdateExpr:
@@ -379,7 +379,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatColList(e, tp, "fetch columns:", t.FetchCols)
 			f.formatMutationCols(e, tp, "update-mapping:", t.UpdateCols, t.Table)
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
-			f.formatMutationWithID(tp, t.WithID)
+			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
 	case *UpsertExpr:
@@ -397,7 +397,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				f.formatMutationCols(e, tp, "upsert-mapping:", t.InsertCols, t.Table)
 			}
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
-			f.formatMutationWithID(tp, t.WithID)
+			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
 	case *DeleteExpr:
@@ -406,7 +406,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			f.formatColList(e, tp, "fetch columns:", t.FetchCols)
-			f.formatMutationWithID(tp, t.WithID)
+			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
 	case *WithScanExpr:
@@ -880,11 +880,14 @@ func (f *ExprFmtCtx) formatMutationCols(
 	}
 }
 
-// formatMutationWithID shows the binding ID, if the mutation is buffering its
-// input.
-func (f *ExprFmtCtx) formatMutationWithID(tp treeprinter.Node, id opt.WithID) {
-	if id != 0 {
-		tp.Childf("input binding: &%d", id)
+// formatMutationCommon shows the MutationPrivate fields that format the same
+// for all types of mutations.
+func (f *ExprFmtCtx) formatMutationCommon(tp treeprinter.Node, p *MutationPrivate) {
+	if p.WithID != 0 {
+		tp.Childf("input binding: &%d", p.WithID)
+	}
+	if p.FKFallback {
+		tp.Childf("fk-fallback")
 	}
 }
 

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -132,6 +132,10 @@ define MutationPrivate {
     # input, making it accessible to FK queries. If this is not required, WithID
     # is zero.
     WithID WithID
+
+    # FKFallback is true if we need to fall back to the legacy path for FK
+    # checks / cascades.
+    FKFallback bool
 }
 
 # Update evaluates a relational input expression that fetches existing rows from

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -868,6 +868,8 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
+	mb.buildFKChecksForUpsert()
+
 	private := mb.makeMutationPrivate(returning != nil)
 	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, mb.checks, private)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -127,6 +127,10 @@ type mutationBuilder struct {
 	// checks contains foreign key check queries; see buildFKChecks methods.
 	checks memo.FKChecksExpr
 
+	// fkFallback is true if we need to fall back on the legacy path for
+	// FK checks / cascades. See buildFKChecks methods.
+	fkFallback bool
+
 	// withID is nonzero if we need to buffer the input for FK checks.
 	withID opt.WithID
 
@@ -724,6 +728,7 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 		UpdateCols: makeColList(mb.updateOrds),
 		CanaryCol:  mb.canaryColID,
 		CheckCols:  makeColList(mb.checkOrds),
+		FKFallback: mb.fkFallback,
 	}
 
 	// If we didn't actually plan any checks (e.g. because of cascades), don't
@@ -884,7 +889,12 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 // buildFKChecks* methods populate mb.checks with queries that check the
 // integrity of foreign key relations that involve modified rows.
 func (mb *mutationBuilder) buildFKChecksForInsert() {
-	if !mb.b.evalCtx.SessionData.OptimizerFKs || mb.tab.OutboundForeignKeyCount() == 0 {
+	if mb.tab.OutboundForeignKeyCount() == 0 {
+		// No relevant FKs.
+		return
+	}
+	if !mb.b.evalCtx.SessionData.OptimizerFKs {
+		mb.fkFallback = true
 		return
 	}
 
@@ -906,7 +916,12 @@ func (mb *mutationBuilder) buildFKChecksForInsert() {
 // buildFKChecks* methods populate mb.checks with queries that check the
 // integrity of foreign key relations that involve modified rows.
 func (mb *mutationBuilder) buildFKChecksForDelete() {
-	if !mb.b.evalCtx.SessionData.OptimizerFKs || mb.tab.InboundForeignKeyCount() == 0 {
+	if mb.tab.InboundForeignKeyCount() == 0 {
+		// No relevant FKs.
+		return
+	}
+	if !mb.b.evalCtx.SessionData.OptimizerFKs {
+		mb.fkFallback = true
 		return
 	}
 
@@ -935,7 +950,8 @@ func (mb *mutationBuilder) buildFKChecksForDelete() {
 		ok := mb.addDeletionCheck(i, input, cols, fk.DeleteReferenceAction())
 		if !ok {
 			mb.checks = nil
-			break
+			mb.fkFallback = true
+			return
 		}
 	}
 }
@@ -943,10 +959,11 @@ func (mb *mutationBuilder) buildFKChecksForDelete() {
 // buildFKChecks* methods populate mb.checks with queries that check the
 // integrity of foreign key relations that involve modified rows.
 func (mb *mutationBuilder) buildFKChecksForUpdate() {
-	if !mb.b.evalCtx.SessionData.OptimizerFKs {
+	if mb.tab.OutboundForeignKeyCount() == 0 && mb.tab.InboundForeignKeyCount() == 0 {
 		return
 	}
-	if mb.tab.OutboundForeignKeyCount() == 0 && mb.tab.InboundForeignKeyCount() == 0 {
+	if !mb.b.evalCtx.SessionData.OptimizerFKs {
+		mb.fkFallback = true
 		return
 	}
 
@@ -1079,9 +1096,22 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 		ok := mb.addDeletionCheck(i, input, outCols, fk.UpdateReferenceAction())
 		if !ok {
 			mb.checks = nil
-			break
+			mb.fkFallback = true
+			return
 		}
 	}
+}
+
+func (mb *mutationBuilder) buildFKChecksForUpsert() {
+	if mb.tab.OutboundForeignKeyCount() == 0 && mb.tab.InboundForeignKeyCount() == 0 {
+		return
+	}
+	if !mb.b.evalCtx.SessionData.OptimizerFKs {
+		mb.fkFallback = true
+		return
+	}
+	// TODO(justin): not implemented yet.
+	mb.fkFallback = true
 }
 
 // addInsertionCheck adds a FK check for rows which are added to a table.

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -159,13 +159,14 @@ exec-ddl
 CREATE TABLE child_cascade (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
 ----
 
-# Bail in the presence of CASCADE, so that exec-style FK checks take over.
+# Fall back to the exec-style checks in the presence of CASCADE.
 build
 DELETE FROM parent WHERE p = 1
 ----
 delete parent
  ├── columns: <none>
  ├── fetch columns: x:4(int) parent.p:5(int) parent.other:6(int)
+ ├── fk-fallback
  └── select
       ├── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
       ├── scan parent

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -36,6 +36,50 @@ update child
                           ├── variable: column5 [type=int]
                           └── variable: parent.p [type=int]
 
+build
+UPDATE parent SET p = p+1
+----
+update parent
+ ├── columns: <none>
+ ├── fetch columns: x:4(int) parent.p:5(int) other:6(int)
+ ├── update-mapping:
+ │    └──  column7:7 => parent.p:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column7:7(int) x:4(int) parent.p:5(int!null) other:6(int)
+ │    ├── scan parent
+ │    │    └── columns: x:4(int) parent.p:5(int!null) other:6(int)
+ │    └── projections
+ │         └── plus [type=int]
+ │              ├── variable: parent.p [type=int]
+ │              └── const: 1 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── semi-join (hash)
+                ├── columns: p:10(int)
+                ├── project
+                │    ├── columns: p:10(int)
+                │    ├── except
+                │    │    ├── columns: p:8(int)
+                │    │    ├── left columns: p:8(int)
+                │    │    ├── right columns: column7:9(int)
+                │    │    ├── with-scan &1
+                │    │    │    ├── columns: p:8(int!null)
+                │    │    │    └── mapping:
+                │    │    │         └──  parent.p:5(int) => p:8(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column7:9(int)
+                │    │         └── mapping:
+                │    │              └──  column7:7(int) => column7:9(int)
+                │    └── projections
+                │         └── variable: p [type=int]
+                ├── scan child
+                │    └── columns: child.p:12(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: p [type=int]
+                          └── variable: child.p [type=int]
+
 exec-ddl
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 ----
@@ -138,6 +182,67 @@ update child
                      └── eq [type=bool]
                           ├── variable: p [type=int]
                           └── variable: parent.p [type=int]
+
+build
+UPDATE child SET p = p+1, c = c+1
+----
+update child
+ ├── columns: <none>
+ ├── fetch columns: child.c:3(int) child.p:4(int)
+ ├── update-mapping:
+ │    ├──  column6:6 => child.c:1
+ │    └──  column5:5 => child.p:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column5:5(int) column6:6(int) child.c:3(int!null) child.p:4(int!null)
+ │    ├── scan child
+ │    │    └── columns: child.c:3(int!null) child.p:4(int!null)
+ │    └── projections
+ │         ├── plus [type=int]
+ │         │    ├── variable: child.p [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── plus [type=int]
+ │              ├── variable: child.c [type=int]
+ │              └── const: 1 [type=int]
+ └── f-k-checks
+      ├── f-k-checks-item: child(p) -> parent(p)
+      │    └── anti-join (hash)
+      │         ├── columns: column5:10(int)
+      │         ├── with-scan &1
+      │         │    ├── columns: column5:10(int)
+      │         │    └── mapping:
+      │         │         └──  column5:5(int) => column5:10(int)
+      │         ├── scan parent
+      │         │    └── columns: parent.p:8(int!null)
+      │         └── filters
+      │              └── eq [type=bool]
+      │                   ├── variable: column5 [type=int]
+      │                   └── variable: parent.p [type=int]
+      └── f-k-checks-item: grandchild(c) -> child(c)
+           └── semi-join (hash)
+                ├── columns: c:13(int)
+                ├── project
+                │    ├── columns: c:13(int)
+                │    ├── except
+                │    │    ├── columns: c:11(int)
+                │    │    ├── left columns: c:11(int)
+                │    │    ├── right columns: column6:12(int)
+                │    │    ├── with-scan &1
+                │    │    │    ├── columns: c:11(int!null)
+                │    │    │    └── mapping:
+                │    │    │         └──  child.c:3(int) => c:11(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column6:12(int)
+                │    │         └── mapping:
+                │    │              └──  column6:6(int) => column6:12(int)
+                │    └── projections
+                │         └── variable: c [type=int]
+                ├── scan grandchild
+                │    └── columns: grandchild.c:15(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: c [type=int]
+                          └── variable: grandchild.c [type=int]
 
 # Multiple grandchild tables
 exec-ddl
@@ -350,3 +455,26 @@ update fam
                      └── eq [type=bool]
                           ├── variable: column13 [type=int]
                           └── variable: two.b [type=int]
+
+exec-ddl
+CREATE TABLE child_cascade (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON UPDATE CASCADE)
+----
+
+# Fall back to the exec-style checks in the presence of CASCADE.
+build
+UPDATE parent SET p = p+1
+----
+update parent
+ ├── columns: <none>
+ ├── fetch columns: x:4(int) parent.p:5(int) other:6(int)
+ ├── update-mapping:
+ │    └──  column7:7 => parent.p:2
+ ├── fk-fallback
+ └── project
+      ├── columns: column7:7(int) x:4(int) parent.p:5(int!null) other:6(int)
+      ├── scan parent
+      │    └── columns: x:4(int) parent.p:5(int!null) other:6(int)
+      └── projections
+           └── plus [type=int]
+                ├── variable: parent.p [type=int]
+                └── const: 1 [type=int]


### PR DESCRIPTION
Currently we fall back to the legacy FK path if there are no checks
planned for a mutation. There's no way of knowing if there are no
checks because none were needed, or because we have to fall back. A
future change will need to make this distinction.

This commit adds a `FKFallback` field to `MutationPrivate` and uses
that in the exec builder. The logic is effectively the same, except
that we now disable the legacy path when there are no checks needed
(which saves an allocation).

Release note: None