### PR TITLE
sql,stats: only sample columns needed for histogram creation

### DIFF
--- a/pkg/sql/execinfrapb/processors_table_stats.pb.go
+++ b/pkg/sql/execinfrapb/processors_table_stats.pb.go
@@ -63,7 +63,7 @@ func (x *SketchType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SketchType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_2fd407c3f73f9e1f, []int{0}
+	return fileDescriptor_processors_table_stats_99f3061131dbffaf, []int{0}
 }
 
 // SketchSpec contains the specification for a generated statistic.
@@ -73,7 +73,6 @@ type SketchSpec struct {
 	// TODO(radu): currently only one column is supported.
 	Columns []uint32 `protobuf:"varint,2,rep,name=columns" json:"columns,omitempty"`
 	// If set, we generate a histogram for the first column in the sketch.
-	// Only used by the SampleAggregator.
 	GenerateHistogram bool `protobuf:"varint,3,opt,name=generate_histogram,json=generateHistogram" json:"generate_histogram"`
 	// Controls the maximum number of buckets in the histogram.
 	// Only used by the SampleAggregator.
@@ -86,7 +85,7 @@ func (m *SketchSpec) Reset()         { *m = SketchSpec{} }
 func (m *SketchSpec) String() string { return proto.CompactTextString(m) }
 func (*SketchSpec) ProtoMessage()    {}
 func (*SketchSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_2fd407c3f73f9e1f, []int{0}
+	return fileDescriptor_processors_table_stats_99f3061131dbffaf, []int{0}
 }
 func (m *SketchSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -129,7 +128,8 @@ var xxx_messageInfo_SketchSpec proto.InternalMessageInfo
 // groups:
 //   1. sampled row columns:
 //       - columns that map 1-1 to the columns in the input (same
-//         schema as the input).
+//         schema as the input). Note that columns unused in a histogram are
+//         set to NULL.
 //       - an INT column with the "rank" of the row; this is a random value
 //         associated with the row (necessary for combining sample sets).
 //   2. sketch columns:
@@ -160,7 +160,7 @@ func (m *SamplerSpec) Reset()         { *m = SamplerSpec{} }
 func (m *SamplerSpec) String() string { return proto.CompactTextString(m) }
 func (*SamplerSpec) ProtoMessage()    {}
 func (*SamplerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_2fd407c3f73f9e1f, []int{1}
+	return fileDescriptor_processors_table_stats_99f3061131dbffaf, []int{1}
 }
 func (m *SamplerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -221,7 +221,7 @@ func (m *SampleAggregatorSpec) Reset()         { *m = SampleAggregatorSpec{} }
 func (m *SampleAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*SampleAggregatorSpec) ProtoMessage()    {}
 func (*SampleAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_2fd407c3f73f9e1f, []int{2}
+	return fileDescriptor_processors_table_stats_99f3061131dbffaf, []int{2}
 }
 func (m *SampleAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1120,10 +1120,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_2fd407c3f73f9e1f)
+	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_99f3061131dbffaf)
 }
 
-var fileDescriptor_processors_table_stats_2fd407c3f73f9e1f = []byte{
+var fileDescriptor_processors_table_stats_99f3061131dbffaf = []byte{
 	// 619 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0x4f, 0x6f, 0xd3, 0x4e,
 	0x10, 0xcd, 0x36, 0x49, 0x93, 0x6e, 0x7e, 0xf9, 0x91, 0x9a, 0x22, 0x59, 0x15, 0x72, 0x4c, 0x54,

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -38,8 +38,8 @@ message SketchSpec {
   repeated uint32 columns = 2;
 
   // If set, we generate a histogram for the first column in the sketch.
-  // Only used by the SampleAggregator.
   optional bool generate_histogram = 3 [(gogoproto.nullable) = false];
+
   // Controls the maximum number of buckets in the histogram.
   // Only used by the SampleAggregator.
   optional uint32 histogram_max_buckets = 4 [(gogoproto.nullable) = false];
@@ -66,7 +66,8 @@ message SketchSpec {
 // groups:
 //   1. sampled row columns:
 //       - columns that map 1-1 to the columns in the input (same
-//         schema as the input).
+//         schema as the input). Note that columns unused in a histogram are
+//         set to NULL.
 //       - an INT column with the "rank" of the row; this is a random value
 //         associated with the row (necessary for combining sample sets).
 //   2. sketch columns:

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -109,6 +109,7 @@ func newSampleAggregator(
 		sketchCol:    rankCol + 4,
 	}
 
+	var sampleCols util.FastIntSet
 	for i := range spec.Sketches {
 		s.sketches[i] = sketchInfo{
 			spec:     spec.Sketches[i],
@@ -116,9 +117,12 @@ func newSampleAggregator(
 			numNulls: 0,
 			numRows:  0,
 		}
+		if spec.Sketches[i].GenerateHistogram {
+			sampleCols.Add(int(spec.Sketches[i].Columns[0]))
+		}
 	}
 
-	s.sr.Init(int(spec.SampleSize), input.OutputTypes()[:rankCol], &s.memAcc)
+	s.sr.Init(int(spec.SampleSize), input.OutputTypes()[:rankCol], &s.memAcc, sampleCols)
 
 	if err := s.Init(
 		nil, post, []types.T{}, flowCtx, processorID, output, memMonitor,

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -116,6 +117,8 @@ func newSamplerProcessor(
 		sketches:        make([]sketchInfo, len(spec.Sketches)),
 		maxFractionIdle: spec.MaxFractionIdle,
 	}
+
+	var sampleCols util.FastIntSet
 	for i := range spec.Sketches {
 		s.sketches[i] = sketchInfo{
 			spec:     spec.Sketches[i],
@@ -123,9 +126,12 @@ func newSamplerProcessor(
 			numNulls: 0,
 			numRows:  0,
 		}
+		if spec.Sketches[i].GenerateHistogram {
+			sampleCols.Add(int(spec.Sketches[i].Columns[0]))
+		}
 	}
 
-	s.sr.Init(int(spec.SampleSize), input.OutputTypes(), &s.memAcc)
+	s.sr.Init(int(spec.SampleSize), input.OutputTypes(), &s.memAcc, sampleCols)
 
 	inTypes := input.OutputTypes()
 	outTypes := make([]types.T, 0, len(inTypes)+5)

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -29,7 +30,7 @@ import (
 func runSampleTest(t *testing.T, evalCtx *tree.EvalContext, numSamples int, ranks []int) {
 	ctx := context.Background()
 	var sr SampleReservoir
-	sr.Init(numSamples, []types.T{*types.Int}, nil /* memAcc */)
+	sr.Init(numSamples, []types.T{*types.Int}, nil /* memAcc */, util.MakeFastIntSet(0))
 	for _, r := range ranks {
 		d := sqlbase.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(r)))
 		if err := sr.SampleRow(ctx, evalCtx, sqlbase.EncDatumRow{d}, uint64(r)); err != nil {


### PR DESCRIPTION
Previously, the `SampleReservoir` used by the `sampler` and `sampleAggregator`
processors would include every column in each sampled row, even if that
column was not needed for histogram creation. This commit changes the
behavior so that only columns needed for histogram creation are stored
in the `SampleReservoir`. This change will hopefully reduce the memory overhead
of histogram collection and reduce the likelihood of out-of-memory errors.

Informs #42331

Release note (bug fix): Reduced the likelihood of out-of-memory errors during
histogram collection.