### PR TITLE
colexec: minor clean up of the check in tests

### DIFF
--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -829,7 +829,13 @@ func tupleEquals(expected tuple, actual tuple) bool {
 					}
 				}
 			}
-			if !reflect.DeepEqual(reflect.ValueOf(actual[i]).Convert(reflect.TypeOf(expected[i])).Interface(), expected[i]) {
+			if !reflect.DeepEqual(
+				reflect.ValueOf(actual[i]).Convert(reflect.TypeOf(expected[i])).Interface(),
+				expected[i],
+			) || !reflect.DeepEqual(
+				reflect.ValueOf(expected[i]).Convert(reflect.TypeOf(actual[i])).Interface(),
+				actual[i],
+			) {
 				return false
 			}
 		}


### PR DESCRIPTION
This commit modifies the way we compare the expected and the actual
values in runTests test harness. Previously, it would convert the actual
value to the type of the expected value and check that those are equal.
However, consider the following situation which I ran into: the expected
is int(0) and the actual is float64(0.5). Previously, the check would
succeed because it would lossfully convert 0.5 to 0. Now we will attempt
the conversion both ways, and if either doesn't succeed, we fail the
check.

Release note: None