### PR TITLE
storage/engine: minor pebble timeseries benchmark fix

### DIFF
--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -160,7 +160,7 @@ func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
 		b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
 			for _, mergesPerKey := range []int{1, 16, 256} {
 				b.Run(fmt.Sprintf("mergesPerKey=%d", mergesPerKey), func(b *testing.B) {
-					runMVCCGetMergedValue(ctx, b, setupMVCCPebble, numKeys, mergesPerKey)
+					runMVCCGetMergedValue(ctx, b, setupMVCCInMemPebble, numKeys, mergesPerKey)
 				})
 			}
 		})


### PR DESCRIPTION
Use an in-memory instance to match RocksDB's equivalent benchmark, and to
avoid writing more merge operands per key than intended.

Release note: None