### PR TITLE
parser: make sinkless changefeeds selectable with square brackets

### DIFF
--- a/docs/generated/sql/bnf/create_changefeed_stmt.bnf
+++ b/docs/generated/sql/bnf/create_changefeed_stmt.bnf
@@ -1,11 +1,3 @@
 create_changefeed_stmt ::=
-	'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 
+	create_changefeed_sinkless_stmt
+	| create_changefeed_with_sink_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1006,7 +1006,8 @@ role_or_group ::=
 	'ROLE'
 
 create_changefeed_stmt ::=
-	'CREATE' 'CHANGEFEED' 'FOR' changefeed_targets opt_changefeed_sink opt_with_options
+	create_changefeed_sinkless_stmt
+	| create_changefeed_with_sink_stmt
 
 create_database_stmt ::=
 	'CREATE' 'DATABASE' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
@@ -1346,12 +1347,11 @@ opt_with ::=
 	'WITH'
 	| 
 
-changefeed_targets ::=
-	single_table_pattern_list
-	| 'TABLE' single_table_pattern_list
+create_changefeed_sinkless_stmt ::=
+	'CREATE' 'CHANGEFEED' 'FOR' changefeed_targets opt_with_options
 
-opt_changefeed_sink ::=
-	'INTO' string_or_placeholder
+create_changefeed_with_sink_stmt ::=
+	'CREATE' 'CHANGEFEED' 'FOR' changefeed_targets changefeed_sink opt_with_options
 
 opt_template_clause ::=
 	'TEMPLATE' opt_equal non_reserved_word_or_sconst
@@ -1741,8 +1741,12 @@ alter_index_cmds ::=
 sequence_option_list ::=
 	( sequence_option_elem ) ( ( sequence_option_elem ) )*
 
-single_table_pattern_list ::=
-	( table_name ) ( ( ',' table_name ) )*
+changefeed_targets ::=
+	single_table_pattern_list
+	| 'TABLE' single_table_pattern_list
+
+changefeed_sink ::=
+	'INTO' string_or_placeholder
 
 opt_equal ::=
 	'='
@@ -1963,6 +1967,7 @@ row_source_extension_stmt ::=
 	| show_stmt
 	| update_stmt
 	| upsert_stmt
+	| create_changefeed_sinkless_stmt
 
 user_priority ::=
 	'LOW'
@@ -2007,6 +2012,9 @@ sequence_option_elem ::=
 	| 'START' signed_iconst64
 	| 'START' 'WITH' signed_iconst64
 	| 'VIRTUAL'
+
+single_table_pattern_list ::=
+	( table_name ) ( ( ',' table_name ) )*
 
 opt_asc_desc ::=
 	'ASC'

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -500,7 +500,7 @@ var specs = []stmtSpec{
 	{name: "create_database_stmt", inline: []string{"opt_encoding_clause"}, replace: map[string]string{"'SCONST'": "encoding"}, unlink: []string{"name", "encoding"}},
 	{
 		name:   "create_changefeed_stmt",
-		inline: []string{"changefeed_targets", "single_table_pattern_list", "opt_changefeed_sink", "opt_with_options", "kv_option_list", "kv_option"},
+		inline: []string{"changefeed_targets", "single_table_pattern_list", "changefeed_sink", "opt_with_options", "kv_option_list", "kv_option"},
 		replace: map[string]string{
 			"table_option":                 "table_name",
 			"'INTO' string_or_placeholder": "'INTO' sink",


### PR DESCRIPTION
Before this PR, there was no way to filter rows from a sinkless
changefeed because it was not permitted by the grammar. This change
enables that filtering by allowing changefeeds to be used inside of
square brackets. See the following query, which is now valid:

```
SELECT
	*
FROM
	(
		SELECT
			convert_from(value, 'utf8')::JSONB AS val,
			key,
			value
		FROM
			[CREATE CHANGEFEED FOR vehicles WITH updated]
	)
WHERE
	val->'after'->>'type' = 'scooter';
```

References #42026.

Release note (sql change): Enable use of sinkless changefeed in square
bracket to allow filtering.