### PR TITLE
settings/cluster: introducing the 19.2 cluster version

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -134,6 +134,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-11</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -46,6 +46,7 @@ const (
 	VersionAtomicChangeReplicas
 	VersionTableDescModificationTimeFromMVCC
 	VersionPartitionedBackup
+	Version19_2
 
 	// Add new versions here (step one of two).
 
@@ -550,6 +551,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionPartitionedBackup is https://github.com/cockroachdb/cockroach/pull/39250.
 		Key:     VersionPartitionedBackup,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 11},
+	},
+	{
+		// Version19_2 is CockroachDB v19.2. It's used for all v19.2.x patch releases.
+		Key:     Version19_2,
+		Version: roachpb.Version{Major: 19, Minor: 2},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/cockroach_versions_test.go
+++ b/pkg/settings/cluster/cockroach_versions_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestVersionsAreValid(t *testing.T) {
+	t.Skip("test skipped on the release 19.2 branch because we haven't " +
+		"removed old migrations introduced in 19.1")
 	defer leaktest.AfterTest(t)()
 
 	require.NoError(t, versionsSingleton.Validate())

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[VersionAtomicChangeReplicas-12]
 	_ = x[VersionTableDescModificationTimeFromMVCC-13]
 	_ = x[VersionPartitionedBackup-14]
+	_ = x[Version19_2-15]
 }
 
-const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackup"
+const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2"
 
-var _VersionKey_index = [...]uint16{0, 10, 47, 82, 93, 109, 133, 149, 171, 198, 220, 246, 280, 307, 347, 371}
+var _VersionKey_index = [...]uint16{0, 10, 47, 82, 93, 109, 133, 149, 171, 198, 220, 246, 280, 307, 347, 371, 382}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -289,7 +289,7 @@ select crdb_internal.set_vmodule('')
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-19.1
+19.2
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -442,7 +442,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-19.1
+19.2
 
 user root
 


### PR DESCRIPTION
This is not a backport; it's original work on the release-19.2 branch.
The corresponding work on master is #41931.

I've had to skip a test because it was validating that we've removed all
the versions introduced before 19.1, since they're now "always active".
Work to remove those versions is in progress on master.

Release note: None