### PR TITLE
release-19.1: opt: fix panic in union

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -1017,3 +1017,11 @@ except
       │                   └── const: 1 [type=int]
       └── tuple [type=tuple{int}]
            └── const: 1 [type=int]
+
+# Regression test for #42216.
+norm
+  SELECT * FROM (VALUES (NULL)) AS t1(a)
+EXCEPT ALL
+  SELECT * FROM (VALUES ((NULL,))) AS t2(b)
+----
+error (42P16): value type unknown cannot be used for table columns

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -166,7 +166,10 @@ func (b *Builder) propagateTypes(dst, src *scope) *scope {
 		srcType := src.cols[i].typ
 		if dstType == types.Unknown && srcType != types.Unknown {
 			// Create a new column which casts the old column to the correct type.
-			colType, _ := coltypes.DatumTypeToColumnType(srcType)
+			colType, err := coltypes.DatumTypeToColumnType(srcType)
+			if err != nil {
+				panic(builderError{err})
+			}
 			castExpr := b.factory.ConstructCast(b.factory.ConstructVariable(dstCols[i].id), colType)
 			b.synthesizeColumn(dst, string(dstCols[i].name), srcType, nil /* expr */, castExpr)
 		} else {


### PR DESCRIPTION
Fixes #42216.

Release note (bug fix): Fixed an internal error in a rare case
involving UNION and tuples inside VALUES clauses.

CC @cockroachdb/release