### PR TITLE
sql: don't look up FK metadata when not checking FKs

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -182,8 +182,9 @@ func Load(
 				}
 			}
 
-			ri, err = row.MakeInserter(nil, tableDesc, nil, tableDesc.Columns,
-				true, &sqlbase.DatumAlloc{})
+			ri, err = row.MakeInserter(
+				nil, tableDesc, tableDesc.Columns, row.SkipFKs, nil /* fkTables */, &sqlbase.DatumAlloc{},
+			)
 			if err != nil {
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make row inserter")
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -210,9 +210,9 @@ func (n *createTableNode) startExec(params runParams) error {
 		ri, err := row.MakeInserter(
 			params.p.txn,
 			sqlbase.NewImmutableTableDescriptor(*desc.TableDesc()),
-			nil,
 			desc.Columns,
 			row.SkipFKs,
+			nil, /* fkTables */
 			&params.p.alloc)
 		if err != nil {
 			return err

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -42,9 +42,9 @@ type Inserter struct {
 func MakeInserter(
 	txn *client.Txn,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
-	fkTables FkTableMetadata,
 	insertCols []sqlbase.ColumnDescriptor,
 	checkFKs checkFKConstraints,
+	fkTables FkTableMetadata,
 	alloc *sqlbase.DatumAlloc,
 ) (Inserter, error) {
 	ri := Inserter{

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -273,8 +273,14 @@ func NewDatumRowConverter(
 		return nil, errors.Wrap(err, "process default columns")
 	}
 
-	ri, err := MakeInserter(nil /* txn */, immutDesc, nil, /* fkTables */
-		cols, false /* checkFKs */, &sqlbase.DatumAlloc{})
+	ri, err := MakeInserter(
+		nil, /* txn */
+		immutDesc,
+		cols,
+		SkipFKs,
+		nil, /* fkTables */
+		&sqlbase.DatumAlloc{},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "make row inserter")
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -199,8 +199,9 @@ func makeUpdaterWithoutCascader(
 		}
 		ru.FetchCols = ru.rd.FetchCols
 		ru.FetchColIDtoRowIndex = ColIDtoRowIndexFromCols(ru.FetchCols)
-		if ru.ri, err = MakeInserter(txn, tableDesc, fkTables,
-			tableCols, SkipFKs, alloc); err != nil {
+		if ru.ri, err = MakeInserter(
+			txn, tableDesc, tableCols, SkipFKs, nil /* fkTables */, alloc,
+		); err != nil {
 			return Updater{}, err
 		}
 	} else {


### PR DESCRIPTION
The `fkTables` argument to `MakeInserter` is only used when we are
checking FKs; don't generate it when skipping the old path.

Release note: None