### PR TITLE
opt: populate autocommit correctly under EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -114,6 +114,14 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 			return execPlan{}, err
 		}
 	} else {
+
+		// The auto commit flag should reflect what would happen if this statement
+		// was run without the explain, so recalculate it.
+		defer func(oldVal bool) {
+			b.autoCommit = oldVal
+		}(b.autoCommit)
+		b.autoCommit = b.canAutoCommit(explain.Input)
+
 		input, err := b.buildRelational(explain.Input)
 		if err != nil {
 			return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -1,8 +1,10 @@
 # LogicTest: local
 
 # This file tests against mutations that we expect to be handled with one-phase
-# commit transactions. Any change to the kv batches produced by these statements
-# should be treated with care.
+# commit transactions. In addition to checking the planning part, we also check
+# (using traces) that this is implemented correctly in terms of KV operations.
+# Any change to the kv batches produced by these statements should be treated
+# with care.
 
 statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT, FAMILY f1 (a, b))
@@ -17,15 +19,17 @@ SELECT * FROM ab
 # ------------
 
 # Single-row insert should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (1, 1)
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (1, 1);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -36,15 +40,17 @@ WHERE message     LIKE '%sending batch%'
 dist sender send  r24: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 
 # Multi-row insert should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (2, 2), (3, 3)
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (2, 2), (3, 3);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -58,15 +64,17 @@ dist sender send  r24: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 statement ok
 BEGIN
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (4, 4), (5, 5)
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (4, 4), (5, 5);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -80,15 +88,17 @@ statement ok
 ROLLBACK
 
 # Insert with simple RETURNING statement should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -99,15 +109,17 @@ WHERE message     LIKE '%sending batch%'
 dist sender send  r24: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -121,15 +133,17 @@ dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   INSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -156,15 +170,17 @@ SELECT count(*) FROM ab WHERE b=0
 # ------------
 
 # Single-row upsert should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (1, 1)
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (1, 1);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -175,15 +191,17 @@ WHERE message     LIKE '%sending batch%'
 dist sender send  r24: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 
 # Multi-row upsert should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (2, 2), (3, 3)
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (2, 2), (3, 3);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -197,15 +215,17 @@ dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 statement ok
 BEGIN
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (4, 4), (5, 5)
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (4, 4), (5, 5);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -219,15 +239,17 @@ statement ok
 ROLLBACK
 
 # Upsert with simple RETURNING statement should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -238,15 +260,17 @@ WHERE message     LIKE '%sending batch%'
 dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -260,15 +284,17 @@ dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
 # Upsert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -295,15 +321,17 @@ SELECT count(*) FROM ab WHERE b=0
 # ------------
 
 # Simple update should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   UPDATE ab SET b=b+1 WHERE a < 3;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -318,15 +346,17 @@ dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 statement ok
 BEGIN
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPDATE ab SET b=b+1 WHERE a < 3;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -341,15 +371,17 @@ statement ok
 ROLLBACK
 
 # Update with simple RETURNING statement should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a, b
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a, b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -361,15 +393,17 @@ dist sender send  r24: sending batch 1 Scan to (n1,s1):1
 dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a + b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a + b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -384,15 +418,17 @@ dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
 # Update with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a / b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a / b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -420,15 +456,17 @@ SELECT count(*) FROM ab WHERE b=0
 # ------------
 
 # Single-row delete should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a = 1
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a = 1;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -439,15 +477,17 @@ WHERE message     LIKE '%sending batch%'
 dist sender send  r24: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # Multi-row delete should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (2, 3)
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a IN (2, 3);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -461,15 +501,17 @@ dist sender send  r24: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 statement ok
 BEGIN
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (4, 5)
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a IN (4, 5);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -483,15 +525,17 @@ statement ok
 ROLLBACK
 
 # Delete with simple RETURNING statement should auto-commit.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (6, 7) RETURNING a, b
+] WHERE field = 'auto commit'
+----
+true
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a IN (6, 7) RETURNING a, b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-true
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -503,15 +547,17 @@ dist sender send  r24: sending batch 1 Scan to (n1,s1):1
 dist sender send  r24: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (8, 9) RETURNING a + b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a IN (8, 9) RETURNING a + b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -526,15 +572,17 @@ dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM ab WHERE a IN (10, 11) RETURNING a / b
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   DELETE FROM ab WHERE a IN (10, 11) RETURNING a / b;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -571,19 +619,20 @@ CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p), FAMILY f1 (a, b));
 SET experimental_optimizer_foreign_keys = true
 
 # Populate table descriptor cache.
-query IIII
+statement ok
 SELECT * FROM fk_parent JOIN fk_child ON p = b
+
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO fk_child VALUES (1, 1), (2, 2)
+] WHERE field = 'auto commit'
 ----
+false
 
 statement ok
 SET TRACING=ON;
   INSERT INTO fk_child VALUES (1, 1), (2, 2);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -596,15 +645,17 @@ dist sender send  r24: sending batch 2 CPut, 2 InitPut to (n1,s1):1
 dist sender send  r24: sending batch 2 Scan to (n1,s1):1
 dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) UPDATE fk_child SET b=b+1 WHERE a < 2
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   UPDATE fk_child SET b=b+1 WHERE a < 2;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -618,15 +669,18 @@ dist sender send  r24: sending batch 1 Put, 1 CPut, 1 Del to (n1,s1):1
 dist sender send  r24: sending batch 1 Scan to (n1,s1):1
 dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) DELETE FROM fk_parent WHERE p = 3
+] WHERE field = 'auto commit'
+----
+false
+
+
 statement ok
 SET TRACING=ON;
   DELETE FROM fk_parent WHERE p = 3;
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -643,6 +697,14 @@ dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 # -----------------------
 # Multiple mutation tests
 # -----------------------
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO ab (
+    SELECT a*10, b*10 FROM [ INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b ]
+  )
+] WHERE field = 'auto commit'
+----
+false
 
 statement ok
 SET TRACING=ON;
@@ -650,11 +712,6 @@ SET TRACING=ON;
     SELECT a*10, b*10 FROM [ INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b ]
   );
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
@@ -667,16 +724,19 @@ dist sender send  r24: sending batch 2 CPut to (n1,s1):1
 dist sender send  r24: sending batch 2 CPut to (n1,s1):1
 dist sender send  r24: sending batch 1 EndTxn to (n1,s1):1
 
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) WITH cte AS (INSERT INTO ab VALUES (3, 3), (4, 4) RETURNING a, b)
+    INSERT INTO ab (SELECT a*10, b*10 FROM cte)
+] WHERE field = 'auto commit'
+----
+false
+
 statement ok
 SET TRACING=ON;
   WITH cte AS (INSERT INTO ab VALUES (3, 3), (4, 4) RETURNING a, b)
   INSERT INTO ab (SELECT a*10, b*10 FROM cte);
 SET TRACING=OFF
-
-query B
-SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
-----
-false
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -28,6 +28,7 @@ count                     ·            ·                          ()          
       │                   table        t9                         ·                                 ·
       │                   set          b                          ·                                 ·
       │                   strategy     updater                    ·                                 ·
+      │                   auto commit  ·                          ·                                 ·
       └── render          ·            ·                          (a, b, column11, check1, check2)  ·
            │              render 0     a                          ·                                 ·
            │              render 1     b                          ·                                 ·
@@ -54,6 +55,7 @@ count                ·            ·           ()                              
       │              table        t9          ·                                          ·
       │              set          a           ·                                          ·
       │              strategy     updater     ·                                          ·
+      │              auto commit  ·           ·                                          ·
       └── render     ·            ·           (a, b, c, d, e, column11, check1, check2)  ·
            │         render 0     a           ·                                          ·
            │         render 1     b           ·                                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -76,6 +76,7 @@ count                     ·            ·
  └── delete               ·            ·
       │                   from         unindexed
       │                   strategy     deleter
+      │                   auto commit  ·
       └── render          ·            ·
            └── limit      ·            ·
                 │         count        10
@@ -94,6 +95,7 @@ count                     ·            ·
  └── delete               ·            ·
       │                   from         unindexed
       │                   strategy     deleter
+      │                   auto commit  ·
       └── render          ·            ·
            └── limit      ·            ·
                 │         count        10
@@ -126,6 +128,7 @@ count           ·            ·
  └── delete     ·            ·
       │         from         unindexed
       │         strategy     deleter
+      │         auto commit  ·
       └── scan  ·            ·
 ·               table        unindexed@primary
 ·               spans        /1-
@@ -140,6 +143,7 @@ count           ·            ·
  └── delete     ·            ·
       │         from         indexed
       │         strategy     deleter
+      │         auto commit  ·
       └── scan  ·            ·
 ·               table        indexed@indexed_value_idx
 ·               spans        /5-/6
@@ -154,6 +158,7 @@ count           ·            ·
  └── delete     ·            ·
       │         from         indexed
       │         strategy     deleter
+      │         auto commit  ·
       └── scan  ·            ·
 ·               table        indexed@indexed_value_idx
 ·               spans        ALL
@@ -169,6 +174,7 @@ run             ·            ·
  └── delete     ·            ·
       │         from         indexed
       │         strategy     deleter
+      │         auto commit  ·
       └── scan  ·            ·
 ·               table        indexed@indexed_value_idx
 ·               spans        /5-/6
@@ -188,6 +194,7 @@ count           ·            ·           ()      ·
  └── delete     ·            ·           ()      ·
       │         from         t38799      ·       ·
       │         strategy     deleter     ·       ·
+      │         auto commit  ·           ·       ·
       └── scan  ·            ·           (a, b)  ·
 ·               table        t38799@foo  ·       ·
 ·               spans        ALL         ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -403,6 +403,7 @@ count             ·            ·
  └── insert       ·            ·
       │           into         t(k, v)
       │           strategy     inserter
+      │           auto commit  ·
       └── values  ·            ·
 ·                 size         2 columns, 1 row
 
@@ -552,6 +553,7 @@ count             ·              ·                 ()                         
  └── insert       ·              ·                 ()                          ·
       │           into           t(k, v)           ·                           ·
       │           strategy       inserter          ·                           ·
+      │           auto commit    ·                 ·                           ·
       └── values  ·              ·                 (column1 int, column2 int)  ·
 ·                 size           2 columns, 1 row  ·                           ·
 ·                 row 0, expr 0  (1)[int]          ·                           ·
@@ -636,6 +638,7 @@ count                ·            ·                            ()             
  └── delete          ·            ·                            ()              ·
       │              from         t                            ·               ·
       │              strategy     deleter                      ·               ·
+      │              auto commit  ·                            ·               ·
       └── render     ·            ·                            (k int)         ·
            │         render 0     (k)[int]                     ·               ·
            └── scan  ·            ·                            (k int, v int)  ·
@@ -653,6 +656,7 @@ count                ·            ·                              ()           
       │              table        t                              ·                            ·
       │              set          v                              ·                            ·
       │              strategy     updater                        ·                            ·
+      │              auto commit  ·                              ·                            ·
       └── render     ·            ·                              (k int, v int, column5 int)  ·
            │         render 0     (k)[int]                       ·                            ·
            │         render 1     (v)[int]                       ·                            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -313,6 +313,7 @@ count                          ·            ·
  └── insert                    ·            ·
       │                        into         insert_t(x, v, rowid)
       │                        strategy     inserter
+      │                        auto commit  ·
       └── render               ·            ·
            │                   render 0     x
            │                   render 1     v
@@ -337,6 +338,7 @@ count                ·            ·
  └── insert          ·            ·
       │              into         insert_t(x, v, rowid)
       │              strategy     inserter
+      │              auto commit  ·
       └── render     ·            ·
            │         render 0     x
            │         render 1     v
@@ -356,6 +358,7 @@ count                       ·            ·
  └── insert                 ·            ·
       │                     into         insert_t(x, v, rowid)
       │                     strategy     inserter
+      │                     auto commit  ·
       └── render            ·            ·
            └── limit        ·            ·
                 │           count        1
@@ -371,6 +374,7 @@ count                            ·            ·
  └── insert                      ·            ·
       │                          into         insert_t(x, v, rowid)
       │                          strategy     inserter
+      │                          auto commit  ·
       └── render                 ·            ·
            └── limit             ·            ·
                 │                count        1
@@ -388,6 +392,7 @@ count                            ·            ·
  └── insert                      ·            ·
       │                          into         insert_t(x, v, rowid)
       │                          strategy     inserter
+      │                          auto commit  ·
       └── render                 ·            ·
            └── limit             ·            ·
                 │                count        1
@@ -405,6 +410,7 @@ count                            ·            ·
  └── insert                      ·            ·
       │                          into         insert_t(x, v, rowid)
       │                          strategy     inserter
+      │                          auto commit  ·
       └── render                 ·            ·
            └── limit             ·            ·
                 │                count        1
@@ -515,6 +521,7 @@ render                    ·            ·                    (z)               
       └── insert          ·            ·                    (z, rowid[hidden])  ·
            │              into         xyz(x, y, z, rowid)  ·                   ·
            │              strategy     inserter             ·                   ·
+           │              auto commit  ·                    ·                   ·
            └── render     ·            ·                    (a, b, c, column9)  +c
                 │         render 0     a                    ·                   ·
                 │         render 1     b                    ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -575,6 +575,7 @@ render                 ·              ·                   (b)              ·
       └── insert       ·              ·                   (a, b)           ·
            │           into           t(a, b, c)          ·                ·
            │           strategy       inserter            ·                ·
+           │           auto commit    ·                   ·                ·
            └── values  ·              ·                   (x, y, column6)  ·
 ·                      size           3 columns, 1 row    ·                ·
 ·                      row 0, expr 0  1                   ·                ·
@@ -592,6 +593,7 @@ render               ·            ·          (b)     ·
       └── delete     ·            ·          (a, b)  ·
            │         from         t          ·       ·
            │         strategy     deleter    ·       ·
+           │         auto commit  ·          ·       ·
            └── scan  ·            ·          (a, b)  ·
 ·                    table        t@primary  ·       ·
 ·                    spans        /3-/3/#    ·       ·
@@ -608,6 +610,7 @@ render                    ·            ·          (b)                 ·
            │              table        t          ·                   ·
            │              set          c          ·                   ·
            │              strategy     updater    ·                   ·
+           │              auto commit  ·          ·                   ·
            └── render     ·            ·          (a, b, c, column7)  ·
                 │         render 0     a          ·                   ·
                 │         render 1     b          ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1523,6 +1523,7 @@ count                ·            ·
       │              table        t4
       │              set          c
       │              strategy     updater
+      │              auto commit  ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        t4@primary
@@ -1536,6 +1537,7 @@ EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ·             vectorized   false
 delete range  ·            ·
 ·             from         t4
+·             auto commit  ·
 ·             spans        /10/20-/10/20/#
 
 # Optimization should not be applied for non point lookups.

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -275,6 +275,7 @@ run             ·            ·
  └── insert     ·            ·
       │         into         t(x)
       │         strategy     inserter
+      │         auto commit  ·
       └── scan  ·            ·
 ·               table        t2@primary
 ·               spans        ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -108,6 +108,7 @@ count                ·            ·
       │              table        xyz
       │              set          y
       │              strategy     updater
+      │              auto commit  ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        xyz@primary
@@ -123,6 +124,7 @@ count                ·            ·            ()                           ·
       │              table        xyz          ·                            ·
       │              set          x, y         ·                            ·
       │              strategy     updater      ·                            ·
+      │              auto commit  ·            ·                            ·
       └── render     ·            ·            (x, y, z, column7, column8)  ·
            │         render 0     x            ·                            ·
            │         render 1     y            ·                            ·
@@ -143,6 +145,7 @@ count                ·            ·            ()               ·
       │              table        xyz          ·                ·
       │              set          x, y         ·                ·
       │              strategy     updater      ·                ·
+      │              auto commit  ·            ·                ·
       └── render     ·            ·            (x, y, z, y, x)  ·
            │         render 0     x            ·                ·
            │         render 1     y            ·                ·
@@ -163,6 +166,7 @@ count                     ·            ·            ()                        
       │                   table        xyz          ·                            ·
       │                   set          x, y         ·                            ·
       │                   strategy     updater      ·                            ·
+      │                   auto commit  ·            ·                            ·
       └── render          ·            ·            (x, y, z, column7, column7)  ·
            │              render 0     x            ·                            ·
            │              render 1     y            ·                            ·
@@ -230,6 +234,7 @@ count                          ·            ·
       │                        table        kv
       │                        set          v
       │                        strategy     updater
+      │                        auto commit  ·
       └── render               ·            ·
            └── limit           ·            ·
                 │              count        10
@@ -250,6 +255,7 @@ count                ·            ·
       │              table        kv
       │              set          v
       │              strategy     updater
+      │              auto commit  ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        kv@primary
@@ -276,6 +282,7 @@ count                ·            ·
       │              table        tu
       │              set          c
       │              strategy     updater
+      │              auto commit  ·
       └── render     ·            ·
            │         render 0     a
            │         render 1     c
@@ -334,6 +341,7 @@ render                    ·            ·              (a)                     
            │              table        abc            ·                         ·
            │              set          a              ·                         ·
            │              strategy     updater        ·                         ·
+           │              auto commit  ·              ·                         ·
            └── render     ·            ·              (a, b, c, rowid, c)       +c
                 │         render 0     a              ·                         ·
                 │         render 1     b              ·                         ·
@@ -382,6 +390,7 @@ count                           ·            ·               ()               
       │                         table        t38799          ·                   ·
       │                         set          c               ·                   ·
       │                         strategy     updater         ·                   ·
+      │                         auto commit  ·               ·                   ·
       └── render                ·            ·               (a, b, c, column7)  ·
            │                    render 0     a               ·                   ·
            │                    render 1     b               ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -14,6 +14,7 @@ count                      ·                   ·
       │                    table               abc
       │                    set                 b, c
       │                    strategy            updater
+      │                    auto commit         ·
       └── render           ·                   ·
            └── merge-join  ·                   ·
                 │          type                inner
@@ -42,6 +43,7 @@ count                          ·                  ·
       │                        table              abc
       │                        set                b, c
       │                        strategy           updater
+      │                        auto commit        ·
       └── render               ·                  ·
            └── distinct        ·                  ·
                 │              distinct on        a
@@ -76,6 +78,7 @@ render                          ·                   ·
            │                    table               abc
            │                    set                 b, c
            │                    strategy            updater
+           │                    auto commit         ·
            └── render           ·                   ·
                 └── merge-join  ·                   ·
                      │          type                inner
@@ -101,6 +104,7 @@ run                        ·                   ·            (a, b, c, a, b, c)
       │                    table               abc          ·                                       ·
       │                    set                 b, c         ·                                       ·
       │                    strategy            updater      ·                                       ·
+      │                    auto commit         ·            ·                                       ·
       └── render           ·                   ·            (a, b, c, column10, column11, a, b, c)  ·
            │               render 0            a            ·                                       ·
            │               render 1            b            ·                                       ·
@@ -134,6 +138,7 @@ count                            ·                      ·
       │                          table                  abc
       │                          set                    b, c
       │                          strategy               updater
+      │                          auto commit            ·
       └── render                 ·                      ·
            └── distinct          ·                      ·
                 │                distinct on            a
@@ -163,6 +168,7 @@ count                               ·                   ·
       │                             table               abc
       │                             set                 b, c
       │                             strategy            updater
+      │                             auto commit         ·
       └── render                    ·                   ·
            └── distinct             ·                   ·
                 │                   distinct on         a
@@ -203,6 +209,7 @@ run                                 ·                   ·
       │                             table               abc
       │                             set                 b, c
       │                             strategy            updater
+      │                             auto commit         ·
       └── render                    ·                   ·
            └── distinct             ·                   ·
                 │                   distinct on         a

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -18,6 +18,7 @@ count                          ·            ·
  └── upsert                    ·            ·
       │                        into         kv(k, v)
       │                        strategy     opt upserter
+      │                        auto commit  ·
       └── render               ·            ·
            │                   render 0     k
            │                   render 1     v
@@ -42,6 +43,7 @@ count                          ·            ·
  └── upsert                    ·            ·
       │                        into         kv(k, v)
       │                        strategy     opt upserter
+      │                        auto commit  ·
       └── render               ·            ·
            │                   render 0     k
            │                   render 1     v
@@ -66,6 +68,7 @@ run                            ·            ·
  └── upsert                    ·            ·
       │                        into         kv(k, v)
       │                        strategy     opt upserter
+      │                        auto commit  ·
       └── render               ·            ·
            │                   render 0     k
            │                   render 1     v
@@ -90,6 +93,7 @@ count                                    ·                      ·
  └── upsert                              ·                      ·
       │                                  into                   kv(k, v)
       │                                  strategy               opt upserter
+      │                                  auto commit            ·
       └── render                         ·                      ·
            │                             render 0               k
            │                             render 1               column5
@@ -135,6 +139,7 @@ count                            ·              ·
  └── upsert                      ·              ·
       │                          into           indexed(a, b, c, d)
       │                          strategy       opt upserter
+      │                          auto commit    ·
       └── render                 ·              ·
            │                     render 0       column1
            │                     render 1       column6
@@ -186,6 +191,7 @@ run                    ·              ·
  └── upsert            ·              ·
       │                into           indexed(a, b, c, d)
       │                strategy       opt upserter
+      │                auto commit    ·
       └── render       ·              ·
            │           render 0       column1
            │           render 1       column6
@@ -346,6 +352,7 @@ render                         ·            ·                    (z)          
       └── upsert               ·            ·                    (z, rowid[hidden])           ·
            │                   into         xyz(x, y, z, rowid)  ·                            ·
            │                   strategy     opt upserter         ·                            ·
+           │                   auto commit  ·                    ·                            ·
            └── render          ·            ·                    (a, b, c, column9, a, b, c)  +c
                 │              render 0     a                    ·                            ·
                 │              render 1     b                    ·                            ·

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -470,6 +470,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
 			v.observer.attr(name, "strategy", n.run.ti.desc())
+			if n.run.ti.autoCommit == autoCommitEnabled {
+				v.observer.attr(name, "auto commit", "")
+			}
 		}
 
 		if v.observer.expr != nil {
@@ -498,6 +501,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
 			v.observer.attr(name, "strategy", n.run.tw.desc())
+			if n.run.tw.autoCommit == autoCommitEnabled {
+				v.observer.attr(name, "auto commit", "")
+			}
 		}
 
 		if v.observer.expr != nil {
@@ -529,6 +535,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 				v.observer.attr(name, "set", buf.String())
 			}
 			v.observer.attr(name, "strategy", n.run.tu.desc())
+			if n.run.tu.autoCommit == autoCommitEnabled {
+				v.observer.attr(name, "auto commit", "")
+			}
 		}
 		if v.observer.expr != nil {
 			for i, cexpr := range n.run.computeExprs {
@@ -547,6 +556,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.attr != nil {
 			v.observer.attr(name, "from", n.run.td.tableDesc().Name)
 			v.observer.attr(name, "strategy", n.run.td.desc())
+			if n.run.td.autoCommit == autoCommitEnabled {
+				v.observer.attr(name, "auto commit", "")
+			}
 		}
 		// A deleter has no sub-expressions, so nothing special to do here.
 		n.source = v.visit(n.source)
@@ -554,6 +566,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *deleteRangeNode:
 		if v.observer.attr != nil {
 			v.observer.attr(name, "from", n.desc.Name)
+			if n.autoCommitEnabled {
+				v.observer.attr(name, "auto commit", "")
+			}
 		}
 		if v.observer.spans != nil {
 			v.observer.spans(name, "spans", &n.desc.PrimaryIndex, n.spans)


### PR DESCRIPTION
The autocommit decision was made on the entire query. This change
modifies the behavior for EXPLAIN, where we want to pretend that the
query under EXPLAIN is the entire query.

We also add an `auto commit` field to the `EXPLAIN (VERBOSE)` output.
We can now test the planning part of auto commit without using traces
(the tests are updated accordingly).

Release note: None