### PR TITLE
storage: fix test ReplicaGCRace flake

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2879,7 +2879,11 @@ func TestReplicaGCRace(t *testing.T) {
 	// Send the heartbeat. Boom. See #11591.
 	// We have to send this multiple times to protect against
 	// dropped messages (see #18355).
-	if sent := fromTransport.SendAsync(&hbReq, rpc.DefaultClass); !sent {
+	sendHeartbeat := func() (sent bool) {
+		r := hbReq
+		return fromTransport.SendAsync(&r, rpc.DefaultClass)
+	}
+	if sent := sendHeartbeat(); !sent {
 		t.Fatal("failed to send heartbeat")
 	}
 	heartbeatsSent := 1
@@ -2899,7 +2903,7 @@ func TestReplicaGCRace(t *testing.T) {
 			t.Fatal("did not get expected error")
 		}
 		heartbeatsSent++
-		if sent := fromTransport.SendAsync(&hbReq, rpc.DefaultClass); !sent {
+		if sent := sendHeartbeat(); !sent {
 			t.Fatal("failed to send heartbeat")
 		}
 	}


### PR DESCRIPTION
I'm not totally clear on where the underlying slice of heartbeats gets
truncated but it definitely does. This commit fixes the flake by sending
a copy of the struct rather than the struct itself. The test used to
flake in a few hundred runs, after this change it does not fail.

Fixes #41809.

Release note: None.