### PR TITLE
roachtest: update gopg ORM test

### DIFF
--- a/pkg/cmd/roachtest/gopg_blacklist.go
+++ b/pkg/cmd/roachtest/gopg_blacklist.go
@@ -70,15 +70,14 @@ var gopgBlackList19_2 = blacklist{
 }
 
 var gopgIgnoreList19_2 = blacklist{
-	// TODO(yuzefovich): remove 'DB Prepare' and 'ORM slice model' tests from the
-	// list once the new version of gopg is released.
-	"pg | DB Prepare | returns an error when query can't be prepared": "41690",
-	"pg | ORM slice model | fetches Book relations":                   "41690",
-	"pg | ORM slice model | fetches Genre relations":                  "41690",
-	"pg | ORM slice model | fetches Translation relation":             "41690",
-	"pg | ORM struct model | fetches Author relations":                "41690",
-	"pg | ORM struct model | fetches Book relations":                  "41690",
-	"pg | ORM struct model | fetches Genre relations":                 "41690",
+	// These "fetching" tests assume a particular order when ORDER BY clause is
+	// omitted from the query by the ORM itself.
+	"pg | ORM slice model | fetches Book relations":       "41690",
+	"pg | ORM slice model | fetches Genre relations":      "41690",
+	"pg | ORM slice model | fetches Translation relation": "41690",
+	"pg | ORM struct model | fetches Author relations":    "41690",
+	"pg | ORM struct model | fetches Book relations":      "41690",
+	"pg | ORM struct model | fetches Genre relations":     "41690",
 	// This test assumes different transaction isolation level (READ COMMITTED).
 	"pg | Tx | supports CopyFrom and CopyIn": "41690",
 }


### PR DESCRIPTION
There was a new release of gopg ORM which included a couple of PRs that
improved the tool's testing infrastructure. Namely, the new release has
several environment variables that can override the default options, and
now we will use those. Also, there was a minor modification of error
matching, so we can remove one of the tests from the ignore lists.

Fixes: #41890.

Release note: None