### PR TITLE
builtins: fix extract from timestamptz to be ctx time zone aware

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -364,7 +364,8 @@ hour, minute, second, millisecond, microsecond, epoch</p>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
 <p>Compatible elements: millennium, century, decade, year, isoyear,
 quarter, month, week, dayofweek, isodow, dayofyear, julian,
-hour, minute, second, millisecond, microsecond, epoch</p>
+hour, minute, second, millisecond, microsecond, epoch,
+timezone, timezone_hour, timezone_minute</p>
 </span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: timetz) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
 <p>Compatible elements: hour, minute, second, millisecond, microsecond, epoch,

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -623,12 +623,12 @@ SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamptz)
 query R
 SELECT extract(hour from '2016-02-10 19:46:33.306157519-04'::timestamptz)
 ----
-19
+23
 
 query R
 SELECT extract(hours from '2016-02-10 19:46:33.306157519-04'::timestamptz)
 ----
-19
+23
 
 query ITTBT
 SELECT k, element, input, date_trunc(element, input::timestamp) = date_trunc_result, date_trunc(element, input::timestamp)::string

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -149,3 +149,41 @@ select column_name, data_type FROM [SHOW COLUMNS FROM timestamp_test] ORDER BY c
 id   INT8
 t    TIMESTAMP
 ttz  TIMESTAMPTZ(5)
+
+subtest regression_django-cockroachdb_47
+
+statement ok
+SET TIME ZONE -3
+
+query R
+SELECT extract(hour FROM '2001-01-01 13:00:00+01'::timestamptz)
+----
+9
+
+query R
+SELECT extract(hour FROM '2001-01-01 13:00:00'::timestamp)
+----
+13
+
+query R
+SELECT extract(timezone FROM '2001-01-01 13:00:00+01:15'::timestamptz)
+----
+-10800
+
+statement ok
+SET TIME ZONE +3
+
+query R
+SELECT extract(hour FROM '2001-01-01 13:00:00+01'::timestamptz)
+----
+15
+
+query R
+SELECT extract(hour FROM '2001-01-01 13:00:00'::timestamp)
+----
+13
+
+query R
+SELECT extract(timezone FROM '2001-01-01 13:00:00+01:15'::timestamptz)
+----
+10800


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/django-cockroachdb/issues/47

When using extract on timestamptz, we should be aware of what time zone
we are currently in when performing the operations.

This PR further adds 'timezone', 'timezone_hour' and 'timezone_minute'
to the extract command for timestamptz.

Release note (sql change): Previously, when using `extract` on a
timestamptz it would always perform the operation as if it was in UTC.
In this PR, it will change it to match the environment's location in
which `extract` was executed in. Furthermore, `timezone`,
`timezone_hour` and `timezone_minute` are added to the `extract`
command.