### PR TITLE
release-19.2: sql: link to issue #42061 from the XXA00 error h…

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2027,6 +2027,8 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 					newErr = errors.WithHint(newErr,
 						"Some of the non-DDL statements may have committed successfully, but some of the DDL statement(s) failed.\n"+
 							"Manual inspection may be required to determine the actual state of the database.")
+					newErr = errors.WithIssueLink(newErr,
+						errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/42061"})
 					res.SetError(newErr)
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
+++ b/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
@@ -1,0 +1,38 @@
+# Default behavior, where atomicity violations are allowed
+
+statement ok
+CREATE TABLE testing (k int, v string);
+  INSERT INTO testing (k,v) VALUES (1, 'a'), (2, 'b'), (3, 'a'), (4, 'b');
+  CREATE TABLE unrelated(x INT)
+
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE testing ADD CONSTRAINT "unique_values" UNIQUE(v)
+
+statement ok
+INSERT INTO testing (k,v) VALUES (5, 'c');
+INSERT INTO unrelated(x) VALUES (1);
+
+
+statement error pgcode XXA00 violates unique constraint.*\n.*\n.*\n.*\n.*issues/42061
+COMMIT
+
+# oops!
+query IT rowsort
+SELECT * FROM testing
+----
+1  a
+2  b
+3  a
+4  b
+5  c
+
+# oops again!
+query I
+SELECT * FROM unrelated
+----
+1
+


### PR DESCRIPTION
Backport 1/1 commits from #42088.

/cc @cockroachdb/release

---

(PR forked from #42063)

Release note (sql change): the error message generated when a
txn containing DDL is both partially committed and partially rolled back
(error XXA00) now contains a link to github issue #42061 where this
situation is discussed further.
