### PR TITLE
cli: add ability to kill and restart nodes in demo

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -117,6 +117,7 @@ func initCLIDefaults() {
 	startCtx.listeningURLFile = ""
 	startCtx.pidFile = ""
 	startCtx.inBackground = false
+	startCtx.backtraceOutputDir = ""
 
 	quitCtx.serverDecommission = false
 
@@ -152,6 +153,7 @@ func initCLIDefaults() {
 	demoCtx.geoPartitionedReplicas = false
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
+	demoCtx.transientCluster = nil
 
 	initPreFlagsDefaults()
 
@@ -296,6 +298,9 @@ var startCtx struct {
 
 	// logging settings specific to file logging.
 	logDir log.DirName
+
+	// directory to use for logging backtrace outputs.
+	backtraceOutputDir string
 }
 
 // quitCtx captures the command-line parameters of the `quit` command.
@@ -353,4 +358,5 @@ var demoCtx struct {
 	localities                demoLocalityList
 	geoPartitionedReplicas    bool
 	simulateLatency           bool
+	transientCluster          *transientCluster
 }

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -742,7 +742,7 @@ func runDebugGossipValues(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to parse provided file as gossip.InfoStatus")
 		}
 	} else {
-		conn, _, finish, err := getClientGRPCConn(ctx)
+		conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 		if err != nil {
 			return err
 		}
@@ -853,7 +853,7 @@ func runTimeSeriesDump(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, _, finish, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -187,7 +187,7 @@ func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn, _, finish, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -44,7 +44,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, _, finish, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -1,0 +1,88 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Check \\demo_node commands work as expected"
+# Start a demo with no nodes.
+spawn $argv demo movr --nodes=5
+
+# Ensure db is movr.
+eexpect "movr>"
+
+# Wrong number of args
+send "\\demo_node\r"
+eexpect "Usage:"
+
+# Cannot shutdown node 1
+send "\\demo_node shutdown 1\r"
+eexpect "cannot shutdown node 1"
+
+# Cannot operate on a node which does not exist.
+send "\\demo_node shutdown 8\r"
+eexpect "node 8 does not exist"
+send "\\demo_node restart 8\r"
+eexpect "node 8 does not exist"
+send "\\demo_node decommission 8\r"
+eexpect "node 8 does not exist"
+send "\\demo_node recommission 8\r"
+eexpect "node 8 does not exist"
+
+# Cannot restart a node that is not shut down.
+send "\\demo_node restart 2\r"
+eexpect "node 2 is already running"
+
+# Shut down a separate node.
+send "\\demo_node shutdown 3\r"
+eexpect "node 3 has been shutdown"
+
+send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false"
+eexpect "2 |  false   |      false"
+eexpect "3 |   true   |      false"
+eexpect "4 |  false   |      false"
+eexpect "5 |  false   |      false"
+
+# Cannot shut it down again.
+send "\\demo_node shutdown 3\r"
+eexpect "node 3 is already shut down"
+
+# Expect queries to still work with just one node down.
+send "SELECT count(*) FROM movr.rides;\r"
+eexpect "500"
+eexpect "movr>"
+
+# Now restart the node.
+send "\\demo_node restart 3\r"
+eexpect "node 3 has been restarted"
+
+send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false"
+eexpect "2 |  false   |      false"
+eexpect "3 |  false   |      false"
+eexpect "4 |  false   |      false"
+eexpect "5 |  false   |      false"
+
+# Try commissioning commands
+send "\\demo_node decommission 4\r"
+eexpect "node 4 has been decommissioned"
+
+send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false"
+eexpect "2 |  false   |      false"
+eexpect "3 |  false   |      false"
+eexpect "4 |  false   |      true"
+eexpect "5 |  false   |      false"
+
+send "\\demo_node recommission 4\r"
+eexpect "node 4 has been recommissioned"
+
+send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false"
+eexpect "2 |  false   |      false"
+eexpect "3 |  false   |      false"
+eexpect "4 |  false   |      false"
+eexpect "5 |  false   |      false"
+
+interrupt
+eexpect eof
+end_test

--- a/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
@@ -1,0 +1,26 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Ensure demo commands are not available in the sql shell"
+
+# Set up the initial cluster.
+start_server $argv
+
+# Spawn a sql shell.
+spawn $argv sql
+set client_spawn_id $spawn_id
+eexpect root@
+
+# Ensure the demo command does not work.
+send "\\demo_node shutdown 2\n"
+eexpect "\\demo_node can only be run with cockroach demo"
+
+# Exit the shell.
+interrupt
+eexpect eof
+
+# Have good manners and clean up.
+stop_server $argv
+
+end_test

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -300,7 +300,7 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, finish, err := getAdminClient(ctx)
+	c, finish, err := getAdminClient(ctx, serverCfg)
 	if err != nil {
 		return err
 	}
@@ -417,7 +417,7 @@ func runRecommissionNode(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, finish, err := getAdminClient(ctx)
+	c, finish, err := getAdminClient(ctx, serverCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -49,6 +50,7 @@ const (
 # To exit, type: \q.
 #
 `
+	// TODO(#42242): document the \demo_node command.
 	helpMessageFmt = `You are using 'cockroach sql', CockroachDB's lightweight SQL client.
 Type:
   \? or "help"      print this help.
@@ -461,6 +463,58 @@ func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) 
 
 func isEndOfStatement(lastTok int) bool {
 	return lastTok == ';' || lastTok == parser.HELPTOKEN
+}
+
+// handleDemoNode handles operations on \demo_node.
+// This can only be done from `cockroach demo`.
+func (c *cliState) handleDemoNode(cmd []string, nextState, errState cliStateEnum) cliStateEnum {
+	usageStr := `Usage: \demo_node <shutdown|restart|recommission|decommission> <node_id>` + "\n"
+	// A transient cluster signifies the presence of `cockroach demo`.
+	if demoCtx.transientCluster == nil {
+		return c.invalidSyntax(errState, `\demo_node can only be run with cockroach demo`)
+	}
+	if len(cmd) != 2 {
+		fmt.Fprint(stderr, usageStr)
+		c.exitErr = errInvalidSyntax
+		return errState
+	}
+	nodeID, err := strconv.ParseInt(cmd[1], 10, 32)
+	if err != nil {
+		return c.invalidSyntax(
+			errState,
+			"%s",
+			errors.Wrapf(err, "cannot convert %s to string", cmd[2]).Error(),
+		)
+	}
+	switch cmd[0] {
+	case "shutdown":
+		if err := demoCtx.transientCluster.DrainNode(roachpb.NodeID(nodeID)); err != nil {
+			return c.invalidSyntax(errState, "%s", err.Error())
+		}
+		fmt.Printf("node %d has been shutdown\n", nodeID)
+		return nextState
+	case "restart":
+		if err := demoCtx.transientCluster.RestartNode(roachpb.NodeID(nodeID)); err != nil {
+			return c.invalidSyntax(errState, "%s", err.Error())
+		}
+		fmt.Printf("node %d has been restarted\n", nodeID)
+		return nextState
+	case "recommission":
+		if err := demoCtx.transientCluster.CallDecommission(roachpb.NodeID(nodeID), false /* decommissioning */); err != nil {
+			return c.invalidSyntax(errState, "%s", err.Error())
+		}
+		fmt.Printf("node %d has been recommissioned\n", nodeID)
+		return nextState
+	case "decommission":
+		if err := demoCtx.transientCluster.CallDecommission(roachpb.NodeID(nodeID), true /* decommissioning */); err != nil {
+			return c.invalidSyntax(errState, "%s", err.Error())
+		}
+		fmt.Printf("node %d has been decommissioned\n", nodeID)
+		return nextState
+	}
+	fmt.Fprint(stderr, usageStr)
+	c.exitErr = errInvalidSyntax
+	return errState
 }
 
 // handleHelp prints SQL help.
@@ -1046,6 +1100,9 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 			return cliRunStatement
 		}
 		return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
+
+	case `\demo_node`:
+		return c.handleDemoNode(cmd[1:], loopState, errState)
 
 	default:
 		if strings.HasPrefix(cmd[0], `\d`) {

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1145,6 +1145,7 @@ func setupAndInitializeLoggingAndProfiling(
 	if p := logOutputDirectory(); p != "" {
 		outputDirectory = p
 	}
+	startCtx.backtraceOutputDir = outputDirectory
 
 	if ambiguousLogDirs {
 		// Note that we can't report this message earlier, because the log directory
@@ -1212,7 +1213,9 @@ func addrWithDefaultHost(addr string) (string, error) {
 
 // getClientGRPCConn returns a ClientConn, a Clock and a method that blocks
 // until the connection (and its associated goroutines) have terminated.
-func getClientGRPCConn(ctx context.Context) (*grpc.ClientConn, *hlc.Clock, func(), error) {
+func getClientGRPCConn(
+	ctx context.Context, cfg server.Config,
+) (*grpc.ClientConn, *hlc.Clock, func(), error) {
 	if ctx.Done() == nil {
 		return nil, nil, nil, errors.New("context must be cancellable")
 	}
@@ -1222,13 +1225,13 @@ func getClientGRPCConn(ctx context.Context) (*grpc.ClientConn, *hlc.Clock, func(
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: serverCfg.Settings.Tracer},
-		serverCfg.Config,
+		log.AmbientContext{Tracer: cfg.Settings.Tracer},
+		cfg.Config,
 		clock,
 		stopper,
-		serverCfg.Settings,
+		cfg.Settings,
 	)
-	addr, err := addrWithDefaultHost(serverCfg.AdvertiseAddr)
+	addr, err := addrWithDefaultHost(cfg.AdvertiseAddr)
 	if err != nil {
 		stopper.Stop(ctx)
 		return nil, nil, nil, err
@@ -1253,8 +1256,8 @@ func getClientGRPCConn(ctx context.Context) (*grpc.ClientConn, *hlc.Clock, func(
 
 // getAdminClient returns an AdminClient and a closure that must be invoked
 // to free associated resources.
-func getAdminClient(ctx context.Context) (serverpb.AdminClient, func(), error) {
-	conn, _, finish, err := getClientGRPCConn(ctx)
+func getAdminClient(ctx context.Context, cfg server.Config) (serverpb.AdminClient, func(), error) {
+	conn, _, finish, err := getClientGRPCConn(ctx, cfg)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Failed to connect to the node")
 	}
@@ -1365,7 +1368,7 @@ func runQuit(cmd *cobra.Command, args []string) (err error) {
 		onModes[i] = int32(m)
 	}
 
-	c, finish, err := getAdminClient(ctx)
+	c, finish, err := getAdminClient(ctx, serverCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -194,7 +194,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	baseCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, _, finish, err := getClientGRPCConn(baseCtx)
+	conn, _, finish, err := getClientGRPCConn(baseCtx, serverCfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/40695

As discussed, this is the "simple" way of allowing the ability to shutdown, restart and {re|de} commission.

----

    cli: add ability to kill and restart nodes in demo

    A feature that was desired in `cockroach demo` was the ability to kill
    and restart nodes and demonstrate that cockroach would continue to run.

    This change adds the ability to shutdown and restart nodes in a
    transient cluster (not the test cluster - which is somehow different),
    as well as the relevant `cli` changes required to call these functions
    as `\demo_node <shutdown|restart|decommission|recommission> <node_num>`.

    These cli commands are only available through `cockroach demo`.

    Release note (cli change): A new feature has been added that allows
    users of `cockroach demo` to shutdown and restart nodes. This is
    available in `cockroach demo` only as `\demo_node
    <decommission|recommission|shutdown|restart>
    <node_num>`. This command is not available in other clis, e.g.
    `cockroach sql`. This feature is experimental.