### PR TITLE
cli/interactive_tests: opt out of telemetry by default

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -8,6 +8,7 @@ system "mkdir -p logs"
 # developer's own history file when running out of Docker.
 set histfile "cockroach_sql_history"
 
+set ::env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
 set ::env(COCKROACH_CONNECT_TIMEOUT) 15
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -2,6 +2,9 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+# The following tests want to access the licensing server.
+set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "false"
+
 start_test "Expect partitioning succeeds"
 # test that partitioning works if a license could be acquired
 spawn $argv demo --geo-partitioned-replicas

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -4,12 +4,6 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check cockroach demo --with-load runs the movr workload"
 
-# Disable trying to acquire the demo license. This test does not
-# need enterprise features, and sometimes if the licensing server
-# is unavailable, the error message from failing to receive the
-# testing license pollutes the test output.
-set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
-
 # Start demo with movr and the movr workload.
 spawn $argv demo movr --with-load
 


### PR DESCRIPTION
Prior to this patch, the CLI interactive tests were running with
diagnostic reporting (including update server checks, telemetry etc)
enabled.

This was unintentional—having implemented the tests initially, I
always worked under the assumption that the acceptance test runner was
disabling telemetry upfront. I only discovered the opposite was true
recently, seeing tests fail with mysterious errors when the telemetry
server happens to be mis-behaving.

This patch fixes the situation by opting the interactive tests out of
telemetry by default. The two tests that check it (with a sensible
fallback) now opt back in explicitly.

Release note: None