### PR TITLE
importccl: Resume CSV imports

### DIFF
--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -10,27 +10,37 @@ package importccl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,9 +94,10 @@ func TestConverterFlushesBatches(t *testing.T) {
 		expectedNumBatches := 0
 		converterSpec := testCase.getConverterSpec()
 
-		// Run multiple tests, increasing batch size until it exceeds the total number of records.
-		// When batch size is 0, we run converters with the default batch size, and use that run
-		// to figure out the expected number of records and batches for the subsequent run.
+		// Run multiple tests, increasing batch size until it exceeds the
+		// total number of records. When batch size is 0, we run converters
+		// with the default batch size, and use that run to figure out the
+		// expected number of records and batches for the subsequent run.
 		for batchSize := 0; batchSize != endBatchSize; {
 			t.Run(testName(testCase.inputFormat, batchSize), func(t *testing.T) {
 				if batchSize > 0 {
@@ -109,7 +120,8 @@ func TestConverterFlushesBatches(t *testing.T) {
 				testNumRecords := 0
 				testNumBatches := 0
 
-				// Read from the channel; we expect batches of testCase.batchSize size, with the exception of the last batch.
+				// Read from the channel; we expect batches of testCase.batchSize
+				// size, with the exception of the last batch.
 				for batch := range kvCh {
 					if batchSize > 0 {
 						assert.True(t, lastBatch == 0 || lastBatch == batchSize)
@@ -159,7 +171,7 @@ func (r *errorReportingRowReceiver) Push(
 		if !r.t.Failed() {
 			r.t.Fail()
 		}
-		r.t.Logf("Row receiver got an error: %v", meta.Err)
+		r.t.Logf("csvRow receiver got an error: %v", meta.Err)
 		return execinfra.ConsumerClosed
 	}
 	return execinfra.NeedMoreRows
@@ -208,8 +220,9 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 		},
 	}
 
-	// In this test, we'll specify import files that do not exist, but mark those files fully processed.
-	// The converters should not attempt to even open these files (and if they do, we should report a test failure)
+	// In this test, we'll specify import files that do not exist, but mark
+	// those files fully processed. The converters should not attempt to even
+	// open these files (and if they do, we should report a test failure)
 	tests := []struct {
 		name         string
 		spec         testSpec
@@ -273,6 +286,365 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 	}
 }
 
+// syncBarrier allows 2 threads (a controller and a worker) to
+// synchronize between themselves. A controller portion of the
+// barrier waits until worker starts running, and then notifies
+// worker to proceed. The worker is the opposite: notifies controller
+// that it started running, and waits for the proceed signal.
+type syncBarrier interface {
+	// Enter blocks the barrier, and returns a function
+	// that, when executed, unblocks the other thread.
+	Enter() func()
+}
+
+type barrier struct {
+	read       <-chan struct{}
+	write      chan<- struct{}
+	controller bool
+}
+
+// Returns controller/worker barriers.
+func newSyncBarrier() (syncBarrier, syncBarrier) {
+	p1 := make(chan struct{})
+	p2 := make(chan struct{})
+	return &barrier{p1, p2, true}, &barrier{p2, p1, false}
+}
+
+func (b *barrier) Enter() func() {
+	if b.controller {
+		b.write <- struct{}{}
+		return func() { <-b.read }
+	}
+
+	<-b.read
+	return func() { b.write <- struct{}{} }
+}
+
+// A special jobs.Resumer that, instead of finishing
+// the job successfully, forces the job to be paused.
+var _ jobs.Resumer = &cancellableImportResumer{}
+
+type cancellableImportResumer struct {
+	ctx              context.Context
+	jobIDCh          chan int64
+	jobID            int64
+	onSuccessBarrier syncBarrier
+	wrapped          *importResumer
+}
+
+func (r *cancellableImportResumer) Resume(
+	_ context.Context, phs interface{}, resultsCh chan<- tree.Datums,
+) error {
+	r.jobID = *r.wrapped.job.ID()
+	r.jobIDCh <- r.jobID
+	return r.wrapped.Resume(r.ctx, phs, resultsCh)
+}
+
+func (r *cancellableImportResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
+	if r.onSuccessBarrier != nil {
+		defer r.onSuccessBarrier.Enter()()
+	}
+	return errors.New("job succeed, but we're forcing it to be paused")
+}
+
+func (r *cancellableImportResumer) OnTerminal(
+	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
+) {
+	r.wrapped.OnTerminal(ctx, status, resultsCh)
+}
+
+func (r *cancellableImportResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) error {
+	// This callback is invoked when an error or cancellation occurs
+	// during the import. Since our OnSuccess handler returned an
+	// error (after pausing the job), we need to short-circuits
+	// jobs machinery so that this job is not marked as failed.
+	return errors.New("bail out")
+}
+
+func setImportReaderParallelism(parallelism int32) func() {
+	factory := rowexec.NewReadImportDataProcessor
+	rowexec.NewReadImportDataProcessor = func(
+		flowCtx *execinfra.FlowCtx, processorID int32,
+		spec execinfrapb.ReadImportDataSpec, output execinfra.RowReceiver) (execinfra.Processor, error) {
+		spec.ReaderParallelism = parallelism
+		return factory(flowCtx, processorID, spec, output)
+	}
+
+	return func() {
+		rowexec.NewReadImportDataProcessor = factory
+	}
+}
+
+// Queries the status and the import progress of the job.
+type jobState struct {
+	err    error
+	status jobs.Status
+	prog   jobspb.ImportProgress
+}
+
+func queryJob(db sqlutils.DBHandle, jobID int64) (js jobState) {
+	js = jobState{
+		err:    nil,
+		status: "",
+		prog:   jobspb.ImportProgress{},
+	}
+	var progressBytes, payloadBytes []byte
+	js.err = db.QueryRowContext(
+		context.TODO(), "SELECT status, payload, progress FROM system.jobs WHERE id = $1", jobID).Scan(
+		&js.status, &payloadBytes, &progressBytes)
+	if js.err != nil {
+		return
+	}
+
+	if js.status == jobs.StatusFailed {
+		payload := &jobspb.Payload{}
+		js.err = protoutil.Unmarshal(payloadBytes, payload)
+		if js.err == nil {
+			js.err = errors.New(payload.Error)
+		}
+		return
+	}
+
+	progress := &jobspb.Progress{}
+	if js.err = protoutil.Unmarshal(progressBytes, progress); js.err != nil {
+		return
+	}
+	js.prog = *(progress.Details.(*jobspb.Progress_Import).Import)
+	return
+}
+
+// Repeatedly queries job status/progress until specified function returns true.
+func queryJobUntil(
+	t *testing.T, db sqlutils.DBHandle, jobID int64, isDone func(js jobState) bool,
+) (js jobState) {
+	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+		js = queryJob(db, jobID)
+		if js.err != nil || isDone(js) {
+			break
+		}
+	}
+	if js.err != nil {
+		t.Fatal(js.err)
+	}
+	return
+}
+
+func TestCSVImportCanBeResumed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setImportReaderParallelism(1)()
+	const batchSize = 5
+	defer TestingSetCsvInputReaderBatchSize(batchSize)()
+	defer row.TestingSetDatumRowConverterBatchSize(2 * batchSize)()
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
+	s, db, _ := serverutils.StartServer(t,
+		base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				DistSQL: &execinfra.TestingKnobs{
+					BulkAdderFlushesEveryBatch: true,
+				},
+			},
+		})
+	registry := s.JobRegistry().(*jobs.Registry)
+	ctx := context.TODO()
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, "CREATE TABLE t (id INT, data STRING)")
+	defer sqlDB.Exec(t, `DROP TABLE t`)
+
+	jobCtx, cancelImport := context.WithCancel(ctx)
+	jobIDCh := make(chan int64)
+	var jobID int64 = -1
+	var importSummary roachpb.BulkOpSummary
+
+	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+		// Arrange for our special job resumer to be returned the very first time we start the import.
+		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+			resumer := raw.(*importResumer)
+			resumer.testingKnobs.alwaysFlushJobProgress = true
+			resumer.testingKnobs.afterImport = func(summary roachpb.BulkOpSummary) error {
+				importSummary = summary
+				return nil
+			}
+			if jobID == -1 {
+				return &cancellableImportResumer{
+					ctx:     jobCtx,
+					jobIDCh: jobIDCh,
+					wrapped: resumer,
+				}
+			}
+			return resumer
+		},
+	}
+
+	testBarrier, csvBarrier := newSyncBarrier()
+	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
+	csv1.addBreakpoint(7*batchSize, func() (bool, error) {
+		defer csvBarrier.Enter()()
+		return false, nil
+	})
+
+	// Convince distsql to use our "external" storage implementation.
+	storage := newGeneratedStorage(csv1)
+	s.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ExternalStorage = storage.externalStorageFactory()
+
+	// Execute import; ignore any errors returned (since we're aborting the first import run.).
+	go func() {
+		_, _ = sqlDB.DB.ExecContext(ctx,
+			`IMPORT INTO t (id, data) CSV DATA ($1)`, storage.getGeneratorURIs()[0])
+	}()
+
+	// Wait for the job to start running
+	jobID = <-jobIDCh
+
+	// Wait until we are blocked handling breakpoint.
+	unblockImport := testBarrier.Enter()
+	// Wait until we have recorded some job progress.
+	js := queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return js.prog.ResumePos[0] > 0 })
+
+	// Pause the job;
+	if err := registry.Pause(ctx, nil, jobID); err != nil {
+		t.Fatal(err)
+	}
+	// Send cancellation and unblock breakpoint.
+	cancelImport()
+	unblockImport()
+
+	// Get updated resume position counter.
+	js = queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return jobs.StatusPaused == js.status })
+	resumePos := js.prog.ResumePos[0]
+	t.Logf("Resume pos: %v\n", js.prog.ResumePos[0])
+
+	// Resume the job and wait for it to complete.
+	if err := registry.Resume(ctx, nil, jobID); err != nil {
+		t.Fatal(err)
+	}
+	js = queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return jobs.StatusSucceeded == js.status })
+
+	// Verify that the import proceeded from the resumeRow position.
+	assert.Equal(t, importSummary.Rows, int64(csv1.numRows)-resumePos)
+
+	sqlDB.CheckQueryResults(t, `SELECT id FROM t ORDER BY id`,
+		sqlDB.QueryStr(t, `SELECT generate_series(0, $1)`, csv1.numRows-1),
+	)
+}
+
+func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const batchSize = 5
+	defer TestingSetCsvInputReaderBatchSize(batchSize)()
+	defer row.TestingSetDatumRowConverterBatchSize(2 * batchSize)()
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
+	s, db, _ := serverutils.StartServer(t,
+		base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				DistSQL: &execinfra.TestingKnobs{
+					BulkAdderFlushesEveryBatch: true,
+				},
+			},
+		})
+	registry := s.JobRegistry().(*jobs.Registry)
+	ctx := context.TODO()
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, "CREATE TABLE t (id INT, data STRING)")
+	defer sqlDB.Exec(t, `DROP TABLE t`)
+
+	jobIDCh := make(chan int64)
+	controllerBarrier, importBarrier := newSyncBarrier()
+
+	var jobID int64 = -1
+	var importSummary roachpb.BulkOpSummary
+
+	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+		// Arrange for our special job resumer to be
+		// returned the very first time we start the import.
+		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+			resumer := raw.(*importResumer)
+			resumer.testingKnobs.alwaysFlushJobProgress = true
+			resumer.testingKnobs.afterImport = func(summary roachpb.BulkOpSummary) error {
+				importSummary = summary
+				return nil
+			}
+			if jobID == -1 {
+				return &cancellableImportResumer{
+					ctx:              ctx,
+					jobIDCh:          jobIDCh,
+					onSuccessBarrier: importBarrier,
+					wrapped:          resumer,
+				}
+			}
+			return resumer
+		},
+	}
+
+	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
+	csv2 := newCsvGenerator(0, 20*batchSize-1, &intGenerator{}, &strGenerator{})
+	csv3 := newCsvGenerator(0, 1, &intGenerator{}, &strGenerator{})
+
+	// Convince distsql to use our "external" storage implementation.
+	storage := newGeneratedStorage(csv1, csv2, csv3)
+	s.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ExternalStorage = storage.externalStorageFactory()
+
+	// Execute import; ignore any errors returned
+	// (since we're aborting the first import run).
+	go func() {
+		_, _ = sqlDB.DB.ExecContext(ctx,
+			`IMPORT INTO t (id, data) CSV DATA ($1, $2, $3)`, storage.getGeneratorURIs()...)
+	}()
+
+	// Wait for the job to start running
+	jobID = <-jobIDCh
+
+	// Tell importer that it can continue with it's onSuccess
+	proceedImport := controllerBarrier.Enter()
+
+	// Pause the job;
+	if err := registry.Pause(ctx, nil, jobID); err != nil {
+		t.Fatal(err)
+	}
+
+	// All files should have been processed,
+	// and the resume position set to maxInt64.
+	js := queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return jobs.StatusPaused == js.status })
+	for _, pos := range js.prog.ResumePos {
+		assert.True(t, pos == math.MaxInt64)
+	}
+
+	// Send cancellation and unblock import.
+	proceedImport()
+
+	// Resume the job and wait for it to complete.
+	if err := registry.Resume(ctx, nil, jobID); err != nil {
+		t.Fatal(err)
+	}
+	js = queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return jobs.StatusSucceeded == js.status })
+
+	// Verify that after resume we have not processed any additional rows.
+	assert.Zero(t, importSummary.Rows)
+}
+
+func (ses *generatedStorage) externalStorageFactory() cloud.ExternalStorageFactory {
+	return func(_ context.Context, es roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
+		uri, err := url.Parse(es.HttpPath.BaseUri)
+		if err != nil {
+			return nil, err
+		}
+		id, ok := ses.nameIDMap[uri.Path]
+		if !ok {
+			id = ses.nextID
+			ses.nextID++
+			ses.nameIDMap[uri.Path] = id
+		}
+		return &generatorExternalStorage{conf: es, gen: ses.generators[id]}, nil
+	}
+}
+
 // External storage factory needed to run converters.
 func externalStorageFactory(
 	ctx context.Context, dest roachpb.ExternalStorage,
@@ -293,8 +665,8 @@ func newTestSpec(
 		inputs:      make(map[int32]string),
 	}
 
-	// Initialize table descriptor for import.
-	// We need valid descriptor to run converters, even though we don't actually import anything in this test.
+	// Initialize table descriptor for import. We need valid descriptor to run
+	// converters, even though we don't actually import anything in this test.
 	var descr *sqlbase.TableDescriptor
 	switch inputFormat {
 	case roachpb.IOFileFormat_CSV:

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1549,7 +1549,7 @@ func TestImportIntoCSV(t *testing.T) {
 		tc.Servers[i].JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
 			jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*importResumer)
-				r.testingKnobs.afterImport = func() error {
+				r.testingKnobs.afterImport = func(_ roachpb.BulkOpSummary) error {
 					if importBodyFinished != nil {
 						importBodyFinished <- struct{}{}
 					}
@@ -2359,7 +2359,7 @@ func BenchmarkConvertRecord(b *testing.B) {
 	// start up workers.
 	for i := 0; i < runtime.NumCPU(); i++ {
 		group.Go(func() error {
-			return c.convertRecordWorker(ctx)
+			return c.convertRecordWorker(ctx, i)
 		})
 	}
 	const batchSize = 500

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -127,7 +127,7 @@ func (c *csvInputReader) readFile(
 	group.GoCtx(func(ctx context.Context) error {
 		ctx, span := tracing.ChildSpan(ctx, "convertcsv")
 		defer tracing.FinishSpan(span)
-		return ctxgroup.GroupWorkers(ctx, c.parallelism, func(ctx context.Context) error {
+		return ctxgroup.GroupWorkers(ctx, c.parallelism, func(ctx context.Context, _ int) error {
 			return c.convertRecordWorker(ctx)
 		})
 	})

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -44,6 +45,18 @@ type csvInputReader struct {
 
 var _ inputConverter = &csvInputReader{}
 
+var inputReaderBatchSize = 500
+
+// TestingSetCsvInputReaderBatchSize is a testing knob to modify
+// csv input reader batch size.
+// Returns a function that resets the value back to the default.
+func TestingSetCsvInputReaderBatchSize(s int) func() {
+	inputReaderBatchSize = s
+	return func() {
+		inputReaderBatchSize = 500
+	}
+}
+
 func newCSVInputReader(
 	kvCh chan row.KVBatch,
 	opts roachpb.CSVOptions,
@@ -65,7 +78,7 @@ func newCSVInputReader(
 		expectedCols: len(tableDesc.VisibleColumns()),
 		tableDesc:    tableDesc,
 		targetCols:   targetCols,
-		batchSize:    500,
+		batchSize:    inputReaderBatchSize,
 		parallelism:  parallelism,
 	}
 }
@@ -118,7 +131,7 @@ func (c *csvInputReader) readFile(
 	c.batch = csvRecord{
 		file:      inputName,
 		fileIndex: inputIdx,
-		rowOffset: 1,
+		rowOffset: 1 + resumePos,
 		r:         make([][]string, 0, c.batchSize),
 		rejected:  rejected,
 	}
@@ -127,13 +140,15 @@ func (c *csvInputReader) readFile(
 	group.GoCtx(func(ctx context.Context) error {
 		ctx, span := tracing.ChildSpan(ctx, "convertcsv")
 		defer tracing.FinishSpan(span)
-		return ctxgroup.GroupWorkers(ctx, c.parallelism, func(ctx context.Context, _ int) error {
-			return c.convertRecordWorker(ctx)
+		return ctxgroup.GroupWorkers(ctx, c.parallelism, func(ctx context.Context, id int) error {
+			return c.convertRecordWorker(ctx, id)
 		})
 	})
 
 	group.GoCtx(func(ctx context.Context) error {
 		defer close(c.recordCh)
+		minEmitted := make([]int64, c.parallelism)
+		c.batch.minEmitted = &minEmitted
 		for i := int64(1); ; i++ {
 			record, err := cr.Read()
 			finished := err == io.EOF
@@ -154,9 +169,10 @@ func (c *csvInputReader) readFile(
 				return errors.Wrapf(err, "row %d: reading CSV record", i)
 			}
 			// Ignore the first N lines.
-			if uint32(i) <= c.opts.Skip {
+			if uint32(i) <= c.opts.Skip || i <= resumePos {
 				continue
 			}
+
 			if len(record) == c.expectedCols {
 				// Expected number of columns.
 			} else if len(record) == c.expectedCols+1 && record[c.expectedCols] == "" {
@@ -187,11 +203,13 @@ type csvRecord struct {
 	progress  float32
 	// Channel on which to report bad rows.
 	rejected chan string
+	// smallest emitted row across all convert workers
+	minEmitted *[]int64
 }
 
 // convertRecordWorker converts CSV records into KV pairs and sends them on the
 // kvCh chan.
-func (c *csvInputReader) convertRecordWorker(ctx context.Context) error {
+func (c *csvInputReader) convertRecordWorker(ctx context.Context, workerID int) error {
 	// Create a new evalCtx per converter so each go routine gets its own
 	// collationenv, which can't be accessed in parallel.
 	evalCtx := c.evalCtx.Copy()
@@ -203,11 +221,20 @@ func (c *csvInputReader) convertRecordWorker(ctx context.Context) error {
 		panic("uninitialized session data")
 	}
 
+	var rowNum int64
+
+	var minEmitted *[]int64 // Set in the loop below.
+	conv.CompletedRowFn = func() int64 {
+		m := c.emittedRowLowWatermark(workerID, rowNum, *minEmitted)
+		return m
+	}
+
 	epoch := time.Date(2015, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
 	const precision = uint64(10 * time.Microsecond)
 	timestamp := uint64(c.walltime-epoch) / precision
 
 	for batch := range c.recordCh {
+		minEmitted = batch.minEmitted
 		if conv.KvBatch.Source != batch.fileIndex {
 			if err := conv.SendBatch(ctx); err != nil {
 				return err
@@ -217,7 +244,7 @@ func (c *csvInputReader) convertRecordWorker(ctx context.Context) error {
 		conv.KvBatch.Progress = batch.progress
 	ROW_LOOP:
 		for batchIdx, record := range batch.r {
-			rowNum := batch.rowOffset + int64(batchIdx)
+			rowNum = batch.rowOffset + int64(batchIdx)
 			datumIdx := 0
 			for i, field := range record {
 				// Skip over record entries corresponding to columns not in the target
@@ -252,4 +279,23 @@ func (c *csvInputReader) convertRecordWorker(ctx context.Context) error {
 		}
 	}
 	return conv.SendBatch(ctx)
+}
+
+// Updates emitted row for the specified worker and returns
+// low watermark for the emitted rows across all workers.
+func (c *csvInputReader) emittedRowLowWatermark(
+	workerID int, emittedRow int64, minEmitted []int64,
+) int64 {
+	atomic.StoreInt64(&minEmitted[workerID], emittedRow)
+
+	for i := 0; i < len(minEmitted); i++ {
+		if i != workerID {
+			w := atomic.LoadInt64(&minEmitted[i])
+			if w < emittedRow {
+				emittedRow = w
+			}
+		}
+	}
+
+	return emittedRow
 }

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -147,7 +147,7 @@ func (w *workloadReader) readFiles(
 	}
 
 	for _, wc := range wcs {
-		if err := ctxgroup.GroupWorkers(ctx, runtime.NumCPU(), func(ctx context.Context) error {
+		if err := ctxgroup.GroupWorkers(ctx, runtime.NumCPU(), func(ctx context.Context, _ int) error {
 			evalCtx := w.evalCtx.Copy()
 			return wc.Worker(ctx, evalCtx)
 		}); err != nil {

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -10,15 +10,22 @@ package importccl
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -69,4 +76,217 @@ var testEvalCtx = &tree.EvalContext{
 	},
 	StmtTimestamp: timeutil.Unix(100000000, 0),
 	Settings:      cluster.MakeTestingClusterSettings(),
+}
+
+// Value generator represents a value of some data at specified row/col.
+type csvRow = int
+type csvCol = int
+
+type valueGenerator interface {
+	getValue(r csvRow, c csvCol) string
+}
+type intGenerator struct{} // Returns row value
+type strGenerator struct{} // Returns generated string
+
+var _ valueGenerator = &intGenerator{}
+var _ valueGenerator = &strGenerator{}
+
+func (g *intGenerator) getValue(r csvRow, _ csvCol) string {
+	return strconv.Itoa(r)
+}
+
+func (g *strGenerator) getValue(r csvRow, c csvCol) string {
+	return fmt.Sprintf("data<r=%d;c=%d>", r, c)
+}
+
+// A breakpoint handler runs some breakpoint specific logic. A handler
+// returns a boolean indicating if this breakpoint should remain active.
+// An error result will cause csv generation to stop and the csv server
+// to return that error.
+type csvBpHandler = func() (bool, error)
+type csvBreakpoint struct {
+	row     csvRow
+	enabled bool
+	handler csvBpHandler
+}
+
+// csvGenerator generates csv data.
+type csvGenerator struct {
+	startRow    int
+	numRows     int
+	columns     []valueGenerator
+	breakpoints map[int]*csvBreakpoint
+
+	data      []string
+	size      int
+	rowPos    int // csvRow number we're emitting
+	rowOffset int // Offset within the current row
+}
+
+const maxBreakpointPos = math.MaxInt32
+
+var _ io.ReadCloser = &csvGenerator{}
+
+func (csv *csvGenerator) Open() (io.ReadCloser, error) {
+	csv.rowPos = 0
+	csv.rowOffset = 0
+	csv.maybeInitData()
+	return csv, nil
+}
+
+// Note: we read one row at a time because reading as much as the
+// buffer space allows might cause problems for breakpoints (e.g.
+// a breakpoint may block until job progress is updated, but that
+// update would never happen because we're still reading the data).
+func (csv *csvGenerator) Read(p []byte) (n int, err error) {
+	n = 0
+	if n < cap(p) && csv.rowPos < len(csv.data) {
+		if csv.rowOffset == 0 {
+			if err = csv.handleBreakpoint(csv.rowPos); err != nil {
+				return
+			}
+		}
+		rowBytes := copy(p[n:], csv.data[csv.rowPos][csv.rowOffset:])
+		csv.rowOffset += rowBytes
+		n += rowBytes
+
+		if rowBytes == len(csv.data[csv.rowPos]) {
+			csv.rowOffset = 0
+			csv.rowPos++
+		}
+	}
+
+	if n == 0 {
+		_ = csv.Close()
+		err = io.EOF
+	}
+
+	return
+}
+
+func (csv *csvGenerator) maybeInitData() {
+	if csv.data != nil {
+		return
+	}
+
+	csv.data = make([]string, csv.numRows)
+	csv.size = 0
+	for i := 0; i < csv.numRows; i++ {
+		csv.data[i] = ""
+		for colIdx, gen := range csv.columns {
+			if len(csv.data[i]) > 0 {
+				csv.data[i] += ","
+			}
+			csv.data[i] += gen.getValue(i+csv.startRow, colIdx)
+		}
+		csv.data[i] += "\n"
+		csv.size += len(csv.data[i])
+	}
+}
+
+func (csv *csvGenerator) handleBreakpoint(idx int) (err error) {
+	if bp, ok := csv.breakpoints[idx]; ok && bp.enabled {
+		bp.enabled, err = bp.handler()
+	}
+	return
+}
+
+func (csv *csvGenerator) Close() error {
+	// Execute breakpoint at the end of the stream.
+	_ = csv.handleBreakpoint(maxBreakpointPos)
+	csv.data = nil
+	return nil
+}
+
+// Add a breakpoint to the generator.
+func (csv *csvGenerator) addBreakpoint(r csvRow, handler csvBpHandler) *csvBreakpoint {
+	csv.breakpoints[r] = &csvBreakpoint{
+		row:     r,
+		enabled: true,
+		handler: handler,
+	}
+	return csv.breakpoints[r]
+}
+
+// Creates a new instance of csvGenerator, generating 'numRows', starting form
+// the specified 'startRow'. The 'columns' list specifies data generators for
+// each column. The optional 'breakpoints' specifies the list of csv breakpoints
+// which allow caller to execute some code while generating csv data.
+func newCsvGenerator(startRow int, numRows int, columns ...valueGenerator) *csvGenerator {
+	return &csvGenerator{
+		startRow:    startRow,
+		numRows:     numRows,
+		columns:     columns,
+		breakpoints: make(map[int]*csvBreakpoint),
+	}
+}
+
+// generatorExternalStorage is an external storage implementation
+// that returns its data from the underlying generator.
+type generatorExternalStorage struct {
+	conf roachpb.ExternalStorage
+	gen  *csvGenerator
+}
+
+var _ cloud.ExternalStorage = &generatorExternalStorage{}
+
+func (es *generatorExternalStorage) Conf() roachpb.ExternalStorage {
+	return es.conf
+}
+
+func (es *generatorExternalStorage) ReadFile(
+	ctx context.Context, basename string,
+) (io.ReadCloser, error) {
+	return es.gen.Open()
+}
+
+func (es *generatorExternalStorage) Close() error {
+	return nil
+}
+
+func (es *generatorExternalStorage) Size(ctx context.Context, basename string) (int64, error) {
+	es.gen.maybeInitData()
+	return int64(es.gen.size), nil
+}
+
+func (es *generatorExternalStorage) WriteFile(
+	ctx context.Context, basename string, content io.ReadSeeker,
+) error {
+	return errors.New("unsupported")
+}
+
+func (es *generatorExternalStorage) ListFiles(ctx context.Context) ([]string, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (es *generatorExternalStorage) Delete(ctx context.Context, basename string) error {
+	return errors.New("unsupported")
+}
+
+// generatedStorage is a factory (cloud.ExternalStorageFactory)
+// that returns the underlying csvGenerators The file name of the
+// generated file doesn't matter: the first time we attempt to get a
+// generator for a file, we return the next generator on the list.
+type generatedStorage struct {
+	generators []*csvGenerator
+	nextID     int
+	nameIDMap  map[string]int
+}
+
+func newGeneratedStorage(gens ...*csvGenerator) *generatedStorage {
+	return &generatedStorage{
+		generators: gens,
+		nextID:     0,
+		nameIDMap:  make(map[string]int),
+	}
+}
+
+// Returns the list of file names (URIs) suitable for this factory.
+func (ses *generatedStorage) getGeneratorURIs() []interface{} {
+	// Names do not matter; all that matters is the number of generators.
+	res := make([]interface{}, len(ses.generators))
+	for i := range ses.generators {
+		res[i] = fmt.Sprintf("http://host.does.not.matter/filename_is_meaningless%d", i)
+	}
+	return res
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -849,11 +849,12 @@ func (sc *SchemaChanger) distBackfill(
 						otherTableDescs = append(otherTableDescs, *table.TableDesc())
 					}
 				}
-				metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) {
+				metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
 					if meta.BulkProcessorProgress != nil {
 						todoSpans = roachpb.SubtractSpans(todoSpans,
 							meta.BulkProcessorProgress.CompletedSpans)
 					}
+					return nil
 				}
 				cbw := metadataCallbackWriter{rowResultWriter: &errOnlyResultWriter{}, fn: metaFn}
 				recv := MakeDistSQLReceiver(

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -484,11 +484,13 @@ type metadataResultWriter interface {
 
 type metadataCallbackWriter struct {
 	rowResultWriter
-	fn func(ctx context.Context, meta *execinfrapb.ProducerMetadata)
+	fn func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error
 }
 
 func (w *metadataCallbackWriter) AddMeta(ctx context.Context, meta *execinfrapb.ProducerMetadata) {
-	w.fn(ctx, meta)
+	if err := w.fn(ctx, meta); err != nil {
+		w.SetError(err)
+	}
 }
 
 // errOnlyResultWriter is a rowResultWriter that only supports receiving an

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -211,6 +211,9 @@ type TestingKnobs struct {
 	// EnableVectorizedInvariantsChecker, if enabled, will allow for planning
 	// the invariant checkers between all columnar operators.
 	EnableVectorizedInvariantsChecker bool
+
+	// Forces bulk adder flush every time a KV batch is processed.
+	BulkAdderFlushesEveryBatch bool
 }
 
 // MetadataTestLevel represents the types of queries where metadata test

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -708,7 +708,7 @@ func testRandomSyntax(
 		}
 	}(ctx)
 	ctx, timeoutCancel := context.WithTimeout(ctx, *flagRSGTime)
-	err = ctxgroup.GroupWorkers(ctx, *flagRSGGoRoutines, func(ctx context.Context) error {
+	err = ctxgroup.GroupWorkers(ctx, *flagRSGGoRoutines, func(ctx context.Context, _ int) error {
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -504,7 +504,7 @@ SELECT count(*), sum(value) FROM crdb_internal.node_metrics WHERE
 	// they can occasionally happen during upreplication.
 	numSnapsBefore := numRaftSnaps("before")
 
-	doSplit := func(ctx context.Context) error {
+	doSplit := func(ctx context.Context, _ int) error {
 		_, _, err := tc.SplitRange(
 			[]byte(fmt.Sprintf("key-%d", perm[atomic.AddInt32(&idx, 1)])))
 		return err

--- a/pkg/util/ctxgroup/ctxgroup.go
+++ b/pkg/util/ctxgroup/ctxgroup.go
@@ -168,10 +168,11 @@ func (g Group) GoCtx(f func(ctx context.Context) error) {
 }
 
 // GroupWorkers runs num worker go routines in an errgroup.
-func GroupWorkers(ctx context.Context, num int, f func(context.Context) error) error {
+func GroupWorkers(ctx context.Context, num int, f func(context.Context, int) error) error {
 	group := WithContext(ctx)
 	for i := 0; i < num; i++ {
-		group.GoCtx(f)
+		workerID := i
+		group.GoCtx(func(ctx context.Context) error { return f(ctx, workerID) })
 	}
 	return group.Wait()
 }


### PR DESCRIPTION
Add ability to resume csv imports based on the state persisted in the
job progress record.

Add an end-to-end test verifying this functionality.

Release note (cli change): CSV import can be resumed from checkpointed state.