### PR TITLE
mutations: add new mutations package

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -41,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1902,7 +1902,10 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 	if *showSQL {
 		t.outf("%s;", stmt.sql)
 	}
-	execSQL := t.assignRandomFamily(stmt.sql)
+	execSQL, changed := mutations.ForAllStatements(stmt.sql, mutations.ColumnFamilyMutator)
+	for _, c := range changed {
+		t.outf("rewrote: %s;", c)
+	}
 	res, err := t.db.Exec(execSQL)
 	if err == nil {
 		sqlutils.VerifyStatementPrettyRoundtrip(t.t(), stmt.sql)
@@ -1930,106 +1933,6 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 		t.finishOne("OK")
 	}
 	return cont, err
-}
-
-// assignRandomFamily modifies any CREATE TABLE statement without any FAMILY
-// definitions to have random FAMILY definitions. Any error encountered will
-// return the original sql string unchanged.
-func (t *logicTest) assignRandomFamily(sql string) string {
-	stmts, err := parser.Parse(sql)
-	if err != nil {
-		return sql
-	}
-	delim := ""
-	var sb strings.Builder
-	for _, stmt := range stmts {
-		sb.WriteString(delim)
-		delim = "\n"
-		ast, ok := stmt.AST.(*tree.CreateTable)
-		if !ok {
-			sb.WriteString(stmt.SQL)
-			sb.WriteString(";")
-			continue
-		}
-
-		hasFamily := false
-		var columns []tree.Name
-		isPKCol := map[tree.Name]bool{}
-		// Only mutate stmt.SQL if something changed.
-		create := stmt.SQL
-		for _, def := range ast.Defs {
-			switch def := def.(type) {
-			case *tree.FamilyTableDef:
-				hasFamily = true
-			case *tree.ColumnTableDef:
-				if def.HasColumnFamily() {
-					hasFamily = true
-					continue
-				}
-				// Primary keys must be in the first
-				// column family, so don't add them to
-				// the list.
-				if def.PrimaryKey {
-					continue
-				}
-				columns = append(columns, def.Name)
-			case *tree.UniqueConstraintTableDef:
-				// If there's an explicit PK index
-				// definition, save the columns from it
-				// and remove them later.
-				if def.PrimaryKey {
-					for _, col := range def.Columns {
-						isPKCol[col.Column] = true
-					}
-				}
-			}
-		}
-		// If there's no family definitions, randomly assign some.
-		if !hasFamily && len(columns) > 1 {
-			// Any columns not specified in column families
-			// are auto assigned to the first family, so
-			// there's no requirement to exhaust columns here.
-
-			// Remove columns specified in PK index
-			// definitions. We need to do this here because
-			// index defs and columns can appear in any
-			// order in the CREATE TABLE.
-			{
-				n := 0
-				for _, x := range columns {
-					if !isPKCol[x] {
-						columns[n] = x
-						n++
-					}
-				}
-				columns = columns[:n]
-			}
-			rand.Shuffle(len(columns), func(i, j int) {
-				columns[i], columns[j] = columns[j], columns[i]
-			})
-			fd := &tree.FamilyTableDef{}
-			for {
-				if len(columns) == 0 {
-					if len(fd.Columns) > 0 {
-						ast.Defs = append(ast.Defs, fd)
-					}
-					break
-				}
-				fd.Columns = append(fd.Columns, columns[0])
-				columns = columns[1:]
-				// 50% chance to make a new column family.
-				if rand.Intn(2) != 0 {
-					ast.Defs = append(ast.Defs, fd)
-					fd = &tree.FamilyTableDef{}
-				}
-			}
-			create = ast.String()
-			t.outf("rewrote: %s;", create)
-		}
-		sb.WriteString(create)
-		sb.WriteString(";")
-	}
-	return sb.String()
 }
 
 func (t *logicTest) hashResults(results []string) (string, error) {

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -1,0 +1,128 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mutations
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// StatementMutator defines a func that can change a statement.
+type StatementMutator func(stmt tree.Statement) (changed bool)
+
+// ForAllStatements executes stmtMutator on all SQL statements of input. The
+// list of changed statements is returned.
+func ForAllStatements(
+	input string, stmtMutator StatementMutator,
+) (output string, changed []string) {
+	parsed, err := parser.Parse(input)
+	if err != nil {
+		return input, nil
+	}
+
+	var sb strings.Builder
+	for _, p := range parsed {
+		stmtChanged := stmtMutator(p.AST)
+		if !stmtChanged {
+			sb.WriteString(p.SQL)
+		} else {
+			s := p.AST.String()
+			sb.WriteString(s)
+			changed = append(changed, s)
+		}
+		sb.WriteString(";\n")
+	}
+	return sb.String(), changed
+}
+
+// ColumnFamilyMutator modifies a CREATE TABLE statement without any FAMILY
+// definitions to have random FAMILY definitions.
+func ColumnFamilyMutator(stmt tree.Statement) (changed bool) {
+	ast, ok := stmt.(*tree.CreateTable)
+	if !ok {
+		return false
+	}
+
+	var columns []tree.Name
+	isPKCol := map[tree.Name]bool{}
+	for _, def := range ast.Defs {
+		switch def := def.(type) {
+		case *tree.FamilyTableDef:
+			return false
+		case *tree.ColumnTableDef:
+			if def.HasColumnFamily() {
+				return false
+			}
+			// Primary keys must be in the first
+			// column family, so don't add them to
+			// the list.
+			if def.PrimaryKey {
+				continue
+			}
+			columns = append(columns, def.Name)
+		case *tree.UniqueConstraintTableDef:
+			// If there's an explicit PK index
+			// definition, save the columns from it
+			// and remove them later.
+			if def.PrimaryKey {
+				for _, col := range def.Columns {
+					isPKCol[col.Column] = true
+				}
+			}
+		}
+	}
+
+	if len(columns) <= 1 {
+		return false
+	}
+
+	// Any columns not specified in column families
+	// are auto assigned to the first family, so
+	// there's no requirement to exhaust columns here.
+
+	// Remove columns specified in PK index
+	// definitions. We need to do this here because
+	// index defs and columns can appear in any
+	// order in the CREATE TABLE.
+	{
+		n := 0
+		for _, x := range columns {
+			if !isPKCol[x] {
+				columns[n] = x
+				n++
+			}
+		}
+		columns = columns[:n]
+	}
+	rand.Shuffle(len(columns), func(i, j int) {
+		columns[i], columns[j] = columns[j], columns[i]
+	})
+	fd := &tree.FamilyTableDef{}
+	for {
+		if len(columns) == 0 {
+			if len(fd.Columns) > 0 {
+				ast.Defs = append(ast.Defs, fd)
+			}
+			break
+		}
+		fd.Columns = append(fd.Columns, columns[0])
+		columns = columns[1:]
+		// 50% chance to make a new column family.
+		if rand.Intn(2) != 0 {
+			ast.Defs = append(ast.Defs, fd)
+			fd = &tree.FamilyTableDef{}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The mutations package will contain common SQL mutations that can be
applied to statements. Mutations are modifications to SQL DDL statements
that can be applied in testing. Mutations may or may not guarantee that
subsequent queries (SELECTs) run after the mutations return identical
results. Due to this, tests will have to opt in to which mutations they
want to run, since some could change output.

The first mutation is a column family randomizer which is being relocated
from the logic tests. RandCreateTable previously did its own column
family randomization, but can now use this mutation.

Depending on what other mutations are added, I expect the API of this
package to change to adapt to the needs of its callers. The current API
is approximately the minimum needed for the current two usages.

Release note: None