### PR TITLE
importccl: Modify readFiles() input converter method to take in a resume position indicator

### DIFF
--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -102,7 +102,7 @@ func TestConverterFlushesBatches(t *testing.T) {
 				group := ctxgroup.WithContext(ctx)
 				group.Go(func() error {
 					defer close(kvCh)
-					return conv.readFiles(ctx, testCase.inputs, converterSpec.Format, externalStorageFactory)
+					return conv.readFiles(ctx, testCase.inputs, nil, converterSpec.Format, externalStorageFactory)
 				})
 
 				lastBatch := 0

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -76,10 +76,11 @@ func (c *csvInputReader) start(group ctxgroup.Group) {
 func (c *csvInputReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 ) error {
-	return readInputFiles(ctx, dataFiles, format, c.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, c.readFile, makeExternalStorage)
 }
 
 func (c *csvInputReader) flushBatch(ctx context.Context, finished bool) error {
@@ -98,7 +99,12 @@ func (c *csvInputReader) flushBatch(ctx context.Context, finished bool) error {
 }
 
 func (c *csvInputReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, inputName string, rejected chan string,
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	cr := csv.NewReader(input)
 	if c.opts.Comma != 0 {

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -81,14 +81,20 @@ func (m *mysqldumpReader) start(ctx ctxgroup.Group) {
 func (m *mysqldumpReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 ) error {
-	return readInputFiles(ctx, dataFiles, format, m.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, makeExternalStorage)
 }
 
 func (m *mysqldumpReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, inputName string, rejected chan string,
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	var inserts, count int64
 	r := bufio.NewReaderSize(input, 1024*64)

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -60,7 +60,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	defer in.Close()
 	wrapped := &fileReader{Reader: in, counter: byteCounter{r: in}}
 
-	if err := converter.readFile(ctx, wrapped, 1, "", nil); err != nil {
+	if err := converter.readFile(ctx, wrapped, 1, "", 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	close(kvCh)

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -53,14 +53,20 @@ func (d *mysqloutfileReader) start(ctx ctxgroup.Group) {
 func (d *mysqloutfileReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 ) error {
-	return readInputFiles(ctx, dataFiles, format, d.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage)
 }
 
 func (d *mysqloutfileReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, inputName string, rejected chan string,
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	d.conv.KvBatch.Source = inputIdx
 	d.conv.FractionFn = input.ReadFraction

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -60,10 +60,11 @@ func (d *pgCopyReader) start(ctx ctxgroup.Group) {
 func (d *pgCopyReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 ) error {
-	return readInputFiles(ctx, dataFiles, format, d.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage)
 }
 
 type postgreStreamCopy struct {
@@ -253,7 +254,12 @@ func (c copyData) String() string {
 }
 
 func (d *pgCopyReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, inputName string, rejected chan string,
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	s := bufio.NewScanner(input)
 	s.Split(bufio.ScanLines)

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -435,14 +435,20 @@ func (m *pgDumpReader) start(ctx ctxgroup.Group) {
 func (m *pgDumpReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 ) error {
-	return readInputFiles(ctx, dataFiles, format, m.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, makeExternalStorage)
 }
 
 func (m *pgDumpReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, inputName string, rejected chan string,
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	var inserts, count int64
 	ps := newPostgreStream(input, int(m.opts.MaxRowSize))

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -99,6 +99,7 @@ func makeDatumFromColOffset(
 func (w *workloadReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
+	_ map[int32]int64,
 	_ roachpb.IOFileFormat,
 	_ cloud.ExternalStorageFactory,
 ) error {


### PR DESCRIPTION
Update inputConverter's readFile method to take in an additional
resume position parameter in order for the converter implementations
to be able to support import resume functionality.

Release note: None