### PR TITLE
storage/engine: migrate Pebble timeseries merge API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4e4242f49156024b2a0634274376fbb2db4e2c6285ce11785b19243d7ecc000e"
+  digest = "1:9a4146891c23995806585607e56540f1700326dcc45e8f08d9f16e6002a9d554"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -487,7 +487,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "48901a109734411492918b9cdd1d34009fb55a23"
+  revision = "a8b23ef97d28d0d424b724e190bde36261bc4d4d"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
@@ -81,12 +80,13 @@ var MVCCComparer = &pebble.Comparer{
 // by Cockroach.
 var MVCCMerger = &pebble.Merger{
 	Name: "cockroach_merge_operator",
-	Merge: func(key, oldValue, newValue, buf []byte) []byte {
-		res, err := merge(key, oldValue, newValue, buf)
+	Merge: func(_, value []byte) (pebble.ValueMerger, error) {
+		res := &MVCCValueMerger{}
+		err := res.MergeNewer(value)
 		if err != nil {
-			log.Fatalf(context.Background(), "merge: %v", err)
+			return nil, err
 		}
-		return res
+		return res, nil
 	},
 }
 


### PR DESCRIPTION
Migrate to the new batch merge API introduced in
https://github.com/cockroachdb/pebble/pull/367. This PR also includes a
version update of Pebble to
https://github.com/cockroachdb/pebble/commit/a8b23ef97d28d0d424b724e190bde36261bc4d4d
in order to obtain the API change.

Release note: None