### PR TITLE
cli: change default --max-sql-memory to 25%

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -143,7 +143,7 @@ Maximum memory capacity available to store temporary data for SQL clients,
 including prepared queries and intermediate data rows during query execution.
 Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
 percentage of physical memory (e.g. .25).
-If left unspecified, defaults to 128MiB.
+If left unspecified, defaults to 25% of physical memory.
 `,
 	}
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -108,6 +108,10 @@ func initCLIDefaults() {
 	serverCfg.JoinList = nil
 	serverCfg.DefaultZoneConfig = config.DefaultZoneConfig()
 	serverCfg.DefaultSystemZoneConfig = config.DefaultSystemZoneConfig()
+	// Attempt to default serverCfg.SQLMemoryPoolSize to 25% if possible.
+	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
+		serverCfg.SQLMemoryPoolSize = bytes
+	}
 
 	startCtx.serverInsecure = baseCfg.Insecure
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1042,19 +1042,6 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		log.Warning(ctx, buf.String())
 	}
 
-	if !sqlSizeValue.IsSet() {
-		var buf bytes.Buffer
-		fmt.Fprintf(&buf, "Using the default setting for --max-sql-memory (%s).\n", sqlSizeValue)
-		fmt.Fprintf(&buf, "  A significantly larger value is usually needed in production.\n")
-		if size, err := status.GetTotalMemory(context.Background()); err == nil {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --max-sql-memory=.25 (%s).",
-				humanizeutil.IBytes(size/4))
-		} else {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
-		}
-		log.Warning(ctx, buf.String())
-	}
-
 	// Check that the total suggested "max" memory is well below the available memory.
 	if maxMemory, err := status.GetTotalMemory(ctx); err == nil {
 		requestedMem := serverCfg.CacheSize + serverCfg.SQLMemoryPoolSize


### PR DESCRIPTION
This flag was changed to default to 128mb in #18040, as part of an
effort to reduce memory usage of small nodes.

Unlike the `cache` memory limit which was changed at the same time, the
SQL memory limit is not passively consumed -- it is only used as-needed
by active operations, so if being fully consumed, it is likely because
it is actively being used, and setting it lower would actually degrade
performance (by forcing disk-spilling, reducing concurrency, etc).

The 128mb limit is thus generally acknowledged to be too small for any
real production usage -- and we even logged warnings if it was used --
but this means any unsuspecting user who does not alter it when firing
up a node for some quick evaluation is also not getting representative
behavior. Given that increasing this limit likely only increases actual
memory usage of an active node -- where such usage is likely within
the reasonable expectations of the user -- a higher default is likely
preferable. Setting it based on a fraction of system memory elegantly
allows adapting to different deployment environments automatically.

Fixes #42437.

Release note (general change): Changed the default value of --max-sql-memory limit from 128mb to 25% of system memory.