### PR TITLE
build: require patch level 10+ for go1.12

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -7,6 +7,8 @@
 
 required_version_major=1
 minimum_version_minor=12
+minimum_version_12_patch=10
+minimum_version_13_patch=4
 
 go=${1-go}
 
@@ -15,14 +17,22 @@ if ! raw_version=$("$go" version 2>&1); then
   exit 1
 fi
 
-if ! version=$(grep -oE "[0-9]+\.[0-9]+" <<< "$raw_version" | head -n1); then
+if ! version=$(grep -oE "[0-9]+(\.[0-9]+)+" <<< "$raw_version" | head -n1); then
   echo "unable to parse go version '$raw_version'" >&2
   exit 1
 fi
 
 version_major=$(cut -f1 -d. <<< "$version")
 version_minor=$(cut -f2 -d. <<< "$version")
-if (( version_major != required_version_major )) || (( version_minor < minimum_version_minor )); then
+version_patch=$(cut -f3 -d. <<< "$version")
+required_version_patch=$(eval echo \$minimum_version_${version_minor}_patch)
+check_patch=$(if test -n "$version_patch"; then echo 1; else echo 0; fi)
+if (( version_major != required_version_major )) || \
+	   (( version_minor < minimum_version_minor )); then
   echo "go$required_version_major.$minimum_version_minor+ required (detected go$version)" >&2
+  exit 1
+elif (( check_patch == 1 && version_patch < required_version_patch )); then
+  minimum_version_patch=$(eval echo \$minimum_version_${minimum_version_minor}_patch)
+  echo "need Go patch $required_version_major.$version_minor.$required_version_patch+ when using go$required_version_major.$version_minor (detected go$version; minimum version for successful builds is go$required_version_major.$minimum_version_minor.$minimum_version_patch+)" >&2
   exit 1
 fi


### PR DESCRIPTION
Fixes #42229

Versions of Go before 1.12.10 were more lenient in the URL format they
were accepting. This was changed in 1.12.10 and CockroachDB tests were
updated accordingly, but these tests will now fail when ran with older
1.12 versions.

This patch enhances the version check to require a specific patch
release.

Release note (build change): Go version 1.12.10+ is now required to
build CockroachDB successfully.