### PR TITLE
release-19.2: opt: don't zigzag redundantly

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1449,18 +1449,22 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 		if iter.indexOrdinal == cat.PrimaryIndex {
 			continue
 		}
+
+		leftFixed := c.indexConstrainedCols(iter.index, scanPrivate.Table, fixedCols)
 		// Short-circuit quickly if the first column in the index is not a fixed
 		// column.
-		if !fixedCols.Contains(scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)) {
+		if leftFixed.Len() == 0 {
 			continue
 		}
-
 		iter2.init(c.e.mem, scanPrivate)
 		// Only look at indexes after this one.
 		iter2.indexOrdinal = iter.indexOrdinal
 
 		for iter2.next() {
-			if !fixedCols.Contains(scanPrivate.Table.ColumnID(iter2.index.Column(0).Ordinal)) {
+			rightFixed := c.indexConstrainedCols(iter2.index, scanPrivate.Table, fixedCols)
+			// If neither side contributes a fixed column not contributed by the
+			// other, then there's no reason to zigzag on this pair of indexes.
+			if leftFixed.SubsetOf(rightFixed) || rightFixed.SubsetOf(leftFixed) {
 				continue
 			}
 			// Columns that are in both indexes are, by definition, equal.
@@ -1621,6 +1625,23 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 			c.e.mem.AddLookupJoinToGroup(&indexJoin, grp)
 		}
 	}
+}
+
+// indexConstrainedCols computes the set of columns in allFixedCols which form
+// a prefix of the key columns in idx.
+func (c *CustomFuncs) indexConstrainedCols(
+	idx cat.Index, tab opt.TableID, allFixedCols opt.ColSet,
+) opt.ColSet {
+	var constrained opt.ColSet
+	for i, n := 0, idx.ColumnCount(); i < n; i++ {
+		col := tab.ColumnID(idx.Column(i).Ordinal)
+		if allFixedCols.Contains(col) {
+			constrained.Add(col)
+		} else {
+			break
+		}
+	}
+	return constrained
 }
 
 // GenerateInvertedIndexZigzagJoins generates zigzag joins for constraints on

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -57,6 +57,16 @@ CREATE TABLE zz (
 )
 ----
 
+exec-ddl
+CREATE TABLE zz_redundant (
+    a INT8 PRIMARY KEY,
+    b INT8 NULL,
+    c INT8 NULL,
+    INDEX idx_u (b ASC, c ASC),
+    INDEX idx_v (b ASC, c ASC)
+)
+----
+
 # --------------------------------------------------
 # CommuteJoin
 # --------------------------------------------------
@@ -1850,8 +1860,8 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
- ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G8 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G9 G7 pqr,keyCols=[1],outCols=(1-4)) (select G10 G11) (select G12 G13) (select G14 G7) (select G15 G7)
+memo (optimized, ~30KB, required=[presentation: p:1,q:2,r:3,s:4])
+ ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (select G8 G9) (select G10 G11) (select G12 G7) (select G13 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
  │         └── cost: 0.01
@@ -1859,73 +1869,65 @@ memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
  │    └── []
  │         ├── best: (scan pqr,cols=(1-4))
  │         └── cost: 1090.02
- ├── G3: (filters G16 G17 G18)
- ├── G4: (zigzag-join G19 pqr@q pqr@r)
+ ├── G3: (filters G14 G15 G16)
+ ├── G4: (zigzag-join G17 pqr@q pqr@r)
  │    └── []
- │         ├── best: (zigzag-join G19 pqr@q pqr@r)
+ │         ├── best: (zigzag-join G17 pqr@q pqr@r)
  │         └── cost: 0.21
- ├── G5: (filters G18)
- ├── G6: (zigzag-join G11 pqr@r pqr@s)
+ ├── G5: (filters G16)
+ ├── G6: (zigzag-join G9 pqr@r pqr@s)
  │    └── []
- │         ├── best: (zigzag-join G11 pqr@r pqr@s)
+ │         ├── best: (zigzag-join G9 pqr@r pqr@s)
  │         └── cost: 0.22
- ├── G7: (filters G16)
- ├── G8: (zigzag-join G11 pqr@r pqr@rs)
+ ├── G7: (filters G14)
+ ├── G8: (index-join G18 pqr,cols=(1-4))
  │    └── []
- │         ├── best: (zigzag-join G11 pqr@r pqr@rs)
- │         └── cost: 0.22
- ├── G9: (zigzag-join G11 pqr@s pqr@rs)
+ │         ├── best: (index-join G18 pqr,cols=(1-4))
+ │         └── cost: 50.91
+ ├── G9: (filters G15 G16)
+ ├── G10: (index-join G19 pqr,cols=(1-4))
  │    └── []
- │         ├── best: (zigzag-join G11 pqr@s pqr@rs)
- │         └── cost: 0.22
- ├── G10: (index-join G20 pqr,cols=(1-4))
+ │         ├── best: (index-join G19 pqr,cols=(1-4))
+ │         └── cost: 50.91
+ ├── G11: (filters G14 G16)
+ ├── G12: (index-join G20 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G20 pqr,cols=(1-4))
- │         └── cost: 50.91
- ├── G11: (filters G17 G18)
- ├── G12: (index-join G21 pqr,cols=(1-4))
+ │         └── cost: 14.87
+ ├── G13: (index-join G21 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G21 pqr,cols=(1-4))
- │         └── cost: 50.91
- ├── G13: (filters G16 G18)
- ├── G14: (index-join G22 pqr,cols=(1-4))
- │    └── []
- │         ├── best: (index-join G22 pqr,cols=(1-4))
- │         └── cost: 14.87
- ├── G15: (index-join G23 pqr,cols=(1-4))
- │    └── []
- │         ├── best: (index-join G23 pqr,cols=(1-4))
  │         └── cost: 0.53
- ├── G16: (eq G24 G25)
- ├── G17: (eq G26 G25)
- ├── G18: (eq G27 G28)
- ├── G19: (filters G16 G17)
- ├── G20: (scan pqr@q,cols=(1,2),constrained)
+ ├── G14: (eq G22 G23)
+ ├── G15: (eq G24 G23)
+ ├── G16: (eq G25 G26)
+ ├── G17: (filters G14 G15)
+ ├── G18: (scan pqr@q,cols=(1,2),constrained)
  │    └── []
  │         ├── best: (scan pqr@q,cols=(1,2),constrained)
  │         └── cost: 10.31
- ├── G21: (scan pqr@r,cols=(1,3),constrained)
+ ├── G19: (scan pqr@r,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan pqr@r,cols=(1,3),constrained)
  │         └── cost: 10.31
- ├── G22: (select G29 G30)
+ ├── G20: (select G27 G28)
  │    └── []
- │         ├── best: (select G29 G30)
+ │         ├── best: (select G27 G28)
  │         └── cost: 10.61
- ├── G23: (scan pqr@rs,cols=(1,3,4),constrained)
+ ├── G21: (scan pqr@rs,cols=(1,3,4),constrained)
  │    └── []
  │         ├── best: (scan pqr@rs,cols=(1,3,4),constrained)
  │         └── cost: 0.11
- ├── G24: (variable q)
- ├── G25: (const 1)
- ├── G26: (variable r)
- ├── G27: (variable s)
- ├── G28: (const 'foo')
- ├── G29: (scan pqr@s,cols=(1,3,4),constrained)
+ ├── G22: (variable q)
+ ├── G23: (const 1)
+ ├── G24: (variable r)
+ ├── G25: (variable s)
+ ├── G26: (const 'foo')
+ ├── G27: (scan pqr@s,cols=(1,3,4),constrained)
  │    └── []
  │         ├── best: (scan pqr@s,cols=(1,3,4),constrained)
  │         └── cost: 10.50
- └── G30: (filters G17)
+ └── G28: (filters G15)
 
 # Zigzag joins cannot be planned for indexes where equality columns do not
 # immediately follow fixed columns. Here, the only index on t is (t,s,p) and
@@ -1984,6 +1986,29 @@ memo (optimized, ~9KB, required=[presentation: q:2,t:5])
  ├── G13: (const 1)
  ├── G14: (variable t)
  └── G15: (const 'foo')
+
+# Don't zigzag on two identical indexes.
+memo
+SELECT c FROM zz_redundant WHERE b = 1
+----
+memo (optimized, ~6KB, required=[presentation: c:3])
+ ├── G1: (project G2 G3 c)
+ │    └── [presentation: c:3]
+ │         ├── best: (project G2 G3 c)
+ │         └── cost: 10.51
+ ├── G2: (select G4 G5) (scan zz_redundant@idx_u,cols=(2,3),constrained) (scan zz_redundant@idx_v,cols=(2,3),constrained)
+ │    └── []
+ │         ├── best: (scan zz_redundant@idx_u,cols=(2,3),constrained)
+ │         └── cost: 10.41
+ ├── G3: (projections)
+ ├── G4: (scan zz_redundant,cols=(2,3)) (scan zz_redundant@idx_u,cols=(2,3)) (scan zz_redundant@idx_v,cols=(2,3))
+ │    └── []
+ │         ├── best: (scan zz_redundant,cols=(2,3))
+ │         └── cost: 1050.02
+ ├── G5: (filters G6)
+ ├── G6: (eq G7 G8)
+ ├── G7: (variable b)
+ └── G8: (const 1)
 
 # --------------------------
 # GenerateInvertedIndexZigzagJoins


### PR DESCRIPTION
Backport 1/1 commits from #42159.

/cc @cockroachdb/release

---

Previously, we would zigzag on any pair of indexes where both had a
prefix constrained by the fixed cols. This restriction can be
strengthened: it's pointless to zigzag on any pair of indexes where the
fixed cols of one are a subset of the fixed cols of another. Adding this
restriction prevents cases like zigzagging on two identical indexes
(which can come up in certain stats scenarios that I do not fully
understand yet).

Release note (sql change): Restricted the set of zigzag joins that are
planned to those which have a chance at being beneficial.
