### PR TITLE
release-19.1: opt: avoid estimating row count = 0

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -445,6 +445,10 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 		// with most recent first.
 		stats.RowCount = float64(tab.Statistic(0).RowCount())
 
+		// Make sure the row count is at least 1. The stats may be stale, and we
+		// can end up with weird and inefficient plans if we estimate 0 rows.
+		stats.RowCount = max(stats.RowCount, 1)
+
 		// Add all the column statistics, using the most recent statistic for each
 		// column set. Stats are ordered with most recent first.
 		for i := 0; i < tab.StatisticCount(); i++ {
@@ -456,6 +460,10 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 			if colStat, ok := stats.ColStats.Add(cols); ok {
 				colStat.DistinctCount = float64(stat.DistinctCount())
 				colStat.NullCount = float64(stat.NullCount())
+
+				// Make sure the distinct count is at least 1, for the same reason as
+				// the row count above.
+				colStat.DistinctCount = max(colStat.DistinctCount, 1)
 			}
 		}
 	}

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -263,20 +263,20 @@ SELECT count(*) FROM (SELECT * FROM tab0 WHERE col3 = 10) GROUP BY col0
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=0]
+ ├── stats: [rows=0.999973439]
  └── group-by
       ├── columns: col0:2(int) count_rows:8(int)
       ├── grouping columns: col0:2(int)
-      ├── stats: [rows=0, distinct(2)=0, null(2)=0]
+      ├── stats: [rows=0.999973439, distinct(2)=0.999973439, null(2)=0.999973439]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── select
       │    ├── columns: col0:2(int) col3:5(int!null)
-      │    ├── stats: [rows=10, distinct(2)=0, null(2)=10, distinct(5)=1, null(5)=0]
+      │    ├── stats: [rows=10, distinct(2)=0.999973439, null(2)=10, distinct(5)=1, null(5)=0]
       │    ├── fd: ()-->(5)
       │    ├── scan tab0
       │    │    ├── columns: col0:2(int) col3:5(int)
-      │    │    └── stats: [rows=100, distinct(2)=0, null(2)=100, distinct(5)=10, null(5)=0]
+      │    │    └── stats: [rows=100, distinct(2)=1, null(2)=100, distinct(5)=10, null(5)=0]
       │    └── filters
       │         └── col3 = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight), fd=()-->(5)]
       └── aggregations
@@ -1308,16 +1308,16 @@ SELECT * FROM nulls WHERE y = 3
 ----
 project
  ├── columns: x:1(int) y:2(int!null)
- ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9]
+ ├── stats: [rows=9.9, distinct(1)=0.99995224, null(1)=9.9]
  ├── fd: ()-->(2)
  └── select
       ├── columns: x:1(int) y:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9, distinct(2)=1, null(2)=0, distinct(3)=9.9, null(3)=0]
+      ├── stats: [rows=9.9, distinct(1)=0.99995224, null(1)=9.9, distinct(2)=1, null(2)=0, distinct(3)=9.9, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(2), (3)-->(1)
       ├── scan nulls
       │    ├── columns: x:1(int) y:2(int) rowid:3(int!null)
-      │    ├── stats: [rows=1000, distinct(1)=0, null(1)=1000, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    ├── stats: [rows=1000, distinct(1)=1, null(1)=1000, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters


### PR DESCRIPTION
This commit is a very small subset of #37729, which should not cause any
issues in the 19.1 branch. The commit ensures that even if the table statistics
for a table show 0 rows, the `statisticsBuilder` in the optimizer will assume there
is at least 1 row. This has a couple of benefits: 
1. We want to avoid estimating zero rows since the stats may be stale, and
we can end up with weird and inefficient plans if we estimate zero rows.
2. There are some places where the statistics code divides by the row count
to estimate the selectivity. Division by 0 could cause parent operators to estimate
a row count of NaN, resulting in an "infinite" cost. 

Closes #41922

(I'm not sure if this will fix #41922, but it seems like a good candidate, and there's no
way to know for sure...)

Release note: None

---

/cc @cockroachdb/release 
