### PR TITLE
colexec: add support for IS NULL and IS NOT NULL

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1050,7 +1050,7 @@ func planSelectionOperators(
 		if constArg, ok := t.Right.(tree.Datum); ok {
 			if t.Operator == tree.Like || t.Operator == tree.NotLike {
 				negate := t.Operator == tree.NotLike
-				op, err := GetLikeOperator(
+				op, err = GetLikeOperator(
 					ctx, leftOp, leftIdx, string(tree.MustBeDString(constArg)), negate)
 				return op, resultIdx, ct, memUsageLeft, err
 			}
@@ -1061,7 +1061,18 @@ func planSelectionOperators(
 					err = errors.Errorf("IN is only supported for constant expressions")
 					return nil, resultIdx, ct, memUsed, err
 				}
-				op, err := GetInOperator(lTyp, leftOp, leftIdx, datumTuple, negate)
+				op, err = GetInOperator(lTyp, leftOp, leftIdx, datumTuple, negate)
+				return op, resultIdx, ct, memUsageLeft, err
+			}
+			if t.Operator == tree.IsDistinctFrom || t.Operator == tree.IsNotDistinctFrom {
+				if t.Right != tree.DNull {
+					err = errors.Errorf("IS DISTINCT FROM and IS NOT DISTINCT FROM are supported only with NULL argument")
+					return nil, resultIdx, ct, memUsageLeft, err
+				}
+				// IS NULL is replaced with IS NOT DISTINCT FROM NULL, so we want to
+				// negate when IS DISTINCT FROM is used.
+				negate := t.Operator == tree.IsDistinctFrom
+				op = newIsNullSelOp(leftOp, leftIdx, negate)
 				return op, resultIdx, ct, memUsageLeft, err
 			}
 			op, err := GetSelectionConstOperator(lTyp, t.TypedRight().ResolvedType(), cmpOp, leftOp, leftIdx, constArg)
@@ -1297,6 +1308,15 @@ func planProjectionExpr(
 				return nil, resultIdx, ct, leftMem, err
 			}
 			op, err = GetInProjectionOperator(&ct[leftIdx], leftOp, leftIdx, resultIdx, datumTuple, negate)
+		} else if binOp == tree.IsDistinctFrom || binOp == tree.IsNotDistinctFrom {
+			if right != tree.DNull {
+				err = errors.Errorf("IS DISTINCT FROM and IS NOT DISTINCT FROM are supported only with NULL argument")
+				return nil, resultIdx, ct, leftMem, err
+			}
+			// IS NULL is replaced with IS NOT DISTINCT FROM NULL, so we want to
+			// negate when IS DISTINCT FROM is used.
+			negate := binOp == tree.IsDistinctFrom
+			op = newIsNullProjOp(leftOp, leftIdx, resultIdx, negate)
 		} else {
 			op, err = GetProjectionRConstOperator(&ct[leftIdx], right.ResolvedType(), binOp, leftOp, leftIdx, rConstArg, resultIdx)
 		}

--- a/pkg/sql/colexec/is_null_ops.go
+++ b/pkg/sql/colexec/is_null_ops.go
@@ -1,0 +1,156 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// isNullProjOp is an Operator that projects into outputIdx Vec whether the
+// corresponding value in colIdx Vec is NULL (i.e. it performs IS NULL check).
+// If negate is true, it does the opposite - it performs IS NOT NULL check.
+type isNullProjOp struct {
+	OneInputNode
+	colIdx    int
+	outputIdx int
+	negate    bool
+}
+
+func newIsNullProjOp(input Operator, colIdx, outputIdx int, negate bool) Operator {
+	return &isNullProjOp{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		outputIdx:    outputIdx,
+		negate:       negate,
+	}
+}
+
+var _ Operator = &isNullProjOp{}
+
+func (o *isNullProjOp) Init() {
+	o.input.Init()
+}
+
+func (o *isNullProjOp) Next(ctx context.Context) coldata.Batch {
+	batch := o.input.Next(ctx)
+	if o.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bool)
+	}
+	n := batch.Length()
+	if n == 0 {
+		return batch
+	}
+	vec := batch.ColVec(o.colIdx)
+	nulls := vec.Nulls()
+	projCol := batch.ColVec(o.outputIdx).Bool()
+	if nulls.MaybeHasNulls() {
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				projCol[i] = nulls.NullAt(i) != o.negate
+			}
+		} else {
+			projCol = projCol[:n]
+			for i := range projCol {
+				projCol[i] = nulls.NullAt(uint16(i)) != o.negate
+			}
+		}
+	} else {
+		// There are no NULLs, so we don't need to check each index for nullity.
+		result := o.negate
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				projCol[i] = result
+			}
+		} else {
+			projCol = projCol[:n]
+			for i := range projCol {
+				projCol[i] = result
+			}
+		}
+	}
+	return batch
+}
+
+// isNullSelOp is an Operator that selects all the tuples that have a NULL
+// value in colIdx Vec. If negate is true, then it does the opposite -
+// selecting all the tuples that have a non-NULL value in colIdx Vec.
+type isNullSelOp struct {
+	OneInputNode
+	colIdx int
+	negate bool
+}
+
+func newIsNullSelOp(input Operator, colIdx int, negate bool) Operator {
+	return &isNullSelOp{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		negate:       negate,
+	}
+}
+
+var _ Operator = &isNullSelOp{}
+
+func (o *isNullSelOp) Init() {
+	o.input.Init()
+}
+
+func (o *isNullSelOp) Next(ctx context.Context) coldata.Batch {
+	for {
+		batch := o.input.Next(ctx)
+		n := batch.Length()
+		if n == 0 {
+			return batch
+		}
+		var idx uint16
+		vec := batch.ColVec(o.colIdx)
+		nulls := vec.Nulls()
+		if nulls.MaybeHasNulls() {
+			// There might be NULLs in the Vec, so we'll need to iterate over all
+			// tuples.
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if nulls.NullAt(i) != o.negate {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()[:n]
+				for i := range sel {
+					if nulls.NullAt(uint16(i)) != o.negate {
+						sel[idx] = uint16(i)
+						idx++
+					}
+				}
+			}
+			if idx > 0 {
+				batch.SetLength(idx)
+				return batch
+			}
+		} else {
+			// There are no NULLs, so we don't need to check each index for nullity.
+			if o.negate {
+				// o.negate is true, so we select all tuples, i.e. we don't need to
+				// modify the batch and can just return it.
+				return batch
+			}
+			// o.negate is false, so we omit all tuples from this batch and move onto
+			// the next one.
+		}
+	}
+}

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -1,0 +1,195 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestIsNullProjOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	testCases := []struct {
+		desc         string
+		inputTuples  tuples
+		outputTuples tuples
+		negate       bool
+	}{
+		{
+			desc:         "SELECT c, c IS NULL FROM t -- both",
+			inputTuples:  tuples{{0}, {nil}, {1}, {2}, {nil}},
+			outputTuples: tuples{{0, false}, {nil, true}, {1, false}, {2, false}, {nil, true}},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c, c IS NULL FROM t -- no NULLs",
+			inputTuples:  tuples{{0}, {1}, {2}},
+			outputTuples: tuples{{0, false}, {1, false}, {2, false}},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c, c IS NULL FROM t -- only NULLs",
+			inputTuples:  tuples{{nil}, {nil}},
+			outputTuples: tuples{{nil, true}, {nil, true}},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c, c IS NOT NULL FROM t -- both",
+			inputTuples:  tuples{{0}, {nil}, {1}, {2}, {nil}},
+			outputTuples: tuples{{0, true}, {nil, false}, {1, true}, {2, true}, {nil, false}},
+			negate:       true,
+		},
+		{
+			desc:         "SELECT c, c IS NOT NULL FROM t -- no NULLs",
+			inputTuples:  tuples{{0}, {1}, {2}},
+			outputTuples: tuples{{0, true}, {1, true}, {2, true}},
+			negate:       true,
+		},
+		{
+			desc:         "SELECT c, c IS NOT NULL FROM t -- only NULLs",
+			inputTuples:  tuples{{nil}, {nil}},
+			outputTuples: tuples{{nil, false}, {nil, false}},
+			negate:       true,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.desc, func(t *testing.T) {
+			opConstructor := func(input []Operator) (Operator, error) {
+				projExpr := "IS NULL"
+				if c.negate {
+					projExpr = "IS NOT NULL"
+				}
+				spec := &execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []types.T{*types.Int}}},
+					Core: execinfrapb.ProcessorCoreUnion{
+						Noop: &execinfrapb.NoopCoreSpec{},
+					},
+					Post: execinfrapb.PostProcessSpec{
+						RenderExprs: []execinfrapb.Expression{
+							{Expr: "@1"},
+							{Expr: fmt.Sprintf("@1 %s", projExpr)},
+						},
+					},
+				}
+				result, err := NewColOperator(ctx, flowCtx, spec, input)
+				if err != nil {
+					return nil, err
+				}
+				return result.Op, nil
+			}
+			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
+		})
+	}
+}
+
+func TestIsNullSelOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	testCases := []struct {
+		desc         string
+		inputTuples  tuples
+		outputTuples tuples
+		negate       bool
+	}{
+		{
+			desc:         "SELECT c FROM t WHERE c IS NULL -- both",
+			inputTuples:  tuples{{0}, {nil}, {1}, {2}, {nil}},
+			outputTuples: tuples{{nil}, {nil}},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c FROM t WHERE c IS NULL -- no NULLs",
+			inputTuples:  tuples{{0}, {1}, {2}},
+			outputTuples: tuples{},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c FROM t WHERE c IS NULL -- only NULLs",
+			inputTuples:  tuples{{nil}, {nil}},
+			outputTuples: tuples{{nil}, {nil}},
+			negate:       false,
+		},
+		{
+			desc:         "SELECT c FROM t WHERE c IS NOT NULL -- both",
+			inputTuples:  tuples{{0}, {nil}, {1}, {2}, {nil}},
+			outputTuples: tuples{{0}, {1}, {2}},
+			negate:       true,
+		},
+		{
+			desc:         "SELECT c FROM t WHERE c IS NOT NULL -- no NULLs",
+			inputTuples:  tuples{{0}, {1}, {2}},
+			outputTuples: tuples{{0}, {1}, {2}},
+			negate:       true,
+		},
+		{
+			desc:         "SELECT c FROM t WHERE c IS NOT NULL -- only NULLs",
+			inputTuples:  tuples{{nil}, {nil}},
+			outputTuples: tuples{},
+			negate:       true,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.desc, func(t *testing.T) {
+			opConstructor := func(input []Operator) (Operator, error) {
+				selExpr := "IS NULL"
+				if c.negate {
+					selExpr = "IS NOT NULL"
+				}
+				spec := &execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []types.T{*types.Int}}},
+					Core: execinfrapb.ProcessorCoreUnion{
+						Noop: &execinfrapb.NoopCoreSpec{},
+					},
+					Post: execinfrapb.PostProcessSpec{
+						Filter: execinfrapb.Expression{Expr: fmt.Sprintf("@1 %s", selExpr)},
+					},
+				}
+				result, err := NewColOperator(ctx, flowCtx, spec, input)
+				if err != nil {
+					return nil, err
+				}
+				return result.Op, nil
+			}
+			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -940,3 +940,54 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-vectorized' AND usage_count > 0
 ----
 sql.exec.query.is-vectorized
+
+# Test IS NULL (and alike) projections.
+query IBBIBB rowsort
+SELECT a, a IS NULL, a IS NOT NULL, b, b IS NOT DISTINCT FROM NULL, b IS DISTINCT FROM NULL FROM nulls
+----
+NULL  true   false  NULL  true   false
+NULL  true   false  1     false  true
+1     false  true   NULL  true   false
+1     false  true   1     false  true
+
+# Test IS NULL (and alike) selections.
+query II rowsort
+SELECT a, b FROM nulls WHERE a IS NULL
+----
+NULL NULL
+NULL 1
+
+query II rowsort
+SELECT a, b FROM nulls WHERE a IS NOT NULL
+----
+1 NULL
+1 1
+
+query II rowsort
+SELECT a, b FROM nulls WHERE a IS NOT DISTINCT FROM NULL
+----
+NULL NULL
+NULL 1
+
+query II rowsort
+SELECT a, b FROM nulls WHERE a IS DISTINCT FROM NULL
+----
+1 NULL
+1 1
+
+query III rowsort
+SELECT
+	a,
+	b,
+	CASE
+	WHEN a IS NOT NULL AND b IS NULL THEN 0
+	WHEN a IS NULL THEN 1
+	WHEN b IS NOT NULL THEN 2
+	END
+FROM
+	nulls
+----
+NULL  NULL  1
+NULL  1     1
+1     NULL  0
+1     1     2

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -305,7 +305,7 @@ query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
 ·     distributed  true
-·     vectorized   false
+·     vectorized   true
 scan  ·            ·
 ·     table        p2@p2_id
 ·     spans        /1/#/55/2/NULL-
@@ -317,7 +317,7 @@ query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 ----
 ·     distributed  true
-·     vectorized   false
+·     vectorized   true
 scan  ·            ·
 ·     table        p2@p2_id
 ·     spans        /1/#/55/2/!NULL-

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1445,7 +1445,7 @@ query TTT
 EXPLAIN SELECT d FROM b WHERE c = 10 AND d = 10 OR c IS NULL AND d > 0 AND d < 2
 ----
 ·          distributed  false
-·          vectorized   false
+·          vectorized   true
 render     ·            ·
  └── scan  ·            ·
 ·          table        b@b_c_d_key

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -991,7 +991,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ----
 ·     distributed  false          ·       ·
-·     vectorized   false          ·       ·
+·     vectorized   true           ·       ·
 scan  ·            ·              (x, y)  ·
 ·     table        xy@primary     ·       ·
 ·     spans        ALL            ·       ·


### PR DESCRIPTION
This commit adds IS NULL projection and selection operators which
adds support for IS NULL and IS NOT NULL operators by the vectorized
engine.

Release note: None