### PR TITLE
engine: don't create aux dir for read-only engine

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -3059,8 +3059,10 @@ func (r *RocksDB) GetAuxiliaryDir() string {
 }
 
 func (r *RocksDB) setAuxiliaryDir(d string) error {
-	if err := os.MkdirAll(d, 0755); err != nil {
-		return err
+	if !r.cfg.ReadOnly {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return err
+		}
 	}
 	r.auxDir = d
 	return nil


### PR DESCRIPTION
It was mildly irritating that

    ./cockroach debug raft-log not/there 1

would create `not/there/auxiliary`.

Release note: None