### PR TITLE
release-19.2: sql/sem/tree: fix OID conversion to TEXT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -319,3 +319,10 @@ query I
 SELECT 'trigger'::REGTYPE::INT
 ----
 -1
+
+# Regression test for #41708.
+
+query TT
+SELECT 1::OID::TEXT, quote_literal(1::OID)
+----
+1  '1'

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3345,7 +3345,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			s = lex.EncodeByteArrayToRawBytes(string(*t),
 				ctx.SessionData.DataConversion.BytesEncodeFormat, false /* skipHexPrefix */)
 		case *DOid:
-			s = t.name
+			s = t.String()
 		case *DJSON:
 			s = t.JSON.String()
 		}


### PR DESCRIPTION
Backport 1/1 commits from #41928.

/cc @cockroachdb/release

---

In cases where the OID did not have a name, it was returing an empty
string.

Fixes #41708

Release note(bug fix): fix some casts from OID to TEXT
