### PR TITLE
storage/engine: enable pebble event logging

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -485,7 +485,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				}
 				engines = append(engines, e)
 			} else {
-				engines = append(engines, engine.NewInMem(cfg.StorageEngine, spec.Attributes, sizeInBytes))
+				engines = append(engines, engine.NewInMem(ctx, cfg.StorageEngine, spec.Attributes, sizeInBytes))
 			}
 		} else {
 			if spec.Size.Percent > 0 {
@@ -522,7 +522,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				}
 				pebbleConfig.Opts.Cache = pebbleCache
 				pebbleConfig.Opts.MaxOpenFiles = int(openFileLimitPerStore)
-				eng, err = engine.NewPebble(pebbleConfig)
+				eng, err = engine.NewPebble(ctx, pebbleConfig)
 			} else {
 				rocksDBConfig := engine.RocksDBConfig{
 					StorageConfig:           storageConfig,

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -95,7 +95,7 @@ func getOrCreateStickyInMemEngine(
 	engine := &stickyInMemEngine{
 		id:     id,
 		closed: false,
-		Engine: engine.NewInMem(engineType, attrs, cacheSize),
+		Engine: engine.NewInMem(ctx, engineType, attrs, cacheSize),
 	}
 	stickyInMemEnginesRegistry.entries[id] = engine
 	return engine, nil

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -38,12 +38,14 @@ import (
 // createTestRocksDBEngine returns a new in-memory RocksDB engine with 1MB of
 // storage capacity.
 func createTestRocksDBEngine() engine.Engine {
-	return engine.NewInMem(enginepb.EngineTypeRocksDB, roachpb.Attributes{}, 1<<20)
+	return engine.NewInMem(context.Background(),
+		enginepb.EngineTypeRocksDB, roachpb.Attributes{}, 1<<20)
 }
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
 func createTestPebbleEngine() engine.Engine {
-	return engine.NewInMem(enginepb.EngineTypePebble, roachpb.Attributes{}, 1<<20)
+	return engine.NewInMem(context.Background(),
+		enginepb.EngineTypePebble, roachpb.Attributes{}, 1<<20)
 }
 
 var engineImpls = []struct {

--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -34,12 +34,14 @@ func testPebbleOptions(fs vfs.FS) *pebble.Options {
 }
 
 func setupMVCCPebble(b testing.TB, dir string) Engine {
-	peb, err := NewPebble(PebbleConfig{
-		StorageConfig: base.StorageConfig{
-			Dir: dir,
-		},
-		Opts: testPebbleOptions(vfs.Default),
-	})
+	peb, err := NewPebble(
+		context.Background(),
+		PebbleConfig{
+			StorageConfig: base.StorageConfig{
+				Dir: dir,
+			},
+			Opts: testPebbleOptions(vfs.Default),
+		})
 	if err != nil {
 		b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
 	}
@@ -47,9 +49,11 @@ func setupMVCCPebble(b testing.TB, dir string) Engine {
 }
 
 func setupMVCCInMemPebble(b testing.TB, loc string) Engine {
-	peb, err := NewPebble(PebbleConfig{
-		Opts: testPebbleOptions(vfs.NewMem()),
-	})
+	peb, err := NewPebble(
+		context.Background(),
+		PebbleConfig{
+			Opts: testPebbleOptions(vfs.NewMem()),
+		})
 	if err != nil {
 		b.Fatalf("could not create new in-mem pebble instance: %+v", err)
 	}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -533,7 +533,7 @@ func NewEngine(
 		}
 		pebbleConfig.Opts.Cache = pebble.NewCache(cacheSize)
 
-		return NewPebble(pebbleConfig)
+		return NewPebble(context.Background(), pebbleConfig)
 	case enginepb.EngineTypeRocksDB:
 		cache := NewRocksDBCache(cacheSize)
 		defer cache.Release()

--- a/pkg/storage/engine/in_mem.go
+++ b/pkg/storage/engine/in_mem.go
@@ -11,6 +11,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -21,10 +22,12 @@ import (
 // must call the engine's Close method when the engine is no longer needed.
 //
 // FIXME(tschottdorf): make the signature similar to NewRocksDB (require a cfg).
-func NewInMem(engine enginepb.EngineType, attrs roachpb.Attributes, cacheSize int64) Engine {
+func NewInMem(
+	ctx context.Context, engine enginepb.EngineType, attrs roachpb.Attributes, cacheSize int64,
+) Engine {
 	switch engine {
 	case enginepb.EngineTypePebble:
-		return newPebbleInMem(attrs, cacheSize)
+		return newPebbleInMem(ctx, attrs, cacheSize)
 	case enginepb.EngineTypeRocksDB:
 		return newRocksDBInMem(attrs, cacheSize)
 	}
@@ -35,5 +38,6 @@ func NewInMem(engine enginepb.EngineType, attrs roachpb.Attributes, cacheSize in
 // the default configuration. The caller must call the engine's Close method
 // when the engine is no longer needed.
 func NewDefaultInMem() Engine {
-	return NewInMem(TestStorageEngine, roachpb.Attributes{}, 1<<20 /* 1 MB */)
+	return NewInMem(context.Background(),
+		TestStorageEngine, roachpb.Attributes{}, 1<<20 /* 1 MB */)
 }

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -86,7 +86,7 @@ func createTestRocksDBEngine() Engine {
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
 func createTestPebbleEngine() Engine {
-	return newPebbleInMem(roachpb.Attributes{}, 1<<20)
+	return newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20)
 }
 
 var mvccEngineImpls = []struct {

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -368,7 +368,7 @@ func (p *pebbleBatch) Repr() []byte {
 	// p.batch.Repr() is an unsafe byte slice owned by p.batch. Since we could be
 	// sending this slice over the wire, we need to make a copy.
 	repr := p.batch.Repr()
-	reprCopy := make([]byte, len(p.batch.Repr()))
+	reprCopy := make([]byte, len(repr))
 	copy(reprCopy, repr)
 	return reprCopy
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -205,7 +205,7 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 		tc.gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), cfg.DefaultZoneConfig)
 	}
 	if tc.engine == nil {
-		tc.engine = engine.NewInMem(engine.TestStorageEngine,
+		tc.engine = engine.NewInMem(context.Background(), engine.TestStorageEngine,
 			roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
 		stopper.AddCloser(tc.engine)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -116,7 +116,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	c := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started
 	ltc.Gossip = gossip.New(ambient, c, nc, cfg.RPCContext, server, ltc.Stopper, metric.NewRegistry(), roachpb.Locality{}, config.DefaultZoneConfigRef())
-	ltc.Eng = engine.NewInMem(engine.TestStorageEngine, roachpb.Attributes{}, 50<<20)
+	ltc.Eng = engine.NewInMem(ambient.AnnotateCtx(context.Background()),
+		engine.TestStorageEngine, roachpb.Attributes{}, 50<<20)
 	ltc.Stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = storage.NewStores(ambient, ltc.Clock, cluster.BinaryMinimumSupportedVersion, cluster.BinaryServerVersion)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -209,6 +209,13 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 			disableLBS = true
 		}
 
+		// Note: uncomment to have the testcluster stored on disk which can aid
+		// post-mortem debugging.
+		//
+		// serverArgs.StoreSpecs = []base.StoreSpec{{
+		// 	Path: fmt.Sprintf("cluster/%d", i+1),
+		// }}
+
 		if args.ParallelStart {
 			go func() {
 				errCh <- tc.doAddServer(t, serverArgs)


### PR DESCRIPTION
Configure the Pebble logger to output to CRDB's logger. A bit of
plumbing was required in order to get a context to `engine.NewPebble` so
that we can get the node's log tags in the logging. Still TBD is getting
the store's log tag.

Release note: None