### PR TITLE
cli: fix double-close of engine.Engine

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -926,7 +926,6 @@ func runDebugUnsafeRemoveDeadReplicas(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
 	deadStoreIDs := map[roachpb.StoreID]struct{}{}
 	for _, id := range removeDeadReplicasOpts.deadStoreIDs {

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -263,7 +263,6 @@ func TestRemoveDeadReplicas(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					defer db.Close()
 
 					batch, err := removeDeadReplicas(db, deadReplicas)
 					if err != nil {


### PR DESCRIPTION
`OpenEngine` adds the opened store to the supplied stopper's closer
list. So callers don't need to explicitly close the returned engine and
doing so causes Pebble to complain more loudly than RocksDB. I audited
all of the uses of `OpenEngine` and `OpenExistingStore`.

Release note: None