### PR TITLE
tree: allow string concat with any type

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -396,6 +396,7 @@
 <table><thead>
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
+<tr><td>anyelement <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
@@ -423,6 +424,7 @@
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> anyelement</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1357,6 +1357,22 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			},
 		},
 		&BinOp{
+			LeftType:   types.String,
+			RightType:  types.Any,
+			ReturnType: types.String,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return NewDString(string(MustBeDString(left)) + right.String()), nil
+			},
+		},
+		&BinOp{
+			LeftType:   types.Any,
+			RightType:  types.String,
+			ReturnType: types.String,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return NewDString(left.String() + string(MustBeDString(right))), nil
+			},
+		},
+		&BinOp{
 			LeftType:   types.Bytes,
 			RightType:  types.Bytes,
 			ReturnType: types.Bytes,

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -19,3 +19,20 @@ eval
 array['foo'] || '{a,b}'
 ----
 ARRAY['foo','a','b']
+
+# String || any; any || String
+
+eval
+3 || 'a' || 3
+----
+3a3
+
+eval
+3::oid || 'a' || 3::oid
+----
+3a3
+
+eval
+3.33 || 'a' || 3.33
+----
+3.33a3.33


### PR DESCRIPTION
Previously, the || concat operator only worked on string pairs. Postgres
supports concatenation between strings and any other type. This patch
adds support for that as well.

fixes #41872
fixes #34404

Release note (sql change): the concatenation operator || is now usable
between strings and any other type.