### PR TITLE
storage/engine: add BenchmarkBatchApplyBatchRepr_Pebble

### DIFF
--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -194,3 +194,28 @@ func BenchmarkMVCCGarbageCollect_Pebble(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkBatchApplyBatchRepr_Pebble(b *testing.B) {
+	if testing.Short() {
+		b.Skip("short flag")
+	}
+	ctx := context.Background()
+	for _, indexed := range []bool{false, true} {
+		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {
+			for _, sequential := range []bool{false, true} {
+				b.Run(fmt.Sprintf("seq=%t", sequential), func(b *testing.B) {
+					for _, valueSize := range []int{10} {
+						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+							for _, batchSize := range []int{10000} {
+								b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+									runBatchApplyBatchRepr(ctx, b, setupMVCCInMemPebble,
+										indexed, sequential, valueSize, batchSize)
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -400,18 +400,23 @@ func BenchmarkMVCCGarbageCollect_RocksDB(b *testing.B) {
 	}
 }
 
-func BenchmarkBatchApplyBatchRepr(b *testing.B) {
+func BenchmarkBatchApplyBatchRepr_RocksDB(b *testing.B) {
 	if testing.Short() {
 		b.Skip("short flag")
 	}
 	ctx := context.Background()
-	for _, writeOnly := range []bool{false, true} {
-		b.Run(fmt.Sprintf("writeOnly=%t ", writeOnly), func(b *testing.B) {
-			for _, valueSize := range []int{10} {
-				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-					for _, batchSize := range []int{1000000} {
-						b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
-							runBatchApplyBatchRepr(ctx, b, setupMVCCInMemRocksDB, writeOnly, valueSize, batchSize)
+	for _, indexed := range []bool{false, true} {
+		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {
+			for _, sequential := range []bool{false, true} {
+				b.Run(fmt.Sprintf("seq=%t", sequential), func(b *testing.B) {
+					for _, valueSize := range []int{10} {
+						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+							for _, batchSize := range []int{10000} {
+								b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+									runBatchApplyBatchRepr(ctx, b, setupMVCCInMemRocksDB,
+										indexed, sequential, valueSize, batchSize)
+								})
+							}
 						})
 					}
 				})


### PR DESCRIPTION
Add sequential vs random variant to this benchmark, and shrink the batch
size from 1,000,000 to 10,000. The 1m size batch was quite
unrealistic. Even 10k might be too large.

Old is RocksDB and new is Pebble. The reason for the discrepancy on the
`indexed=true/seq=true` variant is that RocksDB has a fast path for
in-order insertion, while Pebble does not (yet).

```
name                                                                         old time/op    new time/op     delta
BatchApplyBatchRepr/indexed=false/seq=false/valueSize=10/batchSize=10000-16     540µs ± 2%      187µs ± 2%   -65.41%  (p=0.000 n=10+9)
BatchApplyBatchRepr/indexed=false/seq=true/valueSize=10/batchSize=10000-16      538µs ± 2%      187µs ± 1%   -65.24%  (p=0.000 n=9+9)
BatchApplyBatchRepr/indexed=true/seq=false/valueSize=10/batchSize=10000-16     4.90ms ± 2%     2.08ms ± 3%   -57.66%  (p=0.000 n=10+10)
BatchApplyBatchRepr/indexed=true/seq=true/valueSize=10/batchSize=10000-16       954µs ± 1%     1400µs ± 1%   +46.80%  (p=0.000 n=10+10)
```

Release note: None