### PR TITLE
sql: remove hard limit handling from heuristic planner

### DIFF
--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -59,3 +59,7 @@ func (f *filterNode) Values() tree.Datums {
 }
 
 func (f *filterNode) Close(ctx context.Context) { f.source.plan.Close(ctx) }
+
+func isFilterTrue(expr tree.TypedExpr) bool {
+	return expr == nil || expr == tree.DBoolTrue
+}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -26,10 +26,6 @@ type groupNode struct {
 	// The schema for this groupNode.
 	columns sqlbase.ResultColumns
 
-	// needOnlyOneRow determines whether aggregation should stop as soon
-	// as one result row can be computed.
-	needOnlyOneRow bool
-
 	// The source node (which returns values that feed into the aggregation).
 	plan planNode
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -589,7 +589,7 @@ func (p *planner) SessionData() *sessiondata.SessionData {
 // check and does additional verification of the planner state.
 func (p *planner) prepareForDistSQLSupportCheck() {
 	// Trigger limit propagation.
-	p.setUnlimited(p.curPlan.plan)
+	p.propagateSoftLimits(p.curPlan.plan)
 }
 
 // txnModesSetter is an interface used by SQL execution to influence the current


### PR DESCRIPTION
Previously, the heuristic planner function `applyLimit` propagated and set both
hard and soft limits. Hard limit propagation is now handled in the optimizer by
using rules to push Limit operators down the tree as far as is possible, and to
remove Limits by adding hard limits to child Scan operators. As a result, a
majority of the logic within `applyLimit` that supported propagating hard
limits was never exercised, since optimization rules would have already
eliminated situations in which Limit operators high up in the tree could be the
cause of hard limits further down the tree. The one remaining case for which
`applyLimit` was still responsible for propagating hard limits was eliminated
by the normalization rule introduced in #41908.

The entirety of `applyLimit` will eventually be removed and replaced by the
optimizer. Removing hard limit propagation from it entirely is a step in this
direction, and will make it easier to refactor soft limit propagation later.

This patch changes `applyLimit` into `applySoftLimit`, which no longer performs
any hard limit propagation; the responsibility for setting any hard limits on
scanNodes and spoolNodes is now left to the optimizer.

It also renames `setUnlimited` to `propagateSoftLimits` in order to indicate
more clearly that this function is not used to remove any limits that might
have been set on a node, but instead to trigger soft limit propagation in case
a limit hint can be introduced further down the tree.

In the case where the optimizer does not generate a limited Scan in place of a
Limit around a Scan (because the Scan cannot be constrained), previously
`applyLimit` would still set the `hardLimit` field of the scan.  This change
will result in the `softLimit` being set instead.  The end state of the
planNode tree is otherwise the same as before this refactor.

Release note: None