### PR TITLE
builtins: fix incorrect timezone conversions for `extract` and `date_trunc`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1377,17 +1377,43 @@ select date_trunc('day', '2011-01-01 22:30:00+01:00'::timestamptz);
 2011-01-01 00:00:00 +0000 UTC
 
 statement ok
-SET TIME ZONE 'Africa/Nairobi';
+SET TIME ZONE 'Africa/Nairobi'
 
 query T
-select date_trunc('day', '2011-01-01 22:30:00'::date);
+select date_trunc('day', '2011-01-01 22:30:00'::date)
 ----
 2011-01-01 00:00:00 +0300 +0300
 
 query T
-select date_trunc('day', '2011-01-01 22:30:00+01:00'::timestamptz);
+select date_trunc('day', '2011-01-02 01:30:00'::timestamp)
+----
+2011-01-02 00:00:00 +0000 +0000
+
+query T
+select date_trunc('day', '2011-01-01 22:30:00+01:00'::timestamptz)
 ----
 2011-01-02 00:00:00 +0300 +0300
+
+statement ok
+SET TIME ZONE -5
+
+query TT
+select date_trunc('day', '2011-01-02 01:30:00'::date), pg_typeof(date_trunc('day', '2011-01-02 01:30:00'::date))
+----
+2011-01-02 00:00:00 -0500 -0500  timestamptz
+
+query TT
+select date_trunc('day', '2011-01-02 01:30:00'::timestamp), pg_typeof(date_trunc('day', '2011-01-02 01:30:00'::timestamp))
+----
+2011-01-02 00:00:00 +0000 +0000   timestamp
+
+query TT
+select date_trunc('day', '2011-01-02 01:30:00+00:00'::timestamptz), pg_typeof(date_trunc('day', '2011-01-02 01:30:00+00:00'::timestamptz))
+----
+2011-01-01 00:00:00 -0500 -0500   timestamptz
+
+statement ok
+SET TIME ZONE 0
 
 # Test negative years to ensure they can round-trip through the parser.
 # Also ensure that we don't trigger any of the "convenience" rules.
@@ -1482,3 +1508,17 @@ query T
 SET timezone = 'utc'; SHOW timezone
 ----
 UTC
+
+subtest regression_42244
+
+statement ok
+SET TIME ZONE -5
+
+# Check date is still configured correctly from day.
+query I
+select extract(day from '2019-01-15'::date) as final
+----
+15
+
+statement ok
+SET TIME ZONE 0


### PR DESCRIPTION
Resolves #42244, fixes more of #42006.

Turns out `date_trunc` is more broken than I thought, and `MakeDTimestampTZFromDate` actually *not* ignoring the argument has revealed a lot of weird usages of it. I also missed a test case with a negative timezone in my earlier PR, which also resolves another bug here. Wonder why govet didn't catch these unused arguments.

---
`extract`: Due to actually taking `loc` into account for
`MakeDTimestampTZFromDate` (as opposed to ignoring the argument before) in
`827c97e04041e280a4413984d80cee99520c1d27`, this exposed other bugs.

`date_trunc`: `timestamp` was incorrect because it tried to adapt to the
timezone, even though it is returning a timestamp without time zone
type. Furthermore, the `date` needed an additional `offset` for a given
timezone as the given `date` is in UTC, but we need to truncate it in
the correct timezone. This meant that my fix in the previous PR only
fixed positive UTC offsets, but not negative UTC offsets.

This PR fixes the immediate issue of `extract` and `date_trunc`,
and I will make an audit of all other incorrect usages in an upcoming PR.

There will be an upcoming PR to fix more other bugs found in the Plus
and Minus expressions with the MakeDTimestampTZFromDate change.

Release note (bug fix): Previously, `<date>:date` when context
local timestamp is set would result in the previous day
(`<date-1>::date>`) if the timezone is less than UTC+00:00 due to a
recently introduced bug. This change fixes this.

Release note (bug fix): Previously, date_trunc for timestamp were
incorrect if in a local timezone was set. This change fixes this.

Release note (bug fix): Previously, date_trunc for date types were
incorrect with a negative timezone offset in a local timezone. This
change fixes this.