### PR TITLE
vendor: Update gostdlib to Go 1.13

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -440,19 +440,27 @@
   version = "v1.2.3"
 
 [[projects]]
-  digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"
+  digest = "1:a44e537b3e080ff297315d166956dba9607f070644a89be78b59af6c54876b64"
   name = "github.com/cockroachdb/gostdlib"
   packages = [
     "cmd/gofmt",
     "go/format",
     "go/printer",
     "x/tools/cmd/goimports",
+    "x/tools/go/ast/astutil",
+    "x/tools/go/internal/packagesdriver",
+    "x/tools/go/packages",
     "x/tools/imports",
     "x/tools/internal/fastwalk",
+    "x/tools/internal/gopathwalk",
+    "x/tools/internal/imports",
+    "x/tools/internal/module",
+    "x/tools/internal/semver",
+    "x/tools/internal/span",
   ]
   pruneopts = "UT"
-  revision = "5ba2d4bf557f3a3d4518deb271dcf93244b39363"
-  version = "v1.11.0"
+  revision = "fbdd8f0abc9baea11b7bf52b6a19d5eab5e5af10"
+  version = "v1.13.0"
 
 [[projects]]
   branch = "master"

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -135,7 +135,7 @@ func registerCopy(r *testRegistry) {
 		m.Wait()
 	}
 
-	const rows = int(1E7)
+	const rows = int(1e7)
 	const numNodes = 9
 
 	for _, inTxn := range []bool{true, false} {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -162,7 +162,7 @@ func registerDrop(r *testRegistry) {
 	numNodes := 9
 
 	// 1GB
-	initDiskSpace := int(1E9)
+	initDiskSpace := int(1e9)
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
@@ -176,7 +176,7 @@ func registerDrop(r *testRegistry) {
 				warehouses = 1
 
 				// 100 MB
-				initDiskSpace = 1E8
+				initDiskSpace = 1e8
 				fmt.Printf("running with w=%d,nodes=%d in local mode\n", warehouses, numNodes)
 			}
 			runDrop(ctx, t, c, warehouses, numNodes, initDiskSpace)

--- a/pkg/cmd/roachtest/toxiproxy.go
+++ b/pkg/cmd/roachtest/toxiproxy.go
@@ -219,5 +219,5 @@ func (tc *ToxiCluster) Measure(ctx context.Context, fromNode int, stmt string) t
 	if err != nil {
 		tc.cluster.t.Fatalf("unable to parse %s as float: %s", b, err)
 	}
-	return time.Duration(f * 1E9)
+	return time.Duration(f * 1e9)
 }

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -706,7 +706,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 			// 10k warehouses requires at least 20,000 connections, so add a
 			// bit of breathing room and check the warehouse count.
 			c.Run(ctx, loadNodes, "sed -i 's/maxconn [0-9]\\+/maxconn 21000/' haproxy.cfg")
-			if b.LoadWarehouses > 1E4 {
+			if b.LoadWarehouses > 1e4 {
 				t.Fatal("HAProxy config supports up to 10k warehouses")
 			}
 			c.Run(ctx, loadNodes, "haproxy -f haproxy.cfg -D")

--- a/pkg/col/colserde/arrowserde/file_generated.go
+++ b/pkg/col/colserde/arrowserde/file_generated.go
@@ -118,6 +118,7 @@ func FooterStartRecordBatchesVector(
 func FooterEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Block struct {
 	_tab flatbuffers.Struct
 }
@@ -135,6 +136,7 @@ func (rcv *Block) Table() flatbuffers.Table {
 func (rcv *Block) Offset() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(0))
 }
+
 /// Index to the start of the RecordBlock (note this is past the Message header)
 func (rcv *Block) MutateOffset(n int64) bool {
 	return rcv._tab.MutateInt64(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
@@ -144,6 +146,7 @@ func (rcv *Block) MutateOffset(n int64) bool {
 func (rcv *Block) MetaDataLength() int32 {
 	return rcv._tab.GetInt32(rcv._tab.Pos + flatbuffers.UOffsetT(8))
 }
+
 /// Length of the metadata
 func (rcv *Block) MutateMetaDataLength(n int32) bool {
 	return rcv._tab.MutateInt32(rcv._tab.Pos+flatbuffers.UOffsetT(8), n)
@@ -154,6 +157,7 @@ func (rcv *Block) MutateMetaDataLength(n int32) bool {
 func (rcv *Block) BodyLength() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(16))
 }
+
 /// Length of the data (this is aligned so there can be a gap between this and
 /// the metatdata).
 func (rcv *Block) MutateBodyLength(n int64) bool {

--- a/pkg/col/colserde/arrowserde/message_generated.go
+++ b/pkg/col/colserde/arrowserde/message_generated.go
@@ -13,22 +13,23 @@ import flatbuffers "github.com/google/flatbuffers/go"
 /// which may include experimental metadata types. For maximum compatibility,
 /// it is best to send data using RecordBatch
 type MessageHeader = byte
+
 const (
-	MessageHeaderNONE MessageHeader = 0
-	MessageHeaderSchema MessageHeader = 1
+	MessageHeaderNONE            MessageHeader = 0
+	MessageHeaderSchema          MessageHeader = 1
 	MessageHeaderDictionaryBatch MessageHeader = 2
-	MessageHeaderRecordBatch MessageHeader = 3
-	MessageHeaderTensor MessageHeader = 4
-	MessageHeaderSparseTensor MessageHeader = 5
+	MessageHeaderRecordBatch     MessageHeader = 3
+	MessageHeaderTensor          MessageHeader = 4
+	MessageHeaderSparseTensor    MessageHeader = 5
 )
 
 var EnumNamesMessageHeader = map[MessageHeader]string{
-	MessageHeaderNONE:"NONE",
-	MessageHeaderSchema:"Schema",
-	MessageHeaderDictionaryBatch:"DictionaryBatch",
-	MessageHeaderRecordBatch:"RecordBatch",
-	MessageHeaderTensor:"Tensor",
-	MessageHeaderSparseTensor:"SparseTensor",
+	MessageHeaderNONE:            "NONE",
+	MessageHeaderSchema:          "Schema",
+	MessageHeaderDictionaryBatch: "DictionaryBatch",
+	MessageHeaderRecordBatch:     "RecordBatch",
+	MessageHeaderTensor:          "Tensor",
+	MessageHeaderSparseTensor:    "SparseTensor",
 }
 
 /// ----------------------------------------------------------------------
@@ -58,6 +59,7 @@ func (rcv *FieldNode) Table() flatbuffers.Table {
 func (rcv *FieldNode) Length() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(0))
 }
+
 /// The number of value slots in the Arrow array at this level of a nested
 /// tree
 func (rcv *FieldNode) MutateLength(n int64) bool {
@@ -70,6 +72,7 @@ func (rcv *FieldNode) MutateLength(n int64) bool {
 func (rcv *FieldNode) NullCount() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(8))
 }
+
 /// The number of observed nulls. Fields with null_count == 0 may choose not
 /// to write their physical validity bitmap out as a materialized buffer,
 /// instead setting the length of the bitmap buffer to 0.
@@ -85,6 +88,7 @@ func CreateFieldNode(
 	builder.PrependInt64(length)
 	return builder.Offset()
 }
+
 /// A data header describing the shared memory layout of a "record" or "row"
 /// batch. Some systems call this a "row batch" internally and others a "record
 /// batch".
@@ -199,6 +203,7 @@ func RecordBatchStartBuffersVector(
 func RecordBatchEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// For sending dictionary encoding information. Any Field can be
 /// dictionary-encoded, but in this case none of its children may be
 /// dictionary-encoded.
@@ -281,6 +286,7 @@ func DictionaryBatchAddIsDelta(builder *flatbuffers.Builder, isDelta byte) {
 func DictionaryBatchEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Message struct {
 	_tab flatbuffers.Table
 }

--- a/pkg/col/colserde/arrowserde/schema_generated.go
+++ b/pkg/col/colserde/arrowserde/schema_generated.go
@@ -5,6 +5,7 @@ package arrowserde
 import flatbuffers "github.com/google/flatbuffers/go"
 
 type MetadataVersion = int16
+
 const (
 	/// 0.1.0
 	MetadataVersionV1 MetadataVersion = 0
@@ -17,130 +18,137 @@ const (
 )
 
 var EnumNamesMetadataVersion = map[MetadataVersion]string{
-	MetadataVersionV1:"V1",
-	MetadataVersionV2:"V2",
-	MetadataVersionV3:"V3",
-	MetadataVersionV4:"V4",
+	MetadataVersionV1: "V1",
+	MetadataVersionV2: "V2",
+	MetadataVersionV3: "V3",
+	MetadataVersionV4: "V4",
 }
 
 type UnionMode = int16
+
 const (
 	UnionModeSparse UnionMode = 0
-	UnionModeDense UnionMode = 1
+	UnionModeDense  UnionMode = 1
 )
 
 var EnumNamesUnionMode = map[UnionMode]string{
-	UnionModeSparse:"Sparse",
-	UnionModeDense:"Dense",
+	UnionModeSparse: "Sparse",
+	UnionModeDense:  "Dense",
 }
 
 type Precision = int16
+
 const (
-	PrecisionHALF Precision = 0
+	PrecisionHALF   Precision = 0
 	PrecisionSINGLE Precision = 1
 	PrecisionDOUBLE Precision = 2
 )
 
 var EnumNamesPrecision = map[Precision]string{
-	PrecisionHALF:"HALF",
-	PrecisionSINGLE:"SINGLE",
-	PrecisionDOUBLE:"DOUBLE",
+	PrecisionHALF:   "HALF",
+	PrecisionSINGLE: "SINGLE",
+	PrecisionDOUBLE: "DOUBLE",
 }
 
 type DateUnit = int16
+
 const (
-	DateUnitDAY DateUnit = 0
+	DateUnitDAY         DateUnit = 0
 	DateUnitMILLISECOND DateUnit = 1
 )
 
 var EnumNamesDateUnit = map[DateUnit]string{
-	DateUnitDAY:"DAY",
-	DateUnitMILLISECOND:"MILLISECOND",
+	DateUnitDAY:         "DAY",
+	DateUnitMILLISECOND: "MILLISECOND",
 }
 
 type TimeUnit = int16
+
 const (
-	TimeUnitSECOND TimeUnit = 0
+	TimeUnitSECOND      TimeUnit = 0
 	TimeUnitMILLISECOND TimeUnit = 1
 	TimeUnitMICROSECOND TimeUnit = 2
-	TimeUnitNANOSECOND TimeUnit = 3
+	TimeUnitNANOSECOND  TimeUnit = 3
 )
 
 var EnumNamesTimeUnit = map[TimeUnit]string{
-	TimeUnitSECOND:"SECOND",
-	TimeUnitMILLISECOND:"MILLISECOND",
-	TimeUnitMICROSECOND:"MICROSECOND",
-	TimeUnitNANOSECOND:"NANOSECOND",
+	TimeUnitSECOND:      "SECOND",
+	TimeUnitMILLISECOND: "MILLISECOND",
+	TimeUnitMICROSECOND: "MICROSECOND",
+	TimeUnitNANOSECOND:  "NANOSECOND",
 }
 
 type IntervalUnit = int16
+
 const (
 	IntervalUnitYEAR_MONTH IntervalUnit = 0
-	IntervalUnitDAY_TIME IntervalUnit = 1
+	IntervalUnitDAY_TIME   IntervalUnit = 1
 )
 
 var EnumNamesIntervalUnit = map[IntervalUnit]string{
-	IntervalUnitYEAR_MONTH:"YEAR_MONTH",
-	IntervalUnitDAY_TIME:"DAY_TIME",
+	IntervalUnitYEAR_MONTH: "YEAR_MONTH",
+	IntervalUnitDAY_TIME:   "DAY_TIME",
 }
 
 /// ----------------------------------------------------------------------
 /// Top-level Type value, enabling extensible type-specific metadata. We can
 /// add new logical types to Type without breaking backwards compatibility
 type Type = byte
+
 const (
-	TypeNONE Type = 0
-	TypeNull Type = 1
-	TypeInt Type = 2
-	TypeFloatingPoint Type = 3
-	TypeBinary Type = 4
-	TypeUtf8 Type = 5
-	TypeBool Type = 6
-	TypeDecimal Type = 7
-	TypeDate Type = 8
-	TypeTime Type = 9
-	TypeTimestamp Type = 10
-	TypeInterval Type = 11
-	TypeList Type = 12
-	TypeStruct_ Type = 13
-	TypeUnion Type = 14
+	TypeNONE            Type = 0
+	TypeNull            Type = 1
+	TypeInt             Type = 2
+	TypeFloatingPoint   Type = 3
+	TypeBinary          Type = 4
+	TypeUtf8            Type = 5
+	TypeBool            Type = 6
+	TypeDecimal         Type = 7
+	TypeDate            Type = 8
+	TypeTime            Type = 9
+	TypeTimestamp       Type = 10
+	TypeInterval        Type = 11
+	TypeList            Type = 12
+	TypeStruct_         Type = 13
+	TypeUnion           Type = 14
 	TypeFixedSizeBinary Type = 15
-	TypeFixedSizeList Type = 16
-	TypeMap Type = 17
+	TypeFixedSizeList   Type = 16
+	TypeMap             Type = 17
 )
 
 var EnumNamesType = map[Type]string{
-	TypeNONE:"NONE",
-	TypeNull:"Null",
-	TypeInt:"Int",
-	TypeFloatingPoint:"FloatingPoint",
-	TypeBinary:"Binary",
-	TypeUtf8:"Utf8",
-	TypeBool:"Bool",
-	TypeDecimal:"Decimal",
-	TypeDate:"Date",
-	TypeTime:"Time",
-	TypeTimestamp:"Timestamp",
-	TypeInterval:"Interval",
-	TypeList:"List",
-	TypeStruct_:"Struct_",
-	TypeUnion:"Union",
-	TypeFixedSizeBinary:"FixedSizeBinary",
-	TypeFixedSizeList:"FixedSizeList",
-	TypeMap:"Map",
+	TypeNONE:            "NONE",
+	TypeNull:            "Null",
+	TypeInt:             "Int",
+	TypeFloatingPoint:   "FloatingPoint",
+	TypeBinary:          "Binary",
+	TypeUtf8:            "Utf8",
+	TypeBool:            "Bool",
+	TypeDecimal:         "Decimal",
+	TypeDate:            "Date",
+	TypeTime:            "Time",
+	TypeTimestamp:       "Timestamp",
+	TypeInterval:        "Interval",
+	TypeList:            "List",
+	TypeStruct_:         "Struct_",
+	TypeUnion:           "Union",
+	TypeFixedSizeBinary: "FixedSizeBinary",
+	TypeFixedSizeList:   "FixedSizeList",
+	TypeMap:             "Map",
 }
 
 /// ----------------------------------------------------------------------
 /// Endianness of the platform producing the data
 type Endianness = int16
+
 const (
 	EndiannessLittle Endianness = 0
-	EndiannessBig Endianness = 1
+	EndiannessBig    Endianness = 1
 )
 
 var EnumNamesEndianness = map[Endianness]string{
-	EndiannessLittle:"Little",
-	EndiannessBig:"Big",
+	EndiannessLittle: "Little",
+	EndiannessBig:    "Big",
 }
 
 /// These are stored in the flatbuffer in the Type union below
@@ -170,6 +178,7 @@ func NullStart(builder *flatbuffers.Builder) {
 func NullEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// A Struct_ in the flatbuffer metadata is the same as an Arrow Struct
 /// (according to the physical memory layout). We used Struct_ here as
 /// Struct is a reserved word in Flatbuffers
@@ -199,6 +208,7 @@ func Struct_Start(builder *flatbuffers.Builder) {
 func Struct_End(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type List struct {
 	_tab flatbuffers.Table
 }
@@ -225,6 +235,7 @@ func ListStart(builder *flatbuffers.Builder) {
 func ListEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type FixedSizeList struct {
 	_tab flatbuffers.Table
 }
@@ -268,6 +279,7 @@ func FixedSizeListAddListSize(builder *flatbuffers.Builder, listSize int32) {
 func FixedSizeListEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// A Map is a logical nested type that is represented as
 ///
 /// List<entry: Struct<key: K, value: V>>
@@ -335,6 +347,7 @@ func MapAddKeysSorted(builder *flatbuffers.Builder, keysSorted byte) {
 func MapEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// A union is a complex type with children in Field
 /// By default ids in the type vector refer to the offsets in the children
 /// optionally typeIds provides an indirection between the child offset and the type id
@@ -403,6 +416,7 @@ func UnionStartTypeIdsVector(builder *flatbuffers.Builder, numElems int) flatbuf
 func UnionEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Int struct {
 	_tab flatbuffers.Table
 }
@@ -459,6 +473,7 @@ func IntAddIsSigned(builder *flatbuffers.Builder, isSigned byte) {
 func IntEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type FloatingPoint struct {
 	_tab flatbuffers.Table
 }
@@ -500,6 +515,7 @@ func FloatingPointAddPrecision(builder *flatbuffers.Builder, precision int16) {
 func FloatingPointEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// Unicode with UTF-8 encoding
 type Utf8 struct {
 	_tab flatbuffers.Table
@@ -527,6 +543,7 @@ func Utf8Start(builder *flatbuffers.Builder) {
 func Utf8End(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Binary struct {
 	_tab flatbuffers.Table
 }
@@ -553,6 +570,7 @@ func BinaryStart(builder *flatbuffers.Builder) {
 func BinaryEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type FixedSizeBinary struct {
 	_tab flatbuffers.Table
 }
@@ -596,6 +614,7 @@ func FixedSizeBinaryAddByteWidth(builder *flatbuffers.Builder, byteWidth int32) 
 func FixedSizeBinaryEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Bool struct {
 	_tab flatbuffers.Table
 }
@@ -622,6 +641,7 @@ func BoolStart(builder *flatbuffers.Builder) {
 func BoolEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Decimal struct {
 	_tab flatbuffers.Table
 }
@@ -682,6 +702,7 @@ func DecimalAddScale(builder *flatbuffers.Builder, scale int32) {
 func DecimalEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// Date is either a 32-bit or 64-bit type representing elapsed time since UNIX
 /// epoch (1970-01-01), stored in either of two units:
 ///
@@ -729,6 +750,7 @@ func DateAddUnit(builder *flatbuffers.Builder, unit int16) {
 func DateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// Time type. The physical storage type depends on the unit
 /// - SECOND and MILLISECOND: 32 bits
 /// - MICROSECOND and NANOSECOND: 64 bits
@@ -788,6 +810,7 @@ func TimeAddBitWidth(builder *flatbuffers.Builder, bitWidth int32) {
 func TimeEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// Time elapsed from the Unix epoch, 00:00:00.000 on 1 January 1970, excluding
 /// leap seconds, as a 64-bit integer. Note that UNIX time does not include
 /// leap seconds.
@@ -886,6 +909,7 @@ func TimestampAddTimezone(builder *flatbuffers.Builder, timezone flatbuffers.UOf
 func TimestampEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Interval struct {
 	_tab flatbuffers.Table
 }
@@ -927,6 +951,7 @@ func IntervalAddUnit(builder *flatbuffers.Builder, unit int16) {
 func IntervalEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// ----------------------------------------------------------------------
 /// user defined key value pairs to add custom metadata to arrow
 /// key namespacing is the responsibility of the user
@@ -978,6 +1003,7 @@ func KeyValueAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) 
 func KeyValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// ----------------------------------------------------------------------
 /// Dictionary encoding metadata
 type DictionaryEncoding struct {
@@ -1070,6 +1096,7 @@ func DictionaryEncodingAddIsOrdered(builder *flatbuffers.Builder, isOrdered byte
 func DictionaryEncodingEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// ----------------------------------------------------------------------
 /// A field represents a named column in a record / row batch or child of a
 /// nested type.
@@ -1226,6 +1253,7 @@ func FieldStartCustomMetadataVector(
 func FieldEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// ----------------------------------------------------------------------
 /// A Buffer represents a single contiguous memory segment
 type Buffer struct {
@@ -1246,6 +1274,7 @@ func (rcv *Buffer) Table() flatbuffers.Table {
 func (rcv *Buffer) Offset() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(0))
 }
+
 /// The relative offset into the shared memory page where the bytes for this
 /// buffer starts
 func (rcv *Buffer) MutateOffset(n int64) bool {
@@ -1257,6 +1286,7 @@ func (rcv *Buffer) MutateOffset(n int64) bool {
 func (rcv *Buffer) Length() int64 {
 	return rcv._tab.GetInt64(rcv._tab.Pos + flatbuffers.UOffsetT(8))
 }
+
 /// The absolute length (in bytes) of the memory buffer. The memory is found
 /// from offset (inclusive) to offset + length (non-inclusive).
 func (rcv *Buffer) MutateLength(n int64) bool {
@@ -1269,6 +1299,7 @@ func CreateBuffer(builder *flatbuffers.Builder, offset int64, length int64) flat
 	builder.PrependInt64(offset)
 	return builder.Offset()
 }
+
 /// ----------------------------------------------------------------------
 /// A Schema describes the columns in a row batch
 type Schema struct {

--- a/pkg/col/colserde/arrowserde/tensor_generated.go
+++ b/pkg/col/colserde/arrowserde/tensor_generated.go
@@ -5,16 +5,17 @@ package arrowserde
 import flatbuffers "github.com/google/flatbuffers/go"
 
 type SparseTensorIndex = byte
+
 const (
-	SparseTensorIndexNONE SparseTensorIndex = 0
+	SparseTensorIndexNONE                 SparseTensorIndex = 0
 	SparseTensorIndexSparseTensorIndexCOO SparseTensorIndex = 1
 	SparseTensorIndexSparseMatrixIndexCSR SparseTensorIndex = 2
 )
 
 var EnumNamesSparseTensorIndex = map[SparseTensorIndex]string{
-	SparseTensorIndexNONE:"NONE",
-	SparseTensorIndexSparseTensorIndexCOO:"SparseTensorIndexCOO",
-	SparseTensorIndexSparseMatrixIndexCSR:"SparseMatrixIndexCSR",
+	SparseTensorIndexNONE:                 "NONE",
+	SparseTensorIndexSparseTensorIndexCOO: "SparseTensorIndexCOO",
+	SparseTensorIndexSparseMatrixIndexCSR: "SparseMatrixIndexCSR",
 }
 
 /// ----------------------------------------------------------------------
@@ -76,6 +77,7 @@ func TensorDimAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 func TensorDimEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type Tensor struct {
 	_tab flatbuffers.Table
 }
@@ -204,6 +206,7 @@ func TensorAddData(builder *flatbuffers.Builder, data flatbuffers.UOffsetT) {
 func TensorEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// ----------------------------------------------------------------------
 /// EXPERIMENTAL: Data structures for sparse tensors
 /// Coodinate format of sparse tensor index.
@@ -297,6 +300,7 @@ func SparseTensorIndexCOOAddIndicesBuffer(
 func SparseTensorIndexCOOEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 /// Compressed Sparse Row format, that is matrix-specific.
 type SparseMatrixIndexCSR struct {
 	_tab flatbuffers.Table
@@ -418,6 +422,7 @@ func SparseMatrixIndexCSRAddIndicesBuffer(
 func SparseMatrixIndexCSREnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type SparseTensor struct {
 	_tab flatbuffers.Table
 }

--- a/pkg/gossip/status_test.go
+++ b/pkg/gossip/status_test.go
@@ -21,8 +21,8 @@ func TestGossipStatus(t *testing.T) {
 
 	ss := ServerStatus{
 		ConnStatus: []ConnStatus{
-			{NodeID: 1, Address: "localhost:1234", AgeNanos: 17E9},
-			{NodeID: 4, Address: "localhost:4567", AgeNanos: 18E9},
+			{NodeID: 1, Address: "localhost:1234", AgeNanos: 17e9},
+			{NodeID: 4, Address: "localhost:4567", AgeNanos: 18e9},
 		},
 		MaxConns: 3,
 		MetricSnap: MetricSnap{

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -32,6 +32,7 @@ import (
     "github.com/cockroachdb/cockroach/pkg/sql/lex"
     "github.com/cockroachdb/cockroach/pkg/sql/privilege"
     "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+    "github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // MaxUint is the maximum value of an uint.

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1111,7 +1111,7 @@ func TestLeaseNotUsedAfterRestart(t *testing.T) {
 
 	preRestartLease, _ := mtc.stores[0].LookupReplica(key).GetLease()
 
-	mtc.manualClock.Increment(1E9)
+	mtc.manualClock.Increment(1e9)
 
 	// Restart the mtc. Before we do that, we're installing a callback used to
 	// assert that a new lease has been requested. The callback is installed

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1881,7 +1881,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 	}
 
 	specifiedGCThreshold := hlc.Timestamp{
-		WallTime: 2E9,
+		WallTime: 2e9,
 	}
 	gcArgs := &roachpb.GCRequest{
 		RequestHeader: roachpb.RequestHeader{

--- a/pkg/storage/closedts/container/container_test.go
+++ b/pkg/storage/closedts/container/container_test.go
@@ -78,7 +78,7 @@ func prepareContainer() *TestContainer {
 	// that the Provider will essentially close in a hot loop. In this test
 	// we'll block in the clock to pace the Provider's closer loop.
 	closedts.TargetDuration.Override(&st.SV, time.Second)
-	closedts.CloseFraction.Override(&st.SV, 1E-9)
+	closedts.CloseFraction.Override(&st.SV, 1e-9)
 
 	// We perform a little dance with the Dialer. It needs to be hooked up to the
 	// Server, but that's only created in NewContainer. The Dialer isn't used until
@@ -166,7 +166,7 @@ func TestTwoNodes(t *testing.T) {
 	// to write the remainder of the test because the commands we track below may
 	// fall into either case, and may be forced above the old or new timestamp.
 	for i := 0; i < 2; i++ {
-		c1.TestClock.Tick(hlc.Timestamp{WallTime: 2E9}, ep1, nil)
+		c1.TestClock.Tick(hlc.Timestamp{WallTime: 2e9}, ep1, nil)
 	}
 
 	// The Tracker still won't let us serve anything, even though it has closed out
@@ -180,20 +180,20 @@ func TestTwoNodes(t *testing.T) {
 	// Two more commands come in.
 	ts, release = c1.Tracker.Track(ctx)
 	release(ctx, ep1, roachpb.RangeID(17), ctpb.LAI(16))
-	require.Equal(t, hlc.Timestamp{WallTime: 1E9, Logical: 1}, ts)
+	require.Equal(t, hlc.Timestamp{WallTime: 1e9, Logical: 1}, ts)
 
 	ts, release = c1.Tracker.Track(ctx)
 	release(ctx, ep1, roachpb.RangeID(8), ctpb.LAI(88))
-	require.Equal(t, hlc.Timestamp{WallTime: 1E9, Logical: 1}, ts)
+	require.Equal(t, hlc.Timestamp{WallTime: 1e9, Logical: 1}, ts)
 
 	// Now another tick. Shortly after it, we should be able to serve below 1E9, and 2E9 should
 	// be the next planned closed timestamp (though we can only verify the former).
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: 3E9}, ep1, nil)
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: 3e9}, ep1, nil)
 
 	testutils.SucceedsSoon(t, func() error {
 		if c1.Container.Provider.MaxClosed(
 			c1.NodeID, roachpb.RangeID(17), ep1, ctpb.LAI(12),
-		).Less(hlc.Timestamp{WallTime: 1E9}) {
+		).Less(hlc.Timestamp{WallTime: 1e9}) {
 			return errors.New("still can't serve")
 		}
 		return nil
@@ -202,12 +202,12 @@ func TestTwoNodes(t *testing.T) {
 	// Shouldn't be able to serve the same thing if we haven't caught up yet.
 	require.False(t, !c1.Container.Provider.MaxClosed(
 		c1.NodeID, roachpb.RangeID(17), ep1, ctpb.LAI(11),
-	).Less(hlc.Timestamp{WallTime: 1E9}))
+	).Less(hlc.Timestamp{WallTime: 1e9}))
 
 	// Shouldn't be able to serve at a higher timestamp.
 	require.False(t, !c1.Container.Provider.MaxClosed(
 		c1.NodeID, roachpb.RangeID(17), ep1, ctpb.LAI(12),
-	).Less(hlc.Timestamp{WallTime: 1E9, Logical: 1}))
+	).Less(hlc.Timestamp{WallTime: 1e9, Logical: 1}))
 
 	// Now things get a little more interesting. Tell node2 to get a stream of
 	// information from node1. We do this via Request, which as a side effect lets
@@ -228,7 +228,7 @@ func TestTwoNodes(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		if c2.Container.Provider.MaxClosed(
 			c1.NodeID, roachpb.RangeID(17), ep1, ctpb.LAI(12),
-		).Less(hlc.Timestamp{WallTime: 1E9}) {
+		).Less(hlc.Timestamp{WallTime: 1e9}) {
 			return errors.New("n2 still can't serve")
 		}
 		return nil
@@ -237,7 +237,7 @@ func TestTwoNodes(t *testing.T) {
 	// Remember the other proposals we tracked above on n1: (r17, 16) and (r8, 88). Feeding another
 	// timestamp to n1, we should see them closed out at t=2E9, and both n1 and n2 should automatically
 	// be able to serve them soon thereafter.
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: 4E9}, ep1, nil)
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: 4e9}, ep1, nil)
 
 	checkEpoch1Reads := func(ts hlc.Timestamp) {
 		t.Helper()
@@ -276,13 +276,13 @@ func TestTwoNodes(t *testing.T) {
 			}
 		}
 	}
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 2E9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 2e9})
 
 	// Tick again in epoch 1 and ensure that reads at t=3E9 can be safely served.
 	// 3E9 gets closed out under the first epoch in this tick with 4E9 as the
 	// timestamp to be closed next due to the 1s target interval.
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: 5E9}, ep1, nil)
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 3E9})
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: 5e9}, ep1, nil)
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 3e9})
 
 	// Uh-oh! n1 must've missed a heartbeat. The epoch goes up by one. This means
 	// that soon (after the next tick) timestamps should be closed out under the
@@ -291,11 +291,11 @@ func TestTwoNodes(t *testing.T) {
 	// that this all works out. Consequently we try Tick at the rotation interval
 	// plus the target duration next (so that the next closed timestamp is the
 	// rotation interval).
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 5E9}, ep2, nil)
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 5e9}, ep2, nil)
 
 	// Previously valid reads should remain valid.
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 2E9})
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 3E9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 2e9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 3e9})
 
 	// After the above tick makes it to the tracker, commands get forced above
 	// the next closed timestamp (from the tick above) minus target interval.
@@ -303,20 +303,20 @@ func TestTwoNodes(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		ts, release = c1.Tracker.Track(ctx)
 		release(ctx, ep2, roachpb.RangeID(123), ctpb.LAI(456))
-		if !(&hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 4E9, Logical: 1}).Equal(ts) {
+		if !(&hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 4e9, Logical: 1}).Equal(ts) {
 			return errors.Errorf("command still not forced above %v", ts)
 		}
 		return nil
 	})
 
 	// Previously valid reads should remain valid.
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 2E9})
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 3E9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 2e9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 3e9})
 
 	// With the next tick, epoch two fully goes into effect (as the first epoch two
 	// timestamp gets closed out). We do this twice to make sure it's processed before
 	// the test proceeds.
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 6E9}, ep2, nil)
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 6e9}, ep2, nil)
 
 	// Previously valid reads should remain valid. Note that this is because the
 	// storage keeps historical data, and we've fine tuned the epoch flip so that
@@ -328,17 +328,17 @@ func TestTwoNodes(t *testing.T) {
 	// rotation when the epoch changes, at the expense of pushing out historical
 	// information earlier. Frequent epoch changes could lead to very little
 	// historical information in the storage. Probably better not to risk that.
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 2E9})
-	checkEpoch1Reads(hlc.Timestamp{WallTime: 3E9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 2e9})
+	checkEpoch1Reads(hlc.Timestamp{WallTime: 3e9})
 
 	// Another second, another tick. Now the proposal tracked during epoch 2 should
 	// be readable from followers (as `scale+5E9` gets closed out).
-	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 7E9}, ep2, nil)
+	c1.TestClock.Tick(hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 7e9}, ep2, nil)
 	for i, c := range []*TestContainer{c1, c2} {
 		rangeID := roachpb.RangeID(123)
 		lai := ctpb.LAI(456)
 		epoch := ep2
-		ts := hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 5E9}
+		ts := hlc.Timestamp{WallTime: int64(container.StorageBucketScale) + 5e9}
 
 		testutils.SucceedsSoon(t, func() error {
 			if c.Container.Provider.MaxClosed(

--- a/pkg/storage/closedts/minprop/doc_test.go
+++ b/pkg/storage/closedts/minprop/doc_test.go
@@ -48,7 +48,7 @@ func Example() {
 	fmt.Println(tracker)
 
 	fmt.Println("The system closes out a timestamp (registering 1000 as the next timestamp to close out).")
-	closed1, mlai1, _ := tracker.Close(hlc.Timestamp{WallTime: 1E9}, ep1)
+	closed1, mlai1, _ := tracker.Close(hlc.Timestamp{WallTime: 1e9}, ep1)
 	fmt.Println("No problem: nothing is tracked on the left side; returns:", closed1, "and", mlaiString(mlai1))
 	fmt.Println("Note how the items on the right have moved to the left, as they are relevant for the")
 	fmt.Println("next call to Close.")
@@ -56,7 +56,7 @@ func Example() {
 
 	fmt.Println("Nothing happens for a while until the system tries to close out the next timestamp.")
 	fmt.Println("However, the very first proposal is still tracked and blocks progress.")
-	closed2, mlai2, _ := tracker.Close(hlc.Timestamp{WallTime: 2E9}, ep1)
+	closed2, mlai2, _ := tracker.Close(hlc.Timestamp{WallTime: 2e9}, ep1)
 	fmt.Println("The call returns a no-op in the form", closed2, mlaiString(mlai2), ".")
 	fmt.Println(tracker)
 
@@ -72,7 +72,7 @@ func Example() {
 	done1(ctx, ep1, 12, 79)
 	fmt.Println(tracker)
 
-	closed3, mlai3, _ := tracker.Close(hlc.Timestamp{WallTime: 3E9}, ep1)
+	closed3, mlai3, _ := tracker.Close(hlc.Timestamp{WallTime: 3e9}, ep1)
 	fmt.Println("The next call to Close() is successful and returns:", closed3, "and", mlaiString(mlai3))
 	fmt.Println(tracker)
 

--- a/pkg/storage/closedts/minprop/tracker_test.go
+++ b/pkg/storage/closedts/minprop/tracker_test.go
@@ -48,18 +48,18 @@ func ExampleTracker_Close() {
 	ctx := context.Background()
 	tracker := NewTracker()
 	_, slow := tracker.Track(ctx)
-	_, _, _ = tracker.Close(hlc.Timestamp{WallTime: 1E9}, ep1)
+	_, _, _ = tracker.Close(hlc.Timestamp{WallTime: 1e9}, ep1)
 	_, fast := tracker.Track(ctx)
 
 	fmt.Println("Slow proposal finishes at LAI 2")
 	slow(ctx, ep1, 99, 2)
-	closed, m, ok := tracker.Close(hlc.Timestamp{WallTime: 2E9}, ep1)
+	closed, m, ok := tracker.Close(hlc.Timestamp{WallTime: 2e9}, ep1)
 	fmt.Println("Closed:", closed, m, ok)
 
 	fmt.Println("Fast proposal finishes at LAI 1")
 	fast(ctx, ep1, 99, 1)
 	fmt.Println(tracker)
-	closed, m, ok = tracker.Close(hlc.Timestamp{WallTime: 3E9}, ep1)
+	closed, m, ok = tracker.Close(hlc.Timestamp{WallTime: 3e9}, ep1)
 	fmt.Println("Closed:", closed, m, ok)
 	fmt.Println("Note how the MLAI has 'regressed' from 2 to 1. The consumer")
 	fmt.Println("needs to track the maximum over all deltas received.")
@@ -240,7 +240,7 @@ func TestTrackerConcurrentUse(t *testing.T) {
 	}
 
 	newNext := func(i int) hlc.Timestamp {
-		return hlc.Timestamp{WallTime: int64(i) * 1E9}
+		return hlc.Timestamp{WallTime: int64(i) * 1e9}
 	}
 
 	run := func(i int) error {
@@ -325,9 +325,9 @@ func TestTrackerConcurrentUse(t *testing.T) {
 // ExampleTracker_EpochChanges tests the interactions between epoch values
 // passed to Close and epoch values of proposals being tracked.
 func ExampleTracker_Close_epochChange() {
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	ts3 := hlc.Timestamp{WallTime: 3E9}
+	ts1 := hlc.Timestamp{WallTime: 1e9}
+	ts2 := hlc.Timestamp{WallTime: 2e9}
+	ts3 := hlc.Timestamp{WallTime: 3e9}
 
 	ctx := context.Background()
 	tracker := NewTracker()
@@ -489,9 +489,9 @@ func ExampleTracker_Close_epochChange() {
 // retained and reported.
 func TestTrackerMultipleEpochsReleased(t *testing.T) {
 	ts0 := hlc.Timestamp{Logical: 1}
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	ts3 := hlc.Timestamp{WallTime: 3E9}
+	ts1 := hlc.Timestamp{WallTime: 1e9}
+	ts2 := hlc.Timestamp{WallTime: 2e9}
+	ts3 := hlc.Timestamp{WallTime: 3e9}
 
 	ctx := context.Background()
 	tracker := NewTracker()

--- a/pkg/storage/closedts/provider/provider_test.go
+++ b/pkg/storage/closedts/provider/provider_test.go
@@ -80,7 +80,7 @@ func TestProviderSubscribeNotify(t *testing.T) {
 
 	entryAt := func(i int) ctpb.Entry {
 		return ctpb.Entry{
-			ClosedTimestamp: hlc.Timestamp{WallTime: int64(i) * 1E9},
+			ClosedTimestamp: hlc.Timestamp{WallTime: int64(i) * 1e9},
 			Epoch:           ctpb.Epoch(i),
 			MLAI: map[roachpb.RangeID]ctpb.LAI{
 				roachpb.RangeID(i): ctpb.LAI(10 * i),

--- a/pkg/storage/closedts/storage/storage_test.go
+++ b/pkg/storage/closedts/storage/storage_test.go
@@ -34,7 +34,7 @@ func ExampleSingleStorage() {
 	fmt.Println("After adding the following entry:")
 	e1 := ctpb.Entry{
 		Full:            true,
-		ClosedTimestamp: hlc.Timestamp{WallTime: 123E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 123e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			1: 1000,
 			9: 2000,
@@ -48,7 +48,7 @@ func ExampleSingleStorage() {
 
 	fmt.Println("A new update comes in only two seconds later:")
 	e2 := ctpb.Entry{
-		ClosedTimestamp: hlc.Timestamp{WallTime: 125E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 125e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			1: 1001,
 			7: 12,
@@ -64,7 +64,7 @@ func ExampleSingleStorage() {
 
 	fmt.Println("Another update, another eight seconds later:")
 	e3 := ctpb.Entry{
-		ClosedTimestamp: hlc.Timestamp{WallTime: 133E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 133e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			9: 2020,
 			1: 999,
@@ -79,7 +79,7 @@ func ExampleSingleStorage() {
 
 	fmt.Println("Half a second later, with the next update, it will rotate:")
 	e4 := ctpb.Entry{
-		ClosedTimestamp: hlc.Timestamp{WallTime: 133E9 + 1E9/2},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 133e9 + 1e9/2},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			7: 17,
 			8: 711,
@@ -92,7 +92,7 @@ func ExampleSingleStorage() {
 
 	fmt.Println("Next update arrives a whopping 46.5s later (why not).")
 	e5 := ctpb.Entry{
-		ClosedTimestamp: hlc.Timestamp{WallTime: 180E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 180e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			1: 1004,
 			7: 19,
@@ -108,7 +108,7 @@ func ExampleSingleStorage() {
 
 	fmt.Println("Another five seconds later, another update:")
 	e6 := ctpb.Entry{
-		ClosedTimestamp: hlc.Timestamp{WallTime: 185E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 185e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			3: 1771,
 		},
@@ -258,7 +258,7 @@ func ExampleMultiStorage_epoch() {
 
 	e1 := ctpb.Entry{
 		Epoch:           10,
-		ClosedTimestamp: hlc.Timestamp{WallTime: 1E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 1e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			9: 17,
 		},
@@ -271,7 +271,7 @@ func ExampleMultiStorage_epoch() {
 	fmt.Println("The epoch changes. It can only increase, for we receive Entries in a fixed order.")
 	e2 := ctpb.Entry{
 		Epoch:           11,
-		ClosedTimestamp: hlc.Timestamp{WallTime: 2E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 2e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			9:  18,
 			10: 99,
@@ -285,7 +285,7 @@ func ExampleMultiStorage_epoch() {
 	fmt.Println("The storage itself will simply ignore such updates:")
 	e3 := ctpb.Entry{
 		Epoch:           8,
-		ClosedTimestamp: hlc.Timestamp{WallTime: 3E9},
+		ClosedTimestamp: hlc.Timestamp{WallTime: 3e9},
 		MLAI: map[roachpb.RangeID]ctpb.LAI{
 			9:  19,
 			10: 199,
@@ -415,7 +415,7 @@ func TestConcurrent(t *testing.T) {
 				ct := hlc.Timestamp{WallTime: r.Int63n(100), Logical: r.Int31n(10)}
 				epo := ctpb.Epoch(r.Int63n(100))
 				g.Go(func() error {
-					<-time.After(time.Duration(rand.Intn(1E7)))
+					<-time.After(time.Duration(rand.Intn(1e7)))
 					ms.Add(nodeID, ctpb.Entry{
 						Epoch:           epo,
 						ClosedTimestamp: ct,

--- a/pkg/storage/closedts/transport/transport_test.go
+++ b/pkg/storage/closedts/transport/transport_test.go
@@ -139,7 +139,7 @@ func TestTransportClientReceivesEntries(t *testing.T) {
 
 	// Now the producer (to which the server should maintain a subscription for this client, and
 	// notifications from which it should relay) emits an Entry.
-	e1 := ctpb.Entry{ClosedTimestamp: hlc.Timestamp{WallTime: 1E9}, Epoch: 12, MLAI: map[roachpb.RangeID]ctpb.LAI{12: 7}}
+	e1 := ctpb.Entry{ClosedTimestamp: hlc.Timestamp{WallTime: 1e9}, Epoch: 12, MLAI: map[roachpb.RangeID]ctpb.LAI{12: 7}}
 	container.Producer.sendAll(e1)
 
 	// The client should see this entry soon thereafter. it responds with an empty
@@ -156,7 +156,7 @@ func TestTransportClientReceivesEntries(t *testing.T) {
 	// And again, but only after Request() is called (which should be reflected in the transcript).
 	const rangeID = 7
 	container.Clients.Request(nodeID, rangeID)
-	e2 := ctpb.Entry{ClosedTimestamp: hlc.Timestamp{WallTime: 2E9}, Epoch: 13, MLAI: map[roachpb.RangeID]ctpb.LAI{13: 8}}
+	e2 := ctpb.Entry{ClosedTimestamp: hlc.Timestamp{WallTime: 2e9}, Epoch: 13, MLAI: map[roachpb.RangeID]ctpb.LAI{13: 8}}
 	container.Producer.sendAll(e2)
 	testutils.SucceedsSoon(t, func() error {
 		expectedTranscript := []interface{}{

--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -99,7 +99,7 @@ func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	// Seconds are counted every time each individual nanosecond timestamp
 	// crosses a whole second boundary (i.e. is zero mod 1E9). Thus it would
 	// be a mistake to use the (nonequivalent) expression (a-b)/1E9.
-	diffSeconds := nowNanos/1E9 - ms.LastUpdateNanos/1E9
+	diffSeconds := nowNanos/1e9 - ms.LastUpdateNanos/1e9
 
 	ms.GCBytesAge += ms.GCBytes() * diffSeconds
 	ms.IntentAge += ms.IntentCount * diffSeconds

--- a/pkg/storage/engine/gc.go
+++ b/pkg/storage/engine/gc.go
@@ -28,7 +28,7 @@ type GarbageCollector struct {
 // MakeGarbageCollector allocates and returns a new GC, with expiration
 // computed based on current time and policy.TTLSeconds.
 func MakeGarbageCollector(now hlc.Timestamp, policy config.GCPolicy) GarbageCollector {
-	ttlNanos := int64(policy.TTLSeconds) * 1E9
+	ttlNanos := int64(policy.TTLSeconds) * 1e9
 	return GarbageCollector{
 		Threshold: hlc.Timestamp{WallTime: now.WallTime - ttlNanos},
 		policy:    policy,

--- a/pkg/storage/engine/gc_test.go
+++ b/pkg/storage/engine/gc_test.go
@@ -27,13 +27,13 @@ var (
 	aKey  = roachpb.Key("a")
 	bKey  = roachpb.Key("b")
 	aKeys = []MVCCKey{
-		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 2E9, Logical: 0}),
-		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 1E9, Logical: 1}),
-		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 1E9, Logical: 0}),
+		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 2e9, Logical: 0}),
+		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 1e9, Logical: 1}),
+		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 1e9, Logical: 0}),
 	}
 	bKeys = []MVCCKey{
-		mvccVersionKey(bKey, hlc.Timestamp{WallTime: 2E9, Logical: 0}),
-		mvccVersionKey(bKey, hlc.Timestamp{WallTime: 1E9, Logical: 0}),
+		mvccVersionKey(bKey, hlc.Timestamp{WallTime: 2e9, Logical: 0}),
+		mvccVersionKey(bKey, hlc.Timestamp{WallTime: 1e9, Logical: 0}),
 	}
 )
 
@@ -57,24 +57,24 @@ func TestGarbageCollectorFilter(t *testing.T) {
 		{gcA, hlc.Timestamp{WallTime: 0, Logical: 0}, aKeys, [][]byte{d, d, d}, -1, hlc.Timestamp{}},
 		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
 		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{d, d}, -1, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 1E9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
-		{gcB, hlc.Timestamp{WallTime: 1E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{d, d, d}, 2, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 2E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{d, n, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 3E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 4E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
-		{gcA, hlc.Timestamp{WallTime: 5E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
+		{gcA, hlc.Timestamp{WallTime: 1e9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
+		{gcB, hlc.Timestamp{WallTime: 1e9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 2e9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 2e9, Logical: 0}, aKeys, [][]byte{d, d, d}, 2, hlc.Timestamp{WallTime: 1e9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 2e9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 3e9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1e9, Logical: 1}},
+		{gcA, hlc.Timestamp{WallTime: 3e9, Logical: 0}, aKeys, [][]byte{d, n, n}, 0, hlc.Timestamp{WallTime: 2e9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 3e9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 4e9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1e9, Logical: 1}},
+		{gcB, hlc.Timestamp{WallTime: 4e9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1e9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 4e9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2e9, Logical: 0}},
+		{gcA, hlc.Timestamp{WallTime: 5e9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1e9, Logical: 1}},
+		{gcB, hlc.Timestamp{WallTime: 5e9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1e9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 5e9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2e9, Logical: 0}},
 	}
 	for i, test := range testData {
 		test.gc.Threshold = test.time
-		test.gc.Threshold.WallTime -= int64(test.gc.policy.TTLSeconds) * 1E9
+		test.gc.Threshold.WallTime -= int64(test.gc.policy.TTLSeconds) * 1e9
 		idx, delTS := test.gc.Filter(test.keys, test.values)
 		if idx != test.expIdx {
 			t.Errorf("%d: expected index %d; got %d", i, test.expIdx, idx)

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2860,7 +2860,7 @@ func MVCCGarbageCollect(
 	var count int64
 	defer func(begin time.Time) {
 		log.Eventf(ctx, "done with GC evaluation for %d keys at %.2f keys/sec. Deleted %d entries",
-			len(keys), float64(len(keys))*1E9/float64(timeutil.Since(begin)), count)
+			len(keys), float64(len(keys))*1e9/float64(timeutil.Since(begin)), count)
 	}(timeutil.Now())
 
 	// Iterate through specified GC keys.
@@ -3190,7 +3190,7 @@ func ComputeStatsGo(
 					ms.LiveCount++
 				} else {
 					// First value is deleted, so it's GC'able; add meta key & value bytes to age stat.
-					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - meta.Timestamp.WallTime/1E9)
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - meta.Timestamp.WallTime/1e9)
 				}
 				ms.KeyBytes += metaKeySize
 				ms.ValBytes += metaValSize
@@ -3214,12 +3214,12 @@ func ComputeStatsGo(
 					ms.LiveBytes += totalBytes
 				} else {
 					// First value is deleted, so it's GC'able; add key & value bytes to age stat.
-					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - meta.Timestamp.WallTime/1E9)
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - meta.Timestamp.WallTime/1e9)
 				}
 				if meta.Txn != nil {
 					ms.IntentBytes += totalBytes
 					ms.IntentCount++
-					ms.IntentAge += nowNanos/1E9 - meta.Timestamp.WallTime/1E9
+					ms.IntentAge += nowNanos/1e9 - meta.Timestamp.WallTime/1e9
 				}
 				if meta.KeyBytes != MVCCVersionTimestampSize {
 					return ms, errors.Errorf("expected mvcc metadata key bytes to equal %d; got %d", MVCCVersionTimestampSize, meta.KeyBytes)
@@ -3233,11 +3233,11 @@ func ComputeStatsGo(
 				isTombstone := len(unsafeValue) == 0
 				if isTombstone {
 					// The contribution of the tombstone picks up GCByteAge from its own timestamp on.
-					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - unsafeKey.Timestamp.WallTime/1E9)
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - unsafeKey.Timestamp.WallTime/1e9)
 				} else {
 					// The kv pair is an overwritten value, so it became non-live when the closest more
 					// recent value was written.
-					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - accrueGCAgeNanos/1E9)
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - accrueGCAgeNanos/1e9)
 				}
 				// Update for the next version we may end up looking at.
 				accrueGCAgeNanos = unsafeKey.Timestamp.WallTime

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -75,7 +75,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
 			key := roachpb.Key("a")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
 			// Put a value.
 			value := roachpb.MakeValueFromString("value")
 			if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, nil); err != nil {
@@ -93,12 +93,12 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 				KeyCount:        1,
 				ValBytes:        vValSize, // 10
 				ValCount:        1,
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 			}
 			assertEq(t, engine, "after put", aggMS, &expMS)
 
 			// Delete the value at ts=3. We'll commit this at ts=4 later.
-			ts3 := hlc.Timestamp{WallTime: 3 * 1E9}
+			ts3 := hlc.Timestamp{WallTime: 3 * 1e9}
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts3},
 				OrigTimestamp: ts3,
@@ -109,7 +109,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 
 			// Now commit the value, but with a timestamp gap (i.e. this is a
 			// push-commit as it would happen for a SNAPSHOT txn)
-			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 			txn.Status = roachpb.COMMITTED
 			txn.Timestamp.Forward(ts4)
 			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
@@ -119,7 +119,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 4E9,
+				LastUpdateNanos: 4e9,
 				LiveBytes:       0,
 				LiveCount:       0,
 				KeyCount:        1,
@@ -153,7 +153,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
 			key := roachpb.Key("a")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
 				OrigTimestamp: ts1,
@@ -174,7 +174,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 			vValSize := int64(len(value.RawBytes)) // 10
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
 				LiveCount:       1,
 				KeyBytes:        mKeySize + vKeySize, // 2+12 =14
@@ -189,7 +189,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 
 			// Now commit the intent, but with a timestamp gap (i.e. this is a
 			// push-commit as it would happen for a SNAPSHOT txn)
-			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 			txn.Status = roachpb.COMMITTED
 			txn.Timestamp.Forward(ts4)
 			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
@@ -199,7 +199,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 4E9,
+				LastUpdateNanos: 4e9,
 				LiveBytes:       mKeySize + vKeySize + vValSize, // 2+12+20 = 24
 				LiveCount:       1,
 				KeyCount:        1,
@@ -232,7 +232,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
 			key := roachpb.Key("a")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
 				OrigTimestamp: ts1,
@@ -253,7 +253,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 			vValSize := int64(len(value.RawBytes)) // 10
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
 				LiveCount:       1,
 				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
@@ -268,7 +268,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 
 			// Now push the value, but with a timestamp gap (i.e. this is a
 			// push as it would happen for a SNAPSHOT txn)
-			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 			txn.Timestamp.Forward(ts4)
 			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
 				Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
@@ -277,7 +277,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 4E9,
+				LastUpdateNanos: 4e9,
 				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+20 = 78
 				LiveCount:       1,
 				KeyCount:        1,
@@ -312,8 +312,8 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2 * 1e9}
 
 			key := roachpb.Key("a")
 			txn := &roachpb.Transaction{
@@ -351,7 +351,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, vValSize, 10)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
 				LiveCount:       1,
 				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
@@ -388,7 +388,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				LiveBytes:       0,
 				LiveCount:       0,
 				KeyCount:        1,
@@ -424,8 +424,8 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2 * 1e9}
 
 			key := roachpb.Key("a")
 			txn := &roachpb.Transaction{
@@ -464,7 +464,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			require.EqualValues(t, vValSize, 10)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				LiveBytes:       0,
 				LiveCount:       0,
 				KeyBytes:        mKeySize + vKeySize, // 2 + 12 = 24
@@ -502,7 +502,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
 				LiveCount:       1,
 				KeyCount:        1,
@@ -542,9 +542,9 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 
 			key := roachpb.Key("a")
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
-			ts3 := hlc.Timestamp{WallTime: 3E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
+			ts3 := hlc.Timestamp{WallTime: 3e9}
 
 			// Write a non-transactional tombstone at t=1s.
 			if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil /* txn */); err != nil {
@@ -557,7 +557,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, vKeySize, 12)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				KeyBytes:        mKeySize + vKeySize,
 				KeyCount:        1,
 				ValBytes:        0,
@@ -583,7 +583,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, mValSize, 46)
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
 				KeyCount:        1,
 				ValBytes:        mValSize, // 44
@@ -612,7 +612,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 				}
 
 				expAggMS := enginepb.MVCCStats{
-					LastUpdateNanos: 3E9,
+					LastUpdateNanos: 3e9,
 					KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
 					KeyCount:        1,
 					ValBytes:        0,
@@ -641,7 +641,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 				}
 
 				expAggMS := enginepb.MVCCStats{
-					LastUpdateNanos: 3E9,
+					LastUpdateNanos: 3e9,
 					KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
 					KeyCount:        1,
 					ValBytes:        0,
@@ -681,9 +681,9 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 
 			key := roachpb.Key("a")
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
-			ts3 := hlc.Timestamp{WallTime: 3E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
+			ts3 := hlc.Timestamp{WallTime: 3e9}
 
 			// Write a non-transactional value at t=1s.
 			value := roachpb.MakeValueFromString("value")
@@ -701,7 +701,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, vValSize, 10)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				KeyBytes:        mKeySize + vKeySize,
 				KeyCount:        1,
 				ValBytes:        vValSize,
@@ -729,7 +729,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, mValSize, 46)
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
 				KeyCount:        1,
 				ValBytes:        mValSize + vValSize, // 44+10 = 56
@@ -771,7 +771,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 				}
 
 				expAggMS := enginepb.MVCCStats{
-					LastUpdateNanos: 3E9,
+					LastUpdateNanos: 3e9,
 					KeyBytes:        mKeySize + vKeySize,
 					KeyCount:        1,
 					ValBytes:        vValSize,
@@ -813,7 +813,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 				require.EqualValues(t, m2ValSizeWithHistory, 54)
 
 				expAggMS := enginepb.MVCCStats{
-					LastUpdateNanos: 3E9,
+					LastUpdateNanos: 3e9,
 					KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
 					KeyCount:        1,
 					ValBytes:        m2ValSizeWithHistory + vValSize + vVal2Size,
@@ -849,8 +849,8 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
 			key := roachpb.Key("a")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 
 			// Write tombstones at ts1 and ts2.
 			if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil); err != nil {
@@ -864,7 +864,7 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 			vKeySize := MVCCVersionTimestampSize          // 12
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				KeyBytes:        mKeySize + 2*vKeySize, // 26
 				KeyCount:        1,
 				ValCount:        2,
@@ -891,7 +891,7 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 			}
 
 			expAggMS := enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 			}
 
 			assertEq(t, engine, "after GC", aggMS, &expAggMS)
@@ -925,8 +925,8 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
 			key := roachpb.Key("a")
-			ts201 := hlc.Timestamp{WallTime: 2E9 + 1}
-			ts099 := hlc.Timestamp{WallTime: 1E9 - 1}
+			ts201 := hlc.Timestamp{WallTime: 2e9 + 1}
+			ts099 := hlc.Timestamp{WallTime: 1e9 - 1}
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts201},
 				OrigTimestamp: ts099,
@@ -946,7 +946,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 			vValSize := int64(len(value.RawBytes)) // 10
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 2E9 + 1,
+				LastUpdateNanos: 2e9 + 1,
 				LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
 				LiveCount:       1,
 				KeyBytes:        mKeySize + vKeySize, // 14
@@ -985,7 +985,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 				// will have been written at 2E9+1, so the age will be 0.
 				IntentAge: 0,
 
-				LastUpdateNanos: 2E9 + 1,
+				LastUpdateNanos: 2e9 + 1,
 				LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
 				LiveCount:       1,
 				KeyBytes:        mKeySize + vKeySize, // 14
@@ -1017,8 +1017,8 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 
 			key := roachpb.Key("a")
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 
 			// Write a value at ts1.
 			val1 := roachpb.MakeValueFromString("value")
@@ -1036,7 +1036,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 			require.EqualValues(t, vValSize, 10)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				KeyCount:        1,
 				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
 				ValCount:        1,
@@ -1053,7 +1053,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 			}
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				KeyCount:        1,
 				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
 				ValBytes:        vValSize,              // 10
@@ -1073,7 +1073,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 			}
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 2E9,
+				LastUpdateNanos: 2e9,
 				KeyCount:        1,
 				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
 				ValBytes:        0,
@@ -1104,8 +1104,8 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 
 			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
@@ -1139,7 +1139,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 			require.EqualValues(t, vVal2Size, 14)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
 				SysCount:        1,
 			}
@@ -1167,7 +1167,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 			}
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				SysBytes:        mKeySize + mVal2Size + vKeySize + vVal2Size, // 11+46+12+14 = 83
 				SysCount:        1,
 			}
@@ -1194,7 +1194,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 
 			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
 			txn := &roachpb.Transaction{
 				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
 				OrigTimestamp: ts1,
@@ -1227,7 +1227,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 			require.EqualValues(t, vVal2Size, 14)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
 				SysCount:        1,
 			}
@@ -1242,7 +1242,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 			}
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 			}
 			assertEq(t, engine, "after aborting", aggMS, &expMS)
 		})
@@ -1265,8 +1265,8 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 
 			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 
 			// Write a value at ts1.
 			val1 := roachpb.MakeValueFromString("value")
@@ -1288,7 +1288,7 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 			require.EqualValues(t, vVal2Size, 14)
 
 			expMS := enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				SysBytes:        mKeySize + vKeySize + vVal1Size, // 11+12+10 = 33
 				SysCount:        1,
 			}
@@ -1301,7 +1301,7 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 			}
 
 			expMS = enginepb.MVCCStats{
-				LastUpdateNanos: 1E9,
+				LastUpdateNanos: 1e9,
 				SysBytes:        mKeySize + 2*vKeySize + vVal1Size + vVal2Size,
 				SysCount:        1,
 			}
@@ -1373,7 +1373,7 @@ func (s *randomTest) step(t *testing.T) {
 		// Jump up to a few seconds into the future. In ~1% of cases, jump
 		// backwards instead (this exercises intactness on WriteTooOld, etc).
 		s.TS = hlc.Timestamp{
-			WallTime: s.TS.WallTime + int64((s.state.rng.Float32()-0.01)*4E9),
+			WallTime: s.TS.WallTime + int64((s.state.rng.Float32()-0.01)*4e9),
 			Logical:  int32(s.rng.Intn(10)),
 		}
 		if s.TS.WallTime < 0 {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -228,13 +228,13 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	}
 	delta := goldDelta
 
-	for i, ns := range []int64{1, 1e9 - 1001, 1e9 - 1000, 1E9 - 1, 1E9, 1E9 + 1, 2E9 - 1} {
+	for i, ns := range []int64{1, 1e9 - 1001, 1e9 - 1000, 1e9 - 1, 1e9, 1e9 + 1, 2e9 - 1} {
 		oldDelta := delta
 		delta.AgeTo(ns)
 		if delta.LastUpdateNanos < ns {
 			t.Fatalf("%d: expected LastUpdateNanos < %d, got %d", i, ns, delta.LastUpdateNanos)
 		}
-		shouldAge := ns/1E9-oldDelta.LastUpdateNanos/1E9 > 0
+		shouldAge := ns/1e9-oldDelta.LastUpdateNanos/1e9 > 0
 		didAge := delta.IntentAge != oldDelta.IntentAge &&
 			delta.GCBytesAge != oldDelta.GCBytesAge
 		if shouldAge != didAge {
@@ -243,13 +243,13 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	}
 
 	expDelta := goldDelta
-	expDelta.LastUpdateNanos = 2E9 - 1
+	expDelta.LastUpdateNanos = 2e9 - 1
 	expDelta.GCBytesAge = 42
 	expDelta.IntentAge = 11
 	cmp(delta, expDelta)
 
-	delta.AgeTo(2E9)
-	expDelta.LastUpdateNanos = 2E9
+	delta.AgeTo(2e9)
+	expDelta.LastUpdateNanos = 2e9
 	expDelta.GCBytesAge += 42
 	expDelta.IntentAge += 11
 	cmp(delta, expDelta)
@@ -260,27 +260,27 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 		tmpDelta := delta
 		expDelta := expDelta
 
-		tmpDelta.AgeTo(2E9 - 1)
-		expDelta.LastUpdateNanos = 2E9 - 1
+		tmpDelta.AgeTo(2e9 - 1)
+		expDelta.LastUpdateNanos = 2e9 - 1
 		expDelta.GCBytesAge -= 42
 		expDelta.IntentAge -= 11
 		cmp(tmpDelta, expDelta)
 	}
 
-	delta.AgeTo(3E9 - 1)
+	delta.AgeTo(3e9 - 1)
 	delta.Forward(5) // should be noop
-	expDelta.LastUpdateNanos = 3E9 - 1
+	expDelta.LastUpdateNanos = 3e9 - 1
 	cmp(delta, expDelta)
 
 	// Check that Add calls Forward appropriately.
 	mss := []enginepb.MVCCStats{goldMS, goldMS}
 
-	mss[0].LastUpdateNanos = 2E9 - 1
-	mss[1].LastUpdateNanos = 10E9 + 1
+	mss[0].LastUpdateNanos = 2e9 - 1
+	mss[1].LastUpdateNanos = 10e9 + 1
 
 	expMS := goldMS
 	expMS.Add(goldMS)
-	expMS.LastUpdateNanos = 10E9 + 1
+	expMS.LastUpdateNanos = 10e9 + 1
 	expMS.IntentAge += 9  // from aging 9 ticks from 2E9-1 to 10E9+1
 	expMS.GCBytesAge += 9 // ditto
 
@@ -295,9 +295,9 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	neg.Subtract(goldMS)
 	exp := neg
 
-	neg.AgeTo(2E9)
+	neg.AgeTo(2e9)
 
-	exp.LastUpdateNanos = 2E9
+	exp.LastUpdateNanos = 2e9
 	exp.GCBytesAge = -3
 	exp.IntentAge = -3
 	cmp(neg, exp)
@@ -5505,9 +5505,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			ms := &enginepb.MVCCStats{}
 
 			bytes := []byte("value")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
-			ts3 := hlc.Timestamp{WallTime: 3E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
+			ts3 := hlc.Timestamp{WallTime: 3e9}
 			val1 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts1)
 			val2 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts2)
 			val3 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts3)
@@ -5618,8 +5618,8 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 			defer engine.Close()
 
 			s := "string"
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 			val1 := mkVal(s, ts1)
 			val2 := mkVal(s, ts2)
 			valInline := mkVal(s, hlc.Timestamp{})
@@ -5665,8 +5665,8 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 			defer engine.Close()
 
 			bytes := []byte("value")
-			ts1 := hlc.Timestamp{WallTime: 1E9}
-			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
+			ts2 := hlc.Timestamp{WallTime: 2e9}
 			key := roachpb.Key("a")
 			{
 				val1 := roachpb.MakeValueFromBytes(bytes)
@@ -5741,7 +5741,7 @@ func TestMVCCIdempotentTransactions(t *testing.T) {
 			engine := engineImpl.create()
 			defer engine.Close()
 
-			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1e9}
 
 			key := roachpb.Key("a")
 			value := roachpb.MakeValueFromString("first value")
@@ -5870,9 +5870,9 @@ func TestMVCCIntentHistory(t *testing.T) {
 			engine := engineImpl.create()
 			defer engine.Close()
 
-			ts0 := hlc.Timestamp{WallTime: 1E9}
-			ts1 := hlc.Timestamp{WallTime: 2 * 1E9}
-			ts2 := hlc.Timestamp{WallTime: 3 * 1E9}
+			ts0 := hlc.Timestamp{WallTime: 1e9}
+			ts1 := hlc.Timestamp{WallTime: 2 * 1e9}
+			ts2 := hlc.Timestamp{WallTime: 3 * 1e9}
 
 			key := roachpb.Key("a")
 			defaultValue := roachpb.MakeValueFromString("default")

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -317,7 +317,7 @@ func makeGCQueueScoreImpl(
 	// Intent score. This computes the average age of outstanding intents and
 	// normalizes. Note that at the time of writing this criterion hasn't
 	// undergone a reality check yet.
-	r.IntentScore = ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1E9)
+	r.IntentScore = ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1e9)
 
 	// Randomly skew the score down a bit to cause decoherence of replicas with
 	// similar load. Note that we'll only ever reduce the score, never increase

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -370,15 +370,15 @@ func TestGCQueueProcess(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
-	tc.manualClock.Increment(48 * 60 * 60 * 1E9) // 2d past the epoch
+	tc.manualClock.Increment(48 * 60 * 60 * 1e9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
 
-	ts1 := makeTS(now-2*24*60*60*1E9+1, 0)                     // 2d old (add one nanosecond so we're not using zero timestamp)
-	ts2 := makeTS(now-25*60*60*1E9, 0)                         // GC will occur at time=25 hours
+	ts1 := makeTS(now-2*24*60*60*1e9+1, 0)                     // 2d old (add one nanosecond so we're not using zero timestamp)
+	ts2 := makeTS(now-25*60*60*1e9, 0)                         // GC will occur at time=25 hours
 	ts2m1 := ts2.Prev()                                        // ts2 - 1 so we have something not right at the GC time
 	ts3 := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)     // 2h old
 	ts4 := makeTS(now-(intentAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
-	ts5 := makeTS(now-1E9, 0)                                  // 1s old
+	ts5 := makeTS(now-1e9, 0)                                  // 1s old
 	key1 := roachpb.Key("a")
 	key2 := roachpb.Key("b")
 	key3 := roachpb.Key("c")
@@ -847,7 +847,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
-	tc.manualClock.Set(48 * 60 * 60 * 1E9) // 2d past the epoch
+	tc.manualClock.Set(48 * 60 * 60 * 1e9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
 
 	txns := []*roachpb.Transaction{
@@ -1042,7 +1042,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not find zone config for range %s", err)
 	}
-	tc.manualClock.Increment(int64(zone.GC.TTLSeconds)*1E9 + 1)
+	tc.manualClock.Increment(int64(zone.GC.TTLSeconds)*1e9 + 1)
 	gcQ := newGCQueue(tc.store, tc.gossip)
 	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/replica_consistency_diff.go
+++ b/pkg/storage/replica_consistency_diff.go
@@ -61,7 +61,7 @@ func (rsds ReplicaSnapshotDiffSlice) WriteTo(w io.Writer) (int64, error) {
 		}
 		mvccKey := engine.MVCCKey{Key: d.Key, Timestamp: ts}
 		num, err := fmt.Fprintf(w, format,
-			prefix, ts.WallTime/1E9, ts.WallTime%1E9, ts.Logical, d.Key,
+			prefix, ts.WallTime/1e9, ts.WallTime%1e9, ts.Logical, d.Key,
 			prefix, prettyTime,
 			prefix, SprintKeyValue(engine.MVCCKeyValue{Key: mvccKey, Value: d.Value}, false /* printKey */),
 			prefix, engine.EncodeKey(mvccKey), d.Value)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2660,7 +2660,7 @@ func TestStoreGCThreshold(t *testing.T) {
 	assertThreshold(hlc.Timestamp{})
 
 	threshold := hlc.Timestamp{
-		WallTime: 2E9,
+		WallTime: 2e9,
 	}
 
 	gcr := roachpb.GCRequest{

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -32,7 +32,7 @@ func (t Timestamp) Less(s Timestamp) bool {
 }
 
 func (t Timestamp) String() string {
-	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1E9, t.WallTime%1E9, t.Logical)
+	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1e9, t.WallTime%1e9, t.Logical)
 }
 
 // AsOfSystemTime returns a string to be used in an AS OF SYSTEM TIME query.


### PR DESCRIPTION
This updates the behavior of crlfmt to be like newer versions of
goimports. In particular, this improves the handling of the
opentracing-go imports and should stop the adding/removing of the
package alias.

Release note: None