### PR TITLE
storage: remove the replica up to date check when transfering lease

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -44,6 +44,18 @@ import (
 	"go.etcd.io/etcd/raft"
 )
 
+func (s *Store) Transport() *RaftTransport {
+	return s.cfg.Transport
+}
+
+func (s *Store) FindTargetAndTransferLease(
+	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, zone *config.ZoneConfig,
+) (bool, error) {
+	return s.replicateQueue.findTargetAndTransferLease(
+		ctx, repl, desc, zone, transferLeaseOptions{},
+	)
+}
+
 // AddReplica adds the replica to the store's replica map and to the sorted
 // replicasByKey slice. To be used only by unittests.
 func (s *Store) AddReplica(repl *Replica) error {

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -934,11 +934,10 @@ func (rq *replicateQueue) findTargetAndTransferLease(
 ) (bool, error) {
 	// Learner replicas aren't allowed to become the leaseholder or raft leader,
 	// so only consider the `Voters` replicas.
-	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas().Voters())
 	target := rq.allocator.TransferLeaseTarget(
 		ctx,
 		zone,
-		candidates,
+		desc.Replicas().Voters(),
 		repl.store.StoreID(),
 		desc.RangeID,
 		repl.leaseholderStats,


### PR DESCRIPTION
Previously, we had a check that filtered out all replicas that
are lagging behind the leader in case of a lease transfer.

We remove that check so in case of lease preference for 
a node that is constantly lagging - the lease transfer can occur without delay.

This removes the check that the candidates for lease transfer are only
replicas that aren't lagging behind. etcd implements the
3.10 Leadership transfer extension where the old leader will
bring up to date the new leader's log while blocking any new requests.

Release note (bug fix): now possible to transfer range leases to lagging replicas