### PR TITLE
storage/engine: provide Pebble.String()

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -294,6 +294,18 @@ func newPebbleInMem(attrs roachpb.Attributes, cacheSize int64) *Pebble {
 	return db
 }
 
+func (p *Pebble) String() string {
+	dir := p.path
+	if dir == "" {
+		dir = "<in-mem>"
+	}
+	attrs := p.attrs.String()
+	if attrs == "" {
+		attrs = "<no-attributes>"
+	}
+	return fmt.Sprintf("%s=%s", attrs, dir)
+}
+
 // Close implements the Engine interface.
 func (p *Pebble) Close() {
 	p.closed = true


### PR DESCRIPTION
Provide `Pebble.String()` that matches `RocksDB.String()`. This fixes
`TestStoresClusterVersionIncompatible` when running on Pebble because
that test was expecting an error message which required
`Engine.String()` to be implemented.

See #41987

Release note: None