### PR TITLE
sql: fix assignment of dropped table job status

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -798,8 +798,8 @@ func (p *planner) createDropTablesJob(
 	if !drainNames {
 		detailStatus = jobspb.Status_WAIT_FOR_GC_INTERVAL
 	}
-	for _, droppedDetail := range droppedDetails {
-		droppedDetail.Status = detailStatus
+	for i := range droppedDetails {
+		droppedDetails[i].Status = detailStatus
 	}
 
 	runningStatus := RunningStatusDrainingNames


### PR DESCRIPTION
We were mistakenly mutating a copy of a slice element in a loop while updating
the status for a job for a table drop, causing an incorrect job status to be
reported.

Fixes #39347.

Release note (bug fix): A bug was fixed that caused jobs for dropping tables to
report an inaccurate status.