### PR TITLE
cli: hint missing --join upon already-init errors

### DIFF
--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -93,11 +93,13 @@ func (s *initServer) awaitBootstrap() (initServerResult, error) {
 func (s *initServer) Bootstrap(
 	ctx context.Context, request *serverpb.BootstrapRequest,
 ) (response *serverpb.BootstrapResponse, err error) {
-	if err := s.testOrSetRejectErr(errClusterInitialized); err != nil {
+	if err := s.testOrSetRejectErr(ErrClusterInitialized); err != nil {
 		return nil, err
 	}
 	close(s.bootstrapReqCh)
 	return &serverpb.BootstrapResponse{}, nil
 }
 
-var errClusterInitialized = fmt.Errorf("cluster has already been initialized")
+// ErrClusterInitialized is reported when the Boostrap RPC is ran on
+// a node already part of an initialized cluster.
+var ErrClusterInitialized = fmt.Errorf("cluster has already been initialized")


### PR DESCRIPTION
Requested by @rkruze 

Before:

```
Error: rpc error: code = Unknown desc = cluster has already been initialized
Failed running "init"
```

After:

```
Error: rpc error: code = Unknown desc = cluster has already been initialized
HINT: Please ensure all your start commands are using --join.
Failed running "init"
```

Release note (cli change): The error message produced by `cockroach
init` when it encounters an already-initialized cluster has been
extended with a hint to recommend adding `--join` to the start
commands.