### PR TITLE
sql/sqlbase: add RandCreateTables to make FK-aware tables

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -79,6 +79,7 @@ func registerSQLSmith(r *testRegistry) {
 
 		conn := c.Conn(ctx, 1)
 		t.Status("executing setup")
+		c.l.Printf("setup:\n%s", setup)
 		if _, err := conn.Exec(setup); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -66,7 +66,7 @@ func makeAlter(s *Smither) (tree.Statement, bool) {
 }
 
 func makeCreateTable(s *Smither) (tree.Statement, bool) {
-	table := sqlbase.RandCreateTable(s.rnd, 0)
+	table := sqlbase.RandCreateTable(s.rnd, "", 0)
 	table.Table = tree.MakeUnqualifiedTableName(s.name("tab"))
 	return table, true
 }

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -56,12 +56,11 @@ func stringSetup(s string) Setup {
 }
 
 func randTables(r *rand.Rand) string {
-	var sb strings.Builder
+	stmts := sqlbase.RandCreateTables(r, "table", r.Intn(5)+1)
 
-	n := r.Intn(5)
-	for i := 0; i <= n; i++ {
-		create := sqlbase.RandCreateTable(r, i+1)
-		sb.WriteString(create.String())
+	var sb strings.Builder
+	for _, stmt := range stmts {
+		sb.WriteString(stmt.String())
 		sb.WriteString(";\n")
 	}
 

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -712,8 +712,140 @@ func TestingMakePrimaryIndexKey(desc *TableDescriptor, vals ...interface{}) (roa
 	return roachpb.Key(key), nil
 }
 
+// RandCreateTables creates random table definitions. They may contain foreign
+// key references to each other.
+func RandCreateTables(rng *rand.Rand, prefix string, num int) []tree.Statement {
+	if num < 1 {
+		panic("at least one table required")
+	}
+
+	// Make some random tables.
+	tables := make([]*tree.CreateTable, num)
+	byName := map[tree.TableName]*tree.CreateTable{}
+	for i := 1; i <= num; i++ {
+		t := RandCreateTable(rng, prefix, i)
+		tables[i-1] = t
+		byName[t.Table] = t
+	}
+
+	// Find columns in the tables.
+	cols := map[tree.TableName][]*tree.ColumnTableDef{}
+	for _, table := range tables {
+		for _, def := range table.Defs {
+			switch def := def.(type) {
+			case *tree.ColumnTableDef:
+				cols[table.Table] = append(cols[table.Table], def)
+			}
+		}
+	}
+
+	toNames := func(cols []*tree.ColumnTableDef) tree.NameList {
+		names := make(tree.NameList, len(cols))
+		for i, c := range cols {
+			names[i] = c.Name
+		}
+		return names
+	}
+
+	// We cannot mutate the table definitions themselves because 1) we
+	// don't know the order of dependencies (i.e., table 1 could reference
+	// table 4 which doesn't exist yet) and relatedly 2) we don't prevent
+	// circular dependencies. Instead, add new ALTER TABLE commands to the
+	// end of a list of statements.
+	statements := make([]tree.Statement, len(tables))
+	for i, t := range tables {
+		statements[i] = t
+	}
+
+	// Create some FKs.
+	for rng.Intn(2) == 0 {
+		// Choose a random table.
+		table := tables[rng.Intn(len(tables))]
+		// Choose a random column subset.
+		fkCols := append([]*tree.ColumnTableDef(nil), cols[table.Table]...)
+		rng.Shuffle(len(fkCols), func(i, j int) {
+			fkCols[i], fkCols[j] = fkCols[j], fkCols[i]
+		})
+		// Pick some randomly short prefix. I'm sure there's a closed
+		// form solution to this with a single call to rng.Intn but I'm
+		// not sure what to search for.
+		i := 1
+		for len(fkCols) > i && rng.Intn(2) == 0 {
+			i++
+		}
+		fkCols = fkCols[:i]
+
+		// Check if a table has the needed column types.
+	LoopTable:
+		for refTable, refCols := range cols {
+			// Prevent self references.
+			// TODO(mjibson): Circular references are not
+			// prevented, but it would be nice to detect and
+			// prevent them.
+			if refTable == table.Table || len(refCols) < len(fkCols) {
+				continue
+			}
+
+			// We found a table with enough columns. Check if it
+			// has some columns that are needed types. In order
+			// to not use columns multiple times, keep track of
+			// available columns.
+			availCols := append([]*tree.ColumnTableDef(nil), refCols...)
+			var usingCols []*tree.ColumnTableDef
+			for len(availCols) > 0 && len(usingCols) < len(fkCols) {
+				fkCol := fkCols[len(usingCols)]
+				found := false
+				for refI, refCol := range availCols {
+					if fkCol.Type.Equivalent(refCol.Type) {
+						usingCols = append(usingCols, refCol)
+						availCols = append(availCols[:refI], availCols[refI+1:]...)
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue LoopTable
+				}
+			}
+			// If we didn't find enough columns, try another table.
+			if len(usingCols) != len(fkCols) {
+				continue
+			}
+
+			// Found a suitable table.
+			// TODO(mjibson): prevent the creation of unneeded
+			// unique indexes. One may already exist with the
+			// correct prefix.
+			ref := byName[refTable]
+			refColumns := make(tree.IndexElemList, len(usingCols))
+			for i, c := range usingCols {
+				refColumns[i].Column = c.Name
+			}
+			ref.Defs = append(ref.Defs, &tree.UniqueConstraintTableDef{
+				IndexTableDef: tree.IndexTableDef{
+					Columns: refColumns,
+				},
+			})
+
+			statements = append(statements, &tree.AlterTable{
+				Table: table.Table.ToUnresolvedObjectName(),
+				Cmds: tree.AlterTableCmds{&tree.AlterTableAddConstraint{
+					ConstraintDef: &tree.ForeignKeyConstraintTableDef{
+						Table:    ref.Table,
+						FromCols: toNames(fkCols),
+						ToCols:   toNames(usingCols),
+					},
+				}},
+			})
+			break
+		}
+	}
+
+	return statements
+}
+
 // RandCreateTable creates a random CreateTable definition.
-func RandCreateTable(rng *rand.Rand, tableIdx int) *tree.CreateTable {
+func RandCreateTable(rng *rand.Rand, prefix string, tableIdx int) *tree.CreateTable {
 	// columnDefs contains the list of Columns we'll add to our table.
 	columnDefs := make([]*tree.ColumnTableDef, randutil.RandIntInRange(rng, 1, 20))
 	// defs contains the list of Columns and other attributes (indexes, column
@@ -760,7 +892,7 @@ func RandCreateTable(rng *rand.Rand, tableIdx int) *tree.CreateTable {
 	}
 
 	ret := &tree.CreateTable{
-		Table: tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("table%d", tableIdx))),
+		Table: tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("%s%d", prefix, tableIdx))),
 		Defs:  defs,
 	}
 

--- a/pkg/sql/tests/random_schema_test.go
+++ b/pkg/sql/tests/random_schema_test.go
@@ -46,7 +46,7 @@ func TestCreateRandomSchema(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
-		tab := sqlbase.RandCreateTable(rng, i)
+		tab := sqlbase.RandCreateTable(rng, "table", i)
 		setDb(t, db, "test")
 		_, err := db.Exec(tab.String())
 		if err != nil {

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -503,7 +503,7 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 	testRandomSyntax(t, true, "defaultdb", func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		// Create some random tables for the smither's column references and INSERT.
 		for i := 0; i < len(tableStmts); i++ {
-			create := sqlbase.RandCreateTable(r.Rnd, i)
+			create := sqlbase.RandCreateTable(r.Rnd, "table", i)
 			stmt := create.String()
 			if err := db.exec(ctx, stmt); err != nil {
 				return err

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -91,7 +91,7 @@ func (w *random) Tables() []workload.Table {
 	tables := make([]workload.Table, w.tables)
 	rng := rand.New(rand.NewSource(w.seed))
 	for i := 0; i < w.tables; i++ {
-		createTable := sqlbase.RandCreateTable(rng, rng.Int())
+		createTable := sqlbase.RandCreateTable(rng, "table", rng.Int())
 		ctx := tree.NewFmtCtx(tree.FmtParsable)
 		createTable.FormatBody(ctx)
 		tables[i] = workload.Table{

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -62,7 +62,7 @@ func (g *sqlSmith) Tables() []workload.Table {
 	rng := rand.New(rand.NewSource(g.seed))
 	var tables []workload.Table
 	for idx := 0; idx < g.tables; idx++ {
-		schema := sqlbase.RandCreateTable(rng, idx)
+		schema := sqlbase.RandCreateTable(rng, "table", idx)
 		table := workload.Table{
 			Name:   schema.Table.String(),
 			Schema: tree.Serialize(schema),


### PR DESCRIPTION
RandCreateTables creates a specified number of random tables. Foreign key
references are sometimes created on random columns between various tables.

Release note: None