### PR TITLE
scripts/release-notes.py: derive author aliases from AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,37 +3,48 @@
 # Names should be added to this file as one of
 #     Organization's name
 #     Individual's name <submission email address>
-#     Individual's name <submission email address> <email2> <emailN>
-
+#     Individual's name <submission email address> [alias] <email2> [alias] <emailN>
+#
+# If you wish to keep your @cockroachlabs.com address hidden,
+# please still list <@cockroachlabs.com> (with no user name)
+# in the list of aliases.
+#
+# (Note: there is no point in hiding it if it is mentioned
+# in the git log already.)
+#
+# For more details about the format, see git-check-mailmap(1)
+#
 # Please keep the list sorted.
 
 1lann <me@chuie.io>
-aarondunnington <aaron.dunnington@gmail.com>
-Abhemailk abhi.madan01@gmail.com <abhishek@cockroachlabs.com>
-Abhishek Madan <abhi.madan01@gmail.com> <abhimadan@users.noreply.github.com> <abhishek@cockroachlabs.com>
+Aaron Dunnington <aaron.dunnington@gmail.com> aarondunnington <aaron.dunnington@gmail.com>
+Aayush Shah <aayush.shah15@gmail.com> <@cockroachlabs.com>
+Abhishek Madan <abhi.madan01@gmail.com> <abhimadan@users.noreply.github.com> <abhishek@cockroachlabs.com> Abhemailk abhi.madan01@gmail.com <abhishek@cockroachlabs.com>
 Abhishek Soni <abhishek.rocks26@gmail.com>
-AbhishekSaha <as1695@scarletmail.rutgers.edu>
+Abhishek Saha <as1695@scarletmail.rutgers.edu> AbhishekSaha <as1695@scarletmail.rutgers.edu>
 acoshift <acoshift@gmail.com>
 Adam Gee <adamgee@gmail.com>
 Adam Yao <adam.yao.qinglin@gmail.com>
+Aditya Maru <adityamaru@cockroachlabs.com>
 Aid Idrizović <idrizovicaid@gmail.com>
 Ajaya Agrawal <ajku.agr@gmail.com>
 Alex Gaynor <alex.gaynor@gmail.com>
-Alex Robinson <alexdwanerobinson@gmail.com> <arob@google.com>
-Alfonso Subiotto Marqués <alfonso.subiotto.marques@gmail.com> <alfonso@cockroachlabs.com>
+Alex Robinson <alexdwanerobinson@gmail.com> <arob@google.com> <@cockroachlabs.com>
+Alfonso Subiotto Marqués <alfonso.subiotto.marques@gmail.com> Alfonso Subiotto Marques <alfonso@cockroachlabs.com>
 Amos Bird <amosbird@gmail.com>
-Amruta Ranade <amruta@cockroachlabs.com> <amruta2799@gmail.com>
+Amruta Ranade <amruta@cockroachlabs.com> Amruta <amruta@cockroachlabs.com> <amruta2799@gmail.com>
 Andrei Matei <andrei@cockroachlabs.com> <andreimatei1@gmail.com>
 Andrew Bonventre <abonventre@palantir.com> <andybons@gmail.com>
 Andrew Couch <andrew@cockroachlabs.com> <github@couchand.com> <hi@andrewcou.ch>
-Andrew Kimball <andyk@cockroachlabs.com> <kimball.andy@gmail.com> <32096062+andy-kimball@users.noreply.github.com> <andyk@cockroachlabs.com>
-Andrew Kryczka <andrew.kryczka2@gmail.com>
+Andy Kimball <andyk@cockroachlabs.com> <kimball.andy@gmail.com> <32096062+andy-kimball@users.noreply.github.com> Andrew Kimball <andyk@cockroachlabs.com>
+Andrew Kryczka <andrew.kryczka2@gmail.com> Andrew Kryczka <ajkr@users.noreply.github.com> <@cockroachlabs.com>
 Andrew NS Yeow <ngeesoon80@yahoo.com>
 Andrew Werner <ajwerner@cockroachlabs.com>
-Andrew Woods <andy@cockroachlabs.com>
+Andy Woods <andy@cockroachlabs.com> Andrew Woods <andy@cockroachlabs.com>
 Andrey Shinkevich <andyogen@gmail.com>
+Angela Chang <angelachang27@gmail.com> changangela <angelachang27@gmail.com> <angela@cockroachlabs.com>
 Antoine Grondin <antoinegrondin@gmail.com>
-Arjun Ravi Narayan <arjun@cockroachlabs.com> <arjunravinarayan@gmail.com> <arjun@cockroachlabs.com> <arjunravinarayan@users.noreply.github.com>
+Arjun Ravi Narayan <arjun@cockroachlabs.com> <arjunravinarayan@gmail.com> Arjun Narayan <arjun@cockroachlabs.com> <arjunravinarayan@users.noreply.github.com>
 Art Nikpal <ai.radio.org@gmail.com>
 Arul Ajmani <arula@cockroachlabs.com> <arulajmani@gmail.com>
 Asit Mahato <asitm9@gmail.com>
@@ -42,47 +53,44 @@ Ben Darnell <ben@bendarnell.com> <ben@cockroachlabs.com>
 Bilal Akhtar <bilal@cockroachlabs.com> <me@itsbilal.com>
 Bob Potter <bobby.potter@gmail.com>
 Bob Vawter <bob@cockroachlabs.com>
-Bogdan Batog <bogdanbatog@gmail.com>
-bogdanbatog <bogdanbatog@gmail.com>
+Bogdan Batog <bogdanbatog@gmail.com> bogdanbatog <bogdanbatog@gmail.com>
 Brad Seiler <seiler@squareup.com>
 Bram Gruneir <BramGruneir@users.noreply.github.com> <MycroftH@users.noreply.github.com> <bram.gruneir@gmail.com> <bram@cockroachlabs.com>
 Brandon Gonzalez <brandon.gonzalez.451@gmail.com>
 Brett Snyder <bsnyder788@gmail.com>
 Celia La <celia@cockroachlabs.com>
 Céline O'Neil <celineloneil@gmail.com> <celineo@cockroachlabs.com>
-changangela <angela@cockroachlabs.com> <angelachang27@gmail.com>
 chengwei <252684445@qq.com>
-Chris Seto <chriskseto@gmail.com>
+Chris Seto <chriskseto@gmail.com> <@cockroachlabs.com>
 Christian Meunier <chris@jumpn.com>
-christopherrouth <routhcr@gmail.com>
-CMajeri <chervine.majeri@elca.ch>
+Christopher Routh <routhcr@gmail.com> christopherrouth <routhcr@gmail.com>
+Chervine Majeri <chervine.majeri@elca.ch> CMajeri <chervine.majeri@elca.ch>
 Cockroach Labs Inc.
 coldwater <zhangcoldwater@163.com>
 Constantine Peresypkin <constantine.peresypkin@datarobot.com> <pconstantine@gmail.com>
-ctkou <adamkouct@gmail.com>
+Adam Kouct <adamkouct@gmail.com> ctkou <adamkouct@gmail.com>
 Cuong Do <cdo@cockroachlabs.com> <cuongdo@users.noreply.github.com>
-Dan Kortschak <dan.kortschak@adelaide.edu.au>
-Daniel Harrison <dan@cockroachlabs.com> <daniel.harrison@gmail.com> <daniel.harrison@gmail.com>
+Dan Kortschak <dan.kortschak@adelaide.edu.au> kortschak <dan.kortschak@adelaide.edu.au>
+Daniel Harrison <dan@cockroachlabs.com> <daniel.harrison@gmail.com>
 Daniel Theophanes <kardianos@gmail.com>
 Daniel Upton <daniel@floppy.co>
-Darin Peshev <darinp@gmail.com> <darinp@gmail.com>
+Darin Peshev <darinp@gmail.com> Darin <darinp@gmail.com> <@cockroachlabs.com>
 David Eisenstat <eisen@cockroachlabs.com>
 David López <not4rent@gmail.com>
-David Taylor <tinystatemachine@gmail.com>
+David Taylor <tinystatemachine@gmail.com> <@cockroachlabs.com>
 dchenk <dcherchenko@gmail.com>
 Dexter Valkyrie <skynode@users.noreply.github.com>
-Diana Hsieh <dianahsieh323@gmail.com>
-dianasaur323 <diana@cockroachlabs.com> <dianahsieh323@gmail.com>
-DiSiqueira <dieg0@live.com>
+Diana Hsieh <dianahsieh323@gmail.com> dianasaur323 <dianahsieh323@gmail.com> dianasaur323 <diana@cockroachlabs.com>
+Diego DiSiquera <dieg0@live.com> DiSiqueira <dieg0@live.com>
 Dmitry Saveliev <d.e.saveliev@gmail.com>
 Dmitry Vorobev <dimahabr@gmail.com>
 Dominique Luna <dluna132@gmail.com>
 Dong Liang <dong.liang@rubrik.com>
 Dustin Hiatt <dustin.hiatt@rkinetic.com>
-EamonZhang <zhang.eamon@hotmail.com>
+Eamon Zhang <zhang.eamon@hotmail.com> EamonZhang <zhang.eamon@hotmail.com>
 Eli Lindsey <eli@siliconsprawl.com>
 embark <wolfire9@users.noreply.github.com>
-Emmanuel <absolutezero2a03@gmail.com>
+Emmanuel Sales <absolutezero2a03@gmail.com> Emmanuel <absolutezero2a03@gmail.com> <emsal1863@gmail.com> <@cockroachlabs.com>
 Erik Trinh <erik@cockroachlabs.com>
 es-chow <es-chow@users.noreply.github.com> <es_chow@163.com>
 Evgeniy Vasilev <aquilax@gmail.com>
@@ -94,14 +102,13 @@ George Papadrosou <gpapadrosou@gmail.com>
 George Utsin <george@cockroachlabs.com>
 Georgia Hong <georgiah@cockroachlabs.com>
 Gustav Paul <gpaul@mesosphere.io>
-Haines Chan <zhinhai@gmail.com>
-hainesc <zhinhai@gmail.com>
+Haines Chan <zhinhai@gmail.com> hainesc <zhinhai@gmail.com>
 Harshit Chopra <harshit@squareup.com>
 Hayden A. James <hayden.james@gmail.com>
 Ibrahim AshShohail <ibra.sho@gmail.com>
 Igor Kharin <igorkharin@gmail.com>
 il9ue <oodanq@gmail.com>
-irfan sharif <irfanmahmoudsharif@gmail.com>
+Irfan Sharif <irfanmahmoudsharif@gmail.com> irfan sharif <irfanmahmoudsharif@gmail.com> <@cockroachlabs.com>
 Isaac Rogers <therealplato@gmail.com>
 Israel Gilyadov <israelg99@gmail.com>
 Iuri Sitinschi <iuri.sitinschi@visual-meta.com> <yukas66@gmail.com>
@@ -113,11 +120,11 @@ Jason E. Aten <j.e.aten@gmail.com>
 Jason Young <RustJason@users.noreply.github.com>
 Jay Kominek <kominek@gmail.com>
 Jeffrey Dallatezza <jeffreydallatezza@gmail.com>
-Jeffrey Xiao <jeffrey.xiao1998@gmail.com>
+Jeffrey Xiao <jeffrey.xiao1998@gmail.com> <@cockroachlabs.com>
 Jesse Seldess <j_seldess@hotmail.com> <jesse@cockroachlabs.com>
 Jessica Edwards <jessica@cockroachlabs.com> <jess-edwards@users.noreply.github.com>
 Jiajia Han <jiajia@squareup.com>
-jiangmingyang <jiangming.yang@gmail.com>
+Jiangming Yang <jiangming.yang@gmail.com> jiangmingyang <jiangming.yang@gmail.com>
 Jimmy Larsson <jimmy.larsson@trioptima.com>
 Jincheng Li <mail@jincheng.li>
 Jingguo Yao <yaojingguo@gmail.com>
@@ -142,32 +149,31 @@ Karl Southern <karl@theangryangel.co.uk>
 Kathy Spradlin <kathyspradlin@gmail.com>
 Kenji Kaneda <kaneda@squareup.com> <kenji.kaneda@gmail.com>
 Kenjiro Nakayama <nakayamakenjiro@gmail.com>
+Kenneth Liu <ken@cockroachlabs.com>
 Kevin Guan <keynovo@gmail.com>
 kiran <crackerplace@gmail.com>
-kortschak <dan.kortschak@adelaide.edu.au>
 lanzao <395818758@qq.com>
 Lasantha Pambagoda <lpambagoda@gmail.com>
-Lauren Hirata <lauren@cockroachlabs.com>
+Lauren Hirata <lauren@cockroachlabs.com> Lauren <lauren@cockroachlabs.com> lhirata <lauren@cockroachlabs.com>
 Lee Reilly <lee@github.com>
 Levon Lloyd <levon@squareup.com>
-liuqi <liuqi@wandoujia.com>
 liyanan <liyananfamily@gmail.com>
 Lizhong <z.lizhong@gmail.com>
-louishust <hdchild@163.com>
+Louis Hust <hdchild@163.com> louishust <hdchild@163.com>
 Lu Guanqun <guanqun.lu@gmail.com>
-Lucy Zhang <lucy-zhang@users.noreply.github.com>
+Lucy Zhang <lucy-zhang@users.noreply.github.com> <lucy@cockroachlabs.com>
 M-srivatsa <srivatsa.dev@gmail.com>
 MaBo <mabo163@163.com>
-madhavsuresh <madhav@cockroachlabs.com>
+Madhav Suresh <madhav@cockroachlabs.com> madhavsuresh <madhav@cockroachlabs.com>
 Mahmoud Al-Qudsi <mqudsi@neosmart.net>
 Maitri Morarji <vivek1@viveks-MacBook-Pro.local>
 Manik Surtani <manik@squareup.com> <manik@surtani.org>
-Marc Berhault <marc.berhault@gmail.com> <marc@cockroachlabs.com> <marc.berhault@gmail.com>
+Marc Berhault <marc.berhault@gmail.com> marc <marc@cockroachlabs.com> MBerhault <marc.berhault@gmail.com>
 Marcus Westin <marcus.westin@gmail.com>
 Marko Bonaći <mbonaci@users.noreply.github.com>
 Martin Bertschler <mbertschler@gmail.com>
 Masha Schneider <masha@cockroachlabs.com> <mshv14282@gmail.com>
-Matt Jibson <matt.jibson@gmail.com>
+Matt Jibson <matt.jibson@gmail.com> <@cockroachlabs.com>
 Matt Tracy <matt.r.tracy@gmail.com> <matt@cockroachlabs.com>
 Matthew O'Connor <matthew@squareup.com> <matthew.t.oconnor@gmail.com>
 Max Lang <max@cockroachlabs.com> <maxwell.g.lang@gmail.com>
@@ -175,22 +181,22 @@ Mayank Oli <mayankoli96@gmail.com>
 mbonaci <mbonaci@gmail.com>
 Mo Firouz <mofirouz@mofirouz.com>
 Mohamed Elqdusy <mohamedelqdusy@gmail.com>
-Nate <nathaniel.p.stewart@gmail.com>
+Nate Stewart <nathaniel.p.stewart@gmail.com> Nate <nathaniel.p.stewart@gmail.com> <nate@cockroachlabs.com>
 Nathan Johnson <njohnson@ena.com>
-Nathan VanBenschoten <nvanbenschoten@gmail.com>
-Nathaniel Stewart <nate@cockroachlabs.com>
+Nathan VanBenschoten <nvanbenschoten@gmail.com> <@cockroachlabs.com>
+Nathan Stilwell <nathanstilwell@cockroachlabs.com>
 neeral <neeral@users.noreply.github.com>
-nexdrew <andrewbgoode@gmail.com>
-ngaut <liuqi@wandoujia.com> <ngaut@users.noreply.github.com> <goroutine@126.com> <ngaut@126.com>
+Andrew B. Goode <andrewbgoode@gmail.com> nexdrew <andrewbgoode@gmail.com>
+ngaut <liuqi@wandoujia.com> liuqi <liuqi@wandoujia.com> goroutine <ngaut@users.noreply.github.com> <goroutine@126.com> <ngaut@126.com>
 Nick <linicks@gmail.com>
 Nick Gottlieb <ngottlieb1@gmail.com>
-Nikhil Benesch <nikhil.benesch@gmail.com>
+Nikhil Benesch <nikhil.benesch@gmail.com> <@cockroachlabs.com>
 Nishant Gupta <nishant.gupta@rubrik.com>
 noonan <noonan@noonan-vb-17.10-CDB>
 Oliver Tan <otan@cockroachlabs.com> <sinovercosequalstan@gmail.com>
 Panos Mamatsis <pmamatsis@gmail.com>
 Paul Banks <banks@banksdesigns.co.uk>
-Paul Bardea <paul@pbardea.com> <pbardea@gmail.com>
+Paul Bardea <paul@pbardea.com> <pbardea@gmail.com> <@cockroachlabs.com>
 Peng Gao <peng.gao.dut@gmail.com>
 Pete Vilter <7341+vilterp@users.noreply.github.com> <vilterp@cockroachlabs.com>
 Peter Mattis <peter@cockroachlabs.com> <petermattis@gmail.com>
@@ -199,16 +205,15 @@ Philippe Laflamme <philippe.laflamme@gmail.com>
 phynalle <phynalism@gmail.com>
 Piotr Zurek <p.zurek@gmail.com>
 pocockn <pocockn@hotmail.co.uk>
-Poornima <poornima.malepati@gmail.com>
-Radu Berinde <radu.berinde@gmail.com> <radu@cockroachlabs.com>
+Poornima Malepati <poornima.malepati@gmail.com> Poornima <poornima.malepati@gmail.com>
+Radu Berinde <radu.berinde@gmail.com> RaduBerinde <radu@cockroachlabs.com>
 Rafi Shamim <rafi@cockroachlabs.com> <rafiss@gmail.com>
-Raphael 'kena' Poss <knz@cockroachlabs.com> <knz@thaumogen.net> <knz@thaumogen.net> <knz@users.noreply.github.com>
+Raphael 'kena' Poss <knz@cockroachlabs.com> kena <knz@thaumogen.net> Raphael Poss <knz@thaumogen.net> <knz@users.noreply.github.com>
 ReadmeCritic <frankensteinbot@gmail.com>
-Rebecca Taft <becca@cockroachlabs.com> <rytaft@gmail.com>
-Rich Loveland <loveland.richard@gmail.com> <rich@cockroachlabs.com>
+Rebecca Taft <becca@cockroachlabs.com> rytaft <becca@cockroachlabs.com> <rytaft@gmail.com>
+Rich Loveland <loveland.richard@gmail.com> <rich@cockroachlabs.com> Richard Loveland <rloveland@richards-mbp.lan>
 Richard Artoul <richardartoul@gmail.com>
-Richard Loveland <rloveland@richards-mbp.lan>
-Richard Wu <richardwu1997@gmail.com>
+Richard Wu <richardwu1997@gmail.com> <@cockroachlabs.com>
 Ridwan Sharif <ridwan@cockroachlabs.com> <ridwanmsharif@Ridwans-MacBook-Pro.local>
 Rohan Yadav <rohany@cockroachlabs.com>
 Roland Crosby <roland@cockroachlabs.com>
@@ -221,35 +226,36 @@ Sergei Turukin <rampage644@gmail.com>
 Seth Bunce <seth.bunce@gmail.com>
 shakeelrao <shakeelrao79@gmail.com>
 Shawn Morel <shawn@squareup.com> <shawn@strangemonad.com> <strangemonad@squareup.com>
-Solon Gordon <solon@cockroachlabs.com> <solongordon@gmail.com>
-songhao <songhao9021@gmail.com>
+Solon Gordon <solon@cockroachlabs.com> solongordon <solongordon@gmail.com>
+Song Hao <songhao9021@gmail.com> songhao <songhao9021@gmail.com>
 Spas Bojanov <spas@cockroachlabs.com> <pachob@gmail.com>
-Spencer Kimball <spencer.kimball@gmail.com>
+Spencer Kimball <spencer.kimball@gmail.com> <spencer@cockroachlabs.com>
+Sumeer Bhola <sumeer@cockroachlabs.com> sumeerbhola <sumeer@cockroachlabs.com>
 sum12 <sumitjami@gmail.com>
 Syd <324760805@qq.com>
 Takuya Kuwahara <taakuu19@gmail.com>
-Tamir Duberstein <tamird@gmail.com>
-Tamir Duberstein and Kenji Kaneda <tamird+kenji.kaneda@gmail.com>
+Tamir Duberstein <tamird@gmail.com> <@cockroachlabs.com>
+Tamir Duberstein and Kenji Kaneda <tamird+kenji.kaneda@gmail.com> <@cockroachlabs.com>
 Tarek Badr <tarekbadrshalaan@gmail.com>
 Teodor Pripoae <teodor.pripoae@gmail.com>
 Terrell Russell <terrellrussell@gmail.com>
 Thanakom Sangnetra <thanakom.sangnetra@hotelquickly.com> <loki.top11@gmail.com>
 Thomas Schroeter <thomas@cliqz.com> <thschroeter@gmail.com>
 thundercw <thundercw@gmail.com>
-tim-o <38867162+tim-o@users.noreply.github.com>
+Tim O'Brien <38867162+tim-o@users.noreply.github.com> tim-o <38867162+tim-o@users.noreply.github.com> <@cockroachlabs.com>
 Timothy Chen <tnachen@gmail.com>
-Tobias Schottdorf <tobias@tkschmidt.me> <tobias.schottdorf@gmail.com> <tobias.schottdorf@hrs.de>
-Tristan Ohlson <tsohlson@gmail.com>
+Tobias Schottdorf <tobias@tkschmidt.me> <tobias.schottdorf@gmail.com> <tobias.schottdorf@hrs.de> <@cockroachlabs.com>
+Tristan Ohlson <tsohlson@gmail.com> <@cockroachlabs.com>
 Tristan Rice <rice@fn.lc> <wiz@cockroachlabs.com>
 Txiaozhe <txiaozhe@gmail.com>
 Tyler Neely <tan@tumblr.com>
-Tyler Roberts <tyler@cockroachlabs.com>
+Tyler Roberts <tyler@cockroachlabs.com> Tyler314 <tyler@cockroachlabs.com>
 Umesh Yadav <dungeonmaster18@users.noreply.github.com>
 vagrant <vagrant@precise64.(none)>
 veteranlu <23907238@qq.com>
 Victor Chen <victor@cockroachlabs.com>
 Vijay Karthik <vijay.karthik@rubrik.com>
-Vivek Menezes <vivek.menezes@gmail.com> <vivek1@viveks-MacBook-Pro.local> <vivek@cockroachlabs.com> <vivekmenezes@users.noreply.github.com>
+Vivek Menezes <vivek.menezes@gmail.com> <vivek1@viveks-MacBook-Pro.local> <vivek@cockroachlabs.com> vivekmenezes <vivekmenezes@users.noreply.github.com>
 wenyong-h <weyo.huang@gmail.com>
 Will Haack <will.haack@appboy.com> <will@cockroachlabs.com>
 Xiang Li <xiangli.cs@gmail.com>
@@ -257,7 +263,7 @@ Xinyu Zhou (Joe) <joe.zxy@foxmail.com>
 XisiHuang <cockhuangxh@163.com>
 xphoniex <dj.2dixx@gmail.com>
 Xudong Zheng <7pkvm5aw@slicealias.com>
-Yahor Yuzefovich <yahor@cockroachlabs.com>
+Yahor Yuzefovich <yahor@cockroachlabs.com> yuzefovich <yahor@cockroachlabs.com>
 Yan Long <rafaelyim@qq.com>
 yananzhi <alkfbb@gmail.com> <zac.zhiyanan@gmail.com>
 Yang Yuting <william.yangyt@gmail.com>
@@ -266,8 +272,8 @@ Yevgeniy Miretskiy <yevgeniy@cockroachlabs.com> <yevgeniy@gmail.com>
 Yosi Attias <yosy101@gmail.com>
 yuhit <longyuhit@163.com>
 Yulei Xiao <21739034@qq.com>
-yznming <rafaelyim@qq.com>
+Rafael Yim <rafelyim@qq.com> yznming <rafaelyim@qq.com>
 Zach Brock <zbrock@gmail.com> <zbrock@squareup.com>
-Zachary.smith <Zachary.smith@yodle.com>
+Zachary Smith <Zachary.smith@yodle.com> Zachary.smith <Zachary.smith@yodle.com>
 何羿宏 <heyihong.cn@gmail.com>
 智雅楠 <zac.zhiyanan@gmail.com>

--- a/scripts/release-notes/Makefile
+++ b/scripts/release-notes/Makefile
@@ -2,6 +2,7 @@ TESTS := $(wildcard test*.sh)
 BASH ?= /usr/bin/env bash
 PYTHON ?= python
 NOTESCRIPT := $(PWD)/../release-notes.py
+TDIR := $(shell pwd)
 
 all: test
 
@@ -15,7 +16,7 @@ test: $(TESTS:.sh=.test)
 	@echo
 	@echo "**** Testing for $* ****"
 	@echo
-	$(BASH) $*.sh $(NOTESCRIPT)
+	$(BASH) $(TDIR)/$*.sh $(NOTESCRIPT)
 
 clean:
 	rm -f *.graph.txt *.notes.txt

--- a/scripts/release-notes/common.sh
+++ b/scripts/release-notes/common.sh
@@ -23,6 +23,7 @@ function test_init() {
 function init_repo() {
     git init
     touch foo; git add foo; git commit "${flags[@]}" -m "initial"; git tag initial
+	git tag v000-base
 }
 
 # Perform some arbitrary change.

--- a/scripts/release-notes/test1.notes.ref.txt
+++ b/scripts/release-notes/test1.notes.ref.txt
@@ -6,7 +6,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] master update (test1)
+- [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] master update (test1 <test1@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test2.notes.ref.txt
+++ b/scripts/release-notes/test2.notes.ref.txt
@@ -7,7 +7,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [f872999e8][f872999e8] master update (test2)
+- [#unknown][#unknown] [f872999e8][f872999e8] master update (test2 <test2@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test3.notes.ref.txt
+++ b/scripts/release-notes/test3.notes.ref.txt
@@ -9,7 +9,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [4f4329fdc][4f4329fdc] master update (test3)
+- [#unknown][#unknown] [4f4329fdc][4f4329fdc] master update (test3 <test3@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test5.notes.ref.txt
+++ b/scripts/release-notes/test5.notes.ref.txt
@@ -6,7 +6,7 @@
 
 #### Changes without release note annotation
 
-- [#2][#2] [8156afc96][8156afc96] PR title in need of release note (test5)
+- [#2][#2] [8156afc96][8156afc96] PR title in need of release note (test5 <test5@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test8.graph.ref.txt
+++ b/scripts/release-notes/test8.graph.ref.txt
@@ -1,0 +1,18 @@
+*   801acad030ef8c14766f72609287d323075af29b Merge pull request #200 from foo/bar
+|\  
+| * 4ba203f0af12e361707c20fa4254fe58f9c3a86e merge pr canary
+|/  
+*   20f736f8b7421f226d15111e2377a8e069972bf0 Merge #2
+|\  
+| * fc02f2ab9ac0c1924c479fa601065235579a605e feature A2
+|/  
+*   ac02f9cf6095d6430c609812730a34fe254f5e77 Merge pull request #100 from foo/bar
+|\  
+| * 1fa346db29169f9d1c6f229e34e1e0b0af687af7 merge pr canary
+|/  
+*   931a977579e2e0f0efee763fa289bd2b3162755b Merge #1
+|\  
+| * f76e64ed372d84433ac4c5e0a06e3dfe34a80686 feature A1
+|/  
+* a1dec56519bfa4d850e2771bd9880d2dcdb715aa update AUTHORS
+* 15d3108780a91a71af56bdaeb020dbdf650fd1ef initial

--- a/scripts/release-notes/test8.notes.ref.txt
+++ b/scripts/release-notes/test8.notes.ref.txt
@@ -1,0 +1,45 @@
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#2][#2] [fc02f2ab9][fc02f2ab9] PR 2 title (Foo Foo <foo@example.com>, test8 <test8@example.com>)
+- [#1][#1] [f76e64ed3][f76e64ed3] PR 1 title (Foo Foo <foo@example.com>, test8 <test8@example.com>)
+- [#unknown][#unknown] [a1dec5651][a1dec5651] update AUTHORS (test8 <test8@example.com>)
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 2 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- Foo Foo (first-time contributor)
+- test8
+
+### PRs merged by contributors
+
+- Foo Foo, test8:
+  - 2018-04-22 [#2    ][#2    ] [20f736f8b][20f736f8b] (+   0 -   0 ~   0/ 0) PR 2 title
+  - 2018-04-22 [#1    ][#1    ] [931a97757][931a97757] (+   0 -   0 ~   0/ 0) PR 1 title
+
+- test8:
+  - 2018-04-22 [#unknown][#unknown] [a1dec5651][a1dec5651] (+   1 -   0 ~   1/ 1) update AUTHORS
+  - 2018-04-22 [#200  ][#200  ] [801acad03][801acad03] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
+  - 2018-04-22 [#100  ][#100  ] [ac02f9cf6][ac02f9cf6] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[20f736f8b]: https://github.com/cockroachdb/cockroach/commit/20f736f8b
+[801acad03]: https://github.com/cockroachdb/cockroach/commit/801acad03
+[931a97757]: https://github.com/cockroachdb/cockroach/commit/931a97757
+[a1dec5651]: https://github.com/cockroachdb/cockroach/commit/a1dec5651
+[ac02f9cf6]: https://github.com/cockroachdb/cockroach/commit/ac02f9cf6
+[f76e64ed3]: https://github.com/cockroachdb/cockroach/commit/f76e64ed3
+[fc02f2ab9]: https://github.com/cockroachdb/cockroach/commit/fc02f2ab9
+

--- a/scripts/release-notes/test8.sh
+++ b/scripts/release-notes/test8.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test8
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+
+	cat >AUTHORS <<EOF
+Foo Foo <foo@example.com> foo <foo@example.com> <foo2@example.com>
+EOF
+	git add AUTHORS
+	make_change "update AUTHORS"
+
+    git checkout -b feature
+    make_change "feature A1"
+	git commit --allow-empty --amend --author='foo <foo@example.com>' --no-edit
+	tag_pr 1
+	git checkout master
+	merge_pr feature 1 "PR 1 title"
+
+	git checkout -b feature2
+	make_change "feature A2"
+	git commit --allow-empty --amend --author='foo <foo2@example.com>' --no-edit
+	tag_pr 2
+	git checkout master
+	merge_pr feature2 2 "PR 2 title"
+)
+
+test_end


### PR DESCRIPTION
Previously, the release-notes script contained an explicit list of
contributors to the repo with their name aliases, to disambiguate
entries in the git log while constructing the release notes report.

The explicit list was problematic in numerous ways, foremost because
it was often out of date and incomplete, and also because it couldn't
distinguish different folk with the same name but different addresses.

Luckily, Git has a standard solution for this problem, called a
"mailmap" file. The format of this file is standardized and documented
in the man page git-check-mailmap(1). To simplify, this file format
has one line per _person_, and each line can contain multiple
name/mail combinations for that person.

Meanwhile, the CockroachDB repository also maintains a file `AUTHORS`
at the top of the source tree. This also contains a list of
contributors with names and e-mails, although for far this file was
not maintained to conform exactly to Git's mailmap format.

This commit bridges the two things as follows:

- it updates the `AUTHORS` file to conform to the mailmap format.
  This removes duplicate entries, and spells out Git commit/author
  aliases alongside the primary name of a person.
- it simplifies the release-notes script to use AUTHORS
  as its input database.

Release note: None