### PR TITLE
roachtest: show unexpected test results in github issue

### DIFF
--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -147,6 +147,13 @@ func (r *ormTestsResults) summarizeFailed(
 	p("expected failed but skipped", r.unexpectedSkipCount)
 	p("expected failed but not run", notRunCount)
 
+	fmt.Fprintf(&bResults, "---\n")
+	for _, result := range r.results {
+		if strings.Contains(result, "unexpected") {
+			fmt.Fprintf(&bResults, "%s\n", result)
+		}
+	}
+
 	fmt.Fprintf(&bResults, "For a full summary look at the %s artifacts \n", ormName)
 	t.l.Printf("%s\n", bResults.String())
 	t.l.Printf("------------------------\n")


### PR DESCRIPTION
This should make it easier to glance at the issue to get an idea of
what's wrong, rather than having to click through to the TeamCity
results and navigate many log files.

Release note: None