### PR TITLE
backupccl: stop including OFFLINE tables in backup

### DIFF
--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -32,6 +32,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		*sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{ID: 1, Name: "foo", ParentID: 0}),
 		*sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{ID: 2, Name: "bar", ParentID: 0}),
 		*sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{ID: 4, Name: "baz", ParentID: 3}),
+		*sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{ID: 6, Name: "offline", ParentID: 0, State: sqlbase.TableDescriptor_OFFLINE}),
 		*sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{ID: 3, Name: "data"}),
 		*sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{ID: 5, Name: "empty"}),
 	}
@@ -102,6 +103,10 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		{"", `TABLE system."foo"`, []string{"system", "foo"}, nil, ``},
 		{"", `TABLE system.public."foo"`, []string{"system", "foo"}, nil, ``},
 		{"system", `TABLE "foo"`, []string{"system", "foo"}, nil, ``},
+
+		{"system", `TABLE offline`, nil, nil, `table "offline" does not exist`},
+		{"", `TABLE system.offline`, []string{"system", "foo"}, nil, `table "system.public.offline" does not exist`},
+		{"system", `TABLE *`, []string{"system", "foo", "bar"}, nil, ``},
 	}
 	searchPath := sessiondata.MakeSearchPath([]string{"public", "pg_catalog"})
 	for i, test := range tests {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -192,7 +192,7 @@ func (s LeaseStore) acquire(
 		if err != nil {
 			return err
 		}
-		if err := filterTableState(tableDesc); err != nil {
+		if err := FilterTableState(tableDesc); err != nil {
 			return err
 		}
 		if err := tableDesc.MaybeFillInDescriptor(ctx, txn); err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -55,7 +55,9 @@ type inactiveTableError struct {
 	error
 }
 
-func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
+// FilterTableState inspects the state of a given table and returns an error if
+// the state is anything but PUBLIC. The error describes the state of the table.
+func FilterTableState(tableDesc *sqlbase.TableDescriptor) error {
 	switch tableDesc.State {
 	case sqlbase.TableDescriptor_DROP:
 		return inactiveTableError{errors.New("table is being dropped")}
@@ -326,7 +328,7 @@ func (tc *TableCollection) getTableVersionByID(
 		if err != nil {
 			return nil, err
 		}
-		if err := filterTableState(table); err != nil {
+		if err := FilterTableState(table); err != nil {
 			return nil, err
 		}
 		return sqlbase.NewImmutableTableDescriptor(*table), nil
@@ -593,7 +595,7 @@ func (tc *TableCollection) getUncommittedTable(
 		if mutTbl.Name == string(tn.TableName) &&
 			mutTbl.ParentID == dbID {
 			// Right state?
-			if err = filterTableState(mutTbl.TableDesc()); err != nil && err != errTableAdding {
+			if err = FilterTableState(mutTbl.TableDesc()); err != nil && err != errTableAdding {
 				if !required {
 					// If it's not required here, we simply say we don't have it.
 					err = nil


### PR DESCRIPTION
In 19.2, the OFFLINE table descriptor state was added. This state
indicates that the table is generally not visible to users as it is
being populated by the database (via an in-progress RESTORE or IMPORT).
However, these tables are currently included in backups.

When performing a BACKUP while a RESTORE or IMPORT is being executed,
there will be tables that exist in an OFFLINE state. These should not be
included in a BACKUP as when they are restored they will appear to be in
an intermediary and potentially inconsistent state.

Consider an OFFLINE table `bank.pause`. This table could be included in
a backup either via directly naming the table: `BACKUP bank.pause TO
...` or via table expansion: `BACKUP bank.* TO ...`. In the first case,
an error should be returned as the table should not be directly visible
to the user. In the later case, OFFLINE tables should be silently
ignored since the OFFLINE table was not explicitly requested by the
user. The remaining PUBLIC tables in the database should be expanded.

Note: this commit also changes the name resolution logic for
changefeeds in the same way that it applies to backup.

To address this, the BACKUP and RESTORE name resolution logic was
modified to support filtering OFFLINE tables.

Release note (bug fix): Stop including tables that are being restored or
imported as valid targets in backups and changefeeds.