### PR TITLE
Show user avatar and popover menu with extended user info

### DIFF
--- a/pkg/ui/src/views/app/components/userMenu/index.tsx
+++ b/pkg/ui/src/views/app/components/userMenu/index.tsx
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 import React from "react";
 import { Link } from "react-router";

--- a/pkg/ui/src/views/app/components/userMenu/index.tsx
+++ b/pkg/ui/src/views/app/components/userMenu/index.tsx
@@ -1,0 +1,38 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import React from "react";
+import { Link } from "react-router";
+import { LOGOUT_PAGE } from "src/routes/login";
+
+import "./userMenu.styl";
+
+export interface UserMenuProps {
+  userName: string;
+  onLogoutClick: () => void;
+}
+
+export default function UserMenu (props: UserMenuProps) {
+  const { userName, onLogoutClick } = props;
+  return (
+    <div className="user-menu">
+      <div className="user-menu__item user-menu__username">{userName}</div>
+      <div className="user-menu__item user-menu__logout-menu-item">
+        <Link to={LOGOUT_PAGE} onClick={onLogoutClick}>
+          Logout
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/pkg/ui/src/views/app/components/userMenu/userMenu.styl
+++ b/pkg/ui/src/views/app/components/userMenu/userMenu.styl
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~styl/base/palette.styl"
+
+.user-menu
+  display flex
+  flex-direction column
+  font-size 14px
+  min-width 174px
+  text-transform none
+  text-align left
+  font-weight normal
+  font-family Lato-Regular
+
+.user-menu__item
+  padding 0 16px
+
+.user-menu__username
+  color #394455
+  padding 10px 16px
+  font-weight bold
+
+.user-menu__logout-menu-item
+  color #3a7ce1
+  border-top-width 1px
+  border-top-color $popover-border-color
+  border-top-style solid
+  padding 10px 16px 14px
+

--- a/pkg/ui/src/views/shared/components/outsideEventHandler/index.tsx
+++ b/pkg/ui/src/views/shared/components/outsideEventHandler/index.tsx
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 import React from "react";
 import classNames from "classnames";

--- a/pkg/ui/src/views/shared/components/outsideEventHandler/index.tsx
+++ b/pkg/ui/src/views/shared/components/outsideEventHandler/index.tsx
@@ -1,0 +1,77 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import React from "react";
+import classNames from "classnames";
+
+import "./outsideEventHandler.styl";
+
+export interface OutsideEventHandlerProps {
+  onOutsideClick: () => void;
+  children: any;
+  mountNodePosition?: "fixed" | "initial";
+  ignoreClickOnRefs?: React.RefObject<HTMLDivElement>[];
+}
+
+export class OutsideEventHandler extends React.Component<OutsideEventHandlerProps> {
+  nodeRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: any) {
+    super(props);
+    this.nodeRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.addEventListener();
+  }
+
+  componentWillUnmount() {
+    this.removeEventListener();
+  }
+
+  onClick = (event: any) => {
+    const { onOutsideClick, ignoreClickOnRefs = [] } = this.props;
+    const isChildEl = this.nodeRef.current && this.nodeRef.current.contains(event.target);
+
+    const isOutsideIgnoredEl = ignoreClickOnRefs.some(outsideIgnoredRef => {
+      if (!outsideIgnoredRef || !outsideIgnoredRef.current) {
+        return false;
+      }
+      return outsideIgnoredRef.current.contains(event.target);
+    });
+
+    if (!isChildEl && !isOutsideIgnoredEl) {
+      onOutsideClick();
+    }
+  }
+
+  addEventListener = () => {
+    addEventListener("click", this.onClick);
+  }
+
+  removeEventListener = () => {
+    removeEventListener("click", this.onClick);
+  }
+
+  render() {
+    const { children, mountNodePosition = "initial" } = this.props;
+    const classes = classNames("outside-event-handler", `outside-event-handler--position-${mountNodePosition}`);
+
+    return (
+      <div ref={ this.nodeRef } className={classes}>
+        { children }
+      </div>
+    );
+  }
+}

--- a/pkg/ui/src/views/shared/components/outsideEventHandler/outsideEventHandler.styl
+++ b/pkg/ui/src/views/shared/components/outsideEventHandler/outsideEventHandler.styl
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 .outside-event-handler
   position initial

--- a/pkg/ui/src/views/shared/components/outsideEventHandler/outsideEventHandler.styl
+++ b/pkg/ui/src/views/shared/components/outsideEventHandler/outsideEventHandler.styl
@@ -1,0 +1,22 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+.outside-event-handler
+  position initial
+
+.outside-event-handler--position-fixed
+  position fixed
+
+.outside-event-handler--position-initial
+  position initial

--- a/pkg/ui/src/views/shared/components/popover/index.tsx
+++ b/pkg/ui/src/views/shared/components/popover/index.tsx
@@ -1,0 +1,60 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import React from "react";
+import classNames from "classnames";
+
+import { OutsideEventHandler } from "src/views/shared/components/outsideEventHandler";
+
+import "./popover.styl";
+
+export interface PopoverProps {
+  content: JSX.Element;
+  visible: boolean;
+  onVisibleChange: (nextState: boolean) => void;
+  children: any;
+}
+
+export default class Popover extends React.Component<PopoverProps> {
+  // contentRef is used to pass as element to avoid handling outside event handler
+  // on its instance.
+  contentRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+  render() {
+    const { content, children, visible, onVisibleChange } = this.props;
+
+    const popoverClasses = classNames("popover", {
+      "popover--visible": visible,
+    });
+
+    return (
+      <React.Fragment>
+        <div
+          ref={this.contentRef}
+          className="popover__content"
+          onClick={() => onVisibleChange(!visible)}>
+          { content }
+        </div>
+        <OutsideEventHandler
+          onOutsideClick={() => onVisibleChange(false)}
+          mountNodePosition={"fixed"}
+          ignoreClickOnRefs={[this.contentRef]}>
+          <div className={popoverClasses}>
+            { children }
+          </div>
+        </OutsideEventHandler>
+      </React.Fragment>
+    );
+  }
+}

--- a/pkg/ui/src/views/shared/components/popover/index.tsx
+++ b/pkg/ui/src/views/shared/components/popover/index.tsx
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 import React from "react";
 import classNames from "classnames";

--- a/pkg/ui/src/views/shared/components/popover/popover.styl
+++ b/pkg/ui/src/views/shared/components/popover/popover.styl
@@ -1,0 +1,29 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~styl/base/palette.styl"
+@require "~styl/base/layout-vars.styl"
+
+.popover
+  position absolute
+  z-index $z-index-tooltip
+  box-shadow: 0 0 4px 0 $popover-shadow-color
+  border-radius 4px
+  border: solid 0.5px $popover-border-color
+  display none
+  background-color white
+  left 70px
+  bottom 0px
+
+.popover--visible
+  display block
+
+.popover__content
+  cursor pointer

--- a/pkg/ui/src/views/shared/components/userAvatar/index.tsx
+++ b/pkg/ui/src/views/shared/components/userAvatar/index.tsx
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import * as React from "react";
+import classNames from "classnames";
+
+import "./userAvatar.styl";
+
+export interface UserAvatarProps {
+  userName: string;
+  disabled?: boolean;
+}
+
+export default function UserAvatar(props: UserAvatarProps) {
+  const {
+    userName,
+    disabled = false,
+  } = props;
+
+  const classes = classNames("user-avatar", {
+    "user-avatar--disabled": disabled,
+  });
+
+  const nameAbbreviation = userName[0].toUpperCase();
+
+  return (
+    <div className={classes}>
+      <div>{nameAbbreviation}</div>
+    </div>
+  );
+}

--- a/pkg/ui/src/views/shared/components/userAvatar/index.tsx
+++ b/pkg/ui/src/views/shared/components/userAvatar/index.tsx
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 import * as React from "react";
 import classNames from "classnames";

--- a/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
+++ b/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+.user-avatar
+  height 40px
+  width 40px
+  border-radius 50%
+  background-color #e0eefb
+  color: #0788ff
+  font-size 14px
+  font-weight bold
+  line-height 40px
+  letter-spacing 0.1px
+  margin auto
+
+.user-avatar:hover
+  border solid 2px #0788ff
+  line-height 36px
+
+.user-avatar--disabled
+  background-color #e7ecf3
+  color #7e89a9
+
+.user-avatar--disabled:hover
+  border none
+  line-height 40px

--- a/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
+++ b/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
@@ -1,16 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied. See the License for the specific language governing
-// permissions and limitations under the License.
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 .user-avatar
   height 40px

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -38,3 +38,8 @@ $info-box-heading-color = #3A7DE1
 // Syntax highlight colors
 $syntax-string-color = #E4843C
 $syntax-keyword-color = #91C8F2
+
+// Popover colors
+$popover-color = #394455
+$popover-shadow-color = #9aa1ab
+$popover-border-color = #e7ecf3


### PR DESCRIPTION
This PR adds user menu on the left side bar instead of logout button.
Logout button and extended user information (user name) is placed in menu.

With these changes were added shared UI components (Popover, OutsideEventHander and UserAvatar)
Previous user logout functionality was not affected.

<img width="279" alt="Screenshot 2019-11-15 at 14 53 27" src="https://user-images.githubusercontent.com/3106437/68958864-9f48d380-07d5-11ea-8122-4ac7c9464afa.png">
