### PR TITLE
storage: Update CheckForKeyCollisions to work with Pebble

### DIFF
--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -139,8 +139,7 @@ func EvalAddSSTable(
 	//
 	// However, if the underlying range is _not_ empty, then this is not cheap:
 	// recomputing its stats involves traversing lots of data, and iterating the
-	// merged iterator has to constantly go back and forth to the RocksDB-backed
-	// (cgo) iterator.
+	// merged iterator has to constantly go back and forth to the iterator.
 	//
 	// If we assume that most SSTs don't shadow too many keys, then the error of
 	// simply adding the SST stats directly to the range stats is minimal. In the
@@ -213,15 +212,15 @@ func checkForKeyCollisions(
 	mvccEndKey engine.MVCCKey,
 	data []byte,
 ) (enginepb.MVCCStats, error) {
-	// We could get a spansetBatch so fetch the underlying rocksDBBatchEngine as
+	// We could get a spansetBatch so fetch the underlying db engine as
 	// we need access to the underlying C.DBIterator later, and the
 	// dbIteratorGetter is not implemented by a spansetBatch.
-	rocksDBEngine := spanset.GetDBEngine(batch, roachpb.Span{Key: mvccStartKey.Key, EndKey: mvccEndKey.Key})
+	dbEngine := spanset.GetDBEngine(batch, roachpb.Span{Key: mvccStartKey.Key, EndKey: mvccEndKey.Key})
 
 	emptyMVCCStats := enginepb.MVCCStats{}
 
 	// Create iterator over the existing data.
-	existingDataIter := rocksDBEngine.NewIterator(engine.IterOptions{UpperBound: mvccEndKey.Key})
+	existingDataIter := dbEngine.NewIterator(engine.IterOptions{UpperBound: mvccEndKey.Key})
 	defer existingDataIter.Close()
 	existingDataIter.Seek(mvccStartKey)
 	if ok, err := existingDataIter.Valid(); err != nil {
@@ -231,25 +230,5 @@ func checkForKeyCollisions(
 		return emptyMVCCStats, nil
 	}
 
-	// Create a C++ iterator over the SST being added. This iterator is used to
-	// perform a check for key collisions between the SST being ingested, and the
-	// exisiting data. As the collision check is in C++ we are unable to use a
-	// pure go iterator as in verifySSTable.
-	//
-	// TODO(adityamaru): reuse this iterator in verifySSTable.
-	sst := engine.MakeRocksDBSstFileReader()
-	defer sst.Close()
-
-	if err := sst.IngestExternalFile(data); err != nil {
-		return emptyMVCCStats, err
-	}
-	sstIterator := sst.NewIterator(engine.IterOptions{UpperBound: mvccEndKey.Key})
-	defer sstIterator.Close()
-	sstIterator.Seek(mvccStartKey)
-	if ok, err := sstIterator.Valid(); err != nil || !ok {
-		return emptyMVCCStats, errors.Wrap(err, "checking for key collisions")
-	}
-
-	skippedKVStats, checkErr := engine.CheckForKeyCollisions(existingDataIter, sstIterator)
-	return skippedKVStats, checkErr
+	return existingDataIter.CheckForKeyCollisions(data, mvccStartKey.Key, mvccEndKey.Key)
 }

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -35,6 +35,25 @@ import (
 	"github.com/kr/pretty"
 )
 
+// createTestRocksDBEngine returns a new in-memory RocksDB engine with 1MB of
+// storage capacity.
+func createTestRocksDBEngine() engine.Engine {
+	return engine.NewInMem(enginepb.EngineTypeRocksDB, roachpb.Attributes{}, 1<<20)
+}
+
+// createTestPebbleEngine returns a new in-memory Pebble storage engine.
+func createTestPebbleEngine() engine.Engine {
+	return engine.NewInMem(enginepb.EngineTypePebble, roachpb.Attributes{}, 1<<20)
+}
+
+var engineImpls = []struct {
+	name   string
+	create func() engine.Engine
+}{
+	{"rocksdb", createTestRocksDBEngine},
+	{"pebble", createTestPebbleEngine},
+}
+
 func singleKVSSTable(key engine.MVCCKey, value []byte) ([]byte, error) {
 	sst, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
@@ -309,722 +328,729 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewDefaultInMem()
-	defer e.Close()
+	for _, engineImpl := range engineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	for _, kv := range mvccKVsFromStrs([]strKv{
-		{"A", 1, "A"},
-		{"a", 1, "a"},
-		{"a", 6, ""},
-		{"b", 5, "bb"},
-		{"c", 6, "ccccccccccccccccccccccccccccccccccccccccccccc"}, // key 4b, 50b, live 64b
-		{"d", 1, "d"},
-		{"d", 2, ""},
-		{"e", 1, "e"},
-		{"z", 2, "zzzzzz"},
-	}) {
-		if err := e.Put(kv.Key, kv.Value); err != nil {
-			t.Fatalf("%+v", err)
-		}
-	}
+			for _, kv := range mvccKVsFromStrs([]strKv{
+				{"A", 1, "A"},
+				{"a", 1, "a"},
+				{"a", 6, ""},
+				{"b", 5, "bb"},
+				{"c", 6, "ccccccccccccccccccccccccccccccccccccccccccccc"}, // key 4b, 50b, live 64b
+				{"d", 1, "d"},
+				{"d", 2, ""},
+				{"e", 1, "e"},
+				{"z", 2, "zzzzzz"},
+			}) {
+				if err := e.Put(kv.Key, kv.Value); err != nil {
+					t.Fatalf("%+v", err)
+				}
+			}
 
-	sstKVs := mvccKVsFromStrs([]strKv{
-		{"a", 2, "aa"},     // mvcc-shadowed within SST.
-		{"a", 4, "aaaaaa"}, // mvcc-shadowed by existing delete.
-		{"c", 6, "ccc"},    // same TS as existing, LSM-shadows existing.
-		{"d", 4, "dddd"},   // mvcc-shadow existing deleted d.
-		{"e", 4, "eeee"},   // mvcc-shadow existing 1b.
-		{"j", 2, "jj"},     // no colission – via MVCC or LSM – with existing.
-	})
-	var delta enginepb.MVCCStats
-	// the sst will think it added 4 keys here, but a, c, and e shadow or are shadowed.
-	delta.LiveCount = -3
-	delta.LiveBytes = -109
-	// the sst will think it added 5 keys, but only j is new so 4 are over-counted.
-	delta.KeyCount = -4
-	delta.KeyBytes = -20
-	// the sst will think it added 6 values, but since one was a perfect (key+ts)
-	// collision, it *replaced* the existing value and is over-counted.
-	delta.ValCount = -1
-	delta.ValBytes = -50
+			sstKVs := mvccKVsFromStrs([]strKv{
+				{"a", 2, "aa"},     // mvcc-shadowed within SST.
+				{"a", 4, "aaaaaa"}, // mvcc-shadowed by existing delete.
+				{"c", 6, "ccc"},    // same TS as existing, LSM-shadows existing.
+				{"d", 4, "dddd"},   // mvcc-shadow existing deleted d.
+				{"e", 4, "eeee"},   // mvcc-shadow existing 1b.
+				{"j", 2, "jj"},     // no colission – via MVCC or LSM – with existing.
+			})
+			var delta enginepb.MVCCStats
+			// the sst will think it added 4 keys here, but a, c, and e shadow or are shadowed.
+			delta.LiveCount = -3
+			delta.LiveBytes = -109
+			// the sst will think it added 5 keys, but only j is new so 4 are over-counted.
+			delta.KeyCount = -4
+			delta.KeyBytes = -20
+			// the sst will think it added 6 values, but since one was a perfect (key+ts)
+			// collision, it *replaced* the existing value and is over-counted.
+			delta.ValCount = -1
+			delta.ValBytes = -50
 
-	// Add in a random metadata key.
-	ts := hlc.Timestamp{WallTime: 7}
-	txn := roachpb.MakeTransaction(
-		"test",
-		nil, // baseKey
-		roachpb.NormalUserPriority,
-		ts,
-		base.DefaultMaxClockOffset.Nanoseconds(),
-	)
-	if err := engine.MVCCPut(
-		ctx, e, nil, []byte("i"), ts,
-		roachpb.MakeValueFromBytes([]byte("it")),
-		&txn,
-	); err != nil {
-		if _, isWriteIntentErr := err.(*roachpb.WriteIntentError); !isWriteIntentErr {
-			t.Fatalf("%+v", err)
-		}
-	}
+			// Add in a random metadata key.
+			ts := hlc.Timestamp{WallTime: 7}
+			txn := roachpb.MakeTransaction(
+				"test",
+				nil, // baseKey
+				roachpb.NormalUserPriority,
+				ts,
+				base.DefaultMaxClockOffset.Nanoseconds(),
+			)
+			if err := engine.MVCCPut(
+				ctx, e, nil, []byte("i"), ts,
+				roachpb.MakeValueFromBytes([]byte("it")),
+				&txn,
+			); err != nil {
+				if _, isWriteIntentErr := err.(*roachpb.WriteIntentError); !isWriteIntentErr {
+					t.Fatalf("%+v", err)
+				}
+			}
 
-	// After evalAddSSTable, cArgs.Stats contains a diff to the existing
-	// stats. Make sure recomputing from scratch gets the same answer as
-	// applying the diff to the stats
-	beforeStats := func() enginepb.MVCCStats {
-		iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
-		defer iter.Close()
-		beforeStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		return beforeStats
-	}()
+			// After evalAddSSTable, cArgs.Stats contains a diff to the existing
+			// stats. Make sure recomputing from scratch gets the same answer as
+			// applying the diff to the stats
+			beforeStats := func() enginepb.MVCCStats {
+				iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
+				defer iter.Close()
+				beforeStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return beforeStats
+			}()
 
-	mkSST := func(kvs []engine.MVCCKeyValue) []byte {
-		sst, err := engine.MakeRocksDBSstFileWriter()
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		defer sst.Close()
-		for _, kv := range kvs {
-			if err := sst.Put(kv.Key, kv.Value); err != nil {
+			mkSST := func(kvs []engine.MVCCKeyValue) []byte {
+				sst, err := engine.MakeRocksDBSstFileWriter()
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				defer sst.Close()
+				for _, kv := range kvs {
+					if err := sst.Put(kv.Key, kv.Value); err != nil {
+						t.Fatalf("%+v", err)
+					}
+				}
+				sstBytes, err := sst.Finish()
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return sstBytes
+			}
+
+			sstBytes := mkSST(sstKVs)
+
+			cArgs := batcheval.CommandArgs{
+				Header: roachpb.Header{
+					Timestamp: hlc.Timestamp{WallTime: 7},
+				},
+				Args: &roachpb.AddSSTableRequest{
+					RequestHeader: roachpb.RequestHeader{Key: keys.MinKey, EndKey: keys.MaxKey},
+					Data:          sstBytes,
+				},
+				Stats: &enginepb.MVCCStats{},
+			}
+			if _, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil); err != nil {
 				t.Fatalf("%+v", err)
 			}
-		}
-		sstBytes, err := sst.Finish()
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		return sstBytes
-	}
 
-	sstBytes := mkSST(sstKVs)
+			evaledStats := beforeStats
+			evaledStats.Add(*cArgs.Stats)
 
-	cArgs := batcheval.CommandArgs{
-		Header: roachpb.Header{
-			Timestamp: hlc.Timestamp{WallTime: 7},
-		},
-		Args: &roachpb.AddSSTableRequest{
-			RequestHeader: roachpb.RequestHeader{Key: keys.MinKey, EndKey: keys.MaxKey},
-			Data:          sstBytes,
-		},
-		Stats: &enginepb.MVCCStats{},
-	}
-	if _, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil); err != nil {
-		t.Fatalf("%+v", err)
-	}
+			if err := e.WriteFile("sst", sstBytes); err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if err := e.IngestExternalFiles(ctx, []string{"sst"}); err != nil {
+				t.Fatalf("%+v", err)
+			}
 
-	evaledStats := beforeStats
-	evaledStats.Add(*cArgs.Stats)
+			afterStats := func() enginepb.MVCCStats {
+				iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
+				defer iter.Close()
+				afterStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return afterStats
+			}()
+			evaledStats.Add(delta)
+			evaledStats.ContainsEstimates = false
+			if !afterStats.Equal(evaledStats) {
+				t.Errorf("mvcc stats mismatch: diff(expected, actual): %s", pretty.Diff(afterStats, evaledStats))
+			}
 
-	if err := e.WriteFile("sst", sstBytes); err != nil {
-		t.Fatalf("%+v", err)
+			cArgsWithStats := batcheval.CommandArgs{
+				Header: roachpb.Header{Timestamp: hlc.Timestamp{WallTime: 7}},
+				Args: &roachpb.AddSSTableRequest{
+					RequestHeader: roachpb.RequestHeader{Key: keys.MinKey, EndKey: keys.MaxKey},
+					Data: mkSST([]engine.MVCCKeyValue{{
+						Key:   engine.MVCCKey{Key: roachpb.Key("zzzzzzz"), Timestamp: ts},
+						Value: roachpb.MakeValueFromBytes([]byte("zzz")).RawBytes,
+					}}),
+					MVCCStats: &enginepb.MVCCStats{KeyCount: 10},
+				},
+				Stats: &enginepb.MVCCStats{},
+			}
+			if _, err := batcheval.EvalAddSSTable(ctx, e, cArgsWithStats, nil); err != nil {
+				t.Fatalf("%+v", err)
+			}
+			expected := enginepb.MVCCStats{ContainsEstimates: true, KeyCount: 10}
+			if got := *cArgsWithStats.Stats; got != expected {
+				t.Fatalf("expected %v got %v", expected, got)
+			}
+		})
 	}
-	if err := e.IngestExternalFiles(ctx, []string{"sst"}); err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	afterStats := func() enginepb.MVCCStats {
-		iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
-		defer iter.Close()
-		afterStats, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		return afterStats
-	}()
-	evaledStats.Add(delta)
-	evaledStats.ContainsEstimates = false
-	if !afterStats.Equal(evaledStats) {
-		t.Errorf("mvcc stats mismatch: diff(expected, actual): %s", pretty.Diff(afterStats, evaledStats))
-	}
-
-	cArgsWithStats := batcheval.CommandArgs{
-		Header: roachpb.Header{Timestamp: hlc.Timestamp{WallTime: 7}},
-		Args: &roachpb.AddSSTableRequest{
-			RequestHeader: roachpb.RequestHeader{Key: keys.MinKey, EndKey: keys.MaxKey},
-			Data: mkSST([]engine.MVCCKeyValue{{
-				Key:   engine.MVCCKey{Key: roachpb.Key("zzzzzzz"), Timestamp: ts},
-				Value: roachpb.MakeValueFromBytes([]byte("zzz")).RawBytes,
-			}}),
-			MVCCStats: &enginepb.MVCCStats{KeyCount: 10},
-		},
-		Stats: &enginepb.MVCCStats{},
-	}
-	if _, err := batcheval.EvalAddSSTable(ctx, e, cArgsWithStats, nil); err != nil {
-		t.Fatalf("%+v", err)
-	}
-	expected := enginepb.MVCCStats{ContainsEstimates: true, KeyCount: 10}
-	if got := *cArgsWithStats.Stats; got != expected {
-		t.Fatalf("expected %v got %v", expected, got)
-	}
-
 }
 
 func TestAddSSTableDisallowShadowing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewDefaultInMem()
-	defer e.Close()
+	for _, engineImpl := range engineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	for _, kv := range mvccKVsFromStrs([]strKv{
-		{"a", 2, "aa"},
-		{"b", 1, "bb"},
-		{"b", 6, ""},
-		{"g", 5, "gg"},
-		{"r", 1, "rr"},
-		{"y", 1, "yy"},
-		{"y", 2, ""},
-		{"y", 5, "yyy"},
-		{"z", 2, "zz"},
-	}) {
-		if err := e.Put(kv.Key, kv.Value); err != nil {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	getSSTBytes := func(sstKVs []engine.MVCCKeyValue) []byte {
-		sst, err := engine.MakeRocksDBSstFileWriter()
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		defer sst.Close()
-		for _, kv := range sstKVs {
-			if err := sst.Put(kv.Key, kv.Value); err != nil {
-				t.Fatalf("%+v", err)
+			for _, kv := range mvccKVsFromStrs([]strKv{
+				{"a", 2, "aa"},
+				{"b", 1, "bb"},
+				{"b", 6, ""},
+				{"g", 5, "gg"},
+				{"r", 1, "rr"},
+				{"y", 1, "yy"},
+				{"y", 2, ""},
+				{"y", 5, "yyy"},
+				{"z", 2, "zz"},
+			}) {
+				if err := e.Put(kv.Key, kv.Value); err != nil {
+					t.Fatalf("%+v", err)
+				}
 			}
-		}
-		sstBytes, err := sst.Finish()
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		return sstBytes
-	}
 
-	getStats := func(startKey, endKey roachpb.Key, data []byte) enginepb.MVCCStats {
-		dataIter, err := engine.NewMemSSTIterator(data, true)
-		if err != nil {
-			return enginepb.MVCCStats{}
-		}
-		defer dataIter.Close()
-
-		stats, err := engine.ComputeStatsGo(dataIter, startKey, endKey, 0)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		return stats
-	}
-
-	// Test key collision when ingesting a key in the start of existing data, and
-	// SST. The colliding key is also equal to the header start key.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"a", 7, "aa"}, // colliding key has a higher timestamp than existing version.
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(roachpb.Key("a"), roachpb.Key("b"), sstBytes)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-				MVCCStats:         &stats,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"a\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test key collision when ingesting a key in the middle of existing data, and
-	// start of the SST. The key is equal to the header start key.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"g", 4, "ggg"}, // colliding key has a lower timestamp than existing version.
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"g\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test key collision when ingesting a key at the end of the existing data and
-	// SST. The colliding key is not equal to header start key.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "f"},
-			{"h", 4, "h"},
-			{"s", 1, "s"},
-			{"z", 3, "z"}, // colliding key has a higher timestamp than existing version.
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"z\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test for no key collision where the key range being ingested into is
-	// non-empty. The header start and end keys are not existing keys.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"c", 2, "bb"},
-			{"h", 6, "hh"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-				MVCCStats:         &stats,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test that a collision is not reported when ingesting a key for which we
-	// find a tombstone from an MVCC delete, and the sst key has a ts >= tombstone
-	// ts. Also test that iteration continues from the next key in the existing
-	// data after skipping over all the versions of the deleted key.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"b", 7, "bb"},  // colliding key has a higher timestamp than its deleted version.
-			{"b", 1, "bbb"}, // older version of deleted key (should be skipped over).
-			{"f", 3, "ff"},
-			{"y", 3, "yyyy"}, // colliding key.
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("b"), EndKey: roachpb.Key("z")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test that a collision is  reported when ingesting a key for which we find a
-	// tombstone from an MVCC delete, but the sst key has a ts < tombstone ts.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"b", 4, "bb"}, // colliding key has a lower timestamp than its deleted version.
-			{"f", 3, "ff"},
-			{"y", 3, "yyyy"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("b"), EndKey: roachpb.Key("z")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"b\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test key collision when ingesting a key which has been deleted, and readded
-	// in the middle of the existing data. The colliding key is in the middle of
-	// the SST, and is the earlier of the two possible collisions.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"y", 4, "yyy"}, // colliding key has a lower timestamp than the readded version.
-			{"z", 3, "zzz"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test key collision when ingesting a key which has a write intent in the
-	// existing data.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"q", 4, "qq"},
-			{"t", 3, "ttt"}, // has a write intent in the existing data.
-		})
-
-		// Add in a write intent.
-		ts := hlc.Timestamp{WallTime: 7}
-		txn := roachpb.MakeTransaction(
-			"test",
-			nil, // baseKey
-			roachpb.NormalUserPriority,
-			ts,
-			base.DefaultMaxClockOffset.Nanoseconds(),
-		)
-		if err := engine.MVCCPut(
-			ctx, e, nil, []byte("t"), ts,
-			roachpb.MakeValueFromBytes([]byte("tt")),
-			&txn,
-		); err != nil {
-			if _, isWriteIntentErr := err.(*roachpb.WriteIntentError); !isWriteIntentErr {
-				t.Fatalf("%+v", err)
+			getSSTBytes := func(sstKVs []engine.MVCCKeyValue) []byte {
+				sst, err := engine.MakeRocksDBSstFileWriter()
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				defer sst.Close()
+				for _, kv := range sstKVs {
+					if err := sst.Put(kv.Key, kv.Value); err != nil {
+						t.Fatalf("%+v", err)
+					}
+				}
+				sstBytes, err := sst.Finish()
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return sstBytes
 			}
-		}
 
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("u")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
+			getStats := func(startKey, endKey roachpb.Key, data []byte) enginepb.MVCCStats {
+				dataIter, err := engine.NewMemSSTIterator(data, true)
+				if err != nil {
+					return enginepb.MVCCStats{}
+				}
+				defer dataIter.Close()
 
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "conflicting intents on \"t") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test key collision when ingesting a key which has an inline value in the
-	// existing data.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"i", 4, "ii"}, // has an inline value in existing data.
-			{"j", 3, "jj"},
-		})
-
-		// Add in an inline value.
-		ts := hlc.Timestamp{}
-		if err := engine.MVCCPut(
-			ctx, e, nil, []byte("i"), ts,
-			roachpb.MakeValueFromBytes([]byte("i")),
-			nil,
-		); err != nil {
-			t.Fatalf("%+v", err)
-		}
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("k")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "inline values are unsupported when checking for key collisions") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test ingesting a key with the same timestamp and value. This should not
-	// trigger a collision error.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"e", 4, "ee"},
-			{"f", 2, "ff"},
-			{"y", 5, "yyy"}, // key has the same timestamp and value as the one present in the existing data.
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(roachpb.Key("e"), roachpb.Key("zz"), sstBytes)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("e"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-				MVCCStats:         &stats,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test ingesting a key with different timestamp but same value. This should
-	// trigger a collision error.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"y", 6, "yyy"}, // key has a higher timestamp but same value as the one present in the existing data.
-			{"z", 3, "zzz"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test ingesting a key with the same timestamp but different value. This should
-	// trigger a collision error.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"y", 5, "yyyy"}, // key has the same timestamp but different value as the one present in the existing data.
-			{"z", 3, "zzz"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// Test that a collision after a key with the same timestamp and value causes
-	// a collision error.
-	{
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"f", 2, "ff"},
-			{"y", 5, "yyy"}, // key has the same timestamp and value as the one present in the existing data - not a collision.
-			{"z", 3, "zzz"}, // shadow key
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("e"), EndKey: roachpb.Key("zz")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-			},
-			Stats: &enginepb.MVCCStats{},
-		}
-
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if !testutils.IsError(err, "ingested key collides with an existing one: \"z\"") {
-			t.Fatalf("%+v", err)
-		}
-	}
-
-	// This test ensures accuracy of MVCCStats in the situation that successive
-	// SSTs being ingested via AddSSTable have "perfectly shadowing" keys (same ts
-	// and value). Such KVs are not considered as collisions and so while they are
-	// skipped during ingestion, their stats would previously be double counted.
-	// To mitigate this problem we now return the stats of such skipped KVs while
-	// evaluating the AddSSTable command, and accumulate accurate stats in the
-	// CommandArgs Stats field by using:
-	// cArgs.Stats + ingested_stats - skipped_stats.
-	{
-		// Successfully evaluate the first SST as there are no key collisions.
-		sstKVs := mvccKVsFromStrs([]strKv{
-			{"c", 2, "bb"},
-			{"h", 6, "hh"},
-		})
-
-		sstBytes := getSSTBytes(sstKVs)
-		stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
-
-		// Accumulate stats across SST ingestion.
-		commandStats := enginepb.MVCCStats{}
-
-		cArgs := batcheval.CommandArgs{
-			Header: roachpb.Header{
-				Timestamp: hlc.Timestamp{WallTime: 7},
-			},
-			Args: &roachpb.AddSSTableRequest{
-				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
-				Data:              sstBytes,
-				DisallowShadowing: true,
-				MVCCStats:         &stats,
-			},
-			Stats: &commandStats,
-		}
-		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		firstSSTStats := commandStats
-
-		// Insert KV entries so that we can correctly identify keys to skip when
-		// ingesting the perfectly shadowing KVs (same ts and same value) in the
-		// second SST.
-		for _, kv := range sstKVs {
-			if err := e.Put(kv.Key, kv.Value); err != nil {
-				t.Fatalf("%+v", err)
+				stats, err := engine.ComputeStatsGo(dataIter, startKey, endKey, 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return stats
 			}
-		}
 
-		// Evaluate the second SST. Both the KVs are perfectly shadowing and should
-		// not contribute to the stats.
-		secondSSTKVs := mvccKVsFromStrs([]strKv{
-			{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
-			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
+			// Test key collision when ingesting a key in the start of existing data, and
+			// SST. The colliding key is also equal to the header start key.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"a", 7, "aa"}, // colliding key has a higher timestamp than existing version.
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				stats := getStats(roachpb.Key("a"), roachpb.Key("b"), sstBytes)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+						MVCCStats:         &stats,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"a\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test key collision when ingesting a key in the middle of existing data, and
+			// start of the SST. The key is equal to the header start key.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"g", 4, "ggg"}, // colliding key has a lower timestamp than existing version.
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"g\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test key collision when ingesting a key at the end of the existing data and
+			// SST. The colliding key is not equal to header start key.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "f"},
+					{"h", 4, "h"},
+					{"s", 1, "s"},
+					{"z", 3, "z"}, // colliding key has a higher timestamp than existing version.
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"z\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test for no key collision where the key range being ingested into is
+			// non-empty. The header start and end keys are not existing keys.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"c", 2, "bb"},
+					{"h", 6, "hh"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+						MVCCStats:         &stats,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test that a collision is not reported when ingesting a key for which we
+			// find a tombstone from an MVCC delete, and the sst key has a ts >= tombstone
+			// ts. Also test that iteration continues from the next key in the existing
+			// data after skipping over all the versions of the deleted key.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"b", 7, "bb"},  // colliding key has a higher timestamp than its deleted version.
+					{"b", 1, "bbb"}, // older version of deleted key (should be skipped over).
+					{"f", 3, "ff"},
+					{"y", 3, "yyyy"}, // colliding key.
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("b"), EndKey: roachpb.Key("z")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test that a collision is  reported when ingesting a key for which we find a
+			// tombstone from an MVCC delete, but the sst key has a ts < tombstone ts.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"b", 4, "bb"}, // colliding key has a lower timestamp than its deleted version.
+					{"f", 3, "ff"},
+					{"y", 3, "yyyy"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("b"), EndKey: roachpb.Key("z")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"b\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test key collision when ingesting a key which has been deleted, and readded
+			// in the middle of the existing data. The colliding key is in the middle of
+			// the SST, and is the earlier of the two possible collisions.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"y", 4, "yyy"}, // colliding key has a lower timestamp than the readded version.
+					{"z", 3, "zzz"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test key collision when ingesting a key which has a write intent in the
+			// existing data.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"q", 4, "qq"},
+					{"t", 3, "ttt"}, // has a write intent in the existing data.
+				})
+
+				// Add in a write intent.
+				ts := hlc.Timestamp{WallTime: 7}
+				txn := roachpb.MakeTransaction(
+					"test",
+					nil, // baseKey
+					roachpb.NormalUserPriority,
+					ts,
+					base.DefaultMaxClockOffset.Nanoseconds(),
+				)
+				if err := engine.MVCCPut(
+					ctx, e, nil, []byte("t"), ts,
+					roachpb.MakeValueFromBytes([]byte("tt")),
+					&txn,
+				); err != nil {
+					if _, isWriteIntentErr := err.(*roachpb.WriteIntentError); !isWriteIntentErr {
+						t.Fatalf("%+v", err)
+					}
+				}
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("u")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "conflicting intents on \"t") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test key collision when ingesting a key which has an inline value in the
+			// existing data.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"i", 4, "ii"}, // has an inline value in existing data.
+					{"j", 3, "jj"},
+				})
+
+				// Add in an inline value.
+				ts := hlc.Timestamp{}
+				if err := engine.MVCCPut(
+					ctx, e, nil, []byte("i"), ts,
+					roachpb.MakeValueFromBytes([]byte("i")),
+					nil,
+				); err != nil {
+					t.Fatalf("%+v", err)
+				}
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("k")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "inline values are unsupported when checking for key collisions") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test ingesting a key with the same timestamp and value. This should not
+			// trigger a collision error.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"e", 4, "ee"},
+					{"f", 2, "ff"},
+					{"y", 5, "yyy"}, // key has the same timestamp and value as the one present in the existing data.
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				stats := getStats(roachpb.Key("e"), roachpb.Key("zz"), sstBytes)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("e"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+						MVCCStats:         &stats,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test ingesting a key with different timestamp but same value. This should
+			// trigger a collision error.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"y", 6, "yyy"}, // key has a higher timestamp but same value as the one present in the existing data.
+					{"z", 3, "zzz"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test ingesting a key with the same timestamp but different value. This should
+			// trigger a collision error.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"y", 5, "yyyy"}, // key has the same timestamp but different value as the one present in the existing data.
+					{"z", 3, "zzz"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("f"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"y\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// Test that a collision after a key with the same timestamp and value causes
+			// a collision error.
+			{
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"f", 2, "ff"},
+					{"y", 5, "yyy"}, // key has the same timestamp and value as the one present in the existing data - not a collision.
+					{"z", 3, "zzz"}, // shadow key
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("e"), EndKey: roachpb.Key("zz")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+					},
+					Stats: &enginepb.MVCCStats{},
+				}
+
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if !testutils.IsError(err, "ingested key collides with an existing one: \"z\"") {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			// This test ensures accuracy of MVCCStats in the situation that successive
+			// SSTs being ingested via AddSSTable have "perfectly shadowing" keys (same ts
+			// and value). Such KVs are not considered as collisions and so while they are
+			// skipped during ingestion, their stats would previously be double counted.
+			// To mitigate this problem we now return the stats of such skipped KVs while
+			// evaluating the AddSSTable command, and accumulate accurate stats in the
+			// CommandArgs Stats field by using:
+			// cArgs.Stats + ingested_stats - skipped_stats.
+			{
+				// Successfully evaluate the first SST as there are no key collisions.
+				sstKVs := mvccKVsFromStrs([]strKv{
+					{"c", 2, "bb"},
+					{"h", 6, "hh"},
+				})
+
+				sstBytes := getSSTBytes(sstKVs)
+				stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
+
+				// Accumulate stats across SST ingestion.
+				commandStats := enginepb.MVCCStats{}
+
+				cArgs := batcheval.CommandArgs{
+					Header: roachpb.Header{
+						Timestamp: hlc.Timestamp{WallTime: 7},
+					},
+					Args: &roachpb.AddSSTableRequest{
+						RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+						Data:              sstBytes,
+						DisallowShadowing: true,
+						MVCCStats:         &stats,
+					},
+					Stats: &commandStats,
+				}
+				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				firstSSTStats := commandStats
+
+				// Insert KV entries so that we can correctly identify keys to skip when
+				// ingesting the perfectly shadowing KVs (same ts and same value) in the
+				// second SST.
+				for _, kv := range sstKVs {
+					if err := e.Put(kv.Key, kv.Value); err != nil {
+						t.Fatalf("%+v", err)
+					}
+				}
+
+				// Evaluate the second SST. Both the KVs are perfectly shadowing and should
+				// not contribute to the stats.
+				secondSSTKVs := mvccKVsFromStrs([]strKv{
+					{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
+					{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
+				})
+				secondSSTBytes := getSSTBytes(secondSSTKVs)
+				secondStats := getStats(roachpb.Key("c"), roachpb.Key("i"), secondSSTBytes)
+
+				cArgs.Args = &roachpb.AddSSTableRequest{
+					RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+					Data:              secondSSTBytes,
+					DisallowShadowing: true,
+					MVCCStats:         &secondStats,
+				}
+				_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+
+				// Check that there has been no double counting of stats.
+				if !firstSSTStats.Equal(*cArgs.Stats) {
+					t.Errorf("mvcc stats should not have changed as all keys in second SST are shadowing: %s",
+						pretty.Diff(firstSSTStats, *cArgs.Stats))
+				}
+
+				// Evaluate the third SST. Two of the three KVs are perfectly shadowing, but
+				// there is one valid KV which should contribute to the stats.
+				thirdSSTKVs := mvccKVsFromStrs([]strKv{
+					{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
+					{"e", 2, "ee"},
+					{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
+				})
+				thirdSSTBytes := getSSTBytes(thirdSSTKVs)
+				thirdStats := getStats(roachpb.Key("c"), roachpb.Key("i"), thirdSSTBytes)
+
+				cArgs.Args = &roachpb.AddSSTableRequest{
+					RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+					Data:              thirdSSTBytes,
+					DisallowShadowing: true,
+					MVCCStats:         &thirdStats,
+				}
+				_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+
+				// This is the stats contribution of the KV {"e", 2, "ee"}. This should be
+				// the only addition to the cumulative stats, as the other two KVs are
+				// perfect shadows of existing data.
+				var delta enginepb.MVCCStats
+				delta.LiveCount = 1
+				delta.LiveBytes = 21
+				delta.KeyCount = 1
+				delta.KeyBytes = 14
+				delta.ValCount = 1
+				delta.ValBytes = 7
+
+				// Check that there has been no double counting of stats.
+				firstSSTStats.Add(delta)
+				if !firstSSTStats.Equal(*cArgs.Stats) {
+					t.Errorf("mvcc stats are not accurate: %s",
+						pretty.Diff(firstSSTStats, *cArgs.Stats))
+				}
+			}
 		})
-		secondSSTBytes := getSSTBytes(secondSSTKVs)
-		secondStats := getStats(roachpb.Key("c"), roachpb.Key("i"), secondSSTBytes)
-
-		cArgs.Args = &roachpb.AddSSTableRequest{
-			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
-			Data:              secondSSTBytes,
-			DisallowShadowing: true,
-			MVCCStats:         &secondStats,
-		}
-		_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-
-		// Check that there has been no double counting of stats.
-		if !firstSSTStats.Equal(*cArgs.Stats) {
-			t.Errorf("mvcc stats should not have changed as all keys in second SST are shadowing: %s",
-				pretty.Diff(firstSSTStats, *cArgs.Stats))
-		}
-
-		// Evaluate the third SST. Two of the three KVs are perfectly shadowing, but
-		// there is one valid KV which should contribute to the stats.
-		thirdSSTKVs := mvccKVsFromStrs([]strKv{
-			{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
-			{"e", 2, "ee"},
-			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
-		})
-		thirdSSTBytes := getSSTBytes(thirdSSTKVs)
-		thirdStats := getStats(roachpb.Key("c"), roachpb.Key("i"), thirdSSTBytes)
-
-		cArgs.Args = &roachpb.AddSSTableRequest{
-			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
-			Data:              thirdSSTBytes,
-			DisallowShadowing: true,
-			MVCCStats:         &thirdStats,
-		}
-		_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-
-		// This is the stats contribution of the KV {"e", 2, "ee"}. This should be
-		// the only addition to the cumulative stats, as the other two KVs are
-		// perfect shadows of existing data.
-		var delta enginepb.MVCCStats
-		delta.LiveCount = 1
-		delta.LiveBytes = 21
-		delta.KeyCount = 1
-		delta.KeyBytes = 14
-		delta.ValCount = 1
-		delta.ValBytes = 7
-
-		// Check that there has been no double counting of stats.
-		firstSSTStats.Add(delta)
-		if !firstSSTStats.Equal(*cArgs.Stats) {
-			t.Errorf("mvcc stats are not accurate: %s",
-				pretty.Diff(firstSSTStats, *cArgs.Stats))
-		}
 	}
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -102,6 +102,10 @@ type Iterator interface {
 	// package-level MVCCFindSplitKey instead. For correct operation, the caller
 	// must set the upper bound on the iterator before calling this method.
 	FindSplitKey(start, end, minSplitKey roachpb.Key, targetSize int64) (MVCCKey, error)
+	// CheckForKeyCollisions checks whether any keys collide between the iterator
+	// and the encoded SST data specified, within the provided key range. Returns
+	// stats on skipped KVs, or an error if a collision is found.
+	CheckForKeyCollisions(sstData []byte, start, end roachpb.Key) (enginepb.MVCCStats, error)
 	// MVCCGet is the internal implementation of the family of package-level
 	// MVCCGet functions.
 	//

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -3333,3 +3333,144 @@ func computeCapacity(path string, maxSizeBytes int64) (roachpb.StoreCapacity, er
 		Used:      totalUsedBytes,
 	}, nil
 }
+
+// checkForKeyCollisionsGo iterates through both existingIter and an SST
+// iterator on the provided data in lockstep and errors out at the first key
+// collision, where a collision refers to any two MVCC keys with the
+// same user key, and with a different timestamp or value.
+//
+// An exception is made when the latest version of the colliding key is a
+// tombstone from an MVCC delete in the existing data. If the timestamp of the
+// SST key is greater than or equal to the timestamp of the tombstone, then it
+// is not considered a collision and we continue iteration from the next key in
+// the existing data.
+func checkForKeyCollisionsGo(
+	existingIter Iterator, sstData []byte, start, end roachpb.Key,
+) (enginepb.MVCCStats, error) {
+	var skippedKVStats enginepb.MVCCStats
+	sstIter, err := NewMemSSTIterator(sstData, false)
+	if err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+
+	defer sstIter.Close()
+	sstIter.Seek(MakeMVCCMetadataKey(start))
+	if ok, err := sstIter.Valid(); err != nil || !ok {
+		return enginepb.MVCCStats{}, errors.Wrap(err, "checking for key collisions")
+	}
+
+	ok, extErr := existingIter.Valid()
+	ok2, sstErr := sstIter.Valid()
+	for extErr == nil && sstErr == nil && ok && ok2 {
+		existingKey := existingIter.UnsafeKey()
+		existingValue := existingIter.UnsafeValue()
+		sstKey := sstIter.UnsafeKey()
+		sstValue := sstIter.UnsafeValue()
+
+		if !existingKey.IsValue() {
+			var mvccMeta enginepb.MVCCMetadata
+			err := existingIter.ValueProto(&mvccMeta)
+			if err != nil {
+				return enginepb.MVCCStats{}, err
+			}
+
+			// Check for an inline value, as these are only used in non-user data.
+			// This method is currently used by AddSSTable when performing an IMPORT
+			// INTO. We do not expect to encounter any inline values, and thus we
+			// report an error.
+			if len(mvccMeta.RawBytes) > 0 {
+				return enginepb.MVCCStats{}, errors.Errorf("inline values are unsupported when checking for key collisions")
+			} else if mvccMeta.Txn != nil {
+				// Check for a write intent.
+				//
+				// TODO(adityamaru): Currently, we raise a WriteIntentError on
+				// encountering all intents. This is because, we do not expect to
+				// encounter many intents during IMPORT INTO as we lock the key space we
+				// are importing into. Older write intents could however be found in the
+				// target key space, which will require appropriate resolution logic.
+				var writeIntentErr roachpb.WriteIntentError
+				var intent roachpb.Intent
+				intent.Txn = *mvccMeta.Txn
+				intent.Key = existingIter.Key().Key
+				writeIntentErr.Intents = append(writeIntentErr.Intents, intent)
+
+				return enginepb.MVCCStats{}, &writeIntentErr
+			} else {
+				return enginepb.MVCCStats{}, errors.Errorf("intent without transaction")
+			}
+		}
+
+		bytesCompare := bytes.Compare(existingKey.Key, sstKey.Key)
+		if bytesCompare == 0 {
+			// If the colliding key is a tombstone in the existing data, and the
+			// timestamp of the sst key is greater than or equal to the timestamp of
+			// the tombstone, then this is not considered a collision. We move the
+			// iterator over the existing data to the next potentially colliding key
+			// (skipping all versions of the deleted key), and resume iteration.
+			//
+			// If the ts of the sst key is less than that of the tombstone it is
+			// changing existing data, and we treat this as a collision.
+			if len(existingValue) == 0 && !sstKey.Timestamp.Less(existingKey.Timestamp) {
+				existingIter.NextKey()
+				ok, extErr = existingIter.Valid()
+				ok2, sstErr = sstIter.Valid()
+
+				continue
+			}
+
+			// If the ingested KV has an identical timestamp and value as the existing
+			// data then we do not consider it to be a collision. We move the iterator
+			// over the existing data to the next potentially colliding key (skipping
+			// all versions of the current key), and resume iteration.
+			if sstKey.Timestamp.Equal(existingKey.Timestamp) && bytes.Equal(existingValue, sstValue) {
+				// Even though we skip over the KVs described above, their stats have
+				// already been accounted for resulting in a problem of double-counting.
+				// To solve this we send back the stats of these skipped KVs so that we
+				// can subtract them later. This enables us to construct accurate
+				// MVCCStats and prevents expensive recomputation in the future.
+				metaKeySize := int64(len(sstKey.Key) + 1)
+				metaValSize := int64(0)
+				totalBytes := metaKeySize + metaValSize
+
+				// Update the skipped stats to account fot the skipped meta key.
+				skippedKVStats.LiveBytes += totalBytes
+				skippedKVStats.LiveCount++
+				skippedKVStats.KeyBytes += metaKeySize
+				skippedKVStats.ValBytes += metaValSize
+				skippedKVStats.KeyCount++
+
+				// Update the stats to account for the skipped versioned key/value.
+				totalBytes = int64(len(sstValue)) + MVCCVersionTimestampSize
+				skippedKVStats.LiveBytes += totalBytes
+				skippedKVStats.KeyBytes += MVCCVersionTimestampSize
+				skippedKVStats.ValBytes += int64(len(sstValue))
+				skippedKVStats.ValCount++
+
+				existingIter.NextKey()
+				ok, extErr = existingIter.Valid()
+				ok2, sstErr = sstIter.Valid()
+
+				continue
+			}
+
+			err := &Error{msg: existingIter.Key().Key.String()}
+			return enginepb.MVCCStats{}, errors.Wrap(err, "ingested key collides with an existing one")
+		} else if bytesCompare < 0 {
+			existingIter.Seek(MVCCKey{Key: sstKey.Key})
+		} else {
+			sstIter.Seek(MVCCKey{Key: existingKey.Key})
+		}
+
+		ok, extErr = existingIter.Valid()
+		ok2, sstErr = sstIter.Valid()
+	}
+
+	if extErr != nil {
+		return enginepb.MVCCStats{}, extErr
+	}
+	if sstErr != nil {
+		return enginepb.MVCCStats{}, sstErr
+	}
+
+	return skippedKVStats, nil
+}

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -524,6 +524,14 @@ func (p *pebbleIterator) Stats() IteratorStats {
 	}
 }
 
+// CheckForKeyCollisions indicates if the provided SST data collides with this
+// iterator in the specified range.
+func (p *pebbleIterator) CheckForKeyCollisions(
+	sstData []byte, start, end roachpb.Key,
+) (enginepb.MVCCStats, error) {
+	return checkForKeyCollisionsGo(p, sstData, start, end)
+}
+
 func (p *pebbleIterator) destroy() {
 	if p.inuse {
 		panic("iterator still in use")

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1540,6 +1540,12 @@ func (r *batchIterator) getIter() *C.DBIterator {
 	return r.iter.iter
 }
 
+func (r *batchIterator) CheckForKeyCollisions(
+	sstData []byte, start, end roachpb.Key,
+) (enginepb.MVCCStats, error) {
+	return r.iter.CheckForKeyCollisions(sstData, start, end)
+}
+
 // reusableBatchIterator wraps batchIterator and makes the Close method a no-op
 // to allow reuse of the iterator for the lifetime of the batch. The batch must
 // call iter.destroy() when it closes itself.
@@ -2424,6 +2430,53 @@ func (r *rocksDBIterator) SetUpperBound(key roachpb.Key) {
 	C.DBIterSetUpperBound(r.iter, goToCKey(MakeMVCCMetadataKey(key)))
 }
 
+// CheckForKeyCollisions indicates if the provided SST data collides with this
+// iterator in the specified range.
+func (r *rocksDBIterator) CheckForKeyCollisions(
+	sstData []byte, start, end roachpb.Key,
+) (enginepb.MVCCStats, error) {
+	// Create a C++ iterator over the SST being added. This iterator is used to
+	// perform a check for key collisions between the SST being ingested, and the
+	// exisiting data. As the collision check is in C++ we are unable to use a
+	// pure go iterator as in verifySSTable.
+	sst := MakeRocksDBSstFileReader()
+	defer sst.Close()
+	emptyStats := enginepb.MVCCStats{}
+
+	if err := sst.IngestExternalFile(sstData); err != nil {
+		return emptyStats, err
+	}
+	sstIterator := sst.NewIterator(IterOptions{UpperBound: end}).(*rocksDBIterator)
+	defer sstIterator.Close()
+	sstIterator.Seek(MakeMVCCMetadataKey(start))
+	if ok, err := sstIterator.Valid(); err != nil || !ok {
+		return emptyStats, errors.Wrap(err, "checking for key collisions")
+	}
+
+	var intentErr C.DBString
+	var skippedKVStats C.MVCCStatsResult
+
+	state := C.DBCheckForKeyCollisions(r.iter, sstIterator.iter, &skippedKVStats, &intentErr)
+
+	err := statusToError(state.status)
+	if err != nil {
+		if err.Error() == "WriteIntentError" {
+			var e roachpb.WriteIntentError
+			if err := protoutil.Unmarshal(cStringToGoBytes(intentErr), &e); err != nil {
+				return emptyStats, errors.Wrap(err, "failed to decode write intent error")
+			}
+			return emptyStats, &e
+		} else if err.Error() == "InlineError" {
+			return emptyStats, errors.Errorf("inline values are unsupported when checking for key collisions")
+		}
+		err = errors.Wrap(&Error{msg: cToGoKey(state.key).String()}, "ingested key collides with an existing one")
+		return emptyStats, err
+	}
+
+	skippedStats, err := cStatsToGoStats(skippedKVStats, 0)
+	return skippedStats, err
+}
+
 func copyFromSliceVector(bufs *C.DBSlice, len C.int32_t) []byte {
 	if bufs == nil {
 		return nil
@@ -2818,35 +2871,6 @@ func (fr *RocksDBSstFileReader) Close() {
 	}
 	fr.rocksDB.Close()
 	fr.rocksDB = nil
-}
-
-// CheckForKeyCollisions indicates if the two iterators collide on any keys.
-func CheckForKeyCollisions(existingIter Iterator, sstIter Iterator) (enginepb.MVCCStats, error) {
-	existingIterGetter := existingIter.(dbIteratorGetter)
-	sstableIterGetter := sstIter.(dbIteratorGetter)
-	var intentErr C.DBString
-	var skippedKVStats C.MVCCStatsResult
-	emptyStats := enginepb.MVCCStats{}
-
-	state := C.DBCheckForKeyCollisions(existingIterGetter.getIter(), sstableIterGetter.getIter(), &skippedKVStats, &intentErr)
-
-	err := statusToError(state.status)
-	if err != nil {
-		if err.Error() == "WriteIntentError" {
-			var e roachpb.WriteIntentError
-			if err := protoutil.Unmarshal(cStringToGoBytes(intentErr), &e); err != nil {
-				return emptyStats, errors.Wrap(err, "failed to decode write intent error")
-			}
-			return emptyStats, &e
-		} else if err.Error() == "InlineError" {
-			return emptyStats, errors.Errorf("inline values are unsupported when checking for key collisions")
-		}
-		err = errors.Wrap(&Error{msg: cToGoKey(state.key).String()}, "ingested key collides with an existing one")
-		return emptyStats, err
-	}
-
-	skippedStats, err := cStatsToGoStats(skippedKVStats, 0)
-	return skippedStats, err
 }
 
 // RocksDBSstFileWriter creates a file suitable for importing with

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -156,6 +156,13 @@ func (s *Iterator) FindSplitKey(
 	return s.i.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
+// CheckForKeyCollisions is part of the engine.Iterator interface.
+func (s *Iterator) CheckForKeyCollisions(
+	sstData []byte, start, end roachpb.Key,
+) (enginepb.MVCCStats, error) {
+	return s.i.CheckForKeyCollisions(sstData, start, end)
+}
+
 // MVCCGet is part of the engine.Iterator interface.
 func (s *Iterator) MVCCGet(
 	key roachpb.Key, timestamp hlc.Timestamp, opts engine.MVCCGetOptions,


### PR DESCRIPTION
This change ports CheckForKeyCollisions from libroach (cpp)
to Go for use with Pebble, and makes it implementation
agnostic so it can be used directly with the Iterator
interface. Also update tests to test EvalAddSSTable with
both Pebble and RocksDB as the underlying engines.

Fixes #41744

Release note: None