### PR TITLE
sql/rowexec: fuse bulkRowWriter proc

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -372,7 +372,7 @@ func (h *ProcOutputHelper) consumerClosed() {
 //   }
 //
 //   // Next is part of the RowSource interface.
-//   func (p *concatProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+//   func (p *concatProcessor) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
 //     // Loop while we haven't produced a row or a metadata record. We loop around
 //     // in several cases, including when the filtering rejected a row coming.
 //     for p.State == StateRunning {

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,7 +1,3 @@
-# LogicTest: local local-vec-off local-mixed-19.1-19.2 fakedist fakedist-vec-off fakedist-disk
-# TODO(radu): the test fails on fakedist-metadata config (#41816); remove this
-# directive once that is fixed.
-
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 


### PR DESCRIPTION
This patch makes bulkRowWriter implement RowSource (in addition to
Processor), such that it can be fused with its consumer. This is
mandatory for CREATE TABLE AS queries which end up using a
bulkRowWriter, since the input to the new table might force the planning
to be restricted to the gateway (for example if they read from a virtual
table), which in turns means that the whole plan must have no
concurrency (so all the proc have to be fused together). Fusing only
works for procs implementing RowSource.

Fixes #41816

Release note (bug fix): A bug causing CREATE TABLE AS statements to fail
with the message "unexpected concurrency for a flow that was forced to
be planned locally" was fixed.