### PR TITLE
coldata: remove panic when encountering a decreasing non-zero offset

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -66,16 +66,10 @@ func (b *Bytes) AssertOffsetsAreNonDecreasing(n uint64) {
 func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n uint64) {
 	prev := b.offsets[0]
 	for j := uint64(1); j <= n; j++ {
-		if b.offsets[j] == 0 {
-			b.offsets[j] = prev
-		} else if b.offsets[j] < prev {
-			// Having a zero offset is expected (when an actual NULL value is there)
-			// whereas a non-zero offset that is smaller than the largest offset seen
-			// so far is unexpected.
-			panic(fmt.Sprintf("unexpectedly found a decreasing non-zero offset:"+
-				" previous max=%d, found=%d", prev, b.offsets[j]))
-		} else {
+		if b.offsets[j] > prev {
 			prev = b.offsets[j]
+		} else {
+			b.offsets[j] = prev
 		}
 	}
 }


### PR DESCRIPTION
Previously, when ensuring that offsets in Bytes were non-decreasing (in NULL
cases), we would panic when encountering an offset that was non-zero.

Because we allow a Bytes struct to be Reset without zeroing offsets (it's
cheaper), there are cases where we can have a Bytes with a maxSetIndex of 0
but populated offsets. If that Bytes struct is copied into yet not fully
overwritten, the non-zero non-decreasing offset issue could be encountered.

Release note: None

Fixes #42020