### PR TITLE
builtins: fix remaining incorrect MakeDTimestampTZFromDate usages

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -55,7 +55,7 @@
 <tr><td><code>+</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="date.html">date</a> <code>+</code> <a href="int.html">int</a></td><td><a href="date.html">date</a></td></tr>
-<tr><td><a href="date.html">date</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>+</code> <a href="time.html">time</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>+</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>+</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
@@ -65,7 +65,7 @@
 <tr><td><a href="int.html">int</a> <code>+</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>+</code> <a href="inet.html">inet</a></td><td><a href="inet.html">inet</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>+</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
-<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="date.html">date</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="date.html">date</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>+</code> <a href="time.html">time</a></td><td><a href="time.html">time</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>+</code> <a href="timestamp.html">timestamp</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
@@ -84,7 +84,7 @@
 <tr><td><code>-</code><a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>-</code> <a href="date.html">date</a></td><td><a href="int.html">int</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>-</code> <a href="int.html">int</a></td><td><a href="date.html">date</a></td></tr>
-<tr><td><a href="date.html">date</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>-</code> <a href="time.html">time</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>-</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>-</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -20,9 +20,9 @@ INSERT INTO t VALUES
 query T
 SELECT b + '6 month' from t order by a desc
 ----
-2016-02-29 00:00:00 +0000 UTC
-2016-02-29 00:00:00 +0000 UTC
-2016-02-25 00:00:00 +0000 UTC
+2016-02-29 00:00:00 +0000 +0000
+2016-02-29 00:00:00 +0000 +0000
+2016-02-25 00:00:00 +0000 +0000
 
 query TTT
 SELECT * FROM t WHERE a = '2015-08-25 04:45:45.53453+01:00'::timestamp
@@ -1196,17 +1196,17 @@ SHOW TIME ZONE
 query T
 SELECT DATE '1999-01-01' + INTERVAL '4 minutes'
 ----
-1999-01-01 00:04:00 +0000 UTC
+1999-01-01 00:04:00 +0000 +0000
 
 query T
 SELECT INTERVAL '4 minutes' + DATE '1999-01-01'
 ----
-1999-01-01 00:04:00 +0000 UTC
+1999-01-01 00:04:00 +0000 +0000
 
 query T
 SELECT DATE '1999-01-01' - INTERVAL '4 minutes'
 ----
-1998-12-31 23:56:00 +0000 UTC
+1998-12-31 23:56:00 +0000 +0000
 
 query B
 SELECT DATE '1999-01-02' < TIMESTAMPTZ '1999-01-01'
@@ -1519,6 +1519,155 @@ query I
 select extract(day from '2019-01-15'::date) as final
 ----
 15
+
+# Check other usages of MakeDTimestampTZFromDate
+
+query TT
+select ('2019-01-15'::date + '16:17:18'::time), pg_typeof('2019-01-15'::date + '16:17:18'::time)
+----
+2019-01-15 16:17:18 +0000 +0000  timestamp
+
+query TT
+select ('16:17:18'::time + '2019-01-15'::date), pg_typeof(('16:17:18'::time + '2019-01-15'::date))
+----
+2019-01-15 16:17:18 +0000 +0000  timestamp
+
+query TT
+select ('2019-01-15'::date + '1 hour'::interval), pg_typeof('2019-01-15'::date + '1 hour'::interval)
+----
+2019-01-15 01:00:00 +0000 +0000  timestamp
+
+query TT
+select ('1 hour'::interval + '2019-01-15'::date), pg_typeof('1 hour'::interval + '2019-01-15'::date)
+----
+2019-01-15 01:00:00 +0000 +0000  timestamp
+
+query TT
+select ('2019-01-15'::date - '16:17:18'::time), pg_typeof('2019-01-15'::date - '16:17:18'::time)
+----
+2019-01-14 07:42:42 +0000 +0000  timestamp
+
+query TT
+select ('2019-01-15'::date - '1 hour'::interval), pg_typeof('2019-01-15'::date - '1 hour'::interval)
+----
+2019-01-14 23:00:00 +0000 +0000  timestamp
+
+query B
+select '2019-01-01'::date > '2019-01-01 00:00:00+00'::timestamptz
+----
+true
+
+query B
+select '2019-01-01 00:00:00+00'::timestamptz < '2019-01-01'::date
+----
+true
+
+query B
+select '2019-01-01'::date = '2019-01-01 00:00:00'::timestamp
+----
+true
+
+query B
+select '2019-01-01 00:00:00'::timestamp = '2019-01-01'::date
+----
+true
+
+query B
+select '2019-01-01'::date = '2019-01-01'::date
+----
+true
+
+# Check logic works on a table.
+
+statement ok
+SET TIME ZONE 0
+
+statement ok
+CREATE TABLE date_test (date_val date, time_val time, interval_val interval)
+
+statement ok
+INSERT INTO date_test VALUES ('2019-01-15'::date, '16:17:18'::time, '1 hour'::interval)
+
+statement ok
+SET TIME ZONE -5
+
+query TT
+select (date_test.date_val + date_test.time_val), pg_typeof(date_test.date_val + date_test.time_val) from date_test
+----
+2019-01-15 16:17:18 +0000 +0000  timestamp
+
+query TT
+select (date_test.time_val + date_test.date_val), pg_typeof((date_test.time_val + date_test.date_val)) from date_test
+----
+2019-01-15 16:17:18 +0000 +0000  timestamp
+
+query TT
+select (date_test.date_val + date_test.interval_val), pg_typeof(date_test.date_val + date_test.interval_val) from date_test
+----
+2019-01-15 01:00:00 +0000 +0000  timestamp
+
+query TT
+select (date_test.interval_val + date_test.date_val), pg_typeof(date_test.interval_val + date_test.date_val) from date_test
+----
+2019-01-15 01:00:00 +0000 +0000  timestamp
+
+query TT
+select (date_test.date_val - date_test.time_val), pg_typeof(date_test.date_val - date_test.time_val) from date_test
+----
+2019-01-14 07:42:42 +0000 +0000  timestamp
+
+query TT
+select (date_test.date_val - date_test.interval_val), pg_typeof(date_test.date_val - date_test.interval_val) from date_test
+----
+2019-01-14 23:00:00 +0000 +0000  timestamp
+
+query I
+select count(1) from date_test where date_test.date_val > '2019-01-15 00:00:00+00'::timestamptz
+----
+1
+
+query I
+select count(1) from date_test where '2019-01-15 00:00:00+00'::timestamptz < date_test.date_val
+----
+1
+
+query I
+select count(1) from date_test where '2019-01-15 00:00:00'::timestamp = date_test.date_val
+----
+1
+
+query I
+select count(1) from date_test where date_test.date_val = '2019-01-15 00:00:00'::timestamp
+----
+1
+
+query I
+select count(1) from date_test where date_test.date_val = '2019-01-15'::date
+----
+1
+
+statement ok
+SET TIME ZONE +5
+
+query I
+select count(1) from date_test where date_test.date_val < '2019-01-15 00:00:00+00'::timestamptz
+----
+1
+
+query I
+select count(1) from date_test where '2019-01-15 00:00:00+00'::timestamptz > date_test.date_val
+----
+1
+
+query I
+select count(1) from date_test where date_test.date_val = '2019-01-15 00:00:00'::timestamp
+----
+1
+
+query I
+select count(1) from date_test where date_test.date_val = '2019-01-15'::date
+----
+1
 
 statement ok
 SET TIME ZONE 0

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1788,11 +1788,11 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				date := args[1].(*tree.DDate)
-				fromTSTZ, err := tree.MakeDTimestampTZFromDate(time.UTC, date)
+				fromTime, err := date.ToTime()
 				if err != nil {
 					return nil, err
 				}
-				return extractStringFromTimestamp(ctx, fromTSTZ.Time, timeSpan)
+				return extractStringFromTimestamp(ctx, fromTime, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
 				"Compatible elements: millennium, century, decade, year, isoyear,\n" +

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -578,12 +578,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.Time,
 			ReturnType: types.Timestamp,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				d, err := MakeDTimestampTZFromDate(time.UTC, left.(*DDate))
+				leftTime, err := left.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
 				t := time.Duration(*right.(*DTime)) * time.Microsecond
-				return MakeDTimestamp(d.Add(t), time.Microsecond), nil
+				return MakeDTimestamp(leftTime.Add(t), time.Microsecond), nil
 			},
 		},
 		&BinOp{
@@ -591,12 +591,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.Date,
 			ReturnType: types.Timestamp,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				d, err := MakeDTimestampTZFromDate(time.UTC, right.(*DDate))
+				rightTime, err := right.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
 				t := time.Duration(*left.(*DTime)) * time.Microsecond
-				return MakeDTimestamp(d.Add(t), time.Microsecond), nil
+				return MakeDTimestamp(rightTime.Add(t), time.Microsecond), nil
 			},
 		},
 		&BinOp{
@@ -664,27 +664,27 @@ var BinOps = map[BinaryOperator]binOpOverload{
 		&BinOp{
 			LeftType:   types.Date,
 			RightType:  types.Interval,
-			ReturnType: types.TimestampTZ,
+			ReturnType: types.Timestamp,
 			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				leftTZ, err := MakeDTimestampTZFromDate(ctx.GetLocation(), left.(*DDate))
+				leftTime, err := left.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx, leftTZ.Time, right.(*DInterval).Duration)
-				return MakeDTimestampTZ(t, time.Microsecond), nil
+				t := duration.Add(ctx, leftTime, right.(*DInterval).Duration)
+				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
 		&BinOp{
 			LeftType:   types.Interval,
 			RightType:  types.Date,
-			ReturnType: types.TimestampTZ,
+			ReturnType: types.Timestamp,
 			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				rightTZ, err := MakeDTimestampTZFromDate(ctx.GetLocation(), right.(*DDate))
+				rightTime, err := right.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx, rightTZ.Time, left.(*DInterval).Duration)
-				return MakeDTimestampTZ(t, time.Microsecond), nil
+				t := duration.Add(ctx, rightTime, left.(*DInterval).Duration)
+				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
 		&BinOp{
@@ -803,12 +803,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.Time,
 			ReturnType: types.Timestamp,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				d, err := MakeDTimestampTZFromDate(time.UTC, left.(*DDate))
+				leftTime, err := left.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
 				t := time.Duration(*right.(*DTime)) * time.Microsecond
-				return MakeDTimestamp(d.Add(-1*t), time.Microsecond), nil
+				return MakeDTimestamp(leftTime.Add(-1*t), time.Microsecond), nil
 			},
 		},
 		&BinOp{
@@ -893,15 +893,14 @@ var BinOps = map[BinaryOperator]binOpOverload{
 		&BinOp{
 			LeftType:   types.Date,
 			RightType:  types.Interval,
-			ReturnType: types.TimestampTZ,
+			ReturnType: types.Timestamp,
 			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				leftTZ, err := MakeDTimestampTZFromDate(ctx.GetLocation(), left.(*DDate))
+				leftTime, err := left.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx,
-					leftTZ.Time, right.(*DInterval).Duration.Mul(-1))
-				return MakeDTimestampTZ(t, time.Microsecond), nil
+				t := duration.Add(ctx, leftTime, right.(*DInterval).Duration.Mul(-1))
+				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
 		&BinOp{


### PR DESCRIPTION
Auditing the remaining MakeDTimestampTZFromDate usages and found some
interesting items that do not match postgres behaviour, so fixing all
that up here. Note that the MakeDTimestampTZFromDate bug fix actually
fixed comparators compared to previous behaviour.

This in particular fixes types and return results for:

* date +- interval
* interval + date

And, in addition to the above, adds tests for:
* date +- time
* time + date
* comparator operators.

Release note (bug fix, backward-incompatible change): This PR changes
the return type of (date +- interval) and (interval + date) to be
timestamp instead of timestamptz, to be in line with postgres.
Furthermore, it fixes a bug where these calculations would be incorrect
if the current timezone is not UTC.