### PR TITLE
sql,sqlbase: finish the migration to use MVCC timestamps with table descriptors

### DIFF
--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -95,13 +95,19 @@ func doCreateSequence(
 		telemetry.Inc(sqltelemetry.CreateTempSequenceCounter)
 	}
 
+	// creationTime is initialized to a zero value and populated at read time.
+	// See the comment in desc.MaybeIncrementVersion.
+	//
+	// TODO(ajwerner): remove the timestamp from MakeSequenceTableDesc, it's
+	// currently relied on in import and restore code and tests.
+	var creationTime hlc.Timestamp
 	desc, err := MakeSequenceTableDesc(
 		name.Table(),
 		opts,
 		dbDesc.GetID(),
 		schemaID,
 		id,
-		params.creationTimeForNewTableDescriptor(),
+		creationTime,
 		privs,
 		isTemporary,
 		&params,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -277,7 +277,12 @@ func (n *createTableNode) startExec(params runParams) error {
 	var asCols sqlbase.ResultColumns
 	var desc sqlbase.MutableTableDescriptor
 	var affected map[sqlbase.ID]*sqlbase.MutableTableDescriptor
-	creationTime := params.creationTimeForNewTableDescriptor()
+	// creationTime is initialized to a zero value and populated at read time.
+	// See the comment in desc.MaybeIncrementVersion.
+	//
+	// TODO(ajwerner): remove the timestamp from makeTableDesc and its friends,
+	// it's	currently relied on in import and restore code and tests.
+	var creationTime hlc.Timestamp
 	if n.n.As() {
 		asCols = planColumns(n.sourcePlan)
 		if !n.run.fromHeuristicPlanner && !n.n.AsHasUserSpecifiedPrimaryKey() {

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -133,6 +133,12 @@ func (n *createViewNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
+		// creationTime is initialized to a zero value and populated at read time.
+		// See the comment in desc.MaybeIncrementVersion.
+		//
+		// TODO(ajwerner): remove the timestamp from MakeViewTableDesc, it's
+		// currently relied on in import and restore code and tests.
+		var creationTime hlc.Timestamp
 		desc, err := makeViewTableDesc(
 			params.ctx,
 			viewName,
@@ -141,7 +147,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			schemaID,
 			id,
 			n.columns,
-			params.creationTimeForNewTableDescriptor(),
+			creationTime,
 			privs,
 			&params.p.semaCtx,
 			params.p.EvalContext(),

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -18,7 +18,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1701,20 +1700,12 @@ func (desc *MutableTableDescriptor) MaybeIncrementVersion(
 	}
 	desc.Version++
 
-	// Before 19.2 we needed to observe the transaction CommitTimestamp to ensure
-	// that ModificationTime reflected the timestamp at which the transaction
-	// committed. Starting in 19.2 we use a zero-valued ModificationTime when
-	// incrementing the version and then upon reading use the MVCC timestamp to
-	// populate the ModificationTime.
-	//
-	// TODO(ajwerner): remove this check in 20.1.
-	var modTime hlc.Timestamp
-	if !settings.Version.IsActive(ctx, clusterversion.VersionTableDescModificationTimeFromMVCC) {
-		modTime = txn.CommitTimestamp()
-	}
-	desc.ModificationTime = modTime
-	log.Infof(ctx, "publish: descID=%d (%s) version=%d mtime=%s",
-		desc.ID, desc.Name, desc.Version, modTime.GoTime())
+	// Starting in 19.2 we use a zero-valued ModificationTime when incrementing
+	// the version, and then, upon reading, use the MVCC timestamp to populate
+	// the ModificationTime.
+	desc.ModificationTime = hlc.Timestamp{}
+	log.Infof(ctx, "publish: descID=%d (%s) version=%d",
+		desc.ID, desc.Name, desc.Version)
 	return nil
 }
 


### PR DESCRIPTION
In #40581 we changed the protocol for creating and updating table descriptors
to no longer serialize the hlc timestamp at which the descriptor was created
or modified directly into the value but rather to infer it from the MVCC
timestamp of the row. For backwards compatibility we left a migration in
place. This commit finishes the migration.

Release note: None.