### PR TITLE
workload/tpch: implement TPCH initial data

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
@@ -66,6 +67,17 @@ func makeDatumFromColOffset(
 		case types.DecimalFamily:
 			d := *apd.New(col.Int64()[rowIdx], 0)
 			return alloc.NewDDecimal(tree.DDecimal{Decimal: d}), nil
+		case types.DateFamily:
+			date, err := pgdate.MakeDateFromUnixEpoch(col.Int64()[rowIdx])
+			if err != nil {
+				return nil, err
+			}
+			return alloc.NewDDate(tree.DDate{Date: date}), nil
+		}
+	case coltypes.Int16:
+		switch hint.Family() {
+		case types.IntFamily:
+			return alloc.NewDInt(tree.DInt(col.Int16()[rowIdx])), nil
 		}
 	case coltypes.Float64:
 		switch hint.Family() {

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -72,7 +72,8 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 			// These don't work with IMPORT.
 			continue
 		case `tpch`:
-			// tpch has an incomplete initial data implemention.
+			// TODO(dan): Implement a timmed down version of TPCH to keep the test
+			// runtime down.
 			continue
 		}
 
@@ -207,6 +208,11 @@ func hashTableInitialData(
 					binary.LittleEndian.PutUint64(scratch[:8], uint64(x))
 					_, _ = h.Write(scratch[:8])
 				}
+			case coltypes.Int16:
+				for _, x := range col.Int16()[:b.Length()] {
+					binary.LittleEndian.PutUint16(scratch[:2], uint16(x))
+					_, _ = h.Write(scratch[:2])
+				}
 			case coltypes.Float64:
 				for _, x := range col.Float64()[:b.Length()] {
 					bits := math.Float64bits(x)
@@ -256,6 +262,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
+		`tpch`:       0xdd952207e22aa577,
 		`ycsb`:       0x85dd34d8c07fd808,
 	}
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"       // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/movr"     // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"     // registers workloads
+	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"     // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"     // registers workloads
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -153,6 +153,9 @@ func init() {
 				return runDemo(cmd, gen)
 			}),
 		}
+		if !meta.PublicFacing {
+			genDemoCmd.Hidden = true
+		}
 		demoCmd.AddCommand(genDemoCmd)
 		genDemoCmd.Flags().AddFlagSet(genFlags)
 	}

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -20,12 +20,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
 )
 
 func columnByteSize(col coldata.Vec) int64 {
 	switch col.Type() {
 	case coltypes.Int64:
 		return int64(len(col.Int64()) * 8)
+	case coltypes.Int16:
+		return int64(len(col.Int16()) * 2)
 	case coltypes.Float64:
 		return int64(len(col.Float64()) * 8)
 	case coltypes.Bytes:
@@ -66,5 +69,11 @@ func BenchmarkInitialData(b *testing.B) {
 	})
 	b.Run(`bank/rows=1000`, func(b *testing.B) {
 		benchmarkInitialData(b, bank.FromRows(1000))
+	})
+	b.Run(`tpch/scaleFactor=1`, func(b *testing.B) {
+		if testing.Short() {
+			b.Skip(`tpch loads a lot of data`)
+		}
+		benchmarkInitialData(b, tpch.FromScaleFactor(1))
 	})
 }

--- a/pkg/workload/tpch/generate.go
+++ b/pkg/workload/tpch/generate.go
@@ -1,0 +1,541 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpch
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
+	"golang.org/x/exp/rand"
+)
+
+var regionNames = [...]string{`AFRICA`, `AMERICA`, `ASIA`, `EUROPE`, `MIDDLE EAST`}
+var nations = [...]struct {
+	name      string
+	regionKey int
+}{
+	{name: `ALGERIA`, regionKey: 0},
+	{name: `ARGENTINA`, regionKey: 1},
+	{name: `BRAZIL`, regionKey: 1},
+	{name: `CANADA`, regionKey: 1},
+	{name: `EGYPT`, regionKey: 4},
+	{name: `ETHIOPIA`, regionKey: 0},
+	{name: `FRANCE`, regionKey: 3},
+	{name: `GERMANY`, regionKey: 3},
+	{name: `INDIA`, regionKey: 2},
+	{name: `INDONESIA`, regionKey: 2},
+	{name: `IRAN`, regionKey: 4},
+	{name: `IRAQ`, regionKey: 4},
+	{name: `JAPAN`, regionKey: 2},
+	{name: `JORDAN`, regionKey: 4},
+	{name: `KENYA`, regionKey: 0},
+	{name: `MOROCCO`, regionKey: 0},
+	{name: `MOZAMBIQUE`, regionKey: 0},
+	{name: `PERU`, regionKey: 1},
+	{name: `CHINA`, regionKey: 2},
+	{name: `ROMANIA`, regionKey: 3},
+	{name: `SAUDI ARABIA`, regionKey: 4},
+	{name: `VIETNAM`, regionKey: 2},
+	{name: `RUSSIA`, regionKey: 3},
+	{name: `UNITED KINGDOM`, regionKey: 3},
+	{name: `UNITED STATES`, regionKey: 1},
+}
+
+var regionColTypes = []coltypes.T{
+	coltypes.Int16,
+	coltypes.Bytes,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchRegionInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	regionKey := batchIdx
+	cb.Reset(regionColTypes, 1)
+	cb.ColVec(0).Int16()[0] = int16(regionKey)                       // r_regionkey
+	cb.ColVec(1).Bytes().Set(0, []byte(regionNames[regionKey]))      // r_name
+	cb.ColVec(2).Bytes().Set(0, w.textPool.randString(rng, 31, 115)) // r_comment
+}
+
+var nationColTypes = []coltypes.T{
+	coltypes.Int16,
+	coltypes.Bytes,
+	coltypes.Int16,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchNationInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	nationKey := batchIdx
+	nation := nations[nationKey]
+	cb.Reset(nationColTypes, 1)
+	cb.ColVec(0).Int16()[0] = int16(nationKey)                       // n_nationkey
+	cb.ColVec(1).Bytes().Set(0, []byte(nation.name))                 // n_name
+	cb.ColVec(2).Int16()[0] = int16(nation.regionKey)                // n_regionkey
+	cb.ColVec(3).Bytes().Set(0, w.textPool.randString(rng, 31, 115)) // r_comment
+}
+
+var supplierColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Int16,
+	coltypes.Bytes,
+	coltypes.Float64,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchSupplierInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	suppKey := int64(batchIdx) + 1
+	nationKey := int16(randInt(rng, 0, 24))
+	cb.Reset(supplierColTypes, 1)
+	cb.ColVec(0).Int64()[0] = suppKey                                        // s_suppkey
+	cb.ColVec(1).Bytes().Set(0, supplierName(a, suppKey))                    // s_name
+	cb.ColVec(2).Bytes().Set(0, randVString(rng, a, 10, 40))                 // s_address
+	cb.ColVec(3).Int16()[0] = nationKey                                      // s_nationkey
+	cb.ColVec(4).Bytes().Set(0, randPhone(rng, a, nationKey))                // s_phone
+	cb.ColVec(5).Float64()[0] = float64(randFloat(rng, -99999, 999999, 100)) // s_acctbal
+	// TODO(jordan): this needs to sometimes have Customer Complaints or Customer Recommends. see 4.2.3.
+	cb.ColVec(6).Bytes().Set(0, w.textPool.randString(rng, 25, 100)) // s_comment
+}
+
+var partColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Int16,
+	coltypes.Bytes,
+	coltypes.Float64,
+	coltypes.Bytes,
+}
+
+func makeRetailPriceFromPartKey(partKey int) float32 {
+	return float32(90000+((partKey/10)%20001)+100*(partKey%1000)) / 100
+}
+
+func (w *tpch) tpchPartInitialRowBatch(batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	partKey := batchIdx + 1
+	cb.Reset(partColTypes, 1)
+
+	// P_PARTKEY unique within [SF * 200,000].
+	cb.ColVec(0).Int64()[0] = int64(partKey)
+	// P_NAME generated by concatenating five unique randomly selected part name strings.
+	cb.ColVec(1).Bytes().Set(0, randPartName(rng, l.namePerm, a))
+	m, mfgr := randMfgr(rng, a)
+	// P_MFGR text appended with digit ["Manufacturer#",M], where M = random value [1,5].
+	cb.ColVec(2).Bytes().Set(0, mfgr) //
+	// P_BRAND text appended with digits ["Brand#",MN], where N = random value [1,5] and M is defined
+	// while generating P_MFGR.
+	cb.ColVec(3).Bytes().Set(0, randBrand(rng, a, m))
+	// P_TYPE random string [Types].
+	cb.ColVec(4).Bytes().Set(0, randType(rng, a))
+	// P_SIZE random value [1 .. 50].
+	cb.ColVec(5).Int16()[0] = int16(randInt(rng, 1, 50))
+	// P_CONTAINER random string [Containers].
+	cb.ColVec(6).Bytes().Set(0, randContainer(rng, a))
+	// P_RETAILPRICE = (90000 + ((P_PARTKEY/10) modulo 20001 ) + 100 * (P_PARTKEY modulo 1000))/100.
+	cb.ColVec(7).Float64()[0] = float64(makeRetailPriceFromPartKey(partKey))
+	// P_COMMENT text string [5,22].
+	cb.ColVec(8).Bytes().Set(0, w.textPool.randString(rng, 5, 22))
+}
+
+var partSuppColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Int16,
+	coltypes.Float64,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchPartSuppInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	partKey := batchIdx + 1
+	cb.Reset(partSuppColTypes, numPartSuppPerPart)
+
+	// P_PARTKEY unique within [SF * 200,000].
+	partKeyCol := cb.ColVec(0).Int64()
+	suppKeyCol := cb.ColVec(1).Int64()
+	availQtyCol := cb.ColVec(2).Int16()
+	supplyCostCol := cb.ColVec(3).Float64()
+	commentCol := cb.ColVec(4).Bytes()
+
+	// For each row in the PART table, four rows in PartSupp table.
+	for i := 0; i < numPartSuppPerPart; i++ {
+		// PS_PARTKEY = P_PARTKEY.
+		partKeyCol[i] = int64(partKey)
+		// PS_SUPPKEY = (ps_partkey + (i * (( S/4 ) + (int)(ps_partkey-1 )/S))))
+		// modulo S + 1 where i is the ith supplier within [0 .. 3] and S = SF *
+		// 10,000.
+		s := w.scaleFactor * 10000
+		suppKeyCol[i] = int64((partKey+(i*((s/numPartSuppPerPart)+(partKey-1)/s)))%s + 1)
+		// PS_AVAILQTY random value [1 .. 9,999].
+		availQtyCol[i] = int16(randInt(rng, 1, 9999))
+		// PS_SUPPLYCOST random value [1.00 .. 1,000.00].
+		supplyCostCol[i] = float64(randFloat(rng, 1, 1000, 100))
+		// PS_COMMENT text string [49,198].
+		commentCol.Set(i, w.textPool.randString(rng, 49, 198))
+	}
+}
+
+var customerColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Int16,
+	coltypes.Bytes,
+	coltypes.Float64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchCustomerInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+	rng.Seed(w.seed + uint64(batchIdx))
+
+	custKey := int64(batchIdx) + 1
+	cb.Reset(customerColTypes, 1)
+
+	// C_CUSTKEY unique within [SF * 150,000].
+	cb.ColVec(0).Int64()[0] = custKey
+	// C_NAME text appended with minimum 9 digits with leading zeros ["Customer#", C_CUSTKEY].
+	cb.ColVec(1).Bytes().Set(0, customerName(a, custKey))
+	// C_ADDRESS random v-string [10,40].
+	cb.ColVec(2).Bytes().Set(0, randVString(rng, a, 10, 40))
+	nationKey := int16(randInt(rng, 0, 24))
+	// C_NATIONKEY random value [0 .. 24].
+	cb.ColVec(3).Int16()[0] = nationKey
+	// C_PHONE generated according to Clause 4.2.2.9.
+	cb.ColVec(4).Bytes().Set(0, randPhone(rng, a, nationKey))
+	// C_ACCTBAL random value [-999.99 .. 9,999.99].
+	cb.ColVec(5).Float64()[0] = float64(randFloat(rng, -99999, 999999, 100))
+	// C_MKTSEGMENT random string [Segments].
+	cb.ColVec(6).Bytes().Set(0, randSegment(rng))
+	// C_COMMENT text string [29,116].
+	cb.ColVec(7).Bytes().Set(0, w.textPool.randString(rng, 29, 116))
+}
+
+const sparseBits = 2
+const sparseKeep = 3
+
+var (
+	startDate   = time.Date(1992, 1, 1, 0, 0, 0, 0, time.UTC)
+	currentDate = time.Date(1995, 6, 17, 0, 0, 0, 0, time.UTC)
+	endDate     = time.Date(1998, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	startDateDays   int64
+	currentDateDays int64
+	endDateDays     int64
+)
+
+func init() {
+	var d pgdate.Date
+	var err error
+	d, err = pgdate.MakeDateFromTime(startDate)
+	if err != nil {
+		panic(err)
+	}
+	startDateDays = d.UnixEpochDaysWithOrig()
+	d, err = pgdate.MakeDateFromTime(currentDate)
+	if err != nil {
+		panic(err)
+	}
+	currentDateDays = d.UnixEpochDaysWithOrig()
+	d, err = pgdate.MakeDateFromTime(endDate)
+	if err != nil {
+		panic(err)
+	}
+	endDateDays = d.UnixEpochDaysWithOrig()
+}
+
+func getOrderKey(orderIdx int) int {
+	// This method is taken from dbgen's build.c: mk_sparse. Given an input i, it
+	// returns the ith order id in the tpch database, by using only the first 8
+	// integers from every 32 integers.
+
+	// Our input is 0-indexed; convert to 1-index.
+	i := orderIdx + 1
+
+	lowBits := i & ((1 << sparseKeep) - 1)
+	i = i >> sparseKeep
+	i = i << sparseBits
+	i = i << sparseKeep
+	i += lowBits
+	return i
+}
+
+type orderSharedRandomData struct {
+	nOrders    int
+	orderDate  int
+	partKeys   []int
+	shipDates  []int64
+	quantities []float32
+	discount   []float32
+	tax        []float32
+
+	allO bool
+	allF bool
+}
+
+var ordersColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Float64,
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Int16,
+	coltypes.Bytes,
+}
+
+func populateSharedData(rng *rand.Rand, seed uint64, sf int, data *orderSharedRandomData) {
+	// Seed the rng here to force orders and lineitems to get the same results.
+	rng.Seed(seed)
+
+	data.nOrders = randInt(rng, 1, 7)
+	data.orderDate = randInt(rng, int(startDateDays), int(endDateDays-151))
+	data.partKeys = data.partKeys[:data.nOrders]
+	data.shipDates = data.shipDates[:data.nOrders]
+	data.quantities = data.quantities[:data.nOrders]
+	data.discount = data.discount[:data.nOrders]
+	data.tax = data.tax[:data.nOrders]
+	// These will be invalidated in the loop.
+	data.allF = true
+	data.allO = true
+
+	for i := 0; i < data.nOrders; i++ {
+		shipDate := int64(data.orderDate + randInt(rng, 1, 121))
+		data.shipDates[i] = shipDate
+		if shipDate > currentDateDays {
+			data.allF = false
+		} else {
+			data.allO = false
+		}
+		data.partKeys[i] = randInt(rng, 1, sf*numPartPerSF)
+		data.quantities[i] = float32(randInt(rng, 1, 50))
+		data.discount[i] = randFloat(rng, 0, 10, 100)
+		data.tax[i] = randFloat(rng, 0, 8, 100)
+	}
+}
+
+func (w *tpch) tpchOrdersInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+
+	cb.Reset(ordersColTypes, numOrderPerCustomer)
+
+	orderKeyCol := cb.ColVec(0).Int64()
+	custKeyCol := cb.ColVec(1).Int64()
+	orderStatusCol := cb.ColVec(2).Bytes()
+	totalPriceCol := cb.ColVec(3).Float64()
+	orderDateCol := cb.ColVec(4).Int64()
+	orderPriorityCol := cb.ColVec(5).Bytes()
+	clerkCol := cb.ColVec(6).Bytes()
+	shipPriorityCol := cb.ColVec(7).Int16()
+	commentCol := cb.ColVec(8).Bytes()
+
+	orderStartIdx := numOrderPerCustomer * batchIdx
+	for i := 0; i < numOrderPerCustomer; i++ {
+		populateSharedData(rng, w.seed+uint64(orderStartIdx+i), w.scaleFactor, l.orderData)
+
+		orderKeyCol[i] = int64(getOrderKey(orderStartIdx + i))
+		// O_CUSTKEY = random value c [1 .. (SF * 150,000)], s.t. c % 3 != 0.
+		numCust := w.scaleFactor * numCustomerPerSF
+		custKeyCol[i] = int64((randInt(rng, 1, w.scaleFactor*(numCustomerPerSF/3))*3 + rng.Intn(2) + 1) % numCust)
+		// O_ORDERSTATUS = F if all lineitems.LINESTATUS = F; O if all O; P
+		// otherwise.
+		if l.orderData.allF {
+			orderStatusCol.Set(i, []byte("F"))
+		} else if l.orderData.allO {
+			orderStatusCol.Set(i, []byte("O"))
+		} else {
+			orderStatusCol.Set(i, []byte("P"))
+		}
+		totalPrice := float32(0)
+		for j := 0; j < l.orderData.nOrders; j++ {
+			ep := l.orderData.quantities[j] * makeRetailPriceFromPartKey(l.orderData.partKeys[j])
+			totalPrice += ep * (1 + l.orderData.tax[j]) * (1 - l.orderData.discount[j])
+		}
+		// O_TOTALPRICE computed as:
+		// sum (L_EXTENDEDPRICE * (1+L_TAX) * (1-L_DISCOUNT)) for all LINEITEM of
+		// this order.
+		totalPriceCol[i] = float64(totalPrice)
+		// O_ORDERDATE uniformly distributed between STARTDATE and
+		// (ENDDATE - 151 days).
+		orderDateCol[i] = int64(l.orderData.orderDate)
+		// O_ORDERPRIORITY random string [Priorities].
+		orderPriorityCol.Set(i, randPriority(rng))
+		// O_CLERK text appended with minimum 9 digits with leading zeros
+		// ["Clerk#", C] where C = random value [000000001 .. (SF * 1000)].
+		clerkCol.Set(i, randClerk(rng, a, w.scaleFactor))
+		// O_SHIPPRIORITY set to 0.
+		shipPriorityCol[i] = 0
+		// O_COMMENT text string [19,78].
+		commentCol.Set(i, w.textPool.randString(rng, 19, 78))
+	}
+}
+
+var lineItemColTypes = []coltypes.T{
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Int16,
+	coltypes.Float64,
+	coltypes.Float64,
+	coltypes.Float64,
+	coltypes.Float64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Int64,
+	coltypes.Bytes,
+	coltypes.Bytes,
+	coltypes.Bytes,
+}
+
+func (w *tpch) tpchLineItemInitialRowBatch(
+	batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator,
+) {
+	l := w.localsPool.Get().(*generateLocals)
+	defer w.localsPool.Put(l)
+	rng := l.rng
+
+	cb.Reset(lineItemColTypes, numOrderPerCustomer*7)
+
+	orderKeyCol := cb.ColVec(0).Int64()
+	partKeyCol := cb.ColVec(1).Int64()
+	suppKeyCol := cb.ColVec(2).Int64()
+	lineNumberCol := cb.ColVec(3).Int16()
+	quantityCol := cb.ColVec(4).Float64()
+	extendedPriceCol := cb.ColVec(5).Float64()
+	discountCol := cb.ColVec(6).Float64()
+	taxCol := cb.ColVec(7).Float64()
+	returnFlagCol := cb.ColVec(8).Bytes()
+	lineStatusCol := cb.ColVec(9).Bytes()
+	shipDateCol := cb.ColVec(10).Int64()
+	commitDateCol := cb.ColVec(11).Int64()
+	receiptDateCol := cb.ColVec(12).Int64()
+	shipInstructCol := cb.ColVec(13).Bytes()
+	shipModeCol := cb.ColVec(14).Bytes()
+	commentCol := cb.ColVec(15).Bytes()
+
+	orderStartIdx := numOrderPerCustomer * batchIdx
+	s := w.scaleFactor * 10000
+	offset := 0
+	for i := 0; i < numOrderPerCustomer; i++ {
+		populateSharedData(rng, w.seed+uint64(orderStartIdx+i), w.scaleFactor, l.orderData)
+
+		orderKey := int64(getOrderKey(orderStartIdx + i))
+		for j := 0; j < l.orderData.nOrders; j++ {
+			idx := offset + j
+			// L_ORDERKEY = O_ORDERKEY.
+			orderKeyCol[idx] = orderKey
+			partKey := l.orderData.partKeys[j]
+			// L_PARTKEY random value [1 .. (SF * 200,000)].
+			partKeyCol[idx] = int64(partKey)
+			// L_SUPPKEY = (L_PARTKEY + (i * (( S/4 ) + (int)(L_partkey-1 )/S))))
+			// modulo S + 1 where i is the corresponding supplier within [0 .. 3] and
+			// S = SF * 10,000.
+			suppKey := (partKey+(randInt(rng, 0, 3)*((s/4)+(partKey-1)/s)))%s + 1
+			suppKeyCol[idx] = int64(suppKey)
+			// L_LINENUMBER unique within [7].
+			lineNumberCol[idx] = int16(j)
+			// L_QUANTITY random value [1 .. 50].
+			quantityCol[idx] = float64(l.orderData.quantities[j])
+			// L_EXTENDEDPRICE = L_QUANTITY * P_RETAILPRICE where P_RETAILPRICE is
+			// from the part with P_PARTKEY = L_PARTKEY.
+			extendedPriceCol[idx] = float64(l.orderData.quantities[j] * makeRetailPriceFromPartKey(partKey))
+			// L_DISCOUNT random value [0.00 .. 0.10].
+			discountCol[idx] = float64(l.orderData.discount[j])
+			// L_TAX random value [0.00 .. 0.08].
+			taxCol[idx] = float64(l.orderData.tax[j])
+			// L_SHIPDATE = O_ORDERDATE + random value [1 .. 121].
+			shipDate := l.orderData.shipDates[j]
+			shipDateCol[idx] = shipDate
+			// L_RECEIPTDATE = L_SHIPDATE + random value [1 .. 30].
+			receiptDate := shipDate + int64(randInt(rng, 1, 30))
+			receiptDateCol[idx] = receiptDate
+			// L_COMMITDATE = O_ORDERDATE + random value [30 .. 90].
+			commitDateCol[idx] = int64(l.orderData.orderDate + randInt(rng, 30, 90))
+			// L_RETURNFLAG set to a value selected as follows:
+			// If L_RECEIPTDATE <= CURRENTDATE
+			// then either "R" or "A" is selected at random
+			// else "N" is selected.
+			if receiptDate < currentDateDays {
+				if rng.Intn(2) == 0 {
+					returnFlagCol.Set(idx, []byte("R"))
+				} else {
+					returnFlagCol.Set(idx, []byte("A"))
+				}
+			} else {
+				returnFlagCol.Set(idx, []byte("N"))
+			}
+			// L_LINESTATUS set the following value:
+			// "O" if L_SHIPDATE > CURRENTDATE
+			// "F" otherwise.
+			if shipDate > currentDateDays {
+				lineStatusCol.Set(idx, []byte("O"))
+			} else {
+				lineStatusCol.Set(idx, []byte("F"))
+			}
+			// L_SHIPINSTRUCT random string [Instructions].
+			shipInstructCol.Set(idx, randInstruction(rng))
+			// L_SHIPMODE random string [Modes].
+			shipModeCol.Set(idx, randMode(rng))
+			// L_COMMENT text string [10,43].
+			commentCol.Set(idx, w.textPool.randString(rng, 10, 43))
+		}
+		offset += l.orderData.nOrders
+	}
+	cb.SetLength(uint16(offset))
+}

--- a/pkg/workload/tpch/random.go
+++ b/pkg/workload/tpch/random.go
@@ -1,0 +1,284 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpch
+
+import (
+	"bytes"
+	"strconv"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/workload/faker"
+	"golang.org/x/exp/rand"
+)
+
+const alphanumericLen64 = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890, `
+
+// randInt returns a random value between x and y inclusively, with a mean of
+// (x+y)/2. See 4.2.2.3.
+func randInt(rng *rand.Rand, x, y int) int {
+	return rng.Intn(y-x+1) + x
+}
+
+func randFloat(rng *rand.Rand, x, y, shift int) float32 {
+	return float32(randInt(rng, x, y)) / float32(shift)
+}
+
+type textPool interface {
+	// 4.2.2.10:
+	// The term text string[min, max] represents a substring of a 300 MB string
+	// populated according to the pseudo text grammar defined in Clause 4.2.2.14.
+	// The length of the substring is a random number between min and max
+	// inclusive. The substring offset is randomly chosen.
+	//
+	// randString implementations must be threadsafe.
+	randString(rng *rand.Rand, minLen, maxLen int) []byte
+}
+
+type fakeTextPool struct {
+	seed uint64
+	once struct {
+		sync.Once
+		buf []byte
+	}
+}
+
+// randString implements textPool with a cheaper simulation of the 300 MB
+// string. It's not to spec both because it's shorter and also because it's not
+// generated according to the pseudo text grammar.
+func (p *fakeTextPool) randString(rng *rand.Rand, minLen, maxLen int) []byte {
+	const fakeTextPoolSize = 1 << 20 // 1 MiB
+	p.once.Do(func() {
+		bufRng := rand.New(rand.NewSource(p.seed))
+		f := faker.NewFaker()
+		// This loop generates random paragraphs and adds them until the length is
+		// >= fakeTextPoolSize. Add some extra capacity so that we don't allocate
+		// and copy on the paragraph that goes over.
+		buf := bytes.NewBuffer(make([]byte, 0, fakeTextPoolSize+1024))
+		for buf.Len() < fakeTextPoolSize {
+			buf.WriteString(f.Paragraph(bufRng))
+			buf.WriteString(` `)
+		}
+		p.once.buf = buf.Bytes()[:fakeTextPoolSize:fakeTextPoolSize]
+	})
+	start := rng.Intn(len(p.once.buf) - maxLen)
+	end := start + rng.Intn(maxLen-minLen) + minLen
+	return p.once.buf[start:end]
+}
+
+// randVString returns "a string comprised of randomly generated alphanumeric
+// characters within a character set of at least 64 symbols. The length of the
+// string is a random value between min and max inclusive". See 4.2.2.7.
+func randVString(rng *rand.Rand, a *bufalloc.ByteAllocator, minLen, maxLen int) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(randInt(rng, minLen, maxLen), 0)
+	for i := range buf {
+		buf[i] = alphanumericLen64[rng.Intn(len(alphanumericLen64))]
+	}
+	return buf
+}
+
+// randPhone returns a phone number generated according to 4.2.2.9.
+func randPhone(rng *rand.Rand, a *bufalloc.ByteAllocator, nationKey int16) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(15, 0)
+	buf = buf[:0]
+
+	countryCode := nationKey + 10
+	localNumber1 := randInt(rng, 100, 999)
+	localNumber2 := randInt(rng, 100, 999)
+	localNumber3 := randInt(rng, 1000, 9999)
+	buf = strconv.AppendInt(buf, int64(countryCode), 10)
+	buf = append(buf, '-')
+	buf = strconv.AppendInt(buf, int64(localNumber1), 10)
+	buf = append(buf, '-')
+	buf = strconv.AppendInt(buf, int64(localNumber2), 10)
+	buf = append(buf, '-')
+	buf = strconv.AppendInt(buf, int64(localNumber3), 10)
+	return buf
+}
+
+var randPartNames = [...]string{
+	"almond", "antique", "aquamarine", "azure", "beige", "bisque", "black", "blanched", "blue",
+	"blush", "brown", "burlywood", "burnished", "chartreuse", "chiffon", "chocolate", "coral",
+	"cornflower", "cornsilk", "cream", "cyan", "dark", "deep", "dim", "dodger", "drab", "firebrick",
+	"floral", "forest", "frosted", "gainsboro", "ghost", "goldenrod", "green", "grey", "honeydew",
+	"hot", "indian", "ivory", "khaki", "lace", "lavender", "lawn", "lemon", "light", "lime", "linen",
+	"magenta", "maroon", "medium", "metallic", "midnight", "mint", "misty", "moccasin", "navajo",
+	"navy", "olive", "orange", "orchid", "pale", "papaya", "peach", "peru", "pink", "plum", "powder",
+	"puff", "purple", "red", "rose", "rosy", "royal", "saddle", "salmon", "sandy", "seashell",
+	"sienna", "sky", "slate", "smoke", "snow", "spring", "steel", "tan", "thistle", "tomato",
+	"turquoise", "violet", "wheat", "white", "yellow",
+}
+
+const maxPartNameLen = 10
+const nPartNames = 5
+
+// randPartName concatenates 5 random unique strings from randPartNames, separated
+// by spaces.
+func randPartName(rng *rand.Rand, namePerm []int, a *bufalloc.ByteAllocator) []byte {
+	// do nPartNames iterations of rand.Perm, to get a random 5-subset of the
+	// indexes into randPartNames.
+	for i := 0; i < nPartNames; i++ {
+		j := rng.Intn(i + 1)
+		namePerm[i] = namePerm[j]
+		namePerm[j] = i
+	}
+	var buf []byte
+	*a, buf = a.Alloc(maxPartNameLen*nPartNames+nPartNames, 0)
+	buf = buf[:0]
+	for i := 0; i < nPartNames; i++ {
+		if i != 0 {
+			buf = append(buf, byte(' '))
+		}
+		buf = append(buf, randPartNames[namePerm[i]]...)
+	}
+	return buf
+}
+
+const manufacturerString = "Manufacturer#"
+
+func randMfgr(rng *rand.Rand, a *bufalloc.ByteAllocator) (byte, []byte) {
+	var buf []byte
+	*a, buf = a.Alloc(len(manufacturerString)+1, 0)
+
+	copy(buf, manufacturerString)
+	m := byte(rng.Intn(5) + '1')
+	buf[len(buf)-1] = m
+	return m, buf
+}
+
+const brandString = "Brand#"
+
+func randBrand(rng *rand.Rand, a *bufalloc.ByteAllocator, m byte) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(len(brandString)+2, 0)
+
+	copy(buf, brandString)
+	n := byte(rng.Intn(5) + '1')
+	buf[len(buf)-2] = m
+	buf[len(buf)-1] = n
+	return buf
+}
+
+const clerkString = "Clerk#"
+
+func randClerk(rng *rand.Rand, a *bufalloc.ByteAllocator, scaleFactor int) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(len(clerkString)+9, 0)
+	copy(buf, clerkString)
+	ninePaddedInt(buf[len(clerkString):], int64(randInt(rng, 1, scaleFactor*1000)))
+	return buf
+}
+
+const supplierString = "Supplier#"
+
+func supplierName(a *bufalloc.ByteAllocator, suppKey int64) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(len(supplierString)+9, 0)
+	copy(buf, supplierString)
+	ninePaddedInt(buf[len(supplierString):], suppKey)
+	return buf
+}
+
+const customerString = "Customer#"
+
+func customerName(a *bufalloc.ByteAllocator, custKey int64) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(len(customerString)+9, 0)
+	copy(buf, customerString)
+	ninePaddedInt(buf[len(customerString):], custKey)
+	return buf
+}
+
+const ninePadding = `000000000`
+
+func ninePaddedInt(buf []byte, x int64) {
+	buf = buf[:len(ninePadding)]
+	intLen := len(strconv.AppendInt(buf[:0], x, 10))
+	numZeros := len(ninePadding) - intLen
+	copy(buf[numZeros:], buf[:intLen])
+	copy(buf[:numZeros], ninePadding[:numZeros])
+}
+
+func randSyllables(
+	rng *rand.Rand, a *bufalloc.ByteAllocator, maxLen int, syllables [][]string,
+) []byte {
+	var buf []byte
+	*a, buf = a.Alloc(maxLen, 0)
+	buf = buf[:0]
+
+	for i, syl := range syllables {
+		if i != 0 {
+			buf = append(buf, ' ')
+			buf = append(buf, syl[rng.Intn(len(syl))]...)
+		}
+	}
+	return buf
+}
+
+var typeSyllables = [][]string{
+	{"STANDARD", "SMALL", "MEDIUM", "LARGE", "ECONOMY", "PROMO"},
+	{"ANODIZED", "BURNISHED", "PLATED", "POLISHED", "BRUSHED"},
+	{"TIN", "NICKEL", "BRASS", "STEEL", "COPPER"},
+}
+
+const maxTypeLen = 25
+
+func randType(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
+	return randSyllables(rng, a, maxTypeLen, typeSyllables)
+}
+
+var containerSyllables = [][]string{
+	{"SM", "MED", "JUMBO", "WRAP"},
+	{"BOX", "BAG", "JAR", "PKG", "PACK", "CAN", "DRUM"},
+}
+
+const maxContainerLen = 10
+
+func randContainer(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
+	return randSyllables(rng, a, maxContainerLen, containerSyllables)
+}
+
+var segments = []string{
+	"AUTOMOBILE", "BUILDING", "FURNITURE", "MACHINERY", "HOUSEHOLD",
+}
+
+func randSegment(rng *rand.Rand) []byte {
+	return encoding.UnsafeConvertStringToBytes(segments[rng.Intn(len(segments))])
+}
+
+var priorities = []string{
+	"1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED",
+}
+
+func randPriority(rng *rand.Rand) []byte {
+	return encoding.UnsafeConvertStringToBytes(priorities[rng.Intn(len(priorities))])
+}
+
+var instructions = []string{
+	"DELIVER IN PERSON",
+	"COLLECT COD", "NONE",
+	"TAKE BACK RETURN",
+}
+
+func randInstruction(rng *rand.Rand) []byte {
+	return encoding.UnsafeConvertStringToBytes(instructions[rng.Intn(len(instructions))])
+}
+
+var modes = []string{
+	"REG AIR", "AIR", "RAIL", "SHIP", "TRUCK", "MAIL", "FOB",
+}
+
+func randMode(rng *rand.Rand) []byte {
+	return []byte(modes[rng.Intn(len(modes))])
+}

--- a/pkg/workload/workloadsql/dataload.go
+++ b/pkg/workload/workloadsql/dataload.go
@@ -37,6 +37,11 @@ type InsertsDataLoader struct {
 func (l InsertsDataLoader) InitialDataLoad(
 	ctx context.Context, db *gosql.DB, gen workload.Generator,
 ) (int64, error) {
+	if gen.Meta().Name == `tpch` {
+		return 0, errors.New(
+			`tpch currently doesn't work with the inserts data loader. try --data-loader=import`)
+	}
+
 	if l.BatchSize <= 0 {
 		l.BatchSize = 1000
 	}


### PR DESCRIPTION
This is not spec compliant but it's intended to be close enough to the
spirit of the spec that it can be used for convenience. The spec is very
specific that official results need to use the exact output of the dbgen
program, so any real testing should use our pregenerated dbgen csv
files.

Note that dbgen is totally deterministic and the rng is already set up
to be started at non-zero row offsets, so there's no reason we can't
make this exactly identical to dbegn. It will just be fiddly.

Still TODO in followup PRs:
- Figure out how to create a small subset of the data so
  TestAllRegisteredImportFixture/tpch can run.
- Figure out how to get the date fields to work with InsertsDataLoader
  without being too intrusive to workload.

Release note: None