### PR TITLE
storage: Move SSTWriter to engine, use it instead of Rocks-based writer

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -349,10 +349,7 @@ func writeSST(
 	filename := fmt.Sprintf("load-%d.sst", rand.Int63())
 	log.Info(ctx, "writesst ", filename)
 
-	sst, err := engine.MakeRocksDBSstFileWriter()
-	if err != nil {
-		return err
-	}
+	sst := engine.MakeSSTWriter()
 	defer sst.Close()
 	for _, kv := range kvs {
 		kv.Key.Timestamp = ts
@@ -378,6 +375,6 @@ func writeSST(
 		},
 		Path: filename,
 	})
-	backup.EntryCounts.DataSize += sst.DataSize()
+	backup.EntryCounts.DataSize += sst.DataSize
 	return nil
 }

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -349,7 +349,8 @@ func writeSST(
 	filename := fmt.Sprintf("load-%d.sst", rand.Int63())
 	log.Info(ctx, "writesst ", filename)
 
-	sst := engine.MakeSSTWriter()
+	sstFile := &engine.MemFile{}
+	sst := engine.MakeSSTWriter(sstFile)
 	defer sst.Close()
 	for _, kv := range kvs {
 		kv.Key.Timestamp = ts
@@ -357,12 +358,14 @@ func writeSST(
 			return err
 		}
 	}
-	sstContents, err := sst.Finish()
+	err := sst.Finish()
 	if err != nil {
 		return err
 	}
 
-	if err := base.WriteFile(ctx, filename, bytes.NewReader(sstContents)); err != nil {
+	// TODO(itsbilal): Pass a file handle into SSTWriter instead of writing to a
+	// MemFile first.
+	if err := base.WriteFile(ctx, filename, bytes.NewReader(sstFile.Data())); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -54,10 +54,8 @@ func BenchmarkAddSSTable(b *testing.B) {
 			b.StopTimer()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				sst, err := engine.MakeRocksDBSstFileWriter()
-				if err != nil {
-					b.Fatalf("%+v", err)
-				}
+				sstFile := &engine.MemFile{}
+				sst := engine.MakeSSTWriter(sstFile)
 
 				id++
 				backup.ResetKeyValueIteration()
@@ -70,11 +68,11 @@ func BenchmarkAddSSTable(b *testing.B) {
 						b.Fatalf("%+v", err)
 					}
 				}
-				data, err := sst.Finish()
-				if err != nil {
+				if err := sst.Finish(); err != nil {
 					b.Fatalf("%+v", err)
 				}
 				sst.Close()
+				data := sstFile.Data()
 				totalLen += int64(len(data))
 
 				b.StartTimer()

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -80,7 +80,7 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {
 				mvccKey := engine.MVCCKey{Timestamp: sstTS, Key: kv.Key}
-				if err := sw.Add(engine.MVCCKeyValue{Key: mvccKey, Value: kv.Value.RawBytes}); err != nil {
+				if err := sw.Put(mvccKey, kv.Value.RawBytes); err != nil {
 					return err
 				}
 			}

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -91,6 +91,7 @@ type SSTBatcher struct {
 	// The rest of the fields are per-batch and are reset via Reset() before each
 	// batch is started.
 	sstWriter       engine.SSTWriter
+	sstFile         *engine.MemFile
 	batchStartKey   []byte
 	batchEndKey     []byte
 	batchEndValue   []byte
@@ -175,7 +176,8 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value [
 // Reset clears all state in the batcher and prepares it for reuse.
 func (b *SSTBatcher) Reset() error {
 	b.sstWriter.Close()
-	b.sstWriter = engine.MakeSSTWriter()
+	b.sstFile = &engine.MemFile{}
+	b.sstWriter = engine.MakeSSTWriter(b.sstFile)
 	b.batchStartKey = b.batchStartKey[:0]
 	b.batchEndKey = b.batchEndKey[:0]
 	b.batchEndValue = b.batchEndValue[:0]
@@ -276,7 +278,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		b.flushCounts.split++
 	}
 
-	sstBytes, err := b.sstWriter.Finish()
+	err := b.sstWriter.Finish()
 	if err != nil {
 		return errors.Wrapf(err, "finishing constructed sstable")
 	}
@@ -288,7 +290,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 	}
 
 	beforeSend := timeutil.Now()
-	files, err := AddSSTable(ctx, b.db, start, end, sstBytes, b.disallowShadowing, b.ms, b.settings)
+	files, err := AddSSTable(ctx, b.db, start, end, b.sstFile.Data(), b.disallowShadowing, b.ms, b.settings)
 	if err != nil {
 		return err
 	}
@@ -468,7 +470,8 @@ func createSplitSSTable(
 	disallowShadowing bool,
 	iter engine.SimpleIterator,
 ) (*sstSpan, *sstSpan, error) {
-	w := engine.MakeSSTWriter()
+	sstFile := &engine.MemFile{}
+	w := engine.MakeSSTWriter(sstFile)
 	defer w.Close()
 
 	split := false
@@ -486,17 +489,19 @@ func createSplitSSTable(
 		key := iter.UnsafeKey()
 
 		if !split && key.Key.Compare(splitKey) >= 0 {
-			res, err := w.Finish()
+			err := w.Finish()
+
 			if err != nil {
 				return nil, nil, err
 			}
 			left = &sstSpan{
 				start:             first,
 				end:               last.PrefixEnd(),
-				sstBytes:          res,
+				sstBytes:          sstFile.Data(),
 				disallowShadowing: disallowShadowing,
 			}
-			w = engine.MakeSSTWriter()
+			*sstFile = engine.MemFile{}
+			w = engine.MakeSSTWriter(sstFile)
 			split = true
 			first = nil
 			last = nil
@@ -514,14 +519,14 @@ func createSplitSSTable(
 		iter.Next()
 	}
 
-	res, err := w.Finish()
+	err := w.Finish()
 	if err != nil {
 		return nil, nil, err
 	}
 	right = &sstSpan{
 		start:             first,
 		end:               last.PrefixEnd(),
-		sstBytes:          res,
+		sstBytes:          sstFile.Data(),
 		disallowShadowing: disallowShadowing,
 	}
 	return left, right, nil

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -169,7 +169,7 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value [
 		b.updateMVCCStats(key, value)
 	}
 
-	return b.sstWriter.Add(engine.MVCCKeyValue{Key: key, Value: value})
+	return b.sstWriter.Put(key, value)
 }
 
 // Reset clears all state in the batcher and prepares it for reuse.
@@ -507,7 +507,7 @@ func createSplitSSTable(
 		}
 		last = append(last[:0], key.Key...)
 
-		if err := w.Add(engine.MVCCKeyValue{Key: key, Value: iter.UnsafeValue()}); err != nil {
+		if err := w.Put(key, iter.UnsafeValue()); err != nil {
 			return nil, nil, err
 		}
 

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -37,6 +37,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeIntTableKVs(numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
+	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
+	kvs := make([]engine.MVCCKeyValue, numKeys)
+	r, _ := randutil.NewPseudoRand()
+
+	var k int
+	for i := 0; i < numKeys; {
+		k += 1 + rand.Intn(100)
+		key := encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(k))
+		buf := make([]byte, valueSize)
+		randutil.ReadTestdataBytes(r, buf)
+		revisions := 1 + r.Intn(maxRevisions)
+
+		ts := int64(maxRevisions * 100)
+		for j := 0; j < revisions && i < numKeys; j++ {
+			ts -= 1 + r.Int63n(99)
+			kvs[i].Key.Key = key
+			kvs[i].Key.Timestamp.WallTime = ts
+			kvs[i].Key.Timestamp.Logical = r.Int31()
+			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
+			i++
+		}
+	}
+	return kvs
+}
+
+func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
+	w, err := engine.MakeRocksDBSstFileWriter()
+	require.NoError(t, err)
+	defer w.Close()
+
+	for i := range kvs {
+		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sst, err := w.Finish()
+	require.NoError(t, err)
+	return sst
+}
+
 func TestAddBatched(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Run("batch=default", func(t *testing.T) {
@@ -299,45 +340,4 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 		t.Fatalf("Mem usage grew from %dkb before grew to %dkb later (%.2fx)",
 			early/kb, late/kb, float64(late)/float64(early))
 	}
-}
-
-func makeIntTableKVs(numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
-	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
-	kvs := make([]engine.MVCCKeyValue, numKeys)
-	r, _ := randutil.NewPseudoRand()
-
-	var k int
-	for i := 0; i < numKeys; {
-		k += 1 + rand.Intn(100)
-		key := encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(k))
-		buf := make([]byte, valueSize)
-		randutil.ReadTestdataBytes(r, buf)
-		revisions := 1 + r.Intn(maxRevisions)
-
-		ts := int64(maxRevisions * 100)
-		for j := 0; j < revisions && i < numKeys; j++ {
-			ts -= 1 + r.Int63n(99)
-			kvs[i].Key.Key = key
-			kvs[i].Key.Timestamp.WallTime = ts
-			kvs[i].Key.Timestamp.Logical = r.Int31()
-			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
-			i++
-		}
-	}
-	return kvs
-}
-
-func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
-	w, err := engine.MakeRocksDBSstFileWriter()
-	require.NoError(t, err)
-	defer w.Close()
-
-	for i := range kvs {
-		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
-			t.Fatal(err)
-		}
-	}
-	sst, err := w.Finish()
-	require.NoError(t, err)
-	return sst
 }

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2890,10 +2890,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 		// Range-id local range of subsumed replicas.
 		for _, rangeID := range []roachpb.RangeID{roachpb.RangeID(3), roachpb.RangeID(4)} {
-			sst, err := engine.MakeRocksDBSstFileWriter()
-			if err != nil {
-				return err
-			}
+			sst := engine.MakeSSTWriter()
 			defer sst.Close()
 			r := rditer.MakeRangeIDLocalKeyRange(rangeID, false)
 			if err := sst.ClearRange(r.Start, r.End); err != nil {
@@ -2912,10 +2909,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		}
 
 		// User key range of subsumed replicas.
-		sst, err := engine.MakeRocksDBSstFileWriter()
-		if err != nil {
-			return err
-		}
+		sst := engine.MakeSSTWriter()
 		defer sst.Close()
 		desc := roachpb.RangeDescriptor{
 			StartKey: roachpb.RKey("d"),

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2890,7 +2890,8 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 		// Range-id local range of subsumed replicas.
 		for _, rangeID := range []roachpb.RangeID{roachpb.RangeID(3), roachpb.RangeID(4)} {
-			sst := engine.MakeSSTWriter()
+			sstFile := &engine.MemFile{}
+			sst := engine.MakeSSTWriter(sstFile)
 			defer sst.Close()
 			r := rditer.MakeRangeIDLocalKeyRange(rangeID, false)
 			if err := sst.ClearRange(r.Start, r.End); err != nil {
@@ -2901,15 +2902,16 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			if err := engine.MVCCBlindPutProto(context.TODO(), &sst, nil, tombstoneKey, hlc.Timestamp{}, tombstoneValue, nil); err != nil {
 				return err
 			}
-			expectedSST, err := sst.Finish()
+			err := sst.Finish()
 			if err != nil {
 				return err
 			}
-			expectedSSTs = append(expectedSSTs, expectedSST)
+			expectedSSTs = append(expectedSSTs, sstFile.Data())
 		}
 
 		// User key range of subsumed replicas.
-		sst := engine.MakeSSTWriter()
+		sstFile := &engine.MemFile{}
+		sst := engine.MakeSSTWriter(sstFile)
 		defer sst.Close()
 		desc := roachpb.RangeDescriptor{
 			StartKey: roachpb.RKey("d"),
@@ -2919,11 +2921,11 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		if err := engine.ClearRangeWithHeuristic(eng, &sst, r.Start.Key, r.End.Key); err != nil {
 			return err
 		}
-		expectedSST, err := sst.Finish()
+		err := sst.Finish()
 		if err != nil {
 			return err
 		}
-		expectedSSTs = append(expectedSSTs, expectedSST)
+		expectedSSTs = append(expectedSSTs, sstFile.Data())
 
 		for i := range sstNames {
 			actualSST, err := eng.ReadFile(sstNames[i])

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -317,18 +317,6 @@ type ReadWriter interface {
 	Writer
 }
 
-// SstFileWriter is the write interface to an engine's sst file data.
-type SstFileWriter interface {
-	// TODO(hueypark): Check necessity of Pebble SstFileWriter.
-	// Close finishes and frees memory and other resources. Close is idempotent.
-	Close()
-	// DataSize returns the total key and value bytes added so far.
-	DataSize() int64
-	// Finish finalizes the writer and returns the constructed file's contents. At
-	// least one kv entry must have been added.
-	Finish() ([]byte, error)
-}
-
 // Engine is the interface that wraps the core operations of a key/value store.
 type Engine interface {
 	ReadWriter

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -987,7 +987,7 @@ func pebbleExportToSst(
 				return nil, roachpb.BulkOpSummary{}, errors.Wrapf(err, "decoding %s", unsafeKey)
 			}
 			rows.BulkOpSummary.DataSize += int64(len(unsafeKey.Key) + len(unsafeValue))
-			if err := sstWriter.Add(MVCCKeyValue{Key: unsafeKey, Value: unsafeValue}); err != nil {
+			if err := sstWriter.Put(unsafeKey, unsafeValue); err != nil {
 				return nil, roachpb.BulkOpSummary{}, errors.Wrapf(err, "adding key %s", unsafeKey)
 			}
 		}

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -951,7 +951,8 @@ func (p pebbleSnapshot) NewIterator(opts IterOptions) Iterator {
 func pebbleExportToSst(
 	e Reader, start, end MVCCKey, exportAllRevisions bool, io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
-	sstWriter := MakeSSTWriter()
+	sstFile := &MemFile{}
+	sstWriter := MakeSSTWriter(sstFile)
 	defer sstWriter.Close()
 
 	var rows RowCounter
@@ -999,10 +1000,9 @@ func pebbleExportToSst(
 		}
 	}
 
-	data, err := sstWriter.Finish()
-	if err != nil {
+	if err := sstWriter.Finish(); err != nil {
 		return nil, roachpb.BulkOpSummary{}, err
 	}
 
-	return data, rows.BulkOpSummary, nil
+	return sstFile.Data(), rows.BulkOpSummary, nil
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2943,6 +2943,12 @@ var _ Writer = &RocksDBSstFileWriter{}
 
 // MakeRocksDBSstFileWriter creates a new RocksDBSstFileWriter with the default
 // configuration.
+//
+// NOTE: This is deprecated - and should only be used in tests to check for
+// equivalence with engine.SSTWriter.
+//
+// TODO(itsbilal): Move all tests to SSTWriter and then delete this function
+// and struct.
 func MakeRocksDBSstFileWriter() (RocksDBSstFileWriter, error) {
 	fw := C.DBSstFileWriterNew()
 	err := statusToError(C.DBSstFileWriterOpen(fw))

--- a/pkg/storage/engine/sst_iterator_test.go
+++ b/pkg/storage/engine/sst_iterator_test.go
@@ -72,10 +72,8 @@ func runTestSSTIterator(t *testing.T, iter SimpleIterator, allKVs []MVCCKeyValue
 func TestSSTIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sst, err := MakeRocksDBSstFileWriter()
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	sstFile := &MemFile{}
+	sst := MakeSSTWriter(sstFile)
 	defer sst.Close()
 	var allKVs []MVCCKeyValue
 	for i := 0; i < 10; i++ {
@@ -92,8 +90,7 @@ func TestSSTIterator(t *testing.T) {
 		allKVs = append(allKVs, kv)
 	}
 
-	data, err := sst.Finish()
-	if err != nil {
+	if err := sst.Finish(); err != nil {
 		t.Fatalf("%+v", err)
 	}
 
@@ -102,7 +99,7 @@ func TestSSTIterator(t *testing.T) {
 		defer cleanup()
 
 		path := filepath.Join(tempDir, "data.sst")
-		if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		if err := ioutil.WriteFile(path, sstFile.Data(), 0600); err != nil {
 			t.Fatalf("%+v", err)
 		}
 
@@ -114,7 +111,7 @@ func TestSSTIterator(t *testing.T) {
 		runTestSSTIterator(t, iter, allKVs)
 	})
 	t.Run("Mem", func(t *testing.T) {
-		iter, err := NewMemSSTIterator(data, false)
+		iter, err := NewMemSSTIterator(sstFile.Data(), false)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/storage/engine/sst_writer.go
+++ b/pkg/storage/engine/sst_writer.go
@@ -11,9 +11,7 @@
 package engine
 
 import (
-	"io"
-
-	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/pkg/errors"
 )
@@ -25,36 +23,25 @@ type SSTWriter struct {
 	// DataSize tracks the total key and value bytes added so far.
 	DataSize int64
 	scratch  []byte
+	// lastTruncatedAt tracks the last byte of memFile at which Truncate() was
+	// called. Only return bytes in Finish after this point.
+	lastTruncatedAt uint64
 }
 
 // MakeSSTWriter creates a new SSTWriter.
 func MakeSSTWriter() SSTWriter {
-	opts := sstable.WriterOptions{
-		BlockSize:               32 * 1024,
-		TableFormat:             pebble.TableFormatLevelDB,
-		Comparer:                MVCCComparer,
-		MergerName:              "nullptr",
-		TablePropertyCollectors: PebbleTablePropertyCollectors,
-	}
+	opts := DefaultPebbleOptions().MakeWriterOptions(0)
+	opts.TableFormat = sstable.TableFormatLevelDB
+	opts.MergerName = "nullptr"
+	// Disable bloom filters to produce SSTs matching those from RocksDB.
+	opts.FilterPolicy = nil
 	f := &memFile{}
 	sst := sstable.NewWriter(f, opts)
 	return SSTWriter{fw: sst, f: f}
 }
 
-// Add puts a kv entry into the sstable being built. An error is returned if it
-// is not greater than any previously added entry (according to the comparator
-// configured during writer creation). `Close` cannot have been called.
-func (fw *SSTWriter) Add(kv MVCCKeyValue) error {
-	if fw.fw == nil {
-		return errors.New("cannot call Open on a closed writer")
-	}
-	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
-	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], kv.Key)
-	return fw.fw.Set(fw.scratch, kv.Value)
-}
-
-// Finish finalizes the writer and returns the constructed file's contents. At
-// least one kv entry must have been added.
+// Finish finalizes the writer and returns the constructed file's contents,
+// since the last call to Truncate (if any). At least one kv entry must have been added.
 func (fw *SSTWriter) Finish() ([]byte, error) {
 	if fw.fw == nil {
 		return nil, errors.New("cannot call Finish on a closed writer")
@@ -63,7 +50,105 @@ func (fw *SSTWriter) Finish() ([]byte, error) {
 		return nil, err
 	}
 	fw.fw = nil
-	return fw.f.data, nil
+	return fw.f.data[fw.lastTruncatedAt:], nil
+}
+
+// ClearRange implements the Writer interface.
+func (fw *SSTWriter) ClearRange(start, end MVCCKey) error {
+	if fw.fw == nil {
+		return errors.New("cannot call ClearRange on a closed writer")
+	}
+	fw.DataSize += int64(len(start.Key)) + int64(len(end.Key))
+	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], start)
+	return fw.fw.DeleteRange(fw.scratch, EncodeKey(end))
+}
+
+// Put puts a kv entry into the sstable being built. An error is returned if it
+// is not greater than any previously added entry (according to the comparator
+// configured during writer creation). `Close` cannot have been called.
+func (fw *SSTWriter) Put(key MVCCKey, value []byte) error {
+	if fw.fw == nil {
+		return errors.New("cannot call Put on a closed writer")
+	}
+	fw.DataSize += int64(len(key.Key)) + int64(len(value))
+	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], key)
+	return fw.fw.Set(fw.scratch, value)
+}
+
+// Truncate returns the in-memory buffer from the previous call to Truncate
+// (or the start), until now.
+func (fw *SSTWriter) Truncate() ([]byte, error) {
+	oldData := fw.f.data[fw.lastTruncatedAt:]
+	fw.lastTruncatedAt = uint64(len(fw.f.data))
+	return oldData, nil
+}
+
+// ApplyBatchRepr implements the Writer interface.
+func (fw *SSTWriter) ApplyBatchRepr(repr []byte, sync bool) error {
+	panic("unimplemented")
+}
+
+// Clear implements the Writer interface.
+func (fw *SSTWriter) Clear(key MVCCKey) error {
+	if fw.fw == nil {
+		return errors.New("cannot call Clear on a closed writer")
+	}
+	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], key)
+	fw.DataSize += int64(len(key.Key))
+	return fw.fw.Delete(fw.scratch)
+}
+
+// SingleClear implements the Writer interface.
+func (fw *SSTWriter) SingleClear(key MVCCKey) error {
+	panic("unimplemented")
+}
+
+// ClearIterRange implements the Writer interface.
+func (fw *SSTWriter) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+	if fw.fw == nil {
+		return errors.New("cannot call ClearIterRange on a closed writer")
+	}
+
+	// Set an upper bound on the iterator. This is okay because all calls to
+	// ClearIterRange are with throwaway iterators, so there should be no new
+	// side effects.
+	iter.SetUpperBound(end)
+	iter.Seek(MakeMVCCMetadataKey(start))
+
+	valid, err := iter.Valid()
+	for valid && err == nil {
+		key := iter.UnsafeKey()
+		fw.scratch = EncodeKeyToBuf(fw.scratch[:0], key)
+		fw.DataSize += int64(len(key.Key))
+		if err := fw.fw.Delete(fw.scratch); err != nil {
+			return err
+		}
+
+		iter.Next()
+		valid, err = iter.Valid()
+	}
+	return err
+}
+
+// Merge implements the Writer interface.
+func (fw *SSTWriter) Merge(key MVCCKey, value []byte) error {
+	if fw.fw == nil {
+		return errors.New("cannot call Merge on a closed writer")
+	}
+	fw.DataSize += int64(len(key.Key)) + int64(len(value))
+	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], key)
+	return fw.fw.Merge(fw.scratch, value)
+}
+
+// LogData implements the Writer interface.
+func (fw *SSTWriter) LogData(data []byte) error {
+	// No-op.
+	return nil
+}
+
+// LogLogicalOp implements the Writer interface.
+func (fw *SSTWriter) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+	// No-op.
 }
 
 // Close finishes and frees memory and other resources. Close is idempotent.
@@ -82,7 +167,6 @@ func (fw *SSTWriter) Close() {
 
 type memFile struct {
 	data []byte
-	pos  int
 }
 
 func (*memFile) Close() error {
@@ -91,22 +175,6 @@ func (*memFile) Close() error {
 
 func (*memFile) Sync() error {
 	return nil
-}
-
-func (f *memFile) Read(p []byte) (int, error) {
-	if f.pos >= len(f.data) {
-		return 0, io.EOF
-	}
-	n := copy(p, f.data[f.pos:])
-	f.pos += n
-	return n, nil
-}
-
-func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
-	if off >= int64(len(f.data)) {
-		return 0, io.EOF
-	}
-	return copy(p, f.data[off:]), nil
 }
 
 func (f *memFile) Write(p []byte) (int, error) {

--- a/pkg/storage/engine/sst_writer_test.go
+++ b/pkg/storage/engine/sst_writer_test.go
@@ -11,8 +11,6 @@
 package engine_test
 
 import (
-	"bytes"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -20,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
@@ -68,7 +65,8 @@ func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
 }
 
 func makePebbleSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
-	w := engine.MakeSSTWriter()
+	f := &engine.MemFile{}
+	w := engine.MakeSSTWriter(f)
 	defer w.Close()
 
 	for i := range kvs {
@@ -76,9 +74,9 @@ func makePebbleSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
 			t.Fatal(err)
 		}
 	}
-	sst, err := w.Finish()
+	err := w.Finish()
 	require.NoError(t, err)
-	return sst
+	return f.Data()
 }
 
 // TestPebbleWritesSameSSTs tests that using pebble to write some SST produces
@@ -141,73 +139,6 @@ func TestPebbleWritesSameSSTs(t *testing.T) {
 		}
 	}
 	require.Equal(t, string(sstRocks), string(sstPebble))
-}
-
-// TestSSTFileWriterTruncate ensures that sum of the chunks created by
-// calling Truncate on a RocksDBSstFileWriter is equivalent to an SST built
-// without ever calling Truncate.
-func TestSSTFileWriterTruncate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	// Truncate will be used on this writer.
-	sst1 := engine.MakeSSTWriter()
-	defer sst1.Close()
-
-	// Truncate will not be used on this writer.
-	sst2 := engine.MakeSSTWriter()
-	defer sst2.Close()
-
-	const keyLen = 10
-	const valLen = 950
-	ts := hlc.Timestamp{WallTime: 1}
-	key := engine.MVCCKey{Key: roachpb.Key(make([]byte, keyLen)), Timestamp: ts}
-	value := make([]byte, valLen)
-
-	var resBuf1, resBuf2 []byte
-	const entries = 100000
-	const truncateChunk = entries / 10
-	for i := 0; i < entries; i++ {
-		key.Key = []byte(fmt.Sprintf("%09d", i))
-		copy(value, key.Key)
-
-		if err := sst1.Put(key, value); err != nil {
-			t.Fatal(err)
-		}
-		if err := sst2.Put(key, value); err != nil {
-			t.Fatal(err)
-		}
-
-		if i > 0 && i%truncateChunk == 0 {
-			sst1Chunk, err := sst1.Truncate()
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Logf("iteration %d, truncate chunk\tlen=%d", i, len(sst1Chunk))
-
-			if len(sst1Chunk) == 0 {
-				t.Fatalf("expected non-empty SST chunk during iteration %d", i)
-			}
-			resBuf1 = append(resBuf1, sst1Chunk...)
-		}
-	}
-
-	sst1FinishBuf, err := sst1.Finish()
-	if err != nil {
-		t.Fatal(err)
-	}
-	resBuf1 = append(resBuf1, sst1FinishBuf...)
-	t.Logf("truncated sst final chunk\t\tlen=%d", len(sst1FinishBuf))
-
-	resBuf2, err = sst2.Finish()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("non-truncated sst final chunk\tlen=%d", len(resBuf2))
-
-	if !bytes.Equal(resBuf1, resBuf2) {
-		t.Errorf("expected SST made up of truncate chunks (len=%d) to be equivalent to SST that "+
-			"was not (len=%d)", len(sst1FinishBuf), len(resBuf2))
-	}
 }
 
 func BenchmarkWriteRocksSSTable(b *testing.B) {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -817,7 +817,8 @@ func (r *Replica) applySnapshot(
 			inSnap.SnapUUID.Short(), snap.Metadata.Index)
 	}(timeutil.Now())
 
-	unreplicatedSST := engine.MakeSSTWriter()
+	unreplicatedSSTFile := &engine.MemFile{}
+	unreplicatedSST := engine.MakeSSTWriter(unreplicatedSSTFile)
 	defer unreplicatedSST.Close()
 
 	// Clearing the unreplicated state.
@@ -874,8 +875,15 @@ func (r *Replica) applySnapshot(
 		}
 	}
 
-	if err := inSnap.SSSS.WriteSST(ctx, &unreplicatedSST); err != nil {
+	if err := unreplicatedSST.Finish(); err != nil {
 		return err
+	}
+	if unreplicatedSST.DataSize > 0 {
+		// TODO(itsbilal): Write to SST directly in unreplicatedSST rather than
+		// buffering in a MemFile first.
+		if err := inSnap.SSSS.WriteSST(ctx, unreplicatedSSTFile.Data()); err != nil {
+			return err
+		}
 	}
 
 	if s.RaftAppliedIndex != snap.Metadata.Index {
@@ -996,7 +1004,9 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges[:]...)
 	for _, sr := range subsumedRepls {
 		// We have to create an SST for the subsumed replica's range-id local keys.
-		subsumedReplSST := engine.MakeSSTWriter()
+		subsumedReplSSTFile := &engine.MemFile{}
+		subsumedReplSST := engine.MakeSSTWriter(subsumedReplSSTFile)
+		defer subsumedReplSST.Close()
 		// NOTE: We set mustClearRange to true because we are setting
 		// RaftTombstoneKey. Since Clears and Puts need to be done in increasing
 		// order of keys, it is not safe to use ClearRangeIter.
@@ -1011,8 +1021,15 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 			subsumedReplSST.Close()
 			return err
 		}
-		if err := ssss.WriteSST(ctx, &subsumedReplSST); err != nil {
+		if err := subsumedReplSST.Finish(); err != nil {
 			return err
+		}
+		if subsumedReplSST.DataSize > 0 {
+			// TODO(itsbilal): Write to SST directly in subsumedReplSST rather than
+			// buffering in a MemFile first.
+			if err := ssss.WriteSST(ctx, subsumedReplSSTFile.Data()); err != nil {
+				return err
+			}
 		}
 
 		srKeyRanges := getKeyRanges(sr.Desc())
@@ -1043,7 +1060,9 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	// subsume both r1 and r2 in S1.
 	for i := range keyRanges {
 		if totalKeyRanges[i].End.Key.Compare(keyRanges[i].End.Key) > 0 {
-			subsumedReplSST := engine.MakeSSTWriter()
+			subsumedReplSSTFile := &engine.MemFile{}
+			subsumedReplSST := engine.MakeSSTWriter(subsumedReplSSTFile)
+			defer subsumedReplSST.Close()
 			if err := engine.ClearRangeWithHeuristic(
 				r.store.Engine(),
 				&subsumedReplSST,
@@ -1053,8 +1072,15 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 				subsumedReplSST.Close()
 				return err
 			}
-			if err := ssss.WriteSST(ctx, &subsumedReplSST); err != nil {
+			if err := subsumedReplSST.Finish(); err != nil {
 				return err
+			}
+			if subsumedReplSST.DataSize > 0 {
+				// TODO(itsbilal): Write to SST directly in subsumedReplSST rather than
+				// buffering in a MemFile first.
+				if err := ssss.WriteSST(ctx, subsumedReplSSTFile.Data()); err != nil {
+					return err
+				}
 			}
 		}
 		// The snapshot must never subsume a replica that extends the range of the

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -817,10 +817,7 @@ func (r *Replica) applySnapshot(
 			inSnap.SnapUUID.Short(), snap.Metadata.Index)
 	}(timeutil.Now())
 
-	unreplicatedSST, err := engine.MakeRocksDBSstFileWriter()
-	if err != nil {
-		return err
-	}
+	unreplicatedSST := engine.MakeSSTWriter()
 	defer unreplicatedSST.Close()
 
 	// Clearing the unreplicated state.
@@ -999,10 +996,7 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges[:]...)
 	for _, sr := range subsumedRepls {
 		// We have to create an SST for the subsumed replica's range-id local keys.
-		subsumedReplSST, err := engine.MakeRocksDBSstFileWriter()
-		if err != nil {
-			return err
-		}
+		subsumedReplSST := engine.MakeSSTWriter()
 		// NOTE: We set mustClearRange to true because we are setting
 		// RaftTombstoneKey. Since Clears and Puts need to be done in increasing
 		// order of keys, it is not safe to use ClearRangeIter.
@@ -1049,10 +1043,7 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	// subsume both r1 and r2 in S1.
 	for i := range keyRanges {
 		if totalKeyRanges[i].End.Key.Compare(keyRanges[i].End.Key) > 0 {
-			subsumedReplSST, err := engine.MakeRocksDBSstFileWriter()
-			if err != nil {
-				return err
-			}
+			subsumedReplSST := engine.MakeSSTWriter()
 			if err := engine.ClearRangeWithHeuristic(
 				r.store.Engine(),
 				&subsumedReplSST,

--- a/pkg/storage/replica_sst_snapshot_storage.go
+++ b/pkg/storage/replica_sst_snapshot_storage.go
@@ -98,14 +98,12 @@ func (ssss *SSTSnapshotStorageScratch) NewFile() (*SSTSnapshotStorageFile, error
 	return sssf, nil
 }
 
-// WriteSST writes an entire RocksDBSstFileWriter to a file. The method closes
+// WriteSST writes an entire SST writer to a file. The method closes
 // the provided SST when it is finished using it. If the provided SST is empty,
 // then no file will be created and nothing will be written.
-func (ssss *SSTSnapshotStorageScratch) WriteSST(
-	ctx context.Context, sst engine.SstFileWriter,
-) error {
+func (ssss *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, sst *engine.SSTWriter) error {
 	defer sst.Close()
-	if sst.DataSize() == 0 {
+	if sst.DataSize == 0 {
 		return nil
 	}
 	data, err := sst.Finish()

--- a/pkg/storage/replica_sst_snapshot_storage.go
+++ b/pkg/storage/replica_sst_snapshot_storage.go
@@ -86,31 +86,31 @@ func (ssss *SSTSnapshotStorageScratch) createDir() error {
 }
 
 // NewFile adds another file to SSTSnapshotStorageScratch. This file is lazily
-// created when the file is written to the first time.
-func (ssss *SSTSnapshotStorageScratch) NewFile() (*SSTSnapshotStorageFile, error) {
+// created when the file is written to the first time. A nonzero value for
+// chunkSize buffers up writes until the buffer is greater than chunkSize.
+func (ssss *SSTSnapshotStorageScratch) NewFile(
+	ctx context.Context, chunkSize int64,
+) (*SSTSnapshotStorageFile, error) {
 	id := len(ssss.ssts)
 	filename := ssss.filename(id)
 	ssss.ssts = append(ssss.ssts, filename)
 	sssf := &SSTSnapshotStorageFile{
-		ssss:     ssss,
-		filename: filename,
+		ssss:      ssss,
+		filename:  filename,
+		ctx:       ctx,
+		chunkSize: chunkSize,
 	}
 	return sssf, nil
 }
 
-// WriteSST writes an entire SST writer to a file. The method closes
+// WriteSST writes SST data to a file. The method closes
 // the provided SST when it is finished using it. If the provided SST is empty,
 // then no file will be created and nothing will be written.
-func (ssss *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, sst *engine.SSTWriter) error {
-	defer sst.Close()
-	if sst.DataSize == 0 {
+func (ssss *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, data []byte) error {
+	if len(data) == 0 {
 		return nil
 	}
-	data, err := sst.Finish()
-	if err != nil {
-		return err
-	}
-	sssf, err := ssss.NewFile()
+	sssf, err := ssss.NewFile(ctx, 0)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (ssss *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, sst *engine
 		// actionable if closing fails.
 		_ = sssf.Close()
 	}()
-	if err := sssf.Write(ctx, data); err != nil {
+	if _, err := sssf.Write(data); err != nil {
 		return err
 	}
 	return sssf.Close()
@@ -138,10 +138,13 @@ func (ssss *SSTSnapshotStorageScratch) Clear() error {
 // SSTSnapshotStorageFile is an SST file managed by a
 // SSTSnapshotStorageScratch.
 type SSTSnapshotStorageFile struct {
-	ssss     *SSTSnapshotStorageScratch
-	created  bool
-	file     engine.DBFile
-	filename string
+	ssss      *SSTSnapshotStorageScratch
+	created   bool
+	file      engine.DBFile
+	filename  string
+	ctx       context.Context
+	chunkSize int64
+	buffer    []byte
 }
 
 func (sssf *SSTSnapshotStorageFile) openFile() error {
@@ -168,18 +171,31 @@ func (sssf *SSTSnapshotStorageFile) openFile() error {
 // Write writes contents to the file while respecting the limiter passed into
 // SSTSnapshotStorageScratch. Writing empty contents is okay and is treated as
 // a noop. The file must have not been closed.
-func (sssf *SSTSnapshotStorageFile) Write(ctx context.Context, contents []byte) error {
+func (sssf *SSTSnapshotStorageFile) Write(contents []byte) (int, error) {
 	if len(contents) == 0 {
-		return nil
+		return 0, nil
 	}
 	if err := sssf.openFile(); err != nil {
-		return err
+		return 0, err
 	}
-	limitBulkIOWrite(ctx, sssf.ssss.sss.limiter, len(contents))
+	limitBulkIOWrite(sssf.ctx, sssf.ssss.sss.limiter, len(contents))
+	if sssf.chunkSize > 0 {
+		if int64(len(contents)+len(sssf.buffer)) < sssf.chunkSize {
+			// Don't write to file yet - buffer write until next time.
+			sssf.buffer = append(sssf.buffer, contents...)
+			return len(contents), nil
+		} else if len(sssf.buffer) > 0 {
+			// Write buffered writes and then empty the buffer.
+			if _, err := sssf.file.Write(sssf.buffer); err != nil {
+				return 0, err
+			}
+			sssf.buffer = sssf.buffer[:0]
+		}
+	}
 	if _, err := sssf.file.Write(contents); err != nil {
-		return err
+		return 0, err
 	}
-	return sssf.file.Sync()
+	return len(contents), sssf.file.Sync()
 }
 
 // Close closes the file. Calling this function multiple times is idempotent.
@@ -193,9 +209,21 @@ func (sssf *SSTSnapshotStorageFile) Close() error {
 	if sssf.file == nil {
 		return nil
 	}
+	if len(sssf.buffer) > 0 {
+		// Write out any buffered data.
+		if _, err := sssf.file.Write(sssf.buffer); err != nil {
+			return err
+		}
+		sssf.buffer = sssf.buffer[:0]
+	}
 	if err := sssf.file.Close(); err != nil {
 		return err
 	}
 	sssf.file = nil
 	return nil
+}
+
+// Sync syncs the file to disk. Implements writeCloseSyncer in engine.
+func (sssf *SSTSnapshotStorageFile) Sync() error {
+	return sssf.file.Sync()
 }

--- a/pkg/storage/replica_sst_snapshot_storage_test.go
+++ b/pkg/storage/replica_sst_snapshot_storage_test.go
@@ -43,7 +43,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 		t.Fatalf("expected %s to not exist", ssss.snapDir)
 	}
 
-	sssf, err := ssss.NewFile()
+	sssf, err := ssss.NewFile(ctx, 0)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sssf.Close())
@@ -60,7 +60,8 @@ func TestSSTSnapshotStorage(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, sssf.Write(ctx, []byte("foo")))
+	_, err = sssf.Write([]byte("foo"))
+	require.NoError(t, err)
 
 	// After writing to files, check that they have been flushed to disk.
 	for _, fileName := range ssss.SSTs() {
@@ -75,13 +76,15 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	require.NoError(t, sssf.Close())
 
 	// Check that writing to a closed file is an error.
-	require.EqualError(t, sssf.Write(ctx, []byte("foo")), "file has already been closed")
+	_, err = sssf.Write([]byte("foo"))
+	require.EqualError(t, err, "file has already been closed")
 
 	// Check that closing an empty file is an error.
-	sssf, err = ssss.NewFile()
+	sssf, err = ssss.NewFile(ctx, 0)
 	require.NoError(t, err)
 	require.EqualError(t, sssf.Close(), "file is empty")
-	require.NoError(t, sssf.Write(ctx, []byte("foo")))
+	_, err = sssf.Write([]byte("foo"))
+	require.NoError(t, err)
 
 	// Check that Clear removes the directory.
 	require.NoError(t, ssss.Clear())

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -117,59 +117,50 @@ type kvBatchSnapshotStrategy struct {
 // SSTSnapshotStorageScratch that handles chunking SSTs and persisting them to
 // disk.
 type multiSSTWriter struct {
-	ssss        *SSTSnapshotStorageScratch
-	currSST     engine.SSTWriter
-	currSSTFile *SSTSnapshotStorageFile
-	keyRanges   []rditer.KeyRange
-	currRange   int
-	// The size of the SST the last time the SST file writer was truncated. This
-	// size is used to determine the size of the SST chunk buffered in-memory.
-	truncatedSize int64
+	ssss      *SSTSnapshotStorageScratch
+	currSST   engine.SSTWriter
+	keyRanges []rditer.KeyRange
+	currRange int
 	// The approximate size of the SST chunk to buffer in memory on the receiver
 	// before flushing to disk.
 	sstChunkSize int64
 }
 
 func newMultiSSTWriter(
-	ssss *SSTSnapshotStorageScratch, keyRanges []rditer.KeyRange, sstChunkSize int64,
+	ctx context.Context,
+	ssss *SSTSnapshotStorageScratch,
+	keyRanges []rditer.KeyRange,
+	sstChunkSize int64,
 ) (multiSSTWriter, error) {
 	msstw := multiSSTWriter{
 		ssss:         ssss,
 		keyRanges:    keyRanges,
 		sstChunkSize: sstChunkSize,
 	}
-	if err := msstw.initSST(); err != nil {
+	if err := msstw.initSST(ctx); err != nil {
 		return msstw, err
 	}
 	return msstw, nil
 }
 
-func (msstw *multiSSTWriter) initSST() error {
-	newSSTFile, err := msstw.ssss.NewFile()
+func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
+	newSSTFile, err := msstw.ssss.NewFile(ctx, msstw.sstChunkSize)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new sst file")
 	}
-	msstw.currSSTFile = newSSTFile
-	newSST := engine.MakeSSTWriter()
+	newSST := engine.MakeSSTWriter(newSSTFile)
 	msstw.currSST = newSST
 	if err := msstw.currSST.ClearRange(msstw.keyRanges[msstw.currRange].Start, msstw.keyRanges[msstw.currRange].End); err != nil {
 		msstw.currSST.Close()
 		return errors.Wrap(err, "failed to clear range on sst file writer")
 	}
-	msstw.truncatedSize = 0
 	return nil
 }
 
 func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
-	chunk, err := msstw.currSST.Finish()
+	err := msstw.currSST.Finish()
 	if err != nil {
 		return errors.Wrap(err, "failed to finish sst")
-	}
-	if err := msstw.currSSTFile.Write(ctx, chunk); err != nil {
-		return errors.Wrap(err, "failed to write to sst file")
-	}
-	if err := msstw.currSSTFile.Close(); err != nil {
-		return errors.Wrap(err, "failed to close sst file")
 	}
 	msstw.currRange++
 	msstw.currSST.Close()
@@ -183,7 +174,7 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key engine.MVCCKey, value 
 		if err := msstw.finalizeSST(ctx); err != nil {
 			return err
 		}
-		if err := msstw.initSST(); err != nil {
+		if err := msstw.initSST(ctx); err != nil {
 			return err
 		}
 	}
@@ -192,18 +183,6 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key engine.MVCCKey, value 
 	}
 	if err := msstw.currSST.Put(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
-	}
-	if int64(msstw.currSST.DataSize)-msstw.truncatedSize > msstw.sstChunkSize {
-		msstw.truncatedSize = int64(msstw.currSST.DataSize)
-		chunk, err := msstw.currSST.Truncate()
-		if err != nil {
-			return errors.Wrap(err, "failed to truncate sst")
-		}
-		// NOTE: Chunk may be empty due to the semantics of Truncate(), but Write()
-		// handles an empty chunk as a noop.
-		if err := msstw.currSSTFile.Write(ctx, chunk); err != nil {
-			return errors.Wrap(err, "failed to write to sst file")
-		}
 	}
 	return nil
 }
@@ -217,7 +196,7 @@ func (msstw *multiSSTWriter) Finish(ctx context.Context) error {
 			if msstw.currRange >= len(msstw.keyRanges) {
 				break
 			}
-			if err := msstw.initSST(); err != nil {
+			if err := msstw.initSST(ctx); err != nil {
 				return err
 			}
 		}
@@ -225,9 +204,8 @@ func (msstw *multiSSTWriter) Finish(ctx context.Context) error {
 	return nil
 }
 
-func (msstw *multiSSTWriter) Close() error {
+func (msstw *multiSSTWriter) Close() {
 	msstw.currSST.Close()
-	return msstw.currSSTFile.Close()
 }
 
 // Receive implements the snapshotStrategy interface.
@@ -246,17 +224,11 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	// At the moment we'll write at most three SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeyRanges(header.State.Desc)
-	msstw, err := newMultiSSTWriter(kvSS.ssss, keyRanges, kvSS.sstChunkSize)
+	msstw, err := newMultiSSTWriter(ctx, kvSS.ssss, keyRanges, kvSS.sstChunkSize)
 	if err != nil {
 		return noSnap, err
 	}
-	defer func() {
-		// Nothing actionable if closing multiSSTWriter. Closing the same SST and
-		// SST file multiple times is idempotent.
-		if err := msstw.Close(); err != nil {
-			log.Warningf(ctx, "failed to close multiSSTWriter: %v", err)
-		}
-	}()
+	defer msstw.Close()
 	var logEntries [][]byte
 
 	for {
@@ -300,9 +272,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 				return noSnap, err
 			}
 
-			if err := msstw.Close(); err != nil {
-				return noSnap, err
-			}
+			msstw.Close()
 
 			snapUUID, err := uuid.FromBytes(header.RaftMessageRequest.Message.Snapshot.Data)
 			if err != nil {


### PR DESCRIPTION
Currently, we use `RocksDBSstFileWriter` for writing SSTs when receiving cockroach snapshots. This incurs some extra performance overhead with cgo crossings that we can avoid by using the `sstable.Writer` in pebble.

This PR moves a wrapper for the Pebble-based writer that currently resides in `bulk` to `engine`, then adds methods to it so it could be used as a drop-in replacement (almost) for the RocksDB writer. In the second commit, all non-test uses of `RocksDBSstFileWriter` are moved to `SSTWriter`.

Parts taken from #39802 , and fixes #41657.