### PR TITLE
sql: fill in pg_catalog.pg_index.indoption

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -606,8 +606,8 @@ FROM pg_catalog.pg_index
 WHERE indnatts = 2
 ----
 indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
-450499961   55        true       false           3 4     0 0           0 0       0 0        NULL      NULL
-969972502   57        true       false           1 2     0 0           0 0       0 0        NULL      NULL
+450499961   55        true       false           3 4     0 0           0 0       2 2        NULL      NULL
+969972502   57        true       false           1 2     0 0           0 0       2 1        NULL      NULL
 
 statement ok
 SET DATABASE = system
@@ -618,30 +618,30 @@ FROM pg_catalog.pg_index
 ORDER BY indexrelid
 ----
 indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey   indcollation               indclass  indoption  indexprs  indpred
-543291288   23        1         false        false         false           false         false           true        false         false       true       false           1        3903121477                 0         0          NULL      NULL
-543291289   23        1         false        false         false           false         false           true        false         false       true       false           2        3903121477                 0         0          NULL      NULL
-543291291   23        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477      0 0       0 0        NULL      NULL
-803027558   26        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 3903121477             0 0 0     0 0 0      NULL      NULL
-1062763829  25        4         true         true          false           true          false           true        false         false       true       false           1 2 3 4  0 0 3903121477 3903121477  0 0 0 0   0 0 0 0    NULL      NULL
-1276104432  12        2         true         true          false           true          false           true        false         false       true       false           1 6      0 0                        0 0       0 0        NULL      NULL
-1322500096  28        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         0          NULL      NULL
-1582236367  3         1         true         true          false           true          false           true        false         false       true       false           1        0                          0         0          NULL      NULL
-1628632028  19        1         false        false         false           false         false           true        false         false       true       false           5        0                          0         0          NULL      NULL
-1628632029  19        1         false        false         false           false         false           true        false         false       true       false           4        0                          0         0          NULL      NULL
-1628632031  19        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         0          NULL      NULL
-1841972634  6         1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         0          NULL      NULL
-2101708905  5         1         true         true          false           true          false           true        false         false       true       false           1        0                          0         0          NULL      NULL
-2148104569  21        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477      0 0       0 0        NULL      NULL
-2407840836  24        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 0                      0 0 0     0 0 0      NULL      NULL
-2621181440  15        2         false        false         false           false         false           true        false         false       true       false           2 3      3903121477 0               0 0       0 0        NULL      NULL
-2621181443  15        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         0          NULL      NULL
-2927313374  2         2         true         true          false           true          false           true        false         false       true       false           1 2      0 3903121477               0 0       0 0        NULL      NULL
-3446785912  4         1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         0          NULL      NULL
-3493181576  20        2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                        0 0       0 0        NULL      NULL
-3706522183  11        4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  0 0 0 0                    0 0 0 0   0 0 0 0    NULL      NULL
-3752917847  27        2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                        0 0       0 0        NULL      NULL
-3966258450  14        1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         0          NULL      NULL
-4225994721  13        2         true         true          false           true          false           true        false         false       true       false           1 7      0 0                        0 0       0 0        NULL      NULL
+543291288   23        1         false        false         false           false         false           true        false         false       true       false           1        3903121477                 0         2          NULL      NULL
+543291289   23        1         false        false         false           false         false           true        false         false       true       false           2        3903121477                 0         2          NULL      NULL
+543291291   23        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477      0 0       2 2        NULL      NULL
+803027558   26        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 3903121477             0 0 0     2 2 2      NULL      NULL
+1062763829  25        4         true         true          false           true          false           true        false         false       true       false           1 2 3 4  0 0 3903121477 3903121477  0 0 0 0   2 2 2 2    NULL      NULL
+1276104432  12        2         true         true          false           true          false           true        false         false       true       false           1 6      0 0                        0 0       2 2        NULL      NULL
+1322500096  28        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
+1582236367  3         1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
+1628632028  19        1         false        false         false           false         false           true        false         false       true       false           5        0                          0         2          NULL      NULL
+1628632029  19        1         false        false         false           false         false           true        false         false       true       false           4        0                          0         2          NULL      NULL
+1628632031  19        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
+1841972634  6         1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         2          NULL      NULL
+2101708905  5         1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
+2148104569  21        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477      0 0       2 2        NULL      NULL
+2407840836  24        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 0                      0 0 0     2 2 2      NULL      NULL
+2621181440  15        2         false        false         false           false         false           true        false         false       true       false           2 3      3903121477 0               0 0       2 2        NULL      NULL
+2621181443  15        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
+2927313374  2         2         true         true          false           true          false           true        false         false       true       false           1 2      0 3903121477               0 0       2 2        NULL      NULL
+3446785912  4         1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         2          NULL      NULL
+3493181576  20        2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                        0 0       2 2        NULL      NULL
+3706522183  11        4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  0 0 0 0                    0 0 0 0   2 2 2 2    NULL      NULL
+3752917847  27        2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                        0 0       2 2        NULL      NULL
+3966258450  14        1         true         true          false           true          false           true        false         false       true       false           1        3903121477                 0         2          NULL      NULL
+4225994721  13        2         true         true          false           true          false           true        false         false       true       false           1 7      0 0                        0 0       2 2        NULL      NULL
 
 # From #26504
 query OOI colnames

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -47,6 +47,17 @@ const (
 	defaultCollationTag    = "en-US"
 )
 
+// Bitmasks for pg_index.indoption. Each column in the index has a bitfield
+// indicating how the columns are indexed. The constants below are the same as
+// the ones in Postgres:
+// https://github.com/postgres/postgres/blob/b6423e92abfadaa1ed9642319872aa1654403cd6/src/include/catalog/pg_index.h#L70-L76
+const (
+	// indoptionDesc indicates that the values in the index are in reverse order.
+	indoptionDesc = 0x01
+	// indoptionNullsFirst indicates that NULLs appear first in the index.
+	indoptionNullsFirst = 0x02
+)
+
 var cockroachIndexEncodingOid *tree.DOid
 
 func init() {
@@ -1320,16 +1331,6 @@ func makeZeroedOidVector(size int) (tree.Datum, error) {
 	return tree.NewDOidVectorFromDArray(oidArray), nil
 }
 
-func makeZeroedIntVector(size int) (tree.Datum, error) {
-	intArray := tree.NewDArray(types.Int)
-	for i := 0; i < size; i++ {
-		if err := intArray.Append(zeroVal); err != nil {
-			return nil, err
-		}
-	}
-	return tree.NewDIntVectorFromDArray(intArray), nil
-}
-
 var pgCatalogIndexTable = virtualSchemaTable{
 	comment: `indexes (incomplete)
 https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
@@ -1370,8 +1371,11 @@ CREATE TABLE pg_catalog.pg_index (
 					}
 					// Get the collations for all of the columns. To do this we require
 					// the type of the column.
+					// Also fill in indoption for each column to indicate if the index
+					// is ASC/DESC and if nulls appear first/last.
 					collationOids := tree.NewDArray(types.Oid)
-					for _, columnID := range index.ColumnIDs {
+					indoption := tree.NewDArray(types.Int)
+					for i, columnID := range index.ColumnIDs {
 						col, err := table.FindColumnByID(columnID)
 						if err != nil {
 							return err
@@ -1379,15 +1383,23 @@ CREATE TABLE pg_catalog.pg_index (
 						if err := collationOids.Append(typColl(&col.Type, h)); err != nil {
 							return err
 						}
+						// Currently, nulls always appear first if the order is ascending,
+						// and always appear last if the order is descending.
+						var thisIndOption tree.DInt
+						if index.ColumnDirections[i] == sqlbase.IndexDescriptor_ASC {
+							thisIndOption = indoptionNullsFirst
+						} else {
+							thisIndOption = indoptionDesc
+						}
+						if err := indoption.Append(tree.NewDInt(thisIndOption)); err != nil {
+							return err
+						}
 					}
 					collationOidVector := tree.NewDOidVectorFromDArray(collationOids)
+					indoptionIntVector := tree.NewDIntVectorFromDArray(indoption)
 					// TODO(bram): #27763 indclass still needs to be populated but it
 					// requires pg_catalog.pg_opclass first.
 					indclass, err := makeZeroedOidVector(len(index.ColumnIDs))
-					if err != nil {
-						return err
-					}
-					indoption, err := makeZeroedIntVector(len(index.ColumnIDs))
 					if err != nil {
 						return err
 					}
@@ -1408,7 +1420,7 @@ CREATE TABLE pg_catalog.pg_index (
 						indkey,                                   // indkey
 						collationOidVector,                       // indcollation
 						indclass,                                 // indclass
-						indoption,                                // indoption
+						indoptionIntVector,                       // indoption
 						tree.DNull,                               // indexprs
 						tree.DNull,                               // indpred
 					)


### PR DESCRIPTION
pg_index.indoption is supposed to be an array of bitfields that
store per-column flag bits. Previously, we would just use zeroes for all
of these bitfields.

Now (as Postgres does), the LSB is set if the column is in descending
order in the index, and the 2nd-most-LSB is set if the column has nulls
appearing first in the index.

Because of the current lack of support for custom null ordering, this
means the only two valid values of this bitfield are 0b10 and 0b01.

closes #42175

Release note(sql change): pg_index.indoption now correctly conveys
ascending/descending order and nulls first/last positioning of columns
in an index.