### PR TITLE
roachtest: don't get stuck on consistency check

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1331,10 +1331,14 @@ func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
 		c.l.Printf("no live node found, skipping consistency check")
 		return
 	}
-
 	defer db.Close()
 
-	if err := c.CheckReplicaDivergenceOnDB(ctx, db); err != nil {
+	if err := contextutil.RunWithTimeout(
+		ctx, "consistency check", time.Minute,
+		func(ctx context.Context) error {
+			return c.CheckReplicaDivergenceOnDB(ctx, db)
+		},
+	); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Add a context cancellation. I saw an acceptance failure that got stuck
here and the result was that the logs were never collected (on top of
completely horking up the test run).

Release note: None