### PR TITLE
sql: SHOW ZONE CONFIGURATION only if user has permissions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -48,3 +48,48 @@ SELECT * FROM crdb_internal.partitions ORDER BY table_id, index_id, name
 53  1  p12  pd  1  b  (DEFAULT)  NULL 0 0
 53  2  NULL  p00  2  a, b  (0, 0)  NULL 0 0
 54  1  NULL  pfoo  1  a  ('foo')  NULL 0 0
+
+# Test crdb_internal.zones functions correctly on zoned indexes.
+subtest privileged_zones_test
+
+statement ok
+CREATE DATABASE db2; ALTER DATABASE db2 CONFIGURE ZONE USING num_replicas = 3;
+
+statement ok
+CREATE TABLE t3 (a INT PRIMARY KEY, b INT); CREATE INDEX myindex ON t3 (b); ALTER INDEX myindex CONFIGURE ZONE USING num_replicas = 5; ALTER TABLE t3 CONFIGURE ZONE USING num_replicas = 8
+
+statement ok
+CREATE TABLE t4 (a INT PRIMARY KEY, b INT); ALTER TABLE t4 CONFIGURE ZONE USING num_replicas = 7; GRANT ALL ON t4 TO testuser
+
+user testuser
+
+query error pq: user testuser has no privileges on database db2
+SHOW ZONE CONFIGURATION FOR DATABASE db2
+
+query error pq: user testuser has no privileges on relation t2
+SHOW ZONE CONFIGURATION FOR TABLE t2
+
+query error pq: user testuser has no privileges on relation t3
+SHOW ZONE CONFIGURATION FOR TABLE t3
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t4
+----
+TABLE t4  ALTER TABLE t4 CONFIGURE ZONE USING
+          range_min_bytes = 16777216,
+          range_max_bytes = 67108864,
+          gc.ttlseconds = 90000,
+          num_replicas = 7,
+          constraints = '[]',
+          lease_preferences = '[]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR RANGE default
+----
+RANGE default  ALTER RANGE default CONFIGURE ZONE USING
+               range_min_bytes = 16777216,
+               range_max_bytes = 67108864,
+               gc.ttlseconds = 90000,
+               num_replicas = 3,
+               constraints = '[]',
+               lease_preferences = '[]'

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -107,6 +107,24 @@ func getShowZoneConfigRow(
 		return nil, err
 	}
 
+	if zoneSpecifier.TableOrIndex.Table.TableName != "" {
+		if err = p.CheckAnyPrivilege(ctx, tblDesc); err != nil {
+			return nil, err
+		}
+	} else if zoneSpecifier.Database != "" {
+		database, err := p.ResolveUncachedDatabaseByName(
+			ctx,
+			string(zoneSpecifier.Database),
+			true, /* required */
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err = p.CheckAnyPrivilege(ctx, database); err != nil {
+			return nil, err
+		}
+	}
+
 	targetID, err := resolveZone(ctx, p.txn, &zoneSpecifier)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, SHOW ZONE CONFIGURATION did not respect permissions on
tables. Patch that up by checking permissions when using this command.

Resolves the command in #40917.

Has merge conflicts with https://github.com/cockroachdb/cockroach/pull/42046; I will fix them up with whatever lands first.

Release note (bug fix): fix bug where zones would display in `SHOW ZONE CONFIGURATION` even though the user has no permission to view that table