### PR TITLE
opt: clean up check and default handling in mutation code

### DIFF
--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -102,6 +102,7 @@ define MutationPrivate {
     #
     # Since the check constraint for column "a" can be statically proven to be
     # true, CheckCols would contain [0, b_colid].
+    # TODO(radu): we don't actually implement this optimization currently.
     CheckCols ColList
 
     # CanaryCol is used only with the Upsert operator. It identifies the column

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 // KVInserter implements the putter interface.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -40,9 +40,10 @@ type updateNode struct {
 
 // updateRun contains the run-time state of updateNode during local execution.
 type updateRun struct {
-	tu          tableUpdater
-	checkHelper *sqlbase.CheckHelper
-	rowsNeeded  bool
+	tu         tableUpdater
+	rowsNeeded bool
+
+	checkOrds checkSet
 
 	// rowCount is the number of rows in the current batch.
 	rowCount int
@@ -301,26 +302,10 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// Run the CHECK constraints, if any. CheckHelper will either evaluate the
 	// constraints itself, or else inspect boolean columns from the input that
 	// contain the results of evaluation.
-	if u.run.checkHelper != nil {
-		if u.run.checkHelper.NeedsEval() {
-			// TODO(justin): we have actually constructed the whole row at this point and
-			// thus should be able to avoid loading it separately like this now.
-			if err := u.run.checkHelper.LoadEvalRow(
-				u.run.tu.ru.FetchColIDtoRowIndex, oldValues, false); err != nil {
-				return err
-			}
-			if err := u.run.checkHelper.LoadEvalRow(
-				u.run.updateColsIdx, u.run.updateValues, true); err != nil {
-				return err
-			}
-			if err := u.run.checkHelper.CheckEval(params.EvalContext()); err != nil {
-				return err
-			}
-		} else {
-			checkVals := sourceVals[len(u.run.tu.ru.FetchCols)+len(u.run.tu.ru.UpdateCols)+u.run.numPassthrough:]
-			if err := u.run.checkHelper.CheckInput(checkVals); err != nil {
-				return err
-			}
+	if !u.run.checkOrds.Empty() {
+		checkVals := sourceVals[len(u.run.tu.ru.FetchCols)+len(u.run.tu.ru.UpdateCols)+u.run.numPassthrough:]
+		if err := checkMutationInput(u.run.tu.tableDesc(), u.run.checkOrds, checkVals); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -475,16 +475,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			}
 		}
 
-		if v.observer.expr != nil {
-			for i, dexpr := range n.run.defaultExprs {
-				v.metadataExpr(name, "default", i, dexpr)
-			}
-			if n.run.checkHelper != nil {
-				for i, cexpr := range n.run.checkHelper.Exprs {
-					v.metadataExpr(name, "check", i, cexpr)
-				}
-			}
-		}
 		n.source = v.visit(n.source)
 
 	case *upsertNode:
@@ -506,19 +496,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			}
 		}
 
-		if v.observer.expr != nil {
-			for i, dexpr := range n.run.defaultExprs {
-				v.metadataExpr(name, "default", i, dexpr)
-			}
-			if n.run.checkHelper != nil {
-				for i, cexpr := range n.run.checkHelper.Exprs {
-					v.metadataExpr(name, "check", i, cexpr)
-				}
-			}
-			n.run.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-				v.metadataExpr(name, d, i, e)
-			})
-		}
 		n.source = v.visit(n.source)
 
 	case *updateNode:
@@ -542,11 +519,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.expr != nil {
 			for i, cexpr := range n.run.computeExprs {
 				v.metadataExpr(name, "computed", i, cexpr)
-			}
-			if n.run.checkHelper != nil {
-				for i, cexpr := range n.run.checkHelper.Exprs {
-					v.metadataExpr(name, "check", i, cexpr)
-				}
 			}
 		}
 		// An updater has no sub-expressions, so nothing special to do here.


### PR DESCRIPTION
Now that we ripped out the heuristic planner, we no longer need to
support both frameworks for computing default values and doing checks
during mutations. This change pulls out the "input mode" of the
`CheckHelper` into separate code and simplifies the code that
processes input rows.

Release note: None