### PR TITLE
storage/engine: rename Iterator.{Seek,SeekReverse} to {SeekGE,SeekLT}

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -675,6 +675,12 @@ DBIterState DBIterSeek(DBIterator* iter, DBKey key) {
   return DBIterGetState(iter);
 }
 
+DBIterState DBIterSeekForPrev(DBIterator* iter, DBKey key) {
+  ScopedStats stats(iter);
+  iter->rep->SeekForPrev(EncodeKey(key));
+  return DBIterGetState(iter);
+}
+
 DBIterState DBIterSeekToFirst(DBIterator* iter) {
   ScopedStats stats(iter);
   iter->rep->SeekToFirst();

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -225,6 +225,9 @@ void DBIterDestroy(DBIterator* iter);
 // Positions the iterator at the first key that is >= "key".
 DBIterState DBIterSeek(DBIterator* iter, DBKey key);
 
+// Positions the iterator at the first key that is <= "key".
+DBIterState DBIterSeekForPrev(DBIterator* iter, DBKey key);
+
 typedef struct {
   uint64_t internal_delete_skipped_count;
   // the number of SSTables touched (only for time bound iterators).

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -532,7 +532,7 @@ func (p *poller) slurpSST(ctx context.Context, sst []byte, schemaTimestamp hlc.T
 		return err
 	}
 	defer it.Close()
-	for it.Seek(engine.NilKey); ; it.Next() {
+	for it.SeekGE(engine.NilKey); ; it.Next() {
 		if ok, err := it.Valid(); err != nil {
 			return err
 		} else if !ok {

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -254,7 +254,7 @@ func fetchTableDescriptorVersions(
 				return err
 			}
 			defer it.Close()
-			for it.Seek(engine.NilKey); ; it.Next() {
+			for it.SeekGE(engine.NilKey); ; it.Next() {
 				if ok, err := it.Valid(); err != nil {
 					return err
 				} else if !ok {

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -149,7 +149,7 @@ func runIterate(
 		endTime := hlc.Timestamp{WallTime: int64(loadFactor * numBatches * batchTimeSpan)}
 		it := makeIterator(eng, startTime, endTime)
 		defer it.Close()
-		for it.Seek(engine.MVCCKey{}); ; it.Next() {
+		for it.SeekGE(engine.MVCCKey{}); ; it.Next() {
 			if ok, err := it.Valid(); !ok {
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -236,7 +236,7 @@ func exportUsingGoIterator(
 		EndTime:     endTime,
 	})
 	defer iter.Close()
-	for iter.Seek(engine.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
+	for iter.SeekGE(engine.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 		ok, err := iter.Valid()
 		if err != nil {
 			// The error may be a WriteIntentError. In which case, returning it will

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -202,7 +202,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	defer iter.Close()
 	var keyScratch, valueScratch []byte
 
-	for iter.Seek(startKeyMVCC); ; {
+	for iter.SeekGE(startKeyMVCC); ; {
 		ok, err := iter.Valid()
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -103,7 +103,7 @@ func slurpSSTablesLatestKey(
 	var kvs []engine.MVCCKeyValue
 	it := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
-	for it.Seek(start); ; it.NextKey() {
+	for it.SeekGE(start); ; it.NextKey() {
 		if ok, err := it.Valid(); err != nil {
 			t.Fatal(err)
 		} else if !ok || !it.UnsafeKey().Less(end) {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -98,7 +98,7 @@ func clearExistingData(
 	iter := batch.NewIterator(engine.IterOptions{UpperBound: end})
 	defer iter.Close()
 
-	iter.Seek(engine.MakeMVCCMetadataKey(start))
+	iter.SeekGE(engine.MakeMVCCMetadataKey(start))
 	if ok, err := iter.Valid(); err != nil {
 		return enginepb.MVCCStats{}, err
 	} else if ok && !iter.UnsafeKey().Less(engine.MakeMVCCMetadataKey(end)) {

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -130,7 +130,7 @@ func (b *Backup) NextKeyValues(
 
 		it := sst.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
-		it.Seek(engine.MVCCKey{Key: file.Span.Key})
+		it.SeekGE(engine.MVCCKey{Key: file.Span.Key})
 
 		iterIdx := 0
 		for ; ; it.Next() {

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -43,7 +43,7 @@ func slurpUserDataKVs(t testing.TB, e engine.Engine) []roachpb.KeyValue {
 		kvs = nil
 		it := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
-		for it.Seek(engine.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
+		for it.SeekGE(engine.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
 			ok, err := it.Valid()
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -336,7 +336,7 @@ func (d *DiskRowContainer) NewFinalIterator(ctx context.Context) RowIterator {
 }
 
 func (r *diskRowFinalIterator) Rewind() {
-	r.Seek(r.diskRowIterator.rowContainer.lastReadKey)
+	r.SeekGE(r.diskRowIterator.rowContainer.lastReadKey)
 	if r.diskRowIterator.rowContainer.lastReadKey != nil {
 		r.Next()
 	}

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -575,7 +575,7 @@ func (h *HashDiskRowContainer) NewBucketIterator(
 
 // Rewind implements the RowIterator interface.
 func (i *hashDiskRowBucketIterator) Rewind() {
-	i.Seek(i.encodedEqCols)
+	i.SeekGE(i.encodedEqCols)
 }
 
 // Valid implements the RowIterator interface.
@@ -1034,7 +1034,7 @@ func (h *HashDiskBackedRowContainer) recreateAllRowsIterators(ctx context.Contex
 			return errors.Errorf("the iterator is unexpectedly not hashMemRowIterator")
 		}
 		newIterator := h.NewUnmarkedIterator(ctx)
-		newIterator.(*diskRowIterator).Seek(oldIterator.curKey)
+		newIterator.(*diskRowIterator).SeekGE(oldIterator.curKey)
 		(*iterator).RowIterator.Close()
 		iterator.RowIterator = newIterator
 	}

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -65,7 +65,7 @@ func EvalAddSSTable(
 	defer dataIter.Close()
 
 	// Check that the first key is in the expected range.
-	dataIter.Seek(engine.MVCCKey{Key: keys.MinKey})
+	dataIter.SeekGE(engine.MVCCKey{Key: keys.MinKey})
 	ok, err := dataIter.Valid()
 	if err != nil {
 		return result.Result{}, err
@@ -107,7 +107,7 @@ func EvalAddSSTable(
 		stats = computed
 	}
 
-	dataIter.Seek(mvccEndKey)
+	dataIter.SeekGE(mvccEndKey)
 	ok, err = dataIter.Valid()
 	if err != nil {
 		return result.Result{}, err
@@ -181,7 +181,7 @@ func EvalAddSSTable(
 
 	if args.IngestAsWrites {
 		log.VEventf(ctx, 2, "ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(args.Data))
-		dataIter.Seek(engine.MVCCKey{Key: keys.MinKey})
+		dataIter.SeekGE(engine.MVCCKey{Key: keys.MinKey})
 		for {
 			ok, err := dataIter.Valid()
 			if err != nil {
@@ -227,7 +227,7 @@ func checkForKeyCollisions(
 	// Create iterator over the existing data.
 	existingDataIter := dbEngine.NewIterator(engine.IterOptions{UpperBound: mvccEndKey.Key})
 	defer existingDataIter.Close()
-	existingDataIter.Seek(mvccStartKey)
+	existingDataIter.SeekGE(mvccStartKey)
 	if ok, err := existingDataIter.Valid(); err != nil {
 		return emptyMVCCStats, errors.Wrap(err, "checking for key collisions")
 	} else if !ok {

--- a/pkg/storage/batcheval/cmd_revert_range.go
+++ b/pkg/storage/batcheval/cmd_revert_range.go
@@ -50,7 +50,7 @@ func isEmptyKeyTimeRange(
 		MinTimestampHint: since.Next() /* make exclusive */, MaxTimestampHint: until,
 	})
 	defer iter.Close()
-	iter.Seek(engine.MVCCKey{Key: from})
+	iter.SeekGE(engine.MVCCKey{Key: from})
 	ok, err := iter.Valid()
 	return !ok, err
 }

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -478,7 +478,7 @@ func createSplitSSTable(
 	var first, last roachpb.Key
 	var left, right *sstSpan
 
-	iter.Seek(engine.MVCCKey{Key: start})
+	iter.SeekGE(engine.MVCCKey{Key: start})
 	for {
 		if ok, err := iter.Valid(); err != nil {
 			return nil, nil, err

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -391,7 +391,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	iter := store.Engine().NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 
 	defer iter.Close()
-	for iter.Seek(start); ; iter.Next() {
+	for iter.SeekGE(start); ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			t.Fatal(err)
 		} else if !ok || !iter.UnsafeKey().Less(end) {

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -309,7 +309,7 @@ func (c *Compactor) fetchSuggestions(
 			}
 
 			dataIter.SetUpperBound(sc.EndKey)
-			dataIter.Seek(engine.MakeMVCCMetadataKey(sc.StartKey))
+			dataIter.SeekGE(engine.MakeMVCCMetadataKey(sc.StartKey))
 			if ok, err := dataIter.Valid(); err != nil {
 				return false, err
 			} else if ok && dataIter.UnsafeKey().Less(engine.MakeMVCCMetadataKey(sc.EndKey)) {

--- a/pkg/storage/diskmap/disk_map.go
+++ b/pkg/storage/diskmap/disk_map.go
@@ -37,9 +37,9 @@ type Factory interface {
 //		// Do something.
 // 	}
 type SortedDiskMapIterator interface {
-	// Seek sets the iterator's position to the first key greater than or equal
+	// SeekGE sets the iterator's position to the first key greater than or equal
 	// to the provided key.
-	Seek(key []byte)
+	SeekGE(key []byte)
 	// Rewind seeks to the start key.
 	Rewind()
 	// Valid must be called after any call to Seek(), Rewind(), or Next(). It

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -684,7 +684,7 @@ func runClearRange(
 	// first key and simply ClearRange(NilKey, MVCCKeyMax).
 	iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
-	iter.Seek(NilKey)
+	iter.SeekGE(NilKey)
 	if ok, err := iter.Valid(); !ok {
 		b.Fatalf("unable to find first key (err: %v)", err)
 	}

--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -43,7 +43,7 @@ type rocksDBMapBatchWriter struct {
 type rocksDBMapIterator struct {
 	iter Iterator
 	// makeKey is a function that transforms a key into an MVCCKey with a prefix
-	// used to Seek() the underlying iterator.
+	// used to SeekGE() the underlying iterator.
 	makeKey func(k []byte) MVCCKey
 	// prefix is the prefix of keys that this iterator iterates over.
 	prefix []byte
@@ -166,14 +166,14 @@ func (r *rocksDBMap) Close(ctx context.Context) {
 	}
 }
 
-// Seek implements the SortedDiskMapIterator interface.
-func (i *rocksDBMapIterator) Seek(k []byte) {
-	i.iter.Seek(i.makeKey(k))
+// SeekGE implements the SortedDiskMapIterator interface.
+func (i *rocksDBMapIterator) SeekGE(k []byte) {
+	i.iter.SeekGE(i.makeKey(k))
 }
 
 // Rewind implements the SortedDiskMapIterator interface.
 func (i *rocksDBMapIterator) Rewind() {
-	i.iter.Seek(i.makeKey(nil))
+	i.iter.SeekGE(i.makeKey(nil))
 }
 
 // Valid implements the SortedDiskMapIterator interface.
@@ -266,7 +266,7 @@ type pebbleMapIterator struct {
 	allowDuplicates bool
 	iter            *pebble.Iterator
 	// makeKey is a function that transforms a key into a byte slice with a prefix
-	// used to Seek() the underlying iterator.
+	// used to SeekGE() the underlying iterator.
 	makeKey func(k []byte) []byte
 	// prefix is the prefix of keys that this iterator iterates over.
 	prefix []byte
@@ -376,8 +376,8 @@ func (r *pebbleMap) Close(ctx context.Context) {
 	}
 }
 
-// Seek implements the SortedDiskMapIterator interface.
-func (i *pebbleMapIterator) Seek(k []byte) {
+// SeekGE implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) SeekGE(k []byte) {
 	i.iter.SeekGE(i.makeKey(k))
 }
 

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -53,7 +53,7 @@ func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine
 				iter := e.db.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
 
-				for iter.Seek(NilKey); ; iter.Next() {
+				for iter.SeekGE(NilKey); ; iter.Next() {
 					valid, err := iter.Valid()
 					if valid && err == nil {
 						keyCount++
@@ -166,7 +166,7 @@ func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine
 					if len(parts) != 2 {
 						return fmt.Sprintf("seek <key>\n")
 					}
-					iter.Seek([]byte(strings.TrimSpace(parts[1])))
+					iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 				default:
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -41,9 +41,9 @@ func init() {
 type SimpleIterator interface {
 	// Close frees up resources held by the iterator.
 	Close()
-	// Seek advances the iterator to the first key in the engine which
+	// SeekGE advances the iterator to the first key in the engine which
 	// is >= the provided key.
-	Seek(key MVCCKey)
+	SeekGE(key MVCCKey)
 	// Valid must be called after any call to Seek(), Next(), Prev(), or
 	// similar methods. It returns (true, nil) if the iterator points to
 	// a valid key (it is undefined to call Key(), Value(), or similar
@@ -81,9 +81,9 @@ type IteratorStats struct {
 type Iterator interface {
 	SimpleIterator
 
-	// SeekReverse advances the iterator to the first key in the engine which
-	// is <= the provided key.
-	SeekReverse(key MVCCKey)
+	// SeekLT advances the iterator to the first key in the engine which
+	// is < the provided key.
+	SeekLT(key MVCCKey)
 	// Prev moves the iterator backward to the previous key/value
 	// in the iteration. After this call, Valid() will be true if the
 	// iterator was not positioned at the first key.
@@ -617,7 +617,7 @@ func ClearRangeWithHeuristic(eng Reader, writer Writer, start, end roachpb.Key) 
 	// TODO(bdarnell): Move this into ClearIterRange so we don't have
 	// to do this scan twice.
 	count := 0
-	iter.Seek(MakeMVCCMetadataKey(start))
+	iter.SeekGE(MakeMVCCMetadataKey(start))
 	for {
 		valid, err := iter.Valid()
 		if err != nil {
@@ -727,7 +727,7 @@ func iterateOnReader(
 	it := reader.NewIterator(IterOptions{UpperBound: end})
 	defer it.Close()
 
-	it.Seek(MakeMVCCMetadataKey(start))
+	it.SeekGE(MakeMVCCMetadataKey(start))
 	for ; ; it.Next() {
 		ok, err := it.Valid()
 		if err != nil {

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -140,14 +140,14 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				iter.Seek(key)
+				iter.SeekGE(key)
 
 				if err := batch.Clear(key); err != nil {
 					t.Fatal(err)
 				}
 
 				// Iterator should not reuse its cached result.
-				iter.Seek(key)
+				iter.SeekGE(key)
 
 				if ok, err := iter.Valid(); err != nil {
 					t.Fatal(err)
@@ -305,7 +305,7 @@ func TestEngineBatch(t *testing.T) {
 				}
 				// Try using an iterator to get the value from the batch.
 				iter := b.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-				iter.Seek(key)
+				iter.SeekGE(key)
 				if ok, err := iter.Valid(); !ok {
 					if currentBatch[len(currentBatch)-1].value != nil {
 						t.Errorf("%d: batch seek invalid, err=%v", i, err)
@@ -520,7 +520,7 @@ func TestEngineTimeBound(t *testing.T) {
 
 			check := func(t *testing.T, tbi Iterator, keys, ssts int) {
 				defer tbi.Close()
-				tbi.Seek(NilKey)
+				tbi.SeekGE(NilKey)
 
 				var count int
 				for ; ; tbi.Next() {
@@ -627,7 +627,7 @@ func TestEngineTimeBound(t *testing.T) {
 			// time bounded iterator instead.
 			iter := batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
-			iter.Seek(NilKey)
+			iter.SeekGE(NilKey)
 
 			var count int
 			for ; ; iter.Next() {
@@ -998,7 +998,7 @@ func TestSnapshotMethods(t *testing.T) {
 
 			// Verify NewIterator still iterates over original snapshot.
 			iter := snap.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-			iter.Seek(newKey)
+			iter.SeekGE(newKey)
 			if ok, err := iter.Valid(); err != nil {
 				t.Fatal(err)
 			} else if ok {

--- a/pkg/storage/engine/multi_iterator.go
+++ b/pkg/storage/engine/multi_iterator.go
@@ -57,11 +57,11 @@ func (f *multiIterator) Close() {
 	// No-op, multiIterator doesn't close the underlying iterators.
 }
 
-// Seek advances the iterator to the first key in the engine which is >= the
+// SeekGE advances the iterator to the first key in the engine which is >= the
 // provided key.
-func (f *multiIterator) Seek(key MVCCKey) {
+func (f *multiIterator) SeekGE(key MVCCKey) {
 	for _, iter := range f.iters {
-		iter.Seek(key)
+		iter.SeekGE(key)
 	}
 	// Each of the iterators now points at the first key >= key. Set currentIdx
 	// and itersWithCurrentKey but don't advance any of the underlying

--- a/pkg/storage/engine/multi_iterator_test.go
+++ b/pkg/storage/engine/multi_iterator_test.go
@@ -118,7 +118,7 @@ func TestMultiIterator(t *testing.T) {
 				t.Run(subtest.name, func(t *testing.T) {
 					var output bytes.Buffer
 					it := MakeMultiIterator(iters)
-					for it.Seek(MVCCKey{Key: keys.MinKey}); ; subtest.fn(it) {
+					for it.SeekGE(MVCCKey{Key: keys.MinKey}); ; subtest.fn(it) {
 						ok, err := it.Valid()
 						if err != nil {
 							t.Fatalf("unexpected error: %+v", err)

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -783,7 +783,7 @@ func mvccGetMetadata(
 	if iter == nil {
 		return false, 0, 0, nil
 	}
-	iter.Seek(metaKey)
+	iter.SeekGE(metaKey)
 	if ok, err := iter.Valid(); !ok {
 		return false, 0, 0, err
 	}
@@ -959,7 +959,7 @@ func mvccGetInternal(
 		return nil, ignoredIntent, safeValue, nil
 	}
 
-	iter.Seek(seekKey)
+	iter.SeekGE(seekKey)
 	if ok, err := iter.Valid(); err != nil {
 		return nil, nil, safeValue, err
 	} else if !ok {
@@ -2027,7 +2027,7 @@ func MVCCClearTimeRange(
 	var clearedMetaKey MVCCKey
 	var clearedMeta enginepb.MVCCMetadata
 	var restoredMeta enginepb.MVCCMetadata
-	for it.Seek(MVCCKey{Key: key}); ; it.Next() {
+	for it.SeekGE(MVCCKey{Key: key}); ; it.Next() {
 		ok, err := it.Valid()
 		if err != nil {
 			return nil, err
@@ -2441,7 +2441,7 @@ func MVCCResolveWriteIntentUsingIter(
 func unsafeNextVersion(iter Iterator, latestKey MVCCKey) (MVCCKey, []byte, bool, error) {
 	// Compute the next possible mvcc value for this key.
 	nextKey := latestKey.Next()
-	iter.Seek(nextKey)
+	iter.SeekGE(nextKey)
 
 	if ok, err := iter.Valid(); err != nil || !ok || !iter.UnsafeKey().Key.Equal(latestKey.Key) {
 		return MVCCKey{}, nil, false /* never ok */, err
@@ -2800,7 +2800,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 			return num, &roachpb.Span{Key: nextKey.Key, EndKey: encEndKey.Key}, nil
 		}
 
-		iterAndBuf.iter.Seek(nextKey)
+		iterAndBuf.iter.SeekGE(nextKey)
 		if ok, err := iterAndBuf.iter.Valid(); err != nil {
 			return 0, nil, err
 		} else if !ok || !iterAndBuf.iter.UnsafeKey().Less(encEndKey) {
@@ -3027,7 +3027,7 @@ func MVCCFindSplitKey(
 	// was dangerous because partitioning can split off ranges that do not start
 	// at valid row keys. The keys that are present in the range, by contrast, are
 	// necessarily valid row keys.
-	it.Seek(MakeMVCCMetadataKey(key.AsRawKey()))
+	it.SeekGE(MakeMVCCMetadataKey(key.AsRawKey()))
 	if ok, err := it.Valid(); err != nil {
 		return nil, err
 	} else if !ok {
@@ -3116,7 +3116,7 @@ func ComputeStatsGo(
 	var accrueGCAgeNanos int64
 	mvccEndKey := MakeMVCCMetadataKey(end)
 
-	iter.Seek(MakeMVCCMetadataKey(start))
+	iter.SeekGE(MakeMVCCMetadataKey(start))
 	for ; ; iter.Next() {
 		ok, err := iter.Valid()
 		if err != nil {
@@ -3354,7 +3354,7 @@ func checkForKeyCollisionsGo(
 	}
 
 	defer sstIter.Close()
-	sstIter.Seek(MakeMVCCMetadataKey(start))
+	sstIter.SeekGE(MakeMVCCMetadataKey(start))
 	if ok, err := sstIter.Valid(); err != nil || !ok {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "checking for key collisions")
 	}
@@ -3456,9 +3456,9 @@ func checkForKeyCollisionsGo(
 			err := &Error{msg: existingIter.Key().Key.String()}
 			return enginepb.MVCCStats{}, errors.Wrap(err, "ingested key collides with an existing one")
 		} else if bytesCompare < 0 {
-			existingIter.Seek(MVCCKey{Key: sstKey.Key})
+			existingIter.SeekGE(MVCCKey{Key: sstKey.Key})
 		} else {
-			sstIter.Seek(MVCCKey{Key: existingKey.Key})
+			sstIter.SeekGE(MVCCKey{Key: existingKey.Key})
 		}
 
 		ok, extErr = existingIter.Valid()

--- a/pkg/storage/engine/mvcc_incremental_iterator.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator.go
@@ -38,7 +38,7 @@ import (
 //        UpperBound: endKey,
 //    })
 //    defer iter.Close()
-//    for iter.Seek(startKey); ; iter.Next() {
+//    for iter.SeekGE(startKey); ; iter.Next() {
 //        ok, err := iter.Valid()
 //        if !ok { ... }
 //        [code using iter.Key() and iter.Value()]
@@ -105,10 +105,10 @@ func NewMVCCIncrementalIterator(
 	}
 }
 
-// Seek advances the iterator to the first key in the engine which is >= the
+// SeekGE advances the iterator to the first key in the engine which is >= the
 // provided key.
-func (i *MVCCIncrementalIterator) Seek(startKey MVCCKey) {
-	i.iter.Seek(startKey)
+func (i *MVCCIncrementalIterator) SeekGE(startKey MVCCKey) {
+	i.iter.SeekGE(startKey)
 	i.err = nil
 	i.valid = true
 	i.advance()
@@ -229,7 +229,7 @@ func (i *MVCCIncrementalIterator) sanityCheckMetadataKey() ([]byte, bool, error)
 		return i.iter.UnsafeValue(), true, nil
 	}
 	unsafeKey := i.iter.UnsafeKey()
-	i.sanityIter.Seek(unsafeKey)
+	i.sanityIter.SeekGE(unsafeKey)
 	if ok, err := i.sanityIter.Valid(); err != nil {
 		return nil, false, err
 	} else if !ok {

--- a/pkg/storage/engine/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator_test.go
@@ -43,7 +43,7 @@ func iterateExpectErr(
 			EndTime:   endTime,
 		})
 		defer iter.Close()
-		for iter.Seek(MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
+		for iter.SeekGE(MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 			if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
 				break
 			}
@@ -73,7 +73,7 @@ func assertEqualKVs(
 		})
 		defer iter.Close()
 		var kvs []MVCCKeyValue
-		for iter.Seek(MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
+		for iter.SeekGE(MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 			if ok, err := iter.Valid(); err != nil {
 				t.Fatalf("unexpected error: %+v", err)
 			} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
@@ -320,7 +320,7 @@ func slurpKVsInTimeRange(
 	})
 	defer iter.Close()
 	var kvs []MVCCKeyValue
-	for iter.Seek(MakeMVCCMetadataKey(prefix)); ; iter.Next() {
+	for iter.SeekGE(MakeMVCCMetadataKey(prefix)); ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			return nil, err
 		} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1761,7 +1761,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 					{
 						// Seek the iter to a valid position.
 						iter := batch.NewIterator(iterOptions)
-						iter.Seek(MakeMVCCMetadataKey(key))
+						iter.SeekGE(MakeMVCCMetadataKey(key))
 						iter.Close()
 					}
 

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -977,7 +977,7 @@ func pebbleExportToSst(
 			EndTime:     endTS,
 		})
 	defer iter.Close()
-	for iter.Seek(MakeMVCCMetadataKey(startKey)); ; {
+	for iter.SeekGE(MakeMVCCMetadataKey(startKey)); ; {
 		ok, err := iter.Valid()
 		if err != nil {
 			// The error may be a WriteIntentError. In which case, returning it will

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -264,7 +264,7 @@ func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) erro
 	// Furthermore, the start and end keys are always metadata keys (i.e.
 	// have zero timestamps), so we can ignore the bounds' MVCC timestamps.
 	iter.SetUpperBound(end)
-	iter.Seek(MakeMVCCMetadataKey(start))
+	iter.SeekGE(MakeMVCCMetadataKey(start))
 
 	for ; ; iter.Next() {
 		valid, err := iter.Valid()

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -52,8 +52,8 @@ func TestIterStats(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			// Seeking past the tombstone manually counts it.
 			for i := 0; i < 10; i++ {
-				iter.Seek(NilKey)
-				iter.Seek(MVCCKeyMax)
+				iter.SeekGE(NilKey)
+				iter.SeekGE(MVCCKeyMax)
 				stats := iter.Stats()
 				if e, a := i+1, stats.InternalDeleteSkippedCount; a != e {
 					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)

--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -78,8 +78,8 @@ func (r *sstIterator) Close() {
 	}
 }
 
-// Seek implements the SimpleIterator interface.
-func (r *sstIterator) Seek(key MVCCKey) {
+// SeekGE implements the SimpleIterator interface.
+func (r *sstIterator) SeekGE(key MVCCKey) {
 	if r.err != nil {
 		return
 	}

--- a/pkg/storage/engine/sst_iterator_test.go
+++ b/pkg/storage/engine/sst_iterator_test.go
@@ -28,7 +28,7 @@ func runTestSSTIterator(t *testing.T, iter SimpleIterator, allKVs []MVCCKeyValue
 	// Run the test multiple times to check re-Seeking.
 	for i := 0; i < 3; i++ {
 		var kvs []MVCCKeyValue
-		for iter.Seek(expected[0].Key); ; iter.Next() {
+		for iter.SeekGE(expected[0].Key); ; iter.Next() {
 			ok, err := iter.Valid()
 			if err != nil {
 				t.Fatalf("%+v", err)
@@ -54,7 +54,7 @@ func runTestSSTIterator(t *testing.T, iter SimpleIterator, allKVs []MVCCKeyValue
 		lastElemKey := expected[len(expected)-1].Key
 		seekTo := MVCCKey{Key: lastElemKey.Key.Next()}
 
-		iter.Seek(seekTo)
+		iter.SeekGE(seekTo)
 		if ok, err := iter.Valid(); err != nil {
 			t.Fatalf("%+v", err)
 		} else if ok {

--- a/pkg/storage/engine/sst_writer.go
+++ b/pkg/storage/engine/sst_writer.go
@@ -109,7 +109,7 @@ func (fw *SSTWriter) ClearIterRange(iter Iterator, start, end roachpb.Key) error
 	// ClearIterRange are with throwaway iterators, so there should be no new
 	// side effects.
 	iter.SetUpperBound(end)
-	iter.Seek(MakeMVCCMetadataKey(start))
+	iter.SeekGE(MakeMVCCMetadataKey(start))
 
 	valid, err := iter.Valid()
 	for valid && err == nil {

--- a/pkg/storage/engine/sst_writer_test.go
+++ b/pkg/storage/engine/sst_writer_test.go
@@ -111,8 +111,8 @@ func TestPebbleWritesSameSSTs(t *testing.T) {
 	itPebble, err := engine.NewMemSSTIterator(sstPebble, false)
 	require.NoError(t, err)
 
-	itPebble.Seek(engine.NilKey)
-	for itRocks.Seek(engine.NilKey); ; {
+	itPebble.SeekGE(engine.NilKey)
+	for itRocks.SeekGE(engine.NilKey); ; {
 		okRocks, err := itRocks.Valid()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -239,7 +239,7 @@ func (r *registration) runCatchupScan() error {
 	// can't use NextKey.
 	var meta enginepb.MVCCMetadata
 
-	for r.catchupIter.Seek(startKey); ; r.catchupIter.Next() {
+	for r.catchupIter.SeekGE(startKey); ; r.catchupIter.Next() {
 		if ok, err := r.catchupIter.Valid(); err != nil {
 			return err
 		} else if !ok || !r.catchupIter.UnsafeKey().Less(endKey) {
@@ -259,7 +259,7 @@ func (r *registration) runCatchupScan() error {
 				// past the corresponding provisional key-value. To do this,
 				// scan directly to the provisional key and let the loop Next
 				// to the following key after it.
-				r.catchupIter.Seek(engine.MVCCKey{
+				r.catchupIter.SeekGE(engine.MVCCKey{
 					Key:       unsafeKey.Key,
 					Timestamp: hlc.Timestamp(meta.Timestamp),
 				})

--- a/pkg/storage/rangefeed/task.go
+++ b/pkg/storage/rangefeed/task.go
@@ -74,7 +74,7 @@ func (s *initResolvedTSScan) iterateAndConsume(ctx context.Context) error {
 	// will always be the first version of a key if it exists, so its fine that
 	// we skip over all other versions of keys.
 	var meta enginepb.MVCCMetadata
-	for s.it.Seek(startKey); ; s.it.NextKey() {
+	for s.it.SeekGE(startKey); ; s.it.NextKey() {
 		if ok, err := s.it.Valid(); err != nil {
 			return err
 		} else if !ok || !s.it.UnsafeKey().Less(endKey) {

--- a/pkg/storage/rangefeed/task_test.go
+++ b/pkg/storage/rangefeed/task_test.go
@@ -126,7 +126,7 @@ func (s *testIterator) Close() {
 	close(s.done)
 }
 
-func (s *testIterator) Seek(key engine.MVCCKey) {
+func (s *testIterator) SeekGE(key engine.MVCCKey) {
 	if s.closed {
 		panic("testIterator closed")
 	}

--- a/pkg/storage/rditer/replica_data_iter.go
+++ b/pkg/storage/rditer/replica_data_iter.go
@@ -124,7 +124,7 @@ func NewReplicaDataIterator(
 		ranges: rangeFunc(d),
 		it:     it,
 	}
-	ri.it.Seek(ri.ranges[ri.curIndex].Start)
+	ri.it.SeekGE(ri.ranges[ri.curIndex].Start)
 	ri.advance()
 	return ri
 }
@@ -151,7 +151,7 @@ func (ri *ReplicaDataIterator) advance() {
 		}
 		ri.curIndex++
 		if ri.curIndex < len(ri.ranges) {
-			ri.it.Seek(ri.ranges[ri.curIndex].Start)
+			ri.it.SeekGE(ri.ranges[ri.curIndex].Start)
 		} else {
 			return
 		}

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -95,7 +95,7 @@ func optimizePuts(
 	// we can determine whether any part of the range being written
 	// is "virgin" and set the puts to write blindly.
 	// Find the first non-empty key in the run.
-	iter.Seek(engine.MakeMVCCMetadataKey(minKey))
+	iter.SeekGE(engine.MakeMVCCMetadataKey(minKey))
 	var iterKey roachpb.Key
 	if ok, err := iter.Valid(); err != nil {
 		// TODO(bdarnell): return an error here instead of silently

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2862,7 +2862,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 			iter := tc.engine.NewIterator(engine.IterOptions{Prefix: true})
 			defer iter.Close()
 			mvccKey := engine.MakeMVCCMetadataKey(key)
-			iter.Seek(mvccKey)
+			iter.SeekGE(mvccKey)
 			var keyMeta enginepb.MVCCMetadata
 			if ok, err := iter.Valid(); !ok || !iter.UnsafeKey().Equal(mvccKey) {
 				t.Fatalf("missing mvcc metadata for %q: %+v", mvccKey, err)

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -70,8 +70,8 @@ func (i *Iterator) Iterator() engine.Iterator {
 	return i.i
 }
 
-// Seek is part of the engine.Iterator interface.
-func (i *Iterator) Seek(key engine.MVCCKey) {
+// SeekGE is part of the engine.Iterator interface.
+func (i *Iterator) SeekGE(key engine.MVCCKey) {
 	if i.spansOnly {
 		i.err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
 	} else {
@@ -80,11 +80,14 @@ func (i *Iterator) Seek(key engine.MVCCKey) {
 	if i.err == nil {
 		i.invalid = false
 	}
-	i.i.Seek(key)
+	i.i.SeekGE(key)
 }
 
-// SeekReverse is part of the engine.Iterator interface.
-func (i *Iterator) SeekReverse(key engine.MVCCKey) {
+// SeekLT is part of the engine.Iterator interface.
+func (i *Iterator) SeekLT(key engine.MVCCKey) {
+	// NB: this isn't exactly right because the key provided to SeekLT is
+	// exclusive so requesting the first key in an allowed span should not
+	// be permitted, but it's close enough.
 	if i.spansOnly {
 		i.err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
 	} else {
@@ -93,7 +96,7 @@ func (i *Iterator) SeekReverse(key engine.MVCCKey) {
 	if i.err == nil {
 		i.invalid = false
 	}
-	i.i.SeekReverse(key)
+	i.i.SeekLT(key)
 }
 
 // Valid is part of the engine.Iterator interface.

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -486,7 +486,7 @@ func (rsl StateLoader) LoadLastIndex(ctx context.Context, reader engine.Reader) 
 	defer iter.Close()
 
 	var lastIndex uint64
-	iter.SeekReverse(engine.MakeMVCCMetadataKey(rsl.RaftLogKey(math.MaxUint64)))
+	iter.SeekLT(engine.MakeMVCCMetadataKey(rsl.RaftLogKey(math.MaxUint64)))
 	if ok, _ := iter.Valid(); ok {
 		key := iter.Key()
 		var err error

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1135,7 +1135,7 @@ func IterateIDPrefixKeys(
 	for {
 		bumped := false
 		mvccKey := engine.MakeMVCCMetadataKey(keyFn(rangeID))
-		iter.Seek(mvccKey)
+		iter.SeekGE(mvccKey)
 
 		if ok, err := iter.Valid(); !ok {
 			return err

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -65,7 +65,7 @@ func (tsdb *DB) findTimeSeries(
 	iter := snapshot.NewIterator(engine.IterOptions{UpperBound: endKey.AsRawKey()})
 	defer iter.Close()
 
-	for iter.Seek(next); ; iter.Seek(next) {
+	for iter.SeekGE(next); ; iter.SeekGE(next) {
 		if ok, err := iter.Valid(); err != nil {
 			return nil, err
 		} else if !ok || !iter.UnsafeKey().Less(end) {


### PR DESCRIPTION
This addresses a comment from #42210.

The commit also adjusts the reverse seek (now SeekLT) to be exclusive instead of
inclusive. This matches the API exposed by Pebble and eliminates the need for
the bug fix in 79b4c775862f184d2b6dc6f5ba89cdff04d0c052.