### PR TITLE
server: add concept of StickyInMemEngine

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -162,6 +162,12 @@ type StoreSpec struct {
 	Size       SizeSpec
 	InMemory   bool
 	Attributes roachpb.Attributes
+	// StickyInMemoryEngineID is a unique identifier associated with a given
+	// store which will remain in memory even after the default Engine close
+	// until it has been explicitly cleaned up by CleanupStickyInMemEngine[s]
+	// or the process has been terminated.
+	// This only applies to in-memory storage engine.
+	StickyInMemoryEngineID string
 	// UseFileRegistry is true if the "file registry" store version is desired.
 	// This is set by CCL code when encryption-at-rest is in use.
 	UseFileRegistry bool

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -476,7 +476,17 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			}
 			details = append(details, fmt.Sprintf("store %d: in-memory, size %s",
 				i, humanizeutil.IBytes(sizeInBytes)))
-			engines = append(engines, engine.NewInMem(cfg.StorageEngine, spec.Attributes, sizeInBytes))
+			if spec.StickyInMemoryEngineID != "" {
+				e, err := getOrCreateStickyInMemEngine(
+					ctx, spec.StickyInMemoryEngineID, cfg.StorageEngine, spec.Attributes, sizeInBytes,
+				)
+				if err != nil {
+					return Engines{}, err
+				}
+				engines = append(engines, e)
+			} else {
+				engines = append(engines, engine.NewInMem(cfg.StorageEngine, spec.Attributes, sizeInBytes))
+			}
 		} else {
 			if spec.Size.Percent > 0 {
 				fileSystemUsage := gosigar.FileSystemUsage{}

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -1,0 +1,133 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
+)
+
+// stickyInMemEngine extends a normal engine, but does not allow them to be
+// closed using the normal Close() method, instead keeping the engines in
+// memory until CloseAllStickyInMemEngines is called, hence being "sticky".
+// This prevents users of the in memory engine from having to special
+// case "sticky" engines on every instance of "Close".
+// It is intended for use in demos and/or tests, where we want in-memory
+// storage nodes to persist between killed nodes.
+type stickyInMemEngine struct {
+	// id is the unique identifier for this sticky engine.
+	id string
+	// closed indicates whether the current engine has been closed.
+	closed bool
+
+	// Engine extends the Engine interface.
+	engine.Engine
+}
+
+// stickyInMemEngine implements Engine.
+var _ engine.Engine = &stickyInMemEngine{}
+
+// Close overwrites the default Engine interface to not close the underlying
+// engine if called. We mark the state as closed to reflect a correct result
+// in Closed().
+func (e *stickyInMemEngine) Close() {
+	e.closed = true
+}
+
+// Closed overwrites the default Engine interface.
+func (e *stickyInMemEngine) Closed() bool {
+	return e.closed
+}
+
+// stickyInMemEnginesRegistryImpl is the bookkeeper for all active
+// sticky engines, keyed by their id.
+type stickyInMemEnginesRegistryImpl struct {
+	entries map[string]*stickyInMemEngine
+	mu      syncutil.Mutex
+}
+
+var stickyInMemEnginesRegistry = &stickyInMemEnginesRegistryImpl{
+	entries: map[string]*stickyInMemEngine{},
+}
+
+// getOrCreateStickyInMemEngine returns an engine associated with the given id.
+// It will create a new in-memory engine if one does not already exist.
+// At most one engine with a given id can be active in
+// "getOrCreateStickyInMemEngine" at any given time.
+// Note that if you re-create an existing sticky engine the new attributes
+// and cache size will be ignored.
+// One must Close() on the sticky engine before another can be fetched.
+func getOrCreateStickyInMemEngine(
+	ctx context.Context,
+	id string,
+	engineType enginepb.EngineType,
+	attrs roachpb.Attributes,
+	cacheSize int64,
+) (engine.Engine, error) {
+	stickyInMemEnginesRegistry.mu.Lock()
+	defer stickyInMemEnginesRegistry.mu.Unlock()
+
+	if engine, ok := stickyInMemEnginesRegistry.entries[id]; ok {
+		if !engine.closed {
+			return nil, errors.Errorf("sticky engine %s has not been closed", id)
+		}
+
+		log.Infof(ctx, "re-using sticky in-mem engine %s", id)
+		engine.closed = false
+		return engine, nil
+	}
+
+	log.Infof(ctx, "creating new sticky in-mem engine %s", id)
+	engine := &stickyInMemEngine{
+		id:     id,
+		closed: false,
+		Engine: engine.NewInMem(engineType, attrs, cacheSize),
+	}
+	stickyInMemEnginesRegistry.entries[id] = engine
+	return engine, nil
+}
+
+// CloseStickyInMemEngine closes the underlying engine and
+// removes the sticky engine keyed by the given id.
+// It will error if it does not exist.
+func CloseStickyInMemEngine(id string) error {
+	stickyInMemEnginesRegistry.mu.Lock()
+	defer stickyInMemEnginesRegistry.mu.Unlock()
+
+	if engine, ok := stickyInMemEnginesRegistry.entries[id]; ok {
+		engine.closed = true
+		engine.Engine.Close()
+		delete(stickyInMemEnginesRegistry.entries, id)
+		return nil
+	}
+	return errors.Errorf("sticky in-mem engine %s does not exist", id)
+}
+
+// CloseAllStickyInMemEngines closes and removes all sticky in memory engines.
+func CloseAllStickyInMemEngines() {
+	stickyInMemEnginesRegistry.mu.Lock()
+	defer stickyInMemEnginesRegistry.mu.Unlock()
+
+	for _, engine := range stickyInMemEnginesRegistry.entries {
+		engine.closed = true
+		engine.Engine.Close()
+	}
+
+	for id := range stickyInMemEnginesRegistry.entries {
+		delete(stickyInMemEnginesRegistry.entries, id)
+	}
+}

--- a/pkg/server/sticky_engine_test.go
+++ b/pkg/server/sticky_engine_test.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStickyEngines(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	engineType := enginepb.EngineTypeRocksDB
+	attrs := roachpb.Attributes{}
+	cacheSize := int64(1 << 20)
+
+	engine1, err := getOrCreateStickyInMemEngine(ctx, "engine1", engineType, attrs, cacheSize)
+	require.NoError(t, err)
+	require.False(t, engine1.Closed())
+
+	engine2, err := getOrCreateStickyInMemEngine(ctx, "engine2", engineType, attrs, cacheSize)
+	require.NoError(t, err)
+	require.False(t, engine2.Closed())
+
+	// Regetting the engine whilst it is not closed will fail.
+	_, err = getOrCreateStickyInMemEngine(ctx, "engine1", engineType, attrs, cacheSize)
+	require.EqualError(t, err, "sticky engine engine1 has not been closed")
+
+	// Close the engine, which allows it to be refetched.
+	engine1.Close()
+	require.True(t, engine1.Closed())
+	require.False(t, engine1.(*stickyInMemEngine).Engine.Closed())
+
+	// Refetching the engine should give back the same engine.
+	engine1Refetched, err := getOrCreateStickyInMemEngine(ctx, "engine1", engineType, attrs, cacheSize)
+	require.NoError(t, err)
+	require.Equal(t, engine1, engine1Refetched)
+	require.False(t, engine1.Closed())
+
+	// Closing an engine that does not exist will error.
+	err = CloseStickyInMemEngine("engine3")
+	require.EqualError(t, err, "sticky in-mem engine engine3 does not exist")
+
+	// Cleaning up the engine should result in a new engine.
+	err = CloseStickyInMemEngine("engine1")
+	require.NoError(t, err)
+	require.True(t, engine1.Closed())
+	require.True(t, engine1.(*stickyInMemEngine).Engine.Closed())
+
+	newEngine1, err := getOrCreateStickyInMemEngine(ctx, "engine1", engineType, attrs, cacheSize)
+	require.NoError(t, err)
+	require.NotEqual(t, engine1, newEngine1)
+
+	// Cleaning up everything asserts everything is closed.
+	CloseAllStickyInMemEngines()
+	require.Len(t, stickyInMemEnginesRegistry.entries, 0)
+	for _, engine := range []engine.Engine{engine1, newEngine1, engine2} {
+		require.True(t, engine.Closed())
+		require.True(t, engine.(*stickyInMemEngine).Engine.Closed())
+	}
+}


### PR DESCRIPTION
This will help with #40695, whilst also forming as a base required to make `TestCluster` work (the client work and TestCluster work is *slightly* different, happy to work on both during this onboarding period :P). I am separating this out into it's own PR because it lets me work on the other two constructs at the same time.

The thing I'm fighting myself in is determining whether we want to make making new sticky engines as a separate `GetOrCreateStickyInMemEngine` call, or whether I should fold this into `NewInMem`, with an empty `id` meaning to not make it sticky, e.g. `NewInMem(ctx, engine.NonSticky, ...)`. Let me know what you think.

Also let me know if I should target other reviewers. 

----

Previously, in memory engines would terminate as soon as they were
Closed. However, we want these in memory engines to persist so that they
could be restarted using the TestCluster and `cockroach demo`'s
transient cluster.

To support this, we add the concept of a "sticky" in memory engine to
the engine library. This inherits the Engine interface, but overrides
the `Close` method to instead remain in memory instead of shutting down.
These can be re-used again by passing in a unique identifier.

Release note: none