### PR TITLE
storage: don't update the timestamp cache after failed pushes

### DIFF
--- a/pkg/storage/replica_tscache.go
+++ b/pkg/storage/replica_tscache.go
@@ -126,6 +126,7 @@ func (r *Replica) updateTimestampCache(
 			case roachpb.STAGING:
 				// No need to update the timestamp cache. If a transaction
 				// is in this state then it must have a transaction record.
+				continue
 			case roachpb.COMMITTED:
 				// No need to update the timestamp cache. It was already
 				// updated by the corresponding EndTransaction request.


### PR DESCRIPTION
A PushTxn that finds a STAGING pushee doesn't need to update to leave a
mark in the timestamp cache, just like one for a COMMITTED pushes. The
comment at the relevant code spells it out, and yet the code didn't
follow through.

Release note: None