### PR TITLE
storage/engine: minor pebble seek optimization fixes

### DIFF
--- a/pkg/storage/engine/pebble_mvcc_scanner.go
+++ b/pkg/storage/engine/pebble_mvcc_scanner.go
@@ -386,9 +386,10 @@ func (p *pebbleMVCCScanner) nextKey() bool {
 
 	for iterCount >= 0 && p.parent.Valid() && bytes.Equal(p.keyBuf, p.curKey) {
 		p.iterNext()
+		iterCount--
 	}
 
-	if bytes.Equal(p.keyBuf, p.curKey) {
+	if bytes.Equal(p.keyBuf, p.curKey) && p.parent.Valid() {
 		// We have to seek. Append a null byte to the current key.
 		p.keyBuf = append(p.keyBuf, 0x00)
 


### PR DESCRIPTION
MVCCGet will see an iterator become invalid instead of reaching the next
logical key as it uses SeekPrefixGE to create an iterator that cannot go
outside of one logical key's prefix. We should avoid re-seeking when the
iterator goes invalid as that incurs extra work.

Release note: None