### PR TITLE
storage: Support nodelocal file access using NodeID

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -89,7 +89,16 @@ func (l *localStorage) List(pattern string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filepath.Glob(fullPath)
+	matches, err := filepath.Glob(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var fileList []string
+	for _, file := range matches {
+		fileList = append(fileList, strings.TrimPrefix(strings.TrimPrefix(file, l.externalIODir), "/"))
+	}
+	return fileList, nil
 }
 
 // Delete prepends IO dir to filename and deletes that local file.

--- a/pkg/blobs/service_test.go
+++ b/pkg/blobs/service_test.go
@@ -124,10 +124,9 @@ func TestBlobServiceList(t *testing.T) {
 	defer cleanupFn()
 
 	fileContent := []byte("a")
-	dir := filepath.Join(tmpDir, "file/dir")
-	files := []string{"a.csv", "b.csv", "c.csv"}
+	files := []string{"file/dir/a.csv", "file/dir/b.csv", "file/dir/c.csv"}
 	for _, file := range files {
-		writeTestFile(t, filepath.Join(dir, file), fileContent)
+		writeTestFile(t, filepath.Join(tmpDir, file), fileContent)
 	}
 
 	service, err := NewBlobService(tmpDir)
@@ -148,7 +147,7 @@ func TestBlobServiceList(t *testing.T) {
 			t.Fatal("result list does not have the correct number of files")
 		}
 		for i, f := range resultList {
-			if f != filepath.Join(dir, files[i]) {
+			if f != files[i] {
 				t.Fatalf("result list is incorrect %s", resultList)
 			}
 		}

--- a/pkg/blobs/testutils.go
+++ b/pkg/blobs/testutils.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package blobs
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// TestBlobServiceClient can be used as a mock BlobClient
+// in tests that use nodelocal storage.
+func TestBlobServiceClient(externalIODir string) BlobClientFactory {
+	return func(ctx context.Context, dialing roachpb.NodeID) (BlobClient, error) {
+		return newLocalClient(externalIODir)
+	}
+}
+
+// TestEmptyBlobClientFactory can be used as a mock BlobClient
+// in tests that create ExternalStorage but do not use
+// nodelocal storage.
+var TestEmptyBlobClientFactory = func(
+	ctx context.Context, dialing roachpb.NodeID,
+) (BlobClient, error) {
+	return nil, nil
+}

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -110,7 +110,7 @@ func BenchmarkLoadRestore(b *testing.B) {
 	b.SetBytes(int64(buf.Len() / b.N))
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
 	b.ResetTimer()
-	if _, err := importccl.Load(ctx, sqlDB.DB.(*gosql.DB), buf, "data", dir, ts, 0, dir); err != nil {
+	if _, err := importccl.Load(ctx, sqlDB.DB.(*gosql.DB), buf, "data", dir, ts, 0, dir, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 	sqlDB.Exec(b, fmt.Sprintf(`RESTORE data.* FROM '%s'`, dir))

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -71,8 +72,10 @@ func TestCloudStorageSink(t *testing.T) {
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
 	e, err := makeJSONEncoder(opts)
 	require.NoError(t, err)
+
+	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, settings)
+		return cloud.ExternalStorageFromURI(ctx, uri, settings, clientFactory)
 	}
 
 	t.Run(`golden`, func(t *testing.T) {

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -53,15 +54,11 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	basepath := args[0]
 	if !strings.Contains(basepath, "://") {
-		var err error
-		basepath, err = cloud.MakeLocalStorageURI(basepath)
-		if err != nil {
-			return err
-		}
+		basepath = cloud.MakeLocalStorageURI(basepath)
 	}
 
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, cluster.NoSettings)
+		return cloud.ExternalStorageFromURI(ctx, uri, cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
 	}
 	// This reads the raw backup descriptor (with table descriptors possibly not
 	// upgraded from the old FK representation, or even older formats). If more

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -13,10 +13,11 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -28,28 +29,29 @@ import (
 
 func TestConverterFlushesBatches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(nil)
 
 	// Reset batch size setting upon test completion.
 	defer row.TestingSetDatumRowConverterBatchSize(0)()
 
 	// Returns a map of file id -> URI for the specified test inputs.
+	base, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working dir: %v", err)
+	}
 	makeInputsSpec := func(inputs ...string) map[int32]string {
-		base, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("Failed to get working dir: %v", err)
-		}
 		res := make(map[int32]string)
 		for id, path := range inputs {
-			if res[int32(id)], err = cloud.MakeLocalStorageURI(filepath.Join(base, path)); err != nil {
-				t.Fatalf("Failed to make local uri: %v", err)
-			}
+			res[int32(id)] = cloud.MakeLocalStorageURI(path)
 		}
 		return res
 	}
 
 	// Helper to create external storage
+	clientFactory := blobs.TestBlobServiceClient(base)
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-		return cloud.MakeExternalStorage(ctx, dest, nil)
+		return cloud.MakeExternalStorage(ctx, dest, &cluster.Settings{ExternalIODir: base}, clientFactory)
 	}
 
 	// Returns an import spec for the specified "create table" statement.
@@ -81,9 +83,6 @@ func TestConverterFlushesBatches(t *testing.T) {
 			return fmt.Sprintf("%s-flush-%d-records", inputFormat, batchSize)
 		}
 	}
-
-	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext(nil)
 
 	tests := []struct {
 		inputFormat roachpb.IOFileFormat_FileFormat

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -183,7 +183,7 @@ func importPlanHook(
 		} else {
 			for _, file := range filenamePatterns {
 				if cloud.URINeedsGlobExpansion(file) {
-					s, err := cloud.ExternalStorageFromURI(ctx, file, p.ExecCfg().Settings)
+					s, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, file)
 					if err != nil {
 						return err
 					}

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -57,7 +57,7 @@ func TestImportChunking(t *testing.T) {
 	}
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts), "data", "nodelocal://"+dir, ts, chunkSize, dir)
+	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts), "data", "nodelocal://"+dir, ts, chunkSize, dir, dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -90,7 +90,7 @@ func TestImportOutOfOrder(t *testing.T) {
 	fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, strings.Join(row1, `,`))
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", "nodelocal:///foo", ts, 0, dir)
+	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", "nodelocal:///foo", ts, 0, dir, dir)
 	if !testutils.IsError(err, "out of order row") {
 		t.Fatalf("expected out of order row, got: %+v", err)
 	}
@@ -117,7 +117,7 @@ func BenchmarkLoad(b *testing.B) {
 	buf := bankBuf(b.N)
 	b.SetBytes(int64(buf.Len() / b.N))
 	b.ResetTimer()
-	if _, err := importccl.Load(ctx, tc.Conns[0], buf, "data", dir, ts, 0, dir); err != nil {
+	if _, err := importccl.Load(ctx, tc.Conns[0], buf, "data", dir, ts, 0, dir, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 }

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -62,7 +62,7 @@ func toBackup(t testing.TB, data workload.Table, dir string, chunkBytes int64) (
 
 	// TODO(dan): The csv load will be less overhead, use it when we have it.
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := importccl.Load(ctx, db, &stmts, `data`, `nodelocal://`+dir, ts, chunkBytes, tempDir)
+	desc, err := importccl.Load(ctx, db, &stmts, `data`, `nodelocal:///`, ts, chunkBytes, tempDir, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -451,10 +451,24 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	// This function defines how ExternalStorage objects are created.
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-		return cloud.MakeExternalStorage(ctx, dest, st)
+		return cloud.MakeExternalStorage(
+			ctx, dest, st,
+			blobs.NewBlobClientFactory(
+				s.nodeIDContainer.Get(),
+				s.nodeDialer,
+				st.ExternalIODir,
+			),
+		)
 	}
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, st)
+		return cloud.ExternalStorageFromURI(
+			ctx, uri, st,
+			blobs.NewBlobClientFactory(
+				s.nodeIDContainer.Get(),
+				s.nodeDialer,
+				st.ExternalIODir,
+			),
+		)
 	}
 
 	// Similarly for execCfg.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1191,7 +1191,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
 			stream.GrepNot(`cockroach/pkg/server/debug/pprofui: path$`),
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
-			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
+			stream.GrepNot(`cockroach/pkg/storage/cloud: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/workloadccl: path$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
 		), func(s string) {


### PR DESCRIPTION
In order to support importing from a specific node's local file
system, `ExternalStorage` needs an access to the blob service.
This PR plumbs through the `blobClient` to `ExternalStorage` and
uses that to access nodelocal files.

Many of the changes are related to tests that depended on nodelocal
and now need mock blob clients to run. The majority of code changes
are in `external_storage.go`.

Release notes (enterprise change):
When specifying a nodelocal file URI (ex. within `IMPORT`,`BACKUP`),
you can now specify which node's local file system you would like to
use. This is done by specifying that node's ID:
`nodelocal://<nodeID>/path/file.csv`