### PR TITLE
cli/flags: actually mark --global as hidden

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -599,7 +599,7 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
-	_ = demoCmd.Flags().MarkHidden(cliflags.Global.Name)
+	_ = demoFlags.MarkHidden(cliflags.Global.Name)
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)


### PR DESCRIPTION
Found by @jseldess 

The --global flag is experimental and not currently
advertised/documented. Previously, the code attempted to hide it by
using the `MarkHidden()` method on the flagset available via
`Flags()`. However, the flag is defined via `PersistentFlags()`, a
different flagset. As a result, the `--global` flag was not
effectively hidden.

This patch fixes it by calling `MarkHidden()` via `PersistentFlags()`
as originally intended.

Release note: None