### PR TITLE
colexec: use provided size for the groups buffer in merge joiner

### DIFF
--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -409,7 +409,7 @@ func (o *mergeJoinBase) initWithOutputBatchSize(outBatchSize uint16) {
 	o.builderState.lGroups = make([]group, 1)
 	o.builderState.rGroups = make([]group, 1)
 
-	o.groups = makeGroupsBuffer(int(coldata.BatchSize()))
+	o.groups = makeGroupsBuffer(int(o.outputBatchSize))
 	o.resetBuilderCrossProductState()
 
 	if o.filter != nil {


### PR DESCRIPTION
Previously, the requested circular groups buffer size was hard-coded to
be coldata.BatchSize. This commit changes that to use the given argument
outputBatchSize. It was a "logical" bug, but I don't think any actual
errors would occur because of it.

Release note: None