### PR TITLE
roachtest: increase import/tpch/nodes=8 timeout

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -84,7 +84,8 @@ func registerImportTPCH(r *testRegistry) {
 		// is required to confirm this. Until then, the 4 and 32 node configurations
 		// are removed (4 is too slow and 32 is pretty expensive) while 8-node is
 		// given a 50% longer timeout (which running by hand suggests should be OK).
-		{8, 6 * time.Hour},
+		// (10/30/19) The timeout was increased again to 8 hours.
+		{8, 8 * time.Hour},
 	} {
 		item := item
 		r.Add(testSpec{


### PR DESCRIPTION
`import/tpch/nodes=8` was timing out during nightly roachtests, but the jobs
were almost done at 6 hours, so this PR increases the timeout further to 8
hours. This is meant to be temporary; investigation into why `IMPORT` is slower
is ongoing.

See https://github.com/cockroachdb/cockroach/issues/39113#issuecomment-548596283.

Release note: none