### PR TITLE
lint: properly parallelize TestVet/TestVet

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1221,7 +1221,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestVet", func(t *testing.T) {
-		t.Parallel()
 		runVet := func(t *testing.T, args ...string) {
 			args = append(append([]string{"vet"}, args...), pkgScope)
 			vetCmd(t, crdb.Dir, "go", args, []stream.Filter{
@@ -1289,7 +1288,7 @@ func TestLint(t *testing.T) {
 		//    A function may be a Printf or Print wrapper if its last argument is ...interface{}.
 		//    If the next-to-last argument is a string, then this may be a Printf wrapper.
 		//    Otherwise it may be a Print wrapper.
-		runVet(t, "-all", "-printfuncs", printfuncs)
+		t.Run("vet", func(t *testing.T) { runVet(t, "-all", "-printfuncs", printfuncs) })
 	})
 
 	// TODO(tamird): replace this with errcheck.NewChecker() when


### PR DESCRIPTION
The `shadow` and `printfuncs` testvet invocations were asymmetrically parallelized because of an oddity in how `t.Parallel()` works.

This patch fixes it.

(CI goes down from 18m48s down to 18m23s)

Release note: None