### PR TITLE
storage/engine: configure Pebble to use a bloom filter

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/pkg/errors"
 )
@@ -199,7 +200,9 @@ func DefaultPebbleOptions() *pebble.Options {
 		L0StopWritesThreshold: 1000,
 		LBaseMaxBytes:         64 << 20, // 64 MB
 		Levels: []pebble.LevelOptions{{
-			BlockSize: 32 << 10, // 32 KB
+			BlockSize:    32 << 10, // 32 KB
+			FilterPolicy: bloom.FilterPolicy(10),
+			FilterType:   pebble.TableFilter,
 		}},
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,


### PR DESCRIPTION
Change the default Pebble options to specify a bloom filter in order to
match the RocksDB configuration. Fixes the `TestStoreMetrics` failure
when run on Pebble.

Release note: None