### PR TITLE
colexec: fix OUTER hash joins in some cases

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -32,13 +32,9 @@ func registerTPCHVec(r *testRegistry) {
 	var vecOnQueriesToSkip = map[int]string{
 		// TODO(yuzefovich): remove this once we have memory monitoring.
 		9:  "can cause OOM",
-		10: "incorrect output: #42049",
 		12: "unsupported: sum_int #38845",
-		// TODO(yuzefovich): triage this failure.
-		13: "incorrect output: unknown",
 		15: "unsupported: create view",
 		16: "unsupported: distinct aggregation #39242",
-		20: "incorrect output: #42047",
 		21: "unsupported: non-inner hash join with ON expression #38018",
 	}
 	var vecOffQueriesToSkip = map[int]string{

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -220,7 +220,7 @@ func _COLLECT_RIGHT_OUTER(
 		currentID := prober.ht.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= prober.outputBatchSize {
 				prober.prevBatch = batch
 				return nResults
 			}
@@ -267,7 +267,7 @@ func _COLLECT_NO_OUTER(
 	for i := uint16(0); i < batchSize; i++ {
 		currentID := prober.ht.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= prober.outputBatchSize {
 				prober.prevBatch = batch
 				return nResults
 			}


### PR DESCRIPTION
Previously, when emitting unmatched tuples, the hash joiner would set
the nulls that correspond to the unmatched side only once, before
transitioning into hjEmittingUnmatched state. However, we can emit
multiple batches while in this state, and we need to set nulls on every
one of them. Now this is fixed.

This fixes the problems with queries 13 and 20 of TPCH benchmark, so we
can unskip them from the roachtest (as well as query 10 that was fixed
earlier).

Fixes: #42130.
Fixes: #42047.

Release note: None