### PR TITLE
scripts/release-notes: report missing RNs, don't skip standalone commits

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,37 +3,48 @@
 # Names should be added to this file as one of
 #     Organization's name
 #     Individual's name <submission email address>
-#     Individual's name <submission email address> <email2> <emailN>
-
+#     Individual's name <submission email address> [alias] <email2> [alias] <emailN>
+#
+# If you wish to keep your @cockroachlabs.com address hidden,
+# please still list <@cockroachlabs.com> (with no user name)
+# in the list of aliases.
+#
+# (Note: there is no point in hiding it if it is mentioned
+# in the git log already.)
+#
+# For more details about the format, see git-check-mailmap(1)
+#
 # Please keep the list sorted.
 
 1lann <me@chuie.io>
-aarondunnington <aaron.dunnington@gmail.com>
-Abhemailk abhi.madan01@gmail.com <abhishek@cockroachlabs.com>
-Abhishek Madan <abhi.madan01@gmail.com> <abhimadan@users.noreply.github.com> <abhishek@cockroachlabs.com>
+Aaron Dunnington <aaron.dunnington@gmail.com> aarondunnington <aaron.dunnington@gmail.com>
+Aayush Shah <aayush.shah15@gmail.com> <@cockroachlabs.com>
+Abhishek Madan <abhi.madan01@gmail.com> <abhimadan@users.noreply.github.com> <abhishek@cockroachlabs.com> Abhemailk abhi.madan01@gmail.com <abhishek@cockroachlabs.com>
 Abhishek Soni <abhishek.rocks26@gmail.com>
-AbhishekSaha <as1695@scarletmail.rutgers.edu>
+Abhishek Saha <as1695@scarletmail.rutgers.edu> AbhishekSaha <as1695@scarletmail.rutgers.edu>
 acoshift <acoshift@gmail.com>
 Adam Gee <adamgee@gmail.com>
 Adam Yao <adam.yao.qinglin@gmail.com>
+Aditya Maru <adityamaru@cockroachlabs.com>
 Aid Idrizović <idrizovicaid@gmail.com>
 Ajaya Agrawal <ajku.agr@gmail.com>
 Alex Gaynor <alex.gaynor@gmail.com>
-Alex Robinson <alexdwanerobinson@gmail.com> <arob@google.com>
-Alfonso Subiotto Marqués <alfonso.subiotto.marques@gmail.com> <alfonso@cockroachlabs.com>
+Alex Robinson <alexdwanerobinson@gmail.com> <arob@google.com> <@cockroachlabs.com>
+Alfonso Subiotto Marqués <alfonso.subiotto.marques@gmail.com> Alfonso Subiotto Marques <alfonso@cockroachlabs.com>
 Amos Bird <amosbird@gmail.com>
-Amruta Ranade <amruta@cockroachlabs.com> <amruta2799@gmail.com>
+Amruta Ranade <amruta@cockroachlabs.com> Amruta <amruta@cockroachlabs.com> <amruta2799@gmail.com>
 Andrei Matei <andrei@cockroachlabs.com> <andreimatei1@gmail.com>
 Andrew Bonventre <abonventre@palantir.com> <andybons@gmail.com>
 Andrew Couch <andrew@cockroachlabs.com> <github@couchand.com> <hi@andrewcou.ch>
-Andrew Kimball <andyk@cockroachlabs.com> <kimball.andy@gmail.com> <32096062+andy-kimball@users.noreply.github.com> <andyk@cockroachlabs.com>
-Andrew Kryczka <andrew.kryczka2@gmail.com>
+Andy Kimball <andyk@cockroachlabs.com> <kimball.andy@gmail.com> <32096062+andy-kimball@users.noreply.github.com> Andrew Kimball <andyk@cockroachlabs.com>
+Andrew Kryczka <andrew.kryczka2@gmail.com> Andrew Kryczka <ajkr@users.noreply.github.com> <@cockroachlabs.com>
 Andrew NS Yeow <ngeesoon80@yahoo.com>
 Andrew Werner <ajwerner@cockroachlabs.com>
-Andrew Woods <andy@cockroachlabs.com>
+Andy Woods <andy@cockroachlabs.com> Andrew Woods <andy@cockroachlabs.com>
 Andrey Shinkevich <andyogen@gmail.com>
+Angela Chang <angelachang27@gmail.com> changangela <angelachang27@gmail.com> <angela@cockroachlabs.com>
 Antoine Grondin <antoinegrondin@gmail.com>
-Arjun Ravi Narayan <arjun@cockroachlabs.com> <arjunravinarayan@gmail.com> <arjun@cockroachlabs.com> <arjunravinarayan@users.noreply.github.com>
+Arjun Ravi Narayan <arjun@cockroachlabs.com> <arjunravinarayan@gmail.com> Arjun Narayan <arjun@cockroachlabs.com> <arjunravinarayan@users.noreply.github.com>
 Art Nikpal <ai.radio.org@gmail.com>
 Arul Ajmani <arula@cockroachlabs.com> <arulajmani@gmail.com>
 Asit Mahato <asitm9@gmail.com>
@@ -42,47 +53,44 @@ Ben Darnell <ben@bendarnell.com> <ben@cockroachlabs.com>
 Bilal Akhtar <bilal@cockroachlabs.com> <me@itsbilal.com>
 Bob Potter <bobby.potter@gmail.com>
 Bob Vawter <bob@cockroachlabs.com>
-Bogdan Batog <bogdanbatog@gmail.com>
-bogdanbatog <bogdanbatog@gmail.com>
+Bogdan Batog <bogdanbatog@gmail.com> bogdanbatog <bogdanbatog@gmail.com>
 Brad Seiler <seiler@squareup.com>
 Bram Gruneir <BramGruneir@users.noreply.github.com> <MycroftH@users.noreply.github.com> <bram.gruneir@gmail.com> <bram@cockroachlabs.com>
 Brandon Gonzalez <brandon.gonzalez.451@gmail.com>
 Brett Snyder <bsnyder788@gmail.com>
 Celia La <celia@cockroachlabs.com>
 Céline O'Neil <celineloneil@gmail.com> <celineo@cockroachlabs.com>
-changangela <angela@cockroachlabs.com> <angelachang27@gmail.com>
 chengwei <252684445@qq.com>
-Chris Seto <chriskseto@gmail.com>
+Chris Seto <chriskseto@gmail.com> <@cockroachlabs.com>
 Christian Meunier <chris@jumpn.com>
-christopherrouth <routhcr@gmail.com>
-CMajeri <chervine.majeri@elca.ch>
+Christopher Routh <routhcr@gmail.com> christopherrouth <routhcr@gmail.com>
+Chervine Majeri <chervine.majeri@elca.ch> CMajeri <chervine.majeri@elca.ch>
 Cockroach Labs Inc.
 coldwater <zhangcoldwater@163.com>
 Constantine Peresypkin <constantine.peresypkin@datarobot.com> <pconstantine@gmail.com>
-ctkou <adamkouct@gmail.com>
+Adam Kouct <adamkouct@gmail.com> ctkou <adamkouct@gmail.com>
 Cuong Do <cdo@cockroachlabs.com> <cuongdo@users.noreply.github.com>
-Dan Kortschak <dan.kortschak@adelaide.edu.au>
-Daniel Harrison <dan@cockroachlabs.com> <daniel.harrison@gmail.com> <daniel.harrison@gmail.com>
+Dan Kortschak <dan.kortschak@adelaide.edu.au> kortschak <dan.kortschak@adelaide.edu.au>
+Daniel Harrison <dan@cockroachlabs.com> <daniel.harrison@gmail.com>
 Daniel Theophanes <kardianos@gmail.com>
 Daniel Upton <daniel@floppy.co>
-Darin Peshev <darinp@gmail.com> <darinp@gmail.com>
+Darin Peshev <darinp@gmail.com> Darin <darinp@gmail.com> <@cockroachlabs.com>
 David Eisenstat <eisen@cockroachlabs.com>
 David López <not4rent@gmail.com>
-David Taylor <tinystatemachine@gmail.com>
+David Taylor <tinystatemachine@gmail.com> <@cockroachlabs.com>
 dchenk <dcherchenko@gmail.com>
 Dexter Valkyrie <skynode@users.noreply.github.com>
-Diana Hsieh <dianahsieh323@gmail.com>
-dianasaur323 <diana@cockroachlabs.com> <dianahsieh323@gmail.com>
-DiSiqueira <dieg0@live.com>
+Diana Hsieh <dianahsieh323@gmail.com> dianasaur323 <dianahsieh323@gmail.com> dianasaur323 <diana@cockroachlabs.com>
+Diego DiSiquera <dieg0@live.com> DiSiqueira <dieg0@live.com>
 Dmitry Saveliev <d.e.saveliev@gmail.com>
 Dmitry Vorobev <dimahabr@gmail.com>
 Dominique Luna <dluna132@gmail.com>
 Dong Liang <dong.liang@rubrik.com>
 Dustin Hiatt <dustin.hiatt@rkinetic.com>
-EamonZhang <zhang.eamon@hotmail.com>
+Eamon Zhang <zhang.eamon@hotmail.com> EamonZhang <zhang.eamon@hotmail.com>
 Eli Lindsey <eli@siliconsprawl.com>
 embark <wolfire9@users.noreply.github.com>
-Emmanuel <absolutezero2a03@gmail.com>
+Emmanuel Sales <absolutezero2a03@gmail.com> Emmanuel <absolutezero2a03@gmail.com> <emsal1863@gmail.com> <@cockroachlabs.com>
 Erik Trinh <erik@cockroachlabs.com>
 es-chow <es-chow@users.noreply.github.com> <es_chow@163.com>
 Evgeniy Vasilev <aquilax@gmail.com>
@@ -94,14 +102,13 @@ George Papadrosou <gpapadrosou@gmail.com>
 George Utsin <george@cockroachlabs.com>
 Georgia Hong <georgiah@cockroachlabs.com>
 Gustav Paul <gpaul@mesosphere.io>
-Haines Chan <zhinhai@gmail.com>
-hainesc <zhinhai@gmail.com>
+Haines Chan <zhinhai@gmail.com> hainesc <zhinhai@gmail.com>
 Harshit Chopra <harshit@squareup.com>
 Hayden A. James <hayden.james@gmail.com>
 Ibrahim AshShohail <ibra.sho@gmail.com>
 Igor Kharin <igorkharin@gmail.com>
 il9ue <oodanq@gmail.com>
-irfan sharif <irfanmahmoudsharif@gmail.com>
+Irfan Sharif <irfanmahmoudsharif@gmail.com> irfan sharif <irfanmahmoudsharif@gmail.com> <@cockroachlabs.com>
 Isaac Rogers <therealplato@gmail.com>
 Israel Gilyadov <israelg99@gmail.com>
 Iuri Sitinschi <iuri.sitinschi@visual-meta.com> <yukas66@gmail.com>
@@ -113,11 +120,11 @@ Jason E. Aten <j.e.aten@gmail.com>
 Jason Young <RustJason@users.noreply.github.com>
 Jay Kominek <kominek@gmail.com>
 Jeffrey Dallatezza <jeffreydallatezza@gmail.com>
-Jeffrey Xiao <jeffrey.xiao1998@gmail.com>
+Jeffrey Xiao <jeffrey.xiao1998@gmail.com> <@cockroachlabs.com>
 Jesse Seldess <j_seldess@hotmail.com> <jesse@cockroachlabs.com>
 Jessica Edwards <jessica@cockroachlabs.com> <jess-edwards@users.noreply.github.com>
 Jiajia Han <jiajia@squareup.com>
-jiangmingyang <jiangming.yang@gmail.com>
+Jiangming Yang <jiangming.yang@gmail.com> jiangmingyang <jiangming.yang@gmail.com>
 Jimmy Larsson <jimmy.larsson@trioptima.com>
 Jincheng Li <mail@jincheng.li>
 Jingguo Yao <yaojingguo@gmail.com>
@@ -142,32 +149,31 @@ Karl Southern <karl@theangryangel.co.uk>
 Kathy Spradlin <kathyspradlin@gmail.com>
 Kenji Kaneda <kaneda@squareup.com> <kenji.kaneda@gmail.com>
 Kenjiro Nakayama <nakayamakenjiro@gmail.com>
+Kenneth Liu <ken@cockroachlabs.com>
 Kevin Guan <keynovo@gmail.com>
 kiran <crackerplace@gmail.com>
-kortschak <dan.kortschak@adelaide.edu.au>
 lanzao <395818758@qq.com>
 Lasantha Pambagoda <lpambagoda@gmail.com>
-Lauren Hirata <lauren@cockroachlabs.com>
+Lauren Hirata <lauren@cockroachlabs.com> Lauren <lauren@cockroachlabs.com> lhirata <lauren@cockroachlabs.com>
 Lee Reilly <lee@github.com>
 Levon Lloyd <levon@squareup.com>
-liuqi <liuqi@wandoujia.com>
 liyanan <liyananfamily@gmail.com>
 Lizhong <z.lizhong@gmail.com>
-louishust <hdchild@163.com>
+Louis Hust <hdchild@163.com> louishust <hdchild@163.com>
 Lu Guanqun <guanqun.lu@gmail.com>
-Lucy Zhang <lucy-zhang@users.noreply.github.com>
+Lucy Zhang <lucy-zhang@users.noreply.github.com> <lucy@cockroachlabs.com>
 M-srivatsa <srivatsa.dev@gmail.com>
 MaBo <mabo163@163.com>
-madhavsuresh <madhav@cockroachlabs.com>
+Madhav Suresh <madhav@cockroachlabs.com> madhavsuresh <madhav@cockroachlabs.com>
 Mahmoud Al-Qudsi <mqudsi@neosmart.net>
 Maitri Morarji <vivek1@viveks-MacBook-Pro.local>
 Manik Surtani <manik@squareup.com> <manik@surtani.org>
-Marc Berhault <marc.berhault@gmail.com> <marc@cockroachlabs.com> <marc.berhault@gmail.com>
+Marc Berhault <marc.berhault@gmail.com> marc <marc@cockroachlabs.com> MBerhault <marc.berhault@gmail.com>
 Marcus Westin <marcus.westin@gmail.com>
 Marko Bonaći <mbonaci@users.noreply.github.com>
 Martin Bertschler <mbertschler@gmail.com>
 Masha Schneider <masha@cockroachlabs.com> <mshv14282@gmail.com>
-Matt Jibson <matt.jibson@gmail.com>
+Matt Jibson <matt.jibson@gmail.com> <@cockroachlabs.com>
 Matt Tracy <matt.r.tracy@gmail.com> <matt@cockroachlabs.com>
 Matthew O'Connor <matthew@squareup.com> <matthew.t.oconnor@gmail.com>
 Max Lang <max@cockroachlabs.com> <maxwell.g.lang@gmail.com>
@@ -175,22 +181,22 @@ Mayank Oli <mayankoli96@gmail.com>
 mbonaci <mbonaci@gmail.com>
 Mo Firouz <mofirouz@mofirouz.com>
 Mohamed Elqdusy <mohamedelqdusy@gmail.com>
-Nate <nathaniel.p.stewart@gmail.com>
+Nate Stewart <nathaniel.p.stewart@gmail.com> Nate <nathaniel.p.stewart@gmail.com> <nate@cockroachlabs.com>
 Nathan Johnson <njohnson@ena.com>
-Nathan VanBenschoten <nvanbenschoten@gmail.com>
-Nathaniel Stewart <nate@cockroachlabs.com>
+Nathan VanBenschoten <nvanbenschoten@gmail.com> <@cockroachlabs.com>
+Nathan Stilwell <nathanstilwell@cockroachlabs.com>
 neeral <neeral@users.noreply.github.com>
-nexdrew <andrewbgoode@gmail.com>
-ngaut <liuqi@wandoujia.com> <ngaut@users.noreply.github.com> <goroutine@126.com> <ngaut@126.com>
+Andrew B. Goode <andrewbgoode@gmail.com> nexdrew <andrewbgoode@gmail.com>
+ngaut <liuqi@wandoujia.com> liuqi <liuqi@wandoujia.com> goroutine <ngaut@users.noreply.github.com> <goroutine@126.com> <ngaut@126.com>
 Nick <linicks@gmail.com>
 Nick Gottlieb <ngottlieb1@gmail.com>
-Nikhil Benesch <nikhil.benesch@gmail.com>
+Nikhil Benesch <nikhil.benesch@gmail.com> <@cockroachlabs.com>
 Nishant Gupta <nishant.gupta@rubrik.com>
 noonan <noonan@noonan-vb-17.10-CDB>
 Oliver Tan <otan@cockroachlabs.com> <sinovercosequalstan@gmail.com>
 Panos Mamatsis <pmamatsis@gmail.com>
 Paul Banks <banks@banksdesigns.co.uk>
-Paul Bardea <paul@pbardea.com> <pbardea@gmail.com>
+Paul Bardea <paul@pbardea.com> <pbardea@gmail.com> <@cockroachlabs.com>
 Peng Gao <peng.gao.dut@gmail.com>
 Pete Vilter <7341+vilterp@users.noreply.github.com> <vilterp@cockroachlabs.com>
 Peter Mattis <peter@cockroachlabs.com> <petermattis@gmail.com>
@@ -199,16 +205,15 @@ Philippe Laflamme <philippe.laflamme@gmail.com>
 phynalle <phynalism@gmail.com>
 Piotr Zurek <p.zurek@gmail.com>
 pocockn <pocockn@hotmail.co.uk>
-Poornima <poornima.malepati@gmail.com>
-Radu Berinde <radu.berinde@gmail.com> <radu@cockroachlabs.com>
+Poornima Malepati <poornima.malepati@gmail.com> Poornima <poornima.malepati@gmail.com>
+Radu Berinde <radu.berinde@gmail.com> RaduBerinde <radu@cockroachlabs.com>
 Rafi Shamim <rafi@cockroachlabs.com> <rafiss@gmail.com>
-Raphael 'kena' Poss <knz@cockroachlabs.com> <knz@thaumogen.net> <knz@thaumogen.net> <knz@users.noreply.github.com>
+Raphael 'kena' Poss <knz@cockroachlabs.com> kena <knz@thaumogen.net> Raphael Poss <knz@thaumogen.net> <knz@users.noreply.github.com>
 ReadmeCritic <frankensteinbot@gmail.com>
-Rebecca Taft <becca@cockroachlabs.com> <rytaft@gmail.com>
-Rich Loveland <loveland.richard@gmail.com> <rich@cockroachlabs.com>
+Rebecca Taft <becca@cockroachlabs.com> rytaft <becca@cockroachlabs.com> <rytaft@gmail.com>
+Rich Loveland <loveland.richard@gmail.com> <rich@cockroachlabs.com> Richard Loveland <rloveland@richards-mbp.lan>
 Richard Artoul <richardartoul@gmail.com>
-Richard Loveland <rloveland@richards-mbp.lan>
-Richard Wu <richardwu1997@gmail.com>
+Richard Wu <richardwu1997@gmail.com> <@cockroachlabs.com>
 Ridwan Sharif <ridwan@cockroachlabs.com> <ridwanmsharif@Ridwans-MacBook-Pro.local>
 Rohan Yadav <rohany@cockroachlabs.com>
 Roland Crosby <roland@cockroachlabs.com>
@@ -221,35 +226,36 @@ Sergei Turukin <rampage644@gmail.com>
 Seth Bunce <seth.bunce@gmail.com>
 shakeelrao <shakeelrao79@gmail.com>
 Shawn Morel <shawn@squareup.com> <shawn@strangemonad.com> <strangemonad@squareup.com>
-Solon Gordon <solon@cockroachlabs.com> <solongordon@gmail.com>
-songhao <songhao9021@gmail.com>
+Solon Gordon <solon@cockroachlabs.com> solongordon <solongordon@gmail.com>
+Song Hao <songhao9021@gmail.com> songhao <songhao9021@gmail.com>
 Spas Bojanov <spas@cockroachlabs.com> <pachob@gmail.com>
-Spencer Kimball <spencer.kimball@gmail.com>
+Spencer Kimball <spencer.kimball@gmail.com> <spencer@cockroachlabs.com>
+Sumeer Bhola <sumeer@cockroachlabs.com> sumeerbhola <sumeer@cockroachlabs.com>
 sum12 <sumitjami@gmail.com>
 Syd <324760805@qq.com>
 Takuya Kuwahara <taakuu19@gmail.com>
-Tamir Duberstein <tamird@gmail.com>
-Tamir Duberstein and Kenji Kaneda <tamird+kenji.kaneda@gmail.com>
+Tamir Duberstein <tamird@gmail.com> <@cockroachlabs.com>
+Tamir Duberstein and Kenji Kaneda <tamird+kenji.kaneda@gmail.com> <@cockroachlabs.com>
 Tarek Badr <tarekbadrshalaan@gmail.com>
 Teodor Pripoae <teodor.pripoae@gmail.com>
 Terrell Russell <terrellrussell@gmail.com>
 Thanakom Sangnetra <thanakom.sangnetra@hotelquickly.com> <loki.top11@gmail.com>
 Thomas Schroeter <thomas@cliqz.com> <thschroeter@gmail.com>
 thundercw <thundercw@gmail.com>
-tim-o <38867162+tim-o@users.noreply.github.com>
+Tim O'Brien <38867162+tim-o@users.noreply.github.com> tim-o <38867162+tim-o@users.noreply.github.com> <@cockroachlabs.com>
 Timothy Chen <tnachen@gmail.com>
-Tobias Schottdorf <tobias@tkschmidt.me> <tobias.schottdorf@gmail.com> <tobias.schottdorf@hrs.de>
-Tristan Ohlson <tsohlson@gmail.com>
+Tobias Schottdorf <tobias@tkschmidt.me> <tobias.schottdorf@gmail.com> <tobias.schottdorf@hrs.de> <@cockroachlabs.com>
+Tristan Ohlson <tsohlson@gmail.com> <@cockroachlabs.com>
 Tristan Rice <rice@fn.lc> <wiz@cockroachlabs.com>
 Txiaozhe <txiaozhe@gmail.com>
 Tyler Neely <tan@tumblr.com>
-Tyler Roberts <tyler@cockroachlabs.com>
+Tyler Roberts <tyler@cockroachlabs.com> Tyler314 <tyler@cockroachlabs.com>
 Umesh Yadav <dungeonmaster18@users.noreply.github.com>
 vagrant <vagrant@precise64.(none)>
 veteranlu <23907238@qq.com>
 Victor Chen <victor@cockroachlabs.com>
 Vijay Karthik <vijay.karthik@rubrik.com>
-Vivek Menezes <vivek.menezes@gmail.com> <vivek1@viveks-MacBook-Pro.local> <vivek@cockroachlabs.com> <vivekmenezes@users.noreply.github.com>
+Vivek Menezes <vivek.menezes@gmail.com> <vivek1@viveks-MacBook-Pro.local> <vivek@cockroachlabs.com> vivekmenezes <vivekmenezes@users.noreply.github.com>
 wenyong-h <weyo.huang@gmail.com>
 Will Haack <will.haack@appboy.com> <will@cockroachlabs.com>
 Xiang Li <xiangli.cs@gmail.com>
@@ -257,7 +263,7 @@ Xinyu Zhou (Joe) <joe.zxy@foxmail.com>
 XisiHuang <cockhuangxh@163.com>
 xphoniex <dj.2dixx@gmail.com>
 Xudong Zheng <7pkvm5aw@slicealias.com>
-Yahor Yuzefovich <yahor@cockroachlabs.com>
+Yahor Yuzefovich <yahor@cockroachlabs.com> yuzefovich <yahor@cockroachlabs.com>
 Yan Long <rafaelyim@qq.com>
 yananzhi <alkfbb@gmail.com> <zac.zhiyanan@gmail.com>
 Yang Yuting <william.yangyt@gmail.com>
@@ -266,8 +272,8 @@ Yevgeniy Miretskiy <yevgeniy@cockroachlabs.com> <yevgeniy@gmail.com>
 Yosi Attias <yosy101@gmail.com>
 yuhit <longyuhit@163.com>
 Yulei Xiao <21739034@qq.com>
-yznming <rafaelyim@qq.com>
+Rafael Yim <rafelyim@qq.com> yznming <rafaelyim@qq.com>
 Zach Brock <zbrock@gmail.com> <zbrock@squareup.com>
-Zachary.smith <Zachary.smith@yodle.com>
+Zachary Smith <Zachary.smith@yodle.com> Zachary.smith <Zachary.smith@yodle.com>
 何羿宏 <heyihong.cn@gmail.com>
 智雅楠 <zac.zhiyanan@gmail.com>

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -641,7 +641,6 @@ if excludedFirst is not None:
         _, notes = extract_release_notes(c)
         for cat, note in notes:
             excluded_notes.add((cat, note))
-
     print("\b100%\n", file=sys.stderr)
 
 print("Collecting release notes from\n%s\nuntil\n%s" % (identify_commit(firstCommit), identify_commit(commit)), file=sys.stderr)
@@ -683,7 +682,7 @@ def process_release_notes(pr, title, commit):
     if not foundnote:
         # Missing release note. Keep track for later.
         missing_item = makeitem(pr, '', title, commit.hexsha[:shamin], authors)
-    return missing_item, authors
+    return missing_item, authors, len(notes)
 
 
 def makeitem(pr, cat, prtitle, sha, authors):
@@ -798,6 +797,8 @@ def analyze_pr(merge, pr):
     missing_items = []
     authors = set()
     ncommits = 0
+    num_notes = 0
+    commits_no_note = 0
     for commit in repo.iter_commits(merge_base.hexsha + '..' + tip.hexsha):
         spin()
 
@@ -810,9 +811,12 @@ def analyze_pr(merge, pr):
         commit_to_pr[commit.hexsha[:shamin]] = pr
 
         if not commit.message.startswith("Merge"):
-            missing_item, prauthors = process_release_notes(pr, note, commit)
+            missing_item, prauthors, num_notes1 = process_release_notes(pr, note, commit)
             authors.update(prauthors)
             ncommits += 1
+            num_notes += num_notes1
+            if num_notes == 0:
+                commits_no_note += 1
             if missing_item is not None:
                 missing_items.append(missing_item)
 
@@ -824,10 +828,12 @@ def analyze_pr(merge, pr):
     text = repo.git.diff(merge_base.hexsha, tip.hexsha, '--', numstat=True)
     stats = Stats._list_from_string(repo, text)
 
-    collect_item(pr, note, merge.hexsha[:shamin], ncommits, authors, stats.total, merge.committed_date)
+    collect_item(pr, note, merge.hexsha[:shamin], ncommits, authors,
+                 stats.total, merge.committed_date,
+                 commits_no_note, num_notes == 0)
 
 
-def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
+def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts, ncommits_missing_note, pr_missing_note):
     individual_authors.update(authors)
     if len(authors) == 0:
         authors.add("Unknown Author")
@@ -838,6 +844,8 @@ def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
                  'files': stats['files'],
                  'lines': stats['lines'],
                  'date': datetime.date.fromtimestamp(prts).isoformat(),
+                 'pr_missing_note': pr_missing_note,
+                 'ncommits_missing_note': ncommits_missing_note,
                  })
 
     al = item['authors']
@@ -847,14 +855,19 @@ def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
     per_group_history[k] = history
 
 
+all_standalone_commits = set()
 def analyze_standalone_commit(commit):
     # Some random out-of-branch commit. Let's not forget them.
-    authors = collect_authors(commit)
     title = commit.message.split('\n', 1)[0].strip()
     sha = commit.hexsha[:shamin]
-    item = makeitem('#unknown', '', title, sha, authors)
-    missing_release_notes.append(item)
-    collect_item('#unknown', title, sha, 1, authors, commit.stats.total, commit.committed_date)
+    all_standalone_commits.add(sha)
+    missing_item, authors, num_notes = process_release_notes("#unknown", title, commit)
+    if missing_item is not None:
+        missing_release_notes.append(missing_item)
+    commit_no_notes = num_notes == 0 and 1 or 0
+    collect_item('#unknown', title, sha, 1, authors,
+                 commit.stats.total, commit.committed_date,
+                 commit_no_notes, num_notes == 0)
     commit_to_pr[sha] = '#unknown'
 
 # Collect all the merge points so we can report progress.
@@ -1085,9 +1098,23 @@ print()
 # Print the Contributors section.
 print("### Contributors")
 print()
-print("This release includes %d merged PR%s by %s author%s." %
-      (len(allprs), len(allprs) != 1 and "s" or "",
-       len(individual_authors), (len(individual_authors) != 1 and "s" or "")))
+
+print("This release includes ", end='')
+if len(allprs) > 0:
+    print("%d merged PR%s" %
+          (len(allprs),
+           len(allprs) != 1 and "s" or ""),
+          end='')
+    if len(all_standalone_commits) > 0:
+        print(" and ", end='')
+if len(all_standalone_commits) > 0:
+    print("%d standalone commit%s" %
+          (len(all_standalone_commits),
+           len(all_standalone_commits) != 1 and "s" or ""),
+          end='')
+print(" by %s author%s." % (
+      len(individual_authors),
+      (len(individual_authors) != 1 and "s" or "")))
 
 ext_contributors = individual_authors - crdb_folk
 
@@ -1129,6 +1156,9 @@ if not hidepercontributor:
                 print(" (", end='')
                 print("%d commits" % ncommits, end='')
                 print(")", end='')
+
+            if item['pr_missing_note']:
+                print(" [NO RELEASE NOTE]", end='')
             print()
         print()
     print()

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -236,6 +236,7 @@ form2 = r': *(?P<cat2>[^ ]+(?: +[^ ]+)?) *:'
 # Captures : yyy - no category
 form3 = r':(?P<cat3>)'
 relnote = re.compile(r'(?:^|[\n\r])[rR]elease [nN]otes? *(?:' + form1 + '|' + form2 + '|' + form3 + r') *(?P<note>.*)$', flags=re.S)
+revision = re.compile(r'(?:^|[\n\r])[rR]evised [rR]elease [nN]otes? *\[(?P<target>.*?)\] *' + form1 + r' *(?P<note>.*)$', flags=re.M)
 
 coauthor = re.compile(r'^Co-authored-by: (?P<name>[^<]*) <(?P<email>.*)>', flags=re.M)
 fixannot = re.compile(r'^([fF]ix(es|ed)?|[cC]lose(d|s)?) #', flags=re.M)
@@ -279,6 +280,8 @@ parser.add_option("--exclude-until", dest="exclude_until_commit",
                   help="exclude history ending at COMMIT", metavar="COMMIT")
 parser.add_option("--one-line", dest="one_line", action="store_true", default=False,
                   help="unwrap release notes on a single line")
+parser.add_option("--revisions-until", dest="revisions_until_commit", default='master', metavar="COMMIT",
+                  help="pick release note revisions until this commit")
 
 (options, args) = parser.parse_args()
 
@@ -361,6 +364,9 @@ if options.exclude_from_commit or options.exclude_until_commit:
 # Reading data from repository
 #
 
+revisionFirst, revisionLast = None, None
+if options.revisions_until_commit:
+    revisionFirst, revisionLast = find_commits(options.from_commit, options.revisions_until_commit)
 
 def identify_commit(c):
     return '%s ("%s", %s)' % (
@@ -394,7 +400,129 @@ def check_reachability(start, end):
 
 firstCommit, commit = check_reachability(firstCommit, commit)
 options.from_commit = firstCommit.hexsha
+if revisionFirst is not None:
+    revisionFirst, revisionLast = check_reachability(revisionFirst, revisionLast)
 
+spinner = itertools.cycle(['/', '-', '\\', '|'])
+spin_counter = 0
+
+
+def spin():
+    global spin_counter
+    # Display a progress bar
+    spin_counter += 1
+    if spin_counter % 10 == 0:
+        if spin_counter % 100 == 0:
+            print("\b..", end='', file=sys.stderr)
+        print("\b", end='', file=sys.stderr)
+        print(next(spinner), end='', file=sys.stderr)
+        sys.stderr.flush()
+    
+def get_direct_history(firstCommit, lastCommit):
+    history = []
+    for c in repo.iter_commits(firstCommit.hexsha + '..' + lastCommit.hexsha, first_parent=True):
+        history.append(c)
+    return history
+
+spinner = itertools.cycle(['/', '-', '\\', '|'])
+counter = 0
+def spin():
+    global counter
+    # Display a progress bar
+    counter += 1
+    if counter % 10 == 0:
+        if counter % 100 == 0:
+            print("\b..", end='', file=sys.stderr)
+        print("\b", end='', file=sys.stderr)
+        print(next(spinner),  end='', file=sys.stderr)
+        sys.stderr.flush()
+
+# note_revisions contains entries by-sha and by-PR.
+revisions = {}
+# Load all revisions from the repo until either firstCommit
+# or commit.
+if revisionFirst is not None:
+    print("Collecting release note revisions from\n%s\nuntil\n%s" % (identify_commit(revisionFirst), identify_commit(revisionLast)), file=sys.stderr)
+    for c in repo.iter_commits(revisionFirst.hexsha + '..' + revisionLast.hexsha, first_parent = False):
+        spin()
+        if c == firstCommit:
+            break
+        if revision.search(c.message) is None:
+            # Fast path
+            continue
+        msglines = c.message.split('\n')
+        curnote = []
+        innote = False
+        cat = None
+        target = None
+        notes = []
+        for line in msglines:
+            m = coauthor.search(line)
+            if m is not None:
+                # A Co-authored-line finishes the parsing of the commit message,
+                # because it's included at the end only.
+                break
+
+            m = fixannot.search(line)
+            if m is not None:
+                # Fix/Close etc. Ignore.
+                continue
+
+            m = norelnote.search(line)
+            if m is not None:
+                # Release note: None. Ignore.
+                continue
+
+            m = revision.search(line)
+            if m is None:
+                # Current line does not contain a revision separator.
+                # If we were already collecting a note, continue collecting it.
+                if innote:
+                    curnote.append(line)
+                continue
+
+            # We have a release note boundary. If we were collecting a
+            # note already, complete it.
+            if innote:
+                notes.append((target, cat, reformat_note(curnote)))
+                curnote = []
+                innote = False
+
+            # Start a new release note.
+
+            firstline = m.group('note').strip()
+            innote = True
+
+            # Capitalize the first line.
+            if firstline != "":
+                firstline = firstline[0].upper() + firstline[1:]
+
+            curnote = [firstline]
+            target = m.group('target')
+            if not target.startswith("#"):
+                # We're expecting a commit hash.
+                try:
+                    lc = repo.commit(target)
+                    target = lc.hexsha[:shamin]
+                except exc.ODBError:
+                    print("warning: commit", c.hexha, "amends release note on non-existent target commit", target, file=sys.stderr)
+                
+            cat = m.group('cat1')
+            # Normalize to tolerate various capitalizations.
+            cat = cat.lower()
+            # If there is any misspell, correct it.
+            if cat in cat_misspells:
+                cat = cat_misspells[cat]
+
+        if innote:
+            notes.append((target, cat, reformat_note(curnote)))
+
+        for target, cat, note in notes:
+            rev = revisions.get((target, cat), [])
+            rev = [(note, c.hexsha[:shamin])] + rev
+            revisions[(target, cat)] = rev
+
+print('\b\n', file=sys.stderr)
 
 def extract_release_notes(currentCommit):
     msglines = currentCommit.message.split('\n')
@@ -423,6 +551,15 @@ def extract_release_notes(currentCommit):
             # a release note"), but we won't collect it.
             foundnote = True
             continue
+
+        m = revision.search(line)
+        if m is not None:
+            # Revision block. Ignore and stop the current note.
+            if innote:
+                notes.append((cat, reformat_note(curnote)))
+                innote = False
+                curnote = []
+                continue
 
         m = relnote.search(line)
         if m is None:
@@ -471,29 +608,6 @@ def extract_release_notes(currentCommit):
         notes.append((cat, reformat_note(curnote)))
 
     return foundnote, notes
-
-
-spinner = itertools.cycle(['/', '-', '\\', '|'])
-spin_counter = 0
-
-
-def spin():
-    global spin_counter
-    # Display a progress bar
-    spin_counter += 1
-    if spin_counter % 10 == 0:
-        if spin_counter % 100 == 0:
-            print("\b..", end='', file=sys.stderr)
-        print("\b", end='', file=sys.stderr)
-        print(next(spinner), end='', file=sys.stderr)
-        sys.stderr.flush()
-
-
-def get_direct_history(startCommit, lastCommit):
-    history = []
-    for c in repo.iter_commits(startCommit.hexsha + '..' + lastCommit.hexsha, first_parent=True):
-        history.append(c)
-    return history
 
 
 excluded_notes = set()
@@ -568,12 +682,13 @@ def process_release_notes(pr, title, commit):
     missing_item = None
     if not foundnote:
         # Missing release note. Keep track for later.
-        missing_item = makeitem(pr, title, commit.hexsha[:shamin], authors)
+        missing_item = makeitem(pr, '', title, commit.hexsha[:shamin], authors)
     return missing_item, authors
 
 
-def makeitem(pr, prtitle, sha, authors):
+def makeitem(pr, cat, prtitle, sha, authors):
     return {'authors': authors,
+            'cat': cat,
             'sha': sha,
             'pr': pr,
             'title': prtitle,
@@ -581,7 +696,7 @@ def makeitem(pr, prtitle, sha, authors):
 
 
 def completenote(commit, cat, notemsg, authors, pr, title):
-    item = makeitem(pr, title, commit.hexsha[:shamin], authors)
+    item = makeitem(pr, cat, title, commit.hexsha[:shamin], authors)
     item['note'] = notemsg
 
     # Now collect per category.
@@ -653,6 +768,7 @@ allprs = set()
 # C, E, F, and G will each be checked. F is an ancestor of B, so it will be
 # excluded. E starts with "Merge", so it will not be counted. Only C and G will
 # have statistics included.
+commit_to_pr = {}
 def analyze_pr(merge, pr):
     allprs.add(pr)
 
@@ -691,6 +807,7 @@ def analyze_pr(merge, pr):
             # already.
             continue
         seen_commits.add(commit)
+        commit_to_pr[commit.hexsha[:shamin]] = pr
 
         if not commit.message.startswith("Merge"):
             missing_item, prauthors = process_release_notes(pr, note, commit)
@@ -714,7 +831,7 @@ def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
     individual_authors.update(authors)
     if len(authors) == 0:
         authors.add("Unknown Author")
-    item = makeitem(pr, prtitle, sha, authors)
+    item = makeitem(pr, '', prtitle, sha, authors)
     item.update({'ncommits': ncommits,
                  'insertions': stats['insertions'],
                  'deletions': stats['deletions'],
@@ -734,10 +851,11 @@ def analyze_standalone_commit(commit):
     # Some random out-of-branch commit. Let's not forget them.
     authors = collect_authors(commit)
     title = commit.message.split('\n', 1)[0].strip()
-    item = makeitem('#unknown', title, commit.hexsha[:shamin], authors)
+    sha = commit.hexsha[:shamin]
+    item = makeitem('#unknown', '', title, sha, authors)
     missing_release_notes.append(item)
-    collect_item('#unknown', title, commit.hexsha[:shamin], 1, authors, commit.stats.total, commit.committed_date)
-
+    collect_item('#unknown', title, sha, 1, authors, commit.stats.total, commit.committed_date)
+    commit_to_pr[sha] = '#unknown'
 
 # Collect all the merge points so we can report progress.
 mergepoints = get_direct_history(firstCommit, commit)
@@ -765,6 +883,47 @@ for commit in mergepoints:
         print("                                \r%s (%s) " % (commit.hexsha[:shamin], ctime), end='', file=sys.stderr)
         analyze_standalone_commit(commit)
 
+# For every tuple (PR/sha, cat) which does not have
+# a release note yet, but for which there is a revision
+# available, synthetize a release note from the revision
+# and don't consider it a revision any more.
+has_note = set()
+for cat, items in release_notes.items():
+    for item in items:
+        has_note.add((item['pr'], cat))
+        has_note.add((item['sha'], cat))
+changed_revisions = []
+for (target, cat), note_revisions in revisions.items():
+    if (target, cat) in has_note:
+        continue
+    maybe_pr = target
+    if target.startswith("#"):
+        # Is this PR in-scope for the release note report?
+        # If not, don't synthetize anything.
+        if target not in allprs:
+            continue
+    else:
+        # Is the commit in-scope for this report?
+        # If not, don't synthetize anything.
+        if target not in commit_to_pr:
+            continue
+        else:
+            # We really prefer a PR number.
+            maybe_pr = commit_to_pr[target]
+    l = release_notes.get(cat, [])
+    for note, sha in note_revisions:
+        item = makeitem(maybe_pr, cat, 'unknown', sha, 'unknown')
+        item['note'] = note
+        l.append(item)
+        # The remaining elements will be spelled out
+        # as "NOTE REVISION" below.
+        break
+    release_notes[cat] = l
+    changed_revisions.append((target, cat, note_revisions[1:]))
+    has_note.add((target, cat))
+    has_note.add((maybe_pr, cat))
+for t, c, r in changed_revisions:
+    revisions[(t, c)] = r
 
 print("\b\nAnalyzing authors...", file=sys.stderr)
 sys.stderr.flush()
@@ -863,6 +1022,17 @@ def renderlinks(item):
         seenshas.add(item['sha'])
     return ret
 
+def output_note(item):
+    res = item['note'].replace('\n', '\n  ')
+    revs = revisions.get((item['pr'], item['cat']), [])
+    revs += revisions.get((item['sha'], item['cat']), [])
+    for note, sha in revs:
+        res += '\n  - NOTE REVISION'
+        if not hideshas:
+            res += ' [%s][%s]' % (sha, sha)
+            seenshas.add(sha)
+        res += '\n    ' + note.replace('\n', '\n    ')
+    return res
 
 for sec in relnote_sec_order:
     r = release_notes.get(sec, None)
@@ -874,7 +1044,7 @@ for sec in relnote_sec_order:
     print()
 
     for item in reversed(r):
-        print("-", item['note'].replace('\n', '\n  '), renderlinks(item))
+        print("-", output_note(item), renderlinks(item))
 
     print()
 
@@ -893,7 +1063,7 @@ if len(extrasec) > 0:
         print("#### %s" % extrasec.capitalize())
         print()
         for item in release_notes[extrasec]:
-            print("-", item['note'].replace('\n', '\n  '), renderlinks(item))
+            print("-", output_note(item), renderlinks(item))
         print()
 
 if len(missing_release_notes) > 0:

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -41,6 +41,7 @@ from gitdb import exc
 from git import Repo
 from git.repo.fun import name_to_object
 from git.util import Stats
+import os.path
 
 #
 # Global behavior constants
@@ -49,106 +50,129 @@ from git.util import Stats
 # minimum sha length to disambiguate
 shamin = 9
 
-# FIXME(knz): This probably needs to use the .mailmap.
-author_aliases = {
-    'changangela': "Angela Chang",
-    'dianasaur323': "Diana Hsieh",
-    'kena': "Raphael 'kena' Poss",
-    'vivekmenezes': "Vivek Menezes",
-    'Darin': "Darin Peshev",
-    'RaduBerinde': "Radu Berinde",
-    'Andy Kimball': "Andrew Kimball",
-    'marc': "Marc Berhault",
-    'Lauren': "Lauren Hirata",
-    'lhirata': "Lauren Hirata",
-    'Emmanuel': "Emmanuel Sales",
-    'MBerhault': "Marc Berhault",
-    'Nate': "Nathaniel Stewart",
-    'a6802739': "Song Hao",
-    'Abhemailk abhi.madan01@gmail.com': "Abhishek Madan",
-    'rytaft': "Rebecca Taft",
-    'songhao': "Song Hao",
-    'solongordon': "Solon Gordon",
-    'tim-o': "Tim O'Brien",
-    'Tyler314': "Tyler Roberts",
-    'Amruta': "Amruta Ranade",
-    'yuzefovich': "Yahor Yuzefovich",
-    'madhavsuresh': "Madhav Suresh",
-    'Richard Loveland': "Rich Loveland",
-}
+# Basic mailmap functionality using the AUTHORS file.
+mmre = re.compile(r'^(?P<name>.*?)\s+<(?P<addr>[^>]*)>(?P<aliases>(?:[^<]*<[^>]*>)*)$')
+mmare = re.compile('(?P<alias>[^<]*)<(?P<addr>[^>]*)>')
+crdb_folk = set()
 
-# FIXME(knz): This too.
-crdb_folk = set([
-    "Abhishek Madan",
-    "Alex Robinson",
-    "Alfonso Subiotto Marqués",
-    "Amruta Ranade",
-    "Andrei Matei",
-    "Andrew Couch",
-    "Andrew Kimball",
-    "Andrew Werner",
-    "Andrew Kryczka",
-    "Andy Woods",
-    "Aditya Maru",
-    "Angela Chang",
-    "Arjun Narayan",
-    "Ben Darnell",
-    "Bilal Akhtar",
-    "Bob Vawter",
-    "Bram Gruneir",
-    "Celia La",
-    "Daniel Harrison",
-    "David Taylor",
-    "Darin Peshev",
-    "Diana Hsieh",
-    "Emmanuel Sales",
-    "Erik Trinh",
-    "George Utsin",
-    "Jesse Seldess",
-    "Jessica Edwards",
-    "Joseph Lowinske",
-    "Joey Pereira",
-    "Jordan Lewis",
-    "Justin Jaffray",
-    "Jeffrey Xiao",
-    "Ken Liu",
-    "Kendra Curtis",
-    "Kuan Luo",
-    "Lauren Hirata",
-    "Lucy Zhang",
-    "Madhav Suresh",
-    "Marc Berhault",
-    "Masha Schneider",
-    "Matt Jibson",
-    "Matt Tracy",
-    "Nathan VanBenschoten",
-    "Nathaniel Stewart",
-    "Nikhil Benesch",
-    "Paul Bardea",
-    "Pete Vilter",
-    "Peter Mattis",
-    "Radu Berinde",
-    "Rafi Shamim",
-    "Raphael 'kena' Poss",
-    "Rebecca Taft",
-    "Rich Loveland",
-    "Richard Wu",
-    "Ridwan Sharif",
-    "Rohan Yadav",
-    "Roland Crosby",
-    "Sean Loiselle",
-    "Solon Gordon",
-    "Spencer Kimball",
-    "Tamir Duberstein",
-    "Tim O'Brien",
-    "Tobias Schottdorf",
-    "Tyler Roberts",
-    "Will Cross",
-    "Victor Chen",
-    "Vivek Menezes",
-    "Yahor Yuzefovich",
-])
 
+mmap_bycanon = {}
+mmap_byaddr = {}
+mmap_byname = {}
+
+class Person:
+    def __init__(self, name, addr):
+        self.name = name
+        self.email = addr
+        self.aliases = []
+        self.crdb = False
+        self.add_alias(name, addr)
+
+    def check_crdb(self, addr):
+        if '@cockroachlabs.com' in addr:
+            self.crdb = True
+            crdb_folk.add(self)
+
+    def add_alias(self, name, addr):
+        self.check_crdb(addr)
+        if name == '':
+            name = self.name
+
+        global mmap_bycanon
+        canon = (name, addr)
+        if canon in mmap_bycanon:
+            print('warning: duplicate alias %r, ignoring' % (canon,), file=sys.stderr)
+        else:
+            mmap_bycanon[canon] = self
+        self.aliases.append(canon)
+
+        global mmap_byaddr
+        byaddr = mmap_byaddr.get(addr, [])
+        if self not in byaddr:
+            byaddr.append(self)
+        mmap_byaddr[addr] = byaddr
+
+        global mmap_byname
+        byname = mmap_byname.get(name, [])
+        if self not in byname:
+            byname.append(self)
+        mmap_byname[name] = byname
+
+    def __repr__(self):
+        return "%s <%s>" % (self.name, self.email)
+
+    def __lt__(self, other):
+        return self.name < other.name or (self.name == other.name and self.email < other.email)
+
+
+def define_person(name, addr):
+    canon = (name, addr)
+    if canon in mmap_bycanon:
+        return mmap_bycanon[canon]
+    p = Person(name, addr)
+    mmap_bycanon[canon] = p
+    mmap_byaddr.setdefault(addr, []).append(p)
+    mmap_byname.setdefault(name, []).append(p)
+    return p
+
+
+# Expect AUTHORS in the current directory.
+#
+# We don't want to always fetch AUTOHORS relative to the script,
+# otherwise the script's unit tests cannot override.
+if not os.path.exists('AUTHORS'):
+    print('warning: AUTHORS missing in current directory.', file=sys.stderr)
+    print('Maybe use "cd" to navigate to the working tree root.', file=sys.stderr)
+    # Note: it's OK to continue without the file, we'll just miss
+    # normalization of author names.
+else:
+    with open('AUTHORS', 'r') as f:
+        for line in f.readlines():
+            if line.strip().startswith('#'):
+                continue
+            m = mmre.match(line)
+            if m is None:
+                continue
+            canon = (m.group('name'), m.group('addr'))
+            if canon in mmap_bycanon:
+                print('warning: duplicate person %r, ignoring' % (canon,), file=sys.stderr)
+                continue
+
+            p = define_person(*canon)
+            aliases = m.group('aliases')
+            aliases = mmare.findall(aliases)
+            for alias, addr in aliases:
+                name = alias.strip()
+                p.add_alias(name, addr)
+
+
+# lookup_person retrieves the main identity of a person given one of their
+# names or email aliases in the mailmap.
+def lookup_person(name, email):
+    key = (name, email)
+    if key in mmap_bycanon:
+        # lucky case.
+        return mmap_bycanon[key]
+    # Name+email didn't work.
+    # Let's see email next.
+    if email in mmap_byaddr:
+        candidates = mmap_byaddr[email]
+        if len(candidates) > 1:
+            print('warning: no direct name match for', (name, email),
+                  'and addr', email, 'is ambiguous,',
+                  'keeping as-is', file=sys.stderr)
+            return define_person(name, email)
+        return candidates[0]
+    # Email didn't work either. That's not great.
+    if name in mmap_byname:
+        candidates = mmap_byname[name]
+        if len(candidates) > 1:
+            print('warning: no direct name match for', (name, email),
+                  'and name', name, 'is ambiguous,',
+                  'keeping as-is', file=sys.stderr)
+            return define_person(name, email)
+        return candidates[0]
+    return define_person(name, email)
 
 # Section titles for release notes.
 relnotetitles = {
@@ -514,15 +538,16 @@ missing_release_notes = []
 
 def collect_authors(commit):
     authors = set()
-    author = author_aliases.get(commit.author.name, commit.author.name)
-    if author != 'GitHub':
+    author = lookup_person(commit.author.name, commit.author.email)
+    if author.name != 'GitHub':
         authors.add(author)
-    author = author_aliases.get(commit.committer.name, commit.committer.name)
-    if author != 'GitHub':
+    author = lookup_person(commit.committer.name, commit.committer.email)
+    if author.name != 'GitHub':
         authors.add(author)
     for m in coauthor.finditer(commit.message):
         aname = m.group('name').strip()
-        author = author_aliases.get(aname, aname)
+        amail = m.group('email').strip()
+        author = lookup_person(aname, amail)
         authors.add(author)
     return authors
 
@@ -548,7 +573,7 @@ def process_release_notes(pr, title, commit):
 
 
 def makeitem(pr, prtitle, sha, authors):
-    return {'authors': ', '.join(sorted(authors)),
+    return {'authors': authors,
             'sha': sha,
             'pr': pr,
             'title': prtitle,
@@ -698,9 +723,11 @@ def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
                  'date': datetime.date.fromtimestamp(prts).isoformat(),
                  })
 
-    history = per_group_history.get(item['authors'], [])
-    history.append(item)
-    per_group_history[item['authors']] = history
+    al = item['authors']
+    k = str(sorted(al))
+    history = per_group_history.get(k, (al, []))
+    history[1].append(item)
+    per_group_history[k] = history
 
 
 def analyze_standalone_commit(commit):
@@ -751,15 +778,12 @@ ext_contributors = individual_authors - crdb_folk
 firsttime_contributors = []
 for a in individual_authors:
     # Find all aliases known for this person
-    aliases = [a]
-    for alias, name in author_aliases.items():
-        if name == a:
-            aliases.append(alias)
+    aliases = a.aliases
     # Collect the history for every alias
     hist = b''
     for al in aliases:
         spin()
-        cmd = subprocess.run(["git", "log", "--author=%s" % al, options.from_commit, '-n', '1'], stdout=subprocess.PIPE, check=True)
+        cmd = subprocess.run(["git", "log", "--author=%s <%s>" % al, options.from_commit, '-n', '1'], stdout=subprocess.PIPE, check=True)
         hist += cmd.stdout
     if len(hist) == 0:
         # No commit from that author older than the first commit
@@ -876,7 +900,7 @@ if len(missing_release_notes) > 0:
     print("#### Changes without release note annotation")
     print()
     for item in missing_release_notes:
-        authors = item['authors']
+        authors = ', '.join(str(x) for x in sorted(item['authors']))
         print("- [%(pr)s][%(pr)s] [%(sha)s][%(sha)s] %(title)s" % item, "(%s)" % authors)
         seenshas.add(item['sha'])
         seenprs.add(item['pr'])
@@ -902,10 +926,10 @@ if len(notified_authors) > 0:
     print("We would like to thank the following contributors from the CockroachDB community:")
     print()
     for person in notified_authors:
-        print("-", person, end='')
+        print("-", person.name, end='')
         if person in firsttime_contributors:
             annot = ""
-            if person in crdb_folk:
+            if person.crdb:
                 annot = ", CockroachDB team member"
             print(" (first-time contributor%s)" % annot, end='')
         print()
@@ -921,9 +945,9 @@ if not hidepercontributor:
         fmt = "  - %(date)s [%(pr)-6s][%(pr)-6s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
 
     for group in allgroups:
-        items = per_group_history[group]
-        print("- %s:" % group)
+        al, items = per_group_history[group]
         items.sort(key=lambda x: x[sortkey], reverse=not revsort)
+        print("- %s:" % ', '.join(a.name for a in sorted(al)))
         for item in items:
             print(fmt % item, end='')
             if not hideshas:

--- a/scripts/release-notes/Makefile
+++ b/scripts/release-notes/Makefile
@@ -2,6 +2,7 @@ TESTS := $(wildcard test*.sh)
 BASH ?= /usr/bin/env bash
 PYTHON ?= python
 NOTESCRIPT := $(PWD)/../release-notes.py
+TDIR := $(shell pwd)
 
 all: test
 
@@ -15,7 +16,7 @@ test: $(TESTS:.sh=.test)
 	@echo
 	@echo "**** Testing for $* ****"
 	@echo
-	$(BASH) $*.sh $(NOTESCRIPT)
+	$(BASH) $(TDIR)/$*.sh $(NOTESCRIPT)
 
 clean:
 	rm -f *.graph.txt *.notes.txt

--- a/scripts/release-notes/common.sh
+++ b/scripts/release-notes/common.sh
@@ -23,6 +23,7 @@ function test_init() {
 function init_repo() {
     git init
     touch foo; git add foo; git commit "${flags[@]}" -m "initial"; git tag initial
+	git tag v000-base
 }
 
 # Perform some arbitrary change.

--- a/scripts/release-notes/common.sh
+++ b/scripts/release-notes/common.sh
@@ -22,6 +22,7 @@ function test_init() {
 # Initialize the repository. Tag the initial commit.
 function init_repo() {
     git init
+    mkdir -p .git/refs/pull/origin
     touch foo; git add foo; git commit "${flags[@]}" -m "initial"; git tag initial
 	git tag v000-base
 }
@@ -35,7 +36,6 @@ function make_change() {
 # Mark a branch tip as PR tip.
 # $1 = PR number.
 function tag_pr() {
-    mkdir -p .git/refs/pull/origin
     git log --pretty=tformat:%H > .git/refs/pull/origin/$1
 }
 

--- a/scripts/release-notes/test1.notes.ref.txt
+++ b/scripts/release-notes/test1.notes.ref.txt
@@ -6,7 +6,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] master update (test1)
+- [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] master update (test1 <test1@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test1.notes.ref.txt
+++ b/scripts/release-notes/test1.notes.ref.txt
@@ -14,7 +14,7 @@ Docs team: Please add these manually.
 
 ### Contributors
 
-This release includes 2 merged PRs by 1 author.
+This release includes 2 merged PRs and 1 standalone commit by 1 author.
 We would like to thank the following contributors from the CockroachDB community:
 
 - test1
@@ -22,8 +22,8 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test1:
-  - 2018-04-22 [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] (+   0 -   0 ~   0/ 0) master update
-  - 2018-04-22 [#100  ][#100  ] [884025a61][884025a61] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] (+   0 -   0 ~   0/ 0) master update [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [884025a61][884025a61] (+   0 -   0 ~   0/ 0) PR title alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [c95ebe826][c95ebe826] (+   0 -   0 ~   0/ 0) PR title
 
 

--- a/scripts/release-notes/test10.graph.ref.txt
+++ b/scripts/release-notes/test10.graph.ref.txt
@@ -1,0 +1,2 @@
+* aebaacf8730eba9e9530f92b12179a450d532ec7 master update
+* 89f7cef5fdf8310a9d5a97789c6152a2b9da5921 initial

--- a/scripts/release-notes/test10.notes.ref.txt
+++ b/scripts/release-notes/test10.notes.ref.txt
@@ -1,0 +1,24 @@
+### Bug fixes
+
+- Some fix. [#unknown][#unknown] [aebaacf87][aebaacf87]
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 1 standalone commit by 1 author.
+We would like to thank the following contributors from the CockroachDB community:
+
+- test10
+
+### PRs merged by contributors
+
+- test10:
+  - 2018-04-22 [#unknown][#unknown] [aebaacf87][aebaacf87] (+   0 -   0 ~   0/ 0) master update
+
+
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[aebaacf87]: https://github.com/cockroachdb/cockroach/commit/aebaacf87
+

--- a/scripts/release-notes/test10.sh
+++ b/scripts/release-notes/test10.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test10
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+    git checkout -b feature
+    make_change "feature A"
+	tag_pr 1
+	git checkout master
+	
+    make_change "master update
+
+Release note (bug fix): some fix.
+"
+)
+
+test_end

--- a/scripts/release-notes/test2.notes.ref.txt
+++ b/scripts/release-notes/test2.notes.ref.txt
@@ -7,7 +7,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [f872999e8][f872999e8] master update (test2)
+- [#unknown][#unknown] [f872999e8][f872999e8] master update (test2 <test2@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test2.notes.ref.txt
+++ b/scripts/release-notes/test2.notes.ref.txt
@@ -15,7 +15,7 @@ Docs team: Please add these manually.
 
 ### Contributors
 
-This release includes 2 merged PRs by 1 author.
+This release includes 2 merged PRs and 1 standalone commit by 1 author.
 We would like to thank the following contributors from the CockroachDB community:
 
 - test2
@@ -23,8 +23,8 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test2:
-  - 2018-04-22 [#unknown][#unknown] [f872999e8][f872999e8] (+   0 -   0 ~   0/ 0) master update
-  - 2018-04-22 [#100  ][#100  ] [e9b08c236][e9b08c236] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#unknown][#unknown] [f872999e8][f872999e8] (+   0 -   0 ~   0/ 0) master update [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [e9b08c236][e9b08c236] (+   0 -   0 ~   0/ 0) PR title alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [7358b462a][7358b462a] (+   0 -   0 ~   0/ 0) PR title (2 commits)
 
 

--- a/scripts/release-notes/test3.notes.ref.txt
+++ b/scripts/release-notes/test3.notes.ref.txt
@@ -9,7 +9,7 @@
 
 #### Changes without release note annotation
 
-- [#unknown][#unknown] [4f4329fdc][4f4329fdc] master update (test3)
+- [#unknown][#unknown] [4f4329fdc][4f4329fdc] master update (test3 <test3@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test3.notes.ref.txt
+++ b/scripts/release-notes/test3.notes.ref.txt
@@ -17,7 +17,7 @@ Docs team: Please add these manually.
 
 ### Contributors
 
-This release includes 2 merged PRs by 1 author.
+This release includes 2 merged PRs and 1 standalone commit by 1 author.
 We would like to thank the following contributors from the CockroachDB community:
 
 - test3
@@ -25,8 +25,8 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test3:
-  - 2018-04-22 [#unknown][#unknown] [4f4329fdc][4f4329fdc] (+   0 -   0 ~   0/ 0) master update
-  - 2018-04-22 [#100  ][#100  ] [b719cfe9e][b719cfe9e] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#unknown][#unknown] [4f4329fdc][4f4329fdc] (+   0 -   0 ~   0/ 0) master update [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [b719cfe9e][b719cfe9e] (+   0 -   0 ~   0/ 0) PR title alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [ef634455e][ef634455e] (+   0 -   0 ~   0/ 0) PR title (4 commits)
 
 

--- a/scripts/release-notes/test4.notes.ref.txt
+++ b/scripts/release-notes/test4.notes.ref.txt
@@ -30,7 +30,7 @@ We would like to thank the following contributors from the CockroachDB community
   - 2018-04-22 [#1    ][#1    ] [32204525a][32204525a] (+   0 -   0 ~   0/ 0) PR title (5 commits)
 
 - test4:
-  - 2018-04-22 [#100  ][#100  ] [1525c88bd][1525c88bd] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#100  ][#100  ] [1525c88bd][1525c88bd] (+   0 -   0 ~   0/ 0) PR title alternate format [NO RELEASE NOTE]
 
 
 [#1]: https://github.com/cockroachdb/cockroach/pull/1

--- a/scripts/release-notes/test5.notes.ref.txt
+++ b/scripts/release-notes/test5.notes.ref.txt
@@ -6,7 +6,7 @@
 
 #### Changes without release note annotation
 
-- [#2][#2] [8156afc96][8156afc96] PR title in need of release note (test5)
+- [#2][#2] [8156afc96][8156afc96] PR title in need of release note (test5 <test5@example.com>)
 
 ### Doc updates
 

--- a/scripts/release-notes/test5.notes.ref.txt
+++ b/scripts/release-notes/test5.notes.ref.txt
@@ -22,9 +22,9 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test5:
-  - 2018-04-22 [#200  ][#200  ] [d3ba7bcec][d3ba7bcec] (+   0 -   0 ~   0/ 0) PR title in need of release note alternate format
-  - 2018-04-22 [#2    ][#2    ] [931c78112][931c78112] (+   0 -   0 ~   0/ 0) PR title in need of release note
-  - 2018-04-22 [#100  ][#100  ] [cfb4c716b][cfb4c716b] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#200  ][#200  ] [d3ba7bcec][d3ba7bcec] (+   0 -   0 ~   0/ 0) PR title in need of release note alternate format [NO RELEASE NOTE]
+  - 2018-04-22 [#2    ][#2    ] [931c78112][931c78112] (+   0 -   0 ~   0/ 0) PR title in need of release note [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [cfb4c716b][cfb4c716b] (+   0 -   0 ~   0/ 0) PR title alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [b8a9a7f70][b8a9a7f70] (+   0 -   0 ~   0/ 0) PR title (2 commits)
 
 

--- a/scripts/release-notes/test6.notes.ref.txt
+++ b/scripts/release-notes/test6.notes.ref.txt
@@ -12,10 +12,10 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test6:
-  - 2018-04-22 [#200  ][#200  ] [5105ca93f][5105ca93f] (+   0 -   0 ~   0/ 0) PR title 2 alternate format
-  - 2018-04-22 [#2    ][#2    ] [38b0488f9][38b0488f9] (+   0 -   0 ~   0/ 0) PR title 2 (2 commits)
-  - 2018-04-22 [#100  ][#100  ] [4279dfba7][4279dfba7] (+   0 -   0 ~   0/ 0) PR title 1 alternate format
-  - 2018-04-22 [#1    ][#1    ] [2ae4772fb][2ae4772fb] (+   0 -   0 ~   0/ 0) PR title 1
+  - 2018-04-22 [#200  ][#200  ] [5105ca93f][5105ca93f] (+   0 -   0 ~   0/ 0) PR title 2 alternate format [NO RELEASE NOTE]
+  - 2018-04-22 [#2    ][#2    ] [38b0488f9][38b0488f9] (+   0 -   0 ~   0/ 0) PR title 2 (2 commits) [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [4279dfba7][4279dfba7] (+   0 -   0 ~   0/ 0) PR title 1 alternate format [NO RELEASE NOTE]
+  - 2018-04-22 [#1    ][#1    ] [2ae4772fb][2ae4772fb] (+   0 -   0 ~   0/ 0) PR title 1 [NO RELEASE NOTE]
 
 
 [#1]: https://github.com/cockroachdb/cockroach/pull/1

--- a/scripts/release-notes/test7.notes.ref.txt
+++ b/scripts/release-notes/test7.notes.ref.txt
@@ -17,7 +17,7 @@ We would like to thank the following contributors from the CockroachDB community
 
 - test7:
   - 2018-04-22 [#200  ][#200  ] [28245dacd][28245dacd] (+   0 -   0 ~   0/ 0) PR title 2 alternate format (2 commits)
-  - 2018-04-22 [#100  ][#100  ] [ba15054b5][ba15054b5] (+   0 -   0 ~   0/ 0) PR title 1 alternate format
+  - 2018-04-22 [#100  ][#100  ] [ba15054b5][ba15054b5] (+   0 -   0 ~   0/ 0) PR title 1 alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [191b497b9][191b497b9] (+   0 -   0 ~   0/ 0) PR title 1 (2 commits)
 
 

--- a/scripts/release-notes/test8.graph.ref.txt
+++ b/scripts/release-notes/test8.graph.ref.txt
@@ -1,0 +1,18 @@
+*   801acad030ef8c14766f72609287d323075af29b Merge pull request #200 from foo/bar
+|\  
+| * 4ba203f0af12e361707c20fa4254fe58f9c3a86e merge pr canary
+|/  
+*   20f736f8b7421f226d15111e2377a8e069972bf0 Merge #2
+|\  
+| * fc02f2ab9ac0c1924c479fa601065235579a605e feature A2
+|/  
+*   ac02f9cf6095d6430c609812730a34fe254f5e77 Merge pull request #100 from foo/bar
+|\  
+| * 1fa346db29169f9d1c6f229e34e1e0b0af687af7 merge pr canary
+|/  
+*   931a977579e2e0f0efee763fa289bd2b3162755b Merge #1
+|\  
+| * f76e64ed372d84433ac4c5e0a06e3dfe34a80686 feature A1
+|/  
+* a1dec56519bfa4d850e2771bd9880d2dcdb715aa update AUTHORS
+* 15d3108780a91a71af56bdaeb020dbdf650fd1ef initial

--- a/scripts/release-notes/test8.notes.ref.txt
+++ b/scripts/release-notes/test8.notes.ref.txt
@@ -1,0 +1,45 @@
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#2][#2] [fc02f2ab9][fc02f2ab9] PR 2 title (Foo Foo <foo@example.com>, test8 <test8@example.com>)
+- [#1][#1] [f76e64ed3][f76e64ed3] PR 1 title (Foo Foo <foo@example.com>, test8 <test8@example.com>)
+- [#unknown][#unknown] [a1dec5651][a1dec5651] update AUTHORS (test8 <test8@example.com>)
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 2 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- Foo Foo (first-time contributor)
+- test8
+
+### PRs merged by contributors
+
+- Foo Foo, test8:
+  - 2018-04-22 [#2    ][#2    ] [20f736f8b][20f736f8b] (+   0 -   0 ~   0/ 0) PR 2 title
+  - 2018-04-22 [#1    ][#1    ] [931a97757][931a97757] (+   0 -   0 ~   0/ 0) PR 1 title
+
+- test8:
+  - 2018-04-22 [#unknown][#unknown] [a1dec5651][a1dec5651] (+   1 -   0 ~   1/ 1) update AUTHORS
+  - 2018-04-22 [#200  ][#200  ] [801acad03][801acad03] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
+  - 2018-04-22 [#100  ][#100  ] [ac02f9cf6][ac02f9cf6] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[20f736f8b]: https://github.com/cockroachdb/cockroach/commit/20f736f8b
+[801acad03]: https://github.com/cockroachdb/cockroach/commit/801acad03
+[931a97757]: https://github.com/cockroachdb/cockroach/commit/931a97757
+[a1dec5651]: https://github.com/cockroachdb/cockroach/commit/a1dec5651
+[ac02f9cf6]: https://github.com/cockroachdb/cockroach/commit/ac02f9cf6
+[f76e64ed3]: https://github.com/cockroachdb/cockroach/commit/f76e64ed3
+[fc02f2ab9]: https://github.com/cockroachdb/cockroach/commit/fc02f2ab9
+

--- a/scripts/release-notes/test8.notes.ref.txt
+++ b/scripts/release-notes/test8.notes.ref.txt
@@ -12,7 +12,7 @@ Docs team: Please add these manually.
 
 ### Contributors
 
-This release includes 4 merged PRs by 2 authors.
+This release includes 4 merged PRs and 1 standalone commit by 2 authors.
 We would like to thank the following contributors from the CockroachDB community:
 
 - Foo Foo (first-time contributor)
@@ -21,13 +21,13 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - Foo Foo, test8:
-  - 2018-04-22 [#2    ][#2    ] [20f736f8b][20f736f8b] (+   0 -   0 ~   0/ 0) PR 2 title
-  - 2018-04-22 [#1    ][#1    ] [931a97757][931a97757] (+   0 -   0 ~   0/ 0) PR 1 title
+  - 2018-04-22 [#2    ][#2    ] [20f736f8b][20f736f8b] (+   0 -   0 ~   0/ 0) PR 2 title [NO RELEASE NOTE]
+  - 2018-04-22 [#1    ][#1    ] [931a97757][931a97757] (+   0 -   0 ~   0/ 0) PR 1 title [NO RELEASE NOTE]
 
 - test8:
-  - 2018-04-22 [#unknown][#unknown] [a1dec5651][a1dec5651] (+   1 -   0 ~   1/ 1) update AUTHORS
-  - 2018-04-22 [#200  ][#200  ] [801acad03][801acad03] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
-  - 2018-04-22 [#100  ][#100  ] [ac02f9cf6][ac02f9cf6] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+  - 2018-04-22 [#unknown][#unknown] [a1dec5651][a1dec5651] (+   1 -   0 ~   1/ 1) update AUTHORS [NO RELEASE NOTE]
+  - 2018-04-22 [#200  ][#200  ] [801acad03][801acad03] (+   0 -   0 ~   0/ 0) PR 2 title alternate format [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [ac02f9cf6][ac02f9cf6] (+   0 -   0 ~   0/ 0) PR 1 title alternate format [NO RELEASE NOTE]
 
 
 [#1]: https://github.com/cockroachdb/cockroach/pull/1

--- a/scripts/release-notes/test8.sh
+++ b/scripts/release-notes/test8.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test8
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+
+	cat >AUTHORS <<EOF
+Foo Foo <foo@example.com> foo <foo@example.com> <foo2@example.com>
+EOF
+	git add AUTHORS
+	make_change "update AUTHORS"
+
+    git checkout -b feature
+    make_change "feature A1"
+	git commit --allow-empty --amend --author='foo <foo@example.com>' --no-edit
+	tag_pr 1
+	git checkout master
+	merge_pr feature 1 "PR 1 title"
+
+	git checkout -b feature2
+	make_change "feature A2"
+	git commit --allow-empty --amend --author='foo <foo2@example.com>' --no-edit
+	tag_pr 2
+	git checkout master
+	merge_pr feature2 2 "PR 2 title"
+)
+
+test_end

--- a/scripts/release-notes/test9.graph.ref.txt
+++ b/scripts/release-notes/test9.graph.ref.txt
@@ -1,0 +1,29 @@
+*   63d6ab4163d783bf0757bc22573d9a5a2396e823 Merge pull request #300 from foo/bar
+|\  
+| * 905be19587abc15c62023bd34e24711a2541f889 merge pr canary
+|/  
+*   b10853b4a881b68d5132741487cb20aaa599cd72 Merge #3
+|\  
+| * d6960940e21fa8ab78120ab016b4244f86bd44eb extra revisions
+|/  
+*   3905a9e9504ce5de2f08ce6b1912a8934eb9688b Merge pull request #200 from foo/bar
+|\  
+| * 773310e94bd9c2c2cf6385a3045856c4873fc02d merge pr canary
+|/  
+*   b6d311cae6a8c6225c05a64973b13b6c49de3361 Merge #2
+|\  
+| * 990a43f208d5a010a63580c0677bd443763b095b synthetized note
+| * 0a0926ccbc529ecc0868a5ba6e7515e6dcf92ad2 synthetized note
+| * cca538acaa43e6625450719d5366d0084b5219a5 note revision
+| * cbd5be9c27b460573c886f1d21509c244cadea41 note revision
+|/  
+*   6286c37eaa2b9dec3bd3703bd4e31e59840aeb6a Merge pull request #100 from foo/bar
+|\  
+| * cf5e90b1f3426c6b329eba2d04d88ad1715a88d1 merge pr canary
+|/  
+*   0b2581ed149f72caaf39958864222577be6a9ff6 Merge #1
+|\  
+| * def86d75087c9252ed65bee8a0b611413e405efc feature 2
+| * db1e8c0722c5130f5128ed51aad267143907df8c fix 1
+|/  
+* 278a3705e1aecfb15248823a72ec17f70edfb62e initial

--- a/scripts/release-notes/test9.notes.ref.txt
+++ b/scripts/release-notes/test9.notes.ref.txt
@@ -1,0 +1,65 @@
+### Command-line changes
+
+- This was missing.
+  - NOTE REVISION [d6960940e][d6960940e]
+    This is visible. [#2][#2] [990a43f20][990a43f20]
+- Badly explained
+  - NOTE REVISION [cbd5be9c2][cbd5be9c2]
+    This is better explained.
+  - NOTE REVISION [cca538aca][cca538aca]
+    Wait I think this is even
+    better.
+  - NOTE REVISION [cca538aca][cca538aca]
+    One more detail. [#1][#1] [def86d750][def86d750]
+
+### Bug fixes
+
+- Something wrong!
+  - NOTE REVISION [cbd5be9c2][cbd5be9c2]
+    Something is fixed.
+    The explanation can even be lengthy. [#1][#1] [db1e8c072][db1e8c072]
+
+### Miscellaneous
+
+#### Extra
+
+- This was also missing. [#2][#2] [990a43f20][990a43f20]
+- This release note did not
+  exist before. [#1][#1] [0a0926ccb][0a0926ccb]
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 1 author.
+We would like to thank the following contributors from the CockroachDB community:
+
+- test9
+
+### PRs merged by contributors
+
+- test9:
+  - 2018-04-22 [#200  ][#200  ] [3905a9e95][3905a9e95] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
+  - 2018-04-22 [#2    ][#2    ] [b6d311cae][b6d311cae] (+   0 -   0 ~   0/ 0) PR 2 title (4 commits)
+  - 2018-04-22 [#100  ][#100  ] [6286c37ea][6286c37ea] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+  - 2018-04-22 [#1    ][#1    ] [0b2581ed1][0b2581ed1] (+   0 -   0 ~   0/ 0) PR 1 title (2 commits)
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[0a0926ccb]: https://github.com/cockroachdb/cockroach/commit/0a0926ccb
+[0b2581ed1]: https://github.com/cockroachdb/cockroach/commit/0b2581ed1
+[3905a9e95]: https://github.com/cockroachdb/cockroach/commit/3905a9e95
+[6286c37ea]: https://github.com/cockroachdb/cockroach/commit/6286c37ea
+[990a43f20]: https://github.com/cockroachdb/cockroach/commit/990a43f20
+[b6d311cae]: https://github.com/cockroachdb/cockroach/commit/b6d311cae
+[cbd5be9c2]: https://github.com/cockroachdb/cockroach/commit/cbd5be9c2
+[cca538aca]: https://github.com/cockroachdb/cockroach/commit/cca538aca
+[d6960940e]: https://github.com/cockroachdb/cockroach/commit/d6960940e
+[db1e8c072]: https://github.com/cockroachdb/cockroach/commit/db1e8c072
+[def86d750]: https://github.com/cockroachdb/cockroach/commit/def86d750
+

--- a/scripts/release-notes/test9.notes.ref.txt
+++ b/scripts/release-notes/test9.notes.ref.txt
@@ -41,9 +41,9 @@ We would like to thank the following contributors from the CockroachDB community
 ### PRs merged by contributors
 
 - test9:
-  - 2018-04-22 [#200  ][#200  ] [3905a9e95][3905a9e95] (+   0 -   0 ~   0/ 0) PR 2 title alternate format
-  - 2018-04-22 [#2    ][#2    ] [b6d311cae][b6d311cae] (+   0 -   0 ~   0/ 0) PR 2 title (4 commits)
-  - 2018-04-22 [#100  ][#100  ] [6286c37ea][6286c37ea] (+   0 -   0 ~   0/ 0) PR 1 title alternate format
+  - 2018-04-22 [#200  ][#200  ] [3905a9e95][3905a9e95] (+   0 -   0 ~   0/ 0) PR 2 title alternate format [NO RELEASE NOTE]
+  - 2018-04-22 [#2    ][#2    ] [b6d311cae][b6d311cae] (+   0 -   0 ~   0/ 0) PR 2 title (4 commits) [NO RELEASE NOTE]
+  - 2018-04-22 [#100  ][#100  ] [6286c37ea][6286c37ea] (+   0 -   0 ~   0/ 0) PR 1 title alternate format [NO RELEASE NOTE]
   - 2018-04-22 [#1    ][#1    ] [0b2581ed1][0b2581ed1] (+   0 -   0 ~   0/ 0) PR 1 title (2 commits)
 
 

--- a/scripts/release-notes/test9.sh
+++ b/scripts/release-notes/test9.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test9
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+
+    git checkout -b feature
+    make_change "fix 1
+
+Release note (bug fix): something wrong!
+"
+	make_change "feature 2
+
+Release note (cli change): badly explained
+"
+	last_sha=$(git log -n 1 --pretty=%H)
+	tag_pr 1
+	git checkout master
+	merge_pr feature 1 "PR 1 title"
+
+	git checkout -b feature2
+	make_change "note revision
+
+Release note: None
+Revised release note [#1] (bug fix): something is fixed.
+The explanation can even be lengthy.
+Revised release note [#1] (cli change): This is better explained.
+"
+	make_change "note revision
+
+Revised release note [#1] (cli change): Wait I think this is even
+better.
+
+Revised release note [$last_sha] (cli change): One more detail.
+"
+
+	make_change "synthetized note
+
+Revised release note [#1] (extra): This release note did not
+exist before.
+"
+	last_sha=$(git log -n 1 --pretty=%H)
+	make_change "synthetized note
+
+Revised release note [#2] (cli change): This was missing.
+Revised release note [$last_sha] (extra): This was also missing.
+"
+	tag_pr 2
+	git checkout master
+	merge_pr feature2 2 "PR 2 title"
+	git tag noteend
+
+	git checkout -b feature3
+	make_change "extra revisions
+
+Revised release note [#2] (cli change): This is visible.
+
+Revised release note [#3] (extra): This must not be visible
+because it is not selected for the release note report.
+"
+	tag_pr 3
+	git checkout master
+	merge_pr feature3 3 "PR 3 title"
+)
+
+test_end --until noteend


### PR DESCRIPTION
(All commits but the last from #42344 and prior)

Prior to this patch, the release note script would skip over
standalone commits (without a PR) when extracting release notes.
This was defective, as the git history does have a few example
standalone commits, with release note but without PR.

Additionally, the script now reports PRs that are missing release
notes *or only use 'Release note: none'*, which may indicate
that the engineer did not bother filling in a note despite the
presence of a user-facing change.

For example:

```
$ python3 scripts/release-notes.py \
    --from v19.2.0-beta.20190930 \
    --until provisional_201911080435_v19.2.0-rc.5
```

Outputs (snippet):

- Andrei Matei:
  - 2019-10-04 [#41303][#41303] [ca32e6ff0][ca32e6ff0] sql: remove dead code [NO RELEASE NOTE]
  - 2019-10-05 [#41307][#41307] [1c99165c3][1c99165c3] sql: fix various problematic uses of the txn in DistSQL flows (4 commits)
  - 2019-10-28 [#41935][#41935] [bad8e55bb][bad8e55bb] settings/cluster: introducing the 19.2 cluster version [NO RELEASE NOTE]

In this example, the first PR has no release note but does not deserve
one. The second has a release note. The third is marked with "Release
note: None" but **there should really have been a release note**: the
introduction of the major cluster version is an important user-facing
change and should be announced.

By highlighting the missing release notes in this way, the script
gives an opportunity to the doc writer(s) to find additional
user-facing changes that need to be documented.

[#41303]: https://github.com/cockroachdb/cockroach/pull/41303
[#41307]: https://github.com/cockroachdb/cockroach/pull/41307
[#41935]: https://github.com/cockroachdb/cockroach/pull/41935
[ca32e6ff0]: https://github.com/cockroachdb/cockroach/commit/ca32e6ff0
[1c99165c3]: https://github.com/cockroachdb/cockroach/commit/1c99165c3
[bad8e55bb]: https://github.com/cockroachdb/cockroach/commit/bad8e55bb

