### PR TITLE
sql: remove local ordinality

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -297,23 +297,24 @@ var setNotSupportedError = newQueryNotSupportedError("SET / SET CLUSTER SETTING 
 // TODO(jordan): refactor these to use the observer pattern to avoid duplication.
 func (dsp *DistSQLPlanner) mustWrapNode(planCtx *PlanningCtx, node planNode) bool {
 	switch n := node.(type) {
-	case *scanNode:
-	case *indexJoinNode:
-	case *lookupJoinNode:
-	case *zigzagJoinNode:
-	case *joinNode:
-	case *renderNode:
-	case *groupNode:
-	case *sortNode:
-	case *filterNode:
-	case *limitNode:
 	case *distinctNode:
+	case *filterNode:
+	case *groupNode:
+	case *indexJoinNode:
+	case *joinNode:
+	case *limitNode:
+	case *lookupJoinNode:
+	case *ordinalityNode:
+	case *projectSetNode:
+	case *renderNode:
+	case *scanNode:
+	case *sortNode:
+	case *unaryNode:
 	case *unionNode:
 	case *virtualTableNode:
-	case *projectSetNode:
-	case *unaryNode:
 	case *windowNode:
 	case *zeroNode:
+	case *zigzagJoinNode:
 	case *valuesNode:
 		// This is unfortunately duplicated by createPlanForNode, and must be kept
 		// in sync with its implementation.

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -47,21 +47,15 @@ type ordinalityRun struct {
 }
 
 func (o *ordinalityNode) startExec(runParams) error {
-	return nil
+	panic("ordinalityNode can't be run in local mode")
 }
 
 func (o *ordinalityNode) Next(params runParams) (bool, error) {
-	hasNext, err := o.source.Next(params)
-	if !hasNext || err != nil {
-		return hasNext, err
-	}
-	copy(o.run.row, o.source.Values())
-	// o.run.row was allocated one spot larger than o.source.Values().
-	// Store the ordinality value there.
-	o.run.row[len(o.run.row)-1] = tree.NewDInt(tree.DInt(o.run.curCnt))
-	o.run.curCnt++
-	return true, nil
+	panic("ordinalityNode can't be run in local mode")
 }
 
-func (o *ordinalityNode) Values() tree.Datums       { return o.run.row }
+func (o *ordinalityNode) Values() tree.Datums {
+	panic("ordinalityNode can't be run in local mode")
+}
+
 func (o *ordinalityNode) Close(ctx context.Context) { o.source.Close(ctx) }


### PR DESCRIPTION
Now that it's got a distributed version, we can delete the local
implementation.

Release note: None