### PR TITLE
sql: fix unchecked constraints with cascade loops

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -3702,3 +3702,40 @@ NULL  NULL
 
 statement ok
 DROP TABLE c, b, a;
+
+# Make sure the CHECK constraint is checked when a self-referencing cascade
+# modifies the original table (#42117).
+subtest SelfReferencingCheckFail
+
+# TODO(radu): remove the FAMILY when #42120 is fixed.
+statement ok
+CREATE TABLE self_ab (
+  a INT UNIQUE,
+  b INT DEFAULT 1 CHECK (b != 1),
+  INDEX (b),
+  FAMILY (a, b)
+)
+
+statement ok
+INSERT INTO self_ab VALUES (1, 2), (2, 2)
+
+statement ok
+ALTER TABLE self_ab ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES self_ab (a) ON UPDATE SET DEFAULT
+
+# This update would cause the references to 2 to get reset to the default,
+# which violates the check.
+statement error failed to satisfy CHECK constraint \(b != 1\)
+UPDATE self_ab SET a = 3 WHERE a = 2
+
+# Make sure the check fails when we apply the same update through a cascade.
+statement ok
+CREATE TABLE self_ab_parent (p INT PRIMARY KEY)
+
+statement ok
+INSERT INTO self_ab_parent VALUES (1), (2)
+
+statement ok
+ALTER TABLE self_ab ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES self_ab_parent (p) ON UPDATE CASCADE
+
+statement error failed to satisfy CHECK constraint \(b != 1\)
+UPDATE self_ab_parent SET p = 3 WHERE p = 2

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -3703,3 +3703,40 @@ NULL  NULL
 
 statement ok
 DROP TABLE c, b, a;
+
+# Make sure the CHECK constraint is checked when a self-referencing cascade
+# modifies the original table (#42117).
+subtest SelfReferencingCheckFail
+
+# TODO(radu): remove the FAMILY when #42120 is fixed.
+statement ok
+CREATE TABLE self_ab (
+  a INT UNIQUE,
+  b INT DEFAULT 1 CHECK (b != 1),
+  INDEX (b),
+  FAMILY (a, b)
+)
+
+statement ok
+INSERT INTO self_ab VALUES (1, 2), (2, 2)
+
+statement ok
+ALTER TABLE self_ab ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES self_ab (a) ON UPDATE SET DEFAULT
+
+# This update would cause the references to 2 to get reset to the default,
+# which violates the check.
+statement error failed to satisfy CHECK constraint \(b != 1\)
+UPDATE self_ab SET a = 3 WHERE a = 2
+
+# Make sure the check fails when we apply the same update through a cascade.
+statement ok
+CREATE TABLE self_ab_parent (p INT PRIMARY KEY)
+
+statement ok
+INSERT INTO self_ab_parent VALUES (1), (2)
+
+statement ok
+ALTER TABLE self_ab ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES self_ab_parent (p) ON UPDATE CASCADE
+
+statement error failed to satisfy CHECK constraint \(b != 1\)
+UPDATE self_ab_parent SET p = 3 WHERE p = 2

--- a/pkg/sql/sqlbase/check.go
+++ b/pkg/sql/sqlbase/check.go
@@ -76,10 +76,10 @@ func NewEvalCheckHelper(
 	}
 
 	c := &CheckHelper{}
-	c.cols = tableDesc.Columns
+	c.cols = tableDesc.AllNonDropColumns()
 	c.sourceInfo = NewSourceInfoForSingleTable(
 		tree.MakeUnqualifiedTableName(tree.Name(tableDesc.Name)),
-		ResultColumnsFromColDescs(tableDesc.Columns),
+		ResultColumnsFromColDescs(c.cols),
 	)
 
 	c.Exprs = make([]tree.TypedExpr, len(tableDesc.ActiveChecks()))


### PR DESCRIPTION
#### sql: fix unchecked constraints with cascade loops

The cascader uses a `CheckHelper` when updating rows in a table. Since
we added optimizer support for mutations, we have two types of
`CheckHelper` (the old "eval mode" and the new "input mode").

The mutation code is passing the initial table's `CheckHelper` which
is in "input mode". The cascader is using it in the "eval mode" which
is a no-op. This causes CHECK constraints against the initial table to
not be verified. This can happen with self-referencing cascades, or
when there is a cascading loop.

I plan to follow up with a cleanup that removes the two modes and
separates the new "input mode" code completely. We can do this on
master where we ripped out the heuristic planner.

Fixes #42117.

Release note (bug fix): Fixed a bug in scenarios where we have UPDATE
cascades; and we are updating a table that has CHECK constraints; and
the table is self-referencing or is involved in a reference cycle. In
this case an UPDATE that cascades back in the original table was not
validated with respect to the CHECK constraints.

#### sql: allow check expressions with non-public columns in cascader

When adding a column with a check expression, the schema change
happens as follows:
 1. The backfill starts to initialize the new column; at this time, the
   check is not "active";
 2. The backfill completes; the check becomes "active" but the schema
    change is not complete and the column is still write-only;
 3. The check constraint is validated in another pass;
 4. The schema change is complete.

It is correct to treat the columns as readable once the check becomes
active.

This change modifies the legacy `CheckHelper` (used by the cascader)
to allow non-public columns in check expressions.

Release note: None
