### PR TITLE
sql: new opt-in option `strict_ddl_atomicity`

### DIFF
--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -73,7 +73,9 @@ func (p *planner) renameDatabase(
 func (p *planner) writeNonDropDatabaseChange(
 	ctx context.Context, desc *dbdesc.Mutable, jobDesc string,
 ) error {
-	p.createNonDropDatabaseChangeJob(ctx, desc.ID, jobDesc)
+	if err := p.createNonDropDatabaseChangeJob(ctx, desc.ID, jobDesc); err != nil {
+		return err
+	}
 	b := p.Txn().NewBatch()
 	if err := p.writeDatabaseChangeToBatch(ctx, desc, b); err != nil {
 		return err

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -172,7 +172,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		}
 	}
 
-	p.createDropDatabaseJob(
+	if err := p.createDropDatabaseJob(
 		ctx,
 		n.dbDesc.GetID(),
 		schemasIDsToDelete,
@@ -180,7 +180,9 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		n.d.typesToDelete,
 		n.d.functionsToDelete,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
-	)
+	); err != nil {
+		return err
+	}
 
 	n.dbDesc.SetDropped()
 	b := p.txn.NewBatch()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3251,6 +3251,10 @@ func (m *sessionDataMutator) UpdateSearchPath(paths []string) {
 	m.data.SearchPath = m.data.SearchPath.UpdatePaths(paths)
 }
 
+func (m *sessionDataMutator) SetStrictDDLAtomicity(val bool) {
+	m.data.StrictDDLAtomicity = val
+}
+
 func (m *sessionDataMutator) SetLocation(loc *time.Location) {
 	oldLocation := sessionDataTimeZoneFormat(m.data.Location)
 	m.data.Location = loc

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -343,7 +343,9 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 			if err := p.writeDatabaseChangeToBatch(ctx, d, b); err != nil {
 				return err
 			}
-			p.createNonDropDatabaseChangeJob(ctx, d.ID, fmt.Sprintf("updating privileges for database %d", d.ID))
+			if err := p.createNonDropDatabaseChangeJob(ctx, d.ID, fmt.Sprintf("updating privileges for database %d", d.ID)); err != nil {
+				return err
+			}
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5393,6 +5393,7 @@ ssl_renegotiation_limit                                    0
 standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_enabled                                           on
+strict_ddl_atomicity                                       off
 stub_catalog_tables                                        on
 synchronize_seqscans                                       on
 synchronous_commit                                         on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2821,6 +2821,7 @@ sql_safe_updates                                           off                 N
 standard_conforming_strings                                on                  NULL      NULL        NULL        string
 statement_timeout                                          0                   NULL      NULL        NULL        string
 streamer_enabled                                           on                  NULL      NULL        NULL        string
+strict_ddl_atomicity                                       off                 NULL      NULL        NULL        string
 stub_catalog_tables                                        on                  NULL      NULL        NULL        string
 synchronize_seqscans                                       on                  NULL      NULL        NULL        string
 synchronous_commit                                         on                  NULL      NULL        NULL        string
@@ -2984,6 +2985,7 @@ sql_safe_updates                                           off                 N
 standard_conforming_strings                                on                  NULL  user     NULL      on                  on
 statement_timeout                                          0                   NULL  user     NULL      0s                  0s
 streamer_enabled                                           on                  NULL  user     NULL      on                  on
+strict_ddl_atomicity                                       off                 NULL  user     NULL      off                 off
 stub_catalog_tables                                        on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                       on                  NULL  user     NULL      on                  on
 synchronous_commit                                         on                  NULL  user     NULL      on                  on
@@ -3147,6 +3149,7 @@ sql_safe_updates                                           NULL    NULL     NULL
 standard_conforming_strings                                NULL    NULL     NULL     NULL        NULL
 statement_timeout                                          NULL    NULL     NULL     NULL        NULL
 streamer_enabled                                           NULL    NULL     NULL     NULL        NULL
+strict_ddl_atomicity                                       NULL    NULL     NULL     NULL        NULL
 stub_catalog_tables                                        NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                       NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -151,6 +151,7 @@ sql_safe_updates                                           off
 standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_enabled                                           on
+strict_ddl_atomicity                                       off
 stub_catalog_tables                                        on
 synchronize_seqscans                                       on
 synchronous_commit                                         on

--- a/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
+++ b/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
@@ -35,3 +35,16 @@ query I
 SELECT * FROM unrelated
 ----
 1
+
+statement ok
+DELETE FROM testing WHERE k = 5
+
+# Now try again with the strict setting
+statement ok
+SET strict_ddl_atomicity = true
+
+statement ok
+BEGIN
+
+statement error unimplemented: cannot run this DDL statement inside BEGIN..COMMIT as its atomicity cannot be guaranteed.*\n.*\n.*issue-v/42061
+ALTER TABLE testing ADD CONSTRAINT "unique_values" UNIQUE(v)

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -428,6 +428,19 @@ message LocalOnlySessionData {
   // transactions that see a transaction retry error.
   int32 max_retries_for_read_committed = 110;
 
+  // StrictDDLAtomicity causes errors when the client attempts DDL
+  // operations inside an explicit txn and CockroachDB cannot
+  // guarantee the DDL to be performed atomically.
+  //
+  // When this is not set, a transaction may commit its DML
+  // statements but fail its DDL statements, resulting
+  // in error XXA00 - TransactionCommittedWithSchemaChangeFailure.
+  //
+  // When this is set, that particular atomicity violation should
+  // not occur any more (at the expense of disabling certain
+  // forms of DDL inside explicit txns).
+  bool strict_ddl_atomicity = 111 [(gogoproto.customname) = "StrictDDLAtomicity"];
+
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -28,12 +28,23 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
 func (p *planner) getVirtualTabler() VirtualTabler {
 	return p.extendedEvalCtx.VirtualSchemas
+}
+
+func (p *planner) checkDDLAtomicity() error {
+	if !p.ExtendedEvalContext().TxnImplicit &&
+		p.SessionData().StrictDDLAtomicity {
+		return errors.WithHint(unimplemented.NewWithIssue(42061,
+			"cannot run this DDL statement inside BEGIN..COMMIT as its atomicity cannot be guaranteed"),
+			"You can set the session variable 'strict_ddl_atomicity' to false if you are willing to accept atomicity violations.")
+	}
+	return nil
 }
 
 // createDropDatabaseJob queues a job for dropping a database.
@@ -45,7 +56,11 @@ func (p *planner) createDropDatabaseJob(
 	typesToDrop []*typedesc.Mutable,
 	functionsToDrop []*funcdesc.Mutable,
 	jobDesc string,
-) {
+) error {
+	if err := p.checkDDLAtomicity(); err != nil {
+		return err
+	}
+
 	// TODO (lucy): This should probably be deleting the queued jobs for all the
 	// tables being dropped, so that we don't have duplicate schema changers.
 	tableIDs := make([]descpb.ID, 0, len(tableDropDetails))
@@ -78,6 +93,7 @@ func (p *planner) createDropDatabaseJob(
 	}
 	jobID := p.extendedEvalCtx.QueueJob(jobRecord)
 	log.Infof(ctx, "queued new drop database job %d for database %d", jobID, databaseID)
+	return nil
 }
 
 // CreateNonDropDatabaseChangeJob covers all database descriptor updates other
@@ -86,7 +102,11 @@ func (p *planner) createDropDatabaseJob(
 // don't queue multiple jobs for the same database.
 func (p *planner) createNonDropDatabaseChangeJob(
 	ctx context.Context, databaseID descpb.ID, jobDesc string,
-) {
+) error {
+	if err := p.checkDDLAtomicity(); err != nil {
+		return err
+	}
+
 	jobRecord := &jobs.Record{
 		Description: jobDesc,
 		Username:    p.User(),
@@ -100,6 +120,7 @@ func (p *planner) createNonDropDatabaseChangeJob(
 	}
 	jobID := p.extendedEvalCtx.QueueJob(jobRecord)
 	log.Infof(ctx, "queued new database schema change job %d for database %d", jobID, databaseID)
+	return nil
 }
 
 // createOrUpdateSchemaChangeJob queues a new job for the schema change if there
@@ -108,6 +129,10 @@ func (p *planner) createNonDropDatabaseChangeJob(
 func (p *planner) createOrUpdateSchemaChangeJob(
 	ctx context.Context, tableDesc *tabledesc.Mutable, jobDesc string, mutationID descpb.MutationID,
 ) error {
+	if err := p.checkDDLAtomicity(); err != nil {
+		return err
+	}
+
 	// If there is a concurrent schema change using the declarative schema
 	// changer, then we must fail and wait for that schema change to conclude.
 	// The error here will be dealt with in

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1206,6 +1206,23 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// CockroachDB extension (inspired by MySQL).
+	`strict_ddl_atomicity`: {
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().StrictDDLAtomicity), nil
+		},
+		GetStringVal: makePostgresBoolGetStringValFn("strict_ddl_atomicity"),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("strict_ddl_atomicity", s)
+			if err != nil {
+				return err
+			}
+			m.SetStrictDDLAtomicity(b)
+			return nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
 	// See https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH
 	// https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
 	`search_path`: {


### PR DESCRIPTION
Informs #42061.
informs https://github.com/cockroachdb/cockroach/issues/87236
Fixes #108737.

Previously, CockroachDB always accepted DDL inside explicit
txns (BEGIN...COMMIT) and would issue some of these DDL statements as
asynchronous jobs after the rest of the txn was committed
successfully. If that DDL subsequently failed, a client would also get
error `XXA00` to signal this error. However at that point the txn also
would be both partially committed and partially rolled back. This is
in effect an atomicity violation.

It was considered to be acceptable because in practice most clients
using DDL inside BEGIN...COMMIT do not, in fact, expect ACID semantics
in those cases. So it was considered OK to not deliver ACID semantics
in certain cases.

Except that we now have clients that do want us to "do the right
thing" and never allow a situation that _could_ yield atomicity
violations.

This patch makes a step in this direction by introducing a new session
variable `strict_ddl_atomicity`, which defaults to `false` for
compatibility with existing CockroachDB 23.1 clients and that of
previous CockroachDB versions.

When this setting is enabled / set to `true`, any DDL that would
be otherwise be processed asynchronously and risk triggering error
`XXA00` is now fully disallowed, with the following error:

```
pq: unimplemented: cannot run this DDL statement inside BEGIN..COMMIT as its atomicity cannot be guaranteed
HINT: You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/42061
--
You can set the session variable 'strict_ddl_atomicity' to false if you are willing to accept atomicity violations.
```

Other DDL statements without async processing are still allowed
without triggering that error.

Examples of rejected DDL include but are not limited to: CREATE
INDEX, ALTER ADD CONSTRAINT, ADD COLUMN with DEFAULT, DROP INDEX.

Examples of DDL that's still processed: RENAME COLUMN, RENAME TABLE,
ALTER INDEX CONFIGURE ZONE.

Release note (sql change): a SQL client can now request strict
atomicity for mixed DDL/DML transactions with the new session variable
`strict_ddl_atomicity`, which defaults to `false`. When this variable
is set to `true`, CockroachDB will refuse to accept processing those
specific DDL statements inside BEGIN...COMMIT for which it cannot
guarantee atomic processing (other DDL statements are still allowed).

Note that schema changes implicit in certain operations (e.g. IMPORT)
are not protected via the new mechanism and can still fail with
`XXA00` errors.

Epic: CRDB-28893