### PR TITLE
colexec: track more memory via the Allocator

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -130,6 +130,12 @@ type Vec interface {
 	// SetLength sets the length of the slice that is underlying this Vec. Note
 	// that the length of the batch which this Vec belongs to "takes priority".
 	SetLength(int)
+
+	// Capacity returns the capacity of the Golang's slice that is underlying
+	// this Vec. Note that if there is no "slice" (like in case of flat bytes),
+	// the "capacity" of such object is undefined, so is the behavior of this
+	// method.
+	Capacity() int
 }
 
 var _ Vec = &memColumn{}
@@ -269,6 +275,29 @@ func (m *memColumn) SetLength(l int) {
 		m.col = m.col.([]apd.Decimal)[:l]
 	case coltypes.Timestamp:
 		m.col = m.col.([]time.Time)[:l]
+	default:
+		panic(fmt.Sprintf("unhandled type %s", m.t))
+	}
+}
+
+func (m *memColumn) Capacity() int {
+	switch m.t {
+	case coltypes.Bool:
+		return cap(m.col.([]bool))
+	case coltypes.Bytes:
+		panic("Capacity should not be called on Vec of Bytes type")
+	case coltypes.Int16:
+		return cap(m.col.([]int16))
+	case coltypes.Int32:
+		return cap(m.col.([]int32))
+	case coltypes.Int64:
+		return cap(m.col.([]int64))
+	case coltypes.Float64:
+		return cap(m.col.([]float64))
+	case coltypes.Decimal:
+		return cap(m.col.([]apd.Decimal))
+	case coltypes.Timestamp:
+		return cap(m.col.([]time.Time))
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -312,7 +312,8 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 			// We still have overflow output values.
 			a.scratch.SetLength(uint16(a.scratch.outputSize))
 			for i := 0; i < len(a.outputTypes); i++ {
-				a.unsafeBatch.ColVec(i).Copy(
+				a.allocator.Copy(
+					a.unsafeBatch.ColVec(i),
 					coldata.CopySliceArgs{
 						SliceArgs: coldata.SliceArgs{
 							Src:         a.scratch.ColVec(i),
@@ -365,7 +366,8 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 	if a.scratch.resumeIdx > a.scratch.outputSize {
 		a.scratch.SetLength(uint16(a.scratch.outputSize))
 		for i := 0; i < len(a.outputTypes); i++ {
-			a.unsafeBatch.ColVec(i).Copy(
+			a.allocator.Copy(
+				a.unsafeBatch.ColVec(i),
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
 						Src:         a.scratch.ColVec(i),

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -193,7 +193,7 @@ func NewOrderedAggregator(
 		isScalar:  isScalar,
 	}
 
-	a.aggregateFuncs, a.outputTypes, err = makeAggregateFuncs(aggTypes, aggFns)
+	a.aggregateFuncs, a.outputTypes, err = makeAggregateFuncs(a.allocator, aggTypes, aggFns)
 
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ func NewOrderedAggregator(
 }
 
 func makeAggregateFuncs(
-	aggTyps [][]coltypes.T, aggFns []execinfrapb.AggregatorSpec_Func,
+	allocator *Allocator, aggTyps [][]coltypes.T, aggFns []execinfrapb.AggregatorSpec_Func,
 ) ([]aggregateFunc, []coltypes.T, error) {
 	funcs := make([]aggregateFunc, len(aggFns))
 	outTyps := make([]coltypes.T, len(aggFns))
@@ -212,7 +212,7 @@ func makeAggregateFuncs(
 		var err error
 		switch aggFns[i] {
 		case execinfrapb.AggregatorSpec_ANY_NOT_NULL:
-			funcs[i], err = newAnyNotNullAgg(aggTyps[i][0])
+			funcs[i], err = newAnyNotNullAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_AVG:
 			funcs[i], err = newAvgAgg(aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_SUM, execinfrapb.AggregatorSpec_SUM_INT:
@@ -222,9 +222,9 @@ func makeAggregateFuncs(
 		case execinfrapb.AggregatorSpec_COUNT:
 			funcs[i] = newCountAgg()
 		case execinfrapb.AggregatorSpec_MIN:
-			funcs[i], err = newMinAgg(aggTyps[i][0])
+			funcs[i], err = newMinAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_MAX:
-			funcs[i], err = newMaxAgg(aggTyps[i][0])
+			funcs[i], err = newMaxAgg(allocator, aggTyps[i][0])
 		default:
 			return nil, nil, errors.Errorf("unsupported columnar aggregate function %s", aggFns[i].String())
 		}

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -78,23 +78,29 @@ func (a *Allocator) AppendColumn(b coldata.Batch, t coltypes.T) {
 	b.AppendCol(col)
 }
 
-// performOperation executes 'operation' (that somehow modifies 'dest') and
+// performOperation executes 'operation' (that somehow modifies 'destVecs') and
 // updates the memory account accordingly.
-func (a *Allocator) performOperation(dest coldata.Vec, operation func()) {
+func (a *Allocator) performOperation(destVecs []coldata.Vec, operation func()) {
 	var before, after, delta int64
-	// To simplify the accounting, we perform the operation first and then will
-	// update the memory account. The minor "drift" in accounting that is caused
-	// by this approach is ok.
-	if dest.Type() == coltypes.Bytes {
-		before = int64(dest.Bytes().Size())
-	} else {
-		before = int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Length()))
+	for _, dest := range destVecs {
+		// To simplify the accounting, we perform the operation first and then will
+		// update the memory account. The minor "drift" in accounting that is
+		// caused by this approach is ok.
+		if dest.Type() == coltypes.Bytes {
+			before += int64(dest.Bytes().Size())
+		} else {
+			before += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
+		}
 	}
+
 	operation()
-	if dest.Type() == coltypes.Bytes {
-		after = int64(dest.Bytes().Size())
-	} else {
-		after = int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Length()))
+
+	for _, dest := range destVecs {
+		if dest.Type() == coltypes.Bytes {
+			after += int64(dest.Bytes().Size())
+		} else {
+			after += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
+		}
 	}
 	delta = after - before
 	if delta >= 0 {
@@ -109,16 +115,15 @@ func (a *Allocator) performOperation(dest coldata.Vec, operation func()) {
 // Append appends elements of a source coldata.Vec into dest according to
 // coldata.SliceArgs.
 func (a *Allocator) Append(dest coldata.Vec, args coldata.SliceArgs) {
-	a.performOperation(dest, func() { dest.Append(args) })
+	a.performOperation([]coldata.Vec{dest}, func() { dest.Append(args) })
 }
 
 // Copy copies elements of a source coldata.Vec into dest according to
 // coldata.CopySliceArgs.
 func (a *Allocator) Copy(dest coldata.Vec, args coldata.CopySliceArgs) {
-	a.performOperation(dest, func() { dest.Copy(args) })
+	a.performOperation([]coldata.Vec{dest}, func() { dest.Copy(args) })
 }
 
-// TODO(yuzefovich): execgen.SET needs to also go through the Allocator.
 // TODO(yuzefovich): extend Allocator so that it could free up the memory (and
 // resize the memory account accordingly) when the caller is done with the
 // batches.
@@ -150,14 +155,13 @@ func estimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 		case coltypes.Bool:
 			acc += sizeOfBool
 		case coltypes.Bytes:
-			// TODO(yuzefovich): we actually do not allocate any memory for b.data
-			// when calling NewBytes(), so remove this estimation once execgen.SET is
-			// handled by the Allocator.
-
-			// We don't know without looking at the data in a batch to see how
-			// much space each byte array takes up. Use some default value as a
-			// heuristic right now.
-			acc += 100
+			// For byte arrays, we initially allocate BytesInitialAllocationFactor
+			// number of bytes (plus an int32 for the offset) for each row, so we use
+			// the sum of two values as the estimate. However, later, the exact
+			// memory footprint will be used: whenever a modification of Bytes takes
+			// place, the Allocator will measure the old footprint and the updated
+			// one and will update the memory account accordingly.
+			acc += coldata.BytesInitialAllocationFactor + sizeOfInt32
 		case coltypes.Int16:
 			acc += sizeOfInt16
 		case coltypes.Int32:

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -108,7 +108,7 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 
 	// Write each column into the output batch.
 	for idx, ct := range columnTypes {
-		err := EncDatumRowsToColVec(c.buffered[:nRows], c.batch.ColVec(idx), idx, &ct, &c.da)
+		err := EncDatumRowsToColVec(c.allocator, c.buffered[:nRows], c.batch.ColVec(idx), idx, &ct, &c.da)
 		if err != nil {
 			execerror.VectorizedInternalPanic(err)
 		}

--- a/pkg/sql/colexec/deselector.go
+++ b/pkg/sql/colexec/deselector.go
@@ -59,7 +59,8 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 	for i, t := range p.inputTypes {
 		toCol := p.output.ColVec(i)
 		fromCol := batch.ColVec(i)
-		toCol.Copy(
+		p.allocator.Copy(
+			toCol,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
 					ColType:   t,

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -118,7 +118,7 @@ func NewHashAggregator(
 		},
 	)
 
-	funcs, outTyps, err := makeAggregateFuncs(aggTyps, aggFns)
+	funcs, outTyps, err := makeAggregateFuncs(allocator, aggTyps, aggFns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -246,7 +246,8 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 	for i, colIdx := range op.ht.outCols {
 		toCol := op.batch.ColVec(i)
 		fromCol := op.ht.vals[colIdx]
-		toCol.Copy(
+		op.ht.allocator.Copy(
+			toCol,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
 					ColType:     op.ht.valTypes[op.ht.outCols[i]],

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -319,7 +319,8 @@ func (hj *hashJoinEqOp) emitUnmatched() {
 		valCol := hj.ht.vals[inColIdx]
 		colType := hj.ht.valTypes[inColIdx]
 
-		outCol.Copy(
+		hj.allocator.Copy(
+			outCol,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
 					ColType:   colType,
@@ -980,7 +981,8 @@ func (prober *hashJoinProber) congregate(nResults uint16, batch coldata.Batch, b
 			// Note that if for some index i, probeRowUnmatched[i] is true, then
 			// prober.buildIdx[i] == 0 which will copy the garbage zeroth row of the
 			// hash table, but we will set the NULL value below.
-			outCol.Copy(
+			prober.ht.allocator.Copy(
+				outCol,
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
 						ColType:   colType,
@@ -1007,7 +1009,8 @@ func (prober *hashJoinProber) congregate(nResults uint16, batch coldata.Batch, b
 		valCol := batch.ColVec(int(inColIdx))
 		colType := prober.spec.sourceTypes[inColIdx]
 
-		outCol.Copy(
+		prober.ht.allocator.Copy(
+			outCol,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
 					ColType:   colType,

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -743,30 +743,35 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildLeftGroups(
 	sel := batch.Selection()
 	initialBuilderState := o.builderState.left
 	outputBatchSize := int(o.outputBatchSize)
-	// Loop over every column.
-LeftColLoop:
-	for outColIdx, inColIdx := range input.outCols {
-		outStartIdx := int(destStartIdx)
-		out := o.output.ColVec(outColIdx)
-		src := batch.ColVec(int(inColIdx))
-		colType := input.sourceTypes[inColIdx]
+	o.allocator.performOperation(
+		o.output.ColVecs()[:len(input.outCols)],
+		func() {
+			// Loop over every column.
+		LeftColLoop:
+			for outColIdx, inColIdx := range input.outCols {
+				outStartIdx := int(destStartIdx)
+				out := o.output.ColVec(outColIdx)
+				src := batch.ColVec(int(inColIdx))
+				colType := input.sourceTypes[inColIdx]
 
-		if sel != nil {
-			if src.MaybeHasNulls() {
-				_LEFT_SWITCH(_JOIN_TYPE, true, true)
-			} else {
-				_LEFT_SWITCH(_JOIN_TYPE, true, false)
+				if sel != nil {
+					if src.MaybeHasNulls() {
+						_LEFT_SWITCH(_JOIN_TYPE, true, true)
+					} else {
+						_LEFT_SWITCH(_JOIN_TYPE, true, false)
+					}
+				} else {
+					if src.MaybeHasNulls() {
+						_LEFT_SWITCH(_JOIN_TYPE, false, true)
+					} else {
+						_LEFT_SWITCH(_JOIN_TYPE, false, false)
+					}
+				}
+				o.builderState.left.setBuilderColumnState(initialBuilderState)
 			}
-		} else {
-			if src.MaybeHasNulls() {
-				_LEFT_SWITCH(_JOIN_TYPE, false, true)
-			} else {
-				_LEFT_SWITCH(_JOIN_TYPE, false, false)
-			}
-		}
-		o.builderState.left.setBuilderColumnState(initialBuilderState)
-	}
-	o.builderState.left.reset()
+			o.builderState.left.reset()
+		},
+	)
 }
 
 // {{ end }}
@@ -811,8 +816,6 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 					// Optimization in the case that group length is 1, use assign
 					// instead of copy.
 					if toAppend == 1 {
-						// TODO(yuzefovich): think about making execgen.SET set both the
-						// value and the null.
 						// {{ if _HAS_SELECTION }}
 						// {{ if _HAS_NULLS }}
 						if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
@@ -820,7 +823,20 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 						}
 						// {{ end }}
 						v := execgen.UNSAFEGET(srcCol, int(sel[o.builderState.right.curSrcStartIdx]))
-						execgen.SET(outCol, outStartIdx, v)
+						// We are in the fast path (we're setting a single element), so in
+						// order to not kill the performance, we only update the memory
+						// account in case of Bytes type (other types will not change the
+						// amount of memory accounted for).
+						// {{ if eq .LTyp.String "Bytes" }}
+						o.allocator.performOperation(
+							[]coldata.Vec{out},
+							func() {
+								// {{ end }}
+								execgen.SET(outCol, outStartIdx, v)
+								// {{ if eq .LTyp.String "Bytes" }}
+							},
+						)
+						// {{ end }}
 						// {{ else }}
 						// {{ if _HAS_NULLS }}
 						if src.Nulls().NullAt64(uint64(o.builderState.right.curSrcStartIdx)) {
@@ -828,7 +844,20 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 						}
 						// {{ end }}
 						v := execgen.UNSAFEGET(srcCol, o.builderState.right.curSrcStartIdx)
-						execgen.SET(outCol, outStartIdx, v)
+						// We are in the fast path (we're setting a single element), so in
+						// order to not kill the performance, we only update the memory
+						// account in case of Bytes type (other types will not change the
+						// amount of memory accounted for).
+						// {{ if eq .LTyp.String "Bytes" }}
+						o.allocator.performOperation(
+							[]coldata.Vec{out},
+							func() {
+								// {{ end }}
+								execgen.SET(outCol, outStartIdx, v)
+								// {{ if eq .LTyp.String "Bytes" }}
+							},
+						)
+						// {{ end }}
 						// {{ end }}
 					} else {
 						o.allocator.Copy(

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -831,7 +831,8 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 						execgen.SET(outCol, outStartIdx, v)
 						// {{ end }}
 					} else {
-						out.Copy(
+						o.allocator.Copy(
+							out,
 							coldata.CopySliceArgs{
 								SliceArgs: coldata.SliceArgs{
 									ColType:     colType,

--- a/pkg/sql/colexec/rowstovec_test.go
+++ b/pkg/sql/colexec/rowstovec_test.go
@@ -40,7 +40,7 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 	ct := types.Bool
 
 	// Test converting column 0.
-	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
+	if err := EncDatumRowsToColVec(testAllocator, rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
 	expected := testAllocator.NewMemColumn(coltypes.Bool, 2)
@@ -51,7 +51,7 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 	}
 
 	// Test converting column 1.
-	if err := EncDatumRowsToColVec(rows, vec, 1 /* columnIdx */, ct, &alloc); err != nil {
+	if err := EncDatumRowsToColVec(testAllocator, rows, vec, 1 /* columnIdx */, ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
 	expected.Bool()[0] = true
@@ -68,7 +68,7 @@ func TestEncDatumRowsToColVecInt16(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(42)}},
 	}
 	vec := testAllocator.NewMemColumn(coltypes.Int16, 2)
-	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, types.Int2, &alloc); err != nil {
+	if err := EncDatumRowsToColVec(testAllocator, rows, vec, 0 /* columnIdx */, types.Int2, &alloc); err != nil {
 		t.Fatal(err)
 	}
 	expected := testAllocator.NewMemColumn(coltypes.Int16, 2)
@@ -89,7 +89,7 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 	for _, width := range []int32{0, 25} {
 		ct := types.MakeString(width)
 		vec.Bytes().Reset()
-		if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
+		if err := EncDatumRowsToColVec(testAllocator, rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 			t.Fatal(err)
 		}
 		expected := testAllocator.NewMemColumn(coltypes.Bytes, 2)
@@ -117,7 +117,7 @@ func TestEncDatumRowsToColVecDecimal(t *testing.T) {
 	}
 	vec := testAllocator.NewMemColumn(coltypes.Decimal, 3)
 	ct := types.Decimal
-	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
+	if err := EncDatumRowsToColVec(testAllocator, rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(vec, expected) {

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -262,7 +262,8 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 		}
 
 		for j := 0; j < len(p.inputTypes); j++ {
-			p.output.ColVec(j).Copy(
+			p.allocator.Copy(
+				p.output.ColVec(j),
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
 						ColType:     p.inputTypes[j],

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -165,19 +165,24 @@ func (t *topKSorter) spool(ctx context.Context) {
 	for inputBatch.Length() > 0 {
 		t.updateComparators(inputVecIdx, inputBatch)
 		sel := inputBatch.Selection()
-		for i := inputBatchIdx; i < inputBatch.Length(); i++ {
-			idx := i
-			if sel != nil {
-				idx = sel[i]
-			}
-			maxIdx := t.heap[0]
-			if t.compareRow(inputVecIdx, topKVecIdx, idx, maxIdx) < 0 {
-				for j := range t.inputTypes {
-					t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
+		t.allocator.performOperation(
+			t.topK.ColVecs(),
+			func() {
+				for i := inputBatchIdx; i < inputBatch.Length(); i++ {
+					idx := i
+					if sel != nil {
+						idx = sel[i]
+					}
+					maxIdx := t.heap[0]
+					if t.compareRow(inputVecIdx, topKVecIdx, idx, maxIdx) < 0 {
+						for j := range t.inputTypes {
+							t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
+						}
+						heap.Fix(t, 0)
+					}
 				}
-				heap.Fix(t, 0)
-			}
-		}
+			},
+		)
 		inputBatch = t.input.Next(ctx)
 		inputBatchIdx = 0
 	}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -205,7 +205,8 @@ func (t *topKSorter) emit() coldata.Batch {
 	}
 	for i := range t.inputTypes {
 		vec := t.output.ColVec(i)
-		vec.Copy(
+		t.allocator.Copy(
+			vec,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
 					ColType:   t.inputTypes[i],

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -73,6 +73,8 @@ type vecComparator interface {
 
 	// set sets the value of the vector at dstVecIdx at index dstValIdx to the value
 	// at the vector at srcVecIdx at index srcValIdx.
+	// NOTE: whenever set is used, the caller is responsible for updating the
+	// memory accounts.
 	set(srcVecIdx, dstVecIdx int, srcValIdx, dstValIdx uint16)
 
 	// setVec updates the vector at idx.


### PR DESCRIPTION
**colexec: add Copy method to Allocator**

This commit adds Copy method to Allocator and updates all previous
usages of coldata.Vec.Copy to go through it.

Release note: None

**colexec: make sure that execgen.SETs are accounted for**

This commit make sure that all memory that is allocated during
execgen.SETs is tracked by the allocator. In order to do that
Allocator's performOperation primitive is used. In some cases, we have
a special casing for Bytes type so that the accounting doesn't impact
the fast path for other types (for which the memory account will not be
updated during SET).

Release note: None