### PR TITLE
Makefile: make bin/prereqs depend on submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1646,7 +1646,7 @@ $(testbins): bin/%: bin/%.d | bin/prereqs $(SUBMODULES_TARGET)
 	mv -f $@.d.tmp $@.d
 	$(xgo) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o $@ $($*-package)
 
-bin/prereqs: ./pkg/cmd/prereqs/*.go
+bin/prereqs: ./pkg/cmd/prereqs/*.go | bin/.submodules-initialized
 	@echo go install -v ./pkg/cmd/prereqs
 	@$(GO_INSTALL) -v ./pkg/cmd/prereqs
 


### PR DESCRIPTION
Fixes #42359.

The build of the `prereqs` tool uses some vendored packages
e.g. `github.com/pkg/errors`.

Prior to this commit, `prereqs` did not have a dependency on
`.submodules-initialized` so in very rare cases, running `make build
-j` just after a fresh checkout would prevent `prereqs` from building.

This commit fixes this gap by adding the missing dependency.

Release note (bug fix): Fixed a Makefile bug that would prevent
building CockroachDB from sources in rare circumstances.