### PR TITLE
storage/engine: temporarily disable Pebble bloom filters

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/pkg/errors"
 )
@@ -200,9 +199,10 @@ func DefaultPebbleOptions() *pebble.Options {
 		L0StopWritesThreshold: 1000,
 		LBaseMaxBytes:         64 << 20, // 64 MB
 		Levels: []pebble.LevelOptions{{
-			BlockSize:    32 << 10, // 32 KB
-			FilterPolicy: bloom.FilterPolicy(10),
-			FilterType:   pebble.TableFilter,
+			BlockSize: 32 << 10, // 32 KB
+			// TODO(peter): disable until #42351 is fixed
+			// FilterPolicy: bloom.FilterPolicy(10),
+			// FilterType: pebble.TableFilter,
 		}},
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,


### PR DESCRIPTION
Temporarily disable Pebble bloom filters as they appear to have some
incompatibility with RocksDB generated bloom filters. Specifically, a
bloom filter written by RocksDB will generate false positives when used
by Pebble. This was discovered while debugging
`cli.TestRemoveDeadReplicas` which creates a store using Pebble,
re-opens the store using RocksDB, and the restarts the node using
Pebble. This final step fails to find the `storeIdent` key because the
bloom filter for the sstable the key is stored in is reporting that the
key is not present in the sstable even though it actually is.

See #42351

Release note: None