### PR TITLE
opt: fix bug in GenerateConstrainedScans related to partitioning

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -492,7 +492,7 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	checkFilters := c.checkConstraintFilters(scanPrivate.Table)
 
 	// Consider the checkFilters as well to constrain each of the indexes.
-	filters := append(explicitFilters, checkFilters...)
+	explicitAndCheckFilters := append(explicitFilters, checkFilters...)
 
 	// Iterate over all indexes.
 	var iter scanIndexIter
@@ -500,28 +500,31 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	tabMeta := md.TableMeta(scanPrivate.Table)
 	iter.init(c.e.mem, scanPrivate)
 	for iter.next() {
-		var isIndexPartitioned bool
+		// We may append to this slice below; avoid any potential aliasing by
+		// limiting its capacity (forcing append to reallocate).
+		filters := explicitAndCheckFilters[:len(explicitAndCheckFilters):len(explicitAndCheckFilters)]
 		indexColumns := tabMeta.IndexKeyColumns(iter.indexOrdinal)
 		filterColumns := c.FilterOuterCols(filters)
 		firstIndexCol := scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)
-		var constrainedInBetweenFilters memo.FiltersExpr
 
 		// We only consider the partition values when a particular index can otherwise
 		// not be constrained. For indexes that are constrained, the partitioned values
 		// add no benefit as they don't really constrain anything.
 		// Furthermore, if the filters don't take advantage of the index (use any of the
 		// index columns), using the partition values add no benefit.
+		var constrainedInBetweenFilters memo.FiltersExpr
+		var isIndexPartitioned bool
 		if !filterColumns.Contains(firstIndexCol) && indexColumns.Intersects(filterColumns) {
 			// Add any partition filters if appropriate.
 			partitionFilters, inBetweenFilters := c.partitionValuesFilters(scanPrivate.Table, iter.index)
 
-			// We must add the filters so when we generate the inBetween spans, they are
-			// also constrained. This is also needed so the remaining filters are generated
-			// correctly using the in between spans (some remaining filters may be blown
-			// by the partition constraints).
-			constrainedInBetweenFilters = append(inBetweenFilters, filters...)
-			filters = append(filters, partitionFilters...)
 			if len(partitionFilters) > 0 {
+				// We must add the filters so when we generate the inBetween spans, they are
+				// also constrained. This is also needed so the remaining filters are generated
+				// correctly using the in between spans (some remaining filters may be blown
+				// by the partition constraints).
+				constrainedInBetweenFilters = append(inBetweenFilters, filters...)
+				filters = append(filters, partitionFilters...)
 				isIndexPartitioned = true
 			}
 		}

--- a/pkg/sql/opt/xform/testdata/rules/partitioned
+++ b/pkg/sql/opt/xform/testdata/rules/partitioned
@@ -45,3 +45,29 @@ explain
       │    └── key: (1-4)
       └── filters
            └── val = 1 [type=bool, outer=(4), constraints=(/4: [/1 - /1]; tight), fd=()-->(4)]
+
+# Regression test for #42147.
+exec-ddl
+CREATE TABLE tab42147 (
+  id INT8 NOT NULL,
+  locality STRING,
+  CONSTRAINT pk PRIMARY KEY (locality ASC, id ASC),
+  CONSTRAINT id UNIQUE (id ASC)
+)
+  PARTITION BY LIST (locality)
+    (
+      PARTITION uswest VALUES IN ('us-west'),
+      PARTITION uscentral VALUES IN ('us-central'),
+      PARTITION asiasoutheast VALUES IN ('asia-southeast')
+    )
+----
+
+opt
+SELECT id FROM tab42147 WHERE id = 1
+----
+scan tab42147@id
+ ├── columns: id:1(int!null)
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1)


### PR DESCRIPTION
In this release we added code that can use partitioning values to
generate better index spans in some cases (#38963).

This change addresses a bug in this code - we add to `filters` with
the intention that it will be used by this index, but the variable is
defined outside of the loop so the next index gets some bogus filters.
The results is an invalid plan that cannot be executed.

Fixes #42147.

Release note (bug fix): Fixed a "cannot map variable to an indexed
var" error when executing certain queries against partitioned tables.