### PR TITLE
release-19.2: build: Upgrade to go 1.12.12

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -38,9 +38,9 @@ echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.12.10.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.12.12.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-aaa84147433aed24e70b31da369bb6ca2859464a45de47c2a5023d8573412f6b  /tmp/go.tgz
+4cf11ac6a8fa42d26ab85e27a5d916ee171900a87745d9f7d4a29a21587d78fc  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20191014-135449
+version=20191029-105705
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,8 +196,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.12.10.src.tar.gz -o golang.tar.gz \
- && echo 'f56e48fce80646d3c94dcf36d3e3f490f6d541a92070ad409b87b6bbb9da3954 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.12.12.src.tar.gz -o golang.tar.gz \
+ && echo 'fcb33b5290fa9bcc52be3211501540df7483d7276b031fc77528672a3c705b99 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \


### PR DESCRIPTION
Backport 1/1 commits from #41993.

/cc @cockroachdb/release

---

This change upgrades the go runtime to 1.12.12 in order to pick up a [security
fix](https://github.com/golang/go/issues/34960).

Per the [checklist](build/README.md):
* [X] Adjust version in Docker image
* [X] Rebuild the Docker image and bump the version in builder.sh accordingly
* [ ] ~Bump the version in go-version-check.sh~ (Patch release, not necessary)
* [X] Bump the default installed version of Go in bootstrap-debian.sh

Fixes: #41718

Release note (build change): The go runtime has been upgraded to 1.12.12.
