### PR TITLE
release-19.2: colexec: fix OUTER merge joins in some cases

### DIFF
--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1468,6 +1468,86 @@ func TestMergeJoiner(t *testing.T) {
 	}
 }
 
+// TestFullOuterMergeJoinWithMaximumNumberOfGroups will create two input
+// sources such that the left one contains rows with even numbers 0, 2, 4, ...
+// while the right contains one rows with odd numbers 1, 3, 5, ... The test
+// will perform FULL OUTER JOIN. Such setup will create the maximum number of
+// groups per batch.
+func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	nTuples := int(coldata.BatchSize()) * 4
+	for _, outBatchSize := range []uint16{1, 16, coldata.BatchSize() - 1, coldata.BatchSize(), coldata.BatchSize() + 1} {
+		t.Run(fmt.Sprintf("outBatchSize=%d", outBatchSize),
+			func(t *testing.T) {
+				typs := []coltypes.T{coltypes.Int64}
+				colsLeft := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
+				colsRight := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
+				groupsLeft := colsLeft[0].Int64()
+				groupsRight := colsRight[0].Int64()
+				for i := range groupsLeft {
+					groupsLeft[i] = int64(i * 2)
+					groupsRight[i] = int64(i*2 + 1)
+				}
+				leftSource := newChunkingBatchSource(typs, colsLeft, uint64(nTuples))
+				rightSource := newChunkingBatchSource(typs, colsRight, uint64(nTuples))
+				a, err := NewMergeJoinOp(
+					sqlbase.FullOuterJoin,
+					leftSource,
+					rightSource,
+					[]uint32{0},
+					[]uint32{0},
+					typs,
+					typs,
+					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					nil,   /* filterConstructor */
+					false, /* filterOnlyOnLeft */
+				)
+				if err != nil {
+					t.Fatal("error in merge join op constructor", err)
+				}
+				a.(*mergeJoinFullOuterOp).initWithOutputBatchSize(outBatchSize)
+				i, count, expVal := 0, 0, int64(0)
+				for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+					count += int(b.Length())
+					leftOutCol := b.ColVec(0).Int64()
+					leftNulls := b.ColVec(0).Nulls()
+					rightOutCol := b.ColVec(1).Int64()
+					rightNulls := b.ColVec(1).Nulls()
+					for j := uint16(0); j < b.Length(); j++ {
+						leftVal := leftOutCol[j]
+						leftNull := leftNulls.NullAt(j)
+						rightVal := rightOutCol[j]
+						rightNull := rightNulls.NullAt(j)
+						if expVal%2 == 0 {
+							// It is an even-numbered row, so the left value should contain
+							// expVal and the right value should be NULL.
+							if leftVal != expVal || leftNull || !rightNull {
+								t.Fatalf("found left = %d, left NULL? = %t, right NULL? = %t, "+
+									"expected left = %d, left NULL? = false, right NULL? = true, idx %d of batch %d",
+									leftVal, leftNull, rightNull, expVal, j, i)
+							}
+						} else {
+							// It is an odd-numbered row, so the right value should contain
+							// expVal and the left value should be NULL.
+							if rightVal != expVal || rightNull || !leftNull {
+								t.Fatalf("found right = %d, right NULL? = %t, left NULL? = %t, "+
+									"expected right = %d, right NULL? = false, left NULL? = true, idx %d of batch %d",
+									rightVal, rightNull, leftNull, expVal, j, i)
+							}
+						}
+						expVal++
+					}
+					i++
+				}
+				if count != 2*nTuples {
+					t.Fatalf("found count %d, expected count %d", count, 2*nTuples)
+				}
+			})
+	}
+}
+
 // TestMergeJoinerMultiBatch creates one long input of a 1:1 join, and keeps
 // track of the expected output to make sure the join output is batched
 // correctly.

--- a/pkg/sql/colexec/mergejoiner_util.go
+++ b/pkg/sql/colexec/mergejoiner_util.go
@@ -34,13 +34,32 @@ type circularGroupsBuffer struct {
 	rightGroups []group
 }
 
-func makeGroupsBuffer(cap int) circularGroupsBuffer {
+func makeGroupsBuffer(batchSize int) circularGroupsBuffer {
 	return circularGroupsBuffer{
-		cap: cap,
-		// Allocate twice the amount of space needed so that no additional
-		// allocations are needed to make the resulting slice contiguous.
-		leftGroups:  make([]group, cap*2),
-		rightGroups: make([]group, cap*2),
+		// The maximum number of possible groups per batch is achieved with FULL
+		// OUTER JOIN when no rows have matches, so there will be exactly
+		// batchSize x 2 groups. We add an additional element to the capacity in
+		// order to be able to distinguish between an "empty" (no groups) and a
+		// "full" (2*batchSize groups) buffers.
+		cap: 2*batchSize + 1,
+		// Since we have a circular buffer, it is possible for groups to wrap when
+		// cap is reached. Consider an example when batchSize = 3 and startIdx = 6
+		// when maximum number of groups is present:
+		// buffer = [1, 2, 3, 4, 5, x, 0] (integers denote different groups and 'x'
+		// stands for a garbage).
+		// When getGroups() is called, for ease of usage we need to return the
+		// buffer "flattened out", and in order to reduce allocation, we actually
+		// reserve 4*batchSize. In the example above we will copy the buffer as:
+		// buffer = [1, 2, 3, 4, 5, x, 0, 1, 2, 3, 4, 5]
+		// and will return buffer[6:12] when getGroups is called.
+		// The calculations for why 4*batchSize is sufficient:
+		// - the largest position in which the first group can be placed is
+		//   2*batchSize (cap field enforces that)
+		// - the largest number of groups to copy from the "physical" start of the
+		//   buffer is 2*batchSize-1
+		// - adding those two numbers we arrive at 4*batchSize.
+		leftGroups:  make([]group, 4*batchSize),
+		rightGroups: make([]group, 4*batchSize),
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #42276.

/cc @cockroachdb/release

---

In the merge join we store the "groups" in a circular buffer. We
correctly assume that the maximum number of groups per batch is
a constant which allows us to have a circular buffer with a fixed
capacity in the first place. However, previously, that number was
incorrectly calculated to be 'batchSize' while, in fact, it is twice
that (in case of FULL OUTER JOIN with no matches). Additionally, we were
not handling the case when we had exactly 'batchSize' of groups because
the internal state of the buffer is the same as if the buffer was empty,
and we were treating it as being empty in such case. As a result, we
could omit some data from the output. I believe only OUTER joins are
susceptible to that problem because with other join types we always need
to buffer the last group, and only with OUTER joins (in some cases) it
is not the case. These two problems are now fixed by having the buffer of
capacity '2*batchSize+1'.

Fixes: #42256.

Release note (bug fix): Previously, when an OUTER merge join was
executed via the vectorized engine, it could omit some data from the
output in some edge cases. This is now fixed.
