### PR TITLE
sql/pgwire: improve connection matching algorithm

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestComposeGSS(t *testing.T) {
-	t.Skip("#41318")
 	out, err := exec.Command(
 		"docker-compose",
 		"-f", filepath.Join("compose", "gss", "docker-compose.yml"),

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -104,9 +104,20 @@ var (
 )
 
 const (
-	version30     = 196608
-	versionSSL    = 80877103
-	versionCancel = 80877102
+	// The below constants can occur during the first message a client
+	// sends to the server. There are two categories: protocol version and
+	// request code. The protocol version is (major version number << 16)
+	// + minor version number. Request codes are (1234 << 16) + 5678 + N,
+	// where N started at 0 and is increased by 1 for every new request
+	// code added, which happens rarely during major or minor Postgres
+	// releases.
+	//
+	// See: https://www.postgresql.org/docs/current/protocol-message-formats.html
+
+	version30     = 196608   // (3 << 16) + 0
+	versionCancel = 80877102 // (1234 << 16) + 5678
+	versionSSL    = 80877103 // (1234 << 16) + 5679
+	versionGSSENC = 80877104 // (1234 << 16) + 5680
 )
 
 // cancelMaxWait is the amount of time a draining server gives to sessions to
@@ -268,7 +279,7 @@ func Match(rd io.Reader) bool {
 	if err != nil {
 		return false
 	}
-	return version == version30 || version == versionSSL || version == versionCancel
+	return version == version30 || version == versionSSL || version == versionCancel || version == versionGSSENC
 }
 
 // Start makes the Server ready for serving connections.


### PR DESCRIPTION
Postgres 11.5 and 12.0 added an encrypted GSS request. When those versions
of psql tried to auth via GSS to cockroach, it would first try encrypted
GSS, which we don't support. Our pgwire.Match function (used in cmuxing
incoming connections) didn't detect this new request code and thus sent
the connection over to grpc, resulting in a confusing error message that
would also cause psql to not fallback to unencrypted GSS.

We considered just checking for 1234 << 16 in the upper bits as forward
protecting against more new request codes, but decided that the risk
that would incorrectly match some TLS certs was not worth it.

Fixes #41999

Release note(bug fix): psql from Postgres 11.5 and 12.0 is now supported
for GSS connections.