### PR TITLE
release-2.1: storage: take an engine checkpoint during failing consistency checks

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -18,6 +18,7 @@
 #include <rocksdb/perf_context.h>
 #include <rocksdb/sst_file_writer.h>
 #include <rocksdb/table.h>
+#include <rocksdb/utilities/checkpoint.h>
 #include <stdarg.h>
 #include "batch.h"
 #include "cache.h"
@@ -253,6 +254,22 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
                    db_opts.cache != nullptr ? db_opts.cache->rep : nullptr, event_listener);
   return kSuccess;
 }
+
+DBStatus DBCreateCheckpoint(DBEngine* db, DBSlice dir) {
+  const std::string cp_dir = ToString(dir);
+
+  rocksdb::Checkpoint* cp_ptr;
+  auto status = rocksdb::Checkpoint::Create(db->rep, &cp_ptr);
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  // NB: passing 0 for log_size_for_flush forces a WAL sync, i.e. makes sure
+  // that the checkpoint is up to date.
+  status = cp_ptr->CreateCheckpoint(cp_dir, 0 /* log_size_for_flush */);
+  delete(cp_ptr);
+  return ToDBStatus(status);
+}
+
 
 DBStatus DBDestroy(DBSlice dir) {
   rocksdb::Options options;

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -99,6 +99,12 @@ void DBReleaseCache(DBCache* cache);
 // exist.
 DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions options);
 
+// Creates a RocksDB checkpoint in the specified directory (which must not exist).
+// A checkpoint is a logical copy of the database, though it will hardlink the
+// SSTs references by it (when possible), thus avoiding duplication of any of
+// the actual data.
+DBStatus DBCreateCheckpoint(DBEngine* db, DBSlice dir);
+
 // Set a callback to be invoked during DBOpen that can make changes to RocksDB
 // initialization. Used by CCL code to install additional features.
 //

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -314,6 +314,10 @@ type Engine interface {
 	// the engine implementation. For RocksDB, this means using the Env responsible for the file
 	// which may handle extra logic (eg: copy encryption settings for EncryptedEnv).
 	LinkFile(oldname, newname string) error
+	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
+	// which must not exist. The directory should be on the same file system so
+	// that hard links can be used.
+	CreateCheckpoint(dir string) error
 }
 
 // WithSSTables extends the Engine interface with a method to get info

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -18,19 +18,22 @@ import (
 	"bytes"
 	"context"
 	"math/rand"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func ensureRangeEqual(
@@ -789,5 +792,37 @@ func insertKeysAndValues(keys []MVCCKey, values [][]byte, engine Engine, t *test
 		if err := engine.Put(keys[idx], val); err != nil {
 			t.Errorf("put: expected no error, but got %s", err)
 		}
+	}
+}
+
+func TestCreateCheckpoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+
+	// TODO(tbg): use the method below, but only for on-disk stores.
+	_ = runWithAllEngines
+
+	rocksDB, err := NewRocksDB(
+		RocksDBConfig{
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
+		},
+		RocksDBCache{},
+	)
+
+	db := Engine(rocksDB) // be impl neutral from now on
+	defer db.Close()
+
+	dir = filepath.Join(dir, "checkpoint")
+
+	assert.NoError(t, err)
+	assert.NoError(t, db.CreateCheckpoint(dir))
+	m, err := filepath.Glob(dir + "/*")
+	assert.NoError(t, err)
+	assert.True(t, len(m) > 0)
+	if err := db.CreateCheckpoint(dir); !testutils.IsError(err, "exists") {
+		t.Fatal(err)
 	}
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -733,6 +733,14 @@ func (r *RocksDB) Close() {
 	r.syncer.Unlock()
 }
 
+// CreateCheckpoint creates a RocksDB checkpoint in the given directory (which
+// must not exist). This directory should be located on the same file system, or
+// copies of all data are used instead of hard links, which is very expensive.
+func (r *RocksDB) CreateCheckpoint(dir string) error {
+	status := C.DBCreateCheckpoint(r.rdb, goToCSlice([]byte(dir)))
+	return errors.Wrap(statusToError(status), "unable to take RocksDB checkpoint")
+}
+
 // Closed returns true if the engine is closed.
 func (r *RocksDB) Closed() bool {
 	return r.rdb == nil


### PR DESCRIPTION
Backport 1/2 commits from #36867. 

Useful as part of #42011.

+cc @cockroachdb/release

---

This takes a checkpoint on the nodes with replicas of a failing range,
before the failure leads to nodes shutting down. The checkpoint will, for
the replicas of the affected range, be taken at the same Raft log position.

Release note: None
