### PR TITLE
roachprod: use premium SSDs for Azure

### DIFF
--- a/pkg/cmd/roachprod/vm/azure/azure.go
+++ b/pkg/cmd/roachprod/vm/azure/azure.go
@@ -570,7 +570,7 @@ mounts:
 				DiskSizeGB:   to.Int32Ptr(100),
 				Lun:          to.Int32Ptr(42),
 				ManagedDisk: &compute.ManagedDiskParameters{
-					StorageAccountType: compute.StorageAccountTypesStandardSSDLRS,
+					StorageAccountType: compute.StorageAccountTypesPremiumLRS,
 				},
 			},
 		}


### PR DESCRIPTION
We should be testing with Premium SSDs on Azure, as Standard SSDs do not
have the performance characteristics we would expect of a machine that
is actually running CockroachDB.

Release note: None