### PR TITLE
opt: add support for numeric references in mutations

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -109,7 +109,7 @@ create_stmt ::=
 	| create_stats_stmt
 
 delete_stmt ::=
-	opt_with_clause 'DELETE' 'FROM' table_name_expr_opt_alias_idx opt_where_clause opt_sort_clause opt_limit_clause returning_clause
+	opt_with_clause 'DELETE' 'FROM' table_expr_opt_alias_idx opt_where_clause opt_sort_clause opt_limit_clause returning_clause
 
 drop_stmt ::=
 	drop_ddl_stmt
@@ -197,7 +197,7 @@ truncate_stmt ::=
 	'TRUNCATE' opt_table relation_expr_list opt_drop_behavior
 
 update_stmt ::=
-	opt_with_clause 'UPDATE' table_name_expr_opt_alias_idx 'SET' set_clause_list opt_from_list opt_where_clause opt_sort_clause opt_limit_clause returning_clause
+	opt_with_clause 'UPDATE' table_expr_opt_alias_idx 'SET' set_clause_list opt_from_list opt_where_clause opt_sort_clause opt_limit_clause returning_clause
 
 upsert_stmt ::=
 	opt_with_clause 'UPSERT' 'INTO' insert_target insert_rest returning_clause
@@ -350,10 +350,10 @@ opt_with_clause ::=
 	with_clause
 	| 
 
-table_name_expr_opt_alias_idx ::=
-	table_name_expr_with_index
-	| table_name_expr_with_index table_alias_name
-	| table_name_expr_with_index 'AS' table_alias_name
+table_expr_opt_alias_idx ::=
+	table_name_opt_idx
+	| table_name_opt_idx table_alias_name
+	| table_name_opt_idx 'AS' table_alias_name
 
 opt_where_clause ::=
 	where_clause
@@ -1054,7 +1054,7 @@ with_clause ::=
 	'WITH' cte_list
 	| 'WITH' 'RECURSIVE' cte_list
 
-table_name_expr_with_index ::=
+table_name_opt_idx ::=
 	table_name opt_index_flags
 
 where_clause ::=

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -600,7 +600,7 @@ var specs = []stmtSpec{
 	},
 	{
 		name:   "delete_stmt",
-		inline: []string{"opt_with_clause", "with_clause", "cte_list", "table_name_expr_opt_alias_idx", "table_name_expr_with_index", "opt_where_clause", "where_clause", "returning_clause", "opt_sort_clause", "opt_limit_clause"},
+		inline: []string{"opt_with_clause", "with_clause", "cte_list", "table_expr_opt_alias_idx", "table_name_opt_idx", "opt_where_clause", "where_clause", "returning_clause", "opt_sort_clause", "opt_limit_clause"},
 		replace: map[string]string{
 			"relation_expr": "table_name",
 		},
@@ -1272,8 +1272,8 @@ var specs = []stmtSpec{
 			"opt_with_clause",
 			"with_clause",
 			"cte_list",
-			"table_name_expr_opt_alias_idx",
-			"table_name_expr_with_index",
+			"table_expr_opt_alias_idx",
+			"table_name_opt_idx",
 			"set_clause_list",
 			"set_clause",
 			"single_set_clause",

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -116,6 +116,76 @@ col1  col2  col3
 2     20    200
 3     30    300
 
+statement OK
+UPSERT INTO [$num_ref_id AS num_ref_alias] VALUES (4, 40, 400)
+
+statement OK
+INSERT INTO [$num_ref_id(1) AS num_ref_alias] VALUES (5)
+
+query III rowsort
+SELECT * FROM [$num_ref_id as num_ref_alias]
+----
+1     10    101
+2     20    200
+3     30    300
+4     40    400
+5     NULL  NULL
+
+statement OK
+DELETE FROM [$num_ref_id AS num_ref_alias]@bc WHERE @1=5
+
+query I
+DELETE FROM [$num_ref_id AS num_ref_alias] WHERE d=40 RETURNING num_ref_alias.c
+----
+400
+
+query III rowsort
+SELECT * FROM [$num_ref_id AS num_ref_alias]
+----
+1     10    101
+2     20    200
+3     30    300
+
+statement OK
+INSERT INTO [$num_ref_id AS num_ref_alias] (p, c) VALUES (4, 400)
+
+query I
+INSERT INTO [$num_ref_id(1,4) AS num_ref_alias] VALUES (5, 500) RETURNING num_ref_alias.d
+----
+NULL
+
+query III rowsort
+SELECT * FROM [$num_ref_id AS num_ref_alias]
+----
+1     10    101
+2     20    200
+3     30    300
+4     NULL  400
+5     NULL  500
+
+query I
+UPDATE [$num_ref_id AS num_ref_alias] SET d=40 WHERE p=4 RETURNING num_ref_alias.c
+----
+400
+
+query III rowsort
+SELECT * FROM [$num_ref_id AS num_ref_alias]
+----
+1     10    101
+2     20    200
+3     30    300
+4     40    400
+5     NULL  500
+
+statement error pq: cannot specify both a list of column IDs and a list of column names
+INSERT INTO [$num_ref_id(1,4) AS num_ref_alias] (p,c) VALUES (6, 600)
+
+statement error pq: cannot specify a list of column IDs with DELETE
+DELETE FROM [$num_ref_id(1) AS num_ref_alias]
+
+statement error pq: cannot specify a list of column IDs with UPDATE
+UPDATE [$num_ref_id(1) AS num_ref_alias] SET d=10
+
 let $num_ref_hidden_id
 SELECT id FROM system.namespace WHERE name='num_ref_hidden'
 
@@ -136,3 +206,12 @@ user testuser
 
 statement error pq: user testuser does not have SELECT privilege on relation num_ref
 SELECT * FROM [$num_ref_id AS t]
+
+statement error pq: user testuser does not have INSERT privilege on relation num_ref
+INSERT INTO [$num_ref_id AS t] VALUES (1)
+
+statement error pq: user testuser does not have DELETE privilege on relation num_ref
+DELETE FROM [$num_ref_id AS t]
+
+statement error pq: user testuser does not have UPDATE privilege on relation num_ref
+UPDATE [$num_ref_id AS t] SET d=1

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -120,6 +120,29 @@ func ResolveTableIndex(
 	return found, foundTabName, nil
 }
 
+// ConvertColumnIDsToOrdinals converts a list of ColumnIDs (such as from a
+// tree.TableRef), to a list of ordinal positions of columns within the given
+// table. See tree.Table for more information on column ordinals.
+func ConvertColumnIDsToOrdinals(tab Table, columns []tree.ColumnID) (ordinals []int) {
+	ordinals = make([]int, len(columns))
+	for i, c := range columns {
+		ord := 0
+		cnt := tab.ColumnCount()
+		for ord < cnt {
+			if tab.Column(ord).ColID() == StableID(c) {
+				break
+			}
+			ord++
+		}
+		if ord >= cnt {
+			panic(pgerror.Newf(pgcode.UndefinedColumn,
+				"column [%d] does not exist", c))
+		}
+		ordinals[i] = ord
+	}
+	return ordinals
+}
+
 // FindTableColumnByName returns the ordinal of the non-mutation column having
 // the given name, if one exists in the given table. Otherwise, it returns -1.
 func FindTableColumnByName(tab Table, name tree.Name) int {

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -11,7 +11,6 @@
 package optbuilder
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -39,22 +38,19 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 			"DELETE statement requires LIMIT when ORDER BY is used"))
 	}
 
-	// DELETE FROM xx AS yy - we want to know about xx (tn) because
-	// that's what we get the descriptor with, and yy (alias) because
-	// that's what RETURNING will use.
-	tn, alias := getAliasedTableName(del.Table)
-
 	// Find which table we're working on, check the permissions.
-	tab, resName := b.resolveTable(tn, privilege.DELETE)
-	if alias == nil {
-		alias = &resName
+	tab, depName, alias, refColumns := b.resolveTableForMutation(del.Table, privilege.DELETE)
+
+	if refColumns != nil {
+		panic(pgerror.Newf(pgcode.Syntax,
+			"cannot specify a list of column IDs with DELETE"))
 	}
 
 	// Check Select permission as well, since existing values must be read.
-	b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
+	b.checkPrivilege(depName, tab, privilege.SELECT)
 
 	var mb mutationBuilder
-	mb.init(b, "delete", tab, *alias)
+	mb.init(b, "delete", tab, alias)
 
 	// Build the input expression that selects the rows that will be deleted:
 	//

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1405,32 +1404,6 @@ func resultsNeeded(r tree.ReturningClause) bool {
 	default:
 		panic(errors.AssertionFailedf("unexpected ReturningClause type: %T", t))
 	}
-}
-
-// getAliasedTableName returns the underlying table name for a TableExpr that
-// could be either an alias or a normal table name. It also returns the alias,
-// if there is one.
-//
-// This is not meant to perform name resolution, but rather simply to extract
-// the name indicated after FROM in DELETE/INSERT/UPDATE/UPSERT.
-func getAliasedTableName(n tree.TableExpr) (*tree.TableName, *tree.TableName) {
-	var alias *tree.TableName
-	if ate, ok := n.(*tree.AliasedTableExpr); ok {
-		n = ate.Expr
-		// It's okay to ignore the As columns here, as they're not permitted in
-		// DML aliases where this function is used. The grammar does not allow
-		// them, so the parser would have reported an error if they were present.
-		if ate.As.Alias != "" {
-			alias = tree.NewUnqualifiedTableName(ate.As.Alias)
-		}
-	}
-	tn, ok := n.(*tree.TableName)
-	if !ok {
-		panic(unimplemented.New(
-			"complex table expression in UPDATE/DELETE",
-			"cannot use a complex table name with DELETE/UPDATE"))
-	}
-	return tn, alias
 }
 
 // checkDatumTypeFitsColumnType verifies that a given scalar value type is valid

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1045,6 +1045,15 @@ func TestParse(t *testing.T) {
 		{`SELECT * FROM t@[123]`},
 		{`SELECT * FROM [123 AS t]@[456]`},
 
+		{`INSERT INTO [123 AS t] VALUES (1)`},
+		{`INSERT INTO [123(1, 2) AS t] VALUES (1, 2)`},
+		{`INSERT INTO [123 AS t](col1, col2) VALUES (1, 2)`},
+		{`UPSERT INTO [123 AS t] VALUES (1)`},
+		{`UPDATE [123 AS t] SET b = 3`},
+		{`UPDATE [123 AS t]@idx SET b = 3`},
+		{`DELETE FROM [123 AS t]`},
+		{`DELETE FROM [123 AS t]@idx`},
+
 		{`SELECT (1 + 2).*`},
 		{`SELECT (1 + 2).col`},
 		{`SELECT (abc.def).col`},

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -111,7 +111,7 @@ func NewRelationAlreadyExistsError(name string) error {
 }
 
 // NewWrongObjectTypeError creates a wrong object type error.
-func NewWrongObjectTypeError(name *tree.TableName, desiredObjType string) error {
+func NewWrongObjectTypeError(name tree.NodeFormatter, desiredObjType string) error {
 	return pgerror.Newf(pgcode.WrongObjectType, "%q is not a %s",
 		tree.ErrString(name), desiredObjType)
 }


### PR DESCRIPTION
Fixes #42550.

This commit adds parsing and optbuilder support for referring to tables
in mutation statements using their numeric reference ID, using syntax
such as the following:

``` INSERT INTO [53 AS foo] VALUES (1, 2, 3) ```

It mirrors the behaviour of numeric references in SELECT statements as
much as possible while still making sense (for instance, it only
supports referencing columns by ID in the INSERT case).

Release note (sql change): It is now possible to reference tables by
table descriptor ID in mutations (INSERT/UPSERT/UPDATE/DELETE), in a
similar way to what is already allowed in SELECT statements. The
following syntax is an example:

``` INSERT INTO [53 AS foo] VALUES (1, 2, 3) ```