### PR TITLE
[DNM] colserde: add disk spilling prototype

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -73,7 +73,7 @@ func copyBatch(original coldata.Batch) coldata.Batch {
 	return b
 }
 
-func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
+func assertEqualBatches(t testing.TB, expected, actual coldata.Batch) {
 	t.Helper()
 
 	if actual.Selection() != nil {

--- a/pkg/col/colserde/diskqueue.go
+++ b/pkg/col/colserde/diskqueue.go
@@ -1,0 +1,416 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+
+package colserde
+
+import (
+	"bytes"
+	"io"
+	"path"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/golang/snappy"
+)
+
+type PebbleQueueCfg struct {
+	BaseQueueCfg
+	// SkipRecreateIter skips recreating an iterator every time a dequeue is performed. This should be set to true if
+	// all writes will happen before all reads. If not, a read could miss a write? Is this true?
+	// TODO(asubiotto): Confirm.
+	SkipRecreateIter  bool
+	MaxValueSizeBytes int
+}
+
+type file struct {
+	name            string
+	offsets         []int
+	curOffsetIdx    int
+	totalSize       int
+	finishedWriting bool
+}
+
+// diskQueueWriter is an object that encapsulates the writing logic of a
+// DiskQueue. As bytes are written to it, they are buffered until
+// compressAndFlush is called, which compresses all bytes and writes them to the
+// wrapped io.Writer.
+type diskQueueWriter struct {
+	buffer  bytes.Buffer
+	wrapped io.Writer
+	scratch struct {
+		blockType     [1]byte
+		compressedBuf []byte
+	}
+}
+
+const (
+	snappyUncompressedBlock byte = 0
+	snappyCompressedBlock   byte = 1
+)
+
+func (w *diskQueueWriter) Write(p []byte) (int, error) {
+	return w.buffer.Write(p)
+}
+
+// reset resets the diskQueueWriter's wrapped writer and discards any buffered
+// bytes.
+func (w *diskQueueWriter) reset(wrapped io.Writer) {
+	w.wrapped = wrapped
+	w.buffer.Reset()
+}
+
+/*
+TODO still:
+remove file when done reading.
+implement file naming scheme?
+*/
+
+// compressAndFlush compresses all buffered bytes and writes them to the wrapped
+// io.Writer. The number of total bytes written to the wrapped writer is
+// returned if no error occurred, otherwise 0, err is returned.
+func (w *diskQueueWriter) compressAndFlush() (int, error) {
+	b := w.buffer.Bytes()
+	compressed := snappy.Encode(w.scratch.compressedBuf, b)
+	w.scratch.compressedBuf = compressed[:cap(compressed)]
+
+	blockType := snappyUncompressedBlock
+	// Discard result if < 12.5% size reduction.
+	// TODO(asubiotto): Add testing knob.
+	if len(compressed) < len(b)-len(b)/8 {
+		blockType = snappyCompressedBlock
+		b = compressed
+	}
+
+	// Write whether this data is compressed or not.
+	w.scratch.blockType[0] = blockType
+	nType, err := w.wrapped.Write(w.scratch.blockType[:])
+	if err != nil {
+		return 0, err
+	}
+
+	nBody, err := w.wrapped.Write(b)
+	if err != nil {
+		return 0, err
+	}
+	w.buffer.Reset()
+	return nType + nBody, err
+}
+
+func (w *diskQueueWriter) numBytesBuffered() int {
+	return w.buffer.Len()
+}
+
+// DiskQueue is not currently safe for concurrent use.
+type DiskQueue struct {
+	cfg   FlatQueueCfg
+	fs    vfs.FS
+	files []file
+	seqNo int
+
+	done bool
+
+	serializer        *FileSerializer
+	writer            *diskQueueWriter
+	writeFileIdx      int
+	writeFile         vfs.File
+	deserializerState struct {
+		*FileDeserializer
+		curBatch      int
+		batchToReturn coldata.Batch
+	}
+	// readFileIdx is an index into the current file in files the deserializer is
+	// reading from.
+	readFileIdx           int
+	readFile              vfs.File
+	decompressedReadBytes []byte
+}
+
+type Queue interface {
+	// Enqueue enqueues a coldata.Batch to this queue. A zero-length batch should be enqueued when no
+	// more elements will be enqueued.
+	Enqueue(coldata.Batch) error
+	// Dequeue dequeues a coldata.Batch from the queue. A nil Batch means the queue is currently empty, while a zero-length
+	// batch means no more elements will be enqueued. The dequeued batch should only be considered valid until the next
+	// call to Dequeue.
+	Dequeue() (coldata.Batch, error)
+	Close() error
+}
+
+type FlatQueueCfg struct {
+	BaseQueueCfg
+	MaxFileSizeBytes int
+}
+
+type BaseQueueCfg struct {
+	// Path is where the temporary files should be created.
+	Path string
+	// FilenamePrefix is the prefix of file names
+	FilenamePrefix string
+	// In production we would also have a cacheSize for a circular buffer that would hold the first elements in the queue,
+	// but since we are just benchmarking disk accesses, we elide that.
+	BufferSizeBytes int
+}
+
+var queueTyps = []coltypes.T{coltypes.Int64}
+
+func NewDiskQueue(cfg FlatQueueCfg, fs vfs.FS) *DiskQueue {
+	d := &DiskQueue{
+		cfg:   cfg,
+		fs:    fs,
+		files: make([]file, 0, 4),
+	}
+	d.deserializerState.batchToReturn = coldata.NewMemBatch(queueTyps)
+	return d
+}
+
+func (d *DiskQueue) Init() error {
+	return d.rotateFile()
+}
+
+func (d *DiskQueue) Close() error {
+	if d.done {
+		return nil
+	}
+	if d.serializer != nil {
+		if err := d.writeFooterAndFlush(); err != nil {
+			return err
+		}
+	}
+	if d.deserializerState.FileDeserializer != nil {
+		if err := d.deserializerState.Close(); err != nil {
+			return err
+		}
+	}
+	if d.writeFile != nil {
+		if err := d.writeFile.Close(); err != nil {
+			return err
+		}
+	}
+	if d.readFile != nil {
+		if err := d.readFile.Close(); err != nil {
+			return err
+		}
+		if err := d.fs.Remove(d.files[d.readFileIdx].name); err != nil {
+			return err
+		}
+	}
+	d.done = true
+	return nil
+}
+
+func (d *DiskQueue) rotateFile() error {
+	fName := path.Join(d.cfg.Path, "queuefile"+strconv.Itoa(d.seqNo))
+	f, err := d.fs.Create(fName)
+	if err != nil {
+		return err
+	}
+	d.seqNo++
+	f = vfs.NewSyncingFile(f, vfs.SyncingFileOptions{
+		BytesPerSync: 512 << 10, /* 512 KiB */
+	})
+
+	if d.serializer == nil {
+		// All writes are buffered using a generic buffered writer that flushes to a buffered snappy writer, which in turn
+		// flushes to the file.
+		writer := &diskQueueWriter{wrapped: f}
+		d.serializer, err = NewFileSerializer(writer, queueTyps)
+		if err != nil {
+			return err
+		}
+		d.writer = writer
+	} else {
+		if err := d.writeFooterAndFlush(); err != nil {
+			return err
+		}
+		if err := d.resetWriters(f); err != nil {
+			return err
+		}
+	}
+
+	if d.writeFile != nil {
+		d.files[d.writeFileIdx].finishedWriting = true
+		if err := d.writeFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	d.writeFileIdx = len(d.files)
+	d.files = append(d.files, file{name: fName, offsets: make([]int, 1, 16)})
+	d.writeFile = f
+	return nil
+}
+
+func (d *DiskQueue) resetWriters(f vfs.File) error {
+	d.writer.reset(f)
+	return d.serializer.Reset(d.writer)
+}
+
+func (d *DiskQueue) writeFooterAndFlush() error {
+	err := d.serializer.Finish()
+	if err != nil {
+		return err
+	}
+	written, err := d.writer.compressAndFlush()
+	if err != nil {
+		return err
+	}
+	// Append offset for the readers.
+	d.files[d.writeFileIdx].totalSize += written
+	d.files[d.writeFileIdx].offsets = append(d.files[d.writeFileIdx].offsets, d.files[d.writeFileIdx].totalSize)
+	return nil
+}
+
+func (d *DiskQueue) Enqueue(b coldata.Batch) error {
+	if b.Length() == 0 {
+		if err := d.writeFooterAndFlush(); err != nil {
+			return err
+		}
+		// Done with the serializer. Not setting this will cause us to attempt to flush the serializer on Close.
+		d.serializer = nil
+		// The write file will be closed in Close.
+		// TODO(asubiotto): Take another look at d.done
+		d.done = true
+		return nil
+	}
+	if err := d.serializer.AppendBatch(b); err != nil {
+		return err
+	}
+	bufferSizeLimitReached := d.writer.numBytesBuffered() > d.cfg.BufferSizeBytes
+	fileSizeLimitReached := d.files[d.writeFileIdx].totalSize+d.writer.numBytesBuffered() > d.cfg.MaxFileSizeBytes
+	if bufferSizeLimitReached || fileSizeLimitReached {
+		if fileSizeLimitReached {
+			// rotateFile will flush and reset writers.
+			return d.rotateFile()
+		}
+		if err := d.writeFooterAndFlush(); err != nil {
+			return err
+		}
+		return d.resetWriters(d.writeFile)
+	}
+	return nil
+}
+
+func (d *DiskQueue) maybeInitDeserializer() (bool, error) {
+	if d.deserializerState.FileDeserializer != nil {
+		return true, nil
+	}
+	if d.readFileIdx >= len(d.files) {
+		// There is no valid file to read from. Either more data will be enqueued or not, but the
+		// behavior there depends on the caller.
+		return false, nil
+	}
+	fileToRead := d.files[d.readFileIdx]
+	if fileToRead.curOffsetIdx == len(fileToRead.offsets)-1 {
+		// The current offset index is the last element in offsets. This means that either the region
+		// to read from next is currently being written to or the writer has rotated to a new file.
+		if fileToRead.finishedWriting {
+			// Close current file.
+			if err := d.readFile.Close(); err != nil {
+				return false, err
+			}
+			d.readFile = nil
+			// Read next file.
+			d.readFileIdx++
+			return d.maybeInitDeserializer()
+		}
+		// Not finished writing. there is currently no data to read.
+		return false, nil
+	}
+	if d.readFile == nil {
+		// File is not open.
+		f, err := d.fs.Open(fileToRead.name)
+		if err != nil {
+			return false, err
+		}
+		d.readFile = f
+	}
+	readRegionStart := fileToRead.offsets[fileToRead.curOffsetIdx]
+	readRegionLength := fileToRead.offsets[fileToRead.curOffsetIdx+1] - readRegionStart
+	if cap(d.writer.scratch.compressedBuf) < readRegionLength {
+		// Not enough capacity, we have to allocate a new compressedReadBytes.
+		d.writer.scratch.compressedBuf = make([]byte, readRegionLength)
+	}
+	d.writer.scratch.compressedBuf = d.writer.scratch.compressedBuf[0:readRegionLength]
+	n, err := d.readFile.ReadAt(d.writer.scratch.compressedBuf, int64(readRegionStart))
+	if err != nil {
+		return false, err
+	}
+	if n != len(d.writer.scratch.compressedBuf) {
+		return false, errors.Errorf("expected to read %d bytes but read %d", len(d.writer.scratch.compressedBuf), n)
+	}
+
+	blockType := d.writer.scratch.compressedBuf[0]
+	decompressed := d.writer.scratch.compressedBuf[1:]
+	if blockType == snappyCompressedBlock {
+		// TODO(asubiotto): think about the memory story with decompressed bytes
+		decompressed, err = snappy.Decode(d.decompressedReadBytes, d.writer.scratch.compressedBuf[1:])
+		if err != nil {
+			return false, err
+		}
+		d.decompressedReadBytes = decompressed[:cap(decompressed)]
+	}
+
+	deserializer, err := NewFileDeserializerFromBytes(decompressed)
+	if err != nil {
+		return false, err
+	}
+	d.deserializerState.FileDeserializer = deserializer
+	d.deserializerState.curBatch = 0
+	if d.deserializerState.NumBatches() == 0 {
+		// This would be weird, but let's handle it.
+		if err := d.deserializerState.FileDeserializer.Close(); err != nil {
+			return false, err
+		}
+		d.deserializerState.FileDeserializer = nil
+		return false, nil
+	}
+	return true, nil
+}
+
+func (d *DiskQueue) Dequeue() (coldata.Batch, error) {
+	if d.serializer != nil {
+		if err := d.writeFooterAndFlush(); err != nil {
+			return nil, err
+		}
+		if err := d.resetWriters(d.writeFile); err != nil {
+			return nil, err
+		}
+	}
+
+	if d.deserializerState.FileDeserializer != nil && d.deserializerState.curBatch >= d.deserializerState.NumBatches() {
+		// Finished all the batches, set the deserializer to nil to initialize a new
+		// one to read the next region.
+		if err := d.deserializerState.FileDeserializer.Close(); err != nil {
+			return nil, err
+		}
+		d.deserializerState.FileDeserializer = nil
+		d.files[d.readFileIdx].curOffsetIdx++
+	}
+
+	if dataToRead, err := d.maybeInitDeserializer(); err != nil {
+		return nil, err
+	} else if !dataToRead {
+		// No data to read.
+		if !d.done {
+			// Data might still be added.
+			return nil, nil
+		}
+		// No data will be added.
+		d.deserializerState.batchToReturn.SetLength(0)
+	} else {
+		if err := d.deserializerState.GetBatch(d.deserializerState.curBatch, d.deserializerState.batchToReturn); err != nil {
+			return nil, err
+		}
+		d.deserializerState.curBatch++
+	}
+
+	// In the real implementation we will deserialize as much as we need to place
+	// all but one batch (the batch to return) in the circular buffer.
+	// TODO(asubiotto): Maybe add a TODO or something?
+	return d.deserializerState.batchToReturn, nil
+}

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -72,6 +72,10 @@ func NewFileSerializer(w io.Writer, typs []coltypes.T) (*FileSerializer, error) 
 	return s, s.Reset(w)
 }
 
+func (s *FileSerializer) Written() int {
+	return s.w.written
+}
+
 // Reset can be called to reuse this FileSerializer with a new io.Writer after
 // calling Finish. The types will remain the ones passed to the constructor. The
 // caller is responsible for closing the given writer.
@@ -124,7 +128,8 @@ func (s *FileSerializer) AppendBatch(batch coldata.Batch) error {
 }
 
 // Finish writes the footer metadata described by the arrow spec. Nothing can be
-// called after Finish except Reset.
+// called after Finish except Reset. The total number of bytes written since
+// the serializer was initialized is returned.
 func (s *FileSerializer) Finish() error {
 	defer func() {
 		s.w = nil

--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -37,7 +37,8 @@ func TestFileRoundtrip(t *testing.T) {
 		s, err := colserde.NewFileSerializer(&buf, typs)
 		require.NoError(t, err)
 		require.NoError(t, s.AppendBatch(b))
-		require.NoError(t, s.Finish())
+		err = s.Finish()
+		require.NoError(t, err)
 
 		// Parts of the deserialization modify things (null bitmaps) in place, so
 		// run it twice to make sure those modifications don't leak back to the
@@ -72,7 +73,8 @@ func TestFileRoundtrip(t *testing.T) {
 		s, err := colserde.NewFileSerializer(f, typs)
 		require.NoError(t, err)
 		require.NoError(t, s.AppendBatch(b))
-		require.NoError(t, s.Finish())
+		err = s.Finish()
+		require.NoError(t, err)
 		require.NoError(t, f.Sync())
 
 		// Parts of the deserialization modify things (null bitmaps) in place, so
@@ -110,7 +112,8 @@ func TestFileIndexing(t *testing.T) {
 		b.ColVec(0).Int64()[0] = int64(i)
 		require.NoError(t, s.AppendBatch(b))
 	}
-	require.NoError(t, s.Finish())
+	err = s.Finish()
+	require.NoError(t, err)
 
 	d, err := colserde.NewFileDeserializerFromBytes(buf.Bytes())
 	require.NoError(t, err)

--- a/pkg/col/colserde/pebblequeue.go
+++ b/pkg/col/colserde/pebblequeue.go
@@ -1,0 +1,208 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package colserde
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+type PebbleQueue struct {
+	cfg  PebbleQueueCfg
+	done bool
+
+	serializedBuf bytes.Buffer
+	// serializer is serializes Enqueued batches into bytes. A nil serializer indicates that no more batches will be
+	// enqueued.
+	serializer        *FileSerializer
+	deserializerState struct {
+		*FileDeserializer
+		curBatch int
+	}
+
+	diskMap  diskmap.SortedDiskMap
+	e        diskmap.Factory
+	iterator diskmap.SortedDiskMapIterator
+	writer   diskmap.SortedDiskMapBatchWriter
+
+	batchToReturn coldata.Batch
+	// currentWriteKey is the key that should be created to store batches.
+	currentWriteKey int
+	scratchKey      []byte
+	// currentReadKey is the key of the next batch to read.
+	currentReadKey int
+}
+
+func NewPebbleQueue(cfg PebbleQueueCfg) (*PebbleQueue, error) {
+	e, err := engine.NewPebbleTempEngine(base.TempStorageConfig{Path: cfg.Path}, base.StoreSpec{})
+	if err != nil {
+		return nil, err
+	}
+	diskMap := e.NewSortedDiskMap()
+	q := &PebbleQueue{
+		cfg:           cfg,
+		diskMap:       diskMap,
+		e:             e,
+		writer:        diskMap.NewBatchWriterCapacity(cfg.BufferSizeBytes),
+		batchToReturn: coldata.NewMemBatch(queueTyps),
+		scratchKey:    make([]byte, 4),
+	}
+	s, err := NewFileSerializer(&q.serializedBuf, queueTyps)
+	if err != nil {
+		return nil, err
+	}
+	q.serializer = s
+	return q, nil
+}
+
+func (q *PebbleQueue) flushSerializer() error {
+	if q.serializer == nil {
+		return nil
+	}
+	if q.serializer.Written() == 0 {
+		return nil
+	}
+	if err := q.serializer.Finish(); err != nil {
+		return err
+	}
+	q.scratchKey = q.scratchKey[:0]
+	q.scratchKey = encoding.EncodeVarintAscending(q.scratchKey, int64(q.currentWriteKey))
+	if err := q.writer.Put(q.scratchKey, q.serializedBuf.Bytes()); err != nil {
+		return err
+	}
+
+	// The problem here seems that we could be overwriting `serializedBuf` before *actually* flushing to disk.
+	q.currentWriteKey++
+	// It's ok to reset the buffer here, since the bytes were copied by writer.Put.
+	q.serializedBuf.Reset()
+	return q.serializer.Reset(&q.serializedBuf)
+}
+
+func (q *PebbleQueue) Enqueue(b coldata.Batch) error {
+	if b.Length() == 0 {
+		if err := q.flushSerializer(); err != nil {
+			return err
+		}
+		q.serializer = nil
+		q.done = true
+		return nil
+	}
+	if err := q.serializer.AppendBatch(b); err != nil {
+		return err
+	}
+	if q.serializer.Written() >= q.cfg.MaxValueSizeBytes {
+		return q.flushSerializer()
+	}
+	return nil
+}
+
+func (q *PebbleQueue) Dequeue() (coldata.Batch, error) {
+	if q.serializer != nil && q.serializer.Written() > 0 {
+		if err := q.flushSerializer(); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := q.writer.Flush(); err != nil {
+		return nil, err
+	}
+
+	if q.deserializerState.FileDeserializer != nil {
+		numBatches := q.deserializerState.NumBatches()
+		if numBatches == 0 {
+			q.done = true
+			q.batchToReturn.SetLength(0)
+			return q.batchToReturn, nil
+		}
+
+		// Get next batch and return it while we have in-memory stuff.
+		if q.deserializerState.curBatch < numBatches {
+			if err := q.deserializerState.GetBatch(q.deserializerState.curBatch, q.batchToReturn); err != nil {
+				return nil, err
+			}
+			q.deserializerState.curBatch++
+			return q.batchToReturn, nil
+		}
+
+		// Deserializer exhausted.
+		if err := q.deserializerState.Close(); err != nil {
+			return nil, err
+		}
+		q.deserializerState.FileDeserializer = nil
+	}
+
+	if q.currentReadKey == q.currentWriteKey {
+		// This next value to read has not been written yet.
+		if q.done {
+			q.batchToReturn.SetLength(0)
+			return q.batchToReturn, nil
+		}
+		return nil, nil
+	}
+
+	if q.iterator == nil || !q.cfg.SkipRecreateIter {
+		// Note that q.deserializer must be nil at this point due to the previous if statement.
+		if q.iterator != nil {
+			q.iterator.Close()
+		}
+		q.iterator = q.diskMap.NewIterator()
+		q.scratchKey = q.scratchKey[:0]
+		q.scratchKey = encoding.EncodeVarintAscending(q.scratchKey, int64(q.currentReadKey))
+		q.iterator.SeekGE(q.scratchKey)
+	} else {
+		q.iterator.Next()
+	}
+
+	if ok, err := q.iterator.Valid(); !ok || err != nil {
+		if err == nil {
+			err = errors.New("invalid key")
+		}
+		return nil, err
+	}
+
+	q.currentReadKey++
+
+	deserializer, err := NewFileDeserializerFromBytes(q.iterator.UnsafeValue())
+	if err != nil {
+		return nil, err
+	}
+	q.deserializerState.FileDeserializer = deserializer
+	q.deserializerState.curBatch = 0
+
+	return q.Dequeue()
+}
+
+func (q *PebbleQueue) Close() error {
+	ctx := context.Background()
+	if q.serializer != nil {
+		if err := q.flushSerializer(); err != nil {
+			return err
+		}
+		q.serializer = nil
+	}
+	if q.writer != nil {
+		if err := q.writer.Close(ctx); err != nil {
+			return err
+		}
+	}
+	if q.iterator != nil {
+		q.iterator.Close()
+	}
+	q.diskMap.Close(ctx)
+	q.e.Close()
+	return nil
+}

--- a/pkg/col/colserde/queue_test.go
+++ b/pkg/col/colserde/queue_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package colserde_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/colserde"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+var queueTyps = []coltypes.T{coltypes.Int64}
+
+func testQueue(t *testing.T, q colserde.Queue) {
+	rng, _ := randutil.NewPseudoRand()
+	batches := make([]coldata.Batch, 0, 1024)
+	op := colexec.NewRandomDataOp(testAllocator, rng, colexec.RandomDataOpArgs{
+		DeterministicTyps: queueTyps,
+		NumBatches:        cap(batches),
+		BatchAccumulator: func(b coldata.Batch) {
+			batches = append(batches, copyBatch(b))
+		},
+	})
+	ctx := context.Background()
+	for {
+		b := op.Next(ctx)
+		require.NoError(t, q.Enqueue(b))
+		if b.Length() == 0 {
+			break
+		}
+		if rng.Float64() < 0 {
+			b, err := q.Dequeue()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertEqualBatches(t, batches[0], b)
+			batches = batches[1:]
+		}
+	}
+	for len(batches) > 0 {
+		b, err := q.Dequeue()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqualBatches(t, batches[0], b)
+		batches = batches[1:]
+	}
+}
+
+// TestQueue just ensures that we get the correct behavior from both queue implementations.
+func TestQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	path, cleanup := testutils.TempDir(t)
+	defer cleanup()
+
+	for _, bufferSizeBytes := range []int{0, 1 << 19 /* 500 KiB */, 1 << 20 /* 1 MiB */, 64 << 20 /* 64 MiB */} {
+		t.Run(fmt.Sprintf("BufferSizeBytes=%s", humanizeutil.IBytes(int64(bufferSizeBytes))), func(t *testing.T) {
+			t.Run("Flat", func(t *testing.T) {
+				for _, maxFileSizeBytes := range []int{10 << 10 /* 10 KiB */, 1 << 20 /* 1 MiB */, 64 << 20 /* 64 MiB */, 128 << 20 /* 128 MiB */} {
+					t.Run(fmt.Sprintf("MaxFileSizeBytes=%s", humanizeutil.IBytes(int64(maxFileSizeBytes))), func(t *testing.T) {
+						q := colserde.NewDiskQueue(colserde.FlatQueueCfg{
+							BaseQueueCfg: colserde.BaseQueueCfg{
+								Path:            path,
+								BufferSizeBytes: bufferSizeBytes,
+							},
+							MaxFileSizeBytes: maxFileSizeBytes,
+						}, vfs.Default)
+						require.NoError(t, q.Init())
+						testQueue(t, q)
+						require.NoError(t, q.Close())
+					})
+				}
+			})
+
+			t.Run("Pebble", func(t *testing.T) {
+				for _, skipRecreateIter := range []bool{false, true} {
+					t.Run(fmt.Sprintf("SkipRecreateIter=%t", skipRecreateIter), func(t *testing.T) {
+						for _, maxValueSizeBytes := range []int{1 << 10 /* 1 KiB */, 32 << 10 /* 32 KiB */, 64 << 10 /* 64 KiB */} {
+							t.Run(fmt.Sprintf("MaxValueSizeBytes=%s", humanizeutil.IBytes(int64(maxValueSizeBytes))), func(t *testing.T) {
+								q, err := colserde.NewPebbleQueue(colserde.PebbleQueueCfg{
+									BaseQueueCfg: colserde.BaseQueueCfg{
+										Path:            path,
+										BufferSizeBytes: bufferSizeBytes,
+									},
+									SkipRecreateIter:  skipRecreateIter,
+									MaxValueSizeBytes: maxValueSizeBytes,
+								})
+								require.NoError(t, err)
+								testQueue(t, q)
+								require.NoError(t, q.Close())
+							})
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+// Flags for BenchmarkQueue
+var (
+	store           = flag.String("store", "", "one of flat or pebble, describes which underlying store to use")
+	bufferSizeBytes = flag.String("bufsize", "", "number of bytes to buffer in memory before flushingh")
+	blockSizeBytes  = flag.String("blocksize", "", "block size for the number of bytes stored ina block. In pebble, this is the value size, with the flat implementation, this is the file size")
+	dataSizeBytes   = flag.String("datasize", "", "size of data in bytes to sort")
+)
+
+// BenchmarkQueues benchmarks a queue with parameters provided through flags.
+func BenchmarkQueues(b *testing.B) {
+	bufSize, err := humanizeutil.ParseBytes(*bufferSizeBytes)
+	if err != nil {
+		b.Fatalf("could not parse -bufsize: %s", err)
+	}
+	blockSize, err := humanizeutil.ParseBytes(*blockSizeBytes)
+	if err != nil {
+		b.Fatalf("could not parse -blocksize: %s", err)
+	}
+	dataSize, err := humanizeutil.ParseBytes(*dataSizeBytes)
+	if err != nil {
+		b.Fatalf("could not pase -datasize: %s", err)
+	}
+	numBatches := dataSize / (8 * int64(coldata.BatchSize()))
+
+	path, cleanup := testutils.TempDir(b)
+	defer cleanup()
+
+	var qConstructor func() colserde.Queue
+	switch *store {
+	case "flat":
+		qConstructor = func() colserde.Queue {
+			q := colserde.NewDiskQueue(colserde.FlatQueueCfg{
+				BaseQueueCfg: colserde.BaseQueueCfg{
+					Path:            path,
+					BufferSizeBytes: int(bufSize),
+				},
+				MaxFileSizeBytes: int(blockSize),
+			}, vfs.Default)
+			if err := q.Init(); err != nil {
+				b.Fatal(err)
+			}
+			return q
+		}
+	case "pebble":
+		qConstructor = func() colserde.Queue {
+			q, err := colserde.NewPebbleQueue(colserde.PebbleQueueCfg{
+				BaseQueueCfg: colserde.BaseQueueCfg{
+					Path:            path,
+					BufferSizeBytes: int(bufSize),
+				},
+				SkipRecreateIter:  true,
+				MaxValueSizeBytes: int(blockSize),
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			return q
+		}
+	default:
+		b.Fatalf("unknown -store argument: %s", *store)
+	}
+
+	rng, _ := randutil.NewPseudoRand()
+	batch := colexec.RandomBatch(testAllocator, rng, queueTyps, int(coldata.BatchSize()), 0, 0)
+	// Uncomment this line and assertEqualBatches to ensure correctness.
+	// expectedBatch := copyBatch(batch)
+	op := colexec.NewRepeatableBatchSource(batch)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		op.ResetBatchesToReturn(int(numBatches))
+		q := qConstructor()
+		for {
+			batchToEnqueue := op.Next(ctx)
+			if err := q.Enqueue(batchToEnqueue); err != nil {
+				b.Fatal(err)
+			}
+			if batchToEnqueue.Length() == 0 {
+				break
+			}
+		}
+		for {
+			dequeuedBatch, err := q.Dequeue()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if dequeuedBatch.Length() == 0 {
+				break
+			}
+			// assertEqualBatches(b, expectedBatch, dequeuedBatch)
+		}
+		if err := q.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	time.Sleep(10 * time.Second)
+}


### PR DESCRIPTION
Release note: None

Here is the branch with the benchmarks. To compare both the pebble and file implementations I use:
```
for i in 4KiB 8KiB 16KiB 32KiB 64KiB 128KiB 256KiB 512KiB 1MiB 2MiB 4MiB
do
    echo "running $i"
    pfname=cpeb$i
    ffname=cfl$i
    make bench PKG=./pkg/col/colserde BENCHES=BenchmarkQueue TESTFLAGS="-v -count 10 -store=pebble -bufsize=$i -blocksize=512KiB -datasize=512MiB" > $pfname
    make bench PKG=./pkg/col/colserde BENCHES=BenchmarkQueue TESTFLAGS="-v -count 10 -store=flat -bufsize=$i -blocksize=64MiB -datasize=512MiB" > $ffname
    benchstat $pfname $ffname
done
```