### PR TITLE
sql: fix databaseCache first read old bug

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -639,7 +639,10 @@ var _ dbCacheSubscriber = &databaseCacheHolder{}
 // received.
 func (dc *databaseCacheHolder) updateSystemConfig(cfg *config.SystemConfig) {
 	dc.mu.Lock()
-	dc.mu.c = newDatabaseCache(cfg)
+	dc.mu.c.Lock()
+	dc.mu.c.databases = &sync.Map{}
+	dc.mu.c.Unlock()
+	dc.mu.c.systemConfig = cfg
 	dc.mu.cv.Broadcast()
 	dc.mu.Unlock()
 }


### PR DESCRIPTION
When I started the three-node cluster, I created the database, and created a table under the database, and looked up the data in the table at Node1. Then I looked up the table, renamed the database, and looked up the table again at Node2. Finally, I looked up the table as the original name of the database at Node1, first to retrieve the table information, and second to show that it does not exist.

Fixed: #41894

Release note: None