### PR TITLE
blobs: Fix backup to remote node

### DIFF
--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -61,6 +61,11 @@ func newRemoteClient(blobClient blobspb.BlobClient) BlobClient {
 }
 
 func (c *remoteClient) ReadFile(ctx context.Context, file string) (io.ReadCloser, error) {
+	// Check that file exists before reading from it
+	_, err := c.Stat(ctx, file)
+	if err != nil {
+		return nil, err
+	}
 	stream, err := c.blobClient.GetStream(ctx, &blobspb.GetRequest{
 		Filename: file,
 	})

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -180,15 +180,15 @@ func TestBlobClientReadFile(t *testing.T) {
 			}
 			reader, err := blobClient.ReadFile(ctx, tc.filename)
 			if err != nil {
+				if testutils.IsError(err, tc.err) {
+					// correct error was returned
+					return
+				}
 				t.Fatal(err)
 			}
 			// Check that fetched file content is correct
 			content, err := ioutil.ReadAll(reader)
 			if err != nil {
-				if testutils.IsError(err, tc.err) {
-					// correct error was returned
-					return
-				}
 				t.Fatal(err)
 			}
 			if !bytes.Equal(content, tc.fileContent) {


### PR DESCRIPTION
After the blob service was introduced, backup to nodelocal
now works. eg `BACKUP db TO `nodelocal:///foo` would now
create a restorable backup. However, `nodelocal://2/foo`
would error out.

We check that a BACKUP file descriptor does not already exist
in the directory we backup to using ReadFile. But with our
streaming implementation, ReadFile will not return errors
until we actually attempt to read from the returned reader.

This PR fixes that by checking the stat of a file before reading
from it. It also adds testing for remote node backup and restore.

Release note: None