### PR TITLE
release-19.2: storage: check whether the acquiring replica can receive the lease

### DIFF
--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -53,7 +53,7 @@ func RequestLease(
 	//
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(cArgs.EvalCtx); err != nil {
+	if err := checkCanReceiveLease(&args.Lease, cArgs.EvalCtx); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -46,7 +46,7 @@ func TransferLease(
 	//
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(cArgs.EvalCtx); err != nil {
+	if err := checkCanReceiveLease(&args.Lease, cArgs.EvalCtx); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1057,7 +1057,7 @@ func TestReplicaLease(t *testing.T) {
 				Args: &roachpb.RequestLeaseRequest{
 					Lease: lease,
 				},
-			}, &roachpb.RequestLeaseResponse{}); !testutils.IsError(err, "illegal lease") {
+			}, &roachpb.RequestLeaseResponse{}); !testutils.IsError(err, "replica \\(n0,s0\\):\\? not found in r1") {
 			t.Fatalf("unexpected error: %+v", err)
 		}
 	}
@@ -1462,7 +1462,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 		// Remove ambiguity about where the "replica not found" error comes from.
 		pErr = (<-ch).Err
 	}
-	if !testutils.IsPError(pErr, "replica not found") {
+	if !testutils.IsPError(pErr, "replica.*not found") {
 		t.Errorf("unexpected error obtaining lease for invalid store: %v", pErr)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #42068.

/cc @cockroachdb/release

---

Before this PR, when evaluating lease transfers or requests we'd check whether
the evaluating replica could receive the lease rather than the acquiring
replica. This patch fixes that bug by checking the state of the correct
replica.

Fixes #38720.

Release note (bug fix): The system no longer erroneously transfers leases
to replicas which are in the process of being removed which can lead to
ranges being effectively unavailable due to an invalid lease.
