### PR TITLE
roachtest: skip sqlsmith tests

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -122,6 +122,7 @@ func registerSQLSmith(r *testRegistry) {
 
 	register := func(setup, setting string) {
 		r.Add(testSpec{
+			Skip:    "https://github.com/cockroachdb/cockroach/issues/42109",
 			Name:    fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			Cluster: makeClusterSpec(4),
 			Timeout: time.Minute * 20,


### PR DESCRIPTION
One of the sqlsmith roachtests panicked and prevented the remainder of
the roachtests from running. See #42109 for more details. I added a skip
until this is resolved.

Release note: None