### PR TITLE
settings: share the maxSettings constant with the test

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -17,10 +17,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-const maxSettings = 256
+// MaxSettings is the maximum number of settings that the system supports.
+// Exported for tests.
+const MaxSettings = 256
 
 // Values is a container that stores values for all registered settings.
-// Each setting is assigned a unique slot (up to maxSettings).
+// Each setting is assigned a unique slot (up to MaxSettings).
 // Note that slot indices are 1-based (this is to trigger panics if an
 // uninitialized slot index is used).
 type Values struct {
@@ -39,7 +41,7 @@ type Values struct {
 		syncutil.Mutex
 		// NB: any in place modification to individual slices must also hold the
 		// lock, e.g. if we ever add RemoveOnChange or something.
-		onChange [maxSettings][]func()
+		onChange [MaxSettings][]func()
 	}
 	// opaque is an arbitrary object that can be set by a higher layer to make it
 	// accessible from certain callbacks (like state machine transformers).
@@ -47,8 +49,8 @@ type Values struct {
 }
 
 type valuesContainer struct {
-	intVals     [maxSettings]int64
-	genericVals [maxSettings]atomic.Value
+	intVals     [MaxSettings]int64
+	genericVals [MaxSettings]atomic.Value
 }
 
 func (c *valuesContainer) setGenericVal(slotIdx int, newVal interface{}) {
@@ -212,8 +214,8 @@ func (i *common) setSlotIdx(slotIdx int) {
 	if slotIdx < 1 {
 		panic(fmt.Sprintf("Invalid slot index %d", slotIdx))
 	}
-	if slotIdx > maxSettings {
-		panic(fmt.Sprintf("too many settings; increase maxSettings"))
+	if slotIdx > MaxSettings {
+		panic(fmt.Sprintf("too many settings; increase MaxSettings"))
 	}
 	i.slotIdx = slotIdx
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const maxSettings = 256
-
 type dummy struct {
 	msg1       string
 	growsbyone string
@@ -617,8 +615,8 @@ func TestHide(t *testing.T) {
 }
 
 func TestOnChangeWithMaxSettings(t *testing.T) {
-	// Register maxSettings settings to ensure that no errors occur.
-	maxName, err := batchRegisterSettings(t, t.Name(), maxSettings-1-len(settings.Keys()))
+	// Register MaxSettings settings to ensure that no errors occur.
+	maxName, err := batchRegisterSettings(t, t.Name(), settings.MaxSettings-1-len(settings.Keys()))
 	if err != nil {
 		t.Errorf("expected no error to register 128 settings, but get error : %s", err)
 	}
@@ -653,8 +651,8 @@ func TestMaxSettingsPanics(t *testing.T) {
 	}()
 
 	// Register too many settings which will cause a panic which is caught and converted to an error.
-	_, err := batchRegisterSettings(t, t.Name(), maxSettings-len(settings.Keys()))
-	expectedErr := "too many settings; increase maxSettings"
+	_, err := batchRegisterSettings(t, t.Name(), settings.MaxSettings-len(settings.Keys()))
+	expectedErr := "too many settings; increase MaxSettings"
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("expected error %v, but got %v", expectedErr, err)
 	}


### PR DESCRIPTION
The tests were re-defining the constant, and the values had to match.