### PR TITLE
roachtest: expand set of retryable relocate errors

### DIFF
--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -342,6 +342,7 @@ func isExpectedRelocateError(err error) bool {
 		"unable to add replica .* which is already present",
 		"received invalid ChangeReplicasTrigger .* to remove self",
 		"failed to apply snapshot: raft group deleted",
+		"snapshot failed:",
 	}
 	pattern := "(" + strings.Join(whitelist, "|") + ")"
 	return testutils.IsError(err, pattern)


### PR DESCRIPTION
We sometimes see:

`pq: while carrying out changes [{ADD_REPLICA n5,s5} {REMOVE_REPLICA n2,s2}]: snapshot failed: (n5,s5):7LEARNER: remote couldn't accept LEARNER snapshot 110b1e10 at applied index 3832 with error: [n5,s5],r605: cannot apply snapshot: [n5,s5]: canApplySnapshotLocked: cannot add placeholder, have an existing placeholder range=605 [/Table/53/1/2828746468845570048-/Table/53/1/2847174784603523072) (placeholder) (n3,s3):6`

Probably we should more completely propagate the right error code for
all of these matched errors but we shouldn't fail the test on this one
either so here's a bandaid.

Fixes #41491

Release note: None