### PR TITLE
importccl: Update file progress at the consumer end of the import pipe.

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -355,6 +355,15 @@ func ingestKvs(
 		return nil, err
 	}
 
+	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	prog.ResumePos = make(map[int32]uint64)
+	prog.CompletedFraction = make(map[int32]float32)
+	for i := range spec.Uri {
+		prog.CompletedFraction[i] = 1.0
+		prog.ResumePos[i] = math.MaxUint64
+	}
+	progCh <- prog
+
 	addedSummary := pkIndexAdder.GetSummary()
 	addedSummary.Add(indexAdder.GetSummary())
 	return &addedSummary, nil

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -85,18 +85,7 @@ func runImport(
 	var summary *roachpb.BulkOpSummary
 	group.GoCtx(func(ctx context.Context) error {
 		summary, err = ingestKvs(ctx, flowCtx, spec, progCh, kvCh)
-		if err != nil {
-			return err
-		}
-		var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-		prog.ResumePos = make(map[int32]uint64)
-		prog.CompletedFraction = make(map[int32]float32)
-		for i := range spec.Uri {
-			prog.CompletedFraction[i] = 1.0
-			prog.ResumePos[i] = math.MaxUint64
-		}
-		progCh <- prog
-		return nil
+		return err
 	})
 	if err := group.Wait(); err != nil {
 		return nil, err


### PR DESCRIPTION
The import process is a pipe that sends KVs from the producer
to the consumer.  The consumer is responsible for inserting those KVs
into the database.  In addition, the import job periodically checkpoints
its progress into the system.jobs table so that it can be resumed.
After the files being imported have been processed completely, the progress
is written to the jobs table indicating that those files are done.

Prior to this change, this last progress update has been done on the producer
side of the pipe.  This has a potential of writing "fully done" progress
before we actually had a chance to flush produced KVs from the consumer.
This seems incorrect.  The last update should be done by the consumer
after all of the buffered data has been flushed.

Release note: None