### PR TITLE
roachtest: fix SQL syntax in schemachange test

### DIFF
--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -424,10 +424,10 @@ func makeMixedSchemaChanges(spec clusterSpec, warehouses int, length time.Durati
 						}
 					} else {
 						if err := runAndLogStmts(ctx, t, c, "mixed-schema-changes-19.1", []string{
-							`CREATE TABLE tpcc.orderpks (o_w_id, o_d_id, o_id, PRIMARY KEY(o_w_id, o_d_id, o_id));`,
+							`CREATE TABLE tpcc.orderpks (o_w_id INT, o_d_id INT, o_id INT, PRIMARY KEY(o_w_id, o_d_id, o_id));`,
 							// We can't populate the table with CREATE TABLE AS, so just
-							// insert the rows. AOST is used to reduce contention.
-							`INSERT INTO tpcc.orderpks SELECT o_w_id, o_d_id, o_id FROM tpcc.order AS OF SYSTEM TIME '-1s';`,
+							// insert the rows. The limit exists to reduce contention.
+							`INSERT INTO tpcc.orderpks SELECT o_w_id, o_d_id, o_id FROM tpcc.order LIMIT 10000;`,
 						}); err != nil {
 							return err
 						}


### PR DESCRIPTION
This test had a SQL syntax error (previously not caught while testing the test
because the error is specific to 19.1, and I thought I was testing on 19.1 when
I wasn't.) This PR fixes it.

Release note: None