### PR TITLE
cli: fix Pebble {MustExist,ReadOnly} handling in OpenExistingStore

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -146,6 +146,7 @@ func OpenEngine(dir string, stopper *stop.Stopper, opts OpenEngineOptions) (engi
 		}
 		cfg.Opts.Cache = pebble.NewCache(server.DefaultCacheSize)
 		cfg.Opts.MaxOpenFiles = int(maxOpenFiles)
+		cfg.Opts.ReadOnly = opts.ReadOnly
 
 		db, err = engine.NewPebble(context.Background(), cfg)
 

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -81,7 +81,7 @@ func TestOpenExistingStore(t *testing.T) {
 		},
 		{
 			dir:    dirMissing,
-			expErr: `could not open rocksdb instance: .* does not exist \(create_if_missing is false\)`,
+			expErr: `does not exist|no such file or directory`,
 		},
 	} {
 		t.Run(fmt.Sprintf("dir=%s", test.dir), func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestOpenReadOnlyStore(t *testing.T) {
 		},
 		{
 			readOnly: true,
-			expErr:   `Not supported operation in read only mode.`,
+			expErr:   `Not supported operation in read only mode|pebble: read-only`,
 		},
 	} {
 		t.Run(fmt.Sprintf("readOnly=%t", test.readOnly), func(t *testing.T) {

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -526,7 +526,6 @@ func NewEngine(
 			Opts:          DefaultPebbleOptions(),
 		}
 		pebbleConfig.Opts.Cache = pebble.NewCache(cacheSize)
-		pebbleConfig.Opts.ErrorIfNotExists = storageConfig.MustExist
 
 		return NewPebble(context.Background(), pebbleConfig)
 	case enginepb.EngineTypeRocksDB:

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -264,6 +264,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 	// EnsureDefaults beforehand so we have a matching cfg here for when we save
 	// cfg.FS and cfg.ReadOnly later on.
 	cfg.Opts.EnsureDefaults()
+	cfg.Opts.ErrorIfNotExists = cfg.MustExist
 
 	var auxDir string
 	if cfg.Dir == "" {


### PR DESCRIPTION
Fix the handling of of `OpenEngineOptions.{MustExist,ReadOnly}` for
Pebble. Fixes `TestOpenExistingStore` and `TestOpenReadOnlyStore` on
Pebble.

Release note: None