### PR TITLE
storage: include SST keys in written-key QPS

### DIFF
--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -574,6 +574,9 @@ func (b *replicaAppBatch) runPreApplyTriggers(ctx context.Context, cmd *replicat
 		if copied {
 			b.r.store.metrics.AddSSTableApplicationCopies.Inc(1)
 		}
+		if added := res.Delta.KeyCount; added > 0 {
+			b.r.writeStats.recordCount(float64(added), 0)
+		}
 		res.AddSSTable = nil
 	}
 


### PR DESCRIPTION
Application of normal batches increment the replica writes-per-second by
the number of writes in the batch. This adds a similar increment to the
special-case application of AddSSTable so its written keys are correctly
included in the overall write-rate for the replica.

Release note: none.