### PR TITLE
ccl/importccl: skip BenchmarkImportWorkload

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -42,6 +42,7 @@ type tableSSTable struct {
 }
 
 func BenchmarkImportWorkload(b *testing.B) {
+	b.Skip("#41932: broken due to adding keys out-of-order to an sstable")
 	if testing.Short() {
 		b.Skip("skipping long benchmark")
 	}


### PR DESCRIPTION
See #41932

Release note: None