### PR TITLE
storage: assert around snapshot sending/receiving

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -392,13 +392,29 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 		decision.NewFirstIndex = decision.Input.FirstIndex
 		decision.ChosenVia = truncatableIndexChosenViaFirstIndex
 	}
+
+	// Invariants: NewFirstIndex >= FirstIndex
+	//             NewFirstIndex <= LastIndex (if != 10)
+	//             NewFirstIndex <= QuorumIndex (if != 0)
+	//
+	// For uninit'ed replicas we can have input.FirstIndex > input.LastIndex, more
+	// specifically input.FirstIndex = input.LastIndex + 1. FirstIndex is set to
+	// TruncatedState.Index + 1, and for an unit'ed replica, LastIndex is simply
+	// 10. This is what informs the `input.LastIndex == 10` conditional below.
+	valid := (decision.NewFirstIndex >= input.FirstIndex) &&
+		(decision.NewFirstIndex <= input.LastIndex || input.LastIndex == 10) &&
+		(decision.NewFirstIndex <= decision.QuorumIndex || decision.QuorumIndex == 0)
+	if !valid {
+		err := fmt.Sprintf("invalid truncation decision; output = %d, input: [%d, %d], quorum idx = %d",
+			decision.NewFirstIndex, input.FirstIndex, input.LastIndex, decision.QuorumIndex)
+		panic(err)
+	}
+
 	return decision
 }
 
 // getQuorumIndex returns the index which a quorum of the nodes have
-// committed. The snapshotLogTruncationConstraints indicates the index of a pending
-// snapshot which is considered part of the Raft group even though it hasn't
-// been added yet. Note that getQuorumIndex may return 0 if the progress map
+// committed. Note that getQuorumIndex may return 0 if the progress map
 // doesn't contain information for a sufficient number of followers (e.g. the
 // local replica has only recently become the leader). In general, the value
 // returned by getQuorumIndex may be smaller than raftStatus.Commit which is

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -396,7 +396,7 @@ type Replica struct {
 		// from the Raft log entry. Use the invalidLastTerm constant for this
 		// case.
 		lastIndex, lastTerm uint64
-		// A map of raft log index of pending preemptive snapshots to deadlines.
+		// A map of raft log index of pending snapshots to deadlines.
 		// Used to prohibit raft log truncations that would leave a gap between
 		// the snapshot and the new first index. The map entry has a zero
 		// deadline while the snapshot is being sent and turns nonzero when the

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1030,6 +1030,13 @@ func (r *Replica) sendSnapshot(
 		r.store.Engine().NewBatch,
 		sent,
 	); err != nil {
+		if errors.Cause(err) == malformedSnapshotError {
+			checkpointDir := r.store.checkpoint(ctx,
+				fmt.Sprintf("r%d_%s", r.RangeID, snap.SnapUUID.Short()))
+
+			log.Fatalf(ctx, "malformed snapshot generated, checkpoint created at: %s", checkpointDir)
+		}
+
 		return &snapshotError{err}
 	}
 	return nil

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -109,7 +109,7 @@ type kvBatchSnapshotStrategy struct {
 	newBatch  func() engine.Batch
 }
 
-// Send implements the snapshotStrategy interface.
+// Receive implements the snapshotStrategy interface.
 func (kvSS *kvBatchSnapshotStrategy) Receive(
 	ctx context.Context, stream incomingSnapshotStream, header SnapshotRequest_Header,
 ) (IncomingSnapshot, error) {
@@ -147,6 +147,17 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 				State:      &header.State,
 				snapType:   snapTypeRaft,
 			}
+
+			expLen := inSnap.State.RaftAppliedIndex - inSnap.State.TruncatedState.Index
+			if expLen != uint64(len(logEntries)) {
+				// We've received a botched snapshot. We could fatal right here but opt
+				// to warn loudly instead, and fatal when applying the snapshot
+				// (in Replica.applySnapshot) in order to capture replica hard state.
+				log.Warningf(ctx,
+					"missing log entries in snapshot (%s): got %d entries, expected %d",
+					inSnap.String(), len(logEntries), expLen)
+			}
+
 			if header.RaftMessageRequest.ToReplica.ReplicaID == 0 {
 				inSnap.snapType = snapTypePreemptive
 			}
@@ -155,6 +166,10 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 		}
 	}
 }
+
+// A MalformedSnapshotError indicates that the snapshot in question is
+// malformed, for e.g. missing raft log entries.
+var malformedSnapshotError = errors.New("malformed snapshot generated")
 
 // Send implements the snapshotStrategy interface.
 func (kvSS *kvBatchSnapshotStrategy) Send(
@@ -264,6 +279,24 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 
 	if err := iterateEntries(ctx, snap.EngineSnap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
 		return err
+	}
+
+	// The difference between the snapshot index (applied index at the time of
+	// snapshot) and the truncated index should equal the number of log entries
+	// shipped over.
+	expLen := endIndex - firstIndex
+	if expLen != uint64(len(logEntries)) {
+		// We've generated a botched snapshot. We could fatal right here but opt
+		// to warn loudly instead, and fatal at the caller to capture a checkpoint
+		// of the underlying storage engine.
+		entriesRange, err := extractRangeFromEntries(logEntries)
+		if err != nil {
+			return err
+		}
+		log.Warningf(ctx, "missing log entries in snapshot (%s): "+
+			"got %d entries, expected %d (TruncatedState.Index=%d, LogEntries=%s)",
+			snap.String(), len(logEntries), expLen, snap.State.TruncatedState.Index, entriesRange)
+		return malformedSnapshotError
 	}
 
 	// Inline the payloads for all sideloaded proposals.


### PR DESCRIPTION
In v2.1 log entries are shipped alongside snapshots. The log entries
included in snapshots (which also include the truncated state and the
applied index) cover all indexes in the range
[truncated-state.index + 1, applied-state]. We simply assert that this
is always the case. We also assert during log truncations that the
number of deleted entries is no more than what we expect (last index -
first index).

Additionally rename PendingPreemptiveSnapshotIndex to
PendingSnapshotIndex, as it applies to both raft snapshots and
pre-emptive snapshots.

Release note: None