### PR TITLE
cli/cliflags: add COCKROACH_STORAGE_ENGINE env var

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -699,6 +699,7 @@ Also, if you use equal signs in the file path to a store, you must use the
 Storage engine to use for all stores on this cockroach node. Options are rocksdb
 (default), or pebble.
 `,
+		EnvVar: "COCKROACH_STORAGE_ENGINE",
 	}
 
 	Size = FlagInfo{


### PR DESCRIPTION
`roachprod` passes through COCKROACH_* env vars allowing
`COCKROACH_STORAGE_ENGINE=pebble roachprod start` to work.

Fixes #41620

Release note (cli change): Add COCKROACH_STORAGE_ENGINE env var which
is tied to the `--storage-engine` flag. Allows selection of "pebble" as
an alternative to the default of "rocksdb".