### PR TITLE
storage/engine: separate ExporToSst's MVCCKey into roachpb.Key and hl…

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -115,9 +115,6 @@ func evalExport(
 		return result.Result{}, errors.Errorf("unknown MVCC filter: %s", args.MVCCFilter)
 	}
 
-	start := engine.MVCCKey{Key: args.Key, Timestamp: args.StartTime}
-	end := engine.MVCCKey{Key: args.EndKey, Timestamp: h.Timestamp}
-
 	io := engine.IterOptions{
 		UpperBound: args.EndKey,
 	}
@@ -134,7 +131,7 @@ func evalExport(
 
 	e := spanset.GetDBEngine(batch, roachpb.Span{Key: args.Key, EndKey: args.EndKey})
 
-	data, summary, err := e.ExportToSst(start, end, exportAllRevisions, io)
+	data, summary, err := e.ExportToSst(args.Key, args.EndKey, args.StartTime, h.Timestamp, exportAllRevisions, io)
 
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -321,8 +321,6 @@ func assertEqualKVs(
 		}
 
 		// Run new C++ implementation of IncrementalIterator.
-		start := engine.MVCCKey{Key: startKey, Timestamp: startTime}
-		end := engine.MVCCKey{Key: endKey, Timestamp: endTime}
 		io := engine.IterOptions{
 			UpperBound: endKey,
 		}
@@ -330,7 +328,7 @@ func assertEqualKVs(
 			io.MaxTimestampHint = endTime
 			io.MinTimestampHint = startTime.Next()
 		}
-		sst, _, err := e.ExportToSst(start, end, exportAllRevisions, io)
+		sst, _, err := e.ExportToSst(startKey, endKey, startTime, endTime, exportAllRevisions, io)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -191,17 +191,14 @@ type Reader interface {
 	// that they are not using a closed engine. Intended for use within package
 	// engine; exported to enable wrappers to exist in other packages.
 	Closed() bool
-	// ExportToSst exports changes to the keyrange [start.Key, end.Key) over the
-	// interval (start.Timestamp, end.Timestamp]. Passing exportAllRevisions exports
+	// ExportToSst exports changes to the keyrange [startKey, endKey) over the
+	// interval (startTS, endTS]. Passing exportAllRevisions exports
 	// every revision of a key for the interval, otherwise only the latest value
 	// within the interval is exported. Deletions are included if all revisions are
 	// requested or if the start.Timestamp is non-zero. Returns the bytes of an
 	// SSTable containing the exported keys, the size of exported data, or an error.
-	//
-	// TODO(hueypark): Separate MVCCKey into roachpb.Key and hlc.Timestamp.
-	// (https://github.com/cockroachdb/cockroach/pull/42134#pullrequestreview-311850163)
 	ExportToSst(
-		start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp, exportAllRevisions bool, io IterOptions,
 	) ([]byte, roachpb.BulkOpSummary, error)
 	// Get returns the value for the given key, nil otherwise.
 	//

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -90,7 +90,10 @@ func (p *pebbleBatch) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (p *pebbleBatch) ExportToSst(
-	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
 	panic("unimplemented")
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -777,8 +777,14 @@ func (r *RocksDB) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (r *RocksDB) ExportToSst(
-	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
+	start := MVCCKey{Key: startKey, Timestamp: startTS}
+	end := MVCCKey{Key: endKey, Timestamp: endTS}
+
 	var data C.DBString
 	var intentErr C.DBString
 	var bulkopSummary C.DBString
@@ -994,9 +1000,12 @@ func (r *rocksDBReadOnly) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (r *rocksDBReadOnly) ExportToSst(
-	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
-	return r.parent.ExportToSst(start, end, exportAllRevisions, io)
+	return r.parent.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, io)
 }
 
 func (r *rocksDBReadOnly) Get(key MVCCKey) ([]byte, error) {
@@ -1305,9 +1314,12 @@ func (r *rocksDBSnapshot) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (r *rocksDBSnapshot) ExportToSst(
-	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
-	return r.parent.ExportToSst(start, end, exportAllRevisions, io)
+	return r.parent.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, io)
 }
 
 // Get returns the value for the given key, nil otherwise using
@@ -1707,7 +1719,10 @@ func (r *rocksDBBatch) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (r *rocksDBBatch) ExportToSst(
-	start, end MVCCKey, exportAllRevisions bool, io IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
 	panic("unimplemented")
 }

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -271,9 +271,12 @@ func (s spanSetReader) Closed() bool {
 
 // ExportToSst is part of the engine.Reader interface.
 func (s spanSetReader) ExportToSst(
-	start, end engine.MVCCKey, exportAllRevisions bool, io engine.IterOptions,
+	startKey, endKey roachpb.Key,
+	startTS, endTS hlc.Timestamp,
+	exportAllRevisions bool,
+	io engine.IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
-	return s.r.ExportToSst(start, end, exportAllRevisions, io)
+	return s.r.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, io)
 }
 
 func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {


### PR DESCRIPTION
…c.Timestamp

`roachpb.Key` and `hlc.Timestamp` are not directly related, but were merged into `MVCCKey`. To eliminate the confusion caused by this, separate the two.

Release note: None