### PR TITLE
builtins: make extract work with TimeTZ

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -366,6 +366,10 @@ hour, minute, second, millisecond, microsecond, epoch</p>
 quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
+<tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: timetz) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
+<p>Compatible elements: hour, minute, second, millisecond, microsecond, epoch,
+timezone, timezone_hour, timezone_minute</p>
+</span></td></tr>
 <tr><td><a name="extract_duration"></a><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.
 Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/timetz
+++ b/pkg/sql/logictest/testdata/logic_test/timetz
@@ -19,6 +19,24 @@ SELECT '24:00:00-1559'::timetz > '23:59:59-1559'::timetz;
 ----
 true
 
+query T
+select
+  extract('hour' from '11:12+03:01'::timetz)::string || ':' ||
+  extract('minute' from '11:12+03:01'::timetz)::string || 'Z' ||
+  extract('timezone_hour' from '11:12+03:01'::timetz)::string || ':' ||
+  extract('timezone_minute' from '11:12+03:01'::timetz)::string
+----
+11:12Z3:1
+
+query T
+select
+  extract('hour' from '11:12-03:01'::timetz)::string || ':' ||
+  extract('minute' from '11:12-03:01'::timetz)::string || 'Z' ||
+  extract('timezone_hour' from '11:12-03:01'::timetz)::string || ':' ||
+  extract('timezone_minute' from '11:12-03:01'::timetz)::string
+----
+11:12Z-3:-1
+
 query TTI
 SELECT a::string, b::string, c FROM timetz_test ORDER BY a, c ASC
 ----


### PR DESCRIPTION
Refs: #26097

Add extract for TimeTZ, which has a slight extension to that of Time and
a gotcha in epoch.

No release note as this will be combined in a later PR.

Release note: none