### PR TITLE
storage: don't hardcode the version for testContext

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -185,7 +185,7 @@ func (tc *testContext) Start(t testing.TB, stopper *stop.Stopper) {
 // StartWithStoreConfig initializes the test context with a single
 // range covering the entire keyspace.
 func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper, cfg StoreConfig) {
-	tc.StartWithStoreConfigAndVersion(t, stopper, cfg, cluster.BinaryServerVersion)
+	tc.StartWithStoreConfigAndVersion(t, stopper, cfg, cluster.Version.BinaryVersion(cfg.Settings))
 }
 
 // StartWithStoreConfigAndVersion is like StartWithStoreConfig but additionally


### PR DESCRIPTION
Instead, use the version from the settings.

Release note: None