### PR TITLE
build: fix `make buildshort`

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/cliccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/followerreadsccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/importccl"
@@ -24,5 +25,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 )


### PR DESCRIPTION
Previously, `make buildshort` was failing to include a couple of CCL
package, resulting in a build unable to enable enterprise features.

This patch fixes it.

Release note (build change): `make buildshort` is now able to produce
valid CCL binaries with all enterprise features (minus UI).