### PR TITLE
sqlmigrations: don't run baked-in migrations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,3 +1,7 @@
+# LogicTest: local fakedist
+# This test file fails with the local-mixed-19.1-19.2 config because some extra
+# migrations run in that configuration and create unexpected events.
+
 ##################
 # TABLE DDL
 ##################
@@ -63,7 +67,7 @@ WHERE "eventType" = 'create_table'
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
+WHERE "eventType" = 'alter_table'
 ----
 
 statement ok
@@ -71,7 +75,7 @@ ALTER TABLE a ADD val INT
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
+WHERE "eventType" = 'alter_table'
 ----
 1  test.public.a
 
@@ -108,7 +112,7 @@ ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
+WHERE "eventType" = 'alter_table'
 ----
 1  test.public.a
 1  test.public.a
@@ -389,7 +393,7 @@ ALTER TABLE a CONFIGURE ZONE DISCARD
 query IT
 SELECT "reportingID", "info"
 FROM system.eventlog
-WHERE "eventType" = 'set_zone_config' and info not like '%system.public%'
+WHERE "eventType" = 'set_zone_config'
 ORDER BY "timestamp"
 ----
 1  {"Target":"TABLE test.public.a","Options":"range_max_bytes = 67108865, range_min_bytes = 16777216","User":"root"}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -275,6 +275,8 @@ func databaseIDs(names ...string) func(ctx context.Context, db db) ([]sqlbase.ID
 // See docs/RFCs/cluster_upgrade_tool.md for details.
 type migrationDescriptor struct {
 	// name must be unique amongst all hard-coded migrations.
+	// ATTENTION: A migration's name can never be changed. It is included in a key
+	// marking a migration as completed.
 	name string
 	// workFn must be idempotent so that we can safely re-run it if a node failed
 	// while running it. nil if the migration has been "backed in" and is no


### PR DESCRIPTION
Before this patch, the migration runner had a mechanism by which it
attempted to not run migrations that were included in the cluster
bootstrap schema. That mechanism was weak. A migration could be marked
as includedInBootstrap, and then the migration runner would skip it if
the current node had just performed a bootstrap. However, the respective
migration would still be run (aimlessly) by a 2nd node joining the
cluster, or even by the same node that just skipped them, after a restart.

This patch improves the mechanism such that migrations included in the
bootstrap image are never run if the cluster's bootstrap version is high
enough. It does so by allowing one to mark migrations with the version
at which they've been introduced, and the runner will skip them if the
cluster's bootstrap version is >=.  This means that migrations that want
to be marked in this way also need to introduce a cluster version.

The benefit of this change, besides faster node startup time, removal of
confusing entries from the system.event_log table and more
determinism (because now some migrations are never run instead of not
run on single node clusters but run on multi-node clusters), is that
logic tests that hardcode expected cluster events are more easily
written. Before this patch, those tests had to explicitly ignore some
events that are generated by migrations (because, again, depending on
the configuration, the migration would sometimes run and sometimes not).
It's now the second time this happens to a change that I personally want
to make, and it's very surprising and scary when it happens to you. You
can see the edit in the event_log logic test for a case that I'm not
correcting (there's probably others in the same file but I haven't
looked).

Release note: None.