### PR TITLE
util,requestbatcher: prevent goroutine leaks in test functions

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher_test.go
+++ b/pkg/internal/client/requestbatcher/batcher_test.go
@@ -184,6 +184,11 @@ func TestBackpressure(t *testing.T) {
 	runtime.Gosched() // tickle the runtime in case there might be a timing bug
 	assert.Equal(t, int64(0), atomic.LoadInt64(&sent))
 	canReply <- struct{}{} // now the two requests should send
+	defer func() {
+		if t.Failed() {
+			close(canReply)
+		}
+	}()
 	testutils.SucceedsSoon(t, func() error {
 		if numSent := atomic.LoadInt64(&sent); numSent != 2 {
 			return fmt.Errorf("expected %d to have been sent, so far %d", 2, numSent)

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -86,7 +86,7 @@ func TestQuotaPoolContextCancellation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		_, canceledErr := qp.Acquire(ctx, 1)
 		errCh <- canceledErr

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -49,6 +49,7 @@ func TestStopper(t *testing.T) {
 	<-s.ShouldStop()
 	select {
 	case <-waiting:
+		close(cleanup)
 		t.Fatal("expected stopper to have blocked")
 	case <-time.After(100 * time.Millisecond):
 		// Expected.
@@ -58,6 +59,7 @@ func TestStopper(t *testing.T) {
 	case <-waiting:
 		// Success.
 	case <-time.After(time.Second):
+		close(cleanup)
 		t.Fatal("stopper should have finished waiting")
 	}
 	close(cleanup)
@@ -500,6 +502,7 @@ func TestStopperShouldQuiesce(t *testing.T) {
 	// yet.
 	select {
 	case <-s.ShouldStop():
+		close(cleanup)
 		t.Fatal("expected ShouldStop() to block until quiesceing complete")
 	default:
 		// Expected.
@@ -513,6 +516,7 @@ func TestStopperShouldQuiesce(t *testing.T) {
 	// use the "waiting" channel to detect this.
 	select {
 	case <-waiting:
+		close(cleanup)
 		t.Fatal("expected stopper to have blocked")
 	default:
 		// Expected.


### PR DESCRIPTION
***Description***
There are 4 test functions sharing a similar problem: some goroutines in these functions will be leaked in certain cases (like timeout). 

Although `t.Fatal()` is often called in these certain cases, it won't stop the leaking, because ["Calling FailNow does not stop those other goroutines." ](https://golang.org/pkg/testing/#T.FailNow)

***How they are fixed***
The root cause of all these problems is the blocking of channel operations. This patch makes sure that all these operations will be unblocked if test fails.

Other fixes are straightforward, but `TestBackpressure()` is a little bit more complex because `reply()` is called 3 times, and only the third time may be leaked. I used a timer to unblock it after enough time.