### PR TITLE
release-19.2: colexec: add support for UUID type

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -143,10 +143,10 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	assertEqualBatches(t, expected, actual)
 }
 
-// roundTripAndAssertEquality is a helper function that round trips a batch
-// through the ArrowBatchConverter and RecordBatchSerializer and asserts that
-// the output batch is equal to the input batch. Make sure to copy the input
-// batch before passing it to this function to assert equality.
+// roundTripBatch is a helper function that round trips a batch through the
+// ArrowBatchConverter and RecordBatchSerializer and asserts that the output
+// batch is equal to the input batch. Make sure to copy the input batch before
+// passing it to this function to assert equality.
 func roundTripBatch(
 	b coldata.Batch, c *ArrowBatchConverter, r *RecordBatchSerializer,
 ) (coldata.Batch, error) {

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -248,7 +248,7 @@ func skipTableKey(
 	var rkey []byte
 	var err error
 	switch valType.Family() {
-	case types.BoolFamily, types.IntFamily, types.DateFamily:
+	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily:
 		if dir == sqlbase.IndexDescriptor_ASC {
 			rkey, _, err = encoding.DecodeVarintAscending(key)
 		} else {
@@ -322,7 +322,7 @@ func UnmarshalColumnValueToCol(
 		var v []byte
 		v, err = value.GetBytes()
 		vec.Bytes().Set(int(idx), v)
-	case types.DateFamily:
+	case types.DateFamily, types.OidFamily:
 		var v int64
 		v, err = value.GetInt()
 		vec.Int64()[idx] = v

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DecodeIndexKeyToCols decodes an index key into the idx'th position of the
-// provided slices of exec.ColVecs. The input index key must already have its
+// provided slices of colexec.Vecs. The input index key must already have its
 // first table id / index id prefix removed. If matches is false, the key is
 // from a different table, and the returned remainingKey indicates a
 // "seek prefix": the next key that might be part of the table being searched
@@ -114,7 +114,7 @@ func DecodeIndexKeyToCols(
 }
 
 // DecodeKeyValsToCols decodes the values that are part of the key, writing the
-// result to the idx'th slot of the input slice of exec.ColVecs. If the
+// result to the idx'th slot of the input slice of colexec.Vecs. If the
 // directions slice is nil, the direction used will default to
 // encoding.Ascending.
 // If the unseen int set is non-nil, upon decoding the column with ordinal i,
@@ -154,7 +154,7 @@ func DecodeKeyValsToCols(
 }
 
 // decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the result
-// to the idx'th slot of the input exec.Vec.
+// to the idx'th slot of the input colexec.Vec.
 // See the analog, DecodeTableKey, in sqlbase/column_type_encoding.go.
 func decodeTableKeyToCol(
 	vec coldata.Vec, idx uint16, valType *types.T, key []byte, dir sqlbase.IndexDescriptor_Direction,
@@ -209,7 +209,7 @@ func decodeTableKeyToCol(
 			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
 		}
 		vec.Decimal()[idx] = d
-	case types.BytesFamily, types.StringFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		var r []byte
 		if dir == sqlbase.IndexDescriptor_ASC {
 			rkey, r, err = encoding.DecodeBytesAscending(key, nil)
@@ -260,7 +260,7 @@ func skipTableKey(
 		} else {
 			rkey, _, err = encoding.DecodeFloatDescending(key)
 		}
-	case types.BytesFamily, types.StringFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		if dir == sqlbase.IndexDescriptor_ASC {
 			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
 		} else {
@@ -318,7 +318,7 @@ func UnmarshalColumnValueToCol(
 		vec.Float64()[idx] = v
 	case types.DecimalFamily:
 		err = value.GetDecimalInto(&vec.Decimal()[idx])
-	case types.BytesFamily, types.StringFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		var v []byte
 		v, err = value.GetBytes()
 		vec.Bytes().Set(int(idx), v)

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -47,7 +47,7 @@ type _GOTYPE interface{}
 func _ROWS_TO_COL_VEC(
 	rows sqlbase.EncDatumRows, vec coldata.Vec, columnIdx int, alloc *sqlbase.DatumAlloc,
 ) error { // */}}
-	// {{define "rowsToColVec"}}
+	// {{define "rowsToColVec" -}}
 	col := vec._TemplateType()
 	datumToPhysicalFn := typeconv.GetDatumToPhysicalFn(columnType)
 	for i := range rows {
@@ -89,7 +89,6 @@ func EncDatumRowsToColVec(
 	columnType *types.T,
 	alloc *sqlbase.DatumAlloc,
 ) error {
-
 	switch columnType.Family() {
 	// {{range .}}
 	case _FAMILY:

--- a/pkg/sql/colexec/supported_sql_types.go
+++ b/pkg/sql/colexec/supported_sql_types.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import "github.com/cockroachdb/cockroach/pkg/sql/types"
+
+// allSupportedSQLTypes is a slice of all SQL types that the vectorized engine
+// currently supports. It should be kept in sync with typeconv.FromColumnType().
+var allSupportedSQLTypes = []types.T{
+	*types.Bool,
+	*types.Bytes,
+	*types.Date,
+	*types.Decimal,
+	*types.Int2,
+	*types.Int4,
+	*types.Int,
+	*types.Oid,
+	*types.Float,
+	*types.Float4,
+	*types.String,
+	*types.Uuid,
+}

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -22,7 +22,25 @@ import (
 	"github.com/pkg/errors"
 )
 
+// AllSupportedSQLTypes is a slice of all SQL types that the vectorized engine
+// currently supports. It should be kept in sync with FromColumnType().
+var AllSupportedSQLTypes = []types.T{
+	*types.Bool,
+	*types.Bytes,
+	*types.Date,
+	*types.Decimal,
+	*types.Int2,
+	*types.Int4,
+	*types.Int,
+	*types.Oid,
+	*types.Float,
+	*types.String,
+	*types.Uuid,
+}
+
 // FromColumnType returns the T that corresponds to the input ColumnType.
+// Note: if you're adding a new type here, add it to AllSupportedSQLTypes as
+// well.
 func FromColumnType(ct *types.T) coltypes.T {
 	switch ct.Family() {
 	case types.BoolFamily:

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -27,7 +27,7 @@ func FromColumnType(ct *types.T) coltypes.T {
 	switch ct.Family() {
 	case types.BoolFamily:
 		return coltypes.Bool
-	case types.BytesFamily, types.StringFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		return coltypes.Bytes
 	case types.DateFamily, types.OidFamily:
 		return coltypes.Int64
@@ -163,6 +163,15 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 				return nil, errors.Errorf("expected *tree.DDecimal, found %s", reflect.TypeOf(datum))
 			}
 			return d.Decimal, nil
+		}
+	case types.UuidFamily:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DUuid)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DUuid, found %s", reflect.TypeOf(datum))
+			}
+			// TODO(yuzefovich): this maybe should be GetBytesMut().
+			return d.UUID.GetBytes(), nil
 		}
 	}
 	// It would probably be more correct to return an error here, rather than a

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -22,25 +22,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AllSupportedSQLTypes is a slice of all SQL types that the vectorized engine
-// currently supports. It should be kept in sync with FromColumnType().
-var AllSupportedSQLTypes = []types.T{
-	*types.Bool,
-	*types.Bytes,
-	*types.Date,
-	*types.Decimal,
-	*types.Int2,
-	*types.Int4,
-	*types.Int,
-	*types.Oid,
-	*types.Float,
-	*types.String,
-	*types.Uuid,
-}
-
 // FromColumnType returns the T that corresponds to the input ColumnType.
-// Note: if you're adding a new type here, add it to AllSupportedSQLTypes as
-// well.
+// Note: if you're adding a new type here, add it to
+// colexec.AllSupportedSQLTypes as well.
 func FromColumnType(ct *types.T) coltypes.T {
 	switch ct.Family() {
 	case types.BoolFamily:
@@ -188,8 +172,7 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 			if !ok {
 				return nil, errors.Errorf("expected *tree.DUuid, found %s", reflect.TypeOf(datum))
 			}
-			// TODO(yuzefovich): this maybe should be GetBytesMut().
-			return d.UUID.GetBytes(), nil
+			return d.UUID.GetBytesMut(), nil
 		}
 	}
 	// It would probably be more correct to return an error here, rather than a

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -32,12 +32,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSupportedSQLTypesIntegration tests that all supported by the vectorized
-// engine SQL types can be safely "round-tripped through colserde package." It
-// creates a bunch of rows with a single column of the type in question, passes
-// it through the following chain:
-//   Columnarizer -> arrowTestOperator -> Materializer
-// and verifies that the output rows are equal to the input ones.
+// TestSupportedSQLTypesIntegration tests that all SQL types supported by the
+// vectorized engine are "actually supported." For each type, it creates a bunch
+// of rows consisting of a single datum (possibly null), converts them into
+// column batches, serializes and then deserializes these batches, and finally
+// converts the deserialized batches back to rows which are compared with the
+// original rows.
 func TestSupportedSQLTypesIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -58,7 +58,7 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 	var da sqlbase.DatumAlloc
 	rng, _ := randutil.NewPseudoRand()
 
-	for _, typ := range typeconv.AllSupportedSQLTypes {
+	for _, typ := range allSupportedSQLTypes {
 		if typ.Equal(*types.Decimal) {
 			// Serialization of Decimals is currently not supported.
 			// TODO(yuzefovich): remove this once it is supported.

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -1,0 +1,172 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/colserde"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupportedSQLTypesIntegration tests that all supported by the vectorized
+// engine SQL types can be safely "round-tripped through colserde package." It
+// creates a bunch of rows with a single column of the type in question, passes
+// it through the following chain:
+//   Columnarizer -> arrowTestOperator -> Materializer
+// and verifies that the output rows are equal to the input ones.
+func TestSupportedSQLTypesIntegration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	diskMonitor := execinfra.MakeTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: diskMonitor,
+		},
+	}
+
+	var da sqlbase.DatumAlloc
+	rng, _ := randutil.NewPseudoRand()
+
+	for _, typ := range typeconv.AllSupportedSQLTypes {
+		if typ.Equal(*types.Decimal) {
+			// Serialization of Decimals is currently not supported.
+			// TODO(yuzefovich): remove this once it is supported.
+			continue
+		}
+		for _, numRows := range []uint16{
+			// A few interesting sizes.
+			1,
+			coldata.BatchSize() - 1,
+			coldata.BatchSize(),
+			coldata.BatchSize() + 1,
+		} {
+			rows := make(sqlbase.EncDatumRows, numRows)
+			for i := uint16(0); i < numRows; i++ {
+				rows[i] = make(sqlbase.EncDatumRow, 1)
+				rows[i][0] = sqlbase.DatumToEncDatum(&typ, sqlbase.RandDatum(rng, &typ, true /* nullOk */))
+			}
+			typs := []types.T{typ}
+			source := execinfra.NewRepeatableRowSource(typs, rows)
+
+			columnarizer, err := NewColumnarizer(ctx, flowCtx, 0 /* processorID */, source)
+			require.NoError(t, err)
+
+			coltyps, err := typeconv.FromColumnTypes(typs)
+			require.NoError(t, err)
+			c, err := colserde.NewArrowBatchConverter(coltyps)
+			require.NoError(t, err)
+			r, err := colserde.NewRecordBatchSerializer(coltyps)
+			require.NoError(t, err)
+			arrowOp := newArrowTestOperator(columnarizer, c, r)
+
+			output := distsqlutils.NewRowBuffer(typs, nil /* rows */, distsqlutils.RowBufferArgs{})
+			materializer, err := NewMaterializer(
+				flowCtx,
+				1, /* processorID */
+				arrowOp,
+				typs,
+				&execinfrapb.PostProcessSpec{},
+				output,
+				nil, /* metadataSourcesQueue */
+				nil, /* outputStatsToTrace */
+				nil, /* cancelFlow */
+			)
+			require.NoError(t, err)
+
+			materializer.Start(ctx)
+			materializer.Run(ctx)
+			actualRows := output.GetRowsNoMeta(t)
+			require.Equal(t, len(rows), len(actualRows))
+			for rowIdx, expectedRow := range rows {
+				require.Equal(t, len(expectedRow), len(actualRows[rowIdx]))
+				cmp, err := expectedRow[0].Compare(&typ, &da, &evalCtx, &actualRows[rowIdx][0])
+				require.NoError(t, err)
+				require.Equal(t, 0, cmp)
+			}
+		}
+	}
+}
+
+// arrowTestOperator is an Operator that takes in a coldata.Batch from its
+// input, passes it through a chain of
+// - converting to Arrow format
+// - serializing
+// - deserializing
+// - converting from Arrow format
+// and returns the resulting batch.
+type arrowTestOperator struct {
+	OneInputNode
+
+	c *colserde.ArrowBatchConverter
+	r *colserde.RecordBatchSerializer
+}
+
+var _ Operator = &arrowTestOperator{}
+
+func newArrowTestOperator(
+	input Operator, c *colserde.ArrowBatchConverter, r *colserde.RecordBatchSerializer,
+) Operator {
+	return &arrowTestOperator{
+		OneInputNode: NewOneInputNode(input),
+		c:            c,
+		r:            r,
+	}
+}
+
+func (a *arrowTestOperator) Init() {
+	a.input.Init()
+}
+
+func (a *arrowTestOperator) Next(ctx context.Context) coldata.Batch {
+	batchIn := a.input.Next(ctx)
+	// Note that we don't need to handle zero-length batches in a special way.
+	var buf bytes.Buffer
+	arrowDataIn, err := a.c.BatchToArrow(batchIn)
+	if err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	_, _, err = a.r.Serialize(&buf, arrowDataIn)
+	if err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	var arrowDataOut []*array.Data
+	if err := a.r.Deserialize(&arrowDataOut, buf.Bytes()); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	batchOut := coldata.NewMemBatchWithSize(nil, 0)
+	if err := a.c.ArrowToBatch(arrowDataOut, batchOut); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	return batchOut
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -1,0 +1,51 @@
+# Check that all types supported by the vectorized engine can be read correctly.
+statement ok
+CREATE TABLE all_types (
+    _bool    BOOL,
+    _bytes   BYTES,
+    _date    DATE,
+    _decimal DECIMAL,
+    _int2    INT2,
+    _int4    INT4,
+    _int     INT8,
+    _oid     OID,
+    _float   FLOAT8,
+    _string  STRING,
+    _uuid    UUID
+)
+
+statement ok
+INSERT
+  INTO all_types
+VALUES (
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+       ),
+       (
+       false,
+       '123',
+       '2019-10-22',
+       1.23,
+       123,
+       123,
+       123,
+       123,
+       1.23,
+       '123',
+       '63616665-6630-3064-6465-616462656562'
+       )
+
+query BTTRIIIORTT
+SELECT * FROM all_types ORDER BY 1
+----
+NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562


### PR DESCRIPTION
Backport 3/3 commits from #41658.

/cc @cockroachdb/release

---

**colexec: add support for UUID type**

This commit adds support for UUID type simply by treating it as
[]byte. This is probably inefficient but requires very little
changes to the code, so maybe it'll be ok to backport for 19.2
release.

Release note (sql change): vectorized execution engine now supports UUID
type.

**colexec: add an integration test for all supported types**

This commit adds an end-to-end integration test for all supported by
the vectorized engine SQL types. It verifies that passing Datums
through conversion to coldata.Batch, then from batch to Arrow format,
then serializing and deserializing, back from Arrow format to batch,
and materializing the batch outputs the same Datums.

Release note: None

**colexec: check that CFetcher can read all supported types**

This commit adds a simple logic test that creates a table
with all supported by the vectorized engine SQL types, inserts
a row full of NULL values and a row with non-NULL values, and
reads it back. The test uncovered an issue that Oid type was
not decoded by CFetcher (it was reported as "unsupported").

Release note: None