### PR TITLE
colexec: fix sorted distinct with nulls behavior

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -86,6 +86,8 @@ func (b *Bytes) maybeBackfillOffsets(i int) {
 
 // Get returns the ith []byte in Bytes. Note that the returned byte slice is
 // unsafe for reuse if any write operation happens.
+// NOTE: if ith element was never set in any way, the behavior of Get is
+// undefined.
 func (b *Bytes) Get(i int) []byte {
 	return b.data[b.offsets[i]:b.offsets[i+1]]
 }


### PR DESCRIPTION
Previously, sorted distinct when the nulls might be present would always
get the value at the index without paying attention whether that value
is actually now. This is incorrect behavior because it is undefined in
some cases (like when getting from flat bytes). Now this is fixed.

Fixes: #42055.

Release note: None