### PR TITLE
release-19.2: colexec: fix unmarshaling Timestamp

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -336,6 +336,10 @@ func UnmarshalColumnValueToCol(
 		var v int64
 		v, err = value.GetInt()
 		vec.Int64()[idx] = v
+	case types.TimestampFamily:
+		var v time.Time
+		v, err = value.GetTime()
+		vec.Timestamp()[idx] = v
 	default:
 		return errors.AssertionFailedf("unsupported column type: %s", log.Safe(typ.Family()))
 	}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -1,3 +1,5 @@
+# LogicTest: local-vec
+
 # Check that all types supported by the vectorized engine can be read correctly.
 statement ok
 CREATE TABLE all_types (


### PR DESCRIPTION
Backport 1/1 commits from #42575.

/cc @cockroachdb/release

---

When the support for Timestamp type was added to the vectorized engine,
one place was forgotten. Now this is fixed.

Release note (bug fix): Timestamp type is now fully supported by the
vectorized engine (previously, in some edge cases, an "unsupported type"
error would occur).
