### PR TITLE
sqlsmith: error if a table has zero columns

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -70,7 +70,7 @@ func registerSQLSmith(r *testRegistry) {
 		until := time.After(t.spec.Timeout / 2)
 		done := ctx.Done()
 		for i := 1; ; i++ {
-			if i%500 == 0 {
+			if i%10000 == 0 {
 				t.Status("smithing: ", i, " statements completed")
 			}
 			select {
@@ -122,7 +122,6 @@ func registerSQLSmith(r *testRegistry) {
 
 	register := func(setup, setting string) {
 		r.Add(testSpec{
-			Skip:    "https://github.com/cockroachdb/cockroach/issues/42109",
 			Name:    fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			Cluster: makeClusterSpec(4),
 			Timeout: time.Minute * 20,


### PR DESCRIPTION
The below bug occurred because sqlsmith panic'd during makeUpdate because
it didn't have any update expressions. Examining the code, this can only
happen if the fetched table ref has no columns.

I'm not sure how this happened and have not been able to reproduce it. Add
a normal error check during smith init that should prevent a table from
being added that has no columns, which should prevent this error.

Fixes #42109

Release note: None