### PR TITLE
roachtest: add upgrade/foreign-key test

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -67,6 +67,7 @@ func registerTests(r *testRegistry) {
 	registerSchemaChangeIndexTPCC100(r)
 	registerSchemaChangeIndexTPCC1000(r)
 	registerMixedSchemaChangesTPCC1000(r)
+	registerForeignKeyUpgrade(r)
 	registerSchemaChangeInvertedIndex(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -120,7 +120,9 @@ func setupTPCC(
 				c.Put(ctx, binary, "./cockroach", c.Node(i+1))
 			}
 		}
-		c.Put(ctx, cockroach, "./cockroach", regularNodes...)
+		if len(regularNodes) > 0 {
+			c.Put(ctx, cockroach, "./cockroach", regularNodes...)
+		}
 	}
 
 	// Fixture import needs ./cockroach workload on workloadNode.


### PR DESCRIPTION
**roachtest: add upgrade/foreign-key test**

This PR adds a test that performs a rolling upgrade of a cluster from the
previous version to the current version, and adds and drops a foreign key at
every step of the rolling upgrade, concurrently with the TPCC load generator
running. It's primarily intended to test the forward- and
backward-compatibility of the changes to the foreign key representation on
table descriptors in 19.2 and 20.1.

Release note: None

----

**roachtest: fix CLI argument when staging binaries for tpcc**

When handling the list of versions for cockroach binaries passed to
`setupTPCC()`, we were accumulating a slice of nodes on which to put the
default binary. If this list was empty (i.e., every node gets a version other
than the default), we'd pass no nodes to `roachprod put`, which means "all
nodes." This commit fixes that. It doesn't affect any existing tests.

Release note: None