### PR TITLE
libroach: Fix memory leak in row_counter

### DIFF
--- a/c-deps/libroach/row_counter.cc
+++ b/c-deps/libroach/row_counter.cc
@@ -88,10 +88,12 @@ bool RowCounter::Count(const rocksdb::Slice& key, cockroach::roachpb::BulkOpSumm
   }
 
   // no change key prefix => no new row.
-  if (decoded_key.data() == prev_key.data) {
+  if (decoded_key == prev_key) {
     return true;
   }
-  prev_key = ToDBString(decoded_key);
+
+
+  prev_key.assign(decoded_key.data(), decoded_key.size());
 
   uint64_t tbl;
   if (!DecodeTablePrefix(&decoded_key, &tbl)) {

--- a/c-deps/libroach/row_counter.h
+++ b/c-deps/libroach/row_counter.h
@@ -29,6 +29,6 @@ struct RowCounter {
  private:
   void EnsureSafeSplitKey(rocksdb::Slice* key);
   int GetRowPrefixLength(rocksdb::Slice* key);
-  DBString prev_key;
+  std::string prev_key;
   rocksdb::Slice prev;
 };


### PR DESCRIPTION
Free previous key memory when counting row keys.

Release note (bug fix): Do not leak memory when counting rows during backup.