### PR TITLE
roachprod: switch to NVME interface for GCP local SSDs

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -379,7 +379,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 			p.opts.SSDCount = 2
 		}
 		for i := 0; i < p.opts.SSDCount; i++ {
-			args = append(args, "--local-ssd", "interface=SCSI")
+			args = append(args, "--local-ssd", "interface=NVME")
 		}
 		if opts.SSDOpts.NoExt4Barrier {
 			extraMountOpts = "nobarrier"

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -50,7 +50,7 @@ mount_opts="discard,defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
 disknum=0
-for d in $(ls /dev/disk/by-id/google-local-ssd-*); do
+for d in $(ls /dev/disk/by-id/google-local-*); do
   let "disknum++"
   grep -e "${d}" /etc/fstab > /dev/null
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
I believe this was avoided in the past because the OS image we were using didn't support NVME properly. This seems to be fixed now because the interface works fine.

Furthermore, tpccbench results are demonstrating about a **7%** improvement in the maximum number of warehouses supported on 3x n1-standard-16 VMs, from an average of **1608** warehouses to an average of **1723** warehouses across 10+ runs on each.