### PR TITLE
sql: fix SHOW ALL ZONE CONFIGURATION displaying unprivileged entries

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -56,12 +56,58 @@ statement ok
 CREATE DATABASE db2; ALTER DATABASE db2 CONFIGURE ZONE USING num_replicas = 3;
 
 statement ok
-CREATE TABLE t3 (a INT PRIMARY KEY, b INT); CREATE INDEX myindex ON t3 (b); ALTER INDEX myindex CONFIGURE ZONE USING num_replicas = 5; ALTER TABLE t3 CONFIGURE ZONE USING num_replicas = 8
+CREATE TABLE t3 (a INT PRIMARY KEY, b INT); CREATE INDEX myt3index ON t3 (b); ALTER INDEX myt3index CONFIGURE ZONE USING num_replicas = 5; ALTER TABLE t3 CONFIGURE ZONE USING num_replicas = 8
 
 statement ok
-CREATE TABLE t4 (a INT PRIMARY KEY, b INT); ALTER TABLE t4 CONFIGURE ZONE USING num_replicas = 7; GRANT ALL ON t4 TO testuser
+CREATE TABLE t4 (a INT PRIMARY KEY, b INT); CREATE INDEX myt4index ON t4 (b); ALTER TABLE t4 CONFIGURE ZONE USING num_replicas = 7; ALTER INDEX myt4index CONFIGURE ZONE USING num_replicas = 5; GRANT ALL ON t4 TO testuser
 
 user testuser
+
+query IT
+SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
+----
+0   RANGE default
+16  RANGE meta
+17  RANGE system
+22  RANGE liveness
+57  TABLE test.public.t4
+57  INDEX test.public.t4@myt4index
+
+query TT
+SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] ORDER BY 1
+----
+INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
+                                num_replicas = 5
+RANGE default                   ALTER RANGE default CONFIGURE ZONE USING
+                                range_min_bytes = 16777216,
+                                range_max_bytes = 67108864,
+                                gc.ttlseconds = 90000,
+                                num_replicas = 3,
+                                constraints = '[]',
+                                lease_preferences = '[]'
+RANGE liveness                  ALTER RANGE liveness CONFIGURE ZONE USING
+                                range_min_bytes = 16777216,
+                                range_max_bytes = 67108864,
+                                gc.ttlseconds = 600,
+                                num_replicas = 5,
+                                constraints = '[]',
+                                lease_preferences = '[]'
+RANGE meta                      ALTER RANGE meta CONFIGURE ZONE USING
+                                range_min_bytes = 16777216,
+                                range_max_bytes = 67108864,
+                                gc.ttlseconds = 3600,
+                                num_replicas = 5,
+                                constraints = '[]',
+                                lease_preferences = '[]'
+RANGE system                    ALTER RANGE system CONFIGURE ZONE USING
+                                range_min_bytes = 16777216,
+                                range_max_bytes = 67108864,
+                                gc.ttlseconds = 90000,
+                                num_replicas = 5,
+                                constraints = '[]',
+                                lease_preferences = '[]'
+TABLE test.public.t4            ALTER TABLE test.public.t4 CONFIGURE ZONE USING
+                                num_replicas = 7
 
 query error pq: user testuser has no privileges on database db2
 SHOW ZONE CONFIGURATION FOR DATABASE db2
@@ -71,6 +117,20 @@ SHOW ZONE CONFIGURATION FOR TABLE t2
 
 query error pq: user testuser has no privileges on relation t3
 SHOW ZONE CONFIGURATION FOR TABLE t3
+
+query error pq: user testuser has no privileges on relation t3
+SHOW ZONE CONFIGURATION FOR INDEX myt3index
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX myt4index
+----
+INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
+                                range_min_bytes = 16777216,
+                                range_max_bytes = 67108864,
+                                gc.ttlseconds = 90000,
+                                num_replicas = 5,
+                                constraints = '[]',
+                                lease_preferences = '[]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t4

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -102,6 +102,9 @@ func TryDelegate(
 	case *tree.ShowVar:
 		return d.delegateShowVar(t)
 
+	case *tree.ShowZoneConfig:
+		return d.delegateShowZoneConfig(t)
+
 	case *tree.ShowTransactionStatus:
 		return d.delegateShowVar(&tree.ShowVar{Name: "transaction_status"})
 

--- a/pkg/sql/delegate/show_zone_config.go
+++ b/pkg/sql/delegate/show_zone_config.go
@@ -1,0 +1,22 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package delegate
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// ShowZoneConfig only delegates if it selecting ALL configurations.
+func (d *delegator) delegateShowZoneConfig(n *tree.ShowZoneConfig) (tree.Statement, error) {
+	// Specifying a specific zone; fallback to non-delegation logic.
+	if n.ZoneSpecifier != (tree.ZoneSpecifier{}) {
+		return nil, nil
+	}
+	return parse(`SELECT target, raw_config_sql FROM crdb_internal.zones`)
+}


### PR DESCRIPTION
Fully resolves #40917.

* Made `crdb_internal.zones` not display entries which the executing
    user does not have access to.
* Add a delegate for ShowZoneConfig, which triggers on SHOW ALL
    ZONE CONFIGURATIONS, to use crdb_internal.zones table and run it as
    the executing user so rows are hidden if the user does not have
    permission.

Release note (bug fix): Previously, SHOW ALL ZONE CONFIGURATION ZONES and crdb_internal.zones shows results for resources the user does not have access to. This will instead filter out those entries from displaying.