### PR TITLE
sql: fix validation of MATCH FULL foreign keys with mixed column types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2725,3 +2725,19 @@ user root
 
 statement ok
 COMMIT
+
+# Regression test for #42498: MATCH FULL validation should work when columns in
+# a composite FK reference have different types.
+subtest 42498_match_full_mixed_types
+
+statement ok
+CREATE TABLE table1_42498 (col1 REGPROC NOT NULL, col2 DATE NOT NULL)
+
+statement ok
+CREATE TABLE table2_42498 (col3 REGPROC NOT NULL, col4 DATE NOT NULL, UNIQUE (col4, col3))
+
+statement ok
+ALTER TABLE table1_42498 ADD FOREIGN KEY (col2, col1) REFERENCES table2_42498 (col4, col3) MATCH FULL
+
+statement ok
+DROP TABLE table1_42498, table2_42498 CASCADE


### PR DESCRIPTION
Previously, the internal validation query for MATCH FULL foreign keys checked
for the presence of invalid keys for a set of columns `c_1, ..., c_n` by using
`COALESCE(c_1, ..., c_n) IS NULL`, which fails if any of the columns differ in
type because `COALESCE` requires its arguments to be all of the same type. This
PR fixes the validation query by using `c_1 IS NULL AND ... AND c_n IS NULL`
instead.

Fixes #42498.

Release note (bug fix): Fixed a bug that would produce a spurious failure with
the error message "incompatible COALESCE expressions" when adding or validating
`MATCH FULL` foreign key constraints involving composite keys with columns of
differing types.