### PR TITLE
storage/engine: disable usage of the Pebble archive cleaner

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -196,7 +196,6 @@ var PebbleTablePropertyCollectors = []func() pebble.TablePropertyCollector{
 // DefaultPebbleOptions returns the default pebble options.
 func DefaultPebbleOptions() *pebble.Options {
 	return &pebble.Options{
-		Cleaner:               pebble.ArchiveCleaner{},
 		Comparer:              MVCCComparer,
 		L0CompactionThreshold: 2,
 		L0StopWritesThreshold: 1000,


### PR DESCRIPTION
Disable the usage of the Pebble archive cleaner which was used during a
previous debugging effort and accidentally left enabled.

Release note: None