### PR TITLE
importccl: don't diasable nullif option when escape character is spec…

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -549,6 +549,16 @@ d
 			},
 		},
 		{
+			name:   "nullif empty string plus escape",
+			create: `a INT8, b INT8`,
+			with:   `WITH fields_terminated_by = ',', fields_escaped_by = '\', nullif = ''`,
+			typ:    "DELIMITED",
+			data:   ",4",
+			query: map[string][][]string{
+				`SELECT * from t`: {{"NULL", "4"}},
+			},
+		},
+		{
 			name:   "nullif single char string",
 			create: `a string, b string`,
 			with:   `WITH fields_terminated_by = ',', nullif = 'f'`,

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -143,7 +143,7 @@ func (d *mysqloutfileReader) readFile(
 					"unexpected data after null encoding: %v", row)
 			}
 			row = append(row, tree.DNull)
-		} else if !d.opts.HasEscape && (field == "NULL" || d.opts.NullEncoding != nil && field == *d.opts.NullEncoding) {
+		} else if (!d.opts.HasEscape && field == "NULL") || d.opts.NullEncoding != nil && field == *d.opts.NullEncoding {
 			row = append(row, tree.DNull)
 		} else {
 			datum, err := tree.ParseStringAs(d.conv.VisibleColTypes[len(row)], field, d.conv.EvalCtx)


### PR DESCRIPTION
…ified

By default the string 'NULL' is parsed as null value in DELIMITED IMPORT mode.
It's usefull to treat 'NULL' as just a normal string and parse it verbatim;
this can be accomplished by providing option `WITH fields_escaped_by = '\'` and
using '\N' to specify null values and so in this case the parser upon seeing
the string 'NULL' will treat it as a normal string. However if the customer
provides their own null string via `WITH nullif = 'my_null'` it does not make
sense to disregard it if they use escaping as well for some other purposes,
for example escaping the field separator. A typical use case is when
the empty string should be treated as null.

Fixes: https://github.com/cockroachlabs/support/issues/345.

Release note (bug fix): when custom nullif is provided always treat it as null.