### PR TITLE
opt: support negating columns in tuple comparisons

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/tuple
+++ b/pkg/sql/opt/idxconstraint/testdata/tuple
@@ -361,6 +361,54 @@ index-constraints vars=(int, int, int) index=(@1 not null, @2 not null)
 [ - /1/2]
 Remaining filter: (@1, @2, @3) <= (1, 2, 3)
 
+# Negated columns.
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(@1, -@2, @3) >= (1, 2, 3)
+----
+[/1/-2/3 - ]
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(-@1, @2, -@3) >= (1, 2, 3)
+----
+[ - /-1/2/-3]
+Remaining filter: (-@1, @2, -@3) >= (1, 2, 3)
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(@1, -@2, -@3) >= (1, 2, 3)
+----
+[/1/-2 - ]
+Remaining filter: (@1, -@2, -@3) >= (1, 2, 3)
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(@1, -@2, -@3) > (1, 2, 3)
+----
+[/1/-2 - ]
+Remaining filter: (@1, -@2, -@3) > (1, 2, 3)
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(-@1, @2, @3) >= (1, 2, 3)
+----
+[ - /-1/2]
+Remaining filter: (-@1, @2, @3) >= (1, 2, 3)
+
+index-constraints vars=(int, int, int) index=(@1, @2 desc, @3)
+(-@1, -@2, @3) >= (1, 2, 3)
+----
+[ - /-1]
+Remaining filter: (-@1, -@2, @3) >= (1, 2, 3)
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3)
+(-@1, -@2, @3) >= (1, 2, 3)
+----
+[/-1/-2/3 - ]
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3)
+(@1, @2, -@3) >= (1, 2, 3)
+----
+[ - /1/2/-3]
+Remaining filter: (@1, @2, -@3) >= (1, 2, 3)
+
 # Cases with NULLs in tuple inequalities. These conditions are true only when
 # they don't depend on the NULL value, i.e. when the inequality holds true for
 # the prefix up to the first NULL.

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -691,3 +691,56 @@ SELECT * FROM check_constraint_validity WHERE a > 6
 scan check_constraint_validity@secondary
  ├── columns: a:1(int!null)
  └── constraint: /1/2: [/7 - /19]
+
+exec-ddl
+CREATE TABLE varied_ascendingness (
+    a INT, b INT, c INT,
+    INDEX (a ASC, b DESC, c ASC)
+)
+----
+
+opt
+SELECT * FROM varied_ascendingness where (a, -b, c) > (0, 0, 0)
+----
+scan varied_ascendingness@secondary
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ └── constraint: /1/-2/3/4: [/0/0/1 - ]
+
+opt
+SELECT * FROM varied_ascendingness where (a, -b, c) < (0, 0, 0)
+----
+select
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── scan varied_ascendingness@secondary
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │    └── constraint: /1/-2/3/4: (/NULL - /0/0/-1]
+ └── filters
+      └── (a, -b, c) < (0, 0, 0) [type=bool, outer=(1-3)]
+
+opt
+SELECT * FROM varied_ascendingness where (a, -b, c) = (0, 0, 0)
+----
+select
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ ├── fd: ()-->(1,3)
+ ├── scan varied_ascendingness@secondary
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │    ├── constraint: /1/-2/3/4: [/0 - /0]
+ │    └── fd: ()-->(1)
+ └── filters
+      ├── (-b) = 0 [type=bool, outer=(2)]
+      └── c = 0 [type=bool, outer=(3), constraints=(/3: [/0 - /0]; tight), fd=()-->(3)]
+
+opt
+SELECT * FROM varied_ascendingness where (a, -b, c) = (0, 0, 0)
+----
+select
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ ├── fd: ()-->(1,3)
+ ├── scan varied_ascendingness@secondary
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │    ├── constraint: /1/-2/3/4: [/0 - /0]
+ │    └── fd: ()-->(1)
+ └── filters
+      ├── (-b) = 0 [type=bool, outer=(2)]
+      └── c = 0 [type=bool, outer=(3), constraints=(/3: [/0 - /0]; tight), fd=()-->(3)]


### PR DESCRIPTION
This change allows us to generate index constraints for tuple
comparisons with negated columns on the LHS. For example, prior, we
supported:

  SELECT ... WHERE (a, b, c) >= (1, 2, 3)

but if the index on `b`'s ascendingness was different from that of `a`
and `c`, there was no way to express this inequality in a way that would
be able to constrain the index. Now, given a query of the form

  SELECT ... WHERE (a, -b, c) >= (1, -2, 3)

we can generate index constraints.

I found this a little brain bending so I tested the correctness by
generating a bunch of queries of the form:

```
CREATE TABLE tab (a int NOT NULL, b int NOT NULL, c int NOT NULL, INDEX abc (a, b desc, c));

SELECT count(*) FROM
  (
   (
    (SELECT * FROM tab@primary WHERE %[1]s)
    EXCEPT ALL
    (SELECT * FROM tab@abc WHERE %[1]s)
   )
   UNION ALL
   (
    (SELECT * FROM tab@abc WHERE %[1]s)
    EXCEPT ALL
    (SELECT * FROM tab@primary WHERE %[1]s)
   )
  );
```

Generating various inequalities (and equalities) as filters, and didn't
encounter any discrepancies (program here:
https://gist.github.com/justinj/f2087aa9be9f9e5bc61701c685847f01).

Note that this is not sufficiently expressive in the general case, since it's only valid for data types which are negatable.

Release note (sql change): column names in tuple inequalities can now be
negated to express descendingness.