### PR TITLE
sql: remove ResultColumns.Omitted

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -251,26 +251,15 @@ func joinOutColumns(
 	// The join columns are in two groups:
 	//  - the columns on the left side (numLeftCols)
 	//  - the columns on the right side (numRightCols)
-	joinCol := 0
-	leftCols := 0
 	for i := 0; i < n.pred.numLeftCols; i++ {
-		if !n.columns[i].Omitted {
-			joinToStreamColMap[joinCol] = addOutCol(uint32(leftPlanToStreamColMap[i]))
-		}
-		if leftPlanToStreamColMap[i] != -1 {
-			leftCols++
-		}
-		joinCol++
+		joinToStreamColMap[i] = addOutCol(uint32(leftPlanToStreamColMap[i]))
 	}
 
 	if n.pred.joinType != sqlbase.LeftSemiJoin && n.pred.joinType != sqlbase.LeftAntiJoin {
 		for i := 0; i < n.pred.numRightCols; i++ {
-			if !n.columns[joinCol].Omitted {
-				joinToStreamColMap[joinCol] = addOutCol(
-					uint32(leftCols + rightPlanToStreamColMap[i]),
-				)
-			}
-			joinCol++
+			joinToStreamColMap[n.pred.numLeftCols+i] = addOutCol(
+				uint32(n.pred.numLeftCols + rightPlanToStreamColMap[i]),
+			)
 		}
 	}
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -560,9 +560,6 @@ func formatColumns(cols sqlbase.ResultColumns, printTypes bool) string {
 		if rCol.Hidden {
 			outputProp("hidden")
 		}
-		if rCol.Omitted {
-			outputProp("omitted")
-		}
 		if hasProps {
 			f.WriteByte(']')
 		}

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -94,20 +94,14 @@ func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
 			return false, nil
 		}
 
-		idx := 0
 		types := r.source.OutputTypes()
-		for i, col := range r.planCols {
-			if col.Omitted {
-				r.datumRow[i] = tree.DNull
-				continue
-			}
-			encDatum := r.row[idx]
-			err := encDatum.EnsureDecoded(&types[idx], &r.da)
+		for i := range r.planCols {
+			encDatum := r.row[i]
+			err := encDatum.EnsureDecoded(&types[i], &r.da)
 			if err != nil {
 				return false, err
 			}
 			r.datumRow[i] = encDatum.Datum
-			idx++
 		}
 
 		return true, nil

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -23,9 +23,6 @@ type ResultColumn struct {
 
 	// If set, this is an implicit column; used internally.
 	Hidden bool
-
-	// If set, a value won't be produced for this column; used internally.
-	Omitted bool
 }
 
 // ResultColumns is the type used throughout the sql module to

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -149,14 +149,10 @@ func (n *valuesNode) startExec(params runParams) error {
 	row := make([]tree.Datum, len(n.columns))
 	for _, tupleRow := range n.tuples {
 		for i, typedExpr := range tupleRow {
-			if n.columns[i].Omitted {
-				row[i] = tree.DNull
-			} else {
-				var err error
-				row[i], err = typedExpr.Eval(params.EvalContext())
-				if err != nil {
-					return err
-				}
+			var err error
+			row[i], err = typedExpr.Eval(params.EvalContext())
+			if err != nil {
+				return err
 			}
 		}
 		if _, err := n.rows.AddRow(params.ctx, row); err != nil {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -166,9 +166,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.expr != nil {
 			for i, tuple := range n.tuples {
 				for j, expr := range tuple {
-					if n.columns[j].Omitted {
-						continue
-					}
 					var fieldName string
 					if v.observer.attr != nil {
 						fieldName = fmt.Sprintf("row %d, expr", i)


### PR DESCRIPTION
The `Omitted` field is not set any more (it was an unfortunate
artifact of the heuristic planner). This commit removes the field and
simplified the code that checked it.

Release note: None