### PR TITLE
sql: filter out zones from crdb_internal.zones if user has no privilege

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -48,3 +48,53 @@ SELECT * FROM crdb_internal.partitions ORDER BY table_id, index_id, name
 53  1  p12  pd  1  b  (DEFAULT)  NULL 0 0
 53  2  NULL  p00  2  a, b  (0, 0)  NULL 0 0
 54  1  NULL  pfoo  1  a  ('foo')  NULL 0 0
+
+# Test crdb_internal.zones functions correctly on zoned indexes.
+subtest privileged_zones_test
+
+statement ok
+CREATE TABLE t3 (a INT PRIMARY KEY, b INT); CREATE INDEX myindex ON t3 (b)
+
+statement ok
+CREATE TABLE t4 (a INT PRIMARY KEY, b INT)
+
+statement ok
+ALTER TABLE t3 CONFIGURE ZONE USING num_replicas = 8
+
+statement ok
+ALTER INDEX myindex CONFIGURE ZONE USING num_replicas = 5
+
+statement ok
+ALTER TABLE t4 CONFIGURE ZONE USING num_replicas = 7
+
+query IT
+SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
+----
+0   RANGE default
+1   DATABASE system
+15  TABLE system.public.jobs
+16  RANGE meta
+17  RANGE system
+22  RANGE liveness
+25  TABLE system.public.replication_constraint_stats
+27  TABLE system.public.replication_stats
+55  TABLE test.public.t3
+55  INDEX test.public.t3@myindex
+56  TABLE test.public.t4
+
+statement ok
+REVOKE ALL ON t3 FROM testuser
+
+statement ok
+GRANT ALL ON t4 TO testuser
+
+user testuser
+
+query IT
+SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
+----
+0   RANGE default
+16  RANGE meta
+17  RANGE system
+22  RANGE liveness
+56  TABLE test.public.t4

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2163,6 +2163,27 @@ CREATE TABLE crdb_internal.zones (
 				return err
 			}
 
+			var table *TableDescriptor
+			if zs.Database != "" {
+				database, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, sqlbase.ID(id))
+				if err != nil {
+					return err
+				}
+				if p.CheckAnyPrivilege(ctx, database) != nil {
+					continue
+				}
+			} else if zs.NamedZone == "" {
+				// ZoneSpecifiers only have one of {NamedZone, Database, TableOrIndex} set.
+				// If zs.NamedZone is empty, then it must be TableOrIndex.
+				table, err = sqlbase.GetTableDescFromID(ctx, p.txn, sqlbase.ID(id))
+				if err != nil {
+					return err
+				}
+				if p.CheckAnyPrivilege(ctx, table) != nil {
+					continue
+				}
+			}
+
 			// Write down information about the zone in the table.
 			// TODO (rohany): We would like to just display information about these
 			//  subzone placeholders, but there are a few tests that depend on this
@@ -2189,10 +2210,14 @@ CREATE TABLE crdb_internal.zones (
 			}
 
 			if len(subzones) > 0 {
-				table, err := sqlbase.GetTableDescFromID(ctx, p.txn, sqlbase.ID(id))
-				if err != nil {
-					return err
+				if table == nil {
+					return errors.AssertionFailedf(
+						"object id %d with #subzones %d is not a table",
+						id,
+						len(subzones),
+					)
 				}
+
 				for i, s := range subzones {
 					index, err := table.FindIndexByID(sqlbase.IndexID(s.IndexID))
 					if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -581,3 +581,93 @@ query T
 SELECT crdb_internal.cluster_name()
 ----
 testclustername
+
+
+# Verify that privileged tables in zones cannot be seen by other users.
+subtest regression_40917
+
+user testuser
+
+query IT
+SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
+----
+0   RANGE default
+16  RANGE meta
+17  RANGE system
+18  RANGE timeseries
+22  RANGE liveness
+
+query TT
+SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] ORDER BY 1
+----
+DATABASE system                                   ALTER DATABASE system CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 5,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+DATABASE testdb                                   ALTER DATABASE testdb CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+RANGE default                                     ALTER RANGE default CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+RANGE liveness                                    ALTER RANGE liveness CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 600,
+                                                  num_replicas = 5,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+RANGE meta                                        ALTER RANGE meta CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 3600,
+                                                  num_replicas = 5,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+RANGE system                                      ALTER RANGE system CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 5,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+RANGE timeseries                                  ALTER RANGE timeseries CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+TABLE system.public.jobs                          ALTER TABLE system.public.jobs CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 600,
+                                                  num_replicas = 5,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+TABLE system.public.replication_constraint_stats  ALTER TABLE system.public.replication_constraint_stats CONFIGURE ZONE USING
+                                                  gc.ttlseconds = 600,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+TABLE system.public.replication_stats             ALTER TABLE system.public.replication_stats CONFIGURE ZONE USING
+                                                  gc.ttlseconds = 600,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'
+TABLE testdb.public.foo                           ALTER TABLE testdb.public.foo CONFIGURE ZONE USING
+                                                  range_min_bytes = 16777216,
+                                                  range_max_bytes = 67108864,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '[]',
+                                                  lease_preferences = '[]'


### PR DESCRIPTION
Addresses the fix suggested by #40917 -- but doesn't actually fix the `SHOW ZONE CONFIGURATION` issue -  only `SHOW ALL ZONE CONFIGURATIONS` -- i can fix the `SHOW ZONE` separately. I still think this fix is worthwhile

If we do not have permissions in a table for a specific zone, do not show it for the crdb_internal.zone virtual table

Release note (bug fix): filter out zones from crdb_internal.zones if user has no privileges