### PR TITLE
builtins: add a new hash function compatible w/ all crdb datatypes

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -573,6 +573,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="fnv32a"></a><code>fnv32a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1a hash value of a set of values.</p>
 </span></td></tr>
+<tr><td><a name="fnv32all"></a><code>fnv32all(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1 hash value of a set of columns by first casting them all to strings. Compatible with all CockroachDB SQL data types.</p>
+</span></td></tr>
 <tr><td><a name="fnv64"></a><code>fnv64(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1 hash value of a set of values.</p>
 </span></td></tr>
 <tr><td><a name="fnv64"></a><code>fnv64(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1 hash value of a set of values.</p>


### PR DESCRIPTION
Currently, CRDB does not support a single hash function that can be used
to hash all supported datatypes. This PR adds a new hash
function called `fnv32all` that can be used to hash a set of columns of
any datatype. It achieves this by first casting all given arguments into strings,
and then hashing the resultant string.

This is needed by the upcoming `USING HASH..` syntax (rfc incoming)
in order to hash any given set of index columns, in order to compute
its shard bucket.

Release note (sql change): Added a new hash function `fnv32all` that
                           supports all CRDB datatypes.