### PR TITLE
workload/debug: add `debug merge-tpcc-results`

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl/roachmartccl"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bulkingest"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/debug"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/indexes"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/interleavedpartitioned"

--- a/pkg/workload/debug/debug.go
+++ b/pkg/workload/debug/debug.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package debug provides a workload subcommand under which useful workload
+// utilities live.
+package debug
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/workload/cli"
+	"github.com/spf13/cobra"
+)
+
+var debugCmd = &cobra.Command{
+	Use:   `debug`,
+	Short: `debug subcommands`,
+	Args:  cobra.NoArgs,
+}
+
+func init() {
+	debugCmd.AddCommand(tpccMergeResultsCmd)
+	cli.AddSubCmd(func(userFacing bool) *cobra.Command {
+		return debugCmd
+	})
+}

--- a/pkg/workload/debug/tpcc_results.go
+++ b/pkg/workload/debug/tpcc_results.go
@@ -1,0 +1,78 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debug
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var tpccMergeResultsCmd = &cobra.Command{
+	Use: "tpcc-merge-results [<hist-file> [<hist-file>...]]",
+	Short: "tpcc-merge-results merges the histograms from parallel runs of " +
+		"TPC-C to compute a combined result.",
+	RunE: tpccMergeResults,
+	Args: cobra.MinimumNArgs(1),
+}
+
+func init() {
+	flags := tpccMergeResultsCmd.Flags()
+	flags.Int("warehouses", 0, "number of aggregate warehouses in all of the histograms")
+}
+
+func tpccMergeResults(cmd *cobra.Command, args []string) error {
+	// We want to take histograms and merge them
+	warehouses, err := cmd.Flags().GetInt("warehouses")
+	if err != nil {
+		return errors.Wrap(err, "no warehouses flag found")
+	}
+	var results []*tpcc.Result
+
+	for _, fname := range args {
+		snapshots, err := histogram.DecodeSnapshots(fname)
+		if err != nil {
+			return errors.Wrapf(err, "failed to decode histograms at %q", fname)
+		}
+		results = append(results, tpcc.NewResultWithSnapshots(warehouses, 0, snapshots))
+	}
+
+	res := tpcc.MergeResults(results...)
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Duration: %.5v, Warehouses: %v, Efficiency: %.4v, tpmC: %.2f\n",
+		res.Elapsed, res.ActiveWarehouses, res.Efficiency(), res.TpmC())
+	_, _ = fmt.Fprintf(out, "_elapsed___ops/sec(cum)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)\n")
+
+	var queries []string
+	for query := range res.Cumulative {
+		queries = append(queries, query)
+	}
+	sort.Strings(queries)
+	for _, query := range queries {
+		hist := res.Cumulative[query]
+		_, _ = fmt.Fprintf(out, "%7.1fs %14.1f %8.1f %8.1f %8.1f %8.1f %8.1f %s\n",
+			res.Elapsed.Seconds(),
+			float64(hist.TotalCount())/res.Elapsed.Seconds(),
+			time.Duration(hist.ValueAtQuantile(50)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(90)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(95)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(99)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(100)).Seconds()*1000,
+			query,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a subcommand to workload to merge the histograms from several
parallel runs of TPC-C. Parallel runs of TPC-C are commonly performed when
running in a multi-region setting or when running at very large scale.

Note that this subcommand has not been white-listed and will not be
visible in the main cockroach binary.

```
$ workload debug tpcc-merge-results --warehouses 100000 ~/pass_1h/out.*.ndjson
Duration: 1h0m0, Warehouses: 100000, Efficiency: 98.81, tpmC: 1245461.78
_elapsed___ops/sec(cum)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 3600.1s         2082.1    151.0    369.1    453.0    637.5   5100.3 delivery
 3600.1s        20757.7    167.8    402.7    486.5    671.1   8321.5 newOrder
 3600.1s         2083.2      9.4     62.9     92.3    159.4   1073.7 orderStatus
 3600.1s        20829.5    100.7    251.7    318.8    469.8   7516.2 payment
 3600.1s         2082.8     29.4    100.7    142.6    234.9 103079.2 stockLevel
```

Release note: None.