### PR TITLE
sqlbase: improve column family related comments in structured.go

### DIFF
--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -73,7 +73,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{0}
 }
 
 type ForeignKeyReference_Action int32
@@ -118,7 +118,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{0, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -158,7 +158,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{0, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -195,7 +195,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{6, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{6, 0}
 }
 
 // The type of the index.
@@ -232,7 +232,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{6, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{6, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -275,7 +275,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{7, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{7, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -340,7 +340,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{8, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{8, 0}
 }
 
 // Direction of mutation.
@@ -383,7 +383,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{8, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{8, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -434,7 +434,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -471,7 +471,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 1}
 }
 
 type ForeignKeyReference struct {
@@ -493,7 +493,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -561,7 +561,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -608,7 +608,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{2}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -634,9 +634,14 @@ func (m *ColumnDescriptor) XXX_DiscardUnknown() {
 var xxx_messageInfo_ColumnDescriptor proto.InternalMessageInfo
 
 // ColumnFamilyDescriptor is set of columns stored together in one kv entry.
+// For more information, look at `docs/tech-notes/encoding.md#value-encoding`.
 type ColumnFamilyDescriptor struct {
-	Name string   `protobuf:"bytes,1,opt,name=name" json:"name"`
-	ID   FamilyID `protobuf:"varint,2,opt,name=id,casttype=FamilyID" json:"id"`
+	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
+	// Column family 0 is *always* included in k/v pairs for a row. This makes
+	// sure that rows will all NULL values still have a k/v pair. When performing
+	// optimizations involving column families, ensure that column family 0
+	// is scanned if the row may have nulls.
+	ID FamilyID `protobuf:"varint,2,opt,name=id,casttype=FamilyID" json:"id"`
 	// A list of column names of which the family is comprised. This list
 	// parallels the column_ids list. If duplicating the storage of the column
 	// names here proves to be prohibitive, we could clear this field before
@@ -659,7 +664,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{3}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -705,7 +710,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{4}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -749,7 +754,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{4, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -794,7 +799,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{5}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{5}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -837,7 +842,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{5, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{5, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -882,7 +887,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{5, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{5, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1018,7 +1023,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{6}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{6}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1069,7 +1074,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{7}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{7}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1123,7 +1128,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{8}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{8}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1329,8 +1334,10 @@ type TableDescriptor struct {
 	ModificationTime hlc.Timestamp      `protobuf:"bytes,7,opt,name=modification_time,json=modificationTime" json:"modification_time"`
 	Columns          []ColumnDescriptor `protobuf:"bytes,8,rep,name=columns" json:"columns"`
 	// next_column_id is used to ensure that deleted column ids are not reused.
-	NextColumnID ColumnID                 `protobuf:"varint,9,opt,name=next_column_id,json=nextColumnId,casttype=ColumnID" json:"next_column_id"`
-	Families     []ColumnFamilyDescriptor `protobuf:"bytes,22,rep,name=families" json:"families"`
+	NextColumnID ColumnID `protobuf:"varint,9,opt,name=next_column_id,json=nextColumnId,casttype=ColumnID" json:"next_column_id"`
+	// families holds information about the column families of this table.
+	// This list has at least length 1, in which case all columns are stored in the same family.
+	Families []ColumnFamilyDescriptor `protobuf:"bytes,22,rep,name=families" json:"families"`
 	// next_family_id is used to ensure that deleted family ids are not reused.
 	NextFamilyID FamilyID        `protobuf:"varint,23,opt,name=next_family_id,json=nextFamilyId,casttype=FamilyID" json:"next_family_id"`
 	PrimaryIndex IndexDescriptor `protobuf:"bytes,10,opt,name=primary_index,json=primaryIndex" json:"primary_index"`
@@ -1433,7 +1440,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1725,7 +1732,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1763,7 +1770,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 1}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1866,7 +1873,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 2}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1906,7 +1913,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 3}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1943,7 +1950,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 4}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1986,7 +1993,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 5}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2026,7 +2033,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 5, 0}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 5, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2060,7 +2067,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 6}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2097,7 +2104,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{9, 7}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{9, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2136,7 +2143,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{10}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{10}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2194,7 +2201,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_2003f5b4c33dce61, []int{11}
+	return fileDescriptor_structured_50daf820b4f615f7, []int{11}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -11149,10 +11156,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_2003f5b4c33dce61)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_50daf820b4f615f7)
 }
 
-var fileDescriptor_structured_2003f5b4c33dce61 = []byte{
+var fileDescriptor_structured_50daf820b4f615f7 = []byte{
 	// 3473 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5a, 0xcb, 0x6f, 0x23, 0x47,
 	0x7a, 0x57, 0xf3, 0xcd, 0x8f, 0xaf, 0x66, 0x69, 0x66, 0x4c, 0xcb, 0x5e, 0x91, 0xa2, 0x3d, 0xb6,

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -134,9 +134,14 @@ message ColumnDescriptor {
 }
 
 // ColumnFamilyDescriptor is set of columns stored together in one kv entry.
+// For more information, look at `docs/tech-notes/encoding.md#value-encoding`.
 message ColumnFamilyDescriptor {
   option (gogoproto.equal) = true;
   optional string name = 1 [(gogoproto.nullable) = false];
+  // Column family 0 is *always* included in k/v pairs for a row. This makes
+  // sure that rows will all NULL values still have a k/v pair. When performing
+  // optimizations involving column families, ensure that column family 0
+  // is scanned if the row may have nulls.
   optional uint32 id = 2 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ID", (gogoproto.casttype) = "FamilyID"];
 
@@ -540,6 +545,8 @@ message TableDescriptor {
   // next_column_id is used to ensure that deleted column ids are not reused.
   optional uint32 next_column_id = 9 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextColumnID", (gogoproto.casttype) = "ColumnID"];
+  // families holds information about the column families of this table.
+  // This list has at least length 1, in which case all columns are stored in the same family.
   repeated ColumnFamilyDescriptor families = 22 [(gogoproto.nullable) = false];
   // next_family_id is used to ensure that deleted family ids are not reused.
   optional uint32 next_family_id = 23 [(gogoproto.nullable) = false,


### PR DESCRIPTION
Some gotcha's relating to column families were not documented well
in structured.go, where the column family structures are defined.
This PR adds the documentation and links to related content.

Fixes #42569.

Release note: None