### PR TITLE
colexec: fix interaction between aggregator and flat bytes

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -38,8 +38,6 @@ func registerTPCHVec(r *testRegistry) {
 		13: "incorrect output: unknown",
 		15: "unsupported: create view",
 		16: "unsupported: distinct aggregation #39242",
-		// TODO(yuzefovich): triage this failure.
-		19: "error: likely not updating offsets in selectionBatch of bufferOp",
 		20: "incorrect output: #42047",
 		21: "unsupported: non-inner hash join with ON expression #38018",
 		// TODO(yuzefovich): triage this failure.

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -337,6 +337,13 @@ func (b *Bytes) AppendVal(v []byte) {
 	b.offsets = append(b.offsets, int32(len(b.data)))
 }
 
+// SetLength sets the length of this Bytes. Note that it will panic if there is
+// not enough capacity.
+func (b *Bytes) SetLength(l int) {
+	// We need +1 for an extra offset at the end.
+	b.offsets = b.offsets[:l+1]
+}
+
 // Len returns how many []byte values the receiver contains.
 func (b *Bytes) Len() int {
 	return len(b.offsets) - 1

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -123,6 +123,10 @@ type Vec interface {
 
 	// SetNulls sets the nulls vector for this column.
 	SetNulls(*Nulls)
+
+	// SetLength sets the length of the slice that is underlying this Vec. Note
+	// that the length of the batch which this Vec belongs to "takes priority".
+	SetLength(int)
 }
 
 var _ Vec = &memColumn{}
@@ -219,4 +223,27 @@ func (m *memColumn) Nulls() *Nulls {
 
 func (m *memColumn) SetNulls(n *Nulls) {
 	m.nulls = *n
+}
+
+func (m *memColumn) SetLength(l int) {
+	switch m.t {
+	case coltypes.Bool:
+		m.col = m.col.([]bool)[:l]
+	case coltypes.Bytes:
+		m.Bytes().SetLength(l)
+	case coltypes.Int16:
+		m.col = m.col.([]int16)[:l]
+	case coltypes.Int32:
+		m.col = m.col.([]int32)[:l]
+	case coltypes.Int64:
+		m.col = m.col.([]int64)[:l]
+	case coltypes.Float64:
+		m.col = m.col.([]float64)[:l]
+	case coltypes.Decimal:
+		m.col = m.col.([]apd.Decimal)[:l]
+	case coltypes.Timestamp:
+		m.col = m.col.([]time.Time)[:l]
+	default:
+		panic(fmt.Sprintf("unhandled type %s", m.t))
+	}
 }


### PR DESCRIPTION
Previously, after accumulating at least the desired output size number
of tuples, the ordered aggregator would output the first chunk and would
copy over the remaining tuples in-place. However, such interaction
would leave flat bytes in such a state (maxSetIndex would remain
unchanged) that Set'ting elements right after the copied over second
"chunk" would fail. Now, we have switched to using Append instead of
Copy (which truncates as the aggregator desires), but we also needed
to restore the underlying length of the Vecs. That's why a new method
SetLength is introduced to Vec interface.

Fixes: #42049.

Release note: None