### PR TITLE
release-19.1: sql: fix dist planning of window fns with mutations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -316,6 +316,7 @@ func (dsp *DistSQLPlanner) mustWrapNode(node planNode) bool {
 	case *virtualTableNode:
 	case *projectSetNode:
 	case *unaryNode:
+	case *windowNode:
 	case *zeroNode:
 	default:
 		return true

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -69,3 +69,10 @@ ORDER BY
 ----
 1d6eaf81-8a2c-43c5-a495-a3b102917ab1  3697877132
 d2d225e2-e9be-4420-a645-d1b8f577511c  3697877132
+
+# Regression: #36830 (can't run wrapped window node)
+statement ok
+CREATE TABLE table9 (a INT8);
+
+statement ok
+INSERT INTO table9 SELECT lag(a) OVER (PARTITION BY a) FROM table9;


### PR DESCRIPTION
Backport 1/1 commits from #37171.

/cc @cockroachdb/release

---

Fixes #36830.
Fixes #42556.

Release note (bug fix): permit planning of window functions within
mutation statements (and others that can't be distributed).
