### PR TITLE
storage/engine: add Pebble support to ExportToSst

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -134,7 +134,7 @@ func evalExport(
 
 	e := spanset.GetDBEngine(batch, roachpb.Span{Key: args.Key, EndKey: args.EndKey})
 
-	data, summary, err := engine.ExportToSst(ctx, e, start, end, exportAllRevisions, io)
+	data, summary, err := e.ExportToSst(start, end, exportAllRevisions, io)
 
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -76,7 +75,7 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 	var sst []byte
 	g.GoCtx(func(ctx context.Context) error {
 		sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
-		sw := bulk.MakeSSTWriter()
+		sw := engine.MakeSSTWriter()
 		defer sw.Close()
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {

--- a/pkg/cli/syncbench/syncbench.go
+++ b/pkg/cli/syncbench/syncbench.go
@@ -139,7 +139,7 @@ func Run(opts Options) error {
 
 	fmt.Printf("writing to %s\n", opts.Dir)
 
-	db, err := engine.NewEngine(
+	db, err := engine.NewDefaultEngine(
 		0,
 		base.StorageConfig{
 			Settings: cluster.MakeTestingClusterSettings(),

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -71,7 +71,7 @@ var _ storagebase.BulkAdder = &BufferingAdder{}
 // encounter an error and need to be split and retired to be applied.
 func MakeBulkAdder(
 	ctx context.Context,
-	db sender,
+	db SSTSender,
 	rangeCache *kv.RangeDescriptorCache,
 	settings *cluster.Settings,
 	timestamp hlc.Timestamp,

--- a/pkg/storage/engine/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator_test.go
@@ -36,9 +36,11 @@ func iterateExpectErr(
 	return func(t *testing.T) {
 		t.Helper()
 		iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-			StartTime:  startTime,
-			EndTime:    endTime,
-			UpperBound: endKey,
+			IterOptions: IterOptions{
+				UpperBound: endKey,
+			},
+			StartTime: startTime,
+			EndTime:   endTime,
 		})
 		defer iter.Close()
 		for iter.Seek(MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
@@ -63,9 +65,11 @@ func assertEqualKVs(
 	return func(t *testing.T) {
 		t.Helper()
 		iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-			StartTime:  startTime,
-			EndTime:    endTime,
-			UpperBound: endKey,
+			IterOptions: IterOptions{
+				UpperBound: endKey,
+			},
+			StartTime: startTime,
+			EndTime:   endTime,
 		})
 		defer iter.Close()
 		var kvs []MVCCKeyValue
@@ -298,9 +302,11 @@ func slurpKVsInTimeRange(
 ) ([]MVCCKeyValue, error) {
 	endKey := prefix.PrefixEnd()
 	iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-		StartTime:  startTime,
-		EndTime:    endTime,
-		UpperBound: endKey,
+		IterOptions: IterOptions{
+			UpperBound: endKey,
+		},
+		StartTime: startTime,
+		EndTime:   endTime,
 	})
 	defer iter.Close()
 	var kvs []MVCCKeyValue

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -350,6 +350,13 @@ func (p *Pebble) Closed() bool {
 	return p.closed
 }
 
+// ExportToSst is part of the engine.Reader interface.
+func (p *Pebble) ExportToSst(
+	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	return pebbleExportToSst(p, start, end, exportAllRevisions, io)
+}
+
 // Get implements the Engine interface.
 func (p *Pebble) Get(key MVCCKey) ([]byte, error) {
 	if len(key.Key) == 0 {
@@ -727,6 +734,13 @@ func (p *pebbleReadOnly) Closed() bool {
 	return p.closed
 }
 
+// ExportToSst is part of the engine.Reader interface.
+func (p *pebbleReadOnly) ExportToSst(
+	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	return pebbleExportToSst(p, start, end, exportAllRevisions, io)
+}
+
 func (p *pebbleReadOnly) Get(key MVCCKey) ([]byte, error) {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
@@ -838,6 +852,13 @@ func (p *pebbleSnapshot) Closed() bool {
 	return p.closed
 }
 
+// ExportToSst is part of the engine.Reader interface.
+func (p *pebbleSnapshot) ExportToSst(
+	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	return pebbleExportToSst(p, start, end, exportAllRevisions, io)
+}
+
 // Get implements the Reader interface.
 func (p *pebbleSnapshot) Get(key MVCCKey) ([]byte, error) {
 	if len(key.Key) == 0 {
@@ -880,4 +901,58 @@ func (p *pebbleSnapshot) Iterate(
 // NewIterator implements the Reader interface.
 func (p pebbleSnapshot) NewIterator(opts IterOptions) Iterator {
 	return newPebbleIterator(p.snapshot, opts)
+}
+
+func pebbleExportToSst(
+	e Reader, start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	sstWriter := MakeSSTWriter()
+	defer sstWriter.Close()
+
+	var rows RowCounter
+	iter := NewMVCCIncrementalIterator(
+		e,
+		MVCCIncrementalIterOptions{
+			IterOptions: io,
+			StartTime:   start.Timestamp,
+			EndTime:     end.Timestamp,
+		})
+	defer iter.Close()
+	for iter.Seek(MakeMVCCMetadataKey(start.Key)); ; {
+		ok, err := iter.Valid()
+		if err != nil {
+			// The error may be a WriteIntentError. In which case, returning it will
+			// cause this command to be retried.
+			return []byte{}, roachpb.BulkOpSummary{}, err
+		}
+		if !ok || iter.UnsafeKey().Key.Compare(end.Key) >= 0 {
+			break
+		}
+
+		// Skip tombstone (len=0) records when startTime is zero
+		// (non-incremental) and we're not exporting all versions.
+		if !exportAllRevisions && start.Timestamp.IsEmpty() && len(iter.UnsafeValue()) == 0 {
+			continue
+		}
+
+		if err := rows.Count(iter.UnsafeKey().Key); err != nil {
+			return []byte{}, roachpb.BulkOpSummary{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
+		}
+		if err := sstWriter.Add(MVCCKeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
+			return []byte{}, roachpb.BulkOpSummary{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())
+		}
+
+		if exportAllRevisions {
+			iter.Next()
+		} else {
+			iter.NextKey()
+		}
+	}
+
+	data, err := sstWriter.Finish()
+	if err != nil {
+		return []byte{}, roachpb.BulkOpSummary{}, err
+	}
+
+	return data, roachpb.BulkOpSummary{}, nil
 }

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -88,6 +88,13 @@ func (p *pebbleBatch) Closed() bool {
 	return p.closed
 }
 
+// ExportToSst is part of the engine.Reader interface.
+func (p *pebbleBatch) ExportToSst(
+	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	panic("unimplemented")
+}
+
 // Get implements the Batch interface.
 func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
 	r := pebble.Reader(p.batch)

--- a/pkg/storage/engine/row_counter.go
+++ b/pkg/storage/engine/row_counter.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package bulk
+package engine
 
 import (
 	"bytes"

--- a/pkg/storage/engine/sst_writer.go
+++ b/pkg/storage/engine/sst_writer.go
@@ -8,12 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package bulk
+package engine
 
 import (
 	"io"
 
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/pkg/errors"
@@ -33,9 +32,9 @@ func MakeSSTWriter() SSTWriter {
 	opts := sstable.WriterOptions{
 		BlockSize:               32 * 1024,
 		TableFormat:             pebble.TableFormatLevelDB,
-		Comparer:                engine.MVCCComparer,
+		Comparer:                MVCCComparer,
 		MergerName:              "nullptr",
-		TablePropertyCollectors: engine.PebbleTablePropertyCollectors,
+		TablePropertyCollectors: PebbleTablePropertyCollectors,
 	}
 	f := &memFile{}
 	sst := sstable.NewWriter(f, opts)
@@ -45,12 +44,12 @@ func MakeSSTWriter() SSTWriter {
 // Add puts a kv entry into the sstable being built. An error is returned if it
 // is not greater than any previously added entry (according to the comparator
 // configured during writer creation). `Close` cannot have been called.
-func (fw *SSTWriter) Add(kv engine.MVCCKeyValue) error {
+func (fw *SSTWriter) Add(kv MVCCKeyValue) error {
 	if fw.fw == nil {
 		return errors.New("cannot call Open on a closed writer")
 	}
 	fw.DataSize += uint64(len(kv.Key.Key)) + uint64(len(kv.Value))
-	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], kv.Key)
+	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], kv.Key)
 	return fw.fw.Set(fw.scratch, kv.Value)
 }
 

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -754,7 +754,7 @@ func (mr *mockSender) Recv() (*SnapshotResponse, error) {
 
 func newEngine(t *testing.T) (func(), engine.Engine) {
 	dir, cleanup := testutils.TempDir(t)
-	eng, err := engine.NewEngine(
+	eng, err := engine.NewDefaultEngine(
 		1<<20,
 		base.StorageConfig{
 			Dir:       dir,

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -269,6 +269,13 @@ func (s spanSetReader) Closed() bool {
 	return s.r.Closed()
 }
 
+// ExportToSst is part of the engine.Reader interface.
+func (s spanSetReader) ExportToSst(
+	start, end engine.MVCCKey, exportAllRevisions bool, io engine.IterOptions,
+) ([]byte, roachpb.BulkOpSummary, error) {
+	return s.r.ExportToSst(start, end, exportAllRevisions, io)
+}
+
 func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {


### PR DESCRIPTION
Most of these commits are from [engine: Add ExportToSst method with all logic moved to C++](https://github.com/cockroachdb/cockroach/commit/75f1314b9ad4326069784838c581e1cb7a5ede24).

Fixes #41739

Release note: None