### PR TITLE
roachtest: fix jepsen grep

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -239,7 +239,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException `+
 				// And one more ssh failure we've seen, apparently encountered when
 				// downloading logs.
-				`-e "clojure.lang.ExceptionInfo: clj-ssh scp failure "`+
+				`-e "clojure.lang.ExceptionInfo: clj-ssh scp failure" `+
 				// And sometimes the analysis succeeds and yet we still get an error code for some reason.
 				`-e "Everything looks good"`,
 		); err == nil {


### PR DESCRIPTION
In a previous patch I had botched the grep cmd line.

Release note: None