### PR TITLE
storage: assert around snapshot sending/receiving

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -461,20 +461,36 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 		decision.NewFirstIndex = decision.Input.FirstIndex
 		decision.ChosenVia = truncatableIndexChosenViaFirstIndex
 	}
+
+	// Invariants: NewFirstIndex >= FirstIndex
+	//             NewFirstIndex <= LastIndex (if != 10)
+	//             NewFirstIndex <= QuorumIndex (if != 0)
+	//
+	// For uninit'ed replicas we can have input.FirstIndex > input.LastIndex, more
+	// specifically input.FirstIndex = input.LastIndex + 1. FirstIndex is set to
+	// TruncatedState.Index + 1, and for an unit'ed replica, LastIndex is simply
+	// 10. This is what informs the `input.LastIndex == 10` conditional below.
+	valid := (decision.NewFirstIndex >= input.FirstIndex) &&
+		(decision.NewFirstIndex <= input.LastIndex || input.LastIndex == 10) &&
+		(decision.NewFirstIndex <= decision.QuorumIndex || decision.QuorumIndex == 0)
+	if !valid {
+		err := fmt.Sprintf("invalid truncation decision; output = %d, input: [%d, %d], quorum idx = %d",
+			decision.NewFirstIndex, input.FirstIndex, input.LastIndex, decision.QuorumIndex)
+		panic(err)
+	}
+
 	return decision
 }
 
-// getQuorumIndex returns the index which a quorum of the nodes have
-// committed. The snapshotLogTruncationConstraints indicates the index of a pending
-// snapshot which is considered part of the Raft group even though it hasn't
-// been added yet. Note that getQuorumIndex may return 0 if the progress map
-// doesn't contain information for a sufficient number of followers (e.g. the
-// local replica has only recently become the leader). In general, the value
-// returned by getQuorumIndex may be smaller than raftStatus.Commit which is
-// the log index that has been committed by a quorum of replicas where that
-// quorum was determined at the time the index was written. If you're thinking
-// of using getQuorumIndex for some purpose, consider that raftStatus.Commit
-// might be more appropriate (e.g. determining if a replica is up to date).
+// getQuorumIndex returns the index which a quorum of the nodes have committed.
+// Note that getQuorumIndex may return 0 if the progress map doesn't contain
+// information for a sufficient number of followers (e.g. the local replica has
+// only recently become the leader). In general, the value returned by
+// getQuorumIndex may be smaller than raftStatus.Commit which is the log index
+// that has been committed by a quorum of replicas where that quorum was
+// determined at the time the index was written. If you're thinking of using
+// getQuorumIndex for some purpose, consider that raftStatus.Commit might be
+// more appropriate (e.g. determining if a replica is up to date).
 func getQuorumIndex(raftStatus *raft.Status) uint64 {
 	match := make([]uint64, 0, len(raftStatus.Progress))
 	for _, progress := range raftStatus.Progress {

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -227,13 +227,13 @@ func TestComputeTruncateDecision(t *testing.T) {
 				}
 			}
 			input := truncateDecisionInput{
-				RaftStatus:                     status,
-				LogSize:                        c.raftLogSize,
-				MaxLogSize:                     targetSize,
-				LogSizeTrusted:                 true,
-				FirstIndex:                     c.firstIndex,
-				LastIndex:                      c.lastIndex,
-				PendingPreemptiveSnapshotIndex: c.pendingSnapshot,
+				RaftStatus:           status,
+				LogSize:              c.raftLogSize,
+				MaxLogSize:           targetSize,
+				LogSizeTrusted:       true,
+				FirstIndex:           c.firstIndex,
+				LastIndex:            c.lastIndex,
+				PendingSnapshotIndex: c.pendingSnapshot,
 			}
 			decision := computeTruncateDecision(input)
 			if act, exp := decision.String(), c.exp; act != exp {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -260,7 +260,7 @@ type Replica struct {
 		// from the Raft log entry. Use the invalidLastTerm constant for this
 		// case.
 		lastIndex, lastTerm uint64
-		// A map of raft log index of pending preemptive snapshots to deadlines.
+		// A map of raft log index of pending snapshots to deadlines.
 		// Used to prohibit raft log truncations that would leave a gap between
 		// the snapshot and the new first index. The map entry has a zero
 		// deadline while the snapshot is being sent and turns nonzero when the

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1996,6 +1996,16 @@ func (r *Replica) sendSnapshot(
 		r.store.Engine().NewBatch,
 		sent,
 	); err != nil {
+		if errors.Cause(err) == errMalformedSnapshot {
+			tag := fmt.Sprintf("r%d_%s", r.RangeID, snap.SnapUUID.Short())
+			if dir, err := r.store.checkpoint(ctx, tag); err != nil {
+				log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
+			} else {
+				log.Warningf(ctx, "created checkpoint %s", dir)
+			}
+
+			log.Fatal(ctx, "malformed snapshot generated")
+		}
 		return &snapshotError{err}
 	}
 	return nil

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -210,19 +210,17 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc storagepb.Com
 	// Raft-consistent (i.e. not in the middle of an AddSSTable).
 	snap := r.store.engine.NewSnapshot()
 	if cc.Checkpoint {
-		checkpointBase := filepath.Join(r.store.engine.GetAuxiliaryDir(), "checkpoints")
-		_ = os.MkdirAll(checkpointBase, 0700)
 		sl := stateloader.Make(r.RangeID)
 		rai, _, err := sl.LoadAppliedIndex(ctx, snap)
 		if err != nil {
 			log.Warningf(ctx, "unable to load applied index, continuing anyway")
 		}
 		// NB: the names here will match on all nodes, which is nice for debugging.
-		checkpointDir := filepath.Join(checkpointBase, fmt.Sprintf("r%d_at_%d", r.RangeID, rai))
-		if err := r.store.engine.CreateCheckpoint(checkpointDir); err != nil {
-			log.Warningf(ctx, "unable to create checkpoint %s: %+v", checkpointDir, err)
+		tag := fmt.Sprintf("r%d_at_%d", r.RangeID, rai)
+		if dir, err := r.store.checkpoint(ctx, tag); err != nil {
+			log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
 		} else {
-			log.Infof(ctx, "created checkpoint %s", checkpointDir)
+			log.Warningf(ctx, "created checkpoint %s", dir)
 		}
 	}
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -495,6 +495,10 @@ type IncomingSnapshot struct {
 	snapType                       SnapshotRequest_Type
 }
 
+func (s *IncomingSnapshot) String() string {
+	return fmt.Sprintf("%s snapshot %s at applied index %d", s.snapType, s.SnapUUID.Short(), s.State.RaftAppliedIndex)
+}
+
 // snapshot creates an OutgoingSnapshot containing a rocksdb snapshot for the
 // given range. Note that snapshot() is called without Replica.raftMu held.
 func snapshot(
@@ -891,6 +895,26 @@ func (r *Replica) applySnapshot(
 			s.RaftAppliedIndex, snap.Metadata.Index)
 	}
 
+	if expLen := s.RaftAppliedIndex - s.TruncatedState.Index; expLen != uint64(len(inSnap.LogEntries)) {
+		entriesRange, err := extractRangeFromEntries(inSnap.LogEntries)
+		if err != nil {
+			return err
+		}
+
+		tag := fmt.Sprintf("r%d_%s", r.RangeID, inSnap.SnapUUID.String())
+		dir, err := r.store.checkpoint(ctx, tag)
+		if err != nil {
+			log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
+		} else {
+			log.Warningf(ctx, "created checkpoint %s", dir)
+		}
+
+		log.Fatalf(ctx, "missing log entries in snapshot (%s): got %d entries, expected %d "+
+			"(TruncatedState.Index=%d, HardState=%s, LogEntries=%s)",
+			inSnap.String(), len(inSnap.LogEntries), expLen, s.TruncatedState.Index,
+			hs.String(), entriesRange)
+	}
+
 	// If we're subsuming a replica below, we don't have its last NextReplicaID,
 	// nor can we obtain it. That's OK: we can just be conservative and use the
 	// maximum possible replica ID. preDestroyRaftMuLocked will write a replica
@@ -1123,6 +1147,29 @@ func (r *Replica) clearSubsumedReplicaInMemoryData(
 		}
 	}
 	return nil
+}
+
+// extractRangeFromEntries returns a string representation of the range of
+// marshaled list of raft log entries in the form of [first-index, last-index].
+// If the list is empty, "[n/a, n/a]" is returned instead.
+func extractRangeFromEntries(logEntries [][]byte) (string, error) {
+	var firstIndex, lastIndex string
+	if len(logEntries) == 0 {
+		firstIndex = "n/a"
+		lastIndex = "n/a"
+	} else {
+		firstAndLastLogEntries := make([]raftpb.Entry, 2)
+		if err := protoutil.Unmarshal(logEntries[0], &firstAndLastLogEntries[0]); err != nil {
+			return "", err
+		}
+		if err := protoutil.Unmarshal(logEntries[len(logEntries)-1], &firstAndLastLogEntries[1]); err != nil {
+			return "", err
+		}
+
+		firstIndex = string(firstAndLastLogEntries[0].Index)
+		lastIndex = string(firstAndLastLogEntries[1].Index)
+	}
+	return fmt.Sprintf("[%s, %s]", firstIndex, lastIndex), nil
 }
 
 type raftCommandEncodingVersion byte

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -2299,6 +2301,21 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// checkpoint creates a RocksDB checkpoint in the auxiliary directory with the
+// provided tag used in the filepath. The filepath for the checkpoint directory
+// is returned.
+func (s *Store) checkpoint(ctx context.Context, tag string) (string, error) {
+	checkpointBase := filepath.Join(s.engine.GetAuxiliaryDir(), "checkpoints")
+	_ = os.MkdirAll(checkpointBase, 0700)
+
+	checkpointDir := filepath.Join(checkpointBase, tag)
+	if err := s.engine.CreateCheckpoint(checkpointDir); err != nil {
+		return "", err
+	}
+
+	return checkpointDir, nil
 }
 
 // ComputeMetrics immediately computes the current value of store metrics which


### PR DESCRIPTION
Raft log entries are shipped alongside snapshots. The log entries
included in snapshots (which also include the truncated state and the
applied index) cover all indexes in the range `[truncated-state.index +
1, applied-state]`. We simply assert that this is always the case.

Release note: None

---

@tbg: I thought you said that 19.1+ we no longer sent over raft log entries along side snapshots, but it seems like we do?