### PR TITLE
opt: fix test catalog to not build empty histograms

### DIFF
--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -974,7 +974,7 @@ func (ts *TableStat) NullCount() uint64 {
 // Histogram is part of the cat.TableStatistic interface.
 func (ts *TableStat) Histogram() []cat.HistogramBucket {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	if ts.js.HistogramColumnType == "" {
+	if ts.js.HistogramColumnType == "" || ts.js.HistogramBuckets == nil {
 		return nil
 	}
 	colType, err := parser.ParseType(ts.js.HistogramColumnType)


### PR DESCRIPTION
This commit fixes the optimizer test catalog to not build an
empty histogram if there is no histogram data provided. Previously,
the test catalog would always build a histogram if the histogram
column type was provided, but it did not check if the slice of
histogram buckets was nil. This made it difficult to debug issues
with customer workloads, since the opt tester was using empty
histograms when the real workload was not using histograms.

Release note: None