### PR TITLE
release-19.2: colexec: fix AND and OR projections in some cases

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -141,13 +141,14 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	var curIdx uint16
 	if usesSel {
 		sel := batch.Selection()
+		origSel := o.origSel[:origLen]
 		if leftCol.MaybeHasNulls() {
 			leftNulls := leftCol.Nulls()
-			for _, i := range o.origSel[:origLen] {
+			for _, i := range origSel {
 				_ADD_TUPLE_FOR_RIGHT(true)
 			}
 		} else {
-			for _, i := range o.origSel {
+			for _, i := range origSel {
 				_ADD_TUPLE_FOR_RIGHT(false)
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #42129.

/cc @cockroachdb/release

---

Previously, the original batch length was not respected when the
selection vector is present. This resulted in, for example, query 19 of
TPCH benchmark to return an error. This is now fixed.

I have troubles coming up with a reduced reproduction though.

I also checked that on release-19.2 branch the query is executed
correctly with vectorized, so it must be the switch to flat bytes that
triggers the problem.

Release note: None
