### PR TITLE
release-19.2: storage/reports: convert some fields to timestamptz

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -63,7 +63,7 @@ WHERE "eventType" = 'create_table'
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table'
+WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
 ----
 
 statement ok
@@ -71,7 +71,7 @@ ALTER TABLE a ADD val INT
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table'
+WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
 ----
 1  test.public.a
 
@@ -108,7 +108,7 @@ ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
 query IT rowsort
 SELECT "reportingID", info::JSONB->>'TableName' FROM system.eventlog
-WHERE "eventType" = 'alter_table'
+WHERE "eventType" = 'alter_table' AND info::JSONB->>'TableName' not like 'system.public.%'
 ----
 1  test.public.a
 1  test.public.a

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -874,7 +874,7 @@ var (
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: *types.Int},
-			{Name: "generated", ID: 2, Type: *types.Timestamp},
+			{Name: "generated", ID: 2, Type: *types.TimestampTZ},
 		},
 		NextColumnID: 3,
 		Families: []ColumnFamilyDescriptor{
@@ -917,7 +917,7 @@ var (
 			{Name: "type", ID: 3, Type: *types.String},
 			{Name: "config", ID: 4, Type: *types.String},
 			{Name: "report_id", ID: 5, Type: *types.Int},
-			{Name: "violation_start", ID: 6, Type: *types.Timestamp, Nullable: true},
+			{Name: "violation_start", ID: 6, Type: *types.TimestampTZ, Nullable: true},
 			{Name: "violating_ranges", ID: 7, Type: *types.Int},
 		},
 		NextColumnID: 8,

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -233,6 +233,28 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "update system.locations with default location data",
 		workFn: updateSystemLocationData,
 	},
+	{
+		// Introduced in v19.2.
+		name:                "change reports fields from timestamp to timestamptz",
+		includedInBootstrap: true,
+		workFn: func(ctx context.Context, r runner) error {
+			// Note that these particular schema changes are idempotent.
+			if _, err := r.sqlExecutor.ExecWithUser(ctx, "update-reports-meta-generated", nil, /* txn */
+				security.NodeUser,
+				`ALTER TABLE system.reports_meta ALTER generated TYPE TIMESTAMP WITH TIME ZONE`,
+			); err != nil {
+				return err
+			}
+			if _, err := r.sqlExecutor.ExecWithUser(ctx, "update-reports-meta-generated", nil, /* txn */
+				security.NodeUser,
+				"ALTER TABLE system.replication_constraint_stats ALTER violation_start "+
+					"TYPE TIMESTAMP WITH TIME ZONE",
+			); err != nil {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 func staticIDs(ids ...sqlbase.ID) func(ctx context.Context, db db) ([]sqlbase.ID, error) {

--- a/pkg/storage/reports/reporter.go
+++ b/pkg/storage/reports/reporter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -851,4 +852,38 @@ func (r *meta2RangeIter) reset() {
 	r.buffer = nil
 	r.resumeSpan = nil
 	r.readingDone = false
+}
+
+type reportID int
+
+// getReportGenerationTime returns the time at a particular report was last
+// generated. Returns time.Time{} if the report is not found.
+func getReportGenerationTime(
+	ctx context.Context, rid reportID, ex sqlutil.InternalExecutor, txn *client.Txn,
+) (time.Time, error) {
+	row, err := ex.QueryRow(
+		ctx,
+		"get-previous-timestamp",
+		txn,
+		"select generated from system.reports_meta where id = $1",
+		rid,
+	)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if row == nil {
+		return time.Time{}, nil
+	}
+
+	if len(row) != 1 {
+		return time.Time{}, errors.AssertionFailedf(
+			"expected 1 column from intenal query, got: %d", len(row))
+	}
+	generated, ok := row[0].(*tree.DTimestampTZ)
+	if !ok {
+		return time.Time{}, errors.AssertionFailedf("expected to get timestamptz from "+
+			"system.reports_meta got %+v (%T)", row[0], row[0])
+	}
+	return generated.Time, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #41905.

/cc @cockroachdb/release

---

This patch adds a migration converting the columns
system.reports_meta.generated and system.replication_straint_stats from
timestamp to timestamptz.

Timestamp is a fairly useless data type with surprising behavior -
clients generally interpret a timestamp value to be in their local time
zone. For representing a point in time, one wants a timestamptz.

Release note (sql change): The system.reports_meta.generated and
system.replication_straint_stats columns now have type timestamptz
instead of timestamp.
