### PR TITLE
roachtest: increase retry limit for fetching metrics in overload

### DIFF
--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -79,9 +79,11 @@ func verifyNodeLiveness(ctx context.Context, c *cluster, t *test, runDuration ti
 	// Retry because timeseries queries can fail if the underlying inter-node
 	// connections are in a failed state which can happen due to overload.
 	// Now that the load has stopped, this should resolve itself soon.
+	// Even with 60 retries we'll at most spend 30s attempting to fetch
+	// the metrics.
 	if err := retry.WithMaxAttempts(ctx, retry.Options{
 		MaxBackoff: 500 * time.Millisecond,
-	}, 3, func() (err error) {
+	}, 60, func() (err error) {
 		response, err = getMetrics(adminURLs[0], now.Add(-runDuration), now, []tsQuery{
 			{
 				name:      "cr.node.liveness.heartbeatfailures",


### PR DESCRIPTION
We've been seeing this test fail to fetch the metrics:

```
overload_tpcc_olap.go:93,overload_tpcc_olap.go:69,test_runner.go:697: failed to fetch liveness metrics: Post http://104.198.172.25:26258/ts/query: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

These nodes are probably still churning on the TPC-C queries.
This commit massively increases the number of retries.

Informs #40774.

Release note: None.