### PR TITLE
colexec: plumb through Allocator skeleton

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -44,6 +44,10 @@ type Batch interface {
 	// with the given coltypes. If it's possible, Reset will reuse the existing
 	// columns and allocations, invalidating existing references to the Batch or
 	// its Vecs. However, Reset does _not_ zero out the column data.
+	//
+	// NOTE: Reset can allocate a new Batch, so when calling from the vectorized
+	// engine consider either allocating a new Batch explicitly via
+	// colexec.Allocator or calling ResetInternalBatch.
 	Reset(types []coltypes.T, length int)
 	// ResetInternalBatch resets a batch and its underlying Vecs for reuse. It's
 	// important for callers to call ResetInternalBatch if they own internal

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// Allocator is a memory management tool for vectorized components. It provides
+// new batches (and appends to existing ones) within a fixed memory budget. If
+// the budget is exceeded, it will panic with an error.
+//
+// In the future this can also be used to pool coldata.Vec allocations.
+//
+// TODO(yuzefovich): Add memory budget logic.
+type Allocator struct{}
+
+// NewAllocator constructs a new Allocator instance.
+func NewAllocator() *Allocator {
+	return &Allocator{}
+}
+
+// TODO(yuzefovich): add AppendCol method to Allocator.
+
+// NewMemBatch allocates a new in-memory coldata.Batch.
+func (a *Allocator) NewMemBatch(types []coltypes.T) coldata.Batch {
+	return a.NewMemBatchWithSize(types, int(coldata.BatchSize()))
+}
+
+// NewMemBatchWithSize allocates a new in-memory coldata.Batch with the given
+// column size.
+func (*Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Batch {
+	return coldata.NewMemBatchWithSize(types, size)
+}
+
+// NewMemColumn returns a new coldata.Vec, initialized with a length.
+func (*Allocator) NewMemColumn(t coltypes.T, n int) coldata.Vec {
+	return coldata.NewMemColumn(t, n)
+}
+
+// Append appends elements of a source coldata.Vec into dest according to
+// coldata.SliceArgs.
+func (*Allocator) Append(dest coldata.Vec, args coldata.SliceArgs) {
+	dest.Append(args)
+}

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -233,7 +233,7 @@ func benchmarkLogicalProjOp(
 	}
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Bool, coltypes.Bool})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Bool, coltypes.Bool})
 	col1 := batch.ColVec(0).Bool()
 	col2 := batch.ColVec(0).Bool()
 	for i := 0; i < int(coldata.BatchSize()); i++ {

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -106,7 +106,7 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	ctx := context.Background()
 	tctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	col := batch.ColVec(0).Int64()
 
 	for i := 0; i < int(coldata.BatchSize()); i++ {
@@ -173,7 +173,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	ctx := context.Background()
 	tctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Bytes, coltypes.Int64, coltypes.Int64, coltypes.Bytes})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Bytes, coltypes.Int64, coltypes.Int64, coltypes.Bytes})
 	bCol := batch.ColVec(0).Bytes()
 	sCol := batch.ColVec(1).Int64()
 	eCol := batch.ColVec(2).Int64()

--- a/pkg/sql/colexec/cancel_checker_test.go
+++ b/pkg/sql/colexec/cancel_checker_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -27,7 +26,7 @@ import (
 func TestCancelChecker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx, cancel := context.WithCancel(context.Background())
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	op := NewCancelChecker(NewNoop(NewRepeatableBatchSource(batch)))
 	cancel()
 	err := execerror.CatchVectorizedRuntimeError(func() {

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -237,8 +237,7 @@ type cFetcher struct {
 // non-primary index, tables.ValNeededForCol can only refer to columns in the
 // index.
 func (rf *cFetcher) Init(
-	reverse,
-	returnRangeInfo bool, isCheck bool, tables ...row.FetcherTableArgs,
+	allocator *Allocator, reverse, returnRangeInfo bool, isCheck bool, tables ...row.FetcherTableArgs,
 ) error {
 	if len(tables) == 0 {
 		return errors.AssertionFailedf("no tables to fetch from")
@@ -286,7 +285,7 @@ func (rf *cFetcher) Init(
 		extraValColOrdinals:    oldTable.extraValColOrdinals[:0],
 		allExtraValColOrdinals: oldTable.allExtraValColOrdinals[:0],
 	}
-	rf.machine.batch = coldata.NewMemBatch(typs)
+	rf.machine.batch = allocator.NewMemBatch(typs)
 	rf.machine.colvecs = rf.machine.batch.ColVecs()
 	rf.estimatedStaticMemoryUsage = EstimateBatchSizeBytes(typs, int(coldata.BatchSize()))
 

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -48,7 +48,7 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 		EvalCtx: &evalCtx,
 	}
 
-	c, err := NewColumnarizer(ctx, flowCtx, 0, input)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 
 	const errMsg = "artificial error"
 	rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
-	c, err := NewColumnarizer(ctx, flowCtx, 0 /* processorID */, rb)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
 	require.NoError(t, err)
 
 	// Calling DrainMeta from the vectorized execution engine should propagate to
@@ -111,7 +111,7 @@ func BenchmarkColumnarize(b *testing.B) {
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 
-	c, err := NewColumnarizer(ctx, flowCtx, 0, input)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -32,11 +32,11 @@ type countOp struct {
 var _ StaticMemoryOperator = &countOp{}
 
 // NewCountOp returns a new count operator that counts the rows in its input.
-func NewCountOp(input Operator) Operator {
+func NewCountOp(allocator *Allocator, input Operator) Operator {
 	c := &countOp{
 		OneInputNode: NewOneInputNode(input),
 	}
-	c.internalBatch = coldata.NewMemBatchWithSize([]coltypes.T{coltypes.Int64}, 1)
+	c.internalBatch = allocator.NewMemBatchWithSize([]coltypes.T{coltypes.Int64}, 1)
 	return c
 }
 

--- a/pkg/sql/colexec/count_test.go
+++ b/pkg/sql/colexec/count_test.go
@@ -35,7 +35,7 @@ func TestCount(t *testing.T) {
 		// The tuples consisting of all nulls still count as separate rows, so if
 		// we replace all values with nulls, we should get the same output.
 		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, orderedVerifier, func(input []Operator) (Operator, error) {
-			return NewCountOp(input[0]), nil
+			return NewCountOp(testAllocator, input[0]), nil
 		})
 	}
 }

--- a/pkg/sql/colexec/deselector.go
+++ b/pkg/sql/colexec/deselector.go
@@ -24,6 +24,7 @@ import (
 type deselectorOp struct {
 	OneInputNode
 	NonExplainable
+	allocator  *Allocator
 	inputTypes []coltypes.T
 
 	output coldata.Batch
@@ -33,16 +34,17 @@ var _ Operator = &deselectorOp{}
 
 // NewDeselectorOp creates a new deselector operator on the given input
 // operator with the given column coltypes.
-func NewDeselectorOp(input Operator, colTypes []coltypes.T) Operator {
+func NewDeselectorOp(allocator *Allocator, input Operator, colTypes []coltypes.T) Operator {
 	return &deselectorOp{
 		OneInputNode: NewOneInputNode(input),
+		allocator:    allocator,
 		inputTypes:   colTypes,
 	}
 }
 
 func (p *deselectorOp) Init() {
 	p.input.Init()
-	p.output = coldata.NewMemBatch(p.inputTypes)
+	p.output = p.allocator.NewMemBatch(p.inputTypes)
 }
 
 func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {

--- a/pkg/sql/colexec/deselector_test.go
+++ b/pkg/sql/colexec/deselector_test.go
@@ -63,7 +63,7 @@ func TestDeselector(t *testing.T) {
 
 	for _, tc := range tcs {
 		runTestsWithFixedSel(t, []tuples{tc.tuples}, tc.sel, func(t *testing.T, input []Operator) {
-			op := NewDeselectorOp(input[0], tc.colTypes)
+			op := NewDeselectorOp(testAllocator, input[0], tc.colTypes)
 			out := newOpTestOutput(op, tc.expected)
 
 			if err := out.Verify(); err != nil {
@@ -84,7 +84,7 @@ func BenchmarkDeselector(b *testing.B) {
 		inputTypes[colIdx] = coltypes.Int64
 	}
 
-	batch := coldata.NewMemBatch(inputTypes)
+	batch := testAllocator.NewMemBatch(inputTypes)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
@@ -104,7 +104,7 @@ func BenchmarkDeselector(b *testing.B) {
 				copy(batch.Selection(), sel)
 				batch.SetLength(batchLen)
 				input := NewRepeatableBatchSource(batch)
-				op := NewDeselectorOp(input, inputTypes)
+				op := NewDeselectorOp(testAllocator, input, inputTypes)
 				op.Init()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -116,7 +116,7 @@ func BenchmarkSortedDistinct(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
 	aCol := batch.ColVec(1).Int64()
 	bCol := batch.ColVec(2).Int64()
 	lastA := int64(0)

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -56,6 +56,7 @@ import (
 // columns. The input specifications to this function are the same as that of
 // the NewOrderedAggregator function.
 func NewHashAggregator(
+	allocator *Allocator,
 	input Operator,
 	colTypes []coltypes.T,
 	aggFns []execinfrapb.AggregatorSpec_Func,
@@ -99,6 +100,7 @@ func NewHashAggregator(
 	}
 
 	ht := makeHashTable(
+		allocator,
 		hashTableBucketSize,
 		colTypes,
 		groupCols,
@@ -127,7 +129,7 @@ func NewHashAggregator(
 		builder:     builder,
 		ht:          ht,
 		distinctCol: distinctCol,
-		batch:       coldata.NewMemBatch(ht.outTypes),
+		batch:       allocator.NewMemBatch(ht.outTypes),
 	}
 
 	orderedAgg := &orderedAggregator{

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -936,6 +936,7 @@ func TestHashJoinerOutputsOnlyRequestedColumns(t *testing.T) {
 		leftSource := newOpTestInput(1, tc.leftTuples, tc.leftTypes)
 		rightSource := newOpTestInput(1, tc.rightTuples, tc.rightTypes)
 		hjOp, err := NewEqHashJoinerOp(
+			testAllocator,
 			leftSource, rightSource,
 			tc.leftEqCols, tc.rightEqCols,
 			tc.leftOutCols, tc.rightOutCols,
@@ -963,7 +964,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 		sourceTypes[colIdx] = coltypes.Int64
 	}
 
-	batch := coldata.NewMemBatch(sourceTypes)
+	batch := testAllocator.NewMemBatch(sourceTypes)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
@@ -1024,6 +1025,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										}
 
 										hj := &hashJoinEqOp{
+											allocator:       testAllocator,
 											spec:            spec,
 											outputBatchSize: coldata.BatchSize(),
 										}

--- a/pkg/sql/colexec/joiner_util.go
+++ b/pkg/sql/colexec/joiner_util.go
@@ -30,10 +30,10 @@ type filterFeedOperator struct {
 
 var _ Operator = &filterFeedOperator{}
 
-func newFilterFeedOperator(inputTypes []coltypes.T) *filterFeedOperator {
+func newFilterFeedOperator(allocator *Allocator, inputTypes []coltypes.T) *filterFeedOperator {
 	return &filterFeedOperator{
-		batch:     coldata.NewMemBatchWithSize(inputTypes, 1 /* size */),
-		zeroBatch: coldata.NewMemBatchWithSize([]coltypes.T{}, 0 /* size */),
+		batch:     allocator.NewMemBatchWithSize(inputTypes, 1 /* size */),
+		zeroBatch: allocator.NewMemBatchWithSize([]coltypes.T{}, 0 /* size */),
 	}
 }
 
@@ -54,15 +54,17 @@ func (o *filterFeedOperator) reset() {
 }
 
 func newJoinerFilter(
+	allocator *Allocator,
 	leftSourceTypes []coltypes.T,
 	rightSourceTypes []coltypes.T,
 	filterConstructor func(Operator) (Operator, error),
 	filterOnlyOnLeft bool,
 ) (*joinerFilter, error) {
-	input := newFilterFeedOperator(append(leftSourceTypes, rightSourceTypes...))
+	input := newFilterFeedOperator(allocator, append(leftSourceTypes, rightSourceTypes...))
 	filter, err := filterConstructor(input)
 	return &joinerFilter{
 		Operator:         filter,
+		allocator:        allocator,
 		leftSourceTypes:  leftSourceTypes,
 		rightSourceTypes: rightSourceTypes,
 		input:            input,
@@ -74,6 +76,7 @@ func newJoinerFilter(
 type joinerFilter struct {
 	Operator
 
+	allocator        *Allocator
 	leftSourceTypes  []coltypes.T
 	rightSourceTypes []coltypes.T
 	input            *filterFeedOperator
@@ -123,13 +126,15 @@ func (f *joinerFilter) setInputBatch(lBatch, rBatch coldata.Batch, lIdx, rIdx in
 			idx = int(sel[idx])
 		}
 		for colIdx := 0; colIdx < batch.Width(); colIdx++ {
-			f.input.batch.ColVec(colOffset + colIdx).Append(coldata.SliceArgs{
-				Src:         batch.ColVec(colIdx),
-				ColType:     sourceTypes[colIdx],
-				DestIdx:     0,
-				SrcStartIdx: uint64(idx),
-				SrcEndIdx:   uint64(idx + 1),
-			})
+			f.allocator.Append(
+				f.input.batch.ColVec(colOffset+colIdx),
+				coldata.SliceArgs{
+					Src:         batch.ColVec(colIdx),
+					ColType:     sourceTypes[colIdx],
+					DestIdx:     0,
+					SrcStartIdx: uint64(idx),
+					SrcEndIdx:   uint64(idx + 1),
+				})
 		}
 	}
 	if lBatch != nil {

--- a/pkg/sql/colexec/like_ops_test.go
+++ b/pkg/sql/colexec/like_ops_test.go
@@ -101,7 +101,7 @@ func BenchmarkLikeOps(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Bytes})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Bytes})
 	col := batch.ColVec(0).Bytes()
 	width := 64
 	for i := 0; i < int(coldata.BatchSize()); i++ {

--- a/pkg/sql/colexec/limit_test.go
+++ b/pkg/sql/colexec/limit_test.go
@@ -64,7 +64,7 @@ func TestLimit(t *testing.T) {
 		// The tuples consisting of all nulls still count as separate rows, so if
 		// we replace all values with nulls, we should get the same output.
 		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, orderedVerifier, func(input []Operator) (Operator, error) {
-			return NewLimitOp(input[0], tc.limit), nil
+			return NewLimitOp(testAllocator, input[0], tc.limit), nil
 		})
 	}
 }

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -44,7 +44,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewColumnarizer(ctx, flowCtx, 0, input)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestMaterializeTypes(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewColumnarizer(ctx, flowCtx, 0, input)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewColumnarizer(ctx, flowCtx, 0, input)
+	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/mergejoiner_util.go
+++ b/pkg/sql/colexec/mergejoiner_util.go
@@ -223,12 +223,12 @@ func (b *circularGroupsBuffer) getGroups() ([]group, []group) {
 	return leftGroups[startIdx:endIdx], rightGroups[startIdx:endIdx]
 }
 
-func newMJBufferedGroup(types []coltypes.T) *mjBufferedGroup {
+func newMJBufferedGroup(allocator *Allocator, types []coltypes.T) *mjBufferedGroup {
 	bg := &mjBufferedGroup{
 		colVecs: make([]coldata.Vec, len(types)),
 	}
 	for i, t := range types {
-		bg.colVecs[i] = coldata.NewMemColumn(t, int(coldata.BatchSize()))
+		bg.colVecs[i] = allocator.NewMemColumn(t, int(coldata.BatchSize()))
 	}
 	return bg
 }

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -64,7 +64,7 @@ func TestOffset(t *testing.T) {
 
 func BenchmarkOffset(b *testing.B) {
 	ctx := context.Background()
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
 	batch.SetLength(coldata.BatchSize())
 	source := NewRepeatableBatchSource(batch)
 	source.Init()

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -200,9 +200,9 @@ var _ Operator = &singleTupleNoInputOperator{}
 // NewSingleTupleNoInputOp creates a new Operator which returns a batch of
 // length 1 with no actual columns on the first call to Next() and zero-length
 // batches on all consecutive calls.
-func NewSingleTupleNoInputOp() Operator {
+func NewSingleTupleNoInputOp(allocator *Allocator) Operator {
 	return &singleTupleNoInputOperator{
-		batch: coldata.NewMemBatchWithSize(nil, 1),
+		batch: allocator.NewMemBatchWithSize(nil /* types */, 1 /* size */),
 	}
 }
 

--- a/pkg/sql/colexec/orderedsynchronizer.go
+++ b/pkg/sql/colexec/orderedsynchronizer.go
@@ -26,6 +26,7 @@ import (
 // stream of rows, ordered according to a set of columns. The rows in each input
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
+	allocator   *Allocator
 	inputs      []Operator
 	ordering    sqlbase.ColumnOrdering
 	columnTypes []coltypes.T
@@ -53,9 +54,10 @@ func (o *OrderedSynchronizer) Child(nth int) execinfra.OpNode {
 
 // NewOrderedSynchronizer creates a new OrderedSynchronizer.
 func NewOrderedSynchronizer(
-	inputs []Operator, typs []coltypes.T, ordering sqlbase.ColumnOrdering,
+	allocator *Allocator, inputs []Operator, typs []coltypes.T, ordering sqlbase.ColumnOrdering,
 ) *OrderedSynchronizer {
 	return &OrderedSynchronizer{
+		allocator:   allocator,
 		inputs:      inputs,
 		ordering:    ordering,
 		columnTypes: typs,
@@ -103,7 +105,8 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				srcStartIdx = sel[srcStartIdx]
 			}
-			o.output.ColVec(i).Append(
+			o.allocator.Append(
+				o.output.ColVec(i),
 				coldata.SliceArgs{
 					ColType:     o.columnTypes[i],
 					Src:         vec,
@@ -132,7 +135,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 // Init is part of the Operator interface.
 func (o *OrderedSynchronizer) Init() {
 	o.inputIndices = make([]uint16, len(o.inputs))
-	o.output = coldata.NewMemBatch(o.columnTypes)
+	o.output = o.allocator.NewMemBatch(o.columnTypes)
 	for i := range o.inputs {
 		o.inputs[i].Init()
 	}

--- a/pkg/sql/colexec/orderedsynchronizer_test.go
+++ b/pkg/sql/colexec/orderedsynchronizer_test.go
@@ -205,7 +205,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	numInputs := int64(3)
 	batches := make([]coldata.Batch, numInputs)
 	for i := range batches {
-		batches[i] = coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+		batches[i] = testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 		batches[i].SetLength(coldata.BatchSize())
 	}
 	for i := int64(0); i < int64(coldata.BatchSize())*numInputs; i++ {

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -54,7 +54,7 @@ func TestOrdinality(t *testing.T) {
 func BenchmarkOrdinality(b *testing.B) {
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
 	batch.SetLength(coldata.BatchSize())
 	source := NewRepeatableBatchSource(batch)
 	source.Init()

--- a/pkg/sql/colexec/partitioner.go
+++ b/pkg/sql/colexec/partitioner.go
@@ -25,6 +25,7 @@ import (
 // puts true in partitionColIdx'th column (which is appended if needed) for
 // every tuple that is the first within its partition.
 func NewWindowSortingPartitioner(
+	allocator *Allocator,
 	input Operator,
 	inputTyps []coltypes.T,
 	partitionIdxs []uint32,
@@ -36,7 +37,7 @@ func NewWindowSortingPartitioner(
 		partitionAndOrderingCols[i] = execinfrapb.Ordering_Column{ColIdx: idx}
 	}
 	copy(partitionAndOrderingCols[len(partitionIdxs):], ordCols)
-	input, err = NewSorter(input, inputTyps, partitionAndOrderingCols)
+	input, err = NewSorter(allocator, input, inputTyps, partitionAndOrderingCols)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -79,7 +79,7 @@ func TestProjDivFloat64Float64Op(t *testing.T) {
 func benchmarkProjPlusInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64})
 	col := batch.ColVec(0).Int64()
 	for i := 0; i < int(coldata.BatchSize()); i++ {
 		col[i] = 1
@@ -206,7 +206,7 @@ func TestRandomComparisons(t *testing.T) {
 		if ct.Family() == types.UuidFamily {
 			bytesFixedLength = 16
 		}
-		b := coldata.NewMemBatchWithSize(typs, numTuples)
+		b := testAllocator.NewMemBatchWithSize(typs, numTuples)
 		lVec := b.ColVec(0)
 		rVec := b.ColVec(1)
 		ret := b.ColVec(2)
@@ -291,7 +291,7 @@ func benchmarkProjOp(
 ) {
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{intType, intType, outputType})
+	batch := testAllocator.NewMemBatch([]coltypes.T{intType, intType, outputType})
 	switch intType {
 	case coltypes.Int64:
 		col1 := batch.ColVec(0).Int64()

--- a/pkg/sql/colexec/random_testutils.go
+++ b/pkg/sql/colexec/random_testutils.go
@@ -141,13 +141,16 @@ func RandomVec(
 	}
 }
 
+// testAllocator is an Allocator with an unlimited budget for use in tests.
+var testAllocator = NewAllocator()
+
 // RandomBatch returns a batch with a capacity of capacity and a number of
 // random elements equal to length (capacity if length is 0). The values will be
 // null with a probability of nullProbability.
 func RandomBatch(
 	rng *rand.Rand, typs []coltypes.T, capacity int, length int, nullProbability float64,
 ) coldata.Batch {
-	batch := coldata.NewMemBatchWithSize(typs, capacity)
+	batch := testAllocator.NewMemBatchWithSize(typs, capacity)
 	if length == 0 {
 		length = capacity
 	}
@@ -294,7 +297,7 @@ func (o *RandomDataOp) Init() {}
 func (o *RandomDataOp) Next(ctx context.Context) coldata.Batch {
 	if o.numReturned == o.numBatches {
 		// Done.
-		b := coldata.NewMemBatchWithSize(o.typs, 0)
+		b := testAllocator.NewMemBatchWithSize(o.typs, 0)
 		b.SetLength(0)
 		if o.batchAccumulator != nil {
 			o.batchAccumulator(b)

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -95,7 +95,7 @@ func TestRouterOutputAddBatch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-				[]coltypes.T{coltypes.Int64}, unblockEventsChan, tc.blockedThreshold, tc.outputBatchSize,
+				testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, tc.blockedThreshold, tc.outputBatchSize,
 			)
 			in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
 			out := newOpTestOutput(o, data[:len(tc.selection)])
@@ -176,7 +176,7 @@ func TestRouterOutputNext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var wg sync.WaitGroup
 			batchChan := make(chan coldata.Batch)
-			o := newRouterOutputOp([]coltypes.T{coltypes.Int64}, unblockedEventsChan)
+			o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan)
 			in := newOpTestInput(coldata.BatchSize(), data, nil /* typs */)
 			in.Init()
 			wg.Add(1)
@@ -226,7 +226,7 @@ func TestRouterOutputNext(t *testing.T) {
 	}
 
 	t.Run("NextAfterZeroBatchDoesntBlock", func(t *testing.T) {
-		o := newRouterOutputOp([]coltypes.T{coltypes.Int64}, unblockedEventsChan)
+		o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan)
 		o.addBatch(o.zeroBatch, fullSelection)
 		o.Next(ctx)
 		o.Next(ctx)
@@ -255,7 +255,7 @@ func TestRouterOutputNext(t *testing.T) {
 
 		ch := make(chan struct{}, 2)
 		o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-			[]coltypes.T{coltypes.Int64}, ch, blockThreshold, int(coldata.BatchSize()),
+			testAllocator, []coltypes.T{coltypes.Int64}, ch, blockThreshold, int(coldata.BatchSize()),
 		)
 		in := newOpTestInput(smallBatchSize, data, nil /* typs */)
 		out := newOpTestOutput(o, expected)
@@ -326,7 +326,7 @@ func TestRouterOutputRandom(t *testing.T) {
 			var wg sync.WaitGroup
 			unblockedEventsChans := make(chan struct{}, 2)
 			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-				typs, unblockedEventsChans, blockedThreshold, outputSize,
+				testAllocator, typs, unblockedEventsChans, blockedThreshold, outputSize,
 			)
 			inputs[0].Init()
 
@@ -513,7 +513,7 @@ func TestHashRouterCancellation(t *testing.T) {
 	}
 
 	// Never-ending input of 0s.
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	batch.SetLength(coldata.BatchSize())
 	in := NewRepeatableBatchSource(batch)
 
@@ -609,7 +609,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 	typs := []coltypes.T{coltypes.Int64}
 
 	r, routerOutputs := NewHashRouter(
-		newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []int{0}, 1, /* numOutputs */
+		testAllocator, newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []int{0}, 1, /* numOutputs */
 	)
 
 	if len(routerOutputs) != 1 {
@@ -695,7 +695,7 @@ func TestHashRouterRandom(t *testing.T) {
 			outputsAsOps := make([]Operator, numOutputs)
 			for i := range outputs {
 				op := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-					typs, unblockEventsChan, blockedThreshold, outputSize,
+					testAllocator, typs, unblockEventsChan, blockedThreshold, outputSize,
 				)
 				outputs[i] = op
 				outputsAsOps[i] = op
@@ -776,7 +776,7 @@ func BenchmarkHashRouter(b *testing.B) {
 
 	// Use only one type. Note: the more types you use, the more you inflate the
 	// numbers.
-	batch := coldata.NewMemBatch(types)
+	batch := testAllocator.NewMemBatch(types)
 	batch.SetLength(coldata.BatchSize())
 	input := NewRepeatableBatchSource(batch)
 
@@ -784,7 +784,7 @@ func BenchmarkHashRouter(b *testing.B) {
 	for _, numOutputs := range []int{2, 4, 8, 16} {
 		for _, numInputBatches := range []int{2, 4, 8, 16} {
 			b.Run(fmt.Sprintf("numOutputs=%d/numInputBatches=%d", numOutputs, numInputBatches), func(b *testing.B) {
-				r, outputs := NewHashRouter(input, types, []int{0}, numOutputs)
+				r, outputs := NewHashRouter(testAllocator, input, types, []int{0}, numOutputs)
 				b.SetBytes(8 * int64(coldata.BatchSize()) * int64(numInputBatches))
 				// We expect distribution to not change. This is a sanity check that
 				// we're resetting properly.

--- a/pkg/sql/colexec/rowstovec_test.go
+++ b/pkg/sql/colexec/rowstovec_test.go
@@ -14,7 +14,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -37,14 +36,14 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 			sqlbase.EncDatum{Datum: tree.DBoolFalse},
 		},
 	}
-	vec := coldata.NewMemColumn(coltypes.Bool, 2)
+	vec := testAllocator.NewMemColumn(coltypes.Bool, 2)
 	ct := types.Bool
 
 	// Test converting column 0.
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
-	expected := coldata.NewMemColumn(coltypes.Bool, 2)
+	expected := testAllocator.NewMemColumn(coltypes.Bool, 2)
 	expected.Bool()[0] = false
 	expected.Bool()[1] = true
 	if !reflect.DeepEqual(vec, expected) {
@@ -68,11 +67,11 @@ func TestEncDatumRowsToColVecInt16(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(17)}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(42)}},
 	}
-	vec := coldata.NewMemColumn(coltypes.Int16, 2)
+	vec := testAllocator.NewMemColumn(coltypes.Int16, 2)
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, types.Int2, &alloc); err != nil {
 		t.Fatal(err)
 	}
-	expected := coldata.NewMemColumn(coltypes.Int16, 2)
+	expected := testAllocator.NewMemColumn(coltypes.Int16, 2)
 	expected.Int16()[0] = 17
 	expected.Int16()[1] = 42
 	if !reflect.DeepEqual(vec, expected) {
@@ -86,14 +85,14 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("foo")}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("bar")}},
 	}
-	vec := coldata.NewMemColumn(coltypes.Bytes, 2)
+	vec := testAllocator.NewMemColumn(coltypes.Bytes, 2)
 	for _, width := range []int32{0, 25} {
 		ct := types.MakeString(width)
 		vec.Bytes().Reset()
 		if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 			t.Fatal(err)
 		}
-		expected := coldata.NewMemColumn(coltypes.Bytes, 2)
+		expected := testAllocator.NewMemColumn(coltypes.Bytes, 2)
 		expected.Bytes().Set(0, []byte("foo"))
 		expected.Bytes().Set(1, []byte("bar"))
 		if !reflect.DeepEqual(vec, expected) {
@@ -106,7 +105,7 @@ func TestEncDatumRowsToColVecDecimal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	nRows := 3
 	rows := make(sqlbase.EncDatumRows, nRows)
-	expected := coldata.NewMemColumn(coltypes.Decimal, 3)
+	expected := testAllocator.NewMemColumn(coltypes.Decimal, 3)
 	for i, s := range []string{"1.0000", "-3.12", "NaN"} {
 		var err error
 		dec, err := tree.ParseDDecimal(s)
@@ -116,7 +115,7 @@ func TestEncDatumRowsToColVecDecimal(t *testing.T) {
 		rows[i] = sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: dec}}
 		expected.Decimal()[i] = dec.Decimal
 	}
-	vec := coldata.NewMemColumn(coltypes.Decimal, 3)
+	vec := testAllocator.NewMemColumn(coltypes.Decimal, 3)
 	ct := types.Decimal
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -94,7 +94,7 @@ func TestSelectInInt64(t *testing.T) {
 
 func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	col1 := batch.ColVec(0).Int64()
 
 	for i := 0; i < int(coldata.BatchSize()); i++ {

--- a/pkg/sql/colexec/selection_ops_test.go
+++ b/pkg/sql/colexec/selection_ops_test.go
@@ -138,7 +138,7 @@ func TestGetSelectionOperator(t *testing.T) {
 func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	col := batch.ColVec(0).Int64()
 	for i := 0; i < int(coldata.BatchSize()); i++ {
 		if float64(i) < float64(coldata.BatchSize())*selectivity {
@@ -194,7 +194,7 @@ func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
 
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64})
 	col1 := batch.ColVec(0).Int64()
 	col2 := batch.ColVec(1).Int64()
 	for i := 0; i < int(coldata.BatchSize()); i++ {

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -46,12 +46,12 @@ func (s *SerialUnorderedSynchronizer) Child(nth int) execinfra.OpNode {
 
 // NewSerialUnorderedSynchronizer creates a new SerialUnorderedSynchronizer.
 func NewSerialUnorderedSynchronizer(
-	inputs []Operator, typs []coltypes.T,
+	allocator *Allocator, inputs []Operator, typs []coltypes.T,
 ) *SerialUnorderedSynchronizer {
 	return &SerialUnorderedSynchronizer{
 		inputs:            inputs,
 		curSerialInputIdx: 0,
-		zeroBatch:         coldata.NewMemBatchWithSize(typs, 0),
+		zeroBatch:         allocator.NewMemBatchWithSize(typs, 0 /* size */),
 	}
 }
 
@@ -66,6 +66,7 @@ func (s *SerialUnorderedSynchronizer) Init() {
 func (s *SerialUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	for {
 		if s.curSerialInputIdx == len(s.inputs) {
+			s.zeroBatch.SetLength(0)
 			return s.zeroBatch
 		}
 		b := s.inputs[s.curSerialInputIdx].Next(ctx)

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -32,14 +32,12 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	typs := []coltypes.T{coltypes.Int64}
 	inputs := make([]Operator, numInputs)
 	for i := range inputs {
-		batch := coldata.NewMemBatchWithSize(typs, int(coldata.BatchSize()))
-		batch.SetLength(coldata.BatchSize())
-		source := NewRepeatableBatchSource(
-			RandomBatch(rng, typs, int(coldata.BatchSize()), 0 /* length */, rng.Float64()))
+		batch := RandomBatch(rng, typs, int(coldata.BatchSize()), 0 /* length */, rng.Float64())
+		source := NewRepeatableBatchSource(batch)
 		source.ResetBatchesToReturn(numBatches)
 		inputs[i] = source
 	}
-	s := NewSerialUnorderedSynchronizer(inputs, typs)
+	s := NewSerialUnorderedSynchronizer(testAllocator, inputs, typs)
 	resultBatches := 0
 	for {
 		b := s.Next(ctx)

--- a/pkg/sql/colexec/simple_project_test.go
+++ b/pkg/sql/colexec/simple_project_test.go
@@ -13,7 +13,6 @@ package colexec
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
@@ -75,7 +74,7 @@ func TestSimpleProjectOp(t *testing.T) {
 
 	t.Run("RedundantProjectionIsNotPlanned", func(t *testing.T) {
 		typs := []coltypes.T{coltypes.Int64, coltypes.Int64}
-		input := newFiniteBatchSource(coldata.NewMemBatch(typs), 1 /* usableCount */)
+		input := newFiniteBatchSource(testAllocator.NewMemBatch(typs), 1 /* usableCount */)
 		projectOp := NewSimpleProjectOp(input, len(typs), []uint32{0, 1})
 		require.IsType(t, input, projectOp)
 	})

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -68,7 +68,7 @@ func TestTopKSorter(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(input []Operator) (Operator, error) {
-				return NewTopKSorter(input[0], tc.typ, tc.ordCols, tc.k), nil
+				return NewTopKSorter(testAllocator, input[0], tc.typ, tc.ordCols, tc.k), nil
 			})
 		})
 	}

--- a/pkg/sql/colexec/stats_test.go
+++ b/pkg/sql/colexec/stats_test.go
@@ -83,6 +83,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		rightInput.SetOutputWatch(mjInputWatch)
 
 		mergeJoiner, err := NewMergeJoinOp(
+			testAllocator,
 			sqlbase.InnerJoin,
 			leftInput,
 			rightInput,
@@ -130,7 +131,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 }
 
 func makeFiniteChunksSourceWithBatchSize(nBatches int, batchSize int) Operator {
-	batch := coldata.NewMemBatchWithSize([]coltypes.T{coltypes.Int64}, batchSize)
+	batch := testAllocator.NewMemBatchWithSize([]coltypes.T{coltypes.Int64}, batchSize)
 	vec := batch.ColVec(0).Int64()
 	for i := 0; i < batchSize; i++ {
 		vec[i] = int64(i)

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -79,7 +79,7 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 			typs := []types.T{typ}
 			source := execinfra.NewRepeatableRowSource(typs, rows)
 
-			columnarizer, err := NewColumnarizer(ctx, flowCtx, 0 /* processorID */, source)
+			columnarizer, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, source)
 			require.NoError(t, err)
 
 			coltyps, err := typeconv.FromColumnTypes(typs)
@@ -164,7 +164,7 @@ func (a *arrowTestOperator) Next(ctx context.Context) coldata.Batch {
 	if err := a.r.Deserialize(&arrowDataOut, buf.Bytes()); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
-	batchOut := coldata.NewMemBatchWithSize(nil, 0)
+	batchOut := testAllocator.NewMemBatchWithSize(nil, 0)
 	if err := a.c.ArrowToBatch(arrowDataOut, batchOut); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -469,7 +469,7 @@ func (s *opTestInput) Init() {
 			}
 		}
 	}
-	s.batch = coldata.NewMemBatch(s.typs)
+	s.batch = testAllocator.NewMemBatch(s.typs)
 
 	s.selection = make([]uint16, coldata.BatchSize())
 	for i := range s.selection {
@@ -633,7 +633,7 @@ func (s *opFixedSelTestInput) Init() {
 	}
 
 	s.typs = typs
-	s.batch = coldata.NewMemBatch(typs)
+	s.batch = testAllocator.NewMemBatch(s.typs)
 	tupleLen := len(s.tuples[0])
 	for _, i := range s.sel {
 		if len(s.tuples[i]) != tupleLen {
@@ -908,19 +908,19 @@ type finiteBatchSource struct {
 	ZeroInputNode
 
 	repeatableBatch *RepeatableBatchSource
+	zeroBatch       coldata.Batch
 
 	usableCount int
 }
 
 var _ Operator = &finiteBatchSource{}
 
-var emptyBatch = coldata.NewMemBatchWithSize([]coltypes.T{}, 0)
-
 // newFiniteBatchSource returns a new Operator initialized to return its input
 // batch a specified number of times.
 func newFiniteBatchSource(batch coldata.Batch, usableCount int) *finiteBatchSource {
 	return &finiteBatchSource{
 		repeatableBatch: NewRepeatableBatchSource(batch),
+		zeroBatch:       testAllocator.NewMemBatchWithSize(nil /* types */, 0 /* size */),
 		usableCount:     usableCount,
 	}
 }
@@ -934,7 +934,8 @@ func (f *finiteBatchSource) Next(ctx context.Context) coldata.Batch {
 		f.usableCount--
 		return f.repeatableBatch.Next(ctx)
 	}
-	return emptyBatch
+	f.zeroBatch.SetLength(0)
+	return f.zeroBatch
 }
 
 // finiteChunksSource is an Operator that returns a batch specified number of
@@ -944,6 +945,7 @@ func (f *finiteBatchSource) Next(ctx context.Context) coldata.Batch {
 type finiteChunksSource struct {
 	ZeroInputNode
 	repeatableBatch *RepeatableBatchSource
+	zeroBatch       coldata.Batch
 
 	usableCount int
 	matchLen    int
@@ -955,6 +957,7 @@ var _ Operator = &finiteChunksSource{}
 func newFiniteChunksSource(batch coldata.Batch, usableCount int, matchLen int) *finiteChunksSource {
 	return &finiteChunksSource{
 		repeatableBatch: NewRepeatableBatchSource(batch),
+		zeroBatch:       testAllocator.NewMemBatchWithSize(nil /* types */, 0 /* size */),
 		usableCount:     usableCount,
 		matchLen:        matchLen,
 	}
@@ -989,7 +992,8 @@ func (f *finiteChunksSource) Next(ctx context.Context) coldata.Batch {
 		}
 		return batch
 	}
-	return coldata.NewMemBatch([]coltypes.T{})
+	f.zeroBatch.SetLength(0)
+	return f.zeroBatch
 }
 
 func TestOpTestInputOutput(t *testing.T) {
@@ -1013,7 +1017,7 @@ func TestOpTestInputOutput(t *testing.T) {
 
 func TestRepeatableBatchSource(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	batchLen := uint16(10)
 	batch.SetLength(batchLen)
 	input := NewRepeatableBatchSource(batch)
@@ -1033,7 +1037,7 @@ func TestRepeatableBatchSource(t *testing.T) {
 
 func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
+	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	rng, _ := randutil.NewPseudoRand()
 	sel := randomSel(rng, 10 /* batchSize */, 0 /* probOfOmitting */)
 	batchLen := uint16(len(sel))
@@ -1106,7 +1110,7 @@ func newChunkingBatchSource(
 }
 
 func (c *chunkingBatchSource) Init() {
-	c.batch = coldata.NewMemBatch(c.typs)
+	c.batch = testAllocator.NewMemBatch(c.typs)
 	for i := range c.cols {
 		c.batch.ColVec(i).SetCol(c.cols[i].Col())
 		c.batch.ColVec(i).SetNulls(c.cols[i].Nulls())

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -60,7 +60,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	typs := []coltypes.T{coltypes.Int64}
 	t.Run("ReaderWaitingForStreamHandler", func(t *testing.T) {
-		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 		// Cancel the context.
@@ -75,7 +75,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("DuringRecv", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -106,7 +106,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("StreamHandlerWaitingForReader", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		ctx, cancelFn := context.WithCancel(context.Background())
@@ -124,7 +124,7 @@ func TestInboxCancellation(t *testing.T) {
 func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox([]coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(testAllocator, []coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	rpcLayer := makeMockFlowStreamRPCLayer()
@@ -149,7 +149,7 @@ func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 func TestInboxTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox([]coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(testAllocator, []coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	var (
@@ -218,7 +218,7 @@ func TestInboxShutdown(t *testing.T) {
 					"drain=%t/next=%t/stream=%t/inf=%t",
 					runDrainMetaGoroutine, runNextGoroutine, runRunWithStreamGoroutine, infiniteBatches,
 				), func(t *testing.T) {
-					inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
+					inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
 					c, err := colserde.NewArrowBatchConverter(typs)
 					require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -72,7 +72,10 @@ type Outbox struct {
 
 // NewOutbox creates a new Outbox.
 func NewOutbox(
-	input colexec.Operator, typs []coltypes.T, metadataSources []execinfrapb.MetadataSource,
+	allocator *colexec.Allocator,
+	input colexec.Operator,
+	typs []coltypes.T,
+	metadataSources []execinfrapb.MetadataSource,
 ) (*Outbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -85,7 +88,7 @@ func NewOutbox(
 	o := &Outbox{
 		// Add a deselector as selection vectors are not serialized (nor should they
 		// be).
-		OneInputNode:    colexec.NewOneInputNode(colexec.NewDeselectorOp(input, typs)),
+		OneInputNode:    colexec.NewOneInputNode(colexec.NewDeselectorOp(allocator, input, typs)),
 		typs:            typs,
 		converter:       c,
 		serializer:      s,

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -65,7 +65,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	col, err := colexec.NewColumnarizer(ctx, &flowCtx, 1, mts)
+	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 1, mts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -46,7 +46,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	types := sqlbase.OneIntCol
 	input := execinfra.NewRepeatableRowSource(types, sqlbase.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewColumnarizer(ctx, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	types := sqlbase.OneIntCol
 	input := execinfra.NewRepeatableRowSource(types, sqlbase.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewColumnarizer(ctx, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -75,9 +75,10 @@ func verifyColOperator(
 		return errors.New("processor is unexpectedly not a RowSource")
 	}
 
+	testAllocator := colexec.NewAllocator()
 	columnarizers := make([]colexec.Operator, len(inputs))
 	for i, input := range inputsColOp {
-		c, err := colexec.NewColumnarizer(ctx, flowCtx, int32(i)+1, input)
+		c, err := colexec.NewColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1490,4 +1490,38 @@ func TestLint(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("TestVectorizedAllocator", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			fmt.Sprintf(`coldata\.NewMem(Batch|BatchWithSize|Column)`),
+			"--",
+			"sql/colexec",
+			"sql/colflow",
+			":!sql/colexec/allocator.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use colexec.Allocator object instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
 }


### PR DESCRIPTION
This commit adds the plumbing of newly added Allocator which is
responsible for doling out batches to operators within a fixed budget.
The budgeting logic doesn't exist yet, but this commit adds the new type
and plumbs it through operators which use a variable amount of memory.
Next step is to actually measure the memory required when NewBatch or
Append is called and track that against a budget.

A linter rule is added that prohibits usage of coldata.NewMem* methods
within sql/colexec and sql/colflow packages.

Based on: #38394.
Fixes: #38056.

Release note: None