### PR TITLE
storage/engine: adjust {start,end} arg types on `{Writer,Reader}` methods

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1451,8 +1451,7 @@ func getAllRevisions(
 		if err := sst.IngestExternalFile(file.SST); err != nil {
 			return nil, err
 		}
-		start, end := engine.MVCCKey{Key: startKey}, engine.MVCCKey{Key: endKey}
-		if err := sst.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
+		if err := sst.Iterate(startKey, endKey, func(kv engine.MVCCKeyValue) (bool, error) {
 			if len(res) == 0 || !res[len(res)-1].Key.Equal(kv.Key.Key) {
 				res = append(res, versionedValues{Key: kv.Key.Key})
 			}

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -83,8 +83,7 @@ func TestExportCmd(t *testing.T) {
 			if err := sst.IngestExternalFile(file.SST); err != nil {
 				t.Fatalf("%+v", err)
 			}
-			start, end := engine.MVCCKey{Key: keys.MinKey}, engine.MVCCKey{Key: keys.MaxKey}
-			if err := sst.Iterate(start, end, ingestFunc); err != nil {
+			if err := sst.Iterate(keys.MinKey, keys.MaxKey, ingestFunc); err != nil {
 				t.Fatalf("%+v", err)
 			}
 		}
@@ -280,7 +279,7 @@ func loadSST(t *testing.T, data []byte, start, end roachpb.Key) []engine.MVCCKey
 	}
 
 	var kvs []engine.MVCCKeyValue
-	if err := sst.Iterate(engine.MVCCKey{Key: start}, engine.MVCCKey{Key: end}, func(kv engine.MVCCKeyValue) (bool, error) {
+	if err := sst.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
 		kvs = append(kvs, kv)
 		return false, nil
 	}); err != nil {

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -82,7 +82,7 @@ func slurpSSTablesLatestKey(
 		if err := sst.IngestExternalFile(fileContents); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := sst.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
+		if err := sst.Iterate(start.Key, end.Key, func(kv engine.MVCCKeyValue) (bool, error) {
 			var ok bool
 			kv.Key.Key, ok = kr.rewriteKey(kv.Key.Key)
 			if !ok {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -83,7 +83,7 @@ func clearExistingData(
 ) (enginepb.MVCCStats, error) {
 	{
 		isEmpty := true
-		if err := batch.Iterate(start, end, func(_ engine.MVCCKeyValue) (bool, error) {
+		if err := batch.Iterate(start.Key, end.Key, func(_ engine.MVCCKeyValue) (bool, error) {
 			isEmpty = false
 			return true, nil // stop right away
 		}); err != nil {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -105,8 +105,7 @@ func clearExistingData(
 		return enginepb.MVCCStats{}, nil
 	}
 
-	existingStats, err := iter.ComputeStats(
-		engine.MakeMVCCMetadataKey(start), engine.MakeMVCCMetadataKey(end), nowNanos)
+	existingStats, err := iter.ComputeStats(start, end, nowNanos)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -175,7 +175,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return db.Iterate(debugCtx.startKey, debugCtx.endKey, printer)
+	return db.Iterate(debugCtx.startKey.Key, debugCtx.endKey.Key, printer)
 }
 
 func runDebugBallast(cmd *cobra.Command, args []string) error {
@@ -316,8 +316,8 @@ func loadRangeDescriptor(
 
 	// Range descriptors are stored by key, so we have to scan over the
 	// range-local data to find the one for this RangeID.
-	start := engine.MakeMVCCMetadataKey(keys.LocalRangePrefix)
-	end := engine.MakeMVCCMetadataKey(keys.LocalRangeMax)
+	start := keys.LocalRangePrefix
+	end := keys.LocalRangeMax
 
 	if err := db.Iterate(start, end, handleKV); err != nil {
 		return roachpb.RangeDescriptor{}, err
@@ -337,8 +337,8 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	start := engine.MakeMVCCMetadataKey(keys.LocalRangePrefix)
-	end := engine.MakeMVCCMetadataKey(keys.LocalRangeMax)
+	start := keys.LocalRangePrefix
+	end := keys.LocalRangeMax
 
 	return db.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
 		if storage.IsRangeDescriptorKey(kv.Key) != nil {
@@ -442,10 +442,12 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	start := engine.MakeMVCCMetadataKey(keys.RaftLogPrefix(rangeID))
-	end := engine.MakeMVCCMetadataKey(keys.RaftLogPrefix(rangeID).PrefixEnd())
+	start := keys.RaftLogPrefix(rangeID)
+	end := keys.RaftLogPrefix(rangeID).PrefixEnd()
 	fmt.Printf("Printing keys %s -> %s (RocksDB keys: %#x - %#x )\n",
-		start, end, string(engine.EncodeKey(start)), string(engine.EncodeKey(end)))
+		start, end,
+		string(engine.EncodeKey(engine.MakeMVCCMetadataKey(start))),
+		string(engine.EncodeKey(engine.MakeMVCCMetadataKey(end))))
 
 	return db.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
 		storage.PrintKeyValue(kv)

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -144,8 +144,7 @@ func runSyncer(
 	}
 
 	fmt.Fprintf(stderr, "verifying existing sequence numbers...")
-	keyMin := engine.MakeMVCCMetadataKey(roachpb.KeyMin)
-	if err := db.Iterate(keyMin, engine.MVCCKeyMax, check); err != nil {
+	if err := db.Iterate(roachpb.KeyMin, roachpb.KeyMax, check); err != nil {
 		return 0, err
 	}
 	// We must not lose writes, but sometimes we get extra ones (i.e. we caught an

--- a/pkg/storage/abortspan/abortspan.go
+++ b/pkg/storage/abortspan/abortspan.go
@@ -80,8 +80,7 @@ func (sc *AbortSpan) ClearData(e engine.Engine) error {
 	defer iter.Close()
 	b := e.NewWriteOnlyBatch()
 	defer b.Close()
-	err := b.ClearIterRange(iter, engine.MakeMVCCMetadataKey(sc.min()),
-		engine.MakeMVCCMetadataKey(sc.max()))
+	err := b.ClearIterRange(iter, sc.min(), sc.max())
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -74,7 +74,7 @@ func TestSpanSetBatch(t *testing.T) {
 	}
 	{
 		iter := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
-		err := batch.ClearIterRange(iter, outsideKey, outsideKey2)
+		err := batch.ClearIterRange(iter, outsideKey.Key, outsideKey2.Key)
 		iter.Close()
 		if !isWriteSpanErr(err) {
 			t.Errorf("ClearIterRange: unexpected error %v", err)

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -107,7 +107,7 @@ func TestSpanSetBatch(t *testing.T) {
 	if _, _, _, err := batch.GetProto(outsideKey, nil); !isReadSpanErr(err) {
 		t.Errorf("GetProto: unexpected error %v", err)
 	}
-	if err := batch.Iterate(outsideKey, outsideKey2,
+	if err := batch.Iterate(outsideKey.Key, outsideKey2.Key,
 		func(v engine.MVCCKeyValue) (bool, error) {
 			return false, errors.Errorf("unexpected callback: %v", v)
 		},

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -88,7 +88,8 @@ func EvalAddSSTable(
 	if args.MVCCStats == nil || verifyFastPath {
 		log.VEventf(ctx, 2, "computing MVCCStats for SSTable [%s,%s)", mvccStartKey.Key, mvccEndKey.Key)
 
-		computed, err := engine.ComputeStatsGo(dataIter, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
+		computed, err := engine.ComputeStatsGo(
+			dataIter, mvccStartKey.Key, mvccEndKey.Key, h.Timestamp.WallTime)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "computing SSTable MVCC stats")
 		}

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -373,7 +373,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	beforeStats := func() enginepb.MVCCStats {
 		iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
-		beforeStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, 10)
+		beforeStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -427,7 +427,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	afterStats := func() enginepb.MVCCStats {
 		iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
-		afterStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, 10)
+		afterStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -502,7 +502,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		return sstBytes
 	}
 
-	getStats := func(startKey, endKey engine.MVCCKey, data []byte) enginepb.MVCCStats {
+	getStats := func(startKey, endKey roachpb.Key, data []byte) enginepb.MVCCStats {
 		dataIter, err := engine.NewMemSSTIterator(data, true)
 		if err != nil {
 			return enginepb.MVCCStats{}
@@ -524,7 +524,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		})
 
 		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(engine.MVCCKey{Key: roachpb.Key("a")}, engine.MVCCKey{Key: roachpb.Key("b")}, sstBytes)
+		stats := getStats(roachpb.Key("a"), roachpb.Key("b"), sstBytes)
 		cArgs := batcheval.CommandArgs{
 			Header: roachpb.Header{
 				Timestamp: hlc.Timestamp{WallTime: 7},
@@ -607,7 +607,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		})
 
 		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, sstBytes)
+		stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
 		cArgs := batcheval.CommandArgs{
 			Header: roachpb.Header{
 				Timestamp: hlc.Timestamp{WallTime: 7},
@@ -810,7 +810,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		})
 
 		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(engine.MVCCKey{Key: roachpb.Key("e")}, engine.MVCCKey{Key: roachpb.Key("zz")}, sstBytes)
+		stats := getStats(roachpb.Key("e"), roachpb.Key("zz"), sstBytes)
 		cArgs := batcheval.CommandArgs{
 			Header: roachpb.Header{
 				Timestamp: hlc.Timestamp{WallTime: 7},
@@ -930,7 +930,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		})
 
 		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, sstBytes)
+		stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
 
 		// Accumulate stats across SST ingestion.
 		commandStats := enginepb.MVCCStats{}
@@ -969,7 +969,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
 		})
 		secondSSTBytes := getSSTBytes(secondSSTKVs)
-		secondStats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, secondSSTBytes)
+		secondStats := getStats(roachpb.Key("c"), roachpb.Key("i"), secondSSTBytes)
 
 		cArgs.Args = &roachpb.AddSSTableRequest{
 			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
@@ -996,7 +996,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
 		})
 		thirdSSTBytes := getSSTBytes(thirdSSTKVs)
-		thirdStats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, thirdSSTBytes)
+		thirdStats := getStats(roachpb.Key("c"), roachpb.Key("i"), thirdSSTBytes)
 
 		cArgs.Args = &roachpb.AddSSTableRequest{
 			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -79,7 +79,7 @@ func ClearRange(
 	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
 		if err := batch.Iterate(
-			from, to,
+			from.Key, to.Key,
 			func(kv engine.MVCCKeyValue) (bool, error) {
 				return false, batch.Clear(kv.Key)
 			},

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -62,8 +62,8 @@ func ClearRange(
 
 	// Encode MVCCKey values for start and end of clear span.
 	args := cArgs.Args.(*roachpb.ClearRangeRequest)
-	from := engine.MVCCKey{Key: args.Key}
-	to := engine.MVCCKey{Key: args.EndKey}
+	from := args.Key
+	to := args.EndKey
 	var pd result.Result
 
 	// Before clearing, compute the delta in MVCCStats.
@@ -78,8 +78,7 @@ func ClearRange(
 	// instead of using a range tombstone (inefficient for small ranges).
 	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
-		if err := batch.Iterate(
-			from.Key, to.Key,
+		if err := batch.Iterate(from, to,
 			func(kv engine.MVCCKeyValue) (bool, error) {
 				return false, batch.Clear(kv.Key)
 			},
@@ -93,15 +92,16 @@ func ClearRange(
 	// the key span using engine.ClearRange.
 	pd.Replicated.SuggestedCompactions = []storagepb.SuggestedCompaction{
 		{
-			StartKey: from.Key,
-			EndKey:   to.Key,
+			StartKey: from,
+			EndKey:   to,
 			Compaction: storagepb.Compaction{
 				Bytes:            statsDelta.Total(),
 				SuggestedAtNanos: cArgs.Header.Timestamp.WallTime,
 			},
 		},
 	}
-	if err := batch.ClearRange(from, to); err != nil {
+	if err := batch.ClearRange(engine.MakeMVCCMetadataKey(from),
+		engine.MakeMVCCMetadataKey(to)); err != nil {
 		return result.Result{}, err
 	}
 	return pd, nil
@@ -116,14 +116,14 @@ func ClearRange(
 // path of simply subtracting the non-system values is accurate.
 // Returns the delta stats.
 func computeStatsDelta(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, from, to engine.MVCCKey,
+	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, from, to roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	desc := cArgs.EvalCtx.Desc()
 	var delta enginepb.MVCCStats
 
 	// We can avoid manually computing the stats delta if we're clearing
 	// the entire range.
-	fast := desc.StartKey.Equal(from.Key) && desc.EndKey.Equal(to.Key)
+	fast := desc.StartKey.Equal(from) && desc.EndKey.Equal(to)
 	if fast {
 		// Note this it is safe to use the full range MVCC stats, as
 		// opposed to the usual method of computing only a localizied
@@ -137,7 +137,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled,
 	// compute stats across the key span to be cleared.
 	if !fast || util.RaceEnabled {
-		iter := batch.NewIterator(engine.IterOptions{UpperBound: to.Key})
+		iter := batch.NewIterator(engine.IterOptions{UpperBound: to})
 		computed, err := iter.ComputeStats(from, to, delta.LastUpdateNanos)
 		iter.Close()
 		if err != nil {

--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -139,8 +139,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			if err := batch.Commit(true /* commit */); err != nil {
 				t.Fatal(err)
 			}
-			if err := eng.Iterate(
-				engine.MVCCKey{Key: startKey}, engine.MVCCKey{Key: endKey},
+			if err := eng.Iterate(startKey, endKey,
 				func(kv engine.MVCCKeyValue) (bool, error) {
 					return true, errors.New("expected no data in underlying engine")
 				},

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -1074,10 +1074,7 @@ func mergeTrigger(
 		ridPrefix := keys.MakeRangeIDReplicatedPrefix(merge.RightDesc.RangeID)
 		iter := batch.NewIterator(engine.IterOptions{UpperBound: ridPrefix.PrefixEnd()})
 		defer iter.Close()
-		sysMS, err := iter.ComputeStats(
-			engine.MakeMVCCMetadataKey(ridPrefix),
-			engine.MakeMVCCMetadataKey(ridPrefix.PrefixEnd()),
-			0 /* nowNanos */)
+		sysMS, err := iter.ComputeStats(ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -29,8 +29,7 @@ import (
 func hashRange(t *testing.T, eng engine.Reader, start, end roachpb.Key) []byte {
 	t.Helper()
 	h := sha256.New()
-	if err := eng.Iterate(
-		engine.MVCCKey{Key: start}, engine.MVCCKey{Key: end},
+	if err := eng.Iterate(start, end,
 		func(kv engine.MVCCKeyValue) (bool, error) {
 			h.Write(kv.Key.Key)
 			h.Write(kv.Value)

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -45,7 +45,7 @@ func getStats(t *testing.T, batch engine.Reader) enginepb.MVCCStats {
 	t.Helper()
 	iter := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
-	s, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, 1100)
+	s, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -103,8 +103,8 @@ func TruncateLog(
 	// off either way, though in practice we don't expect followers to have
 	// a first index smaller than the leaseholder's (see #34287), and most of
 	// the time everyone's first index should be the same.
-	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, firstIndex))
-	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, args.Index))
+	start := keys.RaftLogKey(rangeID, firstIndex)
+	end := keys.RaftLogKey(rangeID, args.Index)
 
 	// Compute the stats delta that were to occur should the log entries be
 	// purged. We do this as a side effect of seeing a new TruncatedState,
@@ -117,7 +117,7 @@ func TruncateLog(
 	// bugs that let it diverge. It might be easier to compute the stats
 	// from scratch, stopping when 4mb (defaultRaftLogTruncationThreshold)
 	// is reached as at that point we'll truncate aggressively anyway.
-	iter := batch.NewIterator(engine.IterOptions{UpperBound: end.Key})
+	iter := batch.NewIterator(engine.IterOptions{UpperBound: end})
 	defer iter.Close()
 	// We can pass zero as nowNanos because we're only interested in SysBytes.
 	ms, err := iter.ComputeStats(start, end, 0 /* nowNanos */)

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -374,9 +374,7 @@ func AddSSTable(
 
 	var stats enginepb.MVCCStats
 	if (ms == enginepb.MVCCStats{}) {
-		stats, err = engine.ComputeStatsGo(
-			iter, engine.MVCCKey{Key: start}, engine.MVCCKey{Key: end}, now.UnixNano(),
-		)
+		stats, err = engine.ComputeStatsGo(iter, start, end, now.UnixNano())
 		if err != nil {
 			return 0, errors.Wrapf(err, "computing stats for SST [%s, %s)", start, end)
 		}
@@ -425,7 +423,7 @@ func AddSSTable(
 					}
 
 					right.stats, err = engine.ComputeStatsGo(
-						iter, engine.MVCCKey{Key: right.start}, engine.MVCCKey{Key: right.end}, now.UnixNano(),
+						iter, right.start, right.end, now.UnixNano(),
 					)
 					if err != nil {
 						return err

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2922,7 +2922,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			EndKey:   roachpb.RKeyMax,
 		}
 		r := rditer.MakeUserKeyRange(&desc)
-		if err := engine.ClearRangeWithHeuristic(eng, &sst, r.Start, r.End); err != nil {
+		if err := engine.ClearRangeWithHeuristic(eng, &sst, r.Start.Key, r.End.Key); err != nil {
 			return err
 		}
 		expectedSST, err := sst.Finish()

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -130,7 +130,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 func getEngineKeySet(t *testing.T, e engine.Engine) map[string]struct{} {
 	t.Helper()
-	kvs, err := engine.Scan(e, engine.NilKey, engine.MVCCKeyMax, 0 /* max */)
+	kvs, err := engine.Scan(e, roachpb.KeyMin, roachpb.KeyMax, 0 /* max */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1805,8 +1805,8 @@ func TestClearRange(t *testing.T) {
 
 	verifyKeysWithPrefix := func(prefix roachpb.Key, expectedKeys []roachpb.Key) {
 		t.Helper()
-		start := engine.MakeMVCCMetadataKey(prefix)
-		end := engine.MakeMVCCMetadataKey(prefix.PrefixEnd())
+		start := prefix
+		end := prefix.PrefixEnd()
 		kvs, err := engine.Scan(store.Engine(), start, end, 0 /* maxRows */)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -295,8 +295,8 @@ func (c *Compactor) fetchSuggestions(
 	defer delBatch.Close()
 
 	err = c.eng.Iterate(
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
+		keys.LocalStoreSuggestedCompactionsMin,
+		keys.LocalStoreSuggestedCompactionsMax,
 		func(kv engine.MVCCKeyValue) (bool, error) {
 			var sc storagepb.SuggestedCompaction
 			var err error
@@ -463,8 +463,8 @@ func (c *Compactor) aggregateCompaction(
 func (c *Compactor) examineQueue(ctx context.Context) (int64, error) {
 	var totalBytes int64
 	if err := c.eng.Iterate(
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
+		keys.LocalStoreSuggestedCompactionsMin,
+		keys.LocalStoreSuggestedCompactionsMax,
 		func(kv engine.MVCCKeyValue) (bool, error) {
 			var c storagepb.Compaction
 			if err := protoutil.Unmarshal(kv.Value, &c); err != nil {

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -570,8 +570,8 @@ func TestCompactorThresholds(t *testing.T) {
 				// spans have been cleared and uncompacted spans remain.
 				var idx int
 				return we.Iterate(
-					engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
-					engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
+					keys.LocalStoreSuggestedCompactionsMin,
+					keys.LocalStoreSuggestedCompactionsMax,
 					func(kv engine.MVCCKeyValue) (bool, error) {
 						start, end, err := keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
 						if err != nil {

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -342,7 +342,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		iter := cpEng.NewIterator(engine.IterOptions{UpperBound: []byte("\xff")})
 		defer iter.Close()
 
-		ms, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, 0 /* nowNanos */)
+		ms, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
 		assert.NoError(t, err)
 
 		assert.NotZero(t, ms.KeyBytes)

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -359,7 +359,7 @@ func BenchmarkClearIterRange_RocksDB(b *testing.B) {
 	runClearRange(ctx, b, setupMVCCRocksDB, func(eng Engine, batch Batch, start, end MVCCKey) error {
 		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
-		return batch.ClearIterRange(iter, start, end)
+		return batch.ClearIterRange(iter, start.Key, end.Key)
 	})
 }
 

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -223,7 +223,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 		// timings more stable. Otherwise, the first run will be penalized pulling
 		// data into the cache while later runs will not.
 		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-		_, _ = iter.ComputeStats(MakeMVCCMetadataKey(roachpb.KeyMin), MakeMVCCMetadataKey(roachpb.KeyMax), 0)
+		_, _ = iter.ComputeStats(roachpb.KeyMin, roachpb.KeyMax, 0)
 		iter.Close()
 	}
 
@@ -726,7 +726,7 @@ func runMVCCComputeStats(ctx context.Context, b *testing.B, emk engineMaker, val
 	var err error
 	for i := 0; i < b.N; i++ {
 		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-		stats, err = iter.ComputeStats(mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
+		stats, err = iter.ComputeStats(roachpb.KeyMin, roachpb.KeyMax, 0)
 		iter.Close()
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -96,7 +96,7 @@ type Iterator interface {
 	// recomputed for the first range (i.e. the one with start key == KeyMin).
 	// The nowNanos arg specifies the wall time in nanoseconds since the
 	// epoch and is used to compute the total age of all intents.
-	ComputeStats(start, end MVCCKey, nowNanos int64) (enginepb.MVCCStats, error)
+	ComputeStats(start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error)
 	// FindSplitKey finds a key from the given span such that the left side of
 	// the split is roughly targetSize bytes. The returned key will never be
 	// chosen from the key ranges listed in keys.NoSplitSpans and will always

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -105,7 +105,7 @@ type Iterator interface {
 	// DO NOT CALL directly (except in wrapper Iterator implementations). Use the
 	// package-level MVCCFindSplitKey instead. For correct operation, the caller
 	// must set the upper bound on the iterator before calling this method.
-	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64) (MVCCKey, error)
+	FindSplitKey(start, end, minSplitKey roachpb.Key, targetSize int64) (MVCCKey, error)
 	// MVCCGet is the internal implementation of the family of package-level
 	// MVCCGet functions.
 	//

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/pkg/errors"
 )
 
 // SimpleIterator is an interface for iterating over key/value pairs in an
@@ -198,10 +199,7 @@ type Reader interface {
 	// error. Note that this method is not expected take into account the
 	// timestamp of the end key; all MVCCKeys at end.Key are considered excluded
 	// in the iteration.
-	//
-	// TODO(itsbilal): Change type of start and end to roachpb.Key instead of
-	// MVCCKey. All keys passed in have zero timestamps anyway.
-	Iterate(start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error)) error
+	Iterate(start, end roachpb.Key, f func(MVCCKeyValue) (stop bool, err error)) error
 	// NewIterator returns a new instance of an Iterator over this
 	// engine. The caller must invoke Iterator.Close() when finished
 	// with the iterator to free resources.
@@ -507,7 +505,7 @@ func PutProto(
 // Scan returns up to max key/value objects starting from
 // start (inclusive) and ending at end (non-inclusive).
 // Specify max=0 for unbounded scans.
-func Scan(engine Reader, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) {
+func Scan(engine Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
 	err := engine.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
 		if max != 0 && int64(len(kvs)) >= max {
@@ -651,4 +649,33 @@ func calculatePreIngestDelay(settings *cluster.Settings, stats *Stats) time.Dura
 		return targetDelay
 	}
 	return 0
+}
+
+// Helper function to implement Reader.Iterate().
+func iterateOnReader(
+	reader Reader, start, end roachpb.Key, f func(MVCCKeyValue) (stop bool, err error),
+) error {
+	if reader.Closed() {
+		return errors.New("cannot call Iterate on a closed batch")
+	}
+	if start.Compare(end) >= 0 {
+		return nil
+	}
+
+	it := reader.NewIterator(IterOptions{UpperBound: end})
+	defer it.Close()
+
+	it.Seek(MakeMVCCMetadataKey(start))
+	for ; ; it.Next() {
+		ok, err := it.Valid()
+		if err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+		if done, err := f(MVCCKeyValue{Key: it.Key(), Value: it.Value()}); done || err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -77,11 +77,6 @@ type Iterator interface {
 	// in the iteration. After this call, Valid() will be true if the
 	// iterator was not positioned at the first key.
 	Prev()
-	// PrevKey moves the iterator backward to the previous MVCC key. This
-	// operation is distinct from Prev which moves the iterator backward to the
-	// prev version of the current key or the prev key if the iterator is
-	// currently located at the first version for a key.
-	PrevKey()
 	// Key returns the current key.
 	Key() MVCCKey
 	// Value returns the current value as a byte slice.
@@ -243,6 +238,10 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after ClearRange
 	// returns.
+	//
+	// TODO(peter): Most callers want to pass roachpb.Key, except for
+	// MVCCClearTimeRange. That function actually does what to clear records
+	// between specific versions.
 	ClearRange(start, end MVCCKey) error
 	// ClearIterRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). Similar to Clear and ClearRange, this method actually removes
@@ -530,7 +529,7 @@ func WriteSyncNoop(ctx context.Context, eng Engine) error {
 
 // ClearRangeWithHeuristic clears the keys from start (inclusive) to end
 // (exclusive). Depending on the number of keys, it will either use ClearRange
-// or ClearRangeIter.
+// or ClearIterRange.
 func ClearRangeWithHeuristic(eng Reader, writer Writer, start, end roachpb.Key) error {
 	iter := eng.NewIterator(IterOptions{UpperBound: end})
 	defer iter.Close()

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -844,7 +844,7 @@ func TestEngineDeleteIterRange(t *testing.T) {
 	testEngineDeleteRange(t, func(engine Engine, start, end MVCCKey) error {
 		iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
-		return engine.ClearIterRange(iter, start, end)
+		return engine.ClearIterRange(iter, start.Key, end.Key)
 	})
 }
 

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -3050,11 +3050,7 @@ func MVCCFindSplitKey(
 		minSplitKey = it.Key().Key.Next()
 	}
 
-	splitKey, err := it.FindSplitKey(
-		MakeMVCCMetadataKey(key.AsRawKey()),
-		MakeMVCCMetadataKey(endKey.AsRawKey()),
-		MakeMVCCMetadataKey(minSplitKey),
-		targetSize)
+	splitKey, err := it.FindSplitKey(key.AsRawKey(), endKey.AsRawKey(), minSplitKey, targetSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -3097,7 +3097,10 @@ func willOverflow(a, b int64) bool {
 //
 // This implementation must match engine/db.cc:MVCCComputeStatsInternal.
 func ComputeStatsGo(
-	iter SimpleIterator, start, end roachpb.Key, nowNanos int64, callbacks ...func(MVCCKey, []byte) error,
+	iter SimpleIterator,
+	start, end roachpb.Key,
+	nowNanos int64,
+	callbacks ...func(MVCCKey, []byte) error,
 ) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
 

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1785,7 +1785,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 						_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
 					case "computeStats":
 						iter := batch.NewIterator(iterOptions)
-						_, err = iter.ComputeStats(NilKey, MVCCKeyMax, 0)
+						_, err = iter.ComputeStats(roachpb.KeyMin, roachpb.KeyMax, 0)
 						iter.Close()
 					}
 					if err != nil {
@@ -2941,7 +2941,7 @@ func computeStats(
 	t.Helper()
 	iter := batch.NewIterator(IterOptions{UpperBound: to})
 	defer iter.Close()
-	s, err := ComputeStatsGo(iter, MVCCKey{Key: from}, MVCCKey{Key: to}, nowNanos)
+	s, err := ComputeStatsGo(iter, from, to, nowNanos)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -5598,8 +5598,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			defer iter.Close()
 			for _, mvccStatsTest := range mvccStatsTests {
 				t.Run(mvccStatsTest.name, func(t *testing.T) {
-					expMS, err := mvccStatsTest.fn(iter, mvccKey(roachpb.KeyMin),
-						mvccKey(roachpb.KeyMax), ts3.WallTime)
+					expMS, err := mvccStatsTest.fn(iter, roachpb.KeyMin, roachpb.KeyMax, ts3.WallTime)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -5549,7 +5549,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				}
 			}
 			if log.V(1) {
-				kvsn, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
+				kvsn, err := Scan(engine, keyMin, keyMax, 0)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -5580,7 +5580,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				mvccVersionKey(roachpb.Key("b"), ts2),
 				mvccVersionKey(roachpb.Key("b-del"), ts3),
 			}
-			kvs, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
+			kvs, err := Scan(engine, keyMin, keyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -560,9 +560,7 @@ func (p *pebbleReadOnly) GetProto(
 	return p.parent.GetProto(key, msg)
 }
 
-func (p *pebbleReadOnly) Iterate(
-	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
-) error {
+func (p *pebbleReadOnly) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) (bool, error)) error {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/pkg/errors"
 )
 
 // MVCCComparer is a pebble.Comparer object that implements MVCC-specific

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -300,7 +300,7 @@ func (p *Pebble) ClearRange(start, end MVCCKey) error {
 }
 
 // ClearIterRange implements the Engine interface.
-func (p *Pebble) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+func (p *Pebble) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
 	// Write all the tombstones in one batch.
 	batch := p.NewWriteOnlyBatch()
 	defer batch.Close()
@@ -617,7 +617,7 @@ func (p *pebbleReadOnly) ClearRange(start, end MVCCKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+func (p *pebbleReadOnly) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -242,7 +242,7 @@ func (p *pebbleBatch) ClearRange(start, end MVCCKey) error {
 }
 
 // Clear implements the Batch interface.
-func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
 	}
@@ -253,8 +253,8 @@ func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end MVCCKey) error {
 	// lower bounds, calling SetUpperBound should be sufficient and safe.
 	// Furthermore, the start and end keys are always metadata keys (i.e.
 	// have zero timestamps), so we can ignore the bounds' MVCC timestamps.
-	iter.SetUpperBound(end.Key)
-	iter.Seek(start)
+	iter.SetUpperBound(end)
+	iter.Seek(MakeMVCCMetadataKey(start))
 
 	for ; ; iter.Next() {
 		valid, err := iter.Valid()

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -13,6 +13,7 @@ package engine
 import (
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/pebble"
@@ -143,7 +144,7 @@ func (p *pebbleBatch) GetProto(
 
 // Iterate implements the Batch interface.
 func (p *pebbleBatch) Iterate(
-	start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error),
+	start, end roachpb.Key, f func(MVCCKeyValue) (stop bool, err error),
 ) error {
 	if p.distinctOpen {
 		panic("distinct batch open")

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -293,7 +293,7 @@ func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
 
 // ComputeStats implements the Iterator interface.
 func (p *pebbleIterator) ComputeStats(
-	start, end MVCCKey, nowNanos int64,
+	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	return ComputeStatsGo(p, start, end, nowNanos)
 }

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -311,7 +311,7 @@ func isValidSplitKey(key roachpb.Key, noSplitSpans []roachpb.Span) bool {
 
 // FindSplitKey implements the Iterator interface.
 func (p *pebbleIterator) FindSplitKey(
-	start, end, minSplitKey MVCCKey, targetSize int64,
+	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (MVCCKey, error) {
 	const timestampLen = 12
 
@@ -324,7 +324,7 @@ func (p *pebbleIterator) FindSplitKey(
 	// lies before them. Note that the no-split spans are ordered by end-key.
 	noSplitSpans := keys.NoSplitSpans
 	for i := range noSplitSpans {
-		if minSplitKey.Key.Compare(noSplitSpans[i].EndKey) <= 0 {
+		if minSplitKey.Compare(noSplitSpans[i].EndKey) <= 0 {
 			noSplitSpans = noSplitSpans[i:]
 			break
 		}
@@ -333,7 +333,8 @@ func (p *pebbleIterator) FindSplitKey(
 	// Note that it is unnecessary to compare against "end" to decide to
 	// terminate iteration because the iterator's upper bound has already been
 	// set to end.
-	p.Seek(start)
+	mvccMinSplitKey := MakeMVCCMetadataKey(minSplitKey)
+	p.Seek(MakeMVCCMetadataKey(start))
 	for ; p.iter.Valid(); p.iter.Next() {
 		mvccKey, err := DecodeMVCCKey(p.iter.Key())
 		if err != nil {
@@ -349,7 +350,7 @@ func (p *pebbleIterator) FindSplitKey(
 		}
 
 		if diff < bestDiff &&
-			(minSplitKey.Key == nil || !mvccKey.Less(minSplitKey)) &&
+			(mvccMinSplitKey.Key == nil || !mvccKey.Less(mvccMinSplitKey)) &&
 			(len(noSplitSpans) == 0 || isValidSplitKey(mvccKey.Key, noSplitSpans)) {
 			// We are going to have to copy bestSplitKey, since by the time we find
 			// out it's the actual best split key, the underlying slice would have
@@ -363,7 +364,7 @@ func (p *pebbleIterator) FindSplitKey(
 			bestSplitKey.Key = append(bestSplitKey.Key[:0], mvccKey.Key...)
 			bestSplitKey.Timestamp = mvccKey.Timestamp
 			// Avoid comparing against minSplitKey on future iterations.
-			minSplitKey.Key = nil
+			mvccMinSplitKey.Key = nil
 		}
 
 		sizeSoFar += int64(len(p.iter.Value()))

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -254,19 +254,6 @@ func (p *pebbleIterator) Prev() {
 	p.iter.Prev()
 }
 
-// PrevKey implements the Iterator interface.
-func (p *pebbleIterator) PrevKey() {
-	if valid, err := p.Valid(); err != nil || !valid {
-		return
-	}
-	curKey := p.Key()
-	for p.iter.Prev() {
-		if !bytes.Equal(curKey.Key, p.UnsafeKey().Key) {
-			break
-		}
-	}
-}
-
 // Key implements the Iterator interface.
 func (p *pebbleIterator) Key() MVCCKey {
 	key := p.UnsafeKey()

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1498,7 +1498,7 @@ func (r *batchIterator) ComputeStats(
 }
 
 func (r *batchIterator) FindSplitKey(
-	start, end, minSplitKey MVCCKey, targetSize int64,
+	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (MVCCKey, error) {
 	r.batch.flushMutations()
 	return r.iter.FindSplitKey(start, end, minSplitKey, targetSize)
@@ -2303,11 +2303,13 @@ func (r *rocksDBIterator) ComputeStats(
 }
 
 func (r *rocksDBIterator) FindSplitKey(
-	start, end, minSplitKey MVCCKey, targetSize int64,
+	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (MVCCKey, error) {
 	var splitKey C.DBString
 	r.clearState()
-	status := C.MVCCFindSplitKey(r.iter, goToCKey(start), goToCKey(minSplitKey),
+	status := C.MVCCFindSplitKey(r.iter,
+		goToCKey(MakeMVCCMetadataKey(start)),
+		goToCKey(MakeMVCCMetadataKey(minSplitKey)),
 		C.int64_t(targetSize), &splitKey)
 	if err := statusToError(status); err != nil {
 		return MVCCKey{}, err

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -866,8 +866,10 @@ func (r *RocksDB) ClearIterRange(iter Iterator, start, end MVCCKey) error {
 
 // Iterate iterates from start to end keys, invoking f on each
 // key/value pair. See engine.Iterate for details.
-func (r *RocksDB) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
-	return dbIterate(r.rdb, r, start, end, f)
+func (r *RocksDB) Iterate(
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
+) error {
+	return iterateOnReader(r, start, end, f)
 }
 
 // Capacity queries the underlying file system for disk capacity information.
@@ -970,11 +972,13 @@ func (r *rocksDBReadOnly) GetProto(
 	return dbGetProto(r.parent.rdb, key, msg)
 }
 
-func (r *rocksDBReadOnly) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+func (r *rocksDBReadOnly) Iterate(
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
+) error {
 	if r.isClosed {
 		panic("using a closed rocksDBReadOnly")
 	}
-	return dbIterate(r.parent.rdb, r, start, end, f)
+	return iterateOnReader(r, start, end, f)
 }
 
 // NewIterator returns an iterator over the underlying engine. Note
@@ -1270,8 +1274,10 @@ func (r *rocksDBSnapshot) GetProto(
 // Iterate iterates over the keys between start inclusive and end
 // exclusive, invoking f() on each key/value pair using the snapshot
 // handle.
-func (r *rocksDBSnapshot) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
-	return dbIterate(r.handle, r, start, end, f)
+func (r *rocksDBSnapshot) Iterate(
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
+) error {
+	return iterateOnReader(r, start, end, f)
 }
 
 // NewIterator returns a new instance of an Iterator over the
@@ -1363,9 +1369,11 @@ func (r *distinctBatch) GetProto(
 	return dbGetProto(r.batch, key, msg)
 }
 
-func (r *distinctBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+func (r *distinctBatch) Iterate(
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
+) error {
 	r.ensureBatch()
-	return dbIterate(r.batch, r, start, end, f)
+	return iterateOnReader(r, start, end, f)
 }
 
 func (r *distinctBatch) Put(key MVCCKey, value []byte) error {
@@ -1710,7 +1718,9 @@ func (r *rocksDBBatch) GetProto(
 	return dbGetProto(r.batch, key, msg)
 }
 
-func (r *rocksDBBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+func (r *rocksDBBatch) Iterate(
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
+) error {
 	if r.writeOnly {
 		panic("write-only batch")
 	}
@@ -1719,7 +1729,7 @@ func (r *rocksDBBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, e
 	}
 	r.flushMutations()
 	r.ensureBatch()
-	return dbIterate(r.batch, r, start, end, f)
+	return iterateOnReader(r, start, end, f)
 }
 
 func (r *rocksDBBatch) Clear(key MVCCKey) error {
@@ -2750,34 +2760,6 @@ func dbClearIterRange(rdb *C.DBEngine, iter Iterator, start, end MVCCKey) error 
 	return statusToError(C.DBDeleteIterRange(rdb, getter.getIter(), goToCKey(start), goToCKey(end)))
 }
 
-func dbIterate(
-	rdb *C.DBEngine, engine Reader, start, end MVCCKey, f func(MVCCKeyValue) (bool, error),
-) error {
-	if !start.Less(end) {
-		return nil
-	}
-	it := newRocksDBIterator(rdb, IterOptions{UpperBound: end.Key}, engine, nil)
-	defer it.Close()
-
-	it.Seek(start)
-	for ; ; it.Next() {
-		ok, err := it.Valid()
-		if err != nil {
-			return err
-		} else if !ok {
-			break
-		}
-		k := it.Key()
-		if !k.Less(end) {
-			break
-		}
-		if done, err := f(MVCCKeyValue{Key: k, Value: it.Value()}); done || err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // TODO(dan): Rename this to RocksDBSSTFileReader and RocksDBSSTFileWriter.
 
 // RocksDBSstFileReader allows iteration over a number of non-overlapping
@@ -2825,7 +2807,7 @@ func (fr *RocksDBSstFileReader) IngestExternalFile(data []byte) error {
 // Iterate iterates over the keys between start inclusive and end
 // exclusive, invoking f() on each key/value pair.
 func (fr *RocksDBSstFileReader) Iterate(
-	start, end MVCCKey, f func(MVCCKeyValue) (bool, error),
+	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
 ) error {
 	if fr.rocksDB.RocksDB == nil {
 		return errors.New("cannot call Iterate on a closed reader")

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -866,9 +866,7 @@ func (r *RocksDB) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
 
 // Iterate iterates from start to end keys, invoking f on each
 // key/value pair. See engine.Iterate for details.
-func (r *RocksDB) Iterate(
-	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
-) error {
+func (r *RocksDB) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) (bool, error)) error {
 	return iterateOnReader(r, start, end, f)
 }
 
@@ -1369,9 +1367,7 @@ func (r *distinctBatch) GetProto(
 	return dbGetProto(r.batch, key, msg)
 }
 
-func (r *distinctBatch) Iterate(
-	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
-) error {
+func (r *distinctBatch) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) (bool, error)) error {
 	r.ensureBatch()
 	return iterateOnReader(r, start, end, f)
 }
@@ -1713,9 +1709,7 @@ func (r *rocksDBBatch) GetProto(
 	return dbGetProto(r.batch, key, msg)
 }
 
-func (r *rocksDBBatch) Iterate(
-	start, end roachpb.Key, f func(MVCCKeyValue) (bool, error),
-) error {
+func (r *rocksDBBatch) Iterate(start, end roachpb.Key, f func(MVCCKeyValue) (bool, error)) error {
 	if r.writeOnly {
 		panic("write-only batch")
 	}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1485,11 +1485,6 @@ func (r *batchIterator) NextKey() {
 	r.iter.NextKey()
 }
 
-func (r *batchIterator) PrevKey() {
-	r.batch.flushMutations()
-	r.iter.PrevKey()
-}
-
 func (r *batchIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
@@ -2224,11 +2219,6 @@ func (r *rocksDBIterator) Prev() {
 func (r *rocksDBIterator) NextKey() {
 	r.checkEngineOpen()
 	r.setState(C.DBIterNext(r.iter, C.bool(true) /* skip_current_key_versions */))
-}
-
-func (r *rocksDBIterator) PrevKey() {
-	r.checkEngineOpen()
-	r.setState(C.DBIterPrev(r.iter, C.bool(true) /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) Key() MVCCKey {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -910,7 +910,7 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 		return false, nil
 	}
 	for {
-		if err := sst.Iterate(MVCCKey{Key: keys.MinKey}, MVCCKey{Key: keys.MaxKey}, iterateFn); err != nil {
+		if err := sst.Iterate(keys.MinKey, keys.MaxKey, iterateFn); err != nil {
 			b.Fatal(err)
 		}
 		if count >= b.N {

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -558,8 +558,7 @@ func TestGCQueueProcess(t *testing.T) {
 	// However, because the GC processing pushes transactions and
 	// resolves intents asynchronously, we use a SucceedsSoon loop.
 	testutils.SucceedsSoon(t, func() error {
-		kvs, err := engine.Scan(tc.store.Engine(), engine.MakeMVCCMetadataKey(key1),
-			engine.MakeMVCCMetadataKey(keys.MaxKey), 0)
+		kvs, err := engine.Scan(tc.store.Engine(), key1, keys.MaxKey, 0)
 		if err != nil {
 			return err
 		}
@@ -890,8 +889,8 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	// is initiated asynchronously from the GC queue.
 	testutils.SucceedsSoon(t, func() error {
 		meta := &enginepb.MVCCMetadata{}
-		return tc.store.Engine().Iterate(engine.MakeMVCCMetadataKey(roachpb.KeyMin),
-			engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv engine.MVCCKeyValue) (bool, error) {
+		return tc.store.Engine().Iterate(roachpb.KeyMin, roachpb.KeyMax,
+			func(kv engine.MVCCKeyValue) (bool, error) {
 				if !kv.Key.IsValue() {
 					if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
 						return false, err

--- a/pkg/storage/rditer/stats.go
+++ b/pkg/storage/rditer/stats.go
@@ -27,7 +27,7 @@ func ComputeStatsForRange(
 
 	ms := enginepb.MVCCStats{}
 	for _, keyRange := range MakeReplicatedKeyRanges(d) {
-		msDelta, err := iter.ComputeStats(keyRange.Start, keyRange.End, nowNanos)
+		msDelta, err := iter.ComputeStats(keyRange.Start.Key, keyRange.End.Key, nowNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -563,7 +563,7 @@ func (r *Replica) sha512(
 	if !statsOnly {
 		for _, span := range rditer.MakeReplicatedKeyRanges(&desc) {
 			spanMS, err := engine.ComputeStatsGo(
-				iter, span.Start, span.End, 0 /* nowNanos */, visitor,
+				iter, span.Start.Key, span.End.Key, 0 /* nowNanos */, visitor,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1745,9 +1745,7 @@ func ComputeRaftLogSize(
 		UpperBound: prefixEnd,
 	})
 	defer iter.Close()
-	from := engine.MakeMVCCMetadataKey(prefix)
-	to := engine.MakeMVCCMetadataKey(prefixEnd)
-	ms, err := iter.ComputeStats(from, to, 0 /* nowNanos */)
+	ms, err := iter.ComputeStats(prefix, prefixEnd, 0 /* nowNanos */)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -698,17 +698,17 @@ func clearRangeData(
 	} else {
 		keyRanges = rditer.MakeAllKeyRanges(desc)
 	}
-	var clearRangeFn func(engine.Reader, engine.Writer, engine.MVCCKey, engine.MVCCKey) error
+	var clearRangeFn func(engine.Reader, engine.Writer, roachpb.Key, roachpb.Key) error
 	if mustClearRange {
-		clearRangeFn = func(eng engine.Reader, writer engine.Writer, start, end engine.MVCCKey) error {
-			return writer.ClearRange(start, end)
+		clearRangeFn = func(eng engine.Reader, writer engine.Writer, start, end roachpb.Key) error {
+			return writer.ClearRange(engine.MakeMVCCMetadataKey(start), engine.MakeMVCCMetadataKey(end))
 		}
 	} else {
 		clearRangeFn = engine.ClearRangeWithHeuristic
 	}
 
 	for _, keyRange := range keyRanges {
-		if err := clearRangeFn(eng, writer, keyRange.Start, keyRange.End); err != nil {
+		if err := clearRangeFn(eng, writer, keyRange.Start.Key, keyRange.End.Key); err != nil {
 			return err
 		}
 	}
@@ -1056,8 +1056,8 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 			if err := engine.ClearRangeWithHeuristic(
 				r.store.Engine(),
 				&subsumedReplSST,
-				keyRanges[i].End,
-				totalKeyRanges[i].End,
+				keyRanges[i].End.Key,
+				totalKeyRanges[i].End.Key,
 			); err != nil {
 				subsumedReplSST.Close()
 				return err

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -111,14 +111,6 @@ func (s *Iterator) NextKey() {
 	}
 }
 
-// PrevKey is part of the engine.Iterator interface.
-func (s *Iterator) PrevKey() {
-	s.i.PrevKey()
-	if s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
-		s.invalid = true
-	}
-}
-
 // Key is part of the engine.Iterator interface.
 func (s *Iterator) Key() engine.MVCCKey {
 	return s.i.Key()

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -156,9 +156,9 @@ func (s *Iterator) ComputeStats(
 
 // FindSplitKey is part of the engine.Iterator interface.
 func (s *Iterator) FindSplitKey(
-	start, end, minSplitKey engine.MVCCKey, targetSize int64,
+	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (engine.MVCCKey, error) {
-	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return engine.MVCCKey{}, err
 	}
 	return s.i.FindSplitKey(start, end, minSplitKey, targetSize)

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -290,8 +290,8 @@ func (s spanSetWriter) ClearRange(start, end engine.MVCCKey) error {
 	return s.w.ClearRange(start, end)
 }
 
-func (s spanSetWriter) ClearIterRange(iter engine.Iterator, start, end engine.MVCCKey) error {
-	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+func (s spanSetWriter) ClearIterRange(iter engine.Iterator, start, end roachpb.Key) error {
+	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return err
 	}
 	return s.w.ClearIterRange(iter, start, end)

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -223,9 +223,9 @@ func (s spanSetReader) GetProto(
 }
 
 func (s spanSetReader) Iterate(
-	start, end engine.MVCCKey, f func(engine.MVCCKeyValue) (bool, error),
+	start, end roachpb.Key, f func(engine.MVCCKeyValue) (bool, error),
 ) error {
-	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return err
 	}
 	return s.r.Iterate(start, end, f)

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -146,9 +146,9 @@ func (s *Iterator) UnsafeValue() []byte {
 
 // ComputeStats is part of the engine.Iterator interface.
 func (s *Iterator) ComputeStats(
-	start, end engine.MVCCKey, nowNanos int64,
+	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	return s.i.ComputeStats(start, end, nowNanos)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1916,12 +1916,7 @@ func ReadMaxHLCUpperBound(ctx context.Context, engines []engine.Engine) (int64, 
 }
 
 func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
-	kvs, err := engine.Scan(
-		eng,
-		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMin)),
-		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMax)),
-		10,
-	)
+	kvs, err := engine.Scan(eng, roachpb.KeyMin, roachpb.KeyMax, 10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* storage/engine: remove unused Iterator.PrevKey
* storage/engine: adjust {start,end} arg types for FindSplitKey
* storage/engine: adjust {start,end} arg types for ComputeStats
* storage/engine: adjust {start,end} arg types for ClearIterRange
* storage/engine: adjust {start,end} arg types for {Iterate,Scan}

Release note: None