### PR TITLE
storage/engine: add EncryptedFS and FileCipherStreamCreator for encrypted files in Pebble

### DIFF
--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -1,0 +1,198 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package engineccl
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+)
+
+// FileCipherStreamCreator wraps the KeyManager interface and provides functions to create a
+// FileStream for either a new file (using the active key provided by the KeyManager) or an
+// existing file (by looking up the key in the KeyManager).
+type FileCipherStreamCreator struct {
+	envType    enginepb.EnvType
+	keyManager PebbleKeyManager
+}
+
+const (
+	// The difference is 4 bytes, which are supplied by the counter.
+	ctrBlockSize = 16
+	ctrNonceSize = 12
+)
+
+// CreateNew creates a FileStream for a new file using the currently active key. It returns the
+// settings used, so that the caller can record these in a file registry.
+func (c *FileCipherStreamCreator) CreateNew(
+	ctx context.Context,
+) (*enginepbccl.EncryptionSettings, FileStream, error) {
+	key, err := c.keyManager.ActiveKey(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	settings := &enginepbccl.EncryptionSettings{}
+	if key == nil || key.Info.EncryptionType == enginepbccl.EncryptionType_Plaintext {
+		settings.EncryptionType = enginepbccl.EncryptionType_Plaintext
+		stream := &filePlainStream{}
+		return settings, stream, nil
+	}
+	settings.EncryptionType = key.Info.EncryptionType
+	settings.KeyId = key.Info.KeyId
+	settings.Nonce = make([]byte, ctrNonceSize)
+	_, err = rand.Read(settings.Nonce)
+	if err != nil {
+		return nil, nil, err
+	}
+	counterBytes := make([]byte, 4)
+	if _, err = rand.Read(counterBytes); err != nil {
+		return nil, nil, err
+	}
+	// Does not matter how we convert 4 random bytes into uint32
+	settings.Counter = binary.LittleEndian.Uint32(counterBytes)
+	ctrCS, err := newCTRBlockCipherStream(key, settings.Nonce, settings.Counter)
+	if err != nil {
+		return nil, nil, err
+	}
+	return settings, &fileCipherStream{bcs: ctrCS}, nil
+}
+
+// CreateExisting creates a FileStream for an existing file by looking up the key described by
+// settings in the key manager.
+func (c *FileCipherStreamCreator) CreateExisting(
+	settings *enginepbccl.EncryptionSettings,
+) (FileStream, error) {
+	if settings == nil || settings.EncryptionType == enginepbccl.EncryptionType_Plaintext {
+		return &filePlainStream{}, nil
+	}
+	key, err := c.keyManager.GetKey(settings.KeyId)
+	if err != nil {
+		return nil, err
+	}
+	ctrCS, err := newCTRBlockCipherStream(key, settings.Nonce, settings.Counter)
+	if err != nil {
+		return nil, err
+	}
+	return &fileCipherStream{bcs: ctrCS}, nil
+}
+
+// FileStream encrypts/decrypts byte slices at arbitrary file offsets.
+//
+// There are two implementations: a noop filePlainStream and a fileCipherStream that wraps
+// a ctrBlockCipherStream. The ctrBlockCipherStream does AES in counter mode (CTR). CTR
+// allows us to encrypt/decrypt at arbitrary byte offsets in a file (including partial
+// blocks) without caring about what preceded the bytes.
+type FileStream interface {
+	// Encrypt encrypts the data to be written at fileOffset.
+	Encrypt(fileOffset int64, data []byte)
+	// Decrypt decrypts the data that has been read from fileOffset.
+	Decrypt(fileOffset int64, data []byte)
+}
+
+// Implements a noop FileStream.
+type filePlainStream struct{}
+
+func (s *filePlainStream) Encrypt(fileOffset int64, data []byte) {}
+func (s *filePlainStream) Decrypt(fileOffset int64, data []byte) {}
+
+// Implements a FileStream with AES-CTR.
+type fileCipherStream struct {
+	bcs *cTRBlockCipherStream
+}
+
+func (s *fileCipherStream) Encrypt(fileOffset int64, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	blockIndex := uint64(fileOffset / int64(ctrBlockSize))
+	blockOffset := int(fileOffset % int64(ctrBlockSize))
+	// TODO(sbhola): Use sync.Pool for these temporary buffers.
+	var buf struct {
+		dataScratch [ctrBlockSize]byte
+		ivScratch   [ctrBlockSize]byte
+	}
+	for len(data) > 0 {
+		// The num bytes that must be encrypted in this block.
+		byteCount := ctrBlockSize - blockOffset
+		if byteCount > len(data) {
+			// The data ends before the end of this block.
+			byteCount = len(data)
+		}
+		if byteCount < int(ctrBlockSize) {
+			// Need to copy into dataScratch, starting at blockOffset. NB: in CTR mode it does
+			// not matter what is contained in the other bytes in the block (the ones we are not
+			// initializing using this copy()).
+			copy(buf.dataScratch[blockOffset:blockOffset+byteCount], data[:byteCount])
+			s.bcs.transform(blockIndex, buf.dataScratch[:], buf.ivScratch[:])
+			// Copy the transformed data back into data.
+			copy(data[:byteCount], buf.dataScratch[blockOffset:blockOffset+byteCount])
+			blockOffset = 0
+		} else {
+			s.bcs.transform(blockIndex, data[:byteCount], buf.ivScratch[:])
+		}
+		blockIndex++
+		data = data[byteCount:]
+	}
+}
+
+// For CTR, decryption and encryption are the same
+func (s *fileCipherStream) Decrypt(fileOffset int64, data []byte) {
+	s.Encrypt(fileOffset, data)
+}
+
+// AES in CTR mode.
+type cTRBlockCipherStream struct {
+	key     *enginepbccl.SecretKey
+	nonce   [ctrNonceSize]byte
+	counter uint32
+
+	cBlock cipher.Block
+}
+
+func newCTRBlockCipherStream(
+	key *enginepbccl.SecretKey, nonce []byte, counter uint32,
+) (*cTRBlockCipherStream, error) {
+	switch key.Info.EncryptionType {
+	case enginepbccl.EncryptionType_AES128_CTR:
+	case enginepbccl.EncryptionType_AES192_CTR:
+	case enginepbccl.EncryptionType_AES256_CTR:
+	default:
+		return nil, fmt.Errorf("unknown EncryptionType: %d", key.Info.EncryptionType)
+	}
+	stream := &cTRBlockCipherStream{key: key, counter: counter}
+	// Copy the nonce since the caller may overwrite it in the future.
+	copy(stream.nonce[:], nonce)
+	var err error
+	if stream.cBlock, err = aes.NewCipher(key.Key); err != nil {
+		return nil, err
+	}
+	if stream.cBlock.BlockSize() != ctrBlockSize {
+		return nil, fmt.Errorf("unexpected block size: %d", stream.cBlock.BlockSize())
+	}
+	return stream, nil
+}
+
+// For CTR, decryption and encryption are the same. data must have length equal to
+// the block size, and scratch must have length >= block size.
+func (s *cTRBlockCipherStream) transform(blockIndex uint64, data []byte, scratch []byte) {
+	iv := append(scratch[:0], s.nonce[:]...)
+	var blockCounter = uint32(uint64(s.counter) + blockIndex)
+	binary.BigEndian.PutUint32(iv[len(iv):len(iv)+4], blockCounter)
+	iv = iv[0 : len(iv)+4]
+	s.cBlock.Encrypt(iv, iv)
+	for i := 0; i < ctrBlockSize; i++ {
+		data[i] = data[i] ^ iv[i]
+	}
+}

--- a/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
@@ -1,0 +1,175 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package engineccl
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+var testData = []byte("Call me Ishmael. Some years ago—never mind how long precisely—" +
+	"having little or no money in my purse, and nothing particular to interest me " +
+	"on shore, I thought I would sail about a little and see the watery part of the world.")
+
+func generateKey(encType enginepbccl.EncryptionType) (*enginepbccl.SecretKey, error) {
+	key := &enginepbccl.SecretKey{}
+	key.Info = &enginepbccl.KeyInfo{}
+	key.Info.EncryptionType = encType
+	var keyLength int
+	switch encType {
+	case enginepbccl.EncryptionType_AES128_CTR:
+		keyLength = 16
+	case enginepbccl.EncryptionType_AES192_CTR:
+		keyLength = 24
+	case enginepbccl.EncryptionType_AES256_CTR:
+		keyLength = 32
+	}
+	key.Key = make([]byte, keyLength)
+	_, err := rand.Read(key.Key)
+	return key, err
+}
+
+func TestFileCipherStream(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	encTypes := []enginepbccl.EncryptionType{enginepbccl.EncryptionType_AES128_CTR,
+		enginepbccl.EncryptionType_AES192_CTR, enginepbccl.EncryptionType_AES256_CTR}
+	for _, encType := range encTypes {
+		key, err := generateKey(encType)
+		require.NoError(t, err)
+		var counter uint32 = 5
+		nonce := make([]byte, ctrNonceSize)
+		_, err = rand.Read(nonce)
+		require.NoError(t, err)
+		bcs, err := newCTRBlockCipherStream(key, nonce, counter)
+		require.NoError(t, err)
+		fcs := fileCipherStream{bcs: bcs}
+
+		var data []byte
+		data = append(data, testData...)
+
+		// Using some arbitrary file offsets, and for each of these offsets cycle through the
+		// full block size so that we have tested all partial blocks at the beginning and end
+		// of a sequence.
+		for _, fOffset := range []int64{5, 23, 435, 2000} {
+			for i := 0; i < ctrBlockSize; i++ {
+				offset := fOffset + int64(i)
+				fcs.Encrypt(offset, data)
+				if diff := pretty.Diff(data, testData); diff == nil {
+					t.Fatal("encryption was a noop")
+				}
+				fcs.Decrypt(offset, data)
+				if diff := pretty.Diff(data, testData); diff != nil {
+					t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+				}
+			}
+		}
+	}
+}
+
+type testKeyManager struct {
+	keys     map[string]*enginepbccl.SecretKey
+	activeID string
+}
+
+func (m *testKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
+	key, _ := m.GetKey(m.activeID)
+	return key, nil
+}
+func (m *testKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
+	key, found := m.keys[id]
+	if !found {
+		return nil, fmt.Errorf("")
+	}
+	return key, nil
+}
+
+func TestFileCipherStreamCreator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Key manager with a "foo" active key.
+	km := testKeyManager{}
+	km.activeID = "foo"
+	key, err := generateKey(enginepbccl.EncryptionType_AES192_CTR)
+	key.Info.KeyId = "foo"
+	require.NoError(t, err)
+	km.keys = make(map[string]*enginepbccl.SecretKey)
+	km.keys["foo"] = key
+	fcs := &FileCipherStreamCreator{envType: enginepb.EnvType_Data, keyManager: &km}
+
+	// Existing stream that uses "foo" key.
+	nonce := make([]byte, 12)
+	encSettings := &enginepbccl.EncryptionSettings{
+		EncryptionType: enginepbccl.EncryptionType_AES192_CTR, KeyId: "foo", Nonce: nonce}
+	fs1, err := fcs.CreateExisting(encSettings)
+	require.NoError(t, err)
+	data := append([]byte{}, testData...)
+	fs1.Encrypt(5, data)
+	encData := append([]byte{}, data...) // remember the encrypted data.
+
+	// Create another stream that uses "foo" key with the same nonce and counter (i.e., same file)
+	// and decrypt and compare.
+	fs2, err := fcs.CreateExisting(encSettings)
+	require.NoError(t, err)
+	fs2.Decrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff != nil {
+		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+
+	// Encryption/decryption is noop.
+	encSettings.EncryptionType = enginepbccl.EncryptionType_Plaintext
+	fs3, err := fcs.CreateExisting(encSettings)
+	require.NoError(t, err)
+	fs3.Encrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff != nil {
+		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+	fs3.Decrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff != nil {
+		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+
+	// Create a new stream that uses the "foo" key. A different IV and nonce should be chosen so the
+	// encrypted state will not be the same as the previous stream.
+	encSettings, fs4, err := fcs.CreateNew(context.Background())
+	require.Equal(t, "foo", encSettings.KeyId)
+	require.Equal(t, enginepbccl.EncryptionType_AES192_CTR, encSettings.EncryptionType)
+	require.NoError(t, err)
+	fs4.Encrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff == nil {
+		t.Fatalf("encryption was a noop")
+	}
+	if diff := pretty.Diff(data, encData); diff == nil {
+		t.Fatalf("unexpected equality")
+	}
+	fs4.Decrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff != nil {
+		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+
+	// Make the active key = nil, so encryption/decryption is a noop.
+	km.activeID = "bar"
+	encSettings, fs5, err := fcs.CreateNew(context.Background())
+	require.Equal(t, "", encSettings.KeyId)
+	require.Equal(t, enginepbccl.EncryptionType_Plaintext, encSettings.EncryptionType)
+	require.NoError(t, err)
+	fs5.Encrypt(5, data)
+	if diff := pretty.Diff(data, testData); diff != nil {
+		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+}

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -1,0 +1,199 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package engineccl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// High-level code structure.
+//
+// A pebble instance can operate in two modes:
+// - With a single FS, used for all files.
+// - With three FSs, when encryption-at-rest is on. We refer to these FSs as the base-FS,
+//   store-FS and data-FS. The base-FS contains unencrypted files, the store-FS contains
+//   files encrypted using the user-specified store keys, and the data-FS contains files
+//   encrypted using generated keys.
+//
+// Both the data-FS and store-FS are wrappers around the base-FS, i.e., they encrypt and
+// decrypt data being written to and read from files in the base-FS. The environment in which
+// these exist knows which file to open in which FS. Specifically,
+// - The file registry uses the base-FS to store the FileRegistry proto. This registry provides
+//   information about files in the store-FS and data-FS (the EnvType::Store and EnvType::Data
+//   respectively). This information includes which FS the file belongs to (for consistency
+//   checking that a file created using one FS is not being read in another) and information
+//   about encryption settings used for the file, including the key id.
+// - The StoreKeyManager uses the base-FS to read the user-specified store keys at startup.
+//   These are in two key files: the active key file and the old key file, which contain the
+//   key id and the key.
+// - The store-FS is used only for storing the key file for the generated keys. It is used by
+//   the DataKeyManager. These keys are rotated periodically in a simple manner -- a new
+//   active key is generated for future file writes. Existing files are not affected.
+//
+// The data-FS and store-FS both use a common implementation. They consume:
+// - the FS they are wrapping: it is always the base-FS in our case, but it does not matter.
+// - The single file registry they share to record information about their files.
+// - A KeyManager interface wrapped in a FileStreamCreator, that provides a simple
+//   interface for encrypting and decrypting data in a file at arbitrary byte offsets.
+//
+// Both data-FS and store-FS can be operating in plaintext mode if the user-specified store
+// keys are "plain".
+//
+// For query execution spilling to disk: we want to use encryption, but the registries do not need
+// to be on disk since on restart the query path will wipe all the existing files it has written.
+// The setup would include a memFS and there would logically be four FSs: base-FS (unencrypted
+// disk based FS), mem-FS (unencrypted memory based FS), store-FS (encrypted memory based FS),
+// data-FS (encrypted disk based FS).
+// - The file registry uses mem-FS to store the FileRegistry proto.
+// - The StoreKeyManager uses the base-FS to read the user-specified store keys.
+// - The store-FS wraps a mem-FS for reading/writing data keys.
+// - The DataKeyManager uses the store-FS.
+// - The data-FS wraps a base-FS for reading/writing data.
+
+// encryptedFile implements vfs.File.
+type encryptedFile struct {
+	vfs.File
+	mu struct {
+		syncutil.Mutex
+		rOffset int64
+		wOffset int64
+	}
+	stream FileStream
+}
+
+// Write implements io.Writer.
+func (f *encryptedFile) Write(p []byte) (n int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stream.Encrypt(f.mu.wOffset, p)
+	n, err = f.File.Write(p)
+	f.mu.wOffset += int64(n)
+	return n, err
+}
+
+// Read implements io.Reader.
+func (f *encryptedFile) Read(p []byte) (n int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n, err = f.ReadAt(p, f.mu.rOffset)
+	f.mu.rOffset += int64(n)
+	return n, err
+}
+
+// ReadAt implements io.ReaderAt
+func (f *encryptedFile) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = f.File.ReadAt(p, off)
+	if n > 0 {
+		f.stream.Decrypt(off, p[:n])
+	}
+	return n, err
+}
+
+// encryptedFS implements vfs.FS.
+type encryptedFS struct {
+	vfs.FS
+	fileRegistry  *engine.PebbleFileRegistry
+	streamCreator *FileCipherStreamCreator
+}
+
+// Create implements vfs.FS.Create. It must not be used for WAL reuse -- see ReuseWAL().
+func (fs *encryptedFS) Create(name string) (vfs.File, error) {
+	f, err := fs.FS.Create(name)
+	if err != nil {
+		return f, err
+	}
+	settings, stream, err := fs.streamCreator.CreateNew(context.TODO())
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	fproto := &enginepb.FileEntry{}
+	fproto.EnvType = fs.streamCreator.envType
+	if fproto.EncryptionSettings, err = protoutil.Marshal(settings); err != nil {
+		f.Close()
+		return nil, err
+	}
+	if err = fs.fileRegistry.SetFileEntry(name, fproto); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &encryptedFile{File: f, stream: stream}, nil
+}
+
+// Link implements vfs.FS.Link.
+func (fs *encryptedFS) Link(oldname, newname string) error {
+	if err := fs.FS.Link(oldname, newname); err != nil {
+		return err
+	}
+	return fs.fileRegistry.MaybeLinkEntry(oldname, newname)
+}
+
+// Open implements vfs.FS.Open.
+func (fs *encryptedFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
+	f, err := fs.FS.Open(name, opts...)
+	if err != nil {
+		return f, err
+	}
+	fileEntry := fs.fileRegistry.GetFileEntry(name)
+	var settings *enginepbccl.EncryptionSettings
+	if fileEntry != nil {
+		if fileEntry.EnvType != fs.streamCreator.envType {
+			f.Close()
+			return nil, fmt.Errorf("filename: %s has env %d not equal to FS env %d",
+				name, fileEntry.EnvType, fs.streamCreator.envType)
+		}
+		settings = &enginepbccl.EncryptionSettings{}
+		if err := protoutil.Unmarshal(fileEntry.EncryptionSettings, settings); err != nil {
+			f.Close()
+			return nil, err
+		}
+	}
+	stream, err := fs.streamCreator.CreateExisting(settings)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &encryptedFile{File: f, stream: stream}, nil
+}
+
+// Remove implements vfs.FS.Remove.
+func (fs *encryptedFS) Remove(name string) error {
+	if err := fs.FS.Remove(name); err != nil {
+		return err
+	}
+	return fs.fileRegistry.MaybeDeleteEntry(name)
+}
+
+// Rename implements vfs.FS.Rename. It must not be used for WAL reuse -- see ReuseWAL().
+func (fs *encryptedFS) Rename(oldname, newname string) error {
+	if err := fs.FS.Rename(oldname, newname); err != nil {
+		return err
+	}
+	return fs.fileRegistry.MaybeRenameEntry(oldname, newname)
+}
+
+// ReuseWAL attempts to reuse the WAL file with oldname by renaming it to newname and opening
+// it for writing.
+//
+// We cannot change any of the key/iv/nonce and reuse the same file since RocksDB does not
+// like non-empty WAL files with zero readable entries. There is a todo in env_encryption.cc
+// to change this RocksDB behavior.
+//
+// TODO(sbhola): add this to Pebble's vfs.FS interface and change WAL reuse to use it.
+func (fs *encryptedFS) ReuseWAL(oldname, newname string) (vfs.File, error) {
+	return nil, fmt.Errorf("cannot reuse an encrypted WAL file")
+}

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -357,7 +357,7 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 ) (err error) {
 	defer func() {
 		if err != nil {
-			log.Infof(ctx, "error while attempting to rotate data key: %s", err.Error())
+			log.Infof(ctx, "error while attempting to rotate data key: %s", err)
 		} else {
 			log.Infof(ctx, "rotated to new active data key: %s", proto.CompactTextString(m.mu.activeKey.Info))
 		}


### PR DESCRIPTION
The EncryptedFS uses FileCipherStreamCreator to create a FileStream that does
encryption/decryption. The fileCipherStream implementation of FileStream does
AES in CTR mode. The FileCipherStreamCreator wraps a PebbleKeyManager to
lookup keys by id or to get the active key.

Release note: None
