### PR TITLE
jobs: allow jobs to be created and started separately

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1278,7 +1278,7 @@ func backupPlanHook(
 			return err
 		}
 
-		_, errCh, err := p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
+		_, errCh, err := p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, resultsCh, jobs.Record{
 			Description: description,
 			Username:    p.User(),
 			DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1549,7 +1549,7 @@ func doRestorePlan(
 		}
 	}
 
-	_, errCh, err := p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
+	_, errCh, err := p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, resultsCh, jobs.Record{
 		Description: description,
 		Username:    p.User(),
 		DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -310,7 +310,7 @@ func changefeedPlanHook(
 		// been setup okay. This intentionally abuses what would normally be
 		// hooked up to resultsCh to avoid a bunch of extra plumbing.
 		startedCh := make(chan tree.Datums)
-		job, errCh, err := p.ExecCfg().JobRegistry.StartJob(ctx, startedCh, jobs.Record{
+		job, errCh, err := p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, startedCh, jobs.Record{
 			Description: jobDescription,
 			Username:    p.User(),
 			DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -574,7 +574,7 @@ func importPlanHook(
 
 		telemetry.CountBucketed("import.files", int64(len(files)))
 
-		_, errCh, err := p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
+		_, errCh, err := p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, resultsCh, jobs.Record{
 			Description: jobDesc,
 			Username:    p.User(),
 			Details: jobspb.ImportDetails{

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -120,6 +120,9 @@ func (j *Job) ID() *int64 {
 // remembers the assigned ID of the job in the Job. The job information is read
 // from the Record field at the time Created is called.
 func (j *Job) Created(ctx context.Context) error {
+	if j.ID() != nil {
+		return errors.Errorf("job already created with ID %v", *j.ID())
+	}
 	return j.insert(ctx, j.registry.makeJobID(), nil /* lease */)
 }
 

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -148,7 +148,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 			Details:  jobspb.BackupDetails{},
 			Progress: jobspb.BackupProgress{},
 		}
-		job, _, err := newRegistry(nodeid).StartJob(ctx, nil, rec)
+		job, _, err := newRegistry(nodeid).CreateAndStartJob(ctx, nil, rec)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -119,7 +119,7 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 		telemetry.Inc(sqltelemetry.CreateStatisticsUseCounter)
 	}
 
-	job, errCh, err := n.p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, *record)
+	job, errCh, err := n.p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, resultsCh, *record)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prior to this commit, if a creator of a job wanted to get the results it would
have to create and start it at the same time by calling jobs.Registry.StartJob.
That method would take a jobs.Record, create a new *jobs.Job and start it
immediately, sending results on a passed channel and returning an error
channel.

This is awkward because sometimes callers might want to do other work on the
same transaction which is creating the job. Furthermore those callers might
not want to start the job until after the creating transaction commits.

This refactor provides a mechanism for callers to create and store a job
in a transaction and then start it after that transaction commits.

Here's an example:

```
j := registry.NewJob(record)
if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
    if err := j.WithTxn(txn).Created(ctx); err != nil {
        return err
    }
    ...
}); err != nil {
    ...
}
resultsCh := make(chan tree.Datums)
errCh, err := j.Start(ctx, resultsCh)
...
```

Release note: None