### PR TITLE
sql: fix databaseCache first read old bug

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -639,6 +639,8 @@ var _ dbCacheSubscriber = &databaseCacheHolder{}
 // received.
 func (dc *databaseCacheHolder) updateSystemConfig(cfg *config.SystemConfig) {
 	dc.mu.Lock()
+	dc.mu.c.disable()
+	// use newDatabaseCache avoid race without lock
 	dc.mu.c = newDatabaseCache(cfg)
 	dc.mu.cv.Broadcast()
 	dc.mu.Unlock()


### PR DESCRIPTION
When I started the three-node cluster, I created the database, and created a table under the database, and looked up the data in the table at Node1. Then I looked up the table, renamed the database, and looked up the table again at Node2. Finally, I looked up the table as the original name of the database at Node1, first to retrieve the table information, and second to show that it does not exist.

Fixed: #41894

Release note: None