### PR TITLE
builtins: change assertion failed error to pgerror in crdb_internal.encode_key

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2967,7 +2967,7 @@ may increase either contention or retry errors, or both.`,
 				indexID := int(tree.MustBeDInt(args[1]))
 				rowDatums, ok := tree.AsDTuple(args[2])
 				if !ok {
-					return nil, errors.AssertionFailedf("expected tuple argument for row_tuple, found %s", args[2])
+					return nil, pgerror.Newf(pgcode.DatatypeMismatch, "expected tuple argument for row_tuple, found %s", args[2])
 				}
 
 				tableDesc, err := sqlbase.GetTableDescFromID(ctx.Context, ctx.Txn, sqlbase.ID(tableID))


### PR DESCRIPTION
An assertion error was the incorrect error to raise when an invalid type
datum was provided to crdb_internal.encode_key. This PR changes the error
type to a pgerror with code `DataTypeMismatch`.

Related to #42293.

Release note: None