### PR TITLE
sql: implement pg_prepared_statements virtual table

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2342,6 +2342,17 @@ type connExPrepStmtsAccessor struct {
 
 var _ preparedStatementsAccessor = connExPrepStmtsAccessor{}
 
+// List is part of the preparedStatementsAccessor interface.
+func (ps connExPrepStmtsAccessor) List() map[string]*PreparedStatement {
+	// Return a copy of the data, to prevent modification of the map.
+	stmts := ps.ex.extraTxnState.prepStmtsNamespace.prepStmts
+	ret := make(map[string]*PreparedStatement, len(stmts))
+	for key, stmt := range stmts {
+		ret[key] = stmt
+	}
+	return ret
+}
+
 // Get is part of the preparedStatementsAccessor interface.
 func (ps connExPrepStmtsAccessor) Get(name string) (*PreparedStatement, bool) {
 	s, ok := ps.ex.extraTxnState.prepStmtsNamespace.prepStmts[name]

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -325,6 +325,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				},
 			},
 			typeHints,
+			PreparedStatementOriginSQL,
 		); err != nil {
 			return makeErrEvent(err)
 		}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -49,7 +50,11 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	ps, err := ex.addPreparedStmt(
-		ctx, parseCmd.Name, Statement{Statement: parseCmd.Statement}, parseCmd.TypeHints,
+		ctx,
+		parseCmd.Name,
+		Statement{Statement: parseCmd.Statement},
+		parseCmd.TypeHints,
+		PreparedStatementOriginWire,
 	)
 	if err != nil {
 		return retErr(err)
@@ -87,14 +92,18 @@ func (ex *connExecutor) execPrepare(
 //
 // placeholderHints are used to assist in inferring placeholder types.
 func (ex *connExecutor) addPreparedStmt(
-	ctx context.Context, name string, stmt Statement, placeholderHints tree.PlaceholderTypes,
+	ctx context.Context,
+	name string,
+	stmt Statement,
+	placeholderHints tree.PlaceholderTypes,
+	origin PreparedStatementOrigin,
 ) (*PreparedStatement, error) {
 	if _, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts[name]; ok {
 		panic(fmt.Sprintf("prepared statement already exists: %q", name))
 	}
 
 	// Prepare the query. This completes the typing of placeholders.
-	prepared, err := ex.prepare(ctx, stmt, placeholderHints)
+	prepared, err := ex.prepare(ctx, stmt, placeholderHints, origin)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +123,10 @@ func (ex *connExecutor) addPreparedStmt(
 // The PreparedStatement is returned (or nil if there are no results). The
 // returned PreparedStatement needs to be close()d once its no longer in use.
 func (ex *connExecutor) prepare(
-	ctx context.Context, stmt Statement, placeholderHints tree.PlaceholderTypes,
+	ctx context.Context,
+	stmt Statement,
+	placeholderHints tree.PlaceholderTypes,
+	origin PreparedStatementOrigin,
 ) (*PreparedStatement, error) {
 	if placeholderHints == nil {
 		placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
@@ -128,6 +140,9 @@ func (ex *connExecutor) prepare(
 		},
 		memAcc:   ex.sessionMon.MakeBoundAccount(),
 		refCount: 1,
+
+		createdAt: timeutil.Now(),
+		origin:    origin,
 	}
 	// NB: if we start caching the plan, we'll want to keep around the memory
 	// account used for the plan, rather than clearing it.

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -120,6 +120,7 @@ test           pg_catalog          pg_locks                           public   S
 test           pg_catalog          pg_matviews                        public   SELECT
 test           pg_catalog          pg_namespace                       public   SELECT
 test           pg_catalog          pg_operator                        public   SELECT
+test           pg_catalog          pg_prepared_statements             public   SELECT
 test           pg_catalog          pg_prepared_xacts                  public   SELECT
 test           pg_catalog          pg_proc                            public   SELECT
 test           pg_catalog          pg_range                           public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -296,6 +296,7 @@ pg_catalog          pg_locks
 pg_catalog          pg_matviews
 pg_catalog          pg_namespace
 pg_catalog          pg_operator
+pg_catalog          pg_prepared_statements
 pg_catalog          pg_prepared_xacts
 pg_catalog          pg_proc
 pg_catalog          pg_range
@@ -434,6 +435,7 @@ pg_locks
 pg_matviews
 pg_namespace
 pg_operator
+pg_prepared_statements
 pg_prepared_xacts
 pg_proc
 pg_range
@@ -579,6 +581,7 @@ system         pg_catalog          pg_locks                           SYSTEM VIE
 system         pg_catalog          pg_matviews                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_namespace                       SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_operator                        SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_prepared_statements             SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_prepared_xacts                  SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_proc                            SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_range                           SYSTEM VIEW  NO                  1
@@ -1380,6 +1383,7 @@ NULL     public   system         pg_catalog          pg_locks                   
 NULL     public   system         pg_catalog          pg_matviews                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_namespace                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_operator                        SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_prepared_statements             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_xacts                  SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_proc                            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_range                           SELECT          NULL          YES
@@ -1671,6 +1675,7 @@ NULL     public   system         pg_catalog          pg_locks                   
 NULL     public   system         pg_catalog          pg_matviews                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_namespace                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_operator                        SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_prepared_statements             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_xacts                  SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_proc                            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_range                           SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -44,6 +44,7 @@ pg_locks
 pg_matviews
 pg_namespace
 pg_operator
+pg_prepared_statements
 pg_prepared_xacts
 pg_proc
 pg_range
@@ -117,6 +118,7 @@ pg_locks
 pg_matviews
 pg_namespace
 pg_operator
+pg_prepared_statements
 pg_prepared_xacts
 pg_proc
 pg_range
@@ -1441,26 +1443,27 @@ objoid      classoid    objsubid  description
 4294967211  4294967230  0         available materialized views (empty - feature does not exist)
 4294967210  4294967230  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
 4294967209  4294967230  0         operators (incomplete)
-4294967208  4294967230  0         prepared transactions (empty - feature does not exist)
-4294967207  4294967230  0         built-in functions (incomplete)
-4294967206  4294967230  0         range types (empty - feature does not exist)
-4294967205  4294967230  0         rewrite rules (empty - feature does not exist)
-4294967204  4294967230  0         database roles
-4294967191  4294967230  0         security labels (empty - feature does not exist)
-4294967203  4294967230  0         security labels (empty)
-4294967202  4294967230  0         sequences (see also information_schema.sequences)
-4294967201  4294967230  0         session variables (incomplete)
-4294967200  4294967230  0         shared dependencies (empty - not implemented)
+4294967208  4294967230  0         prepared statements
+4294967207  4294967230  0         prepared transactions (empty - feature does not exist)
+4294967206  4294967230  0         built-in functions (incomplete)
+4294967205  4294967230  0         range types (empty - feature does not exist)
+4294967204  4294967230  0         rewrite rules (empty - feature does not exist)
+4294967203  4294967230  0         database roles
+4294967190  4294967230  0         security labels (empty - feature does not exist)
+4294967202  4294967230  0         security labels (empty)
+4294967201  4294967230  0         sequences (see also information_schema.sequences)
+4294967200  4294967230  0         session variables (incomplete)
+4294967199  4294967230  0         shared dependencies (empty - not implemented)
 4294967222  4294967230  0         shared object comments
-4294967190  4294967230  0         shared security labels (empty - feature not supported)
-4294967192  4294967230  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967197  4294967230  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967196  4294967230  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967195  4294967230  0         triggers (empty - feature does not exist)
-4294967194  4294967230  0         scalar types (incomplete)
-4294967199  4294967230  0         database users
-4294967198  4294967230  0         local to remote user mapping (empty - feature does not exist)
-4294967193  4294967230  0         view definitions (incomplete - see also information_schema.views)
+4294967189  4294967230  0         shared security labels (empty - feature not supported)
+4294967191  4294967230  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967196  4294967230  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967195  4294967230  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967194  4294967230  0         triggers (empty - feature does not exist)
+4294967193  4294967230  0         scalar types (incomplete)
+4294967198  4294967230  0         database users
+4294967197  4294967230  0         local to remote user mapping (empty - feature does not exist)
+4294967192  4294967230  0         view definitions (incomplete - see also information_schema.views)
 
 ## pg_catalog.pg_shdescription
 
@@ -1834,6 +1837,26 @@ SELECT unnest((SELECT proargtypes FROM pg_proc WHERE proname='split_part'));
 25
 25
 20
+
+subtest pg_catalog.pg_prepare_statement
+
+statement ok
+CREATE TABLE types(a timestamptz, b integer)
+
+statement ok
+PREPARE test_insert_statement (integer, timestamptz) AS INSERT INTO types VALUES ($2, $1)
+
+statement ok
+PREPARE test_select_statement AS SELECT * FROM types
+
+query TTTB
+select name, statement, parameter_types, from_sql from pg_prepared_statements ORDER BY 1
+----
+test_insert_statement  PREPARE test_insert_statement (int, timestamptz) AS INSERT INTO types VALUES ($2, $1)  {bigint,"'timestamp with time zone'"}  true
+test_select_statement  PREPARE test_select_statement AS SELECT * FROM types                                   {}                                     true
+
+statement ok
+DROP TABLE types
 
 ## TODO(masha): #16769
 #statement ok

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -135,6 +135,7 @@ const (
 	PgCatalogMatViewsTableID
 	PgCatalogNamespaceTableID
 	PgCatalogOperatorTableID
+	PgCatalogPreparedStatementsTableID
 	PgCatalogPreparedXactsTableID
 	PgCatalogProcTableID
 	PgCatalogRangeTableID

--- a/pkg/sql/sqlbase/prepared_statement.go
+++ b/pkg/sql/sqlbase/prepared_statement.go
@@ -57,5 +57,6 @@ func (pm *PrepareMetadata) MemoryEstimate() int64 {
 
 	res += int64(len(pm.Columns)) * int64(unsafe.Sizeof(ResultColumn{}))
 	res += int64(len(pm.InferredTypes)) * int64(unsafe.Sizeof(oid.Oid(0)))
+
 	return res
 }


### PR DESCRIPTION
* resolves #41778
* add List() to the prepared statements accessor
* implemented pg_prepared_statements, with some fun caveats
   * i think we always use wire format, so from_sql is always false?
   * had to add an extra data type for CreatedAt, not sure how to increment SizeOf here with the location variable set.
   * other caveats are documented as a comment.

Release note (sql change): introduces pg_prepared_statements table for use