### PR TITLE
release-19.2: fix server hangs on HTTP timeouts

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -130,9 +130,9 @@ func (s *benchSink) EmitRow(
 ) error {
 	return s.emit(int64(len(k) + len(v)))
 }
-func (s *benchSink) EmitResolvedTimestamp(_ context.Context, e Encoder, ts hlc.Timestamp) error {
+func (s *benchSink) EmitResolvedTimestamp(ctx context.Context, e Encoder, ts hlc.Timestamp) error {
 	var noTopic string
-	p, err := e.EncodeResolvedTimestamp(noTopic, ts)
+	p, err := e.EncodeResolvedTimestamp(ctx, noTopic, ts)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -178,12 +178,12 @@ func emitEntries(
 			return nil
 		}
 		var keyCopy, valueCopy []byte
-		encodedKey, err := encoder.EncodeKey(row)
+		encodedKey, err := encoder.EncodeKey(ctx, row)
 		if err != nil {
 			return err
 		}
 		scratch, keyCopy = scratch.Copy(encodedKey, 0 /* extraCap */)
-		encodedValue, err := encoder.EncodeValue(row)
+		encodedValue, err := encoder.EncodeValue(ctx, row)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -166,10 +166,10 @@ func TestEncoders(t *testing.T) {
 				updated:   ts,
 				tableDesc: tableDesc,
 			}
-			keyInsert, err := e.EncodeKey(rowInsert)
+			keyInsert, err := e.EncodeKey(context.TODO(), rowInsert)
 			require.NoError(t, err)
 			keyInsert = append([]byte(nil), keyInsert...)
-			valueInsert, err := e.EncodeValue(rowInsert)
+			valueInsert, err := e.EncodeValue(context.TODO(), rowInsert)
 			require.NoError(t, err)
 			require.Equal(t, expected.insert, rowStringFn(keyInsert, valueInsert))
 
@@ -179,14 +179,14 @@ func TestEncoders(t *testing.T) {
 				updated:   ts,
 				tableDesc: tableDesc,
 			}
-			keyDelete, err := e.EncodeKey(rowDelete)
+			keyDelete, err := e.EncodeKey(context.TODO(), rowDelete)
 			require.NoError(t, err)
 			keyDelete = append([]byte(nil), keyDelete...)
-			valueDelete, err := e.EncodeValue(rowDelete)
+			valueDelete, err := e.EncodeValue(context.TODO(), rowDelete)
 			require.NoError(t, err)
 			require.Equal(t, expected.delete, rowStringFn(keyDelete, valueDelete))
 
-			resolved, err := e.EncodeResolvedTimestamp(tableDesc.Name, ts)
+			resolved, err := e.EncodeResolvedTimestamp(context.TODO(), tableDesc.Name, ts)
 			require.NoError(t, err)
 			require.Equal(t, expected.resolved, resolvedStringFn(resolved))
 		})

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -485,7 +485,7 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 	}
 
 	for topic := range s.topics {
-		payload, err := encoder.EncodeResolvedTimestamp(topic, resolved)
+		payload, err := encoder.EncodeResolvedTimestamp(ctx, topic, resolved)
 		if err != nil {
 			return err
 		}
@@ -707,7 +707,7 @@ func (s *sqlSink) EmitResolvedTimestamp(
 ) error {
 	var noKey, noValue []byte
 	for topic := range s.topics {
-		payload, err := encoder.EncodeResolvedTimestamp(topic, resolved)
+		payload, err := encoder.EncodeResolvedTimestamp(ctx, topic, resolved)
 		if err != nil {
 			return err
 		}
@@ -811,13 +811,13 @@ func (s *bufferSink) EmitRow(
 
 // EmitResolvedTimestamp implements the Sink interface.
 func (s *bufferSink) EmitResolvedTimestamp(
-	_ context.Context, encoder Encoder, resolved hlc.Timestamp,
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
 ) error {
 	if s.closed {
 		return errors.New(`cannot EmitResolvedTimestamp on a closed sink`)
 	}
 	var noTopic string
-	payload, err := encoder.EncodeResolvedTimestamp(noTopic, resolved)
+	payload, err := encoder.EncodeResolvedTimestamp(ctx, noTopic, resolved)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -388,7 +388,7 @@ func (s *cloudStorageSink) EmitResolvedTimestamp(
 	}
 
 	var noTopic string
-	payload, err := encoder.EncodeResolvedTimestamp(noTopic, resolved)
+	payload, err := encoder.EncodeResolvedTimestamp(ctx, noTopic, resolved)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -167,9 +167,11 @@ func TestKafkaSinkEscaping(t *testing.T) {
 
 type testEncoder struct{}
 
-func (testEncoder) EncodeKey(encodeRow) ([]byte, error)   { panic(`unimplemented`) }
-func (testEncoder) EncodeValue(encodeRow) ([]byte, error) { panic(`unimplemented`) }
-func (testEncoder) EncodeResolvedTimestamp(_ string, ts hlc.Timestamp) ([]byte, error) {
+func (testEncoder) EncodeKey(context.Context, encodeRow) ([]byte, error)   { panic(`unimplemented`) }
+func (testEncoder) EncodeValue(context.Context, encodeRow) ([]byte, error) { panic(`unimplemented`) }
+func (testEncoder) EncodeResolvedTimestamp(
+	_ context.Context, _ string, ts hlc.Timestamp,
+) ([]byte, error) {
 	return []byte(ts.String()), nil
 }
 

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -8,6 +8,7 @@ system "mkdir -p logs"
 # developer's own history file when running out of Docker.
 set histfile "cockroach_sql_history"
 
+set ::env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
 set ::env(COCKROACH_CONNECT_TIMEOUT) 15
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -2,6 +2,9 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+# The following tests want to access the licensing server.
+set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "false"
+
 start_test "Expect partitioning succeeds"
 # test that partitioning works if a license could be acquired
 spawn $argv demo --geo-partitioned-replicas

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -4,12 +4,6 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check cockroach demo --with-load runs the movr workload"
 
-# Disable trying to acquire the demo license. This test does not
-# need enterprise features, and sometimes if the licensing server
-# is unavailable, the error message from failing to receive the
-# testing license pollutes the test output.
-set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
-
 # Start demo with movr and the movr workload.
 spawn $argv demo movr --with-load
 

--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -13,10 +13,10 @@ package extract
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os/exec"
 	"regexp"
@@ -24,6 +24,7 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg/yacc"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -76,7 +77,7 @@ func GenerateRRNet(bnf []byte) ([]byte, error) {
 	v.Add("options", "factoring")
 	v.Add("options", "inline")
 
-	resp, err := http.Post(rrAddr, "application/x-www-form-urlencoded", strings.NewReader(v.Encode()))
+	resp, err := httputil.Post(context.TODO(), rrAddr, "application/x-www-form-urlencoded", strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ func GenerateRRNet(bnf []byte) ([]byte, error) {
 func GenerateBNF(addr string) (ebnf []byte, err error) {
 	var b []byte
 	if strings.HasPrefix(addr, "http") {
-		resp, err := http.Get(addr)
+		resp, err := httputil.Get(context.TODO(), addr)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -11,10 +11,12 @@
 package install
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
 
 const (
@@ -39,7 +41,7 @@ func getEdgeBinaryURL(binaryName, SHA, arch string) (*url.URL, error) {
 		edgeBinaryLocation.Path += ".LATEST"
 		// Otherwise, find the latest SHA binary available. This works because
 		// "[executable].LATEST" redirects to the latest SHA.
-		resp, err := http.Head(edgeBinaryLocation.String())
+		resp, err := httputil.Head(context.TODO(), edgeBinaryLocation.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"golang.org/x/sync/errgroup"
 )
@@ -100,7 +101,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 			// Wait for the servers to bind their ports.
 			if err := retry.ForDuration(10*time.Second, func() error {
 				for i := 1; i <= c.spec.NodeCount; i++ {
-					resp, err := http.Get(urlMap[i] + "/health")
+					resp, err := httputil.Get(ctx, urlMap[i]+"/health")
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -304,7 +304,7 @@ func getFollowerReadCounts(ctx context.Context, c *cluster) ([]int, error) {
 	getFollowerReadCount := func(ctx context.Context, node int) func() error {
 		return func() error {
 			url := "http://" + c.ExternalAdminUIAddr(ctx, c.Node(node))[0] + "/_status/vars"
-			resp, err := http.Get(url)
+			resp, err := httputil.Get(ctx, url)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -45,10 +45,14 @@ func runStatusServer(ctx context.Context, t *test, c *cluster) {
 		urlMap[i+1] = `http://` + addr
 	}
 
+	// The status endpoints below may take a while to produce their answer, maybe more
+	// than the 3 second timeout of the default http client.
+	httpClient := httputil.NewClientWithTimeout(15 * time.Second)
+
 	// get performs an HTTP GET to the specified path for a specific node.
 	get := func(base, rel string) []byte {
 		url := base + rel
-		resp, err := http.Get(url)
+		resp, err := httpClient.Get(context.TODO(), url)
 		if err != nil {
 			t.Fatalf("could not GET %s - %s", url, err)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -184,7 +184,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	if !strings.HasPrefix(url, "http://") {
 		t.Fatalf("expected insecure admin url to start with http://, but got %s", url)
 	}
-	if resp, err := http.Get(url); err != nil {
+	if resp, err := httputil.Get(context.TODO(), url); err != nil {
 		t.Error(err)
 	} else {
 		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
@@ -197,7 +197,7 @@ func TestPlainHTTPServer(t *testing.T) {
 
 	// Attempting to connect to the insecure server with HTTPS doesn't work.
 	secureURL := strings.Replace(url, "http://", "https://", 1)
-	if _, err := http.Get(secureURL); !testutils.IsError(err, "http: server gave HTTP response to HTTPS client") {
+	if _, err := httputil.Get(context.TODO(), secureURL); !testutils.IsError(err, "http: server gave HTTP response to HTTPS client") {
 		t.Error(err)
 	}
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1434,27 +1434,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestRoachLint", func(t *testing.T) {
-		t.Parallel()
-
-		vetCmd(t, crdb.Dir, "roachlint", []string{pkgScope}, []stream.Filter{
-			// Ignore generated files.
-			stream.GrepNot(`pkg/.*\.pb\.go:`),
-			stream.GrepNot(`pkg/col/coldata/.*\.eg\.go:`),
-			stream.GrepNot(`pkg/col/colserde/arrowserde/.*_generated\.go:`),
-			stream.GrepNot(`pkg/sql/colexec/.*\.eg\.go:`),
-			stream.GrepNot(`pkg/sql/colexec/.*_generated\.go:`),
-			stream.GrepNot(`pkg/sql/pgwire/hba/conf.go:`),
-
-			// Ignore types that can change by system.
-			stream.GrepNot(`pkg/util/sysutil/sysutil_unix.go:`),
-
-			// Ignore tests.
-			// TODO(mjibson): remove this ignore.
-			stream.GrepNot(`pkg/.*_test\.go:`),
-		})
-	})
-
 	t.Run("TestVectorizedPanics", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1221,7 +1221,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestVet", func(t *testing.T) {
-		t.Parallel()
 		runVet := func(t *testing.T, args ...string) {
 			args = append(append([]string{"vet"}, args...), pkgScope)
 			vetCmd(t, crdb.Dir, "go", args, []stream.Filter{
@@ -1289,7 +1288,7 @@ func TestLint(t *testing.T) {
 		//    A function may be a Printf or Print wrapper if its last argument is ...interface{}.
 		//    If the next-to-last argument is a string, then this may be a Printf wrapper.
 		//    Otherwise it may be a Print wrapper.
-		runVet(t, "-all", "-printfuncs", printfuncs)
+		t.Run("vet", func(t *testing.T) { runVet(t, "-all", "-printfuncs", printfuncs) })
 	})
 
 	// TODO(tamird): replace this with errcheck.NewChecker() when

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -330,6 +330,47 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestHttputil", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			re       string
+			excludes []string
+		}{
+			{re: `\bhttp\.(Get|Put|Head)\(`},
+		} {
+			cmd, stderr, filter, err := dirCmd(
+				pkgDir,
+				"git",
+				append([]string{
+					"grep",
+					"-nE",
+					tc.re,
+					"--",
+					"*.go",
+				}, tc.excludes...)...,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := stream.ForEach(filter, func(s string) {
+				t.Errorf("\n%s <- forbidden; use 'httputil' instead", s)
+			}); err != nil {
+				t.Error(err)
+			}
+
+			if err := cmd.Wait(); err != nil {
+				if out := stderr.String(); len(out) > 0 {
+					t.Fatalf("err=%s, stderr=%s", err, out)
+				}
+			}
+		}
+	})
+
 	t.Run("TestEnvutil", func(t *testing.T) {
 		t.Parallel()
 		for _, tc := range []struct {

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -25,6 +25,30 @@ import (
 func TestNightlyLint(t *testing.T) {
 	_, pkgSpecified := os.LookupEnv("PKG")
 
+	// RoachLint is expensive memory-wise and thus should not run with t.Parallel().
+	//
+	// Note: It is too expensive RAM-wise to run roachlint on every CI
+	// until issue https://github.com/cockroachdb/cockroach/issues/42594
+	// has been addressed.
+	t.Run("TestRoachLint", func(t *testing.T) {
+		vetCmd(t, crdb.Dir, "roachlint", []string{pkgScope}, []stream.Filter{
+			// Ignore generated files.
+			stream.GrepNot(`pkg/.*\.pb\.go:`),
+			stream.GrepNot(`pkg/col/coldata/.*\.eg\.go:`),
+			stream.GrepNot(`pkg/col/colserde/arrowserde/.*_generated\.go:`),
+			stream.GrepNot(`pkg/sql/colexec/.*\.eg\.go:`),
+			stream.GrepNot(`pkg/sql/colexec/.*_generated\.go:`),
+			stream.GrepNot(`pkg/sql/pgwire/hba/conf.go:`),
+
+			// Ignore types that can change by system.
+			stream.GrepNot(`pkg/util/sysutil/sysutil_unix.go:`),
+
+			// Ignore tests.
+			// TODO(mjibson): remove this ignore.
+			stream.GrepNot(`pkg/.*_test\.go:`),
+		})
+	})
+
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
 		if testing.Short() {

--- a/pkg/util/cloudinfo/cloudinfo_test.go
+++ b/pkg/util/cloudinfo/cloudinfo_test.go
@@ -12,11 +12,13 @@ package cloudinfo
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -27,9 +29,9 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }
 
-//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
-func NewInstanceMetadataTestClient() *http.Client {
-	return &http.Client{
+// NewInstanceMetadataTestclient returns *http.Client with Transport replaced to avoid making real calls
+func NewInstanceMetadataTestClient() *httputil.Client {
+	return &httputil.Client{Client: &http.Client{
 		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
 			// Test request parameters
 			res := &http.Response{
@@ -142,7 +144,7 @@ func NewInstanceMetadataTestClient() *http.Client {
 
 			return res
 		}),
-	}
+	}}
 }
 
 func TestAWSInstanceMetadataParsing(t *testing.T) {
@@ -150,7 +152,7 @@ func TestAWSInstanceMetadataParsing(t *testing.T) {
 
 	cli := client{NewInstanceMetadataTestClient()}
 
-	s, p, i := cli.getAWSInstanceMetadata(instanceClass)
+	s, p, i := cli.getAWSInstanceMetadata(context.TODO(), instanceClass)
 
 	if !s {
 		t.Fatalf("expected parsing to succeed")
@@ -164,7 +166,7 @@ func TestAWSInstanceMetadataParsing(t *testing.T) {
 		t.Fatalf("expected parsing to get instanceType m5a.large")
 	}
 
-	_, _, r := cli.getAWSInstanceMetadata(region)
+	_, _, r := cli.getAWSInstanceMetadata(context.TODO(), region)
 
 	if r != "us-east-1" {
 		t.Fatalf("expected parsing to get region us-east-1")
@@ -176,7 +178,7 @@ func TestGCPInstanceMetadataParsing(t *testing.T) {
 
 	cli := client{NewInstanceMetadataTestClient()}
 
-	s, p, i := cli.getGCPInstanceMetadata(instanceClass)
+	s, p, i := cli.getGCPInstanceMetadata(context.TODO(), instanceClass)
 
 	if !s {
 		t.Fatalf("expected parsing to succeed")
@@ -190,7 +192,7 @@ func TestGCPInstanceMetadataParsing(t *testing.T) {
 		t.Fatalf("expected parsing to get machineTypes g1-small")
 	}
 
-	_, _, r := cli.getGCPInstanceMetadata(region)
+	_, _, r := cli.getGCPInstanceMetadata(context.TODO(), region)
 
 	if r != "us-east4-c" {
 		t.Fatalf("expected parsing to get region us-east4-c")
@@ -202,7 +204,7 @@ func TestAzureInstanceMetadataParsing(t *testing.T) {
 
 	cli := client{NewInstanceMetadataTestClient()}
 
-	s, p, i := cli.getAzureInstanceMetadata(instanceClass)
+	s, p, i := cli.getAzureInstanceMetadata(context.TODO(), instanceClass)
 
 	if !s {
 		t.Fatalf("expected parsing to succeed")
@@ -216,7 +218,7 @@ func TestAzureInstanceMetadataParsing(t *testing.T) {
 		t.Fatalf("expected parsing to get machineTypes Standard_D2s_v3")
 	}
 
-	_, _, r := cli.getAzureInstanceMetadata(region)
+	_, _, r := cli.getAzureInstanceMetadata(context.TODO(), region)
 
 	if r != "eastus" {
 		t.Fatalf("expected parsing to get region eastus")

--- a/pkg/util/httputil/client.go
+++ b/pkg/util/httputil/client.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package httputil
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// DefaultClient is a replacement for http.DefaultClient which defines
+// a standard timeout.
+var DefaultClient = NewClientWithTimeout(standardHTTPTimeout)
+
+const standardHTTPTimeout time.Duration = 3 * time.Second
+
+// NewClientWithTimeout defines a http.Client with the given timeout.
+func NewClientWithTimeout(timeout time.Duration) *Client {
+	return &Client{&http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Don't leak a goroutine on OSX (the TCP level timeout is probably
+			// much higher than on linux).
+			DialContext:       (&net.Dialer{Timeout: timeout}).DialContext,
+			DisableKeepAlives: true,
+		},
+	}}
+}
+
+// Client is a replacement for http.Client which implements method
+// variants that respect a provided context's cancellation status.
+type Client struct {
+	*http.Client
+}
+
+// Get does like http.Get but uses the provided context and obeys its cancellation.
+// It also uses the default client with a default 3 second timeout.
+func Get(ctx context.Context, url string) (resp *http.Response, err error) {
+	return DefaultClient.Get(ctx, url)
+}
+
+// Head does like http.Head but uses the provided context and obeys its cancellation.
+// It also uses the default client with a default 3 second timeout.
+func Head(ctx context.Context, url string) (resp *http.Response, err error) {
+	return DefaultClient.Head(ctx, url)
+}
+
+// Post does like http.Post but uses the provided context and obeys its cancellation.
+// It also uses the default client with a default 3 second timeout.
+func Post(
+	ctx context.Context, url, contentType string, body io.Reader,
+) (resp *http.Response, err error) {
+	return DefaultClient.Post(ctx, url, contentType, body)
+}
+
+// Get does like http.Client.Get but uses the provided context and obeys its cancellation.
+func (c *Client) Get(ctx context.Context, url string) (resp *http.Response, err error) {
+	req, err := NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+// Head does like http.Client.Head but uses the provided context and obeys its cancellation.
+func (c *Client) Head(ctx context.Context, url string) (resp *http.Response, err error) {
+	req, err := NewRequestWithContext(ctx, "HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+// Post does like http.Client.Post but uses the provided context and obeys its cancellation.
+func (c *Client) Post(
+	ctx context.Context, url, contentType string, body io.Reader,
+) (resp *http.Response, err error) {
+	req, err := NewRequestWithContext(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return c.Do(req)
+}

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -46,6 +46,7 @@ const (
 
 // GetJSON uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
+// TODO(someone): make this context-aware, see client.go.
 func GetJSON(httpClient http.Client, path string, response protoutil.Message) error {
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {
@@ -57,6 +58,7 @@ func GetJSON(httpClient http.Client, path string, response protoutil.Message) er
 
 // PostJSON uses the supplied client to POST request to the URL specified by
 // the parameters and unmarshals the result into response.
+// TODO(someone): make this context-aware, see client.go.
 func PostJSON(httpClient http.Client, path string, request, response protoutil.Message) error {
 	// Hack to avoid upsetting TestProtoMarshal().
 	marshalFn := (&jsonpb.Marshaler{}).Marshal
@@ -78,6 +80,7 @@ func PostJSON(httpClient http.Client, path string, request, response protoutil.M
 //
 // The response is returned to the caller, though its body will have been
 // closed.
+// TODO(someone): make this context-aware, see client.go.
 func PostJSONWithRequest(
 	httpClient http.Client, path string, request, response protoutil.Message,
 ) (*http.Response, error) {

--- a/pkg/util/httputil/req_go112.go
+++ b/pkg/util/httputil/req_go112.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !go1.13
+
+package httputil
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+// NewRequestWithContext provides the same interface as the Go 1.13 function
+// in http but ignores the context argument.
+//
+// This is transition code until the repository is upgraded to use Go
+// 1.13. In the meantime, the callers rely on requests eventually
+// succeeding or failing with a timeout if the remote server does not
+// provide a response on time.
+//
+// TODO(knz): remove this when the repo does not use 1.12 any more.
+func NewRequestWithContext(
+	ctx context.Context, method, url string, body io.Reader,
+) (*http.Request, error) {
+	return http.NewRequest(method, url, body)
+}

--- a/pkg/util/httputil/req_go113.go
+++ b/pkg/util/httputil/req_go113.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build go1.13
+
+package httputil
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+// NewRequestWithContext aliases http.NewRequestWithContext.
+// TODO(knz): this can be removed when the repo is upgraded to use go 1.13.
+func NewRequestWithContext(
+	ctx context.Context, method, url string, body io.Reader,
+) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, method, url, body)
+}

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
@@ -56,7 +57,7 @@ func TestHandleCSV(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			res, err := http.Get(ts.URL + `/bank/bank` + test.params)
+			res, err := httputil.Get(context.TODO(), ts.URL+`/bank/bank`+test.params)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "*: new `httputil.Client` and methods, & use them" (#42536)
  * 1/1 commits from "cli/interactive_tests: opt out of telemetry by default" (#42537)
  * 1/1 commits from "lint: only run TestRoachLint nightly" (#42595)
  * 1/1 commits from "lint: properly parallelize TestVet/TestVet" (#42605) 

Please see individual PRs for details.

/cc @cockroachdb/release
