### PR TITLE
ui: Show livenes status icons for Nodes List table (Cluster Overiew)

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -36,18 +36,11 @@
 .node-status-icon
   display inline-block
   margin-right 6px
-  font-size 6px
-  line-height 14px
+  line-height 16px
   vertical-align middle
-  width 6px
-  height 6px
-  border-radius 3px
+  width 16px
+  height 16px
 
-  &--dead
-    background-color $alert-color
-  &--suspect
-    background-color $warning-color
-  &--decommissioning
-    background-color $warning-color
-  &--healthy
-    background-color $healthy-color
+.node-status-icon > svg
+  width 16px
+  height 16px


### PR DESCRIPTION
Previously, we display coloured bullet points to specify node's status,
it could be difficult to recognise statuses by colour (for users who is
colorblind).
To improve readability, statuses are displayed as coloured icons which
is easier to recognise.

Resolves: #34470

Release note: None