### PR TITLE
builtins: add avg for interval

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -37,6 +37,8 @@
 </span></td></tr>
 <tr><td><a name="avg"></a><code>avg(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
 </span></td></tr>
+<tr><td><a name="avg"></a><code>avg(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
+</span></td></tr>
 <tr><td><a name="bit_and"></a><code>bit_and(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise AND of all non-null input values, or null if none.</p>
 </span></td></tr>
 <tr><td><a name="bit_or"></a><code>bit_or(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise OR of all non-null input values, or null if none.</p>

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -5,7 +5,8 @@ CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT,
   w INT,
-  s STRING
+  s STRING,
+  i INTERVAL
 )
 
 # Aggregate functions return NULL if there are no rows.
@@ -35,6 +36,11 @@ query T
 SELECT jsonb_agg(1) FROM kv
 ----
 NULL
+
+query TTTT
+SELECT min(i), avg(i), max(i), sum(i) FROM kv
+----
+NULL NULL NULL NULL
 
 query IIIIRRRRBBT
 SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
@@ -147,12 +153,12 @@ SELECT (SELECT COALESCE(max(1), 0) FROM generate_series(1,0))
 
 statement OK
 INSERT INTO kv VALUES
-(1, 2, 3, 'a'),
-(3, 4, 5, 'a'),
-(5, NULL, 5, NULL),
-(6, 2, 3, 'b'),
-(7, 2, 2, 'b'),
-(8, 4, 2, 'A')
+(1, 2, 3, 'a', '1min'),
+(3, 4, 5, 'a', '2sec'),
+(5, NULL, 5, NULL, NULL),
+(6, 2, 3, 'b', '1ms'),
+(7, 2, 2, 'b', '4 days'),
+(8, 4, 2, 'A', '3 years')
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
 # NB: The XOR result is 00 because \x01 is XOR'd an even number of times.
@@ -594,6 +600,11 @@ query RRRR
 SELECT avg(k), avg(v), sum(k), sum(v) FROM kv
 ----
 5 2.8 30 14
+
+query TTTT
+SELECT min(i), avg(i), max(i), sum(i) FROM kv
+----
+00:00:00.001  7 mons 6 days 19:12:12.4002  3 years  3 years 4 days 00:01:02.001
 
 query RRRR
 SELECT avg(k::decimal), avg(v::decimal), sum(k::decimal), sum(v::decimal) FROM kv

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -78,6 +78,11 @@ func TestAvgDecimalResultDeepCopy(t *testing.T) {
 	testAggregateResultDeepCopy(t, newDecimalAvgAggregate, makeDecimalTestDatum(10))
 }
 
+func TestAvgIntervalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testAggregateResultDeepCopy(t, newIntervalAvgAggregate, makeIntervalTestDatum(10))
+}
+
 func TestBitAndIntResultDeepCopy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Run("all null", func(t *testing.T) {
@@ -401,6 +406,14 @@ func BenchmarkAvgAggregateDecimal(b *testing.B) {
 	for _, count := range []int{1000} {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
 			runBenchmarkAggregate(b, newDecimalAvgAggregate, makeDecimalTestDatum(count))
+		})
+	}
+}
+
+func BenchmarkAvgAggregateInterval(b *testing.B) {
+	for _, count := range []int{1000} {
+		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
+			runBenchmarkAggregate(b, newIntervalAvgAggregate, makeIntervalTestDatum(count))
 		})
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/42449
Resolves https://github.com/cockroachdb/cockroach-django/issues/72

This PR adds the ability to average intervals. Comes with a few extra
tests for aggregation functions over intervals.

Release note (sql change): Adds the ability to run `avg` over intervals.