### PR TITLE
storage: fix stats inconsistency due to WriteTooOld optimization

### DIFF
--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -362,8 +362,10 @@ func (r *Replica) evaluateWriteBatchWithLocalRetries(
 	spans *spanset.SpanSet,
 	canRetry bool,
 ) (batch engine.Batch, br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
+	goldenMS := *ms
 	for retries := 0; ; retries++ {
 		if batch != nil {
+			*ms = goldenMS
 			batch.Close()
 		}
 		batch = r.store.Engine().NewBatch()


### PR DESCRIPTION
This fixes a bug introduced in #22315 with the introduction of a "local
retry" to avoid WriteTooOldError inside of 1PC transactions that were
not carrying out any reads. Such a transaction can simply be
re-evaluated at a higher timestamp, which can allow it to commit.

The bug was that when such a re-evaluation was carried out, we were
not discarding the MVCCStats accrued from the first attempt. In
effect, the request would thus be double-counted in stats, which
would set off the consistency checker.

The fix is easy: discard the delta before re-evaluating.

Fixes #31870.

Release note (bug fix): remove a source of (benign) stats
inconsistencies (i.e. the stats of a range not accurately reflecting its
contents).