### PR TITLE
colexec: create a new string from bytes in PhysicalTypeColElemToDatum

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -40,8 +40,6 @@ func registerTPCHVec(r *testRegistry) {
 		16: "unsupported: distinct aggregation #39242",
 		20: "incorrect output: #42047",
 		21: "unsupported: non-inner hash join with ON expression #38018",
-		// TODO(yuzefovich): triage this failure.
-		22: "incorrect output: unknown",
 	}
 	var vecOffQueriesToSkip = map[int]string{
 		// TODO(yuzefovich): remove this once we're not skipping query 9 with vec

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"fmt"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
@@ -59,9 +58,9 @@ func PhysicalTypeColElemToDatum(
 	case types.StringFamily:
 		b := col.Bytes().Get(int(rowIdx))
 		if ct.Oid() == oid.T_name {
-			return da.NewDName(tree.DString(*(*string)(unsafe.Pointer(&b))))
+			return da.NewDName(tree.DString(string(b)))
 		}
-		return da.NewDString(tree.DString(*(*string)(unsafe.Pointer(&b))))
+		return da.NewDString(tree.DString(string(b)))
 	case types.BytesFamily:
 		return da.NewDBytes(tree.DBytes(col.Bytes().Get(int(rowIdx))))
 	case types.OidFamily:


### PR DESCRIPTION
Previously, bytes were cast to a string using unsafe.Pointer. Since the
introduction of flat bytes, this would be problematic since the underlying
bytes could be overwritten.

Our contract is that rows should be copied if reused after calling Next, but
processors that use CopyRow only copy the references. This is usually enough,
but in the case of flat bytes the copy needs to be done deeper. It's unclear
whether we want to add a Copy method to all Datums so the temporary solution
is to return Datums whose underlying memory is not overwritten.

Release note: None

Fixes #42191 