### PR TITLE
sql: multiple foreign key cascades bug fixes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -3707,13 +3707,11 @@ DROP TABLE c, b, a;
 # modifies the original table (#42117).
 subtest SelfReferencingCheckFail
 
-# TODO(radu): remove the FAMILY when #42120 is fixed.
 statement ok
 CREATE TABLE self_ab (
   a INT UNIQUE,
   b INT DEFAULT 1 CHECK (b != 1),
-  INDEX (b),
-  FAMILY (a, b)
+  INDEX (b)
 )
 
 statement ok
@@ -3739,3 +3737,43 @@ ALTER TABLE self_ab ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES self_ab_parent
 
 statement error failed to satisfy CHECK constraint \(b != 1\)
 UPDATE self_ab_parent SET p = 3 WHERE p = 2
+
+# Clean up.
+statement ok
+DROP TABLE self_ab, self_ab_parent
+
+# Extra test for self referencing foreign keys with set default.
+subtest SelfReferencingSetDefault
+
+statement ok
+CREATE TABLE self_abcd (
+  a INT DEFAULT 2,
+  b INT DEFAULT 2,
+  c INT DEFAULT 2,
+  d INT DEFAULT 2,
+  INDEX (c),
+  INDEX (d),
+  PRIMARY KEY (a), FAMILY (a, b, c, d)
+)
+
+statement ok
+INSERT INTO self_abcd VALUES (1, 2, 3, 4), (4, 1, 2, 3), (3, 4, 1, 2), (2, 3, 4, 1)
+
+statement ok
+ALTER TABLE self_abcd ADD CONSTRAINT fk1 FOREIGN KEY (c) REFERENCES self_abcd(a) ON UPDATE SET DEFAULT;
+ALTER TABLE self_abcd ADD CONSTRAINT fk2 FOREIGN KEY (d) REFERENCES self_abcd(a) ON UPDATE SET DEFAULT
+
+statement ok
+UPDATE self_abcd SET a = 5 WHERE a = 1
+
+query IIII
+SELECT * FROM self_abcd ORDER BY (a, b, c, d)
+----
+2  3  4  2
+3  4  2  2
+4  1  2  3
+5  2  3  4
+
+# Clean up.
+statement ok
+DROP TABLE self_abcd

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -184,7 +184,6 @@ func makeUpdaterWithoutCascader(
 		UpdateColIDtoRowIndex: updateColIDtoRowIndex,
 		primaryKeyColChange:   primaryKeyColChange,
 		marshaled:             make([]roachpb.Value, len(updateCols)),
-		newValues:             make([]tree.Datum, len(tableCols)),
 	}
 
 	if primaryKeyColChange {
@@ -265,6 +264,11 @@ func makeUpdaterWithoutCascader(
 		}
 	}
 
+	// If we are fetching from specific families, we might get
+	// less columns than in the table. So we cannot assign this to
+	// have length len(tableCols).
+	ru.newValues = make(tree.Datums, len(ru.FetchCols))
+
 	if checkFKs == CheckFKs {
 		var err error
 		if primaryKeyColChange {
@@ -287,13 +291,12 @@ func makeUpdaterWithoutCascader(
 // The return value is only good until the next call to UpdateRow.
 func (ru *Updater) UpdateRow(
 	ctx context.Context,
-	b *client.Batch,
+	batch *client.Batch,
 	oldValues []tree.Datum,
 	updateValues []tree.Datum,
 	checkFKs checkFKConstraints,
 	traceKV bool,
 ) ([]tree.Datum, error) {
-	batch := b
 	if ru.cascader != nil {
 		batch = ru.cascader.txn.NewBatch()
 	}
@@ -405,7 +408,7 @@ func (ru *Updater) UpdateRow(
 	}
 
 	// Add the new values.
-	ru.valueBuf, err = prepareInsertOrUpdateBatch(ctx, b,
+	ru.valueBuf, err = prepareInsertOrUpdateBatch(ctx, batch,
 		&ru.Helper, primaryIndexKey, ru.FetchCols,
 		ru.newValues, ru.FetchColIDtoRowIndex,
 		ru.marshaled, ru.UpdateColIDtoRowIndex,
@@ -480,7 +483,7 @@ func (ru *Updater) UpdateRow(
 	putFn := insertInvertedPutFn
 	// We're adding all of the inverted index entries from the row being updated.
 	for i := len(ru.Helper.Indexes); i < len(newSecondaryIndexEntries); i++ {
-		putFn(ctx, b, &newSecondaryIndexEntries[i].Key, &newSecondaryIndexEntries[i].Value, traceKV)
+		putFn(ctx, batch, &newSecondaryIndexEntries[i].Key, &newSecondaryIndexEntries[i].Value, traceKV)
 	}
 
 	if ru.cascader != nil {


### PR DESCRIPTION
This PR fixes multiple existing foreign key cascade bugs.

* Fixes a panic on performing cascade updates on tables with
 multiple column families.
* Fixes a bug where a self referential foreign key constraint with set default
 would not be maintained on a cascading update.
* Fixes a bug where multiple self referential foreign key constraints
 would cause all the rows in the referenced constraint columns
 to be set to null or default on a cascading update.

The panic was caused by the updater having a mismatch of
fetched columns when only certain column families were
fetched by the get requset.

The first cascade bug was caused by usage of an invalid batch, causing updates
made by the updater to not be visible to reads made by the cascader.

The final bug was a logic error that was caused by rows being
enqueued in the cascader to be updatedeven when there wasn't a change
*on the foreign key column that it was being checked for*.
This caused rows to be updated when constrained values
weren't even changed, leading to cascades that could change large numbers
of unintended rows in the table.

Fixes #42120.

Release note (bug fix): This PR fixes multiple existing bugs:
* Fixes a panic on performing cascade updates on tables with
 multiple column families.
* Fixes a bug where a self referential foreign key constraint with set default
 would not be maintained on a cascading update.
* Fixes a bug where multiple self referential foreign key constraints
 would cause all the rows in the referenced constraint columns
 to be set to null or default on a cascading update.