### PR TITLE
distsql: omit BYTES type when testing operators against processors

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -599,7 +599,9 @@ func generateRandomSupportedTypes(rng *rand.Rand, nCols int) []types.T {
 	for len(typs) < nCols {
 		typ := sqlbase.RandType(rng)
 		converted := typeconv.FromColumnType(typ)
-		if converted != coltypes.Unhandled {
+		if converted != coltypes.Unhandled && converted != coltypes.Bytes {
+			// TODO(yuzefovich): allow generating coltypes.Bytes once the issues with
+			// flat bytes implementation have been resolved.
 			typs = append(typs, *typ)
 		}
 	}


### PR DESCRIPTION
Currently, there are some issues with flat bytes implementation, so
in order to reduce the flakiness of the build, we'll not be using
BYTES type when comparing output of columnar operators against
processors.

Release note: None