### PR TITLE
server: prevent goroutine leak in node tests

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -179,6 +179,7 @@ func createAndStartTestNode(
 		roachpb.Attributes{}, locality, cv, []roachpb.LocalityAddress{},
 		nil, /*nodeDescriptorCallback */
 	); err != nil {
+		stopper.Stop(ctx)
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
We were leaking the heartbeat goroutine if node startup failed, leading
to misery for future tests.