### PR TITLE
roachtest: update hibernate blacklist for new failing test

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -134,6 +134,7 @@ var hibernateBlackList19_2 = blacklist{
 	"org.hibernate.test.hql.ASTParserLoadingTest.testSelectExpressions":                                                                                                              "41943",
 	"org.hibernate.test.hql.ASTParserLoadingTest.testSimpleSelect":                                                                                                                   "unknown",
 	"org.hibernate.test.hql.ASTParserLoadingTest.testStandardFunctions":                                                                                                              "26097",
+	"org.hibernate.test.hql.ASTParserLoadingTest.testStr":                                                                                                                            "42244",
 	"org.hibernate.test.hql.ASTParserLoadingTest.testWhere":                                                                                                                          "unknown",
 	"org.hibernate.test.hql.BulkManipulationTest.testBooleanHandling":                                                                                                                "5807",
 	"org.hibernate.test.hql.BulkManipulationTest.testDeleteOnDiscriminatorSubclass":                                                                                                  "5807",


### PR DESCRIPTION
Release note: None