### PR TITLE
storage: prevent node from restarting after consistency check fatal

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -444,6 +444,12 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 		return err
 	}
 
+	if s, err := serverCfg.Stores.GetPreventedStartupMessage(); err != nil {
+		return err
+	} else if s != "" {
+		log.Fatal(context.Background(), s)
+	}
+
 	// Set up the signal handlers. This also ensures that any of these
 	// signals received beyond this point do not interrupt the startup
 	// sequence until the point signals are checked below.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -437,7 +437,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	// First things first: if the user wants background processing,
 	// relinquish the terminal ASAP by forking and exiting.
 	//
-	// If executing in the backround, the function returns ok == true in
+	// If executing in the background, the function returns ok == true in
 	// the parent process (regardless of err) and the parent exits at
 	// this point.
 	if ok, err := maybeRerunBackground(); ok {

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -279,7 +279,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 			return nil, err
 		}
 	} else {
-		auxDir = cfg.Opts.FS.PathJoin(cfg.Dir, "auxiliary")
+		auxDir = cfg.Opts.FS.PathJoin(cfg.Dir, base.AuxiliaryDir)
 		if err := cfg.Opts.FS.MkdirAll(auxDir, 0755); err != nil {
 			return nil, err
 		}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -528,7 +528,7 @@ func NewRocksDB(cfg RocksDBConfig, cache RocksDBCache) (*RocksDB, error) {
 		cache: cache.ref(),
 	}
 
-	if err := r.setAuxiliaryDir(filepath.Join(cfg.Dir, "auxiliary")); err != nil {
+	if err := r.setAuxiliaryDir(filepath.Join(cfg.Dir, base.AuxiliaryDir)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -6408,6 +6409,10 @@ func TestReplicaCorruption(t *testing.T) {
 	if !testutils.IsPError(pErr, "replica corruption \\(processed=true\\)") {
 		t.Fatalf("unexpected error: %s", pErr)
 	}
+
+	// Should have laid down marker file to prevent startup.
+	_, err := os.Stat(base.PreventedStartupFile(tc.engine.GetAuxiliaryDir()))
+	require.NoError(t, err)
 
 	// Should have triggered fatal error.
 	if exitStatus != 255 {


### PR DESCRIPTION
NB: I'll update the inconsistency roachtest with an end-to-end check on the restart protection.

----

Many deployments auto-restart crashed nodes unconditionally.  As a
result, we are often pulled into inconsistency failures relatively late,
which results in a loss of information (in particular if the source of
the problem turns out to be one of the nodes that did not actually
crash); if the node that crashes *is* the one with the problem,
restarting it lets it serve data again (until the next time the
consistency checker nukes it), which is bad as well.

This commit introduces a "death rattle" - if a node is told to terminate
as the result of a consistency check, it will write a marker file that
prevents subsequent restarts of the node with an informative message
alerting the operator that there is a serious problem that needs to be
addressed.

Fixes #40442.

Release note (general change): nodes that have been terminated as the
result of a failed consistency check now refuse to restart, making it
more likely that the operator notices that there is a persistent issue
in a timely manner.