### PR TITLE
coldata: remove Slice method from Bytes

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -32,6 +32,10 @@ type Bytes struct {
 	// enables us to disallow unordered sets (which would require data movement).
 	// Also, this helps us maintain the assumption of non-decreasing offsets.
 	maxSetIndex int
+
+	// isWindow indicates whether this Bytes is a "window" into another Bytes.
+	// If it is, no modifications are allowed (all of them will panic).
+	isWindow bool
 }
 
 // BytesInitialAllocationFactor is an estimate of how many bytes each []byte
@@ -68,6 +72,9 @@ func (b *Bytes) AssertOffsetsAreNonDecreasing(n uint64) {
 // method - we assume that *always*, before returning a batch, the length is
 // set on it.
 func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n uint64) {
+	// Note that we're not checking whether this Bytes is a window because
+	// although this function modifies the "window" Bytes, it maintains the
+	// invariant that we need to have.
 	prev := b.offsets[0]
 	for j := uint64(1); j <= n; j++ {
 		if b.offsets[j] > prev {
@@ -83,6 +90,9 @@ func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n uint64) {
 // b.maxSetIndex+1 are non-decreasing. Note that this method can be a noop when
 // i <= b.maxSetIndex+1.
 func (b *Bytes) maybeBackfillOffsets(i int) {
+	if b.isWindow {
+		panic("maybeBackfillOffsets is called on a window into Bytes")
+	}
 	for j := b.maxSetIndex + 2; j <= i; j++ {
 		b.offsets[j] = b.offsets[b.maxSetIndex+1]
 	}
@@ -101,6 +111,9 @@ func (b *Bytes) Get(i int) []byte {
 // away necessary space in the flat buffer. Note that a nil value will be
 // "converted" into an empty byte slice.
 func (b *Bytes) Set(i int, v []byte) {
+	if b.isWindow {
+		panic("Set is called on a window into Bytes")
+	}
 	if i < b.maxSetIndex {
 		panic(
 			fmt.Sprintf(
@@ -127,32 +140,20 @@ func (b *Bytes) Set(i int, v []byte) {
 	b.maxSetIndex = i
 }
 
-// Slice returns a shallow copy of the receiver Bytes struct sliced according
-// to start and end.
-// NOTE: slicing is a lightweight operation, so the underlying memory will be
-// shared between the receiver and a newly created Bytes struct. Beware that
-// modification of the newly created slice can invalidate the receiver's data.
-// Use with caution.
-// TODO(yuzefovich): consider removing this entirely or making it a noop.
-func (b *Bytes) Slice(start, end int) *Bytes {
+// Window creates a "window" into the receiver. It behaves similarly to
+// Golang's slice, but the returned object is *not* allowed to be modified - it
+// is read-only. Window is a lightweight operation that doesn't involve copying
+// the underlying data.
+func (b *Bytes) Window(start, end int) *Bytes {
 	if start < 0 || start > end || end > b.Len() {
 		panic(
 			fmt.Sprintf(
-				"invalid slice arguments: start=%d end=%d when Bytes.Len()=%d",
+				"invalid window arguments: start=%d end=%d when Bytes.Len()=%d",
 				start, end, b.Len(),
 			),
 		)
 	}
 	b.maybeBackfillOffsets(end)
-	maxSetIndex := end - start - 1
-	if start == end {
-		maxSetIndex = 0
-	}
-	if maxSetIndex > b.maxSetIndex-start {
-		maxSetIndex = b.maxSetIndex - start
-	}
-	// Note that during slicing we don't use an offset for a start index so
-	// that we don't need to translate the offsets.
 	data := b.data[:b.offsets[end]]
 	if end == 0 {
 		data = b.data[:0]
@@ -160,9 +161,9 @@ func (b *Bytes) Slice(start, end int) *Bytes {
 	return &Bytes{
 		data: data,
 		// We use 'end+1' because of the extra offset to know the length of the
-		// last element of the newly created slice.
-		offsets:     b.offsets[start : end+1],
-		maxSetIndex: maxSetIndex,
+		// last element of the newly created window.
+		offsets:  b.offsets[start : end+1],
+		isWindow: true,
 	}
 }
 
@@ -179,13 +180,16 @@ func (b *Bytes) Slice(start, end int) *Bytes {
 // Similarly, if "a", is instead "alongerstring", "world" would have to be
 // shifted right.
 func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
+	if b.isWindow {
+		panic("CopySlice is called on a window into Bytes")
+	}
 	if destIdx < 0 || destIdx > b.Len() {
 		panic(
 			fmt.Sprintf(
 				"dest index %d out of range (len=%d)", destIdx, b.Len(),
 			),
 		)
-	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() ||
+	} else if srcStartIdx < 0 || srcStartIdx > src.Len() ||
 		srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
 		panic(
 			fmt.Sprintf(
@@ -275,13 +279,16 @@ func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 // AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
 // values from src into the receiver starting at destIdx.
 func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
+	if b.isWindow {
+		panic("AppendSlice is called on a window into Bytes")
+	}
 	if destIdx < 0 || destIdx > b.Len() {
 		panic(
 			fmt.Sprintf(
 				"dest index %d out of range (len=%d)", destIdx, b.Len(),
 			),
 		)
-	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() ||
+	} else if srcStartIdx < 0 || srcStartIdx > src.Len() ||
 		srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
 		panic(
 			fmt.Sprintf(
@@ -336,6 +343,9 @@ func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 // AppendVal appends the given []byte value to the end of the receiver. A nil
 // value will be "converted" into an empty byte slice.
 func (b *Bytes) AppendVal(v []byte) {
+	if b.isWindow {
+		panic("AppendVal is called on a window into Bytes")
+	}
 	b.maybeBackfillOffsets(b.Len())
 	b.maxSetIndex = b.Len()
 	b.offsets[b.Len()] = int32(len(b.data))
@@ -346,6 +356,9 @@ func (b *Bytes) AppendVal(v []byte) {
 // SetLength sets the length of this Bytes. Note that it will panic if there is
 // not enough capacity.
 func (b *Bytes) SetLength(l int) {
+	if b.isWindow {
+		panic("SetLength is called on a window into Bytes")
+	}
 	// We need +1 for an extra offset at the end.
 	b.offsets = b.offsets[:l+1]
 }

--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -20,6 +20,8 @@ import (
 // unknown is a Vec that represents an unhandled type. Used when a batch needs a placeholder Vec.
 type unknown struct{}
 
+var _ Vec = &unknown{}
+
 func (u unknown) Type() coltypes.T {
 	return coltypes.Unhandled
 }
@@ -76,7 +78,7 @@ func (u unknown) Copy(CopySliceArgs) {
 	panic("Vec is of unknown type and should not be accessed")
 }
 
-func (u unknown) Slice(colType coltypes.T, start uint64, end uint64) Vec {
+func (u unknown) Window(colType coltypes.T, start uint64, end uint64) Vec {
 	panic("Vec is of unknown type and should not be accessed")
 }
 

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -106,9 +106,11 @@ type Vec interface {
 	// Refer to the CopySliceArgs comment for specifics and TestCopy for examples.
 	Copy(CopySliceArgs)
 
-	// Slice returns a new Vec representing a slice of the current Vec from
-	// [start, end).
-	Slice(colType coltypes.T, start uint64, end uint64) Vec
+	// Window returns a "window" into the Vec. A "window" is similar to Golang's
+	// slice of the current Vec from [start, end), but the returned object is NOT
+	// allowed to be modified (the modification might result in an undefined
+	// behavior).
+	Window(colType coltypes.T, start uint64, end uint64) Vec
 
 	// PrettyValueAt returns a "pretty"value for the idx'th value in this Vec.
 	// It uses the reflect package and is not suitable for calling in hot paths.

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMemColumnSlice(t *testing.T) {
+func TestMemColumnWindow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, _ := randutil.NewPseudoRand()
@@ -35,25 +35,25 @@ func TestMemColumnSlice(t *testing.T) {
 		}
 	}
 
-	startSlice := uint16(1)
-	endSlice := uint16(0)
-	for startSlice > endSlice {
-		startSlice = uint16(rng.Intn(int(BatchSize())))
-		endSlice = uint16(1 + rng.Intn(int(BatchSize())))
+	startWindow := uint16(1)
+	endWindow := uint16(0)
+	for startWindow > endWindow {
+		startWindow = uint16(rng.Intn(int(BatchSize())))
+		endWindow = uint16(1 + rng.Intn(int(BatchSize())))
 	}
 
-	slice := c.Slice(coltypes.Int64, uint64(startSlice), uint64(endSlice))
-	sliceInts := slice.Int64()
+	window := c.Window(coltypes.Int64, uint64(startWindow), uint64(endWindow))
+	windowInts := window.Int64()
 	// Verify that every other value is null.
-	for i, j := startSlice, uint16(0); i < endSlice; i, j = i+1, j+1 {
+	for i, j := startWindow, uint16(0); i < endWindow; i, j = i+1, j+1 {
 		if i%2 == 0 {
-			if !slice.Nulls().NullAt(j) {
+			if !window.Nulls().NullAt(j) {
 				t.Fatalf("expected null at %d (original index: %d)", j, i)
 			}
 			continue
 		}
-		if ints[i] != sliceInts[j] {
-			t.Fatalf("unexected value at index %d (original index: %d): expected %d got %d", j, i, ints[i], sliceInts[j])
+		if ints[i] != windowInts[j] {
+			t.Fatalf("unexected value at index %d (original index: %d): expected %d got %d", j, i, ints[i], windowInts[j])
 		}
 	}
 }

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -99,8 +99,8 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 		if typ == coltypes.Bytes {
 			// Cannot use require.Equal for this type.
 			// TODO(asubiotto): Again, why not?
-			expectedBytes := expectedVec.Bytes().Slice(0, int(expected.Length()))
-			resultBytes := actualVec.Bytes().Slice(0, int(actual.Length()))
+			expectedBytes := expectedVec.Bytes().Window(0, int(expected.Length()))
+			resultBytes := actualVec.Bytes().Window(0, int(actual.Length()))
 			require.Equal(t, expectedBytes.Len(), resultBytes.Len())
 			for i := 0; i < expectedBytes.Len(); i++ {
 				if !bytes.Equal(expectedBytes.Get(i), resultBytes.Get(i)) {
@@ -110,8 +110,8 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 		} else {
 			require.Equal(
 				t,
-				expectedVec.Slice(expectedVec.Type(), 0, uint64(expected.Length())),
-				actualVec.Slice(actualVec.Type(), 0, uint64(actual.Length())),
+				expectedVec.Window(expectedVec.Type(), 0, uint64(expected.Length())),
+				actualVec.Window(actualVec.Type(), 0, uint64(actual.Length())),
 			)
 		}
 	}

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -136,7 +136,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, int(inputLen))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(inputLen)) {
 						_FIND_ANY_NOT_NULL(a, nulls, i, true)
 					}
 				}
@@ -148,7 +148,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, int(inputLen))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(inputLen)) {
 						_FIND_ANY_NOT_NULL(a, nulls, i, false)
 					}
 				}

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -214,7 +214,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					col = _FROM_TYPE_SLICE(col, 0, int(n))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(n)) {
 						if vecNulls.NullAt(uint16(i)) {
 							projNulls.SetNull(uint16(i))
 						} else {
@@ -236,7 +236,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					col = _FROM_TYPE_SLICE(col, 0, int(n))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(n)) {
 						v := _FROM_TYPE_UNSAFEGET(col, int(i))
 						var r _GOTYPE
 						_ASSIGN_CAST(r, v)

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -110,7 +110,7 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = execgen.SLICE(col, 0, int(n))
-				for execgen.RANGE(i, col) {
+				for execgen.RANGE(i, col, 0, int(n)) {
 					execgen.SET(col, i, c.constVal)
 				}
 			}

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -268,14 +268,14 @@ func (p *sortedDistinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 		// Bounds check elimination.
 		col = execgen.SLICE(col, 0, int(n))
 		outputCol = outputCol[:n]
-		_ = outputCol[execgen.LEN(col)-1]
+		_ = outputCol[n-1]
 		if nulls != nil {
-			for execgen.RANGE(checkIdx, col) {
+			for execgen.RANGE(checkIdx, col, 0, int(n)) {
 				outputIdx := checkIdx
 				_CHECK_DISTINCT_WITH_NULLS(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
-			for execgen.RANGE(checkIdx, col) {
+			for execgen.RANGE(checkIdx, col, 0, int(n)) {
 				outputIdx := checkIdx
 				_CHECK_DISTINCT(checkIdx, outputIdx, lastVal, col, outputCol)
 			}
@@ -334,12 +334,12 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n uint
 	outputCol = outputCol[:n]
 	outputCol[0] = true
 	if nulls != nil {
-		for execgen.RANGE(checkIdx, col) {
+		for execgen.RANGE(checkIdx, col, 0, int(n)) {
 			outputIdx := checkIdx
 			_CHECK_DISTINCT_WITH_NULLS(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol)
 		}
 	} else {
-		for execgen.RANGE(checkIdx, col) {
+		for execgen.RANGE(checkIdx, col, 0, int(n)) {
 			outputIdx := checkIdx
 			_CHECK_DISTINCT(checkIdx, outputIdx, lastVal, col, outputCol)
 		}

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -71,8 +71,13 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 	},
 	{
 		templatePlaceholder: "execgen.RANGE",
-		numArgs:             2,
+		numArgs:             4,
 		replaceWith:         "Range",
+	},
+	{
+		templatePlaceholder: "execgen.WINDOW",
+		numArgs:             3,
+		replaceWith:         "Window",
 	},
 }
 

--- a/pkg/sql/colexec/execgen/placeholders.go
+++ b/pkg/sql/colexec/execgen/placeholders.go
@@ -26,6 +26,7 @@ var (
 	_ = LEN
 	_ = ZERO
 	_ = RANGE
+	_ = WINDOW
 )
 
 // UNSAFEGET is a template function. Use this if you are not keeping data around
@@ -81,7 +82,13 @@ func ZERO(target interface{}) {
 }
 
 // RANGE is a template function.
-func RANGE(loopVariableIdent interface{}, target interface{}) bool {
+func RANGE(loopVariableIdent, target, start, end interface{}) bool {
 	execerror.VectorizedInternalPanic(nonTemplatePanic)
 	return false
+}
+
+// WINDOW is a template function.
+func WINDOW(target, start, end interface{}) interface{} {
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return nil
 }

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -649,7 +649,7 @@ func (builder *hashJoinBuilder) exec(ctx context.Context) {
 		batchSize := uint16(batchEnd - batchStart)
 
 		for i := 0; i < nKeyCols; i++ {
-			builder.ht.keys[i] = builder.ht.vals[builder.ht.keyCols[i]].Slice(builder.ht.valTypes[builder.ht.keyCols[i]], batchStart, batchEnd)
+			builder.ht.keys[i] = builder.ht.vals[builder.ht.keyCols[i]].Window(builder.ht.valTypes[builder.ht.keyCols[i]], batchStart, batchEnd)
 		}
 
 		builder.ht.lookupInitial(ctx, batchSize, nil)

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -176,7 +176,7 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, int(inputLen))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(inputLen)) {
 						_ACCUMULATE_MINMAX(a, nulls, i, true)
 					}
 				}
@@ -188,7 +188,7 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, int(inputLen))
-					for execgen.RANGE(i, col) {
+					for execgen.RANGE(i, col, 0, int(inputLen)) {
 						_ACCUMULATE_MINMAX(a, nulls, i, false)
 					}
 				}

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -131,9 +131,8 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 		}
 	} else {
 		col = execgen.SLICE(col, 0, int(n))
-		colLen := execgen.LEN(col)
-		_ = _RET_UNSAFEGET(projCol, colLen-1)
-		for execgen.RANGE(i, col) {
+		_ = _RET_UNSAFEGET(projCol, int(n)-1)
+		for execgen.RANGE(i, col, 0, int(n)) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	}

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -137,7 +137,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 		colLen := execgen.LEN(col1)
 		_ = _RET_UNSAFEGET(projCol, colLen-1)
 		_ = _R_UNSAFEGET(col2, colLen-1)
-		for execgen.RANGE(i, col1) {
+		for execgen.RANGE(i, col1, 0, int(n)) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	}

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -226,7 +226,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				batch.SetSelection(true)
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, int(n))
-				for execgen.RANGE(i, col) {
+				for execgen.RANGE(i, col, 0, int(n)) {
 					v := execgen.UNSAFEGET(col, i)
 					if !nulls.NullAt(uint16(i)) && cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
@@ -248,7 +248,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				batch.SetSelection(true)
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, int(n))
-				for execgen.RANGE(i, col) {
+				for execgen.RANGE(i, col, 0, int(n)) {
 					v := execgen.UNSAFEGET(col, i)
 					if cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
@@ -307,7 +307,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = execgen.SLICE(col, 0, int(n))
-			for execgen.RANGE(i, col) {
+			for execgen.RANGE(i, col, 0, int(n)) {
 				if nulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
@@ -335,7 +335,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = execgen.SLICE(col, 0, int(n))
-			for execgen.RANGE(i, col) {
+			for execgen.RANGE(i, col, 0, int(n)) {
 				v := execgen.UNSAFEGET(col, i)
 				cmpRes := cmpIn_TYPE(v, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -92,7 +92,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		batch.SetSelection(true)
 		sel := batch.Selection()
 		col = execgen.SLICE(col, 0, int(n))
-		for execgen.RANGE(i, col) {
+		for execgen.RANGE(i, col, 0, int(n)) {
 			var cmp bool
 			arg := execgen.UNSAFEGET(col, i)
 			_ASSIGN_CMP("cmp", "arg", "p.constArg")
@@ -140,7 +140,7 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 		col1 = execgen.SLICE(col1, 0, int(n))
 		col1Len := execgen.LEN(col1)
 		col2 = _R_SLICE(col2, 0, col1Len)
-		for execgen.RANGE(i, col1) {
+		for execgen.RANGE(i, col1, 0, int(n)) {
 			var cmp bool
 			arg1 := execgen.UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -392,9 +392,9 @@ func (s *chunker) spool(ctx context.Context) {
 func (s *chunker) getValues(i int) coldata.Vec {
 	switch s.readFrom {
 	case chunkerReadFromBuffer:
-		return s.bufferedColumns[i].Slice(s.inputTypes[i], 0 /* start */, s.buffered)
+		return s.bufferedColumns[i].Window(s.inputTypes[i], 0 /* start */, s.buffered)
 	case chunkerReadFromBatch:
-		return s.batch.ColVec(i).Slice(s.inputTypes[i], s.chunks[s.chunksStartIdx], s.chunks[len(s.chunks)-1])
+		return s.batch.ColVec(i).Window(s.inputTypes[i], s.chunks[s.chunksStartIdx], s.chunks[len(s.chunks)-1])
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getValues: %v", s.state))
 		// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1123,7 +1123,7 @@ func (c *chunkingBatchSource) Next(context.Context) coldata.Batch {
 		lastIdx = c.len
 	}
 	for i, vec := range c.batch.ColVecs() {
-		vec.SetCol(c.cols[i].Slice(c.typs[i], c.curIdx, lastIdx).Col())
+		vec.SetCol(c.cols[i].Window(c.typs[i], c.curIdx, lastIdx).Col())
 		nullsSlice := c.cols[i].Nulls().Slice(c.curIdx, lastIdx)
 		vec.SetNulls(&nullsSlice)
 	}

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -333,8 +333,8 @@ func TestOutboxInbox(t *testing.T) {
 				for i := range typs {
 					require.Equal(
 						t,
-						inputBatch.ColVec(i).Slice(typs[i], 0, uint64(inputBatch.Length())),
-						outputBatch.ColVec(i).Slice(typs[i], 0, uint64(outputBatch.Length())),
+						inputBatch.ColVec(i).Window(typs[i], 0, uint64(inputBatch.Length())),
+						outputBatch.ColVec(i).Window(typs[i], 0, uint64(outputBatch.Length())),
 						"batchNum: %d", batchNum,
 					)
 				}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1272,6 +1272,8 @@ func TestLint(t *testing.T) {
 				// for efficient hashing.
 				stream.GrepNot(`pkg/sql/colexec/hash.go:[0-9:]+: possible misuse of unsafe.Pointer`),
 				stream.GrepNot(`^#`), // comment line
+				// This exception is for the colexec generated files.
+				stream.GrepNot(`pkg/sql/colexec/.*\.eg.go:[0-9:]+: self-assignment of .* to .*`),
 			})
 		}
 		printfuncs := strings.Join([]string{


### PR DESCRIPTION
Slice method has been very tricky to get right, so we decided to remove
it from flat bytes implementation. Instead, we're introducing 'Window'
method that allows for specifying a "window" into the Bytes, but the
returned object is not allowed to be modified. In a similar vein,
Vec.Slice has been renamed to Vec.Window.

Fixes: #42670.

Release note: None