### PR TITLE
roachtest: add support for azure in tpcc bench

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -190,7 +190,7 @@ the test tags.
 		cmd.Flags().StringVar(
 			&artifacts, "artifacts", "artifacts", "path to artifacts directory")
 		cmd.Flags().StringVar(
-			&cloud, "cloud", cloud, "cloud provider to use (aws or gce)")
+			&cloud, "cloud", cloud, "cloud provider to use (aws, azure, or gce)")
 		cmd.Flags().StringVar(
 			&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
 		cmd.Flags().IntVar(
@@ -208,6 +208,9 @@ the test tags.
 			&zonesF, "zones", "",
 			"Zones for the cluster. (non-geo tests use the first zone, geo tests use all zones) "+
 				"(uses roachprod defaults if empty)")
+		cmd.Flags().StringVar(
+			&instanceType, "instance-type", instanceType,
+			"the instance type to use (see https://aws.amazon.com/ec2/instance-types/, https://cloud.google.com/compute/docs/machine-types or https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes)")
 		cmd.Flags().IntVar(
 			&cpuQuota, "cpu-quota", 300,
 			"The number of cloud CPUs roachtest is allowed to use at any one time.")

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -59,7 +59,7 @@ type tpccOptions struct {
 func tpccFixturesCmd(t *test, cloud string, warehouses int, extraArgs string) string {
 	var command string
 	switch cloud {
-	case "gce":
+	case gce:
 		// TODO(nvanbenschoten): We could switch to import for both clouds.
 		// At the moment, import is still a little unstable and load is still
 		// marginally faster.
@@ -75,7 +75,7 @@ func tpccFixturesCmd(t *test, cloud string, warehouses int, extraArgs string) st
 			t.Fatalf("could not find fixture big enough for %d warehouses", warehouses)
 		}
 		warehouses = fixtureWarehouses
-	case "aws":
+	case aws, azure:
 		// For fixtures import, use the version built into the cockroach binary
 		// so the tpcc workload-versions match on release branches.
 		command = "./cockroach workload fixtures import"


### PR DESCRIPTION
This updates roachtest to be able to create Azure clusters. This is the
minimum needed to run TPCC bench on Azure machines. There remains work
to be done to fully support Azure, denoted by TODOs in this commit.

Additionally, a machine type flag was added so that specific machine
types could be used. This applies to all cloud types.

Release note: None