### PR TITLE
bulk,importccl: re-read settings during ingestion

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -163,7 +163,7 @@ func ingestKvs(
 
 	writeTS := hlc.Timestamp{WallTime: spec.WalltimeNanos}
 
-	flushSize := storageccl.MaxImportBatchSize(flowCtx.Cfg.Settings)
+	flushSize := func() int64 { return storageccl.MaxImportBatchSize(flowCtx.Cfg.Settings) }
 
 	// We create two bulk adders so as to combat the excessive flushing of small
 	// SSTs which was observed when using a single adder for both primary and
@@ -179,10 +179,10 @@ func ingestKvs(
 		Name:              "pkAdder",
 		DisallowShadowing: true,
 		SkipDuplicates:    true,
-		MinBufferSize:     uint64(minBufferSize),
-		MaxBufferSize:     uint64(maxBufferSize),
-		StepBufferSize:    uint64(stepSize),
-		SSTSize:           uint64(flushSize),
+		MinBufferSize:     minBufferSize,
+		MaxBufferSize:     maxBufferSize,
+		StepBufferSize:    stepSize,
+		SSTSize:           flushSize,
 	})
 	if err != nil {
 		return nil, err
@@ -194,10 +194,10 @@ func ingestKvs(
 		Name:              "indexAdder",
 		DisallowShadowing: true,
 		SkipDuplicates:    true,
-		MinBufferSize:     uint64(minBufferSize),
-		MaxBufferSize:     uint64(maxBufferSize),
-		StepBufferSize:    uint64(stepSize),
-		SSTSize:           uint64(flushSize),
+		MinBufferSize:     minBufferSize,
+		MaxBufferSize:     maxBufferSize,
+		StepBufferSize:    stepSize,
+		SSTSize:           flushSize,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -87,14 +87,14 @@ func newIndexBackfiller(
 
 func (ib *indexBackfiller) prepare(ctx context.Context) error {
 	minBufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
-	maxBufferSize := backfillerMaxBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
-	sstSize := backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV)
+	maxBufferSize := func() int64 { return backfillerMaxBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV) }
+	sstSize := func() int64 { return backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV) }
 	stepSize := backfillerBufferIncrementSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	opts := storagebase.BulkAdderOptions{
-		SSTSize:        uint64(sstSize),
-		MinBufferSize:  uint64(minBufferSize),
-		MaxBufferSize:  uint64(maxBufferSize),
-		StepBufferSize: uint64(stepSize),
+		SSTSize:        sstSize,
+		MinBufferSize:  minBufferSize,
+		MaxBufferSize:  maxBufferSize,
+		StepBufferSize: stepSize,
 		SkipDuplicates: ib.ContainsInvertedIndex(),
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.ReadAsOf, opts)

--- a/pkg/storage/engine/sst_writer.go
+++ b/pkg/storage/engine/sst_writer.go
@@ -23,7 +23,7 @@ type SSTWriter struct {
 	fw *sstable.Writer
 	f  *memFile
 	// DataSize tracks the total key and value bytes added so far.
-	DataSize uint64
+	DataSize int64
 	scratch  []byte
 }
 
@@ -48,7 +48,7 @@ func (fw *SSTWriter) Add(kv MVCCKeyValue) error {
 	if fw.fw == nil {
 		return errors.New("cannot call Open on a closed writer")
 	}
-	fw.DataSize += uint64(len(kv.Key.Key)) + uint64(len(kv.Value))
+	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
 	fw.scratch = EncodeKeyToBuf(fw.scratch[:0], kv.Key)
 	return fw.fw.Set(fw.scratch, kv.Value)
 }

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -28,23 +28,23 @@ type BulkAdderOptions struct {
 	// SSTSize is the size at which an SST will be flushed and a new one started.
 	// SSTs are also split during a buffer flush to avoid spanning range bounds so
 	// they may be smaller than this limit.
-	SSTSize uint64
+	SSTSize func() int64
 
 	// SplitAndScatterAfter is the number of bytes which if added without hitting
 	// an existing split will cause the adder to split and scatter the next span.
-	SplitAndScatterAfter uint64
+	SplitAndScatterAfter func() int64
 
 	// MinBufferSize is the initial size of the BulkAdder buffer. It indicates the
 	// amount of memory we require to be able to buffer data before flushing for
 	// SST creation.
-	MinBufferSize uint64
+	MinBufferSize int64
 
 	// BufferSize is the maximum size we can grow the BulkAdder buffer to.
-	MaxBufferSize uint64
+	MaxBufferSize func() int64
 
 	// StepBufferSize is the increment in which we will attempt to grow the
 	// BulkAdder buffer if the memory monitor permits.
-	StepBufferSize uint64
+	StepBufferSize int64
 
 	// SkipLocalDuplicates configures handling of duplicate keys within a local
 	// sorted batch. When true if the same key/value pair is added more than once


### PR DESCRIPTION
Prior to this patch, the bulk-ingestion helpers were configured with size limits read from settings,
but then executed, sometimes for hours, against those values that were passed in, not reacting to
later changes in the underlying setting.

This change plumbs those values though as func() int64 instead of int64, re-reading the setting value
each time it is used and thus reflecting any changes to the underlying setting during execution.

Also, while I'm here: switch uint64 to int64 to match our usual style guidelines.

Release note (bug fix): fix bug where some settings changes were not reflected during currently running IMPORTs.