### PR TITLE
opt: fix panic around hoisting with pruning

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -114,6 +114,24 @@ render                 ·              ·                 ("?column?", "?column?
 ·                      row 0, expr 1  ''                ·                                     ·
 ·                      row 0, expr 2  'x'               ·                                     ·
 
+query TTTTT
+EXPLAIN (VERBOSE)
+SELECT 1 FROM (SELECT k FROM uniontest WHERE k > 3 UNION ALL SELECT k FROM uniontest)
+----
+·                    distributed  false              ·             ·
+·                    vectorized   true               ·             ·
+render               ·            ·                  ("?column?")  ·
+ │                   render 0     1                  ·             ·
+ └── append          ·            ·                  ()            ·
+      ├── scan       ·            ·                  ()            ·
+      │              table        uniontest@primary  ·             ·
+      │              spans        ALL                ·             ·
+      └── render     ·            ·                  ()            ·
+           └── scan  ·            ·                  (k)           ·
+·                    table        uniontest@primary  ·             ·
+·                    spans        ALL                ·             ·
+·                    filter       k > 3              ·             ·
+
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)
 

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -582,7 +582,7 @@
 # EliminateProject.
 [PruneUnionAllCols, Normalize]
 (Project
-    (UnionAll
+    $union:(UnionAll
         $left:*
         $right:*
         $colmap:*
@@ -590,21 +590,17 @@
     $projections:*
     $passthrough:* &
         (CanPruneCols
-            $left
-            $neededLeft:(NeededColMapLeft
-                $needed:(UnionCols
-                    (ProjectionOuterCols $projections) $passthrough
-                )
-                $colmap
-            )
-        ) &
-        (CanPruneCols $right $neededRight:(NeededColMapRight $needed $colmap))
+             $union
+             $needed:(UnionCols
+                 (ProjectionOuterCols $projections) $passthrough
+             )
+         )
 )
 =>
 (Project
     (UnionAll
-        (Project $left [] $neededLeft)
-        (Project $right [] $neededRight)
+        (Project $left [] (NeededColMapLeft $needed $colmap))
+        (Project $right [] (NeededColMapRight $needed $colmap))
         (PruneSetPrivate $needed $colmap)
     )
     $projections

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2874,6 +2874,22 @@ scalar-group-by
       └── count-rows [type=int]
 
 opt expect=PruneUnionAllCols
+SELECT 1 FROM (SELECT a FROM abcde WHERE a > 3 UNION ALL SELECT a FROM abcde)
+----
+project
+ ├── columns: "?column?":12(int!null)
+ ├── fd: ()-->(12)
+ ├── union-all
+ │    ├── project
+ │    │    └── scan abcde
+ │    │         ├── columns: abcde.a:1(int!null)
+ │    │         ├── constraint: /1: [/4 - ]
+ │    │         └── key: (1)
+ │    └── scan abcde@bc
+ └── projections
+      └── const: 1 [type=int]
+
+opt expect=PruneUnionAllCols
 SELECT 1 FROM a INNER JOIN (SELECT a, b FROM abcde UNION ALL SELECT * from xy) AS b ON a.i=b.b
 ----
 project
@@ -2926,3 +2942,72 @@ project
  │              └── fd: ()-->(6)
  └── projections
       └── const: 1 [type=int]
+
+# Regression test for #41772.
+
+exec-ddl
+CREATE TABLE table41772 ()
+----
+
+norm
+WITH
+    a AS (SELECT NULL FROM table41772),
+    b
+        AS (
+            SELECT
+                *
+            FROM
+                (VALUES (NOT NULL, ARRAY[0, 0, 0, 0:::OID]))
+                    AS l (u, v)
+            UNION ALL
+                SELECT
+                    *
+                FROM
+                    (VALUES (NULL, NULL), (false, ARRAY[0:::OID]))
+                        AS r (x, y)
+        )
+SELECT
+    NULL
+FROM
+    a, b
+WHERE
+    b.u
+----
+project
+ ├── columns: "?column?":12(unknown)
+ ├── fd: ()-->(12)
+ ├── inner-join (hash)
+ │    ├── columns: u:7(bool!null)
+ │    ├── scan table41772
+ │    ├── union-all
+ │    │    ├── columns: u:7(bool!null)
+ │    │    ├── left columns: column1:3(bool)
+ │    │    ├── right columns: column1:5(bool)
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── select
+ │    │    │    ├── columns: column1:3(bool!null)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(3)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:3(bool)
+ │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(3)
+ │    │    │    │    └── (NOT NULL,) [type=tuple{bool}]
+ │    │    │    └── filters
+ │    │    │         └── variable: column1 [type=bool, outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ │    │    └── select
+ │    │         ├── columns: column1:5(bool!null)
+ │    │         ├── cardinality: [0 - 2]
+ │    │         ├── fd: ()-->(5)
+ │    │         ├── values
+ │    │         │    ├── columns: column1:5(bool)
+ │    │         │    ├── cardinality: [2 - 2]
+ │    │         │    ├── (NULL,) [type=tuple{bool}]
+ │    │         │    └── (false,) [type=tuple{bool}]
+ │    │         └── filters
+ │    │              └── variable: column1 [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
+ │    └── filters (true)
+ └── projections
+      └── null [type=unknown]


### PR DESCRIPTION
Previously, we would advertise that we can prune all the columns from a
UnionAll operator, but our pruning rule wouldn't actually behave this
way: it would only prune if both inputs could *also* prune. This commit
changes this to only advertise pruning if we can prune from at least one
of the sides, and then prune if at least one of the sides is prunable.

I should have handed this off to Celine when I figured out what was
going on but by then I already had a fix in mind so I just finished it.

Fixes #41973.

Release note (bug fix): fixed a stack overflow that could occur with
certain patterns of queries.