### PR TITLE
WIP: testutils: Implement a light weight dependency injection mechanism.

### DIFF
--- a/pkg/testutils/testvalue/testvalue.go
+++ b/pkg/testutils/testvalue/testvalue.go
@@ -1,0 +1,139 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testvalue
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+// enabled controls whether testvalue.Adjust will perform it's operation.
+// Since the check against enabled happens from production code, we don't want to add additional
+// synchronization overhead when checking this option.  Hence, the use of atomics.
+var enabled int32
+
+var mu sync.Mutex
+var registry = make(map[string]interface{})
+
+// Tests must call Enable() at least once.
+// Enable() should be called from the tests init(): otherwise, due to parallel test execution,
+// it's possible that the code under test may not observe modified value.
+func Enable() {
+	atomic.StoreInt32(&enabled, 1)
+}
+
+// Clears out all registered values.  Requires Enabled() has been called.
+func Reset() {
+	checkEnabled()
+	mu.Lock()
+	registry = make(map[string]interface{})
+	mu.Unlock()
+}
+
+// A CallbackSetter is a callback that's responsible for returning the value to assign.
+type CallbackSetter func() interface{}
+
+type callback struct {
+	setter CallbackSetter
+}
+
+// Set is called by the unit test to arrange an override for the specified 'key'.
+// Requires Enable() has been called.
+func Set(key string, val interface{}) {
+	checkEnabled()
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, ok := registry[key]
+
+	if ok {
+		panic(fmt.Sprintf("Cannot register value with the key '%s'; it's already registered", key))
+	}
+
+	registry[key] = val
+}
+
+// Similar to Set() above, but the setter is specified as a function which takes in the original value
+// and returns the new value for the override.
+func SetCallback(key string, setter CallbackSetter) {
+	Set(key, callback{setter})
+}
+
+// Adjust is called from production code to modify a value for the specified key.
+// The passed in value must be a pointer type, and, if the override has been set, the types
+// of the *ival and the override must match.
+//
+// This method is a no-op if enable has not been called, or if the override has not been set for the 'key'
+func Adjust(key string, ival interface{}) {
+	if atomic.LoadInt32(&enabled) == 0 {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	registered, ok := registry[key]
+	if !ok {
+		return
+	}
+
+	val := reflect.ValueOf(ival)
+	var override reflect.Value
+
+	if cb, ok := registered.(callback); ok {
+		// If our override is a callback setter, execute the callback to get the override value.
+		override = reflect.ValueOf(cb.setter())
+	} else {
+		override = reflect.ValueOf(registered)
+	}
+
+	// Perform various checks (via reflection) before updating the value.
+	// The checks below are not strictly needed; the Set call at the end panics if the value is not assignable for
+	// any reasons.  However, we try to provide a bit more interesting error messages to simplify debugging.
+
+	// Value must be a pointer type so that we can assign to it.
+	if val.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("Cannot adjust non-ptr values for key '%s'", key))
+	}
+
+	// Ensure we can assign override to *value.
+	if !override.Type().AssignableTo(val.Elem().Type()) {
+		msg := fmt.Sprintf("Cannot assing '%v %v' to variable of type '%v' for key '%s'",
+			override, override.Type(), val.Elem().Type(), key)
+		if override.Kind() == reflect.Func {
+			msg += "; did you intend to call testvalue.SetCallback() instead of testvalue.Set()?"
+		}
+		panic(msg)
+	}
+
+	// If the *value is an interface, and the override is a function,
+	// we want to ensure that the function signatures match, and if they don't we return an error.
+	// Note: if the functions signatures do not match, we can still assign to *value (since it's an interface).
+	// We would get a run time error when we try to invoke this function (with wrong arguments), but it's better
+	// to return an error right at the Adjust() point instead of getting the error at (potentially much) later time.
+	if val.Elem().Kind() == reflect.Interface && override.Kind() == reflect.Func {
+		ptrT := reflect.TypeOf(val.Elem().Interface())
+		if !override.Type().AssignableTo(ptrT) {
+			panic(fmt.Sprintf("Cannot assing '%v %v' to interface of type '%v' for key '%s'",
+				override, override.Type(), ptrT, key))
+		}
+	}
+
+	val.Elem().Set(override)
+}
+
+func checkEnabled() {
+	if atomic.LoadInt32(&enabled) == 0 {
+		panic("Cannot set test value; Did you call 'defer testvalue.Enable()()' in your test?")
+	}
+}

--- a/pkg/testutils/testvalue/testvalue_test.go
+++ b/pkg/testutils/testvalue/testvalue_test.go
@@ -1,0 +1,426 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testvalue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func init() {
+	Enable()
+}
+
+func expectPanic(t *testing.T) {
+	if r := recover(); r == nil {
+		t.Errorf("The code did not panic")
+	}
+}
+
+func forceDisable() func() {
+	atomic.StoreInt32(&enabled, 0)
+	return Enable
+}
+
+func TestCannotSetWhenDisabled(t *testing.T) {
+	defer expectPanic(t)
+	defer forceDisable()()
+	Set("foo", 1)
+}
+
+func TestCanCallAdjustWhenDisabled(t *testing.T) {
+	defer forceDisable()()
+	Adjust("foo", nil)
+}
+
+// Adjust requires a pointer type argument.
+func TestAdjustRequiresPointerArg(t *testing.T) {
+	// Attempt to call Adjust for various non-pointer types, and verify that these calls panic.
+	for _, v := range []interface{}{
+		1, 2.0, true, "str",
+		[]int{3, 2, 1}, map[int]bool{0: true, 1: false},
+		struct{}{}, []struct{}{{}, {}},
+		nil, func() {},
+	} {
+		t.Run(fmt.Sprintf("check-non-pointer-%T", v), func(t *testing.T) {
+			defer Reset()
+
+			group := ctxgroup.WithContext(context.Background())
+			defer func() {
+				if err := group.Wait(); err != nil {
+					t.Error(err)
+				}
+			}()
+
+			group.Go(func() (err error) {
+				err = nil
+				defer func() {
+					if r := recover(); r == nil {
+						err = errors.New(fmt.Sprintf("Expected to panic for value %v of type %T", v, v))
+					}
+				}()
+				Set("foo", v)
+				Adjust("foo", v)
+				return
+			})
+		})
+	}
+}
+
+// Calling Adjust() when the override was not set in test is a no-op.
+func TestAdjustWhenNotSetIsNoop(t *testing.T) {
+	defer Reset()
+
+	for _, v := range []interface{}{
+		1, 2.0, true, "str",
+		[]int{3, 2, 1}, map[int]bool{0: true, 1: false},
+		struct{}{}, []struct{}{{}, {}},
+	} {
+		t.Run(fmt.Sprintf("check-adjust-when-not-set-%T", v), func(t *testing.T) {
+			old := v
+			Adjust("not-there", &v)
+			assert.True(t, reflect.DeepEqual(old, v))
+		})
+	}
+}
+
+func TestCanAdjustValues(t *testing.T) {
+	for _, testCase := range []struct {
+		val      interface{}
+		override interface{}
+	}{
+		{
+			val:      1,
+			override: 42,
+		},
+		{
+			val:      true,
+			override: false,
+		},
+		{
+			val:      "hello world",
+			override: "hello moon",
+		},
+		{
+			val:      []int{3, 2, 1},
+			override: []int{42},
+		},
+		{
+			val:      map[string]int{"0": 0, "1": 1},
+			override: map[string]int{"1": 1, "2": 2, "3": 3},
+		},
+	} {
+		t.Run(fmt.Sprintf("adjust-%T", testCase.val), func(t *testing.T) {
+			defer Reset()
+			Set("adjust", testCase.override)
+			Adjust("adjust", &testCase.val)
+			assert.True(t, reflect.DeepEqual(testCase.val, testCase.override))
+		})
+	}
+}
+
+func TestCanAdjustValuesViaSetter(t *testing.T) {
+	for _, testCase := range []struct {
+		val      interface{}
+		expected interface{}
+		setter   CallbackSetter
+	}{
+		{
+			val:      1,
+			expected: 42,
+			setter:   func() interface{} { return 42 },
+		},
+		{
+			val:      true,
+			expected: false,
+			setter:   func() interface{} { return false },
+		},
+		{
+			val:      "hello world",
+			expected: "bonjour monde",
+			setter:   func() interface{} { return "bonjour monde" },
+		},
+		{
+			val:      []int{3, 2, 1},
+			expected: []int{1, 2, 3, 42},
+			setter:   func() interface{} { return []int{1, 2, 3, 42} },
+		},
+		{
+			val:      map[string]int{"0": 0, "1": 1},
+			expected: map[string]int{},
+			setter: func() interface{} {
+				return map[string]int{}
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("adjust-with-setter-%T", testCase.val), func(t *testing.T) {
+			defer Reset()
+
+			SetCallback("var", testCase.setter)
+			Adjust("var", &testCase.val)
+			assert.True(t, reflect.DeepEqual(testCase.expected, testCase.val))
+		})
+	}
+}
+
+func TestAdjustTypesMustMatch(t *testing.T) {
+	makeBadResults := func(b ...interface{}) []interface{} { return b }
+
+	for _, testCase := range []struct {
+		val interface{}
+		bad []interface{}
+	}{
+		{
+			val: 1,
+			bad: makeBadResults(true, []int{}, "bad", 2.0, map[string]int{}),
+		},
+		{
+			val: true,
+			bad: makeBadResults(1, []int{}, "bad", 2.0, map[string]int{}),
+		},
+		{
+			val: "hello world",
+			bad: makeBadResults(true, []int{}, 2.0, map[string]int{}),
+		},
+		{
+			val: []int{3, 2, 1},
+			bad: makeBadResults(true, "bad", []string{}, 2.0, map[string]int{}),
+		},
+		{
+			val: map[string]int{"0": 0, "1": 1},
+			bad: makeBadResults(true, "bad", []string{}, 2.0, map[string]string{}),
+		},
+	} {
+		for _, badVal := range testCase.bad {
+			for _, useSetter := range []bool{false, true} {
+				t.Run(fmt.Sprintf("bad-adjust-%T->%T-use_setter=%v", badVal, testCase.val, useSetter), func(t *testing.T) {
+					defer Reset()
+
+					if useSetter {
+						SetCallback("bad", func() interface{} { return badVal })
+					} else {
+						Set("bad", badVal)
+					}
+
+					// Arrange for panic propagation back to t.
+					group := ctxgroup.WithContext(context.Background())
+					defer func() {
+						if err := group.Wait(); err != nil {
+							t.Error(err)
+						}
+					}()
+
+					group.Go(func() (err error) {
+						err = nil
+						defer func() {
+							if r := recover(); r == nil {
+								err = errors.New("expected panic, but alas")
+							}
+						}()
+						Adjust("bad", testCase.val)
+						return
+					})
+				})
+			}
+		}
+	}
+}
+
+func TestCanAdjustFunc(t *testing.T) {
+	defer Reset()
+
+	val := 1
+	handler := func() {
+		val = 0
+	}
+
+	Set("fun", func() {
+		val = 42
+	})
+
+	Adjust("fun", &handler)
+
+	handler()
+	assert.Equal(t, 42, val)
+}
+
+// Test that adjusting values of function type, the signature of the function
+// must match exactly.
+func TestFuncSignatureMustMatchExactly(t *testing.T) {
+	for i, testCase := range []struct {
+		f1 interface{}
+		f2 interface{}
+	}{
+		{
+			f1: func() {},
+			f2: func() error { return nil },
+		},
+		{
+			f1: func() {},
+			f2: func(int) {},
+		},
+		{
+			f1: func(int) {},
+			f2: func() {},
+		},
+		{
+			f1: func(int) (int, int, int) { return 0, 0, 0 },
+			f2: func(int) (int, int) { return 0, 0 },
+		},
+	} {
+		t.Run(fmt.Sprintf("sig-match-%T-%T", testCase.f1, testCase.f2), func(t *testing.T) {
+			defer Reset()
+
+			group := ctxgroup.WithContext(context.Background())
+			defer func() {
+				if err := group.Wait(); err != nil {
+					t.Error(err)
+				}
+			}()
+
+			group.Go(func() (err error) {
+				err = nil
+				defer func() {
+					if r := recover(); r == nil {
+						err = errors.New(fmt.Sprintf("Expected to panic for test case %d", i))
+					}
+				}()
+				key := fmt.Sprintf("fun-%d", i)
+				Set(key, testCase.f1)
+				Adjust(key, &testCase.f2)
+				return
+			})
+		})
+	}
+}
+
+type greeter interface {
+	getGreeting() string
+}
+
+type dummyGreeter struct{}
+
+var _ greeter = &dummyGreeter{}
+
+func (*dummyGreeter) getGreeting() string {
+	return "dummy"
+}
+
+type cannedResponseGreeter struct {
+	response string
+}
+
+var _ greeter = &cannedResponseGreeter{}
+
+func (g *cannedResponseGreeter) getGreeting() string {
+	return g.response
+}
+
+// Tests adjustment through interface pointer.
+func TestCanAdjustInterface(t *testing.T) {
+	defer Reset()
+
+	var greeting greeter = &dummyGreeter{}
+
+	Set("impl", &cannedResponseGreeter{"hello world"})
+	Adjust("impl", &greeting)
+
+	assert.Equal(t, "hello world", greeting.getGreeting())
+}
+
+func TestCanAdjustChannel(t *testing.T) {
+	defer Reset()
+
+	ch := make(chan string)
+	origCh := ch
+	assert.True(t, ch == origCh)
+
+	Set("ch", make(chan string))
+	Adjust("ch", &ch)
+
+	assert.True(t, ch != origCh)
+}
+
+func TestCannotAdjustChannelsOfIncompatibleTypes(t *testing.T) {
+	defer Reset()
+	defer expectPanic(t)
+
+	ch := make(chan string)
+	Set("ch", make(chan int))
+	Adjust("ch", &ch)
+}
+
+type stoppable struct {
+	stopped bool
+}
+
+func (s *stoppable) stop() {
+	s.stopped = true
+}
+
+// Ensure the cleanup code scheduled w/ defer on the original object runs even if we
+// adjust the value.
+func TestAdjustDoesNotLeakDeferredCleanup(t *testing.T) {
+	defer Reset()
+
+	st := &stoppable{}
+	orig := st
+
+	defer func() {
+		// We schedule the deferred cleanup work below (st.stop), before we override 'st' with a new
+		// value.  The cleanup against original st should have run anyway.
+		assert.True(t, orig.stopped)
+		assert.False(t, st.stopped)
+	}()
+
+	defer st.stop()
+
+	Set("st", &stoppable{})
+	Adjust("st", &st)
+}
+
+// A call to testvalue.Adjust doesn't need to actually change anything.
+// It can be used to synchronise the test with asynchronous execution of production code.
+// This test verifies this behavior.
+func TestCanUseAdjustToSynchronise(t *testing.T) {
+	defer Reset()
+
+	ready := make(chan interface{})
+	proceed := make(chan interface{})
+
+	go func() {
+		// This is the asynchronous code ("server") we want to synchronise with.
+		var z bool
+		Adjust("sync_point", &z)
+	}()
+
+	SetCallback("sync_point", func() interface{} {
+		// This function is called when the "server" runs.
+		// So, notify the test that we're ready (i.e. we're blocked in the server code).
+		ready <- struct{}{}
+
+		// Wait for the test to tell us to continue execution.
+		<-proceed
+		return false
+	})
+
+	// In the test, we wait until we're blocked (ready)...
+	<-ready
+	// We could modify some external state here, while the "server" is paused.
+	// Then we let the server continue.
+	proceed <- struct{}{}
+}


### PR DESCRIPTION
testvalue package provides a way for the production code to enable
the tests to do, essentially, a light weight dependency injection.
This package makes it possible to expose certain aspects of the
internal implemenation (such as return value of a call) to the tests,
and enables those tests to modify those internal attributes without
forcing to use heavy dependenchy injection mechanisms.

Server code:
  ....
  res, err := doSomething()
  testvalue.Adjust("inject_server_error", &err)
  ...

Test code:
  Enable()
  testvalue.Set("inject_server_error", error.New("bad error"))

This library will ensure that the adjusted values have correct types and are assignable
to the value in the first place.  The assignment through interface pointer is supported,
so the test could for example, inject a "mock" implementation should they wish to do so.

The values can also be set via a callback:
  testvalue.SetCallback("inject_server_error", func() interface{} { return myError })

The SetCallback() approach enables the tests to have more interesting use cases,
such as synchronizatgion between the test and the code under the test with minimal fuss.

Release note: None