### PR TITLE
storage: fix incorrect check in VersionContainsEstimatesCounter

### DIFF
--- a/pkg/storage/batcheval/cmd_recompute_stats.go
+++ b/pkg/storage/batcheval/cmd_recompute_stats.go
@@ -99,13 +99,13 @@ func RecomputeStats(
 		// stats for timeseries ranges (which go cold and the approximate stats are
 		// wildly overcounting) and this is paced by the consistency checker, but it
 		// means some extra engine churn.
-		cArgs.Stats.Add(delta)
 		if !cluster.Version.IsActive(ctx, cArgs.EvalCtx.ClusterSettings(), cluster.VersionContainsEstimatesCounter) {
 			// We are running with the older version of MVCCStats.ContainsEstimates
 			// which was a boolean, so we should keep it in {0,1} and not reset it
 			// to avoid racing with another command that sets it to true.
 			delta.ContainsEstimates = currentStats.ContainsEstimates
 		}
+		cArgs.Stats.Add(delta)
 	}
 
 	resp.(*roachpb.RecomputeStatsResponse).AddedDelta = enginepb.MVCCStatsDelta(delta)

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -764,8 +764,8 @@ func (r *Replica) evaluateProposal(
 				// The caller should have checked the cluster version. At the
 				// time of writing, this is only RecomputeStats and the split
 				// trigger, which both have the check, but better safe than sorry.
-				return nil, false, roachpb.NewErrorf("cannot propose negative ContainsEstimates " +
-					"without VersionContainsEstimatesCounter")
+				log.Fatalf(ctx, "cannot propose negative ContainsEstimates "+
+					"without VersionContainsEstimatesCounter in %s", ba.Summary())
 			}
 		}
 


### PR DESCRIPTION
In RecomputeStats, we were supposed to avoid negative deltas until
they're allowed, but the code to do so was accidentally a noop.
This triggered a sanity check about the very same thing, which
in turn triggered a crash.

No release note since this was just introduced and won't be in anything
we release.

This failed in any test that consistency checked the timeseries range, I
used

make stress PKG=./pkg/server/ STRESSFLAGS='-p 4' TESTS=TestClusterVersionUpgrade

to convince myself, which would previously reproduce immediately.

Release note: None