### PR TITLE
storage/engine: fix pebbleExportToSst behavior on empty sstables

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -1017,5 +1017,11 @@ func pebbleExportToSst(
 		return nil, roachpb.BulkOpSummary{}, err
 	}
 
+	if rows.BulkOpSummary.DataSize == 0 {
+		// If no records were added to the sstable, return an empty sstable. This
+		// is used by export code to avoid ingestion of empty sstables.
+		return nil, roachpb.BulkOpSummary{}, nil
+	}
+
 	return sstFile.Data(), rows.BulkOpSummary, nil
 }


### PR DESCRIPTION
Fix `pebbleExportToSst` to return a `nil` sstable if the no records were
added. The previous behavior was a minor behavioral difference from the
C++ version of `ExportToSst` which caused
`TestRandomKeyAndTimestampExport` to be flaky when run on Pebble.

Release note: None