### PR TITLE
release-19.2: builtins: fix potential panic in crdb_internal.encode_key

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -498,3 +498,21 @@ query TT
 SELECT start_key, end_key from [SHOW RANGE FROM INDEX range_for_row_nulls@i FOR ROW (1, NULL)]
 ----
 /NULL NULL
+
+# Regression for #42456
+statement ok
+CREATE TABLE t42456 (x int primary key);
+
+statement ok
+CREATE INDEX i1 on t42456 (x);
+CREATE INDEX i2 on t42456 (x);
+DROP INDEX t42456@i1;
+DROP INDEX t42456@i2;
+CREATE INDEX i3 on t42456 (x)
+
+query T
+SELECT crdb_internal.pretty_key(crdb_internal.encode_key(70, 4, (1, )), 0)
+----
+/70/4/1/0
+
+

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2994,7 +2994,10 @@ may increase either contention or retry errors, or both.`,
 					datums = append(datums, newDatum)
 				}
 
-				indexDesc := tableDesc.AllNonDropIndexes()[indexID-1]
+				indexDesc, err := tableDesc.FindIndexByID(sqlbase.IndexID(indexID))
+				if err != nil {
+					return nil, err
+				}
 
 				// Create a column id to row index map. In this case, each column ID just maps to the i'th ordinal.
 				colMap := make(map[sqlbase.ColumnID]int)


### PR DESCRIPTION
Backport 1/1 commits from #42456.

/cc @cockroachdb/release

---

crdb_internal.encode_key was indexing into a table descriptor's
indexes slice using index ID's, when it should have been using
`FindIndexByID`.

Release note (bug fix): For tables with dropped indexes, the SHOW RANGE FOR ROW command sometimes returned incorrect
results or an error. Fixed the underlying issue in the crdb_internal.encode_key built-in.
