### PR TITLE
pkg/sql: Use the TUPLE value type tag on secondary index encoded values

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -867,7 +867,18 @@ func (rf *cFetcher) processValue(
 			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
 		}
 	} else {
-		valueBytes, err := val.GetBytes()
+		var (
+			valueBytes []byte
+			err        error
+		)
+		switch t := val.GetTag(); t {
+		case roachpb.ValueType_TUPLE:
+			valueBytes, err = val.GetTuple()
+		case roachpb.ValueType_BYTES:
+			valueBytes, err = val.GetBytes()
+		default:
+			err = fmt.Errorf("expected value type BYTES or TUPLE, but found: %s", t)
+		}
 		if err != nil {
 			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
 		}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -877,7 +877,18 @@ func (rf *Fetcher) processKV(
 			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
 		}
 	} else {
-		valueBytes, err := kv.Value.GetBytes()
+		var (
+			valueBytes []byte
+			err        error
+		)
+		switch t := kv.Value.GetTag(); t {
+		case roachpb.ValueType_TUPLE:
+			valueBytes, err = kv.Value.GetTuple()
+		case roachpb.ValueType_BYTES:
+			valueBytes, err = kv.Value.GetBytes()
+		default:
+			err = fmt.Errorf("expected value type BYTES or TUPLE, but found: %s", t)
+		}
 		if err != nil {
 			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
 		}

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -850,7 +850,7 @@ func EncodeSecondaryIndex(
 				return []IndexEntry{}, err
 			}
 		}
-		entry.Value.SetBytes(entryValue)
+		entry.Value.SetTuple(entryValue)
 		entries[i] = entry
 	}
 


### PR DESCRIPTION
Secondary index values use the TUPLE type encoding, but the BYTES encoding
tag is present on encoded secondary index values. This PR updates the
value encoding for secondary indexes to now use the TUPLE type tag, but
keeps around the ability for the fetchers to decode the BYTES tag on secondary
indexes for backwards compatibility.

Release note: None