### PR TITLE
cli: fix TestDebugCheckStore on Pebble

### DIFF
--- a/pkg/cli/debug_check_store_test.go
+++ b/pkg/cli/debug_check_store_test.go
@@ -79,14 +79,12 @@ func TestDebugCheckStore(t *testing.T) {
 
 	// Introduce a stats divergence on s1.
 	func() {
-		cache := engine.NewRocksDBCache(10 << 20 /* 10mb */)
-		defer cache.Release()
-		eng, err := engine.NewRocksDB(engine.RocksDBConfig{
-			StorageConfig: base.StorageConfig{
+		eng, err := engine.NewDefaultEngine(
+			10<<20, /* 10mb */
+			base.StorageConfig{
 				Dir:       storePaths[0],
 				MustExist: true,
-			},
-		}, cache)
+			})
 		require.NoError(t, err)
 		defer eng.Close()
 		sl := stateloader.Make(1)


### PR DESCRIPTION
Pebble and RocksDB have some sort of incompatibily causing
`TestDebugCheckStore` to never complete. Force this test to always use
either Pebble or RocksDB, and not use both. Investigating and fixing the
compatibility issues between Pebble and RocksDB is being left to the
next milestone.

Release note: None