### PR TITLE
vendor: bump pebble to 857cfddc5fc96477a6e38ca8ebba10f65ca82729

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f228e06bfbeffb59fcdac4a271a0f8b59cf56cb50b9856de066df328beb24d49"
+  digest = "1:18d8484196d0aca8afe89d6ec480144373bf653b5cf4c79dd7cda0ccbf09d270"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -495,7 +495,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "58fbf96a8f51843163a39ca14410f8a4d81762f4"
+  revision = "857cfddc5fc96477a6e38ca8ebba10f65ca82729"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Picks up the `batchskl` optimizations which speed up the
`MVCCBatchApplyBatchRepr` benchmarks.

```
name                                                                                old time/op    new time/op    delta
BatchApplyBatchRepr_Pebble/indexed=false/seq=false/valueSize=10/batchSize=10000-16     185µs ± 2%     148µs ± 2%   -19.86%  (p=0.000 n=9+9)
BatchApplyBatchRepr_Pebble/indexed=false/seq=true/valueSize=10/batchSize=10000-16      185µs ± 2%     152µs ± 3%   -17.79%  (p=0.000 n=10+10)
BatchApplyBatchRepr_Pebble/indexed=true/seq=false/valueSize=10/batchSize=10000-16     2.09ms ± 3%    1.59ms ± 2%   -23.75%  (p=0.000 n=10+10)
BatchApplyBatchRepr_Pebble/indexed=true/seq=true/valueSize=10/batchSize=10000-16      1.42ms ± 2%    0.55ms ± 1%   -61.53%  (p=0.000 n=10+8)
```

Release note: None