### PR TITLE
colexec: add unordered distinct

### DIFF
--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -108,6 +108,16 @@ func _CHECK_COL_BODY(
 
 			/* {{if .AllowNullEquality}} */
 			if probeIsNull && buildIsNull {
+				// Both values are NULLs, and since we're allowing null equality, we
+				// proceed to the next value to check.
+				continue
+			} else if probeIsNull {
+				// Only probing value is NULL, so it is different from the build value
+				// (which is non-NULL). We mark it as "different" and proceed to the
+				// next value to check. This behavior is special in case of allowing
+				// null equality because we don't want to reset the groupID of the
+				// current probing tuple.
+				ht.differs[toCheck] = true
 				continue
 			}
 			/* {{end}} */

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -70,10 +70,6 @@ func _ASSIGN_NE(_, _, _ interface{}) uint64 {
 // coltypes.Foo for each type Foo in the coltypes.T type.
 const _TYPES_T = coltypes.Unhandled
 
-// _SEL_IND is the template type variable for the loop variable that's either
-// i or sel[i] depending on whether we're in a selection or not.
-const _SEL_IND = 0
-
 func _CHECK_COL_BODY(
 	ht *hashTable,
 	probeVec, buildVec coldata.Vec,
@@ -83,7 +79,7 @@ func _CHECK_COL_BODY(
 	_BUILD_HAS_NULLS bool,
 	_ALLOW_NULL_EQUALITY bool,
 ) { // */}}
-	// {{define "checkColBody"}}
+	// {{define "checkColBody" -}}
 	probeIsNull := false
 	buildIsNull := false
 	// Early bounds check.
@@ -125,9 +121,7 @@ func _CHECK_COL_BODY(
 				var unique bool
 				_ASSIGN_NE(unique, buildVal, probeVal)
 
-				if unique {
-					ht.differs[toCheck] = true
-				}
+				ht.differs[toCheck] = ht.differs[toCheck] || unique
 			}
 		}
 	}
@@ -142,7 +136,7 @@ func _CHECK_COL_WITH_NULLS(
 	nToCheck uint16,
 	_USE_SEL bool,
 ) { // */}}
-	// {{define "checkColWithNulls"}}
+	// {{define "checkColWithNulls" -}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
 			if ht.allowNullEquality {
@@ -177,7 +171,7 @@ func _REHASH_BODY(
 	_HAS_SEL bool,
 	_HAS_NULLS bool,
 ) { // */}}
-	// {{define "rehashBody"}}
+	// {{define "rehashBody" -}}
 	// Early bounds checks.
 	_ = buckets[nKeys-1]
 	// {{ if .HasSel }}
@@ -210,7 +204,7 @@ func _REHASH_BODY(
 func _COLLECT_RIGHT_OUTER(
 	prober *hashJoinProber, batchSize uint16, nResults uint16, batch coldata.Batch, _USE_SEL bool,
 ) uint16 { // */}}
-	// {{define "collectRightOuter"}}
+	// {{define "collectRightOuter" -}}
 	// Early bounds checks.
 	_ = prober.ht.headID[batchSize-1]
 	// {{if .UseSel}}
@@ -258,7 +252,7 @@ func _COLLECT_RIGHT_OUTER(
 func _COLLECT_NO_OUTER(
 	prober *hashJoinProber, batchSize uint16, nResults uint16, batch coldata.Batch, _USE_SEL bool,
 ) uint16 { // */}}
-	// {{define "collectNoOuter"}}
+	// {{define "collectNoOuter" -}}
 	// Early bounds checks.
 	_ = prober.ht.headID[batchSize-1]
 	// {{if .UseSel}}
@@ -290,7 +284,7 @@ func _COLLECT_NO_OUTER(
 }
 
 func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _USE_SEL bool) { // */}}
-	// {{define "distinctCollectRightOuter"}}
+	// {{define "distinctCollectRightOuter" -}}
 	// Early bounds checks.
 	_ = prober.ht.groupID[batchSize-1]
 	_ = prober.probeRowUnmatched[batchSize-1]
@@ -320,7 +314,7 @@ func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _US
 func _DISTINCT_COLLECT_NO_OUTER(
 	prober *hashJoinProber, batchSize uint16, nResults uint16, _USE_SEL bool,
 ) { // */}}
-	// {{define "distinctCollectNoOuter"}}
+	// {{define "distinctCollectNoOuter" -}}
 	// Early bounds checks.
 	_ = prober.ht.groupID[batchSize-1]
 	_ = prober.buildIdx[batchSize-1]

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -1,0 +1,166 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+)
+
+// NewUnorderedDistinct creates an unordered distinct on the given distinct
+// columns.
+func NewUnorderedDistinct(
+	allocator *Allocator, input Operator, distinctCols []uint32, colTypes []coltypes.T,
+) Operator {
+	outCols := make([]uint32, len(colTypes))
+	for i := range outCols {
+		outCols[i] = uint32(i)
+	}
+	ht := makeHashTable(
+		allocator,
+		hashTableBucketSize,
+		colTypes,
+		distinctCols,
+		outCols,
+		true, /* allowNullEquality */
+	)
+
+	builder := makeHashJoinBuilder(
+		ht,
+		hashJoinerSourceSpec{
+			source:      input,
+			eqCols:      distinctCols,
+			outCols:     outCols,
+			sourceTypes: colTypes,
+		},
+	)
+
+	return &unorderedDistinct{
+		allocator: allocator,
+		builder:   builder,
+		ht:        ht,
+		output:    allocator.NewMemBatch(ht.outTypes),
+	}
+}
+
+// unorderedDistinct performs a DISTINCT operation using a hashTable. Once the
+// building of the hashTable is completed, this operator iterates over all of
+// the tuples to check whether the tuple is the "head" of a linked list that
+// contain all of the tuples that are equal on distinct columns. Only the
+// "head" is included into the big selection vector. Once the big selection
+// vector is populated, the operator proceeds to returning the batches
+// according to a chunk of the selection vector.
+type unorderedDistinct struct {
+	allocator     *Allocator
+	builder       *hashJoinBuilder
+	ht            *hashTable
+	buildFinished bool
+
+	// sel is a list of indices to select representing the distinct rows.
+	sel           []uint64
+	distinctCount uint64
+
+	output           coldata.Batch
+	outputBatchStart uint64
+}
+
+var _ Operator = &unorderedDistinct{}
+
+func (op *unorderedDistinct) ChildCount(bool) int {
+	return 1
+}
+
+func (op *unorderedDistinct) Child(nth int, _ bool) execinfra.OpNode {
+	if nth == 0 {
+		return op.builder.spec.source
+	}
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
+func (op *unorderedDistinct) Init() {
+	op.builder.spec.source.Init()
+}
+
+func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
+	op.output.ResetInternalBatch()
+	// First, build the hash table.
+	if !op.buildFinished {
+		op.buildFinished = true
+		op.builder.exec(ctx)
+	}
+
+	// The selection vector needs to be populated before any batching can be
+	// done.
+	if op.sel == nil {
+		// Since next is no longer useful and pre-allocated to the appropriate
+		// size, we can use it as the selection vector. This way we don't have to
+		// reallocate a huge array.
+		op.sel = op.ht.next
+		// We calculate keyID for tuple at index i as "i+1," so we start from
+		// position 1.
+		for i, isHead := range op.ht.head[1:] {
+			if isHead {
+				// The tuple at index i is the "head" of the linked list of tuples that
+				// are the same on the distinct columns, so we will include it while
+				// all other tuples from the linked list will be skipped.
+				op.sel[op.distinctCount] = uint64(i)
+				op.distinctCount++
+			}
+		}
+	}
+
+	// Create and return the next batch of input to a maximum size of
+	// coldata.BatchSize(). The rows in the new batch are specified by the
+	// corresponding slice in the selection vector.
+	nSelected := uint16(0)
+	batchEnd := op.outputBatchStart + uint64(coldata.BatchSize())
+	if batchEnd > op.distinctCount {
+		batchEnd = op.distinctCount
+	}
+	nSelected = uint16(batchEnd - op.outputBatchStart)
+
+	op.allocator.PerformOperation(op.output.ColVecs(), func() {
+		for i, colIdx := range op.ht.outCols {
+			toCol := op.output.ColVec(i)
+			fromCol := op.ht.vals.colVecs[colIdx]
+			toCol.Copy(
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						ColType:     op.ht.valTypes[op.ht.outCols[i]],
+						Src:         fromCol,
+						SrcStartIdx: op.outputBatchStart,
+						SrcEndIdx:   batchEnd,
+					},
+					Sel64: op.sel,
+				},
+			)
+		}
+	})
+
+	op.outputBatchStart = batchEnd
+	op.output.SetLength(nSelected)
+	return op.output
+}
+
+// Reset resets the unorderedDistinct for another run. Primarily used for
+// benchmarks.
+func (op *unorderedDistinct) reset() {
+	op.outputBatchStart = 0
+	op.ht.vals.reset()
+	op.buildFinished = false
+}

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -129,9 +129,9 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 	seed := rand.Int()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	nRuns := 10
-	nRows := 100
+	nRows := 10
 	maxCols := 3
-	maxNum := 10
+	maxNum := 3
 	intTyps := make([]types.T, maxCols)
 	for i := range intTyps {
 		intTyps[i] = *types.Int

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -42,79 +42,127 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 
 	seed := rand.Int()
 	rng := rand.New(rand.NewSource(int64(seed)))
-	nRuns := 100
+	nRuns := 20
 	nRows := 100
-	const nextGroupProb = 0.3
-
-	aggregations := make([]execinfrapb.AggregatorSpec_Aggregation, len(colexec.SupportedAggFns))
-	for i, aggFn := range colexec.SupportedAggFns {
-		aggregations[i].Func = aggFn
-		aggregations[i].ColIdx = []uint32{uint32(i + 1)}
+	const (
+		maxNumGroupingCols = 3
+		nextGroupProb      = 0.2
+	)
+	groupingCols := make([]uint32, maxNumGroupingCols)
+	orderingCols := make([]execinfrapb.Ordering_Column, maxNumGroupingCols)
+	for i := uint32(0); i < maxNumGroupingCols; i++ {
+		groupingCols[i] = i
+		orderingCols[i].ColIdx = i
 	}
-	inputTypes := make([]types.T, len(aggregations)+1)
-	inputTypes[0] = *types.Int
-	outputTypes := make([]types.T, len(aggregations))
+	var da sqlbase.DatumAlloc
 
-	for run := 0; run < nRuns; run++ {
-		var rows sqlbase.EncDatumRows
-		// We will be grouping based on the zeroth column (which we already set to
-		// be of INT type) with the values for the column set manually below.
-		for i := range aggregations {
-			aggFn := aggregations[i].Func
-			var aggTyp *types.T
-			for {
-				aggTyp = sqlbase.RandType(rng)
-				aggInputTypes := []types.T{*aggTyp}
-				if aggFn == execinfrapb.AggregatorSpec_COUNT_ROWS {
-					// Count rows takes no arguments.
-					aggregations[i].ColIdx = []uint32{}
-					aggInputTypes = aggInputTypes[:0]
+	deterministicAggFns := make([]execinfrapb.AggregatorSpec_Func, 0, len(colexec.SupportedAggFns)-1)
+	for _, aggFn := range colexec.SupportedAggFns {
+		if aggFn == execinfrapb.AggregatorSpec_ANY_NOT_NULL {
+			// We skip ANY_NOT_NULL aggregate function because it returns
+			// non-deterministic results.
+			continue
+		}
+		deterministicAggFns = append(deterministicAggFns, aggFn)
+	}
+	aggregations := make([]execinfrapb.AggregatorSpec_Aggregation, len(deterministicAggFns))
+	for _, hashAgg := range []bool{false, true} {
+		for numGroupingCols := 1; numGroupingCols <= maxNumGroupingCols; numGroupingCols++ {
+			for i, aggFn := range deterministicAggFns {
+				aggregations[i].Func = aggFn
+				aggregations[i].ColIdx = []uint32{uint32(i + numGroupingCols)}
+			}
+			inputTypes := make([]types.T, len(aggregations)+numGroupingCols)
+			for i := 0; i < numGroupingCols; i++ {
+				inputTypes[i] = *types.Int
+			}
+			outputTypes := make([]types.T, len(aggregations))
+
+			for run := 0; run < nRuns; run++ {
+				var rows sqlbase.EncDatumRows
+				// We will be grouping based on the first numGroupingCols columns (which
+				// we already set to be of INT types) with the values for the column set
+				// manually below.
+				for i := range aggregations {
+					aggFn := aggregations[i].Func
+					var aggTyp *types.T
+					for {
+						aggTyp = sqlbase.RandType(rng)
+						aggInputTypes := []types.T{*aggTyp}
+						if aggFn == execinfrapb.AggregatorSpec_COUNT_ROWS {
+							// Count rows takes no arguments.
+							aggregations[i].ColIdx = []uint32{}
+							aggInputTypes = aggInputTypes[:0]
+						}
+						if isSupportedType(aggTyp) {
+							if _, outputType, err := execinfrapb.GetAggregateInfo(aggFn, aggInputTypes...); err == nil {
+								outputTypes[i] = *outputType
+								break
+							}
+						}
+					}
+					inputTypes[i+numGroupingCols] = *aggTyp
 				}
-				if isSupportedType(aggTyp) {
-					if _, outputType, err := execinfrapb.GetAggregateInfo(aggFn, aggInputTypes...); err == nil {
-						outputTypes[i] = *outputType
-						break
+				rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
+				groupIdx := 0
+				for _, row := range rows {
+					for i := 0; i < numGroupingCols; i++ {
+						if rng.Float64() < nullProbability {
+							row[i] = sqlbase.EncDatum{Datum: tree.DNull}
+						} else {
+							row[i] = sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(groupIdx))}
+							if rng.Float64() < nextGroupProb {
+								groupIdx++
+							}
+						}
 					}
 				}
-			}
-			inputTypes[i+1] = *aggTyp
-		}
-		rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
-		groupIdx := 0
-		for _, row := range rows {
-			row[0] = sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(groupIdx))}
-			if rng.Float64() < nextGroupProb {
-				groupIdx++
-			}
-		}
 
-		aggregatorSpec := &execinfrapb.AggregatorSpec{
-			Type:         execinfrapb.AggregatorSpec_NON_SCALAR,
-			GroupCols:    []uint32{0},
-			Aggregations: aggregations,
-		}
-		for _, hashAgg := range []bool{false, true} {
-			if !hashAgg {
-				aggregatorSpec.OrderedGroupCols = []uint32{0}
-			}
-			pspec := &execinfrapb.ProcessorSpec{
-				Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
-				Core:  execinfrapb.ProcessorCoreUnion{Aggregator: aggregatorSpec},
-			}
-			if err := verifyColOperator(
-				hashAgg,
-				nil, /* colsForEqCheck */
-				[][]types.T{inputTypes},
-				[]sqlbase.EncDatumRows{rows},
-				outputTypes,
-				pspec,
-				0, /* memoryLimit */
-			); err != nil {
-				fmt.Printf("--- seed = %d run = %d hash = %t ---\n",
-					seed, run, hashAgg)
-				prettyPrintTypes(inputTypes, "t" /* tableName */)
-				prettyPrintInput(rows, inputTypes, "t" /* tableName */)
-				t.Fatal(err)
+				aggregatorSpec := &execinfrapb.AggregatorSpec{
+					Type:         execinfrapb.AggregatorSpec_NON_SCALAR,
+					GroupCols:    groupingCols[:numGroupingCols],
+					Aggregations: aggregations,
+				}
+				if !hashAgg {
+					aggregatorSpec.OrderedGroupCols = groupingCols[:numGroupingCols]
+					orderedCols := execinfrapb.ConvertToColumnOrdering(
+						execinfrapb.Ordering{Columns: orderingCols[:numGroupingCols]},
+					)
+					// Although we build the input rows in "non-decreasing" order, it is
+					// possible that some NULL values are present here and there, so we
+					// need to sort the rows to satisfy the ordering conditions.
+					sort.Slice(rows, func(i, j int) bool {
+						cmp, err := rows[i].Compare(inputTypes, &da, orderedCols, &evalCtx, rows[j])
+						if err != nil {
+							t.Fatal(err)
+						}
+						return cmp < 0
+					})
+				}
+				pspec := &execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
+					Core:  execinfrapb.ProcessorCoreUnion{Aggregator: aggregatorSpec},
+				}
+				args := verifyColOperatorArgs{
+					anyOrder:    hashAgg,
+					inputTypes:  [][]types.T{inputTypes},
+					inputs:      []sqlbase.EncDatumRows{rows},
+					outputTypes: outputTypes,
+					pspec:       pspec,
+				}
+				if err := verifyColOperator(args); err != nil {
+					// Columnar aggregators check whether an overflow occurs whereas
+					// processors don't, so we simply swallow the integer out of range
+					// error if such occurs and move on.
+					if strings.Contains(err.Error(), tree.ErrIntOutOfRange.Error()) {
+						continue
+					}
+					fmt.Printf("--- seed = %d run = %d hash = %t ---\n",
+						seed, run, hashAgg)
+					prettyPrintTypes(inputTypes, "t" /* tableName */)
+					prettyPrintInput(rows, inputTypes, "t" /* tableName */)
+					t.Fatal(err)
+				}
 			}
 		}
 	}
@@ -137,7 +185,7 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 		intTyps[i] = *types.Int
 	}
 
-	for run := 1; run < nRuns; run++ {
+	for run := 0; run < nRuns; run++ {
 		for nCols := 1; nCols <= maxCols; nCols++ {
 			for nDistinctCols := 1; nDistinctCols <= nCols; nDistinctCols++ {
 				for nOrderedCols := 0; nOrderedCols <= nDistinctCols; nOrderedCols++ {
@@ -189,15 +237,15 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
 						Core:  execinfrapb.ProcessorCoreUnion{Distinct: spec},
 					}
-					if err := verifyColOperator(
-						true, /* anyOrder */
-						distinctCols,
-						[][]types.T{inputTypes},
-						[]sqlbase.EncDatumRows{rows},
-						inputTypes,
-						pspec,
-						0, /* memoryLimit */
-					); err != nil {
+					args := verifyColOperatorArgs{
+						anyOrder:       true,
+						colsForEqCheck: distinctCols,
+						inputTypes:     [][]types.T{inputTypes},
+						inputs:         []sqlbase.EncDatumRows{rows},
+						outputTypes:    inputTypes,
+						pspec:          pspec,
+					}
+					if err := verifyColOperator(args); err != nil {
 						fmt.Printf("--- seed = %d run = %d nCols = %d distinct cols = %v ordered cols = %v ---\n",
 							seed, run, nCols, distinctCols, orderedCols)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
@@ -258,15 +306,14 @@ func TestSorterAgainstProcessor(t *testing.T) {
 					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
 					Core:  execinfrapb.ProcessorCoreUnion{Sorter: sorterSpec},
 				}
-				if err := verifyColOperator(
-					false, /* anyOrder */
-					nil,   /* colsForEqCheck */
-					[][]types.T{inputTypes},
-					[]sqlbase.EncDatumRows{rows},
-					inputTypes,
-					pspec,
-					memoryLimit,
-				); err != nil {
+				args := verifyColOperatorArgs{
+					inputTypes:  [][]types.T{inputTypes},
+					inputs:      []sqlbase.EncDatumRows{rows},
+					outputTypes: inputTypes,
+					pspec:       pspec,
+					memoryLimit: memoryLimit,
+				}
+				if err := verifyColOperator(args); err != nil {
 					fmt.Printf("--- seed = %d memoryLimit = %d nCols = %d ---\n", seed, memoryLimit, nCols)
 					prettyPrintTypes(inputTypes, "t" /* tableName */)
 					prettyPrintInput(rows, inputTypes, "t" /* tableName */)
@@ -332,15 +379,13 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
 					Core:  execinfrapb.ProcessorCoreUnion{Sorter: sorterSpec},
 				}
-				if err := verifyColOperator(
-					false, /* anyOrder */
-					nil,   /* colsForEqCheck */
-					[][]types.T{inputTypes},
-					[]sqlbase.EncDatumRows{rows},
-					inputTypes,
-					pspec,
-					0, /* memoryLimit */
-				); err != nil {
+				args := verifyColOperatorArgs{
+					inputTypes:  [][]types.T{inputTypes},
+					inputs:      []sqlbase.EncDatumRows{rows},
+					outputTypes: inputTypes,
+					pspec:       pspec,
+				}
+				if err := verifyColOperator(args); err != nil {
 					fmt.Printf("--- seed = %d nCols = %d ---\n", seed, nCols)
 					prettyPrintTypes(inputTypes, "t" /* tableName */)
 					prettyPrintInput(rows, inputTypes, "t" /* tableName */)
@@ -458,15 +503,14 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 								Core:  execinfrapb.ProcessorCoreUnion{HashJoiner: hjSpec},
 								Post:  execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outputColumns, Filter: filter},
 							}
-							if err := verifyColOperator(
-								true, /* anyOrder */
-								nil,  /* colsForEqCheck */
-								[][]types.T{inputTypes, inputTypes},
-								[]sqlbase.EncDatumRows{lRows, rRows},
-								outputTypes,
-								pspec,
-								0, /* memoryLimit */
-							); err != nil {
+							args := verifyColOperatorArgs{
+								anyOrder:    true,
+								inputTypes:  [][]types.T{inputTypes, inputTypes},
+								inputs:      []sqlbase.EncDatumRows{lRows, rRows},
+								outputTypes: outputTypes,
+								pspec:       pspec,
+							}
+							if err := verifyColOperator(args); err != nil {
 								fmt.Printf("--- join type = %s onExpr = %q filter = %q seed = %d run = %d ---\n",
 									testSpec.joinType.String(), onExpr.Expr, filter.Expr, seed, run)
 								fmt.Printf("--- lEqCols = %v rEqCols = %v ---\n", lEqCols, rEqCols)
@@ -641,15 +685,14 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 								Core:  execinfrapb.ProcessorCoreUnion{MergeJoiner: mjSpec},
 								Post:  execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outputColumns, Filter: filter},
 							}
-							if err := verifyColOperator(
-								testSpec.anyOrder,
-								nil, /* colsForEqCheck */
-								[][]types.T{inputTypes, inputTypes},
-								[]sqlbase.EncDatumRows{lRows, rRows},
-								outputTypes,
-								pspec,
-								0, /* memoryLimit */
-							); err != nil {
+							args := verifyColOperatorArgs{
+								anyOrder:    testSpec.anyOrder,
+								inputTypes:  [][]types.T{inputTypes, inputTypes},
+								inputs:      []sqlbase.EncDatumRows{lRows, rRows},
+								outputTypes: outputTypes,
+								pspec:       pspec,
+							}
+							if err := verifyColOperator(args); err != nil {
 								fmt.Printf("--- join type = %s onExpr = %q filter = %q seed = %d run = %d ---\n",
 									testSpec.joinType.String(), onExpr.Expr, filter.Expr, seed, run)
 								prettyPrintTypes(inputTypes, "left" /* tableName */)
@@ -803,14 +846,14 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
 						Core:  execinfrapb.ProcessorCoreUnion{Windower: windowerSpec},
 					}
-					if err := verifyColOperator(
-						true, /* anyOrder */
-						nil,  /* colsForEqCheck */
-						[][]types.T{inputTypes},
-						[]sqlbase.EncDatumRows{rows},
-						append(inputTypes, *types.Int),
-						pspec, 0, /* memoryLimit */
-					); err != nil {
+					args := verifyColOperatorArgs{
+						anyOrder:    true,
+						inputTypes:  [][]types.T{inputTypes},
+						inputs:      []sqlbase.EncDatumRows{rows},
+						outputTypes: append(inputTypes, *types.Int),
+						pspec:       pspec,
+					}
+					if err := verifyColOperator(args); err != nil {
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
 						prettyPrintInput(rows, inputTypes, "t" /* tableName */)
 						t.Fatal(err)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -12,6 +12,9 @@ package distsql
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -26,24 +29,33 @@ import (
 	"github.com/pkg/errors"
 )
 
+type verifyColOperatorArgs struct {
+	// anyOrder determines whether the results should be matched in order (when
+	// anyOrder is false) or as sets (when anyOrder is true).
+	anyOrder bool
+	// colsForEqCheck (when non-nil) specifies the column indices that should be
+	// used for equality check. If it is nil, then the whole rows are compared.
+	colsForEqCheck []uint32
+	inputTypes     [][]types.T
+	inputs         []sqlbase.EncDatumRows
+	outputTypes    []types.T
+	pspec          *execinfrapb.ProcessorSpec
+	// memoryLimit specifies the desired memory limit on the testing knob (in
+	// bytes). If it is 0, then the default limit of 64MiB will be used.
+	memoryLimit int64
+}
+
 // verifyColOperator passes inputs through both the processor defined by pspec
 // and the corresponding columnar operator and verifies that the results match.
-//
-// - anyOrder determines whether the results should be matched in order (when
-//   anyOrder is false) or as sets (when anyOrder is true).
-// - colsForEqCheck (when non-nil) specifies the column indices that should be
-//   used for equality check. If it is nil, then the whole rows are compared.
-// - memoryLimit specifies the desired memory limit on the testing knob (in
-//   bytes). If it is 0, then the default limit of 64MiB will be used.
-func verifyColOperator(
-	anyOrder bool,
-	colsForEqCheck []uint32,
-	inputTypes [][]types.T,
-	inputs []sqlbase.EncDatumRows,
-	outputTypes []types.T,
-	pspec *execinfrapb.ProcessorSpec,
-	memoryLimit int64,
-) error {
+func verifyColOperator(args verifyColOperatorArgs) error {
+	const floatPrecision = 0.0000001
+	if args.colsForEqCheck == nil {
+		args.colsForEqCheck = make([]uint32, len(args.outputTypes))
+		for i := range args.colsForEqCheck {
+			args.colsForEqCheck[i] = uint32(i)
+		}
+	}
+
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
@@ -64,16 +76,19 @@ func verifyColOperator(
 			DiskMonitor: diskMonitor,
 		},
 	}
-	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = args.memoryLimit
 
-	inputsProc := make([]execinfra.RowSource, len(inputs))
-	inputsColOp := make([]execinfra.RowSource, len(inputs))
-	for i, input := range inputs {
-		inputsProc[i] = execinfra.NewRepeatableRowSource(inputTypes[i], input)
-		inputsColOp[i] = execinfra.NewRepeatableRowSource(inputTypes[i], input)
+	inputsProc := make([]execinfra.RowSource, len(args.inputs))
+	inputsColOp := make([]execinfra.RowSource, len(args.inputs))
+	for i, input := range args.inputs {
+		inputsProc[i] = execinfra.NewRepeatableRowSource(args.inputTypes[i], input)
+		inputsColOp[i] = execinfra.NewRepeatableRowSource(args.inputTypes[i], input)
 	}
 
-	proc, err := rowexec.NewProcessor(ctx, flowCtx, 0, &pspec.Core, &pspec.Post, inputsProc, []execinfra.RowReceiver{nil}, nil)
+	proc, err := rowexec.NewProcessor(
+		ctx, flowCtx, 0, &args.pspec.Core, &args.pspec.Post,
+		inputsProc, []execinfra.RowReceiver{nil}, nil,
+	)
 	if err != nil {
 		return err
 	}
@@ -85,7 +100,7 @@ func verifyColOperator(
 	acc := evalCtx.Mon.MakeBoundAccount()
 	defer acc.Close(ctx)
 	testAllocator := colexec.NewAllocator(ctx, &acc)
-	columnarizers := make([]colexec.Operator, len(inputs))
+	columnarizers := make([]colexec.Operator, len(args.inputs))
 	for i, input := range inputsColOp {
 		c, err := colexec.NewColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)
 		if err != nil {
@@ -94,17 +109,17 @@ func verifyColOperator(
 		columnarizers[i] = c
 	}
 
-	args := colexec.NewColOperatorArgs{
-		Spec:                 pspec,
+	constructorArgs := colexec.NewColOperatorArgs{
+		Spec:                 args.pspec,
 		Inputs:               columnarizers,
 		StreamingMemAccount:  &acc,
 		ProcessorConstructor: rowexec.NewProcessor,
 	}
 	var spilled bool
-	if memoryLimit > 0 {
-		args.TestingKnobs.SpillingCallbackFn = func() { spilled = true }
+	if args.memoryLimit > 0 {
+		constructorArgs.TestingKnobs.SpillingCallbackFn = func() { spilled = true }
 	}
-	result, err := colexec.NewColOperator(ctx, flowCtx, args)
+	result, err := colexec.NewColOperator(ctx, flowCtx, constructorArgs)
 	if err != nil {
 		return err
 	}
@@ -119,9 +134,9 @@ func verifyColOperator(
 
 	outColOp, err := colexec.NewMaterializer(
 		flowCtx,
-		int32(len(inputs))+2,
+		int32(len(args.inputs))+2,
 		result.Op,
-		outputTypes,
+		args.outputTypes,
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		result.MetadataSources,
@@ -137,24 +152,24 @@ func verifyColOperator(
 	defer outProc.ConsumerClosed()
 	defer outColOp.ConsumerClosed()
 
-	scratchRow := make(sqlbase.EncDatumRow, len(colsForEqCheck))
-	scratchTypes := make([]types.T, len(colsForEqCheck))
-	printRowForChecking := func(r sqlbase.EncDatumRow) string {
-		if colsForEqCheck == nil {
-			return r.String(outputTypes)
+	printRowForChecking := func(r sqlbase.EncDatumRow) []string {
+		res := make([]string, len(args.colsForEqCheck))
+		for i, col := range args.colsForEqCheck {
+			res[i] = r[col].String(&args.outputTypes[col])
 		}
-		for i, col := range colsForEqCheck {
-			scratchRow[i] = r[col]
-			scratchTypes[i] = outputTypes[col]
-		}
-		return scratchRow.String(scratchTypes)
+		return res
 	}
-	var procRows, colOpRows []string
+	var procRows, colOpRows [][]string
 	var procMetas, colOpMetas []execinfrapb.ProducerMetadata
 	for {
 		rowProc, metaProc := outProc.Next()
 		if rowProc != nil {
-			procRows = append(procRows, printRowForChecking(rowProc))
+			row := printRowForChecking(rowProc)
+			if len(row) != len(args.colsForEqCheck) {
+				return errors.Errorf("unexpectedly processor returned a row of"+
+					"different length\n%s", row)
+			}
+			procRows = append(procRows, row)
 		}
 		if metaProc != nil {
 			if metaProc.Err == nil {
@@ -165,6 +180,11 @@ func verifyColOperator(
 		}
 		rowColOp, metaColOp := outColOp.Next()
 		if rowColOp != nil {
+			row := printRowForChecking(rowColOp)
+			if len(row) != len(args.colsForEqCheck) {
+				return errors.Errorf("unexpectedly columnar operator returned a row of "+
+					"different length\n%s", row)
+			}
 			colOpRows = append(colOpRows, printRowForChecking(rowColOp))
 		}
 		if metaColOp != nil {
@@ -212,15 +232,66 @@ func verifyColOperator(
 			procRows, colOpRows, procMetas, colOpMetas)
 	}
 
-	if anyOrder {
+	printRowsOutput := func(rows [][]string) string {
+		res := ""
+		for i, row := range rows {
+			res = fmt.Sprintf("%s\n%d: %v", res, i, row)
+		}
+		return res
+	}
+
+	datumsMatch := func(expected, actual string, typ *types.T) (bool, error) {
+		switch typ.Family() {
+		case types.FloatFamily:
+			// Some operations on floats (for example, aggregation) can produce
+			// slightly different results in the row-by-row and vectorized engines.
+			// That's why we handle them separately.
+
+			// We first try direct string matching. If that succeeds, then great!
+			if expected == actual {
+				return true, nil
+			}
+			// If only one of the values is NULL, then the datums do not match.
+			if expected == `NULL` || actual == `NULL` {
+				return false, nil
+			}
+			// Now we will try parsing both strings as floats and check whether they
+			// are within allowed precision from each other.
+			expFloat, err := strconv.ParseFloat(expected, 64)
+			if err != nil {
+				return false, err
+			}
+			actualFloat, err := strconv.ParseFloat(actual, 64)
+			if err != nil {
+				return false, err
+			}
+			return math.Abs(expFloat-actualFloat) < floatPrecision, nil
+		default:
+			return expected == actual, nil
+		}
+	}
+
+	if args.anyOrder {
 		used := make([]bool, len(colOpRows))
-		for i, expStr := range procRows {
+		for i, expStrRow := range procRows {
 			rowMatched := false
-			for j, retStr := range colOpRows {
+			for j, retStrRow := range colOpRows {
 				if used[j] {
 					continue
 				}
-				if expStr == retStr {
+				foundDifference := false
+				for k, col := range args.colsForEqCheck {
+					match, err := datumsMatch(expStrRow[k], retStrRow[k], &args.outputTypes[col])
+					if err != nil {
+						return errors.Errorf("error while parsing datum in rows\n%v\n%v\n%s",
+							expStrRow, retStrRow, err.Error())
+					}
+					if !match {
+						foundDifference = true
+						break
+					}
+				}
+				if !foundDifference {
 					rowMatched = true
 					used[j] = true
 					break
@@ -228,23 +299,31 @@ func verifyColOperator(
 			}
 			if !rowMatched {
 				return errors.Errorf("different results: no match found for row %d of processor output\n"+
-					"processor output:\n		%v\ncolumnar operator output:\n		%v", i, procRows, colOpRows)
+					"processor output:%s\n\ncolumnar operator output:%s",
+					i, printRowsOutput(procRows), printRowsOutput(colOpRows))
 			}
 		}
 	} else {
-		for i, expStr := range procRows {
-			retStr := colOpRows[i]
+		for i, expStrRow := range procRows {
+			retStrRow := colOpRows[i]
 			// anyOrder is false, so the result rows must match in the same order.
-			if expStr != retStr {
-				return errors.Errorf(
-					"different results on row %d;\nexpected:\n%s\ngot:\n%s",
-					i, expStr, retStr,
-				)
+			for k, col := range args.colsForEqCheck {
+				match, err := datumsMatch(expStrRow[k], retStrRow[k], &args.outputTypes[col])
+				if err != nil {
+					return errors.Errorf("error while parsing datum in rows\n%v\n%v\n%s",
+						expStrRow, retStrRow, err.Error())
+				}
+				if !match {
+					return errors.Errorf(
+						"different results on row %d;\nexpected:\n%s\ngot:\n%s",
+						i, expStrRow, retStrRow,
+					)
+				}
 			}
 		}
 	}
 
-	if memoryLimit > 0 {
+	if args.memoryLimit > 0 {
 		// Check that the spilling did occur.
 		if !spilled {
 			return errors.Errorf("expected spilling to disk but it did *not* occur")

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -951,7 +951,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
 ----
 ·                         distributed  false                                      ·                         ·
-·                         vectorized   true                                       ·                         ·
+·                         vectorized   false                                      ·                         ·
 render                    ·            ·                                          (a int)                   ·
  │                        render 0     (1)[int]                                   ·                         ·
  └── distinct             ·            ·                                          (column5 decimal, v int)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -10,7 +10,7 @@ query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 ·          distributed  true
-·          vectorized   true
+·          vectorized   false
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -28,7 +28,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
 ·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -39,7 +39,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
 ·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (x)        ·
  │              render 0     x            ·          ·
  └── distinct   ·            ·            (x, y, z)  ·
@@ -90,7 +90,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
 ·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
+·               vectorized   false        ·       ·
 render          ·            ·            (y, x)  ·
  │              render 0     y            ·       ·
  │              render 1     x            ·       ·
@@ -104,7 +104,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
 ·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
+·               vectorized   false        ·       ·
 render          ·            ·            (x)     ·
  │              render 0     x            ·       ·
  └── distinct   ·            ·            (x, y)  ·
@@ -117,7 +117,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
@@ -128,7 +128,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
 ·               distributed  false        ·         ·
-·               vectorized   true         ·         ·
+·               vectorized   false        ·         ·
 render          ·            ·            (pk1, x)  ·
  │              render 0     pk1          ·         ·
  │              render 1     x            ·         ·
@@ -143,7 +143,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
 ·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (a, b)     ·
  │              render 0     a            ·          ·
  │              render 1     b            ·          ·
@@ -158,7 +158,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
 ·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (b, c, a)  ·
  │              render 0     b            ·          ·
  │              render 1     c            ·          ·
@@ -360,7 +360,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
 ·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x            ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -386,7 +386,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (y, x)  ·
  │         distinct on  y            ·       ·
  └── scan  ·            ·            (y, x)  ·
@@ -398,7 +398,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
 ·          distributed  false        ·    ·
-·          vectorized   true         ·    ·
+·          vectorized   false        ·    ·
 distinct   ·            ·            (y)  ·
  │         distinct on  y            ·    ·
  └── scan  ·            ·            (y)  ·
@@ -413,7 +413,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -68,7 +68,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
 ·          distributed  true         ·          ·
-·          vectorized   true         ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -504,7 +504,7 @@ query TTT
 EXPLAIN SELECT DISTINCT v FROM t
 ----
 ·          distributed  false
-·          vectorized   true
+·          vectorized   false
 distinct   ·            ·
  │         distinct on  v
  └── scan  ·            ·
@@ -515,7 +515,7 @@ query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
 ·                    distributed  false
-·                    vectorized   true
+·                    vectorized   false
 limit                ·            ·
  │                   offset       1
  └── limit           ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -48,7 +48,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
 ·                         distributed  false      ·       ·
-·                         vectorized   true       ·       ·
+·                         vectorized   false      ·       ·
 render                    ·            ·          (c, b)  ·
  │                        render 0     c          ·       ·
  │                        render 1     b          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -10,7 +10,7 @@ query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 ·          distributed  false
-·          vectorized   true
+·          vectorized   false
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary


### PR DESCRIPTION
**distsql: add a test comparing distinct operator and processor**

Release note: None

**colexec: minor cleanup of hashjoiner_tmpl**

This commit removes some extra empty lines from the generated code by
appending `-` to the end of the template definitions. Also, it refactors
one conditional into an assignment.

Release note: None

**colexec: fix a bug in hash table when null equality is allowed**

Previously we incorrectly were handling the case of allowed null
equality in the hash table (which is used by the hash grouper and
unordered distinct) - we were resetting groupID of the tuple on the
probe side of that tuple has NULL value in the equality column whereas
the build tuple has a non-NULL value. This could result in incorrectly
populated `same` array and is now fixed.

Release note: None

**colexec: add unordered distinct**

This commit adds an unordered distinct operator. The operator simply
builds a hashTable on the first call to Next() on the whole input, then
iterates over all of the tuples to check whether the tuple is the "head"
of a linked list that contain all of the tuples that are equal on
distinct columns. Only the "head" is included into the big selection
vector. Once the big selection vector is populated, the operator
proceeds to returning the batches according to a chunk of the selection
vector.

This doesn't take into account whether the input is partially ordered,
and this item is left as a follow-up work.

Fixes: #39240.

Release note (sql change): vectorized execution engine now supports
DISTINCT on unordered input.

**colexec: fix hash grouper**

Previously, hash grouper could hit an internal error of index outside of
range when it was looking for the "head" of a linked list. Now this is
fixed by refactoring the code in question. I think the code is now more
comprehensible.

There is no release note since hash grouper so far has been used only
with `experimental_on`.

Release note: None

**distsql: enhance testing columnar aggregator against processor**

This commit adds an ability to insert NULL values into grouping columns
and increases the number of grouping columns tested (previously it was
hard-coded as one). ANY_NOT_NULL aggregate is now skipped since it
returns non-deterministic output.

This change required modifications to the test harness to allow the
results of aggregation to deviate slightly when operating on float
values because direct string matching will not work in some cases.

Also, this commit extracts out arguments to the test harness into
a separate struct.

Release note: None