### PR TITLE
acceptance: enable TestComposeGSS

### DIFF
--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgres:11
+# TODO(mjibson): See #41999
+FROM postgres:11.4
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestComposeGSS(t *testing.T) {
-	t.Skip("#41318")
 	out, err := exec.Command(
 		"docker-compose",
 		"-f", filepath.Join("compose", "gss", "docker-compose.yml"),


### PR DESCRIPTION
Pin psql image version to a known working one. This is a workaround
until #41999 is fixed, since it indicates the presence of an actual bug.

Release note: None