### PR TITLE
storage: rename malformedSnapshotError to errMalformedSnapshot

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1030,7 +1030,7 @@ func (r *Replica) sendSnapshot(
 		r.store.Engine().NewBatch,
 		sent,
 	); err != nil {
-		if errors.Cause(err) == malformedSnapshotError {
+		if errors.Cause(err) == errMalformedSnapshot {
 			checkpointDir := r.store.checkpoint(ctx,
 				fmt.Sprintf("r%d_%s", r.RangeID, snap.SnapUUID.Short()))
 

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -167,9 +167,9 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	}
 }
 
-// A MalformedSnapshotError indicates that the snapshot in question is
+// A errMalformedSnapshot indicates that the snapshot in question is
 // malformed, for e.g. missing raft log entries.
-var malformedSnapshotError = errors.New("malformed snapshot generated")
+var errMalformedSnapshot = errors.New("malformed snapshot generated")
 
 // Send implements the snapshotStrategy interface.
 func (kvSS *kvBatchSnapshotStrategy) Send(
@@ -296,7 +296,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 		log.Warningf(ctx, "missing log entries in snapshot (%s): "+
 			"got %d entries, expected %d (TruncatedState.Index=%d, LogEntries=%s)",
 			snap.String(), len(logEntries), expLen, snap.State.TruncatedState.Index, entriesRange)
-		return malformedSnapshotError
+		return errMalformedSnapshot
 	}
 
 	// Inline the payloads for all sideloaded proposals.


### PR DESCRIPTION
malformedSnapshotError trips up TestGoLint. This was not picked up
through CI when temporarily disabled in the way of
https://github.com/cockroachdb/examples-orms/issues/82.

Release note: None