### PR TITLE
sql: fix handling of date_trunc with alternate timezones

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -721,27 +721,27 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 query T
 SELECT date_trunc('millennia', '2000-02-10 19:46:33.306157519-04'::timestamptz)::string
 ----
-1001-01-01 00:00:00-04:00
+1001-01-01 00:00:00+00:00
 
 query T
 SELECT date_trunc('centuries', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
 ----
-2001-01-01 00:00:00-04:00
+2001-01-01 00:00:00+00:00
 
 query T
 SELECT date_trunc('decades', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
 ----
-2010-01-01 00:00:00-04:00
+2010-01-01 00:00:00+00:00
 
 query T
 SELECT date_trunc('hour', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
 ----
-2016-02-10 19:00:00-04:00
+2016-02-10 23:00:00+00:00
 
 query T
 SELECT date_trunc('hours', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
 ----
-2016-02-10 19:00:00-04:00
+2016-02-10 23:00:00+00:00
 
 query IBT
 SELECT k, date_trunc(element, input::date) = date_trunc_result::date, date_trunc(element, input::date)::string
@@ -1363,6 +1363,31 @@ SELECT date_trunc('month', "date") AS date_trunc_month_created_at FROM "topics";
 ----
 2017-12-01 00:00:00 +0000 UTC
 
+# Test date_trunc works when timestamp zone changes.
+subtest regression_41663
+
+query T
+select date_trunc('day', '2011-01-01 22:30:00'::date);
+----
+2011-01-01 00:00:00 +0000 UTC
+
+query T
+select date_trunc('day', '2011-01-01 22:30:00+01:00'::timestamptz);
+----
+2011-01-01 00:00:00 +0000 UTC
+
+statement ok
+SET TIME ZONE 'Africa/Nairobi';
+
+query T
+select date_trunc('day', '2011-01-01 22:30:00'::date);
+----
+2011-01-01 00:00:00 +0300 +0300
+
+query T
+select date_trunc('day', '2011-01-01 22:30:00+01:00'::timestamptz);
+----
+2011-01-02 00:00:00 +0300 +0300
 
 # Test negative years to ensure they can round-trip through the parser.
 # Also ensure that we don't trigger any of the "convenience" rules.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1954,7 +1954,7 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				fromTSTZ := args[1].(*tree.DTimestampTZ)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
-				return truncateTimestamp(ctx, fromTSTZ.Time, timeSpan)
+				return truncateTimestamp(ctx, fromTSTZ.Time.In(ctx.GetLocation()), timeSpan)
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -15,11 +15,15 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCategory(t *testing.T) {
@@ -239,6 +243,40 @@ func TestLPadRPad(t *testing.T) {
 		if out != tc.expected {
 			t.Errorf("expected %s, found %s", tc.expected, out)
 		}
+	}
+}
+
+func TestTruncateTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	loc, err := timeutil.LoadLocation("Australia/Sydney")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		fromTime time.Time
+		timeSpan string
+		expected *tree.DTimestampTZ
+	}{
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "millennium", tree.MakeDTimestampTZ(time.Date(2001, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "century", tree.MakeDTimestampTZ(time.Date(2101, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "decade", tree.MakeDTimestampTZ(time.Date(2110, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "year", tree.MakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "quarter", tree.MakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "month", tree.MakeDTimestampTZ(time.Date(2118, time.March, 1, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "day", tree.MakeDTimestampTZ(time.Date(2118, time.March, 11, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "week", tree.MakeDTimestampTZ(time.Date(2118, time.March, 6, 0, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "hour", tree.MakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 0, 0, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "second", tree.MakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 0, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "millisecond", tree.MakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80000000, loc), time.Microsecond)},
+		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "microsecond", tree.MakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80009000, loc), time.Microsecond)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.timeSpan, func(t *testing.T) {
+			result, err := truncateTimestamp(nil, tc.fromTime, tc.timeSpan)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
 	}
 }
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2124,7 +2124,7 @@ func MakeDTimestampTZFromDate(loc *time.Location, d *DDate) (*DTimestampTZ, erro
 	if err != nil {
 		return nil, err
 	}
-	return MakeDTimestampTZ(t, time.Microsecond), nil
+	return MakeDTimestampTZ(t.In(loc), time.Microsecond), nil
 }
 
 // ParseDTimestampTZ parses and returns the *DTimestampTZ Datum value represented by


### PR DESCRIPTION
* resolves cockroachdb/cockroach#41663
* resolves cockroachdb/cockroach-django#32
* timestamptz was set incorrectly when `SET TIME ZONE` is set, as it did not take local timezone into account
* date was set incorrectly, because helper function `MakeDTimestampTZFromDate` did NOT use `In`. This helper function is used in another location but forces UTC so that's why this did not manifest elsewhere
* added unit tests for `truncateTimestamp` because I didn't trust it.
* modified tests to reflect expected behaviour (verified it is the same as psql).

Release note (bug fix): fix date_trunc to correctly consider timezones for timestamptz / date types 