### PR TITLE
 scripts/release-notes: enable amending past release notes

### DIFF
--- a/scripts/release-notes/test9.graph.ref.txt
+++ b/scripts/release-notes/test9.graph.ref.txt
@@ -1,0 +1,29 @@
+*   63d6ab4163d783bf0757bc22573d9a5a2396e823 Merge pull request #300 from foo/bar
+|\  
+| * 905be19587abc15c62023bd34e24711a2541f889 merge pr canary
+|/  
+*   b10853b4a881b68d5132741487cb20aaa599cd72 Merge #3
+|\  
+| * d6960940e21fa8ab78120ab016b4244f86bd44eb extra revisions
+|/  
+*   3905a9e9504ce5de2f08ce6b1912a8934eb9688b Merge pull request #200 from foo/bar
+|\  
+| * 773310e94bd9c2c2cf6385a3045856c4873fc02d merge pr canary
+|/  
+*   b6d311cae6a8c6225c05a64973b13b6c49de3361 Merge #2
+|\  
+| * 990a43f208d5a010a63580c0677bd443763b095b synthetized note
+| * 0a0926ccbc529ecc0868a5ba6e7515e6dcf92ad2 synthetized note
+| * cca538acaa43e6625450719d5366d0084b5219a5 note revision
+| * cbd5be9c27b460573c886f1d21509c244cadea41 note revision
+|/  
+*   6286c37eaa2b9dec3bd3703bd4e31e59840aeb6a Merge pull request #100 from foo/bar
+|\  
+| * cf5e90b1f3426c6b329eba2d04d88ad1715a88d1 merge pr canary
+|/  
+*   0b2581ed149f72caaf39958864222577be6a9ff6 Merge #1
+|\  
+| * def86d75087c9252ed65bee8a0b611413e405efc feature 2
+| * db1e8c0722c5130f5128ed51aad267143907df8c fix 1
+|/  
+* 278a3705e1aecfb15248823a72ec17f70edfb62e initial

--- a/scripts/release-notes/test9.notes.ref.txt
+++ b/scripts/release-notes/test9.notes.ref.txt
@@ -1,0 +1,65 @@
+### Command-line changes
+
+- This was missing.
+  - NOTE REVISION [d6960940e][d6960940e]
+    This is visible. [#2][#2] [990a43f20][990a43f20]
+- Badly explained
+  - NOTE REVISION [cbd5be9c2][cbd5be9c2]
+    This is better explained.
+  - NOTE REVISION [cca538aca][cca538aca]
+    Wait I think this is even
+    better.
+  - NOTE REVISION [cca538aca][cca538aca]
+    One more detail. [#1][#1] [def86d750][def86d750]
+
+### Bug fixes
+
+- Something wrong!
+  - NOTE REVISION [cbd5be9c2][cbd5be9c2]
+    Something is fixed.
+    The explanation can even be lengthy. [#1][#1] [db1e8c072][db1e8c072]
+
+### Miscellaneous
+
+#### Extra
+
+- This was also missing. [#2][#2] [990a43f20][990a43f20]
+- This release note did not
+  exist before. [#1][#1] [0a0926ccb][0a0926ccb]
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 1 author.
+We would like to thank the following contributors from the CockroachDB community:
+
+- test9
+
+### PRs merged by contributors
+
+- test9:
+  - 2018-04-22 [#200  ][#200  ] [3905a9e95][3905a9e95] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
+  - 2018-04-22 [#2    ][#2    ] [b6d311cae][b6d311cae] (+   0 -   0 ~   0/ 0) PR 2 title (4 commits)
+  - 2018-04-22 [#100  ][#100  ] [6286c37ea][6286c37ea] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+  - 2018-04-22 [#1    ][#1    ] [0b2581ed1][0b2581ed1] (+   0 -   0 ~   0/ 0) PR 1 title (2 commits)
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[0a0926ccb]: https://github.com/cockroachdb/cockroach/commit/0a0926ccb
+[0b2581ed1]: https://github.com/cockroachdb/cockroach/commit/0b2581ed1
+[3905a9e95]: https://github.com/cockroachdb/cockroach/commit/3905a9e95
+[6286c37ea]: https://github.com/cockroachdb/cockroach/commit/6286c37ea
+[990a43f20]: https://github.com/cockroachdb/cockroach/commit/990a43f20
+[b6d311cae]: https://github.com/cockroachdb/cockroach/commit/b6d311cae
+[cbd5be9c2]: https://github.com/cockroachdb/cockroach/commit/cbd5be9c2
+[cca538aca]: https://github.com/cockroachdb/cockroach/commit/cca538aca
+[d6960940e]: https://github.com/cockroachdb/cockroach/commit/d6960940e
+[db1e8c072]: https://github.com/cockroachdb/cockroach/commit/db1e8c072
+[def86d750]: https://github.com/cockroachdb/cockroach/commit/def86d750
+

--- a/scripts/release-notes/test9.sh
+++ b/scripts/release-notes/test9.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test9
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+
+    git checkout -b feature
+    make_change "fix 1
+
+Release note (bug fix): something wrong!
+"
+	make_change "feature 2
+
+Release note (cli change): badly explained
+"
+	last_sha=$(git log -n 1 --pretty=%H)
+	tag_pr 1
+	git checkout master
+	merge_pr feature 1 "PR 1 title"
+
+	git checkout -b feature2
+	make_change "note revision
+
+Release note: None
+Revised release note [#1] (bug fix): something is fixed.
+The explanation can even be lengthy.
+Revised release note [#1] (cli change): This is better explained.
+"
+	make_change "note revision
+
+Revised release note [#1] (cli change): Wait I think this is even
+better.
+
+Revised release note [$last_sha] (cli change): One more detail.
+"
+
+	make_change "synthetized note
+
+Revised release note [#1] (extra): This release note did not
+exist before.
+"
+	last_sha=$(git log -n 1 --pretty=%H)
+	make_change "synthetized note
+
+Revised release note [#2] (cli change): This was missing.
+Revised release note [$last_sha] (extra): This was also missing.
+"
+	tag_pr 2
+	git checkout master
+	merge_pr feature2 2 "PR 2 title"
+	git tag noteend
+
+	git checkout -b feature3
+	make_change "extra revisions
+
+Revised release note [#2] (cli change): This is visible.
+
+Revised release note [#3] (extra): This must not be visible
+because it is not selected for the release note report.
+"
+	tag_pr 3
+	git checkout master
+	merge_pr feature3 3 "PR 3 title"
+)
+
+test_end --until noteend


### PR DESCRIPTION
Fixes #42163.
First two commits from #42339.

Previously, the only moment when a team member could contribute a
release note to a change was on the PR implementing the change.

This is because the script to extract release notes maps
release notes to the PRs enclosing the note's own commit.

The present change extends the mechanism by enabling authors to revise
release notes *at an arbitrary later point in the repository*,
including even when the revision is out of the selection range for the
release note script.

For example:

   ```
   Revised release note [#123] (bug fix): blah blah...
   ```

or:

   ```
   Revised release note [abd1123f] (bug fix): blah blah...
   ```

This instructs the script to add a "NOTE REVISION" entry to the `bug
fix` release note present in PR #123 or commit abd1123f.

Example use:

```shell
$ python3 scripts/release-notes.py \
  --from  c107719 \
  --until 28b447a
```

(This selects automatically `--revisions-until=master`, but this can
be overridden if needed.)

Example output, using the release note revision on this
commit below:

```
- Revert ability to create second-precision
  (0-precision) timestamp datatypes, which inadvertently caused a backward
  compatibility issue that automatically made previously-existing
  timestamp columns from 19.1 into second-precision columns.
  - NOTE REVISION [424a225c7][424a225c7]
    The newly-introduced
    support for second-precision columns (e.g. `TIMESTAMP(0)`) was
    removed, due to its unintended backward-incompatible applicaton
    to all previously-defined columns without a precision. [#42285][#42285] [5a4e077][5a4e077]
```

Moreover, if the target PR or commit SHA did not have a release note
in the same category already, the note revision is inserted as a fresh
release note.

Revised release note [#42285] (bug fix): The newly-introduced
support for second-precision columns (e.g. `TIMESTAMP(0)`) was
removed, due to its unintended backward-incompatible applicaton
to all previously-defined columns without a precision.

Release note: None