### PR TITLE
backport-19.2: cli: productionize debug check-store

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -37,12 +37,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -59,7 +57,6 @@ import (
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"go.etcd.io/etcd/raft/raftpb"
 )
 
 var debugKeysCmd = &cobra.Command{
@@ -550,195 +547,6 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 		fmt.Printf("RangeID: %d [%s, %s):\n", desc.RangeID, desc.StartKey, desc.EndKey)
 		_, _ = pretty.Println(info)
 	}
-	return nil
-}
-
-var debugCheckStoreCmd = &cobra.Command{
-	Use:   "check-store <directory>",
-	Short: "consistency check for a single store",
-	Long: `
-Perform local consistency checks of a single store.
-
-Capable of detecting the following errors:
-* Raft logs that are inconsistent with their metadata
-* MVCC stats that are inconsistent with the data within the range
-`,
-	Args: cobra.ExactArgs(1),
-	RunE: MaybeDecorateGRPCError(runDebugCheckStoreCmd),
-}
-
-type replicaCheckInfo struct {
-	truncatedIndex uint64
-	appliedIndex   uint64
-	firstIndex     uint64
-	lastIndex      uint64
-	committedIndex uint64
-}
-
-func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	ctx := context.Background()
-
-	db, err := OpenExistingStore(args[0], stopper, true /* readOnly */)
-	if err != nil {
-		return err
-	}
-	var hasError bool
-	if err := runDebugCheckStoreRaft(ctx, db); err != nil {
-		hasError = true
-		log.Warning(ctx, err)
-	}
-	if err := runDebugCheckStoreDescriptors(ctx, db); err != nil {
-		hasError = true
-		log.Warning(ctx, err)
-	}
-	if hasError {
-		return errors.New("errors detected")
-	}
-	return nil
-}
-
-func runDebugCheckStoreDescriptors(ctx context.Context, db *engine.RocksDB) error {
-	fmt.Println("checking MVCC stats")
-	defer fmt.Println()
-
-	var failed bool
-	if err := storage.IterateRangeDescriptors(ctx, db,
-		func(desc roachpb.RangeDescriptor) (bool, error) {
-			claimedMS, err := stateloader.Make(desc.RangeID).LoadMVCCStats(ctx, db)
-			if err != nil {
-				return false, err
-			}
-			ms, err := rditer.ComputeStatsForRange(&desc, db, claimedMS.LastUpdateNanos)
-			if err != nil {
-				return false, err
-			}
-
-			if !ms.Equal(claimedMS) {
-				var prefix string
-				if !claimedMS.ContainsEstimates {
-					failed = true
-				} else {
-					ms.ContainsEstimates = true
-					prefix = "(ignored) "
-				}
-				fmt.Printf("\n%s%+v: diff(actual, claimed): %s\n", prefix, desc, strings.Join(pretty.Diff(ms, claimedMS), "\n"))
-			}
-			return false, nil
-		}); err != nil {
-		return err
-	}
-	if failed {
-		return errors.New("check failed")
-	}
-	return nil
-}
-
-func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
-	// Iterate over the entire range-id-local space.
-	start := roachpb.Key(keys.LocalRangeIDPrefix)
-	end := start.PrefixEnd()
-
-	replicaInfo := map[roachpb.RangeID]*replicaCheckInfo{}
-	getReplicaInfo := func(rangeID roachpb.RangeID) *replicaCheckInfo {
-		if info, ok := replicaInfo[rangeID]; ok {
-			return info
-		}
-		replicaInfo[rangeID] = &replicaCheckInfo{}
-		return replicaInfo[rangeID]
-	}
-
-	var hasError bool
-
-	if _, err := engine.MVCCIterate(ctx, db, start, end, hlc.MaxTimestamp,
-		engine.MVCCScanOptions{Inconsistent: true}, func(kv roachpb.KeyValue) (bool, error) {
-			rangeID, _, suffix, detail, err := keys.DecodeRangeIDKey(kv.Key)
-			if err != nil {
-				return false, err
-			}
-
-			switch {
-			case bytes.Equal(suffix, keys.LocalRaftHardStateSuffix):
-				var hs raftpb.HardState
-				if err := kv.Value.GetProto(&hs); err != nil {
-					return false, err
-				}
-				getReplicaInfo(rangeID).committedIndex = hs.Commit
-			case bytes.Equal(suffix, keys.LocalRaftTruncatedStateLegacySuffix):
-				var trunc roachpb.RaftTruncatedState
-				if err := kv.Value.GetProto(&trunc); err != nil {
-					return false, err
-				}
-				getReplicaInfo(rangeID).truncatedIndex = trunc.Index
-			case bytes.Equal(suffix, keys.LocalRangeAppliedStateSuffix):
-				var state enginepb.RangeAppliedState
-				if err := kv.Value.GetProto(&state); err != nil {
-					return false, err
-				}
-				getReplicaInfo(rangeID).appliedIndex = state.RaftAppliedIndex
-			case bytes.Equal(suffix, keys.LocalRaftAppliedIndexLegacySuffix):
-				idx, err := kv.Value.GetInt()
-				if err != nil {
-					return false, err
-				}
-				getReplicaInfo(rangeID).appliedIndex = uint64(idx)
-			case bytes.Equal(suffix, keys.LocalRaftLogSuffix):
-				_, index, err := encoding.DecodeUint64Ascending(detail)
-				if err != nil {
-					return false, err
-				}
-				ri := getReplicaInfo(rangeID)
-				if ri.firstIndex == 0 {
-					ri.firstIndex = index
-					ri.lastIndex = index
-				} else {
-					if index != ri.lastIndex+1 {
-						fmt.Printf("range %s: log index anomaly: %v followed by %v\n",
-							rangeID, ri.lastIndex, index)
-						hasError = true
-					}
-					ri.lastIndex = index
-				}
-			}
-
-			return false, nil
-		}); err != nil {
-		return err
-	}
-
-	for rangeID, info := range replicaInfo {
-		if info.truncatedIndex != 0 && info.truncatedIndex != info.firstIndex-1 {
-			hasError = true
-			fmt.Printf("range %s: truncated index %v should equal first index %v - 1\n",
-				rangeID, info.truncatedIndex, info.firstIndex)
-		}
-		if info.firstIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: [first index, last index] is [%d, %d]\n",
-				rangeID, info.firstIndex, info.lastIndex)
-		}
-		if info.appliedIndex < info.firstIndex || info.appliedIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: applied index %v should be between first index %v and last index %v\n",
-				rangeID, info.appliedIndex, info.firstIndex, info.lastIndex)
-		}
-		if info.appliedIndex > info.committedIndex {
-			hasError = true
-			fmt.Printf("range %s: committed index %d must not trail applied index %d\n",
-				rangeID, info.committedIndex, info.appliedIndex)
-		}
-		if info.committedIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: committed index %d ahead of last index  %d\n",
-				rangeID, info.committedIndex, info.lastIndex)
-		}
-	}
-	if hasError {
-		return errors.New("anomalies detected in Raft state")
-	}
-
 	return nil
 }
 

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -1,0 +1,223 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/kr/pretty"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.etcd.io/etcd/raft/raftpb"
+)
+
+var debugCheckStoreCmd = &cobra.Command{
+	Use:   "check-store <directory>",
+	Short: "consistency check for a single store",
+	Long: `
+Perform local consistency checks of a single store.
+
+Capable of detecting the following errors:
+* Raft logs that are inconsistent with their metadata
+* MVCC stats that are inconsistent with the data within the range
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runDebugCheckStoreCmd),
+}
+
+type replicaCheckInfo struct {
+	truncatedIndex uint64
+	appliedIndex   uint64
+	firstIndex     uint64
+	lastIndex      uint64
+	committedIndex uint64
+}
+
+func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	ctx := context.Background()
+
+	db, err := OpenExistingStore(args[0], stopper, true /* readOnly */)
+	if err != nil {
+		return err
+	}
+	var hasError bool
+	if err := runDebugCheckStoreRaft(ctx, db); err != nil {
+		hasError = true
+		log.Warning(ctx, err)
+	}
+	if err := runDebugCheckStoreDescriptors(ctx, db); err != nil {
+		hasError = true
+		log.Warning(ctx, err)
+	}
+	if hasError {
+		return errors.New("errors detected")
+	}
+	return nil
+}
+
+func runDebugCheckStoreDescriptors(ctx context.Context, db *engine.RocksDB) error {
+	fmt.Println("checking MVCC stats")
+	defer fmt.Println()
+
+	var failed bool
+	if err := storage.IterateRangeDescriptors(ctx, db,
+		func(desc roachpb.RangeDescriptor) (bool, error) {
+			claimedMS, err := stateloader.Make(desc.RangeID).LoadMVCCStats(ctx, db)
+			if err != nil {
+				return false, err
+			}
+			ms, err := rditer.ComputeStatsForRange(&desc, db, claimedMS.LastUpdateNanos)
+			if err != nil {
+				return false, err
+			}
+
+			if !ms.Equal(claimedMS) {
+				var prefix string
+				if !claimedMS.ContainsEstimates {
+					failed = true
+				} else {
+					ms.ContainsEstimates = true
+					prefix = "(ignored) "
+				}
+				fmt.Printf("\n%s%+v: diff(actual, claimed): %s\n", prefix, desc, strings.Join(pretty.Diff(ms, claimedMS), "\n"))
+			}
+			return false, nil
+		}); err != nil {
+		return err
+	}
+	if failed {
+		return errors.New("check failed")
+	}
+	return nil
+}
+
+func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
+	// Iterate over the entire range-id-local space.
+	start := roachpb.Key(keys.LocalRangeIDPrefix)
+	end := start.PrefixEnd()
+
+	replicaInfo := map[roachpb.RangeID]*replicaCheckInfo{}
+	getReplicaInfo := func(rangeID roachpb.RangeID) *replicaCheckInfo {
+		if info, ok := replicaInfo[rangeID]; ok {
+			return info
+		}
+		replicaInfo[rangeID] = &replicaCheckInfo{}
+		return replicaInfo[rangeID]
+	}
+
+	var hasError bool
+
+	if _, err := engine.MVCCIterate(ctx, db, start, end, hlc.MaxTimestamp,
+		engine.MVCCScanOptions{Inconsistent: true}, func(kv roachpb.KeyValue) (bool, error) {
+			rangeID, _, suffix, detail, err := keys.DecodeRangeIDKey(kv.Key)
+			if err != nil {
+				return false, err
+			}
+
+			switch {
+			case bytes.Equal(suffix, keys.LocalRaftHardStateSuffix):
+				var hs raftpb.HardState
+				if err := kv.Value.GetProto(&hs); err != nil {
+					return false, err
+				}
+				getReplicaInfo(rangeID).committedIndex = hs.Commit
+			case bytes.Equal(suffix, keys.LocalRaftTruncatedStateLegacySuffix):
+				var trunc roachpb.RaftTruncatedState
+				if err := kv.Value.GetProto(&trunc); err != nil {
+					return false, err
+				}
+				getReplicaInfo(rangeID).truncatedIndex = trunc.Index
+			case bytes.Equal(suffix, keys.LocalRangeAppliedStateSuffix):
+				var state enginepb.RangeAppliedState
+				if err := kv.Value.GetProto(&state); err != nil {
+					return false, err
+				}
+				getReplicaInfo(rangeID).appliedIndex = state.RaftAppliedIndex
+			case bytes.Equal(suffix, keys.LocalRaftAppliedIndexLegacySuffix):
+				idx, err := kv.Value.GetInt()
+				if err != nil {
+					return false, err
+				}
+				getReplicaInfo(rangeID).appliedIndex = uint64(idx)
+			case bytes.Equal(suffix, keys.LocalRaftLogSuffix):
+				_, index, err := encoding.DecodeUint64Ascending(detail)
+				if err != nil {
+					return false, err
+				}
+				ri := getReplicaInfo(rangeID)
+				if ri.firstIndex == 0 {
+					ri.firstIndex = index
+					ri.lastIndex = index
+				} else {
+					if index != ri.lastIndex+1 {
+						fmt.Printf("range %s: log index anomaly: %v followed by %v\n",
+							rangeID, ri.lastIndex, index)
+						hasError = true
+					}
+					ri.lastIndex = index
+				}
+			}
+
+			return false, nil
+		}); err != nil {
+		return err
+	}
+
+	for rangeID, info := range replicaInfo {
+		if info.truncatedIndex != 0 && info.truncatedIndex != info.firstIndex-1 {
+			hasError = true
+			fmt.Printf("range %s: truncated index %v should equal first index %v - 1\n",
+				rangeID, info.truncatedIndex, info.firstIndex)
+		}
+		if info.firstIndex > info.lastIndex {
+			hasError = true
+			fmt.Printf("range %s: [first index, last index] is [%d, %d]\n",
+				rangeID, info.firstIndex, info.lastIndex)
+		}
+		if info.appliedIndex < info.firstIndex || info.appliedIndex > info.lastIndex {
+			hasError = true
+			fmt.Printf("range %s: applied index %v should be between first index %v and last index %v\n",
+				rangeID, info.appliedIndex, info.firstIndex, info.lastIndex)
+		}
+		if info.appliedIndex > info.committedIndex {
+			hasError = true
+			fmt.Printf("range %s: committed index %d must not trail applied index %d\n",
+				rangeID, info.committedIndex, info.appliedIndex)
+		}
+		if info.committedIndex > info.lastIndex {
+			hasError = true
+			fmt.Printf("range %s: committed index %d ahead of last index  %d\n",
+				rangeID, info.committedIndex, info.lastIndex)
+		}
+	}
+	if hasError {
+		return errors.New("anomalies detected in Raft state")
+	}
+
+	return nil
+}

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -25,12 +26,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.etcd.io/etcd/raft/raftpb"
+	"golang.org/x/sync/errgroup"
 )
 
 var debugCheckStoreCmd = &cobra.Command{
@@ -47,6 +48,36 @@ Capable of detecting the following errors:
 	RunE: MaybeDecorateGRPCError(runDebugCheckStoreCmd),
 }
 
+var errCheckFoundProblem = errors.New("check-store found problems")
+
+func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	dir := args[0]
+	foundProblem := false
+	// At time of writing, this takes around ~110s for 71GB (1k warehouse TPCC
+	// fully compacted) on local SSD. This is quite fast, well north of 600MB/s.
+	err := checkStoreRangeStats(ctx, dir, func(args ...interface{}) {
+		fmt.Println(args...)
+	})
+	foundProblem = foundProblem || err != nil
+	if err != nil && !errors.Is(err, errCheckFoundProblem) {
+		_, _ = fmt.Println(err)
+	}
+	// This is not optimized at all, but for the same data set as above, it
+	// returns instantly, so we won't need to optimize it for quite some time.
+	err = checkStoreRaftState(ctx, dir, func(format string, args ...interface{}) {
+		_, _ = fmt.Printf(format, args...)
+	})
+	foundProblem = foundProblem || err != nil
+	if err != nil && !errors.Is(err, errCheckFoundProblem) {
+		fmt.Println(err)
+	}
+	if foundProblem {
+		return errCheckFoundProblem
+	}
+	return nil
+}
+
 type replicaCheckInfo struct {
 	truncatedIndex uint64
 	appliedIndex   uint64
@@ -55,68 +86,147 @@ type replicaCheckInfo struct {
 	committedIndex uint64
 }
 
-func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
+type checkInput struct {
+	eng  engine.Engine
+	desc *roachpb.RangeDescriptor
+	sl   stateloader.StateLoader
+}
+
+type checkResult struct {
+	desc           *roachpb.RangeDescriptor
+	err            error
+	claimMS, actMS enginepb.MVCCStats
+}
+
+func (cr *checkResult) Error() error {
+	var errs []string
+	if cr.err != nil {
+		errs = append(errs, cr.err.Error())
+	}
+	if !cr.actMS.Equal(enginepb.MVCCStats{}) && !cr.actMS.Equal(cr.claimMS) && !cr.claimMS.ContainsEstimates {
+		err := fmt.Sprintf("stats inconsistency:\n- stored:\n%+v\n- recomputed:\n%+v\n- diff:\n%s",
+			cr.claimMS, cr.actMS, strings.Join(pretty.Diff(cr.claimMS, cr.actMS), ","),
+		)
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		if cr.desc != nil {
+			prefix := cr.desc.String() + ": "
+			for i := range errs {
+				errs[i] = prefix + errs[i]
+			}
+		}
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func worker(ctx context.Context, in checkInput) checkResult {
+	desc, eng := in.desc, in.eng
+
+	res := checkResult{desc: desc}
+	claimedMS, err := in.sl.LoadMVCCStats(ctx, eng)
+	if err != nil {
+		res.err = err
+		return res
+	}
+	ms, err := rditer.ComputeStatsForRange(desc, eng, claimedMS.LastUpdateNanos)
+	if err != nil {
+		res.err = err
+		return res
+	}
+	res.claimMS = claimedMS
+	res.actMS = ms
+	return res
+}
+
+func checkStoreRangeStats(
+	ctx context.Context,
+	dir string, // the store directory
+	println func(...interface{}), // fmt.Println outside of tests
+) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
+	defer stopper.Stop(ctx)
 
-	ctx := context.Background()
-
-	db, err := OpenExistingStore(args[0], stopper, true /* readOnly */)
+	eng, err := OpenExistingStore(dir, stopper, true /* readOnly */)
 	if err != nil {
 		return err
 	}
-	var hasError bool
-	if err := runDebugCheckStoreRaft(ctx, db); err != nil {
-		hasError = true
-		log.Warning(ctx, err)
+
+	inCh := make(chan checkInput)
+	outCh := make(chan checkResult, 1000)
+
+	n := runtime.NumCPU()
+	var g errgroup.Group
+	for i := 0; i < n; i++ {
+		g.Go(func() error {
+			for in := range inCh {
+				outCh <- worker(ctx, in)
+			}
+			return nil
+		})
 	}
-	if err := runDebugCheckStoreDescriptors(ctx, db); err != nil {
-		hasError = true
-		log.Warning(ctx, err)
+
+	go func() {
+		if err := storage.IterateRangeDescriptors(ctx, eng,
+			func(desc roachpb.RangeDescriptor) (bool, error) {
+				inCh <- checkInput{eng: eng, desc: &desc, sl: stateloader.Make(desc.RangeID)}
+				return false, nil
+			}); err != nil {
+			outCh <- checkResult{err: err}
+		}
+		close(inCh) // we were the only writer
+		if err := g.Wait(); err != nil {
+			outCh <- checkResult{err: err}
+		}
+		close(outCh) // all writers done due to Wait()
+	}()
+
+	foundProblem := false
+	var total enginepb.MVCCStats
+	var cR, cE int
+	for res := range outCh {
+		cR++
+		if err := res.Error(); err != nil {
+			foundProblem = true
+			errS := err.Error()
+			println(errS)
+		} else {
+			if res.claimMS.ContainsEstimates {
+				cE++
+			}
+			total.Add(res.actMS)
+		}
 	}
-	if hasError {
-		return errors.New("errors detected")
+
+	println(fmt.Sprintf("scanned %d ranges (%d with estimates), total stats %s", cR, cE, &total))
+
+	if foundProblem {
+		// The details were already emitted.
+		return errCheckFoundProblem
 	}
 	return nil
 }
 
-func runDebugCheckStoreDescriptors(ctx context.Context, db *engine.RocksDB) error {
-	fmt.Println("checking MVCC stats")
-	defer fmt.Println()
+func checkStoreRaftState(
+	ctx context.Context,
+	dir string, // the store directory
+	printf func(string, ...interface{}), // fmt.Printf outside of tests
+) error {
+	foundProblem := false
+	goldenPrintf := printf
+	printf = func(format string, args ...interface{}) {
+		foundProblem = true
+		goldenPrintf(format, args...)
+	}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
 
-	var failed bool
-	if err := storage.IterateRangeDescriptors(ctx, db,
-		func(desc roachpb.RangeDescriptor) (bool, error) {
-			claimedMS, err := stateloader.Make(desc.RangeID).LoadMVCCStats(ctx, db)
-			if err != nil {
-				return false, err
-			}
-			ms, err := rditer.ComputeStatsForRange(&desc, db, claimedMS.LastUpdateNanos)
-			if err != nil {
-				return false, err
-			}
-
-			if !ms.Equal(claimedMS) {
-				var prefix string
-				if !claimedMS.ContainsEstimates {
-					failed = true
-				} else {
-					ms.ContainsEstimates = true
-					prefix = "(ignored) "
-				}
-				fmt.Printf("\n%s%+v: diff(actual, claimed): %s\n", prefix, desc, strings.Join(pretty.Diff(ms, claimedMS), "\n"))
-			}
-			return false, nil
-		}); err != nil {
+	db, err := OpenExistingStore(dir, stopper, true /* readOnly */)
+	if err != nil {
 		return err
 	}
-	if failed {
-		return errors.New("check failed")
-	}
-	return nil
-}
 
-func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 	// Iterate over the entire range-id-local space.
 	start := roachpb.Key(keys.LocalRangeIDPrefix)
 	end := start.PrefixEnd()
@@ -129,8 +239,6 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 		replicaInfo[rangeID] = &replicaCheckInfo{}
 		return replicaInfo[rangeID]
 	}
-
-	var hasError bool
 
 	if _, err := engine.MVCCIterate(ctx, db, start, end, hlc.MaxTimestamp,
 		engine.MVCCScanOptions{Inconsistent: true}, func(kv roachpb.KeyValue) (bool, error) {
@@ -175,9 +283,8 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 					ri.lastIndex = index
 				} else {
 					if index != ri.lastIndex+1 {
-						fmt.Printf("range %s: log index anomaly: %v followed by %v\n",
+						printf("range %s: log index anomaly: %v followed by %v\n",
 							rangeID, ri.lastIndex, index)
-						hasError = true
 					}
 					ri.lastIndex = index
 				}
@@ -190,33 +297,28 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 
 	for rangeID, info := range replicaInfo {
 		if info.truncatedIndex != 0 && info.truncatedIndex != info.firstIndex-1 {
-			hasError = true
-			fmt.Printf("range %s: truncated index %v should equal first index %v - 1\n",
+			printf("range %s: truncated index %v should equal first index %v - 1\n",
 				rangeID, info.truncatedIndex, info.firstIndex)
 		}
 		if info.firstIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: [first index, last index] is [%d, %d]\n",
+			printf("range %s: [first index, last index] is [%d, %d]\n",
 				rangeID, info.firstIndex, info.lastIndex)
 		}
 		if info.appliedIndex < info.firstIndex || info.appliedIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: applied index %v should be between first index %v and last index %v\n",
+			printf("range %s: applied index %v should be between first index %v and last index %v\n",
 				rangeID, info.appliedIndex, info.firstIndex, info.lastIndex)
 		}
 		if info.appliedIndex > info.committedIndex {
-			hasError = true
-			fmt.Printf("range %s: committed index %d must not trail applied index %d\n",
+			printf("range %s: committed index %d must not trail applied index %d\n",
 				rangeID, info.committedIndex, info.appliedIndex)
 		}
 		if info.committedIndex > info.lastIndex {
-			hasError = true
-			fmt.Printf("range %s: committed index %d ahead of last index  %d\n",
+			printf("range %s: committed index %d ahead of last index  %d\n",
 				rangeID, info.committedIndex, info.lastIndex)
 		}
 	}
-	if hasError {
-		return errors.New("anomalies detected in Raft state")
+	if foundProblem {
+		return errCheckFoundProblem
 	}
 
 	return nil

--- a/pkg/cli/debug_check_store_test.go
+++ b/pkg/cli/debug_check_store_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugCheckStore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	baseDir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	// Number of nodes. Increasing this will make the test flaky as written
+	// because it relies on finding r1 on n1.
+	const n = 3
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{},
+	}
+	var storePaths []string
+	for i := 0; i < n; i++ {
+		args := base.TestServerArgs{}
+		args.ScanMaxIdleTime = time.Millisecond
+		args.ScanMaxIdleTime = time.Millisecond
+		storeID := roachpb.StoreID(i + 1)
+		path := filepath.Join(baseDir, fmt.Sprintf("s%d", storeID))
+		storePaths = append(storePaths, path)
+		args.StoreSpecs = []base.StoreSpec{{Path: path}}
+		clusterArgs.ServerArgsPerNode[i] = args
+	}
+
+	// Start the cluster, wait for full replication, stop the cluster.
+	func() {
+		tc := testcluster.StartTestCluster(t, n, clusterArgs)
+		defer tc.Stopper().Stop(ctx)
+		require.NoError(t, tc.WaitForFullReplication())
+	}()
+
+	check := func(dir string) (string, error) {
+		var buf strings.Builder
+		err := checkStoreRangeStats(ctx, dir, func(args ...interface{}) {
+			fmt.Fprintln(&buf, args...)
+		})
+		return buf.String(), err
+	}
+
+	// Should not error out randomly.
+	for _, dir := range storePaths {
+		out, err := check(dir)
+		require.NoError(t, err, dir)
+		require.Contains(t, out, "total stats", dir)
+	}
+
+	// Introduce a stats divergence on s1.
+	func() {
+		cache := engine.NewRocksDBCache(10 << 20 /* 10mb */)
+		defer cache.Release()
+		eng, err := engine.NewRocksDB(engine.RocksDBConfig{
+			Dir:       storePaths[0],
+			MustExist: true,
+		}, cache)
+		require.NoError(t, err)
+		defer eng.Close()
+		sl := stateloader.Make(1)
+		ms, err := sl.LoadMVCCStats(ctx, eng)
+		require.NoError(t, err)
+		ms.ContainsEstimates = false
+		ms.LiveBytes++
+		require.NoError(t, sl.SetMVCCStats(ctx, eng, &ms))
+	}()
+
+	// The check should now fail on s1.
+	{
+		const s = "stats inconsistency"
+		out, err := check(storePaths[0])
+		require.Error(t, err)
+		require.Contains(t, out, s)
+		require.Contains(t, out, "total stats")
+	}
+}


### PR DESCRIPTION
Backport 2/2 commits from #41805.

/cc @cockroachdb/release

---

In light of the stats inconsistency seen in [clearrange], we want to be
stricter about verifying the stats in nightly testing. This commit makes
sure `./cockroach debug check-store` is fast enough to do so:

On a ~71GB fully compacted store directory it reliably takes well below
two minutes (on GCE local SSD).

[clearrange]: #38720 (comment)

Release note (performance improvement): The `./cockroach debug check-store` command is now faster.
