### PR TITLE
roachtest: always assign ORM/driver failures to app-dev team

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -190,6 +190,7 @@ func registerDjango(r *testRegistry) {
 		MinVersion: "v19.2.0",
 		Name:       "django",
 		Cluster:    makeClusterSpec(1),
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runDjango(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -153,6 +153,7 @@ func registerGopg(r *testRegistry) {
 		Name:       "gopg",
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.2.0",
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runGopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -188,6 +188,7 @@ func registerHibernate(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "hibernate",
 		Cluster: makeClusterSpec(1),
+		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -106,6 +106,7 @@ func registerLibPQ(r *testRegistry) {
 		Name:       "lib/pq",
 		MinVersion: "v19.2.0",
 		Cluster:    makeClusterSpec(1),
+		Tags:       []string{`default`, `driver`},
 		Run:        runLibPQ,
 	})
 }

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -178,6 +178,7 @@ func registerPgjdbc(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "pgjdbc",
 		Cluster: makeClusterSpec(1),
+		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runPgjdbc(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -128,6 +128,7 @@ func registerPsycopg(r *testRegistry) {
 		Name:       "psycopg",
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
+		Tags:       []string{`default`, `driver`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runPsycopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -206,6 +206,7 @@ func registerSQLAlchemy(r *testRegistry) {
 		Name:       "sqlalchemy",
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v2.1.0",
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSQLAlchemy(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -420,8 +420,14 @@ func teamCityNameEscape(name string) string {
 }
 
 // getAuthorEmail retrieves the author of a line of code. Returns the empty
-// string if the author cannot be determined.
-func getAuthorEmail(file string, line int) string {
+// string if the author cannot be determined. Some test tags override this
+// behavior and have a hardcoded author email.
+func getAuthorEmail(tags []string, file string, line int) string {
+	for _, tag := range tags {
+		if tag == `orm` || tag == `driver` {
+			return `rafi@cockroachlabs.com`
+		}
+	}
 	const repo = "github.com/cockroachdb/cockroach/"
 	i := strings.Index(file, repo)
 	if i == -1 {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -595,7 +595,7 @@ func (r *testRunner) runTest(
 			shout(ctx, l, stdout, "--- FAIL: %s %s\n%s", t.Name(), durationStr, output)
 			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
 			if issues.CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
-				authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
+				authorEmail := getAuthorEmail(t.spec.Tags, failLoc.file, failLoc.line)
 				branch := "<unknown branch>"
 				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
 					branch = b

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -155,6 +155,7 @@ func registerTypeORM(r *testRegistry) {
 		Name:       "typeorm",
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTypeORM(ctx, t, c)
 		},


### PR DESCRIPTION
Use test spec tags to make sure these failures always go to the app-dev
team. Previously, the assignee would be based on a heuristic of using
git blame on a failing line of code, which would not be accurate for ORM
and driver test failures.

Release note: none