### PR TITLE
build: Pass GITHUB_API_TOKEN into github-pull-request-make

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -24,7 +24,7 @@ fi
 
 tc_start_block "Ensure dependencies are up-to-date"
 run build/builder.sh go install ./vendor/github.com/golang/dep/cmd/dep ./pkg/cmd/github-pull-request-make
-run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps github-pull-request-make
+runlogged "build/builder.sh ... github-pull-request-make" build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps github-pull-request-make
 tc_end_block "Ensure dependencies are up-to-date"
 
 tc_start_block "Ensure generated code is up-to-date"

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -24,6 +24,13 @@ run() {
   "$@"
 }
 
+runlogged() {
+  echo "$1"
+  shift
+  "$@"
+}
+
+
 # Returns the list of release branches from origin (origin/release-*), ordered
 # by version (higher version numbers first).
 get_release_branches() {


### PR DESCRIPTION
The lint tests were getting IP rate-limited by GitHub since it didn't have an
API token to pass along. The TC build step provides a restricted-use token via
the environment, but we need to pass it through to the builder invocation.

Release note: None