### PR TITLE
colexec: clean up remapping of indexed vars for filter expressions

### DIFF
--- a/pkg/sql/execinfra/expr.go
+++ b/pkg/sql/execinfra/expr.go
@@ -143,12 +143,21 @@ func (eh *ExprHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 func (eh *ExprHelper) Init(
 	expr execinfrapb.Expression, types []types.T, evalCtx *tree.EvalContext,
 ) error {
+	return eh.InitWithRemapping(expr, types, evalCtx, nil /* indexVarMap */)
+}
+
+// InitWithRemapping initializes the ExprHelper.
+// indexVarMap specifies an optional (i.e. it can be left nil) map that will be
+// used to remap the indices of IndexedVars before binding them to a container.
+func (eh *ExprHelper) InitWithRemapping(
+	expr execinfrapb.Expression, types []types.T, evalCtx *tree.EvalContext, indexVarMap []int,
+) error {
 	if expr.Empty() {
 		return nil
 	}
 	eh.evalCtx = evalCtx
 	eh.Types = types
-	eh.Vars = tree.MakeIndexedVarHelper(eh, len(types))
+	eh.Vars = tree.MakeIndexedVarHelperWithRemapping(eh, len(types), indexVarMap)
 
 	if expr.LocalExpr != nil {
 		eh.Expr = expr.LocalExpr

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -124,3 +124,34 @@ x     y
 NULL  NULL
 NULL  42
 NULL  44
+
+# Regression test for #41407.
+statement ok
+CREATE TABLE t41407 AS
+	SELECT
+		g AS _float8,
+		g % 0 = 0 AS _bool,
+		g AS _decimal,
+		g AS _string,
+		g AS _bytes
+	FROM
+		generate_series(NULL, NULL) AS g;
+
+query TRTTRRBR
+SELECT
+  tab_1688._bytes,
+  tab_1688._float8,
+  tab_1689._string,
+  tab_1689._string,
+  tab_1688._float8,
+  tab_1688._float8,
+  tab_1689._bool,
+  tab_1690._decimal
+FROM
+  t41407 AS tab_1688
+  JOIN t41407 AS tab_1689
+    JOIN t41407 AS tab_1690 ON
+        tab_1689._bool = tab_1690._bool ON
+      tab_1688._float8 = tab_1690._float8
+      AND tab_1688._bool = tab_1689._bool;
+----

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -34,9 +34,8 @@ type IndexedVarContainer interface {
 // represents a dynamic value. It defers calls to TypeCheck, Eval, String to an
 // IndexedVarContainer.
 type IndexedVar struct {
-	Idx         int
-	Used        bool
-	bindInPlace bool
+	Idx  int
+	Used bool
 
 	col NodeFormatter
 
@@ -164,13 +163,6 @@ func (h *IndexedVarHelper) BindIfUnbound(ivar *IndexedVar) (*IndexedVar, error) 
 	}
 
 	if !ivar.Used {
-		if ivar.bindInPlace {
-			// This container must also remember it has "seen" the variable
-			// so that IndexedVarUsed() below returns the right results.
-			// The IndexedVar() method ensures this.
-			*ivar = *h.IndexedVar(ivarIdx)
-			return ivar, nil
-		}
 		return h.IndexedVar(ivarIdx), nil
 	}
 	return ivar, nil

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -119,11 +119,33 @@ func NewTypedOrdinalReference(r int, typ *types.T) *IndexedVar {
 type IndexedVarHelper struct {
 	vars      []IndexedVar
 	container IndexedVarContainer
+
+	// indexVarMap is an optional mapping for indices of IndexedVars. If it is
+	// not nil, it will be used to determine the "actual index" of an IndexedVar
+	// before binding - instead of using ivar.Idx, a new IndexedVar will have
+	// indexVarMap[ivar.Idx] as its index.
+	indexVarMap []int
 }
 
 // Container returns the container associated with the helper.
 func (h *IndexedVarHelper) Container() IndexedVarContainer {
 	return h.container
+}
+
+// getIndex is a helper function that returns an "actual index" of the
+// IndexedVar.
+func (h *IndexedVarHelper) getIndex(ivar *IndexedVar) int {
+	if ivar.Used {
+		// ivar has already been bound, so the remapping step (if it was needed)
+		// has already occurred.
+		return ivar.Idx
+	}
+	if h.indexVarMap != nil {
+		// indexVarMap is non-nil, so we need to remap the index.
+		return h.indexVarMap[ivar.Idx]
+	}
+	// indexVarMap is nil, so we return the index as is.
+	return ivar.Idx
 }
 
 // BindIfUnbound ensures the IndexedVar is attached to this helper's container.
@@ -135,9 +157,10 @@ func (h *IndexedVarHelper) BindIfUnbound(ivar *IndexedVar) (*IndexedVar, error) 
 	// We perform the range check always, even if the ivar is already
 	// bound, as a form of safety assertion against misreuse of ivars
 	// across containers.
-	if ivar.Idx < 0 || ivar.Idx >= len(h.vars) {
+	ivarIdx := h.getIndex(ivar)
+	if ivarIdx < 0 || ivarIdx >= len(h.vars) {
 		return ivar, pgerror.Newf(
-			pgcode.UndefinedColumn, "invalid column ordinal: @%d", ivar.Idx+1)
+			pgcode.UndefinedColumn, "invalid column ordinal: @%d", ivarIdx+1)
 	}
 
 	if !ivar.Used {
@@ -145,17 +168,30 @@ func (h *IndexedVarHelper) BindIfUnbound(ivar *IndexedVar) (*IndexedVar, error) 
 			// This container must also remember it has "seen" the variable
 			// so that IndexedVarUsed() below returns the right results.
 			// The IndexedVar() method ensures this.
-			*ivar = *h.IndexedVar(ivar.Idx)
+			*ivar = *h.IndexedVar(ivarIdx)
 			return ivar, nil
 		}
-		return h.IndexedVar(ivar.Idx), nil
+		return h.IndexedVar(ivarIdx), nil
 	}
 	return ivar, nil
 }
 
 // MakeIndexedVarHelper initializes an IndexedVarHelper structure.
 func MakeIndexedVarHelper(container IndexedVarContainer, numVars int) IndexedVarHelper {
-	return IndexedVarHelper{vars: make([]IndexedVar, numVars), container: container}
+	return MakeIndexedVarHelperWithRemapping(container, numVars, nil /* indexVarMap */)
+}
+
+// MakeIndexedVarHelperWithRemapping initializes an IndexedVarHelper structure.
+// An optional (it can be left nil) indexVarMap argument determines a mapping
+// for indices of IndexedVars (see comment above for more details).
+func MakeIndexedVarHelperWithRemapping(
+	container IndexedVarContainer, numVars int, indexVarMap []int,
+) IndexedVarHelper {
+	return IndexedVarHelper{
+		vars:        make([]IndexedVar, numVars),
+		container:   container,
+		indexVarMap: indexVarMap,
+	}
 }
 
 // AppendSlot expands the capacity of this IndexedVarHelper by one and returns
@@ -252,7 +288,8 @@ var _ Visitor = &IndexedVarHelper{}
 // VisitPre implements the Visitor interface.
 func (h *IndexedVarHelper) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if iv, ok := expr.(*IndexedVar); ok {
-		return false, h.IndexedVar(iv.Idx)
+		ivarIdx := h.getIndex(iv)
+		return false, h.IndexedVar(ivarIdx)
 	}
 	return true, expr
 }


### PR DESCRIPTION
**colexec: fix handling of filters by joiners**

Previously, in order to handle ON expression of the joiners, we would
modify the expression itself (i.e. we would remap the IndexedVars inside
of the expression). However, this approach is error-prone and doesn't
work in all cases (consider an example when we have a filter like
"@1 = 'abc@2def'" - @2 is not an ordinal, but it would get treated as an
IndexedVar with index 1). Now we have enhanced the IndexedVarHelper to
handle the remapping internally when the IndexedVar is being bound to
a container. This way no modifications to the actual expressions are
needed, and such approach should work in all cases.

Fixes: #41407.
Fixes: #41944.
Fixes: #42100.

**sem/tree: remove unused field from IndexedVar**

This commit removes 'bindInPlace' field from IndexedVar struct since it
is not being used anywhere.

Release note: None