### PR TITLE
storage/engine: improve MVCCComparer's Separator and Successor functions

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -100,6 +100,7 @@ enable_testing()
 set(tests
   chunked_buffer_test.cc
   db_test.cc
+  comparator_test.cc
   encoding_test.cc
   file_registry_test.cc
   merge_test.cc

--- a/c-deps/libroach/comparator.cc
+++ b/c-deps/libroach/comparator.cc
@@ -39,9 +39,82 @@ int DBComparator::Compare(const rocksdb::Slice& a, const rocksdb::Slice& b) cons
 
 bool DBComparator::Equal(const rocksdb::Slice& a, const rocksdb::Slice& b) const { return a == b; }
 
-// The RocksDB docs say it is safe to leave these two methods unimplemented.
-void DBComparator::FindShortestSeparator(std::string* start, const rocksdb::Slice& limit) const {}
+namespace {
 
-void DBComparator::FindShortSuccessor(std::string* key) const {}
+void ShrinkSlice(rocksdb::Slice* a, size_t size) {
+  a->remove_suffix(a->size() - size);
+}
+
+int SharedPrefixLen(const rocksdb::Slice& a, const rocksdb::Slice& b) {
+  auto n = std::min(a.size(), b.size());
+  int i = 0;
+  for (; i < n && a[i] == b[i]; ++i) {}
+  return i;
+}
+
+bool FindSeparator(rocksdb::Slice* a, std::string* a_backing, const rocksdb::Slice& b) {
+  auto prefix = SharedPrefixLen(*a, b);
+  auto n = std::min(a->size(), b.size());
+  if (prefix >= n) {
+    // The > case is not actually possible.
+    assert(prefix == n);
+    // One slice is a prefix of another.
+    return false;
+  }
+  // prefix < n. So can look at the characters at prefix, where they differed.
+  if (static_cast<unsigned char>((*a)[prefix]) >= static_cast<unsigned char>(b[prefix])) {
+    // == is not possible since they differed.
+    assert((*a)[prefix] != b[prefix]);
+    // So b is smaller than a.
+    return false;
+  }
+  if ((prefix < b.size() - 1) || static_cast<unsigned char>((*a)[prefix]) + 1 < static_cast<unsigned char>(b[prefix])) {
+    // a and b do not have consecutive characters at prefix.
+    (*a_backing)[prefix]++;
+    ShrinkSlice(a, prefix + 1);
+    return true;
+  }
+  // They two slices have consecutive characters at prefix, so we leave the
+  // character at prefix unchanged for a. Now we are free to increment any
+  // subsequent character in a, to make the new a bigger than the old a.
+  ++prefix;
+  for (int i = prefix; i < a->size() - 1; ++i) {
+    if (static_cast<unsigned char>((*a)[i]) != 0xff) {
+      (*a_backing)[i]++;
+      ShrinkSlice(a, i + 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+void DBComparator::FindShortestSeparator(std::string* start, const rocksdb::Slice& limit) const {
+  rocksdb::Slice key_s, key_l;
+  rocksdb::Slice ts_s, ts_l;
+  if (!SplitKey(*start, &key_s, &ts_s) || !SplitKey(limit, &key_l, &ts_l)) {
+    return;
+  }
+  auto found = FindSeparator(&key_s, start, key_l);
+  if (!found) return;
+  start->resize(key_s.size() + 1);
+  (*start)[key_s.size()] = 0x00;
+}
+
+void DBComparator::FindShortSuccessor(std::string* key) const {
+  rocksdb::Slice k, ts;
+  if (!SplitKey(*key, &k, &ts)) {
+    return;
+  }
+  for (int i = 0; i < k.size(); ++i) {
+    if (static_cast<unsigned char>(k[i]) != 0xff) {
+      (*key)[i]++;
+      key->resize(i + 2);
+      (*key)[i + 1] = 0;
+      return;
+    }
+  }
+}
 
 }  // namespace cockroach

--- a/c-deps/libroach/comparator_test.cc
+++ b/c-deps/libroach/comparator_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <cinttypes>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+#include "comparator.h"
+#include "encoding.h"
+#include "libroach.h"
+
+using namespace cockroach;
+
+namespace {
+
+struct SeparatorTestCase {
+  DBKey a;
+  DBKey b;
+  DBKey expected;
+};
+
+struct SuccessorTestCase {
+  DBKey a;
+  DBKey expected;
+};
+
+DBKey makeKey(const char* s, int64_t wall_time = 0, int32_t logical = 0) {
+  return {DBSlice{const_cast<char*>(s), strlen(s)}, wall_time, logical};
+}
+
+}  // namespace
+
+TEST(Libroach, Comparator) {
+  DBComparator comp;
+  std::vector<SeparatorTestCase> sepCases = {
+    // Many cases here are adapted from a Pebble unit test.
+
+    // Non-empty b values.
+    {makeKey("black"), makeKey("blue"), makeKey("blb")},
+    {makeKey(""), makeKey("2"), makeKey("")},
+    {makeKey("1"), makeKey("2"), makeKey("1")},
+    {makeKey("1"), makeKey("29"), makeKey("2")},
+    {makeKey("13"), makeKey("19"), makeKey("14")},
+    {makeKey("13"), makeKey("99"), makeKey("2")},
+    {makeKey("135"), makeKey("19"), makeKey("14")},
+    {makeKey("1357"), makeKey("19"), makeKey("14")},
+    {makeKey("1357"), makeKey("2"), makeKey("14")},
+    {makeKey("13\xff"), makeKey("14"), makeKey("13\xff")},
+    {makeKey("13\xff"), makeKey("19"), makeKey("14")},
+    {makeKey("1\xff\xff"), makeKey("19"), makeKey("1\xff\xff")},
+    {makeKey("1\xff\xff"), makeKey("2"), makeKey("1\xff\xff")},
+    {makeKey("1\xff\xff"), makeKey("9"), makeKey("2")},
+    {makeKey("1\xfd\xff"), makeKey("1\xff"), makeKey("1\xfe")},
+    {makeKey("1\xff\xff", 20, 3), makeKey("9"), makeKey("2")},
+    {makeKey("1\xff\xff", 20, 3), makeKey("19"), makeKey("1\xff\xff", 20, 3)},
+
+    // Empty b values
+    {makeKey(""), makeKey(""), makeKey("")},
+    {makeKey("green"), makeKey(""), makeKey("green")},
+    {makeKey("1"), makeKey(""), makeKey("1")},
+    {makeKey("11\xff"), makeKey(""), makeKey("11\xff")},
+    {makeKey("1\xff"), makeKey(""), makeKey("1\xff")},
+    {makeKey("1\xff\xff"), makeKey(""), makeKey("1\xff\xff")},
+    {makeKey("\xff"), makeKey(""), makeKey("\xff")},
+    {makeKey("\xff\xff"), makeKey(""), makeKey("\xff\xff")},
+  };
+  
+  for (const auto& c: sepCases) {
+    auto a_str = EncodeKey(c.a);
+    auto b_str = EncodeKey(c.b);
+    std::printf("a_str: %s, b_str: %s\n", a_str.c_str(), b_str.c_str());
+    comp.FindShortestSeparator(&a_str, b_str);
+    EXPECT_EQ(EncodeKey(c.expected), a_str);
+  }
+
+  std::vector<SuccessorTestCase> succCases = {
+    {makeKey("black"), makeKey("c")},
+    {makeKey("green"), makeKey("h")},
+    {makeKey(""), makeKey("")},
+    {makeKey("13"), makeKey("2")},
+    {makeKey("135"), makeKey("2")},
+    {makeKey("13\xff"), makeKey("2")},
+    {makeKey("1\xff\xff", 20, 3), makeKey("2")},
+    {makeKey("\xff"), makeKey("\xff")},
+    {makeKey("\xff\xff"), makeKey("\xff\xff")},
+    {makeKey("\xff\xff\xff"), makeKey("\xff\xff\xff")},
+    {makeKey("\xfe\xff\xff"), makeKey("\xff")},
+    {makeKey("\xff\xff", 20, 3), makeKey("\xff\xff", 20, 3)},
+  };
+
+  for (const auto& c: succCases) {
+    auto a_str = EncodeKey(c.a);
+    std::printf("a_str: %s\n", a_str.c_str());
+    comp.FindShortSuccessor(&a_str);
+    EXPECT_EQ(EncodeKey(c.expected), a_str);
+  }
+}

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -937,6 +937,10 @@ DBSstFileWriter* DBSstFileWriterNew() {
   table_options.format_version = 0;
   table_options.checksum = rocksdb::kCRC32c;
   table_options.whole_key_filtering = false;
+  // This makes the sstables produced by Pebble and RocksDB byte-by-byte identical, which is
+  // useful for testing.
+  table_options.index_shortening =
+    rocksdb::BlockBasedTableOptions::IndexShorteningMode::kShortenSeparatorsAndSuccessor;
 
   rocksdb::Options* options = new rocksdb::Options();
   options->comparator = &kComparator;


### PR DESCRIPTION
to make smaller sstable indices.

Release note: None