### PR TITLE
sql/parser: better error messages for unimplemented features

### DIFF
--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -150,7 +150,7 @@ func (l *lexer) UpdateNumPlaceholders(p *tree.Placeholder) {
 
 // Unimplemented wraps Error, setting lastUnimplementedError.
 func (l *lexer) Unimplemented(feature string) {
-	l.lastError = unimp.New(feature, "this syntax")
+	l.lastError = unimp.Newf(feature, "%s", feature)
 	l.populateErrorDetails()
 }
 
@@ -162,7 +162,7 @@ func (l *lexer) UnimplementedWithIssue(issue int) {
 
 // UnimplementedWithIssueDetail wraps Error, setting lastUnimplementedError.
 func (l *lexer) UnimplementedWithIssueDetail(issue int, detail string) {
-	l.lastError = unimp.NewWithIssueDetail(issue, detail, "this syntax")
+	l.lastError = unimp.NewWithIssueDetailf(issue, detail /* detail */, "%s", detail)
 	l.populateErrorDetails()
 }
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3437,8 +3437,14 @@ func TestUnimplementedSyntax(t *testing.T) {
 				t.Errorf("%s: expected error, got nil", d.sql)
 				return
 			}
-			if errMsg := err.Error(); !strings.Contains(errMsg, "unimplemented: this syntax") {
-				t.Errorf("%s: expected unimplemented in message, got %q", d.sql, errMsg)
+			expMsg := "unimplemented: "
+			if d.expected != "" {
+				expMsg += d.expected
+			} else {
+				expMsg += "this syntax"
+			}
+			if errMsg := err.Error(); !strings.Contains(errMsg, expMsg) {
+				t.Errorf("%s: expected %q, got %q", d.sql, expMsg, errMsg)
 			}
 			tkeys := errors.GetTelemetryKeys(err)
 			if len(tkeys) == 0 {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5884,9 +5884,9 @@ create_type_stmt:
   }
 | CREATE TYPE error // SHOW HELP: CREATE TYPE
   // Record/Composite types.
-| CREATE TYPE type_name AS '(' error      { return unimplementedWithIssue(sqllex, 27792) }
+| CREATE TYPE type_name AS '(' error      { return unimplementedWithIssueDetail(sqllex, 27792, "composite types") }
   // Range types.
-| CREATE TYPE type_name AS RANGE error    { return unimplementedWithIssue(sqllex, 27791) }
+| CREATE TYPE type_name AS RANGE error    { return unimplementedWithIssueDetail(sqllex, 27791, "range types") }
   // Base (primitive) types.
 | CREATE TYPE type_name '(' error         { return unimplementedWithIssueDetail(sqllex, 27793, "base") }
   // Shell types, gateway to define base types using the previous syntax.

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -36,7 +36,9 @@ var requireConstMsg = map[string]bool{
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire.newAdminShutdownErr": true,
 
-	"(*github.com/cockroachdb/cockroach/pkg/parser/lexer).Error": true,
+	"(*github.com/cockroachdb/cockroach/pkg/parser/lexer).Error":                        true,
+	"(*github.com/cockroachdb/cockroach/pkg/parser/lexer).Unimplemented":                true,
+	"(*github.com/cockroachdb/cockroach/pkg/parser/lexer).UnimplementedWithIssueDetail": true,
 
 	"github.com/cockroachdb/cockroach/pkg/util/log.Shout":     true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Info":      true,


### PR DESCRIPTION
Before this patch, error messages for unimplemented features detected by
the parser looked like:
reate type t as enum('a');
invalid syntax: statement ignored: at or near "a": syntax error: unimplemented: this syntax

after this patch, they spell out the missing feature:
invalid syntax: statement ignored: at or near "a": syntax error: unimplemented: enum types

The information about the feature is already present when creating the
error and was used as a "detail" for telemetry. Now I've made it part of
the error message too.

Release note (sql change): Error messages for unimplemented features
have been improved to spell out what the unimplemented feature is.