### PR TITLE
opt/memo: make IsTypeEqual more accurate

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -388,6 +388,8 @@ func (h *hasher) hashDatumsWithType(datums tree.Datums, typ *types.T, alwaysHash
 }
 
 func (h *hasher) HashType(val *types.T) {
+	// NOTE: type.String() is not a perfect hash of the type, as items such as
+	// precision and width may be lost. Collision handling must still occur.
 	h.HashString(val.String())
 }
 
@@ -660,7 +662,7 @@ func (h *hasher) IsOperatorEqual(l, r opt.Operator) bool {
 }
 
 func (h *hasher) IsTypeEqual(l, r *types.T) bool {
-	return l.String() == r.String()
+	return l.Identical(r)
 }
 
 func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -434,3 +434,17 @@ project
  │    └── columns: b.x:1(string!null) z:2(decimal!null)
  └── projections
       └── b.x::VARCHAR(2) [type=varchar]
+
+# Cast same type with different precisions.
+# See #42571.
+build
+SELECT z::decimal(10, 3), z::decimal(10, 1), z::decimal(10, 4) FROM b
+----
+project
+ ├── columns: z:3(decimal) z:4(decimal) z:5(decimal)
+ ├── scan b
+ │    └── columns: x:1(string!null) b.z:2(decimal!null)
+ └── projections
+      ├── b.z::DECIMAL(10,3) [type=decimal]
+      ├── b.z::DECIMAL(10,1) [type=decimal]
+      └── b.z::DECIMAL(10,4) [type=decimal]


### PR DESCRIPTION
Resolves #42571.

This PR changes IsTypeEqual to use `Identical` instead of comparing the
String()'d type objects. This otherwise causes a bug when casting a
column to two or more different precision / widths in the same SELECT
clause.

Backport to 19.1 and 19.2 will come afterwards.

Release note (bug fix): Previously, if one were to cast the same type
into two or more different precisions/widths from a table in the same
`SELECT` query, they would only get the first precision specified. For
example, `SELECT a::decimal(10, 3), a::decimal(10, 1) FROM t` would
return both results as `a::decimal(10, 3)`. This PR fixes that
behaviour.