### PR TITLE
storage/engine: remove InMem type

### DIFF
--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -66,7 +66,7 @@ func slurpSSTablesLatestKey(
 ) []engine.MVCCKeyValue {
 	start, end := engine.MVCCKey{Key: keys.MinKey}, engine.MVCCKey{Key: keys.MaxKey}
 
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 	batch := e.NewBatch()
 	defer batch.Close()

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -111,7 +111,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 
 	var batch engine.RocksDBBatchBuilder

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -476,7 +476,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			}
 			details = append(details, fmt.Sprintf("store %d: in-memory, size %s",
 				i, humanizeutil.IBytes(sizeInBytes)))
-			engines = append(engines, engine.NewInMem(spec.Attributes, sizeInBytes))
+			engines = append(engines, engine.NewInMem(cfg.StorageEngine, spec.Attributes, sizeInBytes))
 		} else {
 			if spec.Size.Percent > 0 {
 				fileSystemUsage := gosigar.FileSystemUsage{}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -205,7 +205,7 @@ func (s keySlice) Less(i, j int) bool { return bytes.Compare(s[i], s[j]) < 0 }
 func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 	if _, err := bootstrapCluster(
 		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
@@ -261,7 +261,7 @@ func TestBootstrapCluster(t *testing.T) {
 func TestBootstrapNewStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	if _, err := bootstrapCluster(
 		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 	); err != nil {
@@ -271,8 +271,8 @@ func TestBootstrapNewStore(t *testing.T) {
 	// Start a new node with two new stores which will require bootstrapping.
 	engines := Engines([]engine.Engine{
 		e,
-		engine.NewInMem(roachpb.Attributes{}, 1<<20),
-		engine.NewInMem(roachpb.Attributes{}, 1<<20),
+		engine.NewDefaultInMem(),
+		engine.NewDefaultInMem(),
 	})
 	defer engines.Close()
 	_, _, node, stopper := createAndStartTestNode(
@@ -314,7 +314,7 @@ func TestNodeJoin(t *testing.T) {
 	ctx := context.Background()
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop(ctx)
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	engineStopper.AddCloser(e)
 
 	if _, err := bootstrapCluster(
@@ -336,7 +336,7 @@ func TestNodeJoin(t *testing.T) {
 	defer stopper1.Stop(ctx)
 
 	// Create a new node.
-	e2 := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e2 := engine.NewDefaultInMem()
 	engineStopper.AddCloser(e2)
 	engines2 := []engine.Engine{e2}
 	_, server2Addr, node2, stopper2 := createAndStartTestNode(
@@ -385,7 +385,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 
 	if _, err := bootstrapCluster(
@@ -730,7 +730,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 	ctx := context.Background()
 
 	testLocalityWithNewNode := func(locality roachpb.Locality) {
-		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		e := engine.NewDefaultInMem()
 		defer e.Close()
 		if _, err := bootstrapCluster(
 			ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -579,7 +579,7 @@ func TestClusterIDMismatch(t *testing.T) {
 
 	engines := make([]engine.Engine, 2)
 	for i := range engines {
-		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		e := engine.NewDefaultInMem()
 		defer e.Close()
 
 		sIdent := roachpb.StoreIdent{

--- a/pkg/storage/abortspan/abortspan_test.go
+++ b/pkg/storage/abortspan/abortspan_test.go
@@ -44,7 +44,7 @@ var (
 func createTestAbortSpan(
 	t *testing.T, rangeID roachpb.RangeID, stopper *stop.Stopper,
 ) (*AbortSpan, engine.Engine) {
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 	return New(rangeID), eng
 }

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestSpanSetBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	var ss spanset.SpanSet
@@ -197,7 +197,7 @@ func TestSpanSetBatch(t *testing.T) {
 // See #20894.
 func TestSpanSetMVCCResolveWriteIntentRangeUsingIter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	ctx := context.Background()

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -309,7 +309,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 
 	for _, kv := range mvccKVsFromStrs([]strKv{
@@ -465,7 +465,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 
 	for _, kv := range mvccKVsFromStrs([]strKv{

--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -86,7 +86,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			ctx := context.Background()
-			eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+			eng := engine.NewDefaultInMem()
 			defer eng.Close()
 
 			var stats enginepb.MVCCStats

--- a/pkg/storage/batcheval/cmd_end_transaction_test.go
+++ b/pkg/storage/batcheval/cmd_end_transaction_test.go
@@ -1021,7 +1021,7 @@ func TestEndTransactionUpdatesTransactionRecord(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			db := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+			db := engine.NewDefaultInMem()
 			defer db.Close()
 			batch := db.NewBatch()
 			defer batch.Close()

--- a/pkg/storage/batcheval/cmd_recover_txn_test.go
+++ b/pkg/storage/batcheval/cmd_recover_txn_test.go
@@ -40,7 +40,7 @@ func TestRecoverTxn(t *testing.T) {
 	txn.InFlightWrites = []roachpb.SequencedWrite{{Key: k2, Sequence: 0}}
 
 	testutils.RunTrueAndFalse(t, "missing write", func(t *testing.T, missingWrite bool) {
-		db := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+		db := engine.NewDefaultInMem()
 		defer db.Close()
 
 		// Write the transaction record.
@@ -191,7 +191,7 @@ func TestRecoverTxnRecordChanged(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			db := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+			db := engine.NewDefaultInMem()
 			defer db.Close()
 
 			// Write the modified transaction record, simulating a concurrent

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -181,7 +181,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	engine := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	engine := engine.NewDefaultInMem()
 	defer engine.Close()
 	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
 		for _, test := range tests {

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -60,7 +60,7 @@ func TestCmdRevertRange(t *testing.T) {
 	const keyCount = 10
 
 	ctx := context.Background()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	baseTime := hlc.Timestamp{WallTime: 1000}

--- a/pkg/storage/batcheval/truncate_log_test.go
+++ b/pkg/storage/batcheval/truncate_log_test.go
@@ -141,7 +141,7 @@ func runUnreplicatedTruncatedState(t *testing.T, tc unreplicatedTruncStateTest) 
 		firstIndex:      firstIndex,
 	}
 
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	truncState := roachpb.RaftTruncatedState{

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -88,7 +88,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop(context.TODO())
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	engineStopper.AddCloser(eng)
 	var rangeID2 roachpb.RangeID
 
@@ -194,7 +194,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 	// and trying to handle that complicates the test without providing any
 	// added benefit.
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	numIncrements := 0

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -232,7 +232,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 			}
 			return nil
 		}
-	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 	store := createTestStoreWithOpts(t,
 		testStoreOpts{eng: eng, cfg: &cfg},

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -116,7 +116,7 @@ func createTestStoreWithOpts(
 	}
 	eng := opts.eng
 	if eng == nil {
-		eng = engine.NewInMem(roachpb.Attributes{}, 10<<20)
+		eng = engine.NewDefaultInMem()
 		stopper.AddCloser(eng)
 	}
 
@@ -800,7 +800,7 @@ func (m *multiTestContext) addStore(idx int) {
 	} else {
 		engineStopper := stop.NewStopper()
 		m.engineStoppers = append(m.engineStoppers, engineStopper)
-		eng = engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		eng = engine.NewDefaultInMem()
 		engineStopper.AddCloser(eng)
 		m.engines = append(m.engines, eng)
 		needBootstrap = true

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -44,7 +44,7 @@ type wrappedEngine struct {
 
 func newWrappedEngine() *wrappedEngine {
 	return &wrappedEngine{
-		Engine: engine.NewInMem(roachpb.Attributes{}, 1<<20),
+		Engine: engine.NewDefaultInMem(),
 	}
 }
 

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -43,9 +43,8 @@ type wrappedEngine struct {
 }
 
 func newWrappedEngine() *wrappedEngine {
-	inMem := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	return &wrappedEngine{
-		Engine: inMem.RocksDB,
+		Engine: engine.NewInMem(roachpb.Attributes{}, 1<<20),
 	}
 }
 

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -193,7 +193,7 @@ func TestRocksDBMap(t *testing.T) {
 	e := newRocksDBInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	runTestForEngine(ctx, t, "testdata/diskmap", &rocksDBTempEngine{db: e.RocksDB})
+	runTestForEngine(ctx, t, "testdata/diskmap", &rocksDBTempEngine{db: e})
 }
 
 func TestRocksDBMultiMap(t *testing.T) {
@@ -202,7 +202,7 @@ func TestRocksDBMultiMap(t *testing.T) {
 	e := newRocksDBInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	runTestForEngine(ctx, t, "testdata/diskmap_duplicates", &rocksDBTempEngine{db: e.RocksDB})
+	runTestForEngine(ctx, t, "testdata/diskmap_duplicates", &rocksDBTempEngine{db: e})
 }
 
 func TestRocksDBMapClose(t *testing.T) {

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -384,11 +384,20 @@ type Engine interface {
 	// that the key range is compacted all the way to the bottommost level of
 	// SSTables, which is necessary to pick up changes to bloom filters.
 	CompactRange(start, end roachpb.Key, forceBottommost bool) error
+	// InMem returns true if the receiver is an in-memory engine and false
+	// otherwise.
+	//
+	// TODO(peter): This is a bit of a wart in the interface. It is used by
+	// addSSTablePreApply to select alternate code paths, but really there should
+	// be a unified code path there.
+	InMem() bool
 	// OpenFile opens a DBFile with the given filename. The file should be created
 	// if it doesn't exist already, and should be writable.
 	OpenFile(filename string) (DBFile, error)
 	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
 	ReadFile(filename string) ([]byte, error)
+	// WriteFile writes data to a file in this RocksDB's env.
+	WriteFile(filename string, data []byte) error
 	// DeleteFile deletes the file with the given filename from this RocksDB's env.
 	// If the file with given filename doesn't exist, return os.ErrNotExist.
 	DeleteFile(filename string) error

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -69,6 +69,9 @@ func runWithAllEngines(test func(e Engine, t *testing.T), t *testing.T) {
 
 	func() {
 		pebbleInMem, err := NewPebble(PebbleConfig{
+			StorageConfig: base.StorageConfig{
+				Attrs: inMemAttrs,
+			},
 			Opts: testPebbleOptions(vfs.NewMem()),
 		})
 		if err != nil {
@@ -918,13 +921,8 @@ func TestSnapshotMethods(t *testing.T) {
 		defer snap.Close()
 
 		// Verify Attrs.
-		var attrs roachpb.Attributes
-		switch engine.(type) {
-		case InMem:
-			attrs = inMemAttrs
-		}
-		if !reflect.DeepEqual(engine.Attrs(), attrs) {
-			t.Errorf("attrs mismatch; expected %+v, got %+v", attrs, engine.Attrs())
+		if !reflect.DeepEqual(engine.Attrs(), inMemAttrs) {
+			t.Errorf("attrs mismatch; expected %+v, got %+v", inMemAttrs, engine.Attrs())
 		}
 
 		// Verify Get.

--- a/pkg/storage/engine/in_mem.go
+++ b/pkg/storage/engine/in_mem.go
@@ -10,13 +10,30 @@
 
 package engine
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+)
 
 // NewInMem allocates and returns a new, opened in-memory engine. The caller
 // must call the engine's Close method when the engine is no longer needed.
 //
 // FIXME(tschottdorf): make the signature similar to NewRocksDB (require a cfg).
-func NewInMem(attrs roachpb.Attributes, cacheSize int64) *RocksDB {
-	// TODO(hueypark): Support all engines like NewTempEngine.
-	return newRocksDBInMem(attrs, cacheSize)
+func NewInMem(engine enginepb.EngineType, attrs roachpb.Attributes, cacheSize int64) Engine {
+	switch engine {
+	case enginepb.EngineTypePebble:
+		return newPebbleInMem(attrs, cacheSize)
+	case enginepb.EngineTypeRocksDB:
+		return newRocksDBInMem(attrs, cacheSize)
+	}
+	panic(fmt.Sprintf("unknown engine type: %d", engine))
+}
+
+// NewDefaultInMem allocates and returns a new, opened in-memory engine with
+// the default configuration. The caller must call the engine's Close method
+// when the engine is no longer needed.
+func NewDefaultInMem() Engine {
+	return NewInMem(TestStorageEngine, roachpb.Attributes{}, 1<<20 /* 1 MB */)
 }

--- a/pkg/storage/engine/in_mem.go
+++ b/pkg/storage/engine/in_mem.go
@@ -12,19 +12,11 @@ package engine
 
 import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
-// InMem wraps RocksDB and configures it for in-memory only storage.
-type InMem struct {
-	*RocksDB
-}
-
-// NewInMem allocates and returns a new, opened InMem engine.
-// The caller must call the engine's Close method when the engine is no longer
-// needed.
+// NewInMem allocates and returns a new, opened in-memory engine. The caller
+// must call the engine's Close method when the engine is no longer needed.
 //
 // FIXME(tschottdorf): make the signature similar to NewRocksDB (require a cfg).
-func NewInMem(attrs roachpb.Attributes, cacheSize int64) InMem {
+func NewInMem(attrs roachpb.Attributes, cacheSize int64) *RocksDB {
 	// TODO(hueypark): Support all engines like NewTempEngine.
 	return newRocksDBInMem(attrs, cacheSize)
 }
-
-var _ Engine = InMem{}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -6150,10 +6150,8 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 				}
 
 				if i == 1 {
-					if eng, ok := engine.(InMem); ok {
-						if err := eng.Compact(); err != nil {
-							t.Fatal(err)
-						}
+					if err := engine.Compact(); err != nil {
+						t.Fatal(err)
 					}
 				}
 
@@ -6165,10 +6163,8 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 				}
 
 				if i == 1 {
-					if eng, ok := engine.(InMem); ok {
-						if err := eng.Compact(); err != nil {
-							t.Fatal(err)
-						}
+					if err := engine.Compact(); err != nil {
+						t.Fatal(err)
 					}
 				}
 

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -252,6 +252,25 @@ func NewPebble(cfg PebbleConfig) (*Pebble, error) {
 	}, nil
 }
 
+func newPebbleInMem(attrs roachpb.Attributes, cacheSize int64) *Pebble {
+	opts := DefaultPebbleOptions()
+	opts.Cache = pebble.NewCache(cacheSize)
+	opts.FS = vfs.NewMem()
+	db, err := NewPebble(PebbleConfig{
+		StorageConfig: base.StorageConfig{
+			Attrs: attrs,
+			// TODO(bdarnell): The hard-coded 512 MiB is wrong; see
+			// https://github.com/cockroachdb/cockroach/issues/16750
+			MaxSize: 512 << 20, /* 512 MiB */
+		},
+		Opts: opts,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
 // Close implements the Engine interface.
 func (p *Pebble) Close() {
 	p.closed = true

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1226,12 +1226,12 @@ func TestRocksDBFileNotFoundError(t *testing.T) {
 func TestRocksDBDeleteRangeCompaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	db := setupMVCCInMemRocksDB(t, "delrange").(InMem)
+	db := setupMVCCInMemRocksDB(t, "delrange")
 	defer db.Close()
 
 	// Disable automatic compactions which interfere with test expectations
 	// below.
-	if err := db.disableAutoCompaction(); err != nil {
+	if err := db.(*RocksDB).disableAutoCompaction(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1361,7 +1361,7 @@ func BenchmarkRocksDBDeleteRangeIterate(b *testing.B) {
 		b.Run(fmt.Sprintf("entries=%d", entries), func(b *testing.B) {
 			for _, deleted := range []int{entries, entries - 1} {
 				b.Run(fmt.Sprintf("deleted=%d", deleted), func(b *testing.B) {
-					db := setupMVCCInMemRocksDB(b, "unused").(InMem)
+					db := setupMVCCInMemRocksDB(b, "unused")
 					defer db.Close()
 
 					makeKey := func(i int) roachpb.Key {
@@ -1484,7 +1484,7 @@ func TestSstFileWriterTimeBound(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	db := setupMVCCInMemRocksDB(t, "sstwriter-timebound").(InMem)
+	db := setupMVCCInMemRocksDB(t, "sstwriter-timebound")
 	defer db.Close()
 
 	for walltime := int64(1); walltime < 5; walltime++ {

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -69,7 +69,7 @@ func NewRocksDBTempEngine(
 	if tempStorage.InMemory {
 		// TODO(arjun): Limit the size of the store once #16750 is addressed.
 		// Technically we do not pass any attributes to temporary store.
-		db := newRocksDBInMem(roachpb.Attributes{} /* attrs */, 0 /* cacheSize */).RocksDB
+		db := newRocksDBInMem(roachpb.Attributes{} /* attrs */, 0 /* cacheSize */)
 		return &rocksDBTempEngine{db: db}, nil
 	}
 

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -12,6 +12,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -35,11 +36,13 @@ func init() {
 func NewTempEngine(
 	engine enginepb.EngineType, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (diskmap.Factory, error) {
-	if engine == enginepb.EngineTypePebble {
+	switch engine {
+	case enginepb.EngineTypePebble:
 		return NewPebbleTempEngine(tempStorage, storeSpec)
+	case enginepb.EngineTypeRocksDB:
+		return NewRocksDBTempEngine(tempStorage, storeSpec)
 	}
-
-	return NewRocksDBTempEngine(tempStorage, storeSpec)
+	panic(fmt.Sprintf("unknown engine type: %d", engine))
 }
 
 type rocksDBTempEngine struct {

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -178,7 +178,7 @@ func (cws *cachedWriteSimulator) value(size int) roachpb.Value {
 func (cws *cachedWriteSimulator) multiKey(
 	numOps int, size int, txn *roachpb.Transaction, ms *enginepb.MVCCStats,
 ) {
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 	t, ctx := cws.t, context.Background()
 
@@ -196,7 +196,7 @@ func (cws *cachedWriteSimulator) multiKey(
 func (cws *cachedWriteSimulator) singleKeySteady(
 	qps int, duration time.Duration, size int, ms *enginepb.MVCCStats,
 ) {
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 	t, ctx := cws.t, context.Background()
 	cacheKey := fmt.Sprintf("%d-%s-%s", qps, duration, humanizeutil.IBytes(int64(size)))

--- a/pkg/storage/rditer/replica_data_iter_test.go
+++ b/pkg/storage/rditer/replica_data_iter_test.go
@@ -172,7 +172,7 @@ func verifyRDIter(
 func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	desc := &roachpb.RangeDescriptor{
@@ -193,7 +193,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 func TestReplicaDataIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	defer eng.Close()
 
 	descPre := roachpb.RangeDescriptor{

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -484,9 +484,9 @@ func addSSTablePreApply(
 	canSkipSeqNo := st.Version.IsActive(cluster.VersionUnreplicatedRaftTruncatedState)
 
 	copied := false
-	if inmem, ok := eng.(engine.InMem); ok {
+	if eng.InMem() {
 		path = fmt.Sprintf("%x", checksum)
-		if err := inmem.WriteFile(path, sst.Data); err != nil {
+		if err := eng.WriteFile(path, sst.Data); err != nil {
 			panic(err)
 		}
 	} else {

--- a/pkg/storage/replica_raft_truncation_test.go
+++ b/pkg/storage/replica_raft_truncation_test.go
@@ -45,7 +45,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 	datadriven.Walk(t, "testdata/truncated_state_migration", func(t *testing.T, path string) {
 		const rangeID = 12
 		loader := stateloader.Make(rangeID)
-		eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		eng := engine.NewDefaultInMem()
 		defer eng.Close()
 
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -194,7 +194,8 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		tc.gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), cfg.DefaultZoneConfig)
 	}
 	if tc.engine == nil {
-		tc.engine = engine.NewInMem(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
+		tc.engine = engine.NewInMem(engine.TestStorageEngine,
+			roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
 		stopper.AddCloser(tc.engine)
 	}
 	if tc.transport == nil {
@@ -7923,7 +7924,7 @@ func TestGCWithoutThreshold(t *testing.T) {
 				t.Fatalf("expected %d declared keys, found %d", expSpans, numSpans)
 			}
 
-			eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+			eng := engine.NewDefaultInMem()
 			defer eng.Close()
 
 			batch := eng.NewBatch()

--- a/pkg/storage/stateloader/initial_test.go
+++ b/pkg/storage/stateloader/initial_test.go
@@ -27,7 +27,7 @@ func TestSynthesizeHardState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 
 	tHS := raftpb.HardState{Term: 2, Vote: 3, Commit: 4}

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -577,7 +577,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 
 	// Create store.
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 	cfg := TestStoreConfig(clock)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -211,7 +211,7 @@ func createTestStoreWithoutStart(
 	// and merge queues separately to cover event-driven splits and merges.
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.DisableMergeQueue = true
-	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
@@ -280,7 +280,7 @@ func TestIterateIDPrefixKeys(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 
 	seed := randutil.NewPseudoSeed()
@@ -409,7 +409,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
@@ -481,7 +481,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	eng := engine.NewDefaultInMem()
 	stopper.AddCloser(eng)
 
 	// Put some random garbage into the engine.
@@ -2987,7 +2987,7 @@ func (sp *fakeStorePool) throttle(reason throttleReason, why string, toStoreID r
 // various exceptional conditions and new capacity estimates.
 func TestSendSnapshotThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<10)
+	e := engine.NewDefaultInMem()
 	defer e.Close()
 
 	ctx := context.Background()

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -123,7 +123,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		rangeID := roachpb.RangeID(i)
 		replicaID := roachpb.ReplicaID(1)
 
-		memEngine := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		memEngine := engine.NewDefaultInMem()
 		stopper.AddCloser(memEngine)
 
 		cfg := TestStoreConfig(clock)
@@ -218,7 +218,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	stores := []*Store{}
 	for i := 0; i < count; i++ {
 		cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-		eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		eng := engine.NewDefaultInMem()
 		stopper.AddCloser(eng)
 		s := NewStore(context.TODO(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		storeIDAlloc++

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -116,7 +116,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	c := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started
 	ltc.Gossip = gossip.New(ambient, c, nc, cfg.RPCContext, server, ltc.Stopper, metric.NewRegistry(), roachpb.Locality{}, config.DefaultZoneConfigRef())
-	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)
+	ltc.Eng = engine.NewInMem(engine.TestStorageEngine, roachpb.Attributes{}, 50<<20)
 	ltc.Stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = storage.NewStores(ambient, ltc.Clock, cfg.Settings.Version.MinSupportedVersion, cfg.Settings.Version.ServerVersion)


### PR DESCRIPTION
The InMem type was specific to RocksDB and only used in one place
outside of the storage/engine package. This is prep-work for allowing
`engine.NewInMem` return either a `*RocksDB` or `*Pebble`.

See #41987

Release note: None