### PR TITLE
blobs: Stream large files between nodes

### DIFF
--- a/pkg/blobs/bench_test.go
+++ b/pkg/blobs/bench_test.go
@@ -1,0 +1,138 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package blobs
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+type benchmarkTestCase struct {
+	localNodeID       roachpb.NodeID
+	remoteNodeID      roachpb.NodeID
+	localExternalDir  string
+	remoteExternalDir string
+
+	blobClient BlobClient
+	fileSize   int64
+	fileName   string
+}
+
+func writeLargeFile(t testing.TB, file string, size int64) {
+	err := os.MkdirAll(filepath.Dir(file), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := make([]byte, size)
+	err = ioutil.WriteFile(file, content, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkStreamingReadFile(b *testing.B) {
+	localNodeID := roachpb.NodeID(1)
+	remoteNodeID := roachpb.NodeID(2)
+	localExternalDir, remoteExternalDir, stopper, cleanUpFn := createTestResources(b)
+	defer cleanUpFn()
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
+
+	factory := setUpService(b, rpcContext, localNodeID, remoteNodeID, localExternalDir, remoteExternalDir)
+	blobClient, err := factory(context.TODO(), remoteNodeID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	params := &benchmarkTestCase{
+		localNodeID:       localNodeID,
+		remoteNodeID:      remoteNodeID,
+		localExternalDir:  localExternalDir,
+		remoteExternalDir: remoteExternalDir,
+		blobClient:        blobClient,
+		fileSize:          1 << 30, // 1 GB
+		fileName:          "test/largefile.csv",
+	}
+	benchmarkStreamingReadFile(b, params)
+}
+
+func benchmarkStreamingReadFile(b *testing.B, tc *benchmarkTestCase) {
+	writeLargeFile(b, filepath.Join(tc.remoteExternalDir, tc.fileName), tc.fileSize)
+	writeTo := localStorage{externalIODir: tc.localExternalDir}
+	b.ResetTimer()
+	b.SetBytes(tc.fileSize)
+	for i := 0; i < b.N; i++ {
+		reader, err := tc.blobClient.ReadFile(context.TODO(), tc.fileName)
+		if err != nil {
+			b.Fatal(err)
+		}
+		err = writeTo.WriteFile(tc.fileName, reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+		stat, err := writeTo.Stat(tc.fileName)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if stat.Filesize != tc.fileSize {
+			b.Fatal("incorrect number of bytes written")
+		}
+	}
+}
+
+func BenchmarkStreamingWriteFile(b *testing.B) {
+	localNodeID := roachpb.NodeID(1)
+	remoteNodeID := roachpb.NodeID(2)
+	localExternalDir, remoteExternalDir, stopper, cleanUpFn := createTestResources(b)
+	defer cleanUpFn()
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
+
+	factory := setUpService(b, rpcContext, localNodeID, remoteNodeID, localExternalDir, remoteExternalDir)
+	blobClient, err := factory(context.TODO(), remoteNodeID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	params := &benchmarkTestCase{
+		localNodeID:       localNodeID,
+		remoteNodeID:      remoteNodeID,
+		localExternalDir:  localExternalDir,
+		remoteExternalDir: remoteExternalDir,
+		blobClient:        blobClient,
+		fileSize:          1 << 30, // 1 GB
+		fileName:          "test/largefile.csv",
+	}
+	benchmarkStreamingWriteFile(b, params)
+}
+
+func benchmarkStreamingWriteFile(b *testing.B, tc *benchmarkTestCase) {
+	content := make([]byte, tc.fileSize)
+	b.ResetTimer()
+	b.SetBytes(tc.fileSize)
+	for i := 0; i < b.N; i++ {
+		err := tc.blobClient.WriteFile(context.TODO(), tc.fileName, bytes.NewReader(content))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/blobs/blobspb/blobs.pb.go
+++ b/pkg/blobs/blobspb/blobs.pb.go
@@ -37,7 +37,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{0}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{0}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -71,7 +71,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{1}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{1}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -107,7 +107,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{2}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{2}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -140,7 +140,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{3}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{3}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -174,7 +174,7 @@ func (m *GlobRequest) Reset()         { *m = GlobRequest{} }
 func (m *GlobRequest) String() string { return proto.CompactTextString(m) }
 func (*GlobRequest) ProtoMessage()    {}
 func (*GlobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{4}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{4}
 }
 func (m *GlobRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -208,7 +208,7 @@ func (m *GlobResponse) Reset()         { *m = GlobResponse{} }
 func (m *GlobResponse) String() string { return proto.CompactTextString(m) }
 func (*GlobResponse) ProtoMessage()    {}
 func (*GlobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{5}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{5}
 }
 func (m *GlobResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -243,7 +243,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{6}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{6}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -276,7 +276,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{7}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{7}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -311,7 +311,7 @@ func (m *StatRequest) Reset()         { *m = StatRequest{} }
 func (m *StatRequest) String() string { return proto.CompactTextString(m) }
 func (*StatRequest) ProtoMessage()    {}
 func (*StatRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{8}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{8}
 }
 func (m *StatRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -345,7 +345,7 @@ func (m *BlobStat) Reset()         { *m = BlobStat{} }
 func (m *BlobStat) String() string { return proto.CompactTextString(m) }
 func (*BlobStat) ProtoMessage()    {}
 func (*BlobStat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_224b84178c4de3a4, []int{9}
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{9}
 }
 func (m *BlobStat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -370,6 +370,73 @@ func (m *BlobStat) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_BlobStat proto.InternalMessageInfo
 
+// StreamChunk contains a chunk of the payload we are streaming
+type StreamChunk struct {
+	Payload []byte `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+}
+
+func (m *StreamChunk) Reset()         { *m = StreamChunk{} }
+func (m *StreamChunk) String() string { return proto.CompactTextString(m) }
+func (*StreamChunk) ProtoMessage()    {}
+func (*StreamChunk) Descriptor() ([]byte, []int) {
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{10}
+}
+func (m *StreamChunk) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StreamChunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *StreamChunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamChunk.Merge(dst, src)
+}
+func (m *StreamChunk) XXX_Size() int {
+	return m.Size()
+}
+func (m *StreamChunk) XXX_DiscardUnknown() {
+	xxx_messageInfo_StreamChunk.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StreamChunk proto.InternalMessageInfo
+
+// StreamResponse is used to acknowledge a stream ending.
+type StreamResponse struct {
+}
+
+func (m *StreamResponse) Reset()         { *m = StreamResponse{} }
+func (m *StreamResponse) String() string { return proto.CompactTextString(m) }
+func (*StreamResponse) ProtoMessage()    {}
+func (*StreamResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_blobs_cee2a8f681c337ac, []int{11}
+}
+func (m *StreamResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StreamResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *StreamResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamResponse.Merge(dst, src)
+}
+func (m *StreamResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *StreamResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_StreamResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StreamResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*GetRequest)(nil), "cockroach.blobs.GetRequest")
 	proto.RegisterType((*GetResponse)(nil), "cockroach.blobs.GetResponse")
@@ -381,6 +448,8 @@ func init() {
 	proto.RegisterType((*DeleteResponse)(nil), "cockroach.blobs.DeleteResponse")
 	proto.RegisterType((*StatRequest)(nil), "cockroach.blobs.StatRequest")
 	proto.RegisterType((*BlobStat)(nil), "cockroach.blobs.BlobStat")
+	proto.RegisterType((*StreamChunk)(nil), "cockroach.blobs.StreamChunk")
+	proto.RegisterType((*StreamResponse)(nil), "cockroach.blobs.StreamResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -395,11 +464,11 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type BlobClient interface {
-	GetBlob(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetResponse, error)
-	PutBlob(ctx context.Context, in *PutRequest, opts ...grpc.CallOption) (*PutResponse, error)
 	List(ctx context.Context, in *GlobRequest, opts ...grpc.CallOption) (*GlobResponse, error)
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
 	Stat(ctx context.Context, in *StatRequest, opts ...grpc.CallOption) (*BlobStat, error)
+	GetStream(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (Blob_GetStreamClient, error)
+	PutStream(ctx context.Context, opts ...grpc.CallOption) (Blob_PutStreamClient, error)
 }
 
 type blobClient struct {
@@ -408,24 +477,6 @@ type blobClient struct {
 
 func NewBlobClient(cc *grpc.ClientConn) BlobClient {
 	return &blobClient{cc}
-}
-
-func (c *blobClient) GetBlob(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetResponse, error) {
-	out := new(GetResponse)
-	err := c.cc.Invoke(ctx, "/cockroach.blobs.Blob/GetBlob", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *blobClient) PutBlob(ctx context.Context, in *PutRequest, opts ...grpc.CallOption) (*PutResponse, error) {
-	out := new(PutResponse)
-	err := c.cc.Invoke(ctx, "/cockroach.blobs.Blob/PutBlob", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 func (c *blobClient) List(ctx context.Context, in *GlobRequest, opts ...grpc.CallOption) (*GlobResponse, error) {
@@ -455,53 +506,83 @@ func (c *blobClient) Stat(ctx context.Context, in *StatRequest, opts ...grpc.Cal
 	return out, nil
 }
 
+func (c *blobClient) GetStream(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (Blob_GetStreamClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_Blob_serviceDesc.Streams[0], "/cockroach.blobs.Blob/GetStream", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &blobGetStreamClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type Blob_GetStreamClient interface {
+	Recv() (*StreamChunk, error)
+	grpc.ClientStream
+}
+
+type blobGetStreamClient struct {
+	grpc.ClientStream
+}
+
+func (x *blobGetStreamClient) Recv() (*StreamChunk, error) {
+	m := new(StreamChunk)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *blobClient) PutStream(ctx context.Context, opts ...grpc.CallOption) (Blob_PutStreamClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_Blob_serviceDesc.Streams[1], "/cockroach.blobs.Blob/PutStream", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &blobPutStreamClient{stream}
+	return x, nil
+}
+
+type Blob_PutStreamClient interface {
+	Send(*StreamChunk) error
+	CloseAndRecv() (*StreamResponse, error)
+	grpc.ClientStream
+}
+
+type blobPutStreamClient struct {
+	grpc.ClientStream
+}
+
+func (x *blobPutStreamClient) Send(m *StreamChunk) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *blobPutStreamClient) CloseAndRecv() (*StreamResponse, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(StreamResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // BlobServer is the server API for Blob service.
 type BlobServer interface {
-	GetBlob(context.Context, *GetRequest) (*GetResponse, error)
-	PutBlob(context.Context, *PutRequest) (*PutResponse, error)
 	List(context.Context, *GlobRequest) (*GlobResponse, error)
 	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
 	Stat(context.Context, *StatRequest) (*BlobStat, error)
+	GetStream(*GetRequest, Blob_GetStreamServer) error
+	PutStream(Blob_PutStreamServer) error
 }
 
 func RegisterBlobServer(s *grpc.Server, srv BlobServer) {
 	s.RegisterService(&_Blob_serviceDesc, srv)
-}
-
-func _Blob_GetBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(BlobServer).GetBlob(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/cockroach.blobs.Blob/GetBlob",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BlobServer).GetBlob(ctx, req.(*GetRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _Blob_PutBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PutRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(BlobServer).PutBlob(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/cockroach.blobs.Blob/PutBlob",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BlobServer).PutBlob(ctx, req.(*PutRequest))
-	}
-	return interceptor(ctx, in, info, handler)
 }
 
 func _Blob_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -558,18 +639,57 @@ func _Blob_Stat_Handler(srv interface{}, ctx context.Context, dec func(interface
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Blob_GetStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(GetRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(BlobServer).GetStream(m, &blobGetStreamServer{stream})
+}
+
+type Blob_GetStreamServer interface {
+	Send(*StreamChunk) error
+	grpc.ServerStream
+}
+
+type blobGetStreamServer struct {
+	grpc.ServerStream
+}
+
+func (x *blobGetStreamServer) Send(m *StreamChunk) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func _Blob_PutStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(BlobServer).PutStream(&blobPutStreamServer{stream})
+}
+
+type Blob_PutStreamServer interface {
+	SendAndClose(*StreamResponse) error
+	Recv() (*StreamChunk, error)
+	grpc.ServerStream
+}
+
+type blobPutStreamServer struct {
+	grpc.ServerStream
+}
+
+func (x *blobPutStreamServer) SendAndClose(m *StreamResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *blobPutStreamServer) Recv() (*StreamChunk, error) {
+	m := new(StreamChunk)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 var _Blob_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cockroach.blobs.Blob",
 	HandlerType: (*BlobServer)(nil),
 	Methods: []grpc.MethodDesc{
-		{
-			MethodName: "GetBlob",
-			Handler:    _Blob_GetBlob_Handler,
-		},
-		{
-			MethodName: "PutBlob",
-			Handler:    _Blob_PutBlob_Handler,
-		},
 		{
 			MethodName: "List",
 			Handler:    _Blob_List_Handler,
@@ -583,7 +703,18 @@ var _Blob_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Blob_Stat_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "GetStream",
+			Handler:       _Blob_GetStream_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "PutStream",
+			Handler:       _Blob_PutStream_Handler,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "blobs/blobspb/blobs.proto",
 }
 
@@ -829,6 +960,48 @@ func (m *BlobStat) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *StreamChunk) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StreamChunk) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Payload) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintBlobs(dAtA, i, uint64(len(m.Payload)))
+		i += copy(dAtA[i:], m.Payload)
+	}
+	return i, nil
+}
+
+func (m *StreamResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StreamResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
 func encodeVarintBlobs(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -962,6 +1135,28 @@ func (m *BlobStat) Size() (n int) {
 	if m.Filesize != 0 {
 		n += 1 + sovBlobs(uint64(m.Filesize))
 	}
+	return n
+}
+
+func (m *StreamChunk) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Payload)
+	if l > 0 {
+		n += 1 + l + sovBlobs(uint64(l))
+	}
+	return n
+}
+
+func (m *StreamResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	return n
 }
 
@@ -1733,6 +1928,137 @@ func (m *BlobStat) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *StreamChunk) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBlobs
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StreamChunk: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StreamChunk: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBlobs
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthBlobs
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Payload = append(m.Payload[:0], dAtA[iNdEx:postIndex]...)
+			if m.Payload == nil {
+				m.Payload = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBlobs(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBlobs
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StreamResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBlobs
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StreamResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StreamResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBlobs(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBlobs
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func skipBlobs(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1838,33 +2164,35 @@ var (
 	ErrIntOverflowBlobs   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("blobs/blobspb/blobs.proto", fileDescriptor_blobs_224b84178c4de3a4) }
+func init() { proto.RegisterFile("blobs/blobspb/blobs.proto", fileDescriptor_blobs_cee2a8f681c337ac) }
 
-var fileDescriptor_blobs_224b84178c4de3a4 = []byte{
-	// 386 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xcf, 0x4e, 0xea, 0x40,
-	0x14, 0xc6, 0x67, 0x80, 0xcb, 0x9f, 0x03, 0xdc, 0x7b, 0x33, 0x61, 0x01, 0x55, 0x47, 0xd2, 0x18,
-	0x85, 0x98, 0x94, 0x44, 0x9f, 0x40, 0xa2, 0xb2, 0xd0, 0x05, 0xa9, 0x3b, 0x77, 0x2d, 0x8e, 0x48,
-	0xac, 0x4c, 0x65, 0x86, 0x85, 0x3e, 0x85, 0x8f, 0xc5, 0x92, 0x25, 0x4b, 0x2d, 0x6b, 0xdf, 0xc1,
-	0x74, 0xa6, 0x2d, 0x20, 0x90, 0xb0, 0x81, 0x39, 0xfd, 0xbe, 0xfe, 0xce, 0xe9, 0xf9, 0x32, 0x50,
-	0x73, 0x3d, 0xee, 0x8a, 0x96, 0xfa, 0xf5, 0x5d, 0xfd, 0x6f, 0xf9, 0x23, 0x2e, 0x39, 0xf9, 0xd7,
-	0xe3, 0xbd, 0xe7, 0x11, 0x77, 0x7a, 0x4f, 0x96, 0x7a, 0x6c, 0x54, 0xfa, 0xbc, 0xcf, 0x95, 0xd6,
-	0x0a, 0x4f, 0xda, 0x66, 0x36, 0x00, 0x3a, 0x4c, 0xda, 0xec, 0x75, 0xcc, 0x84, 0x24, 0x06, 0xe4,
-	0x1f, 0x07, 0x1e, 0x1b, 0x3a, 0x2f, 0xac, 0x8a, 0xeb, 0xb8, 0x51, 0xb0, 0x93, 0xda, 0x3c, 0x81,
-	0xa2, 0x72, 0x0a, 0x9f, 0x0f, 0x05, 0x23, 0x55, 0xc8, 0xf9, 0xce, 0x9b, 0xc7, 0x9d, 0x07, 0xe5,
-	0x2c, 0xd9, 0x71, 0x69, 0xb6, 0x01, 0xba, 0xe3, 0x5d, 0x90, 0xcb, 0x8c, 0xd4, 0x2a, 0xa3, 0x0c,
-	0x45, 0xc5, 0xd0, 0xcd, 0x54, 0x6f, 0x8f, 0xbb, 0x31, 0x53, 0xbd, 0x27, 0x25, 0x1b, 0x0d, 0x23,
-	0x64, 0x5c, 0x9a, 0x47, 0x50, 0xd2, 0xc6, 0x68, 0xca, 0x0a, 0xfc, 0x09, 0xbb, 0x89, 0x2a, 0xae,
-	0xa7, 0x1b, 0x05, 0x5b, 0x17, 0xe6, 0x29, 0x94, 0x2f, 0x99, 0xc7, 0x24, 0xdb, 0xe5, 0xbb, 0xff,
-	0xc3, 0xdf, 0xd8, 0x1c, 0x4d, 0xd3, 0x84, 0xe2, 0x9d, 0x74, 0x76, 0x5a, 0xda, 0x31, 0xe4, 0xdb,
-	0x1e, 0x77, 0x43, 0x7b, 0xec, 0x13, 0x83, 0x77, 0xed, 0x4b, 0xdb, 0x49, 0x7d, 0xf6, 0x9d, 0x82,
-	0x4c, 0x68, 0x24, 0xd7, 0x90, 0xeb, 0x30, 0xa9, 0x8e, 0x7b, 0xd6, 0xaf, 0x08, 0xad, 0x45, 0x52,
-	0xc6, 0xfe, 0x66, 0x31, 0x9a, 0x10, 0x85, 0x9c, 0xee, 0x78, 0x1b, 0x67, 0x11, 0xcf, 0x06, 0xce,
-	0xf2, 0xde, 0x11, 0xb9, 0x82, 0xcc, 0xed, 0x40, 0x48, 0xb2, 0xa1, 0xdf, 0x22, 0x10, 0xe3, 0x60,
-	0x8b, 0x9a, 0x60, 0x6e, 0x20, 0xab, 0x97, 0x48, 0xe8, 0x9a, 0x75, 0x25, 0x0a, 0xe3, 0x70, 0xab,
-	0x9e, 0xc0, 0x2e, 0x20, 0xa3, 0x16, 0xba, 0x3e, 0xd3, 0x52, 0x2c, 0x46, 0x6d, 0x4d, 0x8d, 0x93,
-	0x30, 0x51, 0xbb, 0x39, 0xf9, 0xa2, 0x68, 0x12, 0x50, 0x3c, 0x0d, 0x28, 0x9e, 0x05, 0x14, 0x7f,
-	0x06, 0x14, 0x7f, 0xcc, 0x29, 0x9a, 0xce, 0x29, 0x9a, 0xcd, 0x29, 0xba, 0xcf, 0x45, 0x97, 0xca,
-	0xcd, 0xaa, 0x8b, 0x72, 0xfe, 0x13, 0x00, 0x00, 0xff, 0xff, 0xa6, 0xfa, 0x0a, 0x8b, 0x6c, 0x03,
+var fileDescriptor_blobs_cee2a8f681c337ac = []byte{
+	// 418 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0x41, 0x8f, 0xd2, 0x40,
+	0x14, 0xc7, 0x67, 0x76, 0x71, 0x77, 0xfb, 0xd8, 0x5d, 0x37, 0x93, 0x3d, 0xb0, 0x55, 0x47, 0x32,
+	0x31, 0x5a, 0x62, 0x52, 0x8c, 0x7e, 0x02, 0x51, 0x43, 0xa2, 0xc6, 0x90, 0x72, 0xf3, 0xd6, 0xe2,
+	0x08, 0x84, 0xd2, 0xa9, 0xed, 0xf4, 0xa0, 0x9f, 0xc2, 0x8f, 0xc5, 0x91, 0x23, 0x47, 0x2d, 0x9f,
+	0xc2, 0x9b, 0xe9, 0x4c, 0xa7, 0x81, 0x2d, 0x10, 0x2e, 0xd0, 0xd7, 0xf7, 0xeb, 0xff, 0xbd, 0xff,
+	0xbf, 0x1d, 0xb8, 0x0b, 0x42, 0x11, 0xa4, 0x5d, 0xf5, 0x1b, 0x07, 0xfa, 0xdf, 0x8d, 0x13, 0x21,
+	0x05, 0x79, 0x38, 0x12, 0xa3, 0x59, 0x22, 0xfc, 0xd1, 0xc4, 0x55, 0xb7, 0xed, 0xdb, 0xb1, 0x18,
+	0x0b, 0xd5, 0xeb, 0x16, 0x57, 0x1a, 0x63, 0x0e, 0x40, 0x9f, 0x4b, 0x8f, 0xff, 0xc8, 0x78, 0x2a,
+	0x89, 0x0d, 0x17, 0xdf, 0xa7, 0x21, 0x8f, 0xfc, 0x39, 0x6f, 0xe1, 0x36, 0x76, 0x2c, 0xaf, 0xaa,
+	0xd9, 0x0b, 0x68, 0x2a, 0x32, 0x8d, 0x45, 0x94, 0x72, 0xd2, 0x82, 0xf3, 0xd8, 0xff, 0x19, 0x0a,
+	0xff, 0x9b, 0x22, 0x2f, 0x3d, 0x53, 0xb2, 0x1e, 0xc0, 0x20, 0x3b, 0x46, 0x72, 0x53, 0xe3, 0x64,
+	0x5b, 0xe3, 0x0a, 0x9a, 0x4a, 0x43, 0x0f, 0x53, 0xb3, 0x43, 0x11, 0x18, 0x4d, 0xf5, 0x9c, 0x94,
+	0x3c, 0x89, 0x4a, 0x49, 0x53, 0xb2, 0x67, 0x70, 0xa9, 0xc1, 0x72, 0xcb, 0x5b, 0x78, 0x50, 0x4c,
+	0x4b, 0x5b, 0xb8, 0x7d, 0xea, 0x58, 0x9e, 0x2e, 0xd8, 0x4b, 0xb8, 0x7a, 0xcf, 0x43, 0x2e, 0xf9,
+	0x31, 0xbe, 0x6f, 0xe0, 0xda, 0xc0, 0xe5, 0x36, 0x1d, 0x68, 0x0e, 0xa5, 0x7f, 0x54, 0x68, 0xcf,
+	0xe1, 0xa2, 0x17, 0x8a, 0xa0, 0xc0, 0x0d, 0x97, 0x4e, 0x7f, 0x69, 0xee, 0xd4, 0xab, 0xea, 0xc2,
+	0xe0, 0x50, 0x26, 0xdc, 0x9f, 0xbf, 0x9b, 0x64, 0xd1, 0xec, 0x40, 0xb8, 0x37, 0x70, 0xad, 0x41,
+	0xb3, 0xcd, 0xeb, 0x7f, 0x27, 0xd0, 0x28, 0x66, 0x90, 0x0f, 0xd0, 0xf8, 0x3c, 0x4d, 0x25, 0x79,
+	0xec, 0xde, 0x7b, 0xf5, 0xee, 0x46, 0x76, 0xf6, 0x93, 0x3d, 0xdd, 0xd2, 0x1b, 0x22, 0x9f, 0xe0,
+	0x4c, 0xfb, 0x25, 0xb4, 0x86, 0x6e, 0xa5, 0x66, 0x3f, 0xdd, 0xdb, 0xaf, 0xc4, 0xde, 0x42, 0x43,
+	0x79, 0xaf, 0xef, 0xb4, 0x91, 0xa0, 0x7d, 0x57, 0xeb, 0x9a, 0xd0, 0x18, 0x22, 0x1f, 0xc1, 0xea,
+	0x73, 0xa9, 0x4d, 0x93, 0x47, 0xf5, 0xed, 0xab, 0xaf, 0xd7, 0xde, 0x35, 0xa4, 0xca, 0x94, 0xa1,
+	0x57, 0x98, 0x7c, 0x01, 0x6b, 0x90, 0x19, 0xad, 0x83, 0xf8, 0x0e, 0x73, 0xdb, 0xb9, 0x33, 0xe4,
+	0xe0, 0x5e, 0x67, 0xf1, 0x97, 0xa2, 0x45, 0x4e, 0xf1, 0x32, 0xa7, 0x78, 0x95, 0x53, 0xfc, 0x27,
+	0xa7, 0xf8, 0xf7, 0x9a, 0xa2, 0xe5, 0x9a, 0xa2, 0xd5, 0x9a, 0xa2, 0xaf, 0xe7, 0xe5, 0xd9, 0x0c,
+	0xce, 0xd4, 0x79, 0x7b, 0xf3, 0x3f, 0x00, 0x00, 0xff, 0xff, 0x8a, 0xc1, 0xfa, 0x95, 0xb3, 0x03,
 	0x00, 0x00,
 }

--- a/pkg/blobs/blobspb/blobs.proto
+++ b/pkg/blobs/blobspb/blobs.proto
@@ -69,13 +69,22 @@ message BlobStat {
   int64 filesize = 1;
 }
 
+// StreamChunk contains a chunk of the payload we are streaming
+message StreamChunk {
+  bytes payload = 1;
+}
+
+// StreamResponse is used to acknowledge a stream ending.
+message StreamResponse {
+}
+
 // Blob service allows for inter node file sharing.
 // It is used by ExternalStorage when interacting with
 // files that are stored on a node's local file system.
 service Blob {
-  rpc GetBlob(GetRequest) returns (GetResponse) {}
-  rpc PutBlob(PutRequest) returns (PutResponse) {}
   rpc List(GlobRequest) returns (GlobResponse) {}
   rpc Delete(DeleteRequest) returns (DeleteResponse) {}
   rpc Stat(StatRequest) returns (BlobStat) {}
+  rpc GetStream(GetRequest) returns (stream StreamChunk) {}
+  rpc PutStream(stream StreamChunk) returns (StreamResponse) {}
 }

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -11,16 +11,15 @@
 package blobs
 
 import (
-	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/metadata"
 )
 
 // BlobClient provides an interface for file access on all nodes' local storage.
@@ -30,15 +29,11 @@ type BlobClient interface {
 	// ReadFile fetches the named payload from the requested node,
 	// and stores it in memory. It then returns an io.ReadCloser to
 	// read the contents.
-	// TODO(georgiah): this currently sends the entire file over
-	// 	over the wire. Still need to implement streaming.
 	ReadFile(ctx context.Context, file string) (io.ReadCloser, error)
 
 	// WriteFile sends the named payload to the requested node.
 	// This method will read entire content of file and send
 	// it over to another node, based on the nodeID.
-	// TODO(georgiah): this currently sends the entire file over
-	// 	over the wire. Still need to implement streaming.
 	WriteFile(ctx context.Context, file string, content io.ReadSeeker) error
 
 	// List lists the corresponding filenames from the requested node.
@@ -66,26 +61,28 @@ func newRemoteClient(blobClient blobspb.BlobClient) BlobClient {
 }
 
 func (c *remoteClient) ReadFile(ctx context.Context, file string) (io.ReadCloser, error) {
-	resp, err := c.blobClient.GetBlob(ctx, &blobspb.GetRequest{
+	stream, err := c.blobClient.GetStream(ctx, &blobspb.GetRequest{
 		Filename: file,
 	})
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching file")
-	}
-	return ioutil.NopCloser(bytes.NewReader(resp.Payload)), err
+	return newGetStreamReader(stream), errors.Wrap(err, "fetching file")
 }
 
-func (c *remoteClient) WriteFile(ctx context.Context, file string, content io.ReadSeeker) error {
-	payload, err := ioutil.ReadAll(content)
+func (c *remoteClient) WriteFile(
+	ctx context.Context, file string, content io.ReadSeeker,
+) (err error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "filename", file)
+	stream, err := c.blobClient.PutStream(ctx)
 	if err != nil {
-		return errors.Wrap(err, "reading file contents")
+		return
 	}
-	b, err := c.blobClient.PutBlob(ctx, &blobspb.PutRequest{
-		Filename: file,
-		Payload:  payload,
-	})
-	b.Size()
-	return err
+	defer func() {
+		_, closeErr := stream.CloseAndRecv()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	err = streamContent(stream, content)
+	return
 }
 
 func (c *remoteClient) List(ctx context.Context, pattern string) ([]string, error) {

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -47,7 +47,7 @@ func (l *localStorage) prependExternalIODir(path string) (string, error) {
 }
 
 // WriteFile prepends IO dir to filename and writes the content to that local file.
-func (l *localStorage) WriteFile(filename string, content io.ReadSeeker) error {
+func (l *localStorage) WriteFile(filename string, content io.Reader) error {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
 		return err

--- a/pkg/blobs/stream.go
+++ b/pkg/blobs/stream.go
@@ -1,0 +1,145 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package blobs
+
+import (
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
+)
+
+// Within the blob service, streaming is used in two functions:
+//   - GetStream, streaming from server to client
+//   - PutStream, streaming from client to server
+// These functions are used to read or write files on a remote node.
+// The io.ReadCloser we implement here are used on the _receiver's_
+// side, to read from either Blob_GetStreamClient or Blob_PutStreamServer.
+// The function streamContent() is used on the _sender's_ side to split
+// the content and send it using Blob_GetStreamServer or Blob_PutStreamClient.
+
+// chunkSize was decided to be 128K after running an experiment benchmarking
+// ReadFile and WriteFile. It seems like the benefits of streaming do not appear
+// until files of 1 MB or larger, and for those files, 128K chunks are optimal.
+// For ReadFile, larger chunks are more efficient but the gains are not as significant
+// past 128K. For WriteFile, 128K chunks perform best, and past that, performance
+// starts decreasing.
+var chunkSize = 128 * 1 << 10
+
+// blobStreamReader implements a ReadCloser which receives
+// gRPC streaming messages.
+var _ io.ReadCloser = &blobStreamReader{}
+
+type streamReceiver interface {
+	SendAndClose(*blobspb.StreamResponse) error
+	Recv() (*blobspb.StreamChunk, error)
+}
+
+// nopSendAndClose creates a GetStreamClient that has a nop SendAndClose function.
+// This is needed as Blob_GetStreamClient does not have a Close() function, whereas
+// the other sender, Blob_PutStreamServer, does.
+type nopSendAndClose struct {
+	blobspb.Blob_GetStreamClient
+}
+
+func (*nopSendAndClose) SendAndClose(*blobspb.StreamResponse) error {
+	return nil
+}
+
+// newGetStreamReader creates an io.ReadCloser that uses gRPC's streaming API
+// to read chunks of data.
+func newGetStreamReader(client blobspb.Blob_GetStreamClient) io.ReadCloser {
+	return &blobStreamReader{
+		stream: &nopSendAndClose{client},
+	}
+}
+
+// newPutStreamReader creates an io.ReadCloser that uses gRPC's streaming API
+// to read chunks of data.
+func newPutStreamReader(client blobspb.Blob_PutStreamServer) io.ReadCloser {
+	return &blobStreamReader{stream: client}
+}
+
+type blobStreamReader struct {
+	lastPayload []byte
+	lastOffset  int
+	stream      streamReceiver
+	EOFReached  bool
+}
+
+func (r *blobStreamReader) Read(out []byte) (int, error) {
+	if r.EOFReached {
+		return 0, io.EOF
+	}
+
+	offset := 0
+	// Use the last payload.
+	if r.lastPayload != nil {
+		offset = len(r.lastPayload) - r.lastOffset
+		if len(out) < offset {
+			copy(out, r.lastPayload[r.lastOffset:])
+			r.lastOffset += len(out)
+			return len(out), nil
+		}
+		copy(out[:offset], r.lastPayload[r.lastOffset:])
+		r.lastPayload = nil
+	}
+	for offset < len(out) {
+		chunk, err := r.stream.Recv()
+		if err == io.EOF {
+			r.EOFReached = true
+			break
+		}
+		if err != nil {
+			return offset, err
+		}
+		var lenToWrite int
+		if len(out)-offset >= len(chunk.Payload) {
+			lenToWrite = len(chunk.Payload)
+		} else {
+			lenToWrite = len(out) - offset
+			// Need to cache payload.
+			r.lastPayload = chunk.Payload
+			r.lastOffset = lenToWrite
+		}
+		copy(out[offset:offset+lenToWrite], chunk.Payload[:lenToWrite])
+		offset += lenToWrite
+	}
+	return offset, nil
+}
+
+func (r *blobStreamReader) Close() error {
+	return r.stream.SendAndClose(&blobspb.StreamResponse{})
+}
+
+type streamSender interface {
+	Send(*blobspb.StreamChunk) error
+}
+
+// streamContent splits the content into chunks, of size `chunkSize`,
+// and streams those chunks to sender.
+// Note: This does not close the stream.
+func streamContent(sender streamSender, content io.Reader) error {
+	payload := make([]byte, chunkSize)
+	var chunk blobspb.StreamChunk
+	for {
+		n, err := content.Read(payload)
+		if n > 0 {
+			chunk.Payload = payload[:n]
+			err = sender.Send(&chunk)
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}


### PR DESCRIPTION
Currently, the blob service reads and write large files across
different nodes by sending the entire file across the wire. This
cannot support larger files.

This PR adds support for streaming files across to another node
by implementing an `io.ReadCloser` which uses gRPC's streaming
API underneath.

Release note: None