### PR TITLE
opt: eliminate duplicate expressions in a Range operator

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -773,8 +773,8 @@ func (c *CustomFuncs) ConsolidateFilters(filters memo.FiltersExpr) memo.FiltersE
 				// This is the first condition.
 				rangeItem.Condition = cond
 			} else {
-				// Build a left-deep tree of ANDs.
-				rangeItem.Condition = c.f.ConstructAnd(rangeItem.Condition, cond)
+				// Build a left-deep tree of ANDs sorted by ID.
+				rangeItem.Condition = c.mergeSortedAnds(rangeItem.Condition, cond)
 			}
 		} else {
 			newFilters = append(newFilters, filters[i])
@@ -788,6 +788,40 @@ func (c *CustomFuncs) ConsolidateFilters(filters memo.FiltersExpr) memo.FiltersE
 	}
 
 	return newFilters
+}
+
+// mergeSortedAnds merges two left-deep trees of nested AndExprs sorted by ID.
+// Returns a single sorted, left-deep tree of nested AndExprs, with any
+// duplicate expressions eliminated.
+func (c *CustomFuncs) mergeSortedAnds(left, right opt.ScalarExpr) opt.ScalarExpr {
+	if right == nil {
+		return left
+	}
+	if left == nil {
+		return right
+	}
+
+	// Since both trees are left-deep, perform a merge-sort from right to left.
+	nextLeft := left
+	nextRight := right
+	var remainingLeft, remainingRight opt.ScalarExpr
+	if and, ok := left.(*memo.AndExpr); ok {
+		remainingLeft = and.Left
+		nextLeft = and.Right
+	}
+	if and, ok := right.(*memo.AndExpr); ok {
+		remainingRight = and.Left
+		nextRight = and.Right
+	}
+
+	if nextLeft.ID() == nextRight.ID() {
+		// Eliminate duplicates.
+		return c.mergeSortedAnds(left, remainingRight)
+	}
+	if nextLeft.ID() < nextRight.ID() {
+		return c.f.ConstructAnd(c.mergeSortedAnds(left, remainingRight), nextRight)
+	}
+	return c.f.ConstructAnd(c.mergeSortedAnds(remainingLeft, right), nextLeft)
 }
 
 // AreFiltersSorted determines whether the expressions in a FiltersExpr are

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -49,9 +49,9 @@ func TestSimplifyFilters(t *testing.T) {
 		Cols: opt.ColList{},
 		ID:   f.Metadata().NextValuesID(),
 	})
-	filters := memo.FiltersExpr{{Condition: eq}, {Condition: &memo.FalseFilter}, {Condition: eq}}
+	filters := memo.FiltersExpr{{Condition: eq}, {Condition: memo.FalseSingleton}, {Condition: eq}}
 	sel := f.ConstructSelect(vals, filters)
-	if sel.Relational().Cardinality.Max == 0 {
+	if sel.Relational().Cardinality.Max != 0 {
 		t.Fatalf("result should have been collapsed to zero cardinality rowset")
 	}
 

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -237,9 +237,145 @@ inner-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7-10)
  │    └── filters
- │         └── (e.k > 1) AND (e.k < 10) [type=bool, outer=(6), constraints=(/6: [/2 - /9]; tight)]
+ │         └── (e.k < 10) AND (e.k > 1) [type=bool, outer=(6), constraints=(/6: [/2 - /9]; tight)]
  └── filters
       └── a.k = e.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# The duplicate filter i >= 5 should be eliminated.
+norm expect=ConsolidateSelectFilters
+SELECT * FROM (SELECT * FROM a WHERE i >= 5 AND i < 10) AS a, xy WHERE i >= 5
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── (i >= 5) AND (i < 10) [type=bool, outer=(2), constraints=(/2: [/5 - /9]; tight)]
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+norm expect=ConsolidateSelectFilters
+SELECT * FROM (SELECT * FROM a WHERE i < 10 AND i >= 5) AS a, xy WHERE i >= 5
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── (i < 10) AND (i >= 5) [type=bool, outer=(2), constraints=(/2: [/5 - /9]; tight)]
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+norm expect=ConsolidateSelectFilters
+SELECT * FROM (SELECT * FROM a WHERE i < 10 AND i >= 5 AND i IN (0, 2, 4, 6, 8, 10, 12)) AS a, xy
+WHERE i >= 5 AND i < 10
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── ((i < 10) AND (i >= 5)) AND (i IN (0, 2, 4, 6, 8, 10, 12)) [type=bool, outer=(2), constraints=(/2: [/6 - /6] [/8 - /8]; tight)]
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+# Regression test for #42035.
+opt expect=ConsolidateSelectFilters
+SELECT * FROM
+      (VALUES ('x', 'x'), ('y', 'y')) AS vab (a, b)
+    JOIN
+        (VALUES ('z'), ('u')) AS vc (c)
+      JOIN
+        (VALUES ('v')) AS vd (d)
+      ON c = d
+    ON a = d AND b = d
+  JOIN
+    (VALUES ('w'), ('w')) AS ve (e)
+  ON d = e
+----
+inner-join (hash)
+ ├── columns: a:1(string!null) b:2(string!null) c:3(string!null) d:4(string!null) e:5(string!null)
+ ├── cardinality: [0 - 8]
+ ├── fd: ()-->(1-5), (1)==(2,4,5), (2)==(1,4,5), (4)==(1,2,5), (5)==(1,2,4)
+ ├── values
+ │    ├── columns: column1:5(string!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('w',) [type=tuple{string}]
+ │    └── ('w',) [type=tuple{string}]
+ ├── inner-join (hash)
+ │    ├── columns: column1:1(string!null) column2:2(string!null) column1:3(string!null) column1:4(string!null)
+ │    ├── cardinality: [0 - 4]
+ │    ├── fd: ()-->(1-4), (1)==(2,4), (2)==(1,4), (4)==(1,2)
+ │    ├── select
+ │    │    ├── columns: column1:1(string!null) column2:2(string!null)
+ │    │    ├── cardinality: [0 - 2]
+ │    │    ├── fd: (1)==(2), (2)==(1)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1(string!null) column2:2(string!null)
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── ('x', 'x') [type=tuple{string, string}]
+ │    │    │    └── ('y', 'y') [type=tuple{string, string}]
+ │    │    └── filters
+ │    │         └── column1 = column2 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ │    ├── inner-join (hash)
+ │    │    ├── columns: column1:3(string!null) column1:4(string!null)
+ │    │    ├── cardinality: [0 - 2]
+ │    │    ├── fd: ()-->(3,4)
+ │    │    ├── select
+ │    │    │    ├── columns: column1:3(string!null)
+ │    │    │    ├── cardinality: [0 - 2]
+ │    │    │    ├── fd: ()-->(3)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:3(string!null)
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── ('z',) [type=tuple{string}]
+ │    │    │    │    └── ('u',) [type=tuple{string}]
+ │    │    │    └── filters
+ │    │    │         └── column1 = 'v' [type=bool, outer=(3), constraints=(/3: [/'v' - /'v']; tight), fd=()-->(3)]
+ │    │    ├── values
+ │    │    │    ├── columns: column1:4(string!null)
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(4)
+ │    │    │    └── ('v',) [type=tuple{string}]
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── column1 = column1 [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ └── filters
+      └── column1 = column1 [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
 
 # --------------------------------------------------
 # EliminateSelect


### PR DESCRIPTION
A `Range` operator is used to consolidate `Select` filters on the same variable
into a tree of nested `AND` expressions. Previously, the `Range` operator
could include multiple identical expressions, so it was possible for
the same expression to be added over and over again in an infinite loop.
This commit addresses the problem by keeping the tree of `AND` expressions
sorted and eliminating duplicates as new expressions are added.

Also includes a small fix to `TestSimplifyFilters` in `factory_test.go`.

Fixes #42035

Release note (bug fix): Fixed a bug during planning for some queries
that could cause an infinite loop and prevent the query from being cancelled.