### PR TITLE
build: improve teamcity-testrace script

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -24,17 +24,142 @@ run() {
   "$@"
 }
 
+# Returns the list of release branches from origin (origin/release-*), ordered
+# by version (higher version numbers first).
+get_release_branches() {
+  # We sort by the minor version first, followed by a stable sort on the major
+  # version.
+  git branch -r --format='%(refname)' \
+    | sed 's/^refs\/remotes\///' \
+    | grep '^origin\/release-*' \
+    | sort -t. -k2 -n -r \
+    | sort -t- -k2 -n -r -s
+}
+
+# Returns the number of commits in the curent branch that are not shared with
+# the given branch.
+get_branch_distance() {
+  git rev-list --count $1..HEAD
+}
+
+# Returns the branch among origin/master, origin/release-* which is the
+# closest to the current HEAD.
+#
+# Suppose the origin looks like this:
+#
+#                e (master)
+#                |
+#                d       w (release-19.2)
+#                |       |
+#                c       u
+#                 \     /
+#                  \   /
+#                   \ /
+#                    b
+#                    |
+#                    a
+#
+# Example 1. PR on master on top of d:
+#
+#      e (master)   pr
+#             \     /
+#              \   /
+#               \ /
+#                d       w (release-19.2)
+#                |       |
+#                c       u
+#                 \     /
+#                  \   /
+#                   \ /
+#                    b
+#                    |
+#                    a
+#
+# The pr commit has distance 1 from master and distance 3 from release-19.2
+# (commits c, d, and pr); so we deduce that the upstream branch is master.
+#
+# Example 2. PR on release-19.2 on top of u:
+#
+#                e (master)
+#                |
+#                d   w (release-19.2)
+#                |     \
+#                |      \   pr
+#                |       \ /
+#                c       u
+#                 \     /
+#                  \   /
+#                   \ /
+#                    b
+#                    |
+#                    a
+#
+# The pr commit has distance 2 from master (commits u and w) and distance 1 from
+# release-19.2; so we deduce that the upstream branch is release-19.2.
+#
+# If the PR is on top of the fork point (b in the example above), we return the
+# release-19.2 branch.
+#
+# Example 3. PR on even older release:
+#
+#                e (master)
+#                |
+#                d    w (release-19.2)
+#                |       |
+#                |       |
+#                |       |        pr
+#                c       u       /
+#                 \     /       y (release-19.1)
+#                  \   /       /
+#                   \ /       /
+#                    b       x
+#                     \     /
+#                      \   /
+#                       \ /
+#                        a
+#
+# The pr commit has distance 3 from both master and release-19.2 (commits x, y,
+# pr) and distance 1 from release-19.1. In general, the distance w.r.t. all
+# newer releases than the correct one will be equal; specifically, it is the
+# number of commits since the fork point of the correct release (the fork point
+# in this example is commit a).
+#
+get_upstream_branch() {
+  local UPSTREAM DISTANCE D
+
+  UPSTREAM="origin/master"
+  DISTANCE=$(get_branch_distance origin/master)
+
+  # Check if we're closer to any release branches. The branches are ordered
+  # new-to-old, so stop as soon as the distance starts to increase.
+  for branch in $(get_release_branches); do
+    D=$(get_branch_distance $branch)
+    # It is important to continue the loop if the distance is the same; see
+    # example 3 above.
+    if [ $D -gt $DISTANCE ]; then
+      break
+    fi
+    UPSTREAM=$branch
+    DISTANCE=$D
+  done
+
+  echo "$UPSTREAM"
+}
+
 changed_go_pkgs() {
-  git fetch --quiet origin master
-  # Find changed packages, minus those that have been removed entirely.
-  git diff --name-only origin/master... -- "pkg/**/*.go" ":!*/testdata/*" \
+  git fetch --quiet origin
+  upstream_branch=$(get_upstream_branch)
+  # Find changed packages, minus those that have been removed entirely. Note
+  # that the three-dot notation means we are diffing against the merge-base of
+  # the two branches, not against the tip of the upstream branch.
+  git diff --name-only "$upstream_branch..." -- "pkg/**/*.go" ":!*/testdata/*" \
     | xargs -rn1 dirname \
     | sort -u \
     | { while read path; do if ls "$path"/*.go &>/dev/null; then echo -n "./$path "; fi; done; }
 }
 
 tc_release_branch() {
-  [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* ]]
+  [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* || "$TC_BUILD_BRANCH" == provisional_* ]]
 }
 
 tc_start_block() {


### PR DESCRIPTION
This change fixes two problems with the teamcity scripts:

 - when we are preparing releases, we use a `provisional_` branch name
   which is not detected as a release. This causes us to enable
   ccache, and enables the PR-specific "packages that changed"
   testrace mode. Example:
     `Building PR (#provisional_201911052027_v19.2.0-rc.4), so enabling ccache.`

 - the PR-specific testrace mode checks all the packages that changed
   compared to the current `origin/master`. This is bad for
   `release-*` builds: it will effectively mean we are testing most
   packages, except we are testing them one at a time (as opposed to
   the default mode which allows parallelization).
   We now figure out the upstream branch as follows:
    - we list all remote branches of the form `origin/release-*`
    - we calculate the "distance" between HEAD and these branches
      (number of commits that are not on the release branch) and pick
      the closest one. As an optimization, we pre-sort the branches by
      version number and stop when the distance starts increasing so
      that in practice we only have to look at the latest couple of
      branches.

Release note: None