### PR TITLE
opt: inline constant variables in Select filters

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1301,8 +1301,7 @@ index-join  ·            ·
  │          key columns  a
  └── scan   ·            ·
 ·           table        t2@bc
-·           spans        /2/!NULL-/3
-·           filter       c != b
+·           spans        /2/!NULL-/2/2 /2/3-/3
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1314,7 +1313,6 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
-fetched: /t2/bc/2/2/5 -> NULL
 fetched: /t2/bc/2/3/6 -> NULL
 fetched: /t2/primary/4 -> NULL
 fetched: /t2/primary/4/b -> 2
@@ -1337,7 +1335,6 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
-fetched: /t2/bc/2/2/5 -> NULL
 fetched: /t2/bc/2/3/6 -> NULL
 fetched: /t2/primary/4 -> NULL
 fetched: /t2/primary/4/b -> 2

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -230,11 +230,11 @@ memo (optimized, ~4KB, required=[presentation: a:3,b:4,c:5,d:6])
 memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
-memo (optimized, ~4KB, required=[presentation: x:1])
+memo (optimized, ~5KB, required=[presentation: x:1])
  ├── G1: (project G2 G3 x)
  │    └── [presentation: x:1]
  │         ├── best: (project G2 G3 x)
- │         └── cost: 1.08
+ │         └── cost: 1.09
  ├── G2: (select G4 G5) (select G6 G7)
  │    └── []
  │         ├── best: (select G6 G7)
@@ -251,11 +251,11 @@ memo (optimized, ~4KB, required=[presentation: x:1])
  │         └── cost: 1.05
  ├── G7: (filters G9)
  ├── G8: (eq G10 G11)
- ├── G9: (eq G12 G11)
+ ├── G9: (eq G12 G13)
  ├── G10: (variable x)
  ├── G11: (const 1)
- ├── G12: (plus G10 G13)
- └── G13: (variable y)
+ ├── G12: (variable y)
+ └── G13: (const 0)
 
 memo 
 SELECT x, y FROM a UNION SELECT x+1, y+1 FROM a

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -113,17 +113,17 @@ SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=3.33333333, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(2)=1, null(2)=0]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(2)=400, null(2)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
       ├── y = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
-      └── (x + y) < 10 [type=bool, outer=(1,2)]
+      └── x < 5 [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
 
 # Contradiction.
 norm
@@ -492,14 +492,14 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id = customer_id A
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=0.9801, distinct(1)=0.9801, null(1)=0, distinct(2)=0.9801, null(2)=0, distinct(3)=0.9801, null(3)=0]
- ├── fd: ()-->(1-3), (1)==(2,3), (2)==(1,3), (3)==(1,2)
+ ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
+ ├── fd: ()-->(1-3)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10]
  └── filters
-      ├── item_id = order_id [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
-      ├── item_id = customer_id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+      ├── order_id = 5 [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      ├── item_id = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       └── customer_id = 5 [type=bool, outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
 
 # Test equality condition with another condition on one of the attributes.
@@ -581,13 +581,13 @@ SELECT * FROM uvw WHERE u=v AND u=10
 ----
 select
  ├── columns: u:1(int!null) v:2(int!null) w:3(int)
- ├── stats: [rows=0.99, distinct(1)=0.99, null(1)=0, distinct(2)=0.99, null(2)=0]
- ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+ ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(2)=0.1, null(2)=0]
+ ├── fd: ()-->(1,2)
  ├── scan uvw
  │    ├── columns: u:1(int) v:2(int) w:3(int)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
  └── filters
-      ├── u = v [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+      ├── v = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
       └── u = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
 
 norm disable=MergeSelects
@@ -1012,17 +1012,17 @@ SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=3.34168755, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=3.34168755, distinct(1)=3.34168755, null(1)=0, distinct(2)=1, null(2)=0]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=5000, distinct(2)=400, null(2)=1000]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=1000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
       ├── y = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
-      └── (x + y) < 10 [type=bool, outer=(1,2)]
+      └── x < 5 [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
 
 # Test that the null count for x is propagated correctly (since it's a weak
 # key).

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -368,3 +368,20 @@
     $input
     (RemoveFiltersItem $filters $item)
 )
+
+# InlineConstVar inlines variables which are restricted to be constant, as in
+#   SELECT * FROM foo WHERE a = 4 AND a IN (1, 2, 3, 4).
+# =>
+#   SELECT * FROM foo WHERE a = 4 AND 4 IN (1, 2, 3, 4).
+# Note that a single iteration of this rule might not be sufficient to inline
+# all variables, in which case it will trigger itself again.
+[InlineConstVar, Normalize]
+(Select
+    $input:*
+    $filters:* & (CanInlineConstVar $filters)
+)
+=>
+(Select
+    $input
+    (InlineConstVar $filters)
+)

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -227,7 +227,7 @@ project
 # SimplifyRange
 # --------------------------------------------------
 
-opt expect=SimplifyRange
+opt expect=SimplifyRange disable=InlineConstVar
 SELECT * FROM a WHERE k = 1 AND k = 2-1
 ----
 scan a

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -3464,7 +3464,7 @@ project
            └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Multiple other conjuncts, including uncorrelated subquery (don't hoist).
-opt expect=HoistSelectSubquery
+opt expect=HoistSelectSubquery disable=InlineConstVar
 SELECT *
 FROM a
 WHERE k=10 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i AND (SELECT x FROM xy LIMIT 1) = 100

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -142,7 +142,7 @@ select
       ├── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
       └── b = c [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
 
-opt expect=ConsolidateSelectFilters
+opt expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM a WHERE i IS NOT NULL AND i = 3
 AND f > 5 AND f < 15 AND s >= 'bar' AND s <= 'foo'
 ----
@@ -173,7 +173,7 @@ select
  └── filters
       └── (i IS NULL) AND (i IS DISTINCT FROM 5) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
 
-opt expect=ConsolidateSelectFilters
+opt expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM a WHERE s LIKE 'a%' AND s SIMILAR TO 'a_' AND s = 'aa'
 ----
 select
@@ -208,7 +208,7 @@ project
            └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
 
 # Ranges can be merged with other filters to create new ranges.
-norm expect=ConsolidateSelectFilters
+norm expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM (SELECT * FROM a WHERE k = 5) AS a, e WHERE a.k = e.k AND a.k > 1 AND e.k < 10
 ----
 inner-join (hash)
@@ -313,7 +313,7 @@ inner-join (hash)
  └── filters (true)
 
 # Regression test for #42035.
-opt expect=ConsolidateSelectFilters
+opt expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM
       (VALUES ('x', 'x'), ('y', 'y')) AS vab (a, b)
     JOIN
@@ -1383,3 +1383,114 @@ values
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
+
+# --------------------------------------------------
+# InlineConstVar
+# --------------------------------------------------
+
+opt expect=InlineConstVar
+SELECT k FROM b WHERE i=5 AND i IN (1, 2, 3, 4, 5)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan b
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+
+opt expect=InlineConstVar
+SELECT k FROM b WHERE i=8 AND 3 = mod(i, 5)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan b
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i = 8 [type=bool, outer=(2), constraints=(/2: [/8 - /8]; tight), fd=()-->(2)]
+
+opt expect=InlineConstVar
+SELECT k FROM b WHERE i=5 AND i IN (1, 2, 3, 4)
+----
+values
+ ├── columns: k:1(int!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# Case that requires multiple iterations to fully inline.
+opt expect=InlineConstVar
+SELECT * FROM xy WHERE x=y AND y=4 AND x IN (1, 2, 3, 4)
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── constraint: /1: [/4 - /4]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    └── fd: ()-->(1,2)
+ └── filters
+      └── y = 4 [type=bool, outer=(2), constraints=(/2: [/4 - /4]; tight), fd=()-->(2)]
+
+opt expect=InlineConstVar
+SELECT * FROM xy WHERE x=y AND y=4 AND x=3
+----
+values
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+# Can't inline composite types.
+opt expect-not=InlineConstVar
+SELECT * FROM (VALUES (0.0), (0.00), (0.000)) AS v (x) WHERE x = 0 AND x::STRING = '0.00';
+----
+select
+ ├── columns: x:1(decimal!null)
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── columns: column1:1(decimal!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── (0.0,) [type=tuple{decimal}]
+ │    ├── (0.00,) [type=tuple{decimal}]
+ │    └── (0.000,) [type=tuple{decimal}]
+ └── filters
+      ├── column1 = 0 [type=bool, outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+      └── column1::STRING = '0.00' [type=bool, outer=(1)]
+
+# The rule should trigger, but not inline the composite type.
+opt expect=InlineConstVar
+SELECT * FROM (VALUES (0.0, 'a'), (0.00, 'b'), (0.000, 'b')) AS v (x, y) WHERE x = 0 AND x::STRING = '0.00' AND y = 'b' AND y IN ('a', 'b');
+----
+select
+ ├── columns: x:1(decimal!null) y:2(string!null)
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: column1:1(decimal!null) column2:2(string!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── (0.0, 'a') [type=tuple{decimal, string}]
+ │    ├── (0.00, 'b') [type=tuple{decimal, string}]
+ │    └── (0.000, 'b') [type=tuple{decimal, string}]
+ └── filters
+      ├── column1 = 0 [type=bool, outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+      ├── column1::STRING = '0.00' [type=bool, outer=(1)]
+      └── column2 = 'b' [type=bool, outer=(2), constraints=(/2: [/'b' - /'b']; tight), fd=()-->(2)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1490,49 +1490,47 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── project
+ └── semi-join (hash)
       ├── columns: pk:1(int!null) col0:2(int!null) col2:4(int!null) col4:5(int!null)
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1,2,4,5)
-      └── project
-           ├── columns: pk:1(int!null) col0:2(int!null) col2:4(int!null) col4:5(int!null) col0:7(int!null)
-           ├── cardinality: [0 - 1]
-           ├── key: ()
-           ├── fd: ()-->(1,2,4,5,7)
-           └── inner-join (lookup t)
-                ├── columns: pk:1(int!null) col0:2(int!null) col2:4(int!null) col4:5(int!null) col0:7(int!null) col2:9(int)
-                ├── key columns: [1] = [1]
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(1,2,4,5,7,9)
-                ├── inner-join (lookup t@secondary)
-                │    ├── columns: pk:1(int!null) col2:4(int!null) col0:7(int!null) col2:9(int)
-                │    ├── key columns: [7] = [4]
-                │    ├── cardinality: [0 - 1]
-                │    ├── key: ()
-                │    ├── fd: ()-->(1,4,7,9)
-                │    ├── select
-                │    │    ├── columns: col0:7(int!null) col2:9(int)
-                │    │    ├── cardinality: [0 - 1]
-                │    │    ├── key: ()
-                │    │    ├── fd: ()-->(7,9)
-                │    │    ├── index-join t
-                │    │    │    ├── columns: col0:7(int) col2:9(int)
-                │    │    │    ├── lax-key: (7)
-                │    │    │    ├── fd: ()-->(9), (9)~~>(7)
-                │    │    │    └── scan t@secondary
-                │    │    │         ├── columns: pk:6(int!null) col2:9(int)
-                │    │    │         ├── constraint: /9: [/NULL - /NULL]
-                │    │    │         ├── key: (6)
-                │    │    │         └── fd: ()-->(9), (9)~~>(6)
-                │    │    └── filters
-                │    │         └── col0 = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
-                │    └── filters
-                │         └── col2 = 1 [type=bool, outer=(4), constraints=(/4: [/1 - /1]; tight), fd=()-->(4)]
-                └── filters
-                     ├── col4 = 1 [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
-                     └── col0 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      ├── select
+      │    ├── columns: pk:1(int!null) col0:2(int!null) col2:4(int!null) col4:5(int!null)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1,2,4,5)
+      │    ├── index-join t
+      │    │    ├── columns: pk:1(int!null) col0:2(int) col2:4(int) col4:5(int)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2,4,5)
+      │    │    └── scan t@secondary
+      │    │         ├── columns: pk:1(int!null) col2:4(int!null)
+      │    │         ├── constraint: /4: [/1 - /1]
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         └── fd: ()-->(1,4)
+      │    └── filters
+      │         ├── col4 = 1 [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+      │         └── col0 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      ├── select
+      │    ├── columns: col0:7(int!null) col2:9(int)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7,9)
+      │    ├── index-join t
+      │    │    ├── columns: col0:7(int) col2:9(int)
+      │    │    ├── lax-key: (7)
+      │    │    ├── fd: ()-->(9), (9)~~>(7)
+      │    │    └── scan t@secondary
+      │    │         ├── columns: pk:6(int!null) col2:9(int)
+      │    │         ├── constraint: /9: [/NULL - /NULL]
+      │    │         ├── key: (6)
+      │    │         └── fd: ()-->(9), (9)~~>(6)
+      │    └── filters
+      │         └── col0 = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── filters (true)
 
 # --------------------------------------------------
 # GenerateZigZagJoins

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -138,18 +138,15 @@ SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
 project
  ├── columns: k:1(int!null)
- ├── key: (1)
- └── select
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── scan a@u
       ├── columns: k:1(int!null) u:2(int!null)
-      ├── key: (1)
-      ├── fd: ()-->(2)
-      ├── scan a@u
-      │    ├── columns: k:1(int!null) u:2(int!null)
-      │    ├── constraint: /2/1: [/1 - /1]
-      │    ├── key: (1)
-      │    └── fd: ()-->(2)
-      └── filters
-           └── (k + u) = 1 [type=bool, outer=(1,2)]
+      ├── constraint: /2/1: [/1/0 - /1/0]
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      └── fd: ()-->(1,2)
 
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
@@ -158,28 +155,28 @@ memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
- │         └── cost: 10.66
- ├── G2: (select G4 G5) (select G6 G7)
+ │         └── cost: 1.07
+ ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
  │    └── []
- │         ├── best: (select G6 G7)
- │         └── cost: 10.62
+ │         ├── best: (scan a@u,cols=(1,2),constrained)
+ │         └── cost: 1.05
  ├── G3: (projections)
  ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── []
  │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1050.02
  ├── G5: (filters G8 G9)
- ├── G6: (scan a@u,cols=(1,2),constrained)
+ ├── G6: (scan a,cols=(1,2),constrained)
  │    └── []
- │         ├── best: (scan a@u,cols=(1,2),constrained)
- │         └── cost: 10.51
- ├── G7: (filters G9)
+ │         ├── best: (scan a,cols=(1,2),constrained)
+ │         └── cost: 1.06
+ ├── G7: (filters G8)
  ├── G8: (eq G10 G11)
- ├── G9: (eq G12 G11)
+ ├── G9: (eq G12 G13)
  ├── G10: (variable u)
  ├── G11: (const 1)
- ├── G12: (plus G13 G10)
- └── G13: (variable k)
+ ├── G12: (variable k)
+ └── G13: (const 0)
 
 opt
 SELECT k FROM a WHERE u = 1 AND v = 5


### PR DESCRIPTION
This optimization came from a discussion in Slack, I understand it's
helpful for a kv project that's ongoing.

Depending on the day of the week I may or may not find it obvious to
justify the correctness of this optimization, but I think the easiest
way to see it is to separate the two relevant filters into two composed
Selects:

Instead of

    SELECT * FROM t WHERE a = D AND f(a),

think of it as

    SELECT * FROM
      (SELECT * FROM t WHERE a = D)
    WHERE f(a),

and then I think it's more obvious that this is equivalent to

    SELECT * FROM
      (SELECT * FROM t WHERE a = D)
    WHERE f(D),

and thus

    SELECT * FROM t WHERE a = D AND f(D)

Release note: none

cc @ajwerner @aayushshah15 