### PR TITLE
vendor: No-change bump of pebble to 49455523

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4e4242f49156024b2a0634274376fbb2db4e2c6285ce11785b19243d7ecc000e"
+  digest = "1:5202e85ca3da7df010227aa9ca8f22e7e4424471497489a1d82de6a736f36c05"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -487,7 +487,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "48901a109734411492918b9cdd1d34009fb55a23"
+  revision = "494555237c300634756aba4c68adb4a1bce40e06"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Picks up `blockIter` fix, `tool` improvements, etc

Release note: None