### PR TITLE
release-19.2: cli/flags: actually mark --global as hidden

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -601,7 +601,7 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
-	_ = demoCmd.Flags().MarkHidden(cliflags.Global.Name)
+	_ = demoFlags.MarkHidden(cliflags.Global.Name)
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)


### PR DESCRIPTION
**Note:** We don't need this in the initial 19.2 release so I can hold off the merge for a little while, however we'll want it in 19.2.1.

Backport 1/1 commits from #41936.

/cc @cockroachdb/release

---
