### PR TITLE
release-19.2: sql: fix validation of MATCH FULL foreign keys with mixed column types

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -70,14 +70,16 @@ func validateCheckExpr(
 //
 // SELECT s.a_id, s.b_id, s.pk1, s.pk2 FROM child@c_idx
 // WHERE
-//   NOT ((COALESCE(a_id, b_id) IS NULL) OR (a_id IS NOT NULL AND b_id IS NOT NULL))
+//   (a_id IS NULL OR b_id IS NULL) AND (a_id IS NOT NULL OR b_id IS NOT NULL)
 // LIMIT 1;
 func matchFullUnacceptableKeyQuery(
 	srcTbl *sqlbase.TableDescriptor, fk *sqlbase.ForeignKeyConstraint, limitResults bool,
 ) (sql string, colNames []string, _ error) {
 	nCols := len(fk.OriginColumnIDs)
 	srcCols := make([]string, nCols)
-	srcNotNullClause := make([]string, nCols)
+	srcNullExistsClause := make([]string, nCols)
+	srcNotNullExistsClause := make([]string, nCols)
+
 	returnedCols := srcCols
 	for i := 0; i < nCols; i++ {
 		col, err := srcTbl.FindColumnByID(fk.OriginColumnIDs[i])
@@ -85,7 +87,8 @@ func matchFullUnacceptableKeyQuery(
 			return "", nil, err
 		}
 		srcCols[i] = tree.NameString(col.Name)
-		srcNotNullClause[i] = fmt.Sprintf("%s IS NOT NULL", srcCols[i])
+		srcNullExistsClause[i] = fmt.Sprintf("%s IS NULL", srcCols[i])
+		srcNotNullExistsClause[i] = fmt.Sprintf("%s IS NOT NULL", srcCols[i])
 	}
 
 	for _, id := range srcTbl.PrimaryIndex.ColumnIDs {
@@ -110,12 +113,12 @@ func matchFullUnacceptableKeyQuery(
 		limit = " LIMIT 1"
 	}
 	return fmt.Sprintf(
-		`SELECT %[1]s FROM [%[2]d AS tbl] WHERE NOT ((COALESCE(%[3]s) IS NULL) OR (%[4]s)) %[5]s`,
-		strings.Join(returnedCols, ","),         // 1
-		srcTbl.ID,                               // 2
-		strings.Join(srcCols, ", "),             // 3
-		strings.Join(srcNotNullClause, " AND "), // 4
-		limit,                                   // 5
+		`SELECT %[1]s FROM [%[2]d AS tbl] WHERE (%[3]s) AND (%[4]s) %[5]s`,
+		strings.Join(returnedCols, ","),              // 1
+		srcTbl.ID,                                    // 2
+		strings.Join(srcNullExistsClause, " OR "),    // 3
+		strings.Join(srcNotNullExistsClause, " OR "), // 4
+		limit, // 5
 	), returnedCols, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2660,3 +2660,19 @@ pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                    true
 
 statement ok
 DROP TABLE person, pet
+
+# Regression test for #42498: MATCH FULL validation should work when columns in
+# a composite FK reference have different types.
+subtest 42498_match_full_mixed_types
+
+statement ok
+CREATE TABLE table1_42498 (col1 REGPROC NOT NULL, col2 DATE NOT NULL)
+
+statement ok
+CREATE TABLE table2_42498 (col3 REGPROC NOT NULL, col4 DATE NOT NULL, UNIQUE (col4, col3))
+
+statement ok
+ALTER TABLE table1_42498 ADD FOREIGN KEY (col2, col1) REFERENCES table2_42498 (col4, col3) MATCH FULL
+
+statement ok
+DROP TABLE table1_42498, table2_42498 CASCADE


### PR DESCRIPTION
Backport 1/1 commits from #42528.

/cc @cockroachdb/release

---

Previously, the internal validation query for MATCH FULL foreign keys checked
for the presence of invalid keys for a set of columns `c_1, ..., c_n` by using
`COALESCE(c_1, ..., c_n) IS NULL`, which fails if any of the columns differ in
type because `COALESCE` requires its arguments to be all of the same type. This
PR fixes the validation query by using `c_1 IS NULL AND ... AND c_n IS NULL`
instead.

Release note (bug fix): Fixed a bug that would produce a spurious failure with
the error message "incompatible COALESCE expressions" when adding or validating
`MATCH FULL` foreign key constraints involving composite keys with columns of
differing types.