### PR TITLE
builtins: fix panic in crdb_internal.encode_key found by sqlsmith

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -976,7 +976,7 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.cluster_name"></a><code>crdb_internal.cluster_name() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the cluster name.</p>
 </span></td></tr>
-<tr><td><a name="crdb_internal.encode_key"></a><code>crdb_internal.encode_key(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>, row_tuple: tuple) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate the key for a row on a particular table and index.</p>
+<tr><td><a name="crdb_internal.encode_key"></a><code>crdb_internal.encode_key(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>, row_tuple: anyelement) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate the key for a row on a particular table and index.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.force_assertion_error"></a><code>crdb_internal.force_assertion_error(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -581,3 +581,18 @@ query T
 SELECT crdb_internal.cluster_name()
 ----
 testclustername
+
+# Regression for 41834.
+statement ok
+CREATE TABLE table41834 ();
+SELECT
+	crdb_internal.encode_key(
+		-8912529861854991652,
+		0,
+		CASE
+		WHEN false THEN (NULL,)
+		ELSE (NULL,)
+		END
+	)
+FROM
+	table41834;

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2950,7 +2950,7 @@ may increase either contention or retry errors, or both.`,
 			Types: tree.ArgTypes{
 				{"table_id", types.Int},
 				{"index_id", types.Int},
-				{"row_tuple", types.AnyTuple},
+				{"row_tuple", types.Any},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2958,7 +2958,7 @@ may increase either contention or retry errors, or both.`,
 				indexID := int(tree.MustBeDInt(args[1]))
 				rowDatums, ok := tree.AsDTuple(args[2])
 				if !ok {
-					return nil, errors.AssertionFailedf("expected DTuple, found %s", args[2])
+					return nil, errors.AssertionFailedf("expected tuple argument for row_tuple, found %s", args[2])
 				}
 
 				tableDesc, err := sqlbase.GetTableDescFromID(ctx.Context, ctx.Txn, sqlbase.ID(tableID))
@@ -2969,7 +2969,6 @@ may increase either contention or retry errors, or both.`,
 				if len(rowDatums.D) != len(tableDesc.Columns) {
 					return nil, pgerror.Newf(pgcode.Syntax, "number of values provided must equal number of columns in table")
 				}
-
 				// Check that all the input datums have types that line up with the columns.
 				var datums tree.Datums
 				for i, d := range rowDatums.D {


### PR DESCRIPTION
SQLSmith found a panic where typechecking would try and perform
an "invalid" cast on a null passed into crdb_internal.encode_key.
In order to avoid the error at type checking and use the error handling
within the function, the argument type for encode_key was generalized
to Any, rather than AnyTuple.

Fixes #41834.

Release note: None