### PR TITLE
internal/sqlsmith: fix go1.13 failure

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -34,10 +34,6 @@ var (
 	flagCheckVec = flag.Bool("check-vec", false, "fail if a generated statement cannot be vectorized")
 )
 
-func init() {
-	flag.Parse()
-}
-
 // TestSetups verifies that all setups generate executable SQL.
 func TestSetups(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Remove a call to `flag.Parse()` that is unnecessary on go1.12 and
problematic on go1.13. On go1.13, the `flag.Parse()` call in an `init()`
function seems to lock out the initialization of flags from the
`testing` package.

Release note: None