### PR TITLE
cmd/roachtest: pay attention to ignorelist in ORM tests

### DIFF
--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -177,7 +177,7 @@ func registerGopg(r *testRegistry) {
 				destPath, goPath, resultsFilePath, goPath),
 		)
 
-		results.parseJUnitXML(t, expectedFailures, xmlResults)
+		results.parseJUnitXML(t, expectedFailures, ignorelist, xmlResults)
 		results.summarizeFailed(
 			t, "gopg", blacklistName, expectedFailures, version, latestTag,
 			0, /* notRunCount */

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -181,7 +181,7 @@ func registerHibernate(r *testRegistry) {
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "hibernate" /* ormName */, output,
-			blacklistName, expectedFailures, version, latestTag,
+			blacklistName, expectedFailures, nil /* ignorelist */, version, latestTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -96,16 +96,9 @@ func registerLibPQ(r *testRegistry) {
 			fmt.Sprintf("cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -v 2>&1 | %s/bin/go-junit-report > %s", libPQPath, goPath, resultsPath),
 		)
 
-		// Add ignored failures to expected failures.
-		// TODO(asubiotto): Add ignored tests to
-		//  parseAndSummarizeJavaORMTestsResults.
-		for k, v := range ignoredFailures {
-			expectedFailures[k] = v
-		}
-
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "lib/pq" /* ormName */, []byte(resultsPath),
-			blacklistName, expectedFailures, version, latestTag,
+			blacklistName, expectedFailures, ignoredFailures, version, latestTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -115,11 +115,16 @@ func registerPgjdbc(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		blacklistName, expectedFailures, _, _ := pgjdbcBlacklists.getLists(version)
+		blacklistName, expectedFailures, ignorelistName, ignorelist := pgjdbcBlacklists.getLists(version)
 		if expectedFailures == nil {
 			t.Fatalf("No pgjdbc blacklist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blacklist %s", version, blacklistName)
+		status := fmt.Sprintf("Running cockroach version %s, using blacklist %s", version, blacklistName)
+		if ignorelist != nil {
+			status = fmt.Sprintf("Running cockroach version %s, using blacklist %s, using ignorelist %s",
+				version, blacklistName, ignorelistName)
+		}
+		c.l.Printf("%s", status)
 
 		t.Status("running pgjdbc test suite")
 		// Note that this is expected to return an error, since the test suite
@@ -166,7 +171,7 @@ func registerPgjdbc(r *testRegistry) {
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "pgjdbc" /* ormName */, output,
-			blacklistName, expectedFailures, version, latestTag,
+			blacklistName, expectedFailures, ignorelist, version, latestTag,
 		)
 	}
 


### PR DESCRIPTION
Previously, pgjdbc and libpq would ignore the ignore list.
Now this is fixed.

Fixes: #41886.

Release note: None