### PR TITLE
storage: make queue timeouts dynamic and add cluster setting for snapshots

### DIFF
--- a/pkg/storage/queue_concurrency_test.go
+++ b/pkg/storage/queue_concurrency_test.go
@@ -30,6 +30,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+func constantTimeoutFunc(d time.Duration) func(replicaInQueue) time.Duration {
+	return func(replicaInQueue) time.Duration { return d }
+}
+
 // TestBaseQueueConcurrent verifies that under concurrent adds/removes of ranges
 // to the queue including purgatory errors and regular errors, the queue
 // invariants are upheld. The test operates on fake ranges and a mock queue
@@ -49,7 +53,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 		maxSize:              num / 2,
 		maxConcurrency:       4,
 		acceptsUnsplitRanges: true,
-		processTimeout:       time.Millisecond,
+		processTimeoutFunc:   constantTimeoutFunc(time.Millisecond),
 		// We don't care about these, but we don't want to crash.
 		successes:       metric.NewCounter(metric.Metadata{Name: "processed"}),
 		failures:        metric.NewCounter(metric.Metadata{Name: "failures"}),

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -864,7 +864,7 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
 		queueConfig{
 			maxSize:              1,
-			processTimeout:       time.Millisecond,
+			processTimeoutFunc:   constantTimeoutFunc(time.Millisecond),
 			acceptsUnsplitRanges: true,
 		})
 	bq.Start(stopper)
@@ -920,7 +920,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
 		queueConfig{
 			maxSize:              1,
-			processTimeout:       time.Millisecond,
+			processTimeoutFunc:   constantTimeoutFunc(time.Millisecond),
 			acceptsUnsplitRanges: true,
 		})
 	bq.Start(stopper)
@@ -930,7 +930,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 		if v := bq.successes.Count(); v != 1 {
 			return errors.Errorf("expected 1 processed replicas; got %d", v)
 		}
-		if min, v := bq.queueConfig.processTimeout, bq.processingNanos.Count(); v < min.Nanoseconds() {
+		if min, v := bq.queueConfig.processTimeoutFunc(nil), bq.processingNanos.Count(); v < min.Nanoseconds() {
 			return errors.Errorf("expected >= %s in processing time; got %s", min, time.Duration(v))
 		}
 		return nil

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -31,6 +32,24 @@ const (
 
 	raftSnapshotPriority float64 = 0
 )
+
+// raftSnapshotQueueMinimumTimeout is the minimum duration after which the
+// processing of the raft snapshot queue will time out. See the timeoutFunc
+// in newRaftSnapshotQueue.
+var raftSnapshotQueueMinimumTimeout = settings.RegisterDurationSetting(
+	// NB: this setting has a relatively awkward name because the linter does not
+	// permit `minimum_timeout` but rather asks for it to be `.minimum.timeout`.
+	"kv.raft_snapshot_queue.process.timeout_minimum",
+	"minimum duration after which the processing of the raft snapshot queue will "+
+		"time out; it is an escape hatch to raise the minimum timeout for sending "+
+		"a raft snapshot which is sent much more slowly than the allowable rate "+
+		"as specified by kv.snapshot_recovery.max_rate",
+	defaultProcessTimeout,
+)
+
+func init() {
+	raftSnapshotQueueMinimumTimeout.SetVisibility(settings.Reserved)
+}
 
 // raftSnapshotQueue manages a queue of replicas which may need to catch a
 // replica up with a snapshot to their range.
@@ -51,10 +70,35 @@ func newRaftSnapshotQueue(store *Store, g *gossip.Gossip) *raftSnapshotQueue {
 			needsLease:           false,
 			needsSystemConfig:    false,
 			acceptsUnsplitRanges: true,
-			successes:            store.metrics.RaftSnapshotQueueSuccesses,
-			failures:             store.metrics.RaftSnapshotQueueFailures,
-			pending:              store.metrics.RaftSnapshotQueuePending,
-			processingNanos:      store.metrics.RaftSnapshotQueueProcessingNanos,
+			// Create a timeout which is a function of the size of the range and the
+			// maximum allowed rate of data transfer that adheres to a minimum timeout
+			// specified in a cluster setting.
+			processTimeoutFunc: func(r replicaInQueue) (d time.Duration) {
+				minimumTimeout := raftSnapshotQueueMinimumTimeout.Get(&store.ClusterSettings().SV)
+				// NB: In production code this will type assertion will always succeed.
+				// Some tests set up a fake implementation of replicaInQueue in which
+				// case we fall back to the configured minimum timeout.
+				repl, ok := r.(*Replica)
+				if !ok {
+					return minimumTimeout
+				}
+				stats := repl.GetMVCCStats()
+				totalBytes := stats.KeyBytes + stats.ValBytes + stats.IntentBytes + stats.SysBytes
+				snapshotRecoveryRate := recoverySnapshotRate.Get(&store.ClusterSettings().SV)
+				estimatedDuration := time.Duration(totalBytes / snapshotRecoveryRate)
+				// Set a timeout to 1/10th of the allowed throughput.
+				const permittedSlowdown = 10
+				timeout := estimatedDuration * permittedSlowdown
+
+				if timeout < minimumTimeout {
+					timeout = minimumTimeout
+				}
+				return timeout
+			},
+			successes:       store.metrics.RaftSnapshotQueueSuccesses,
+			failures:        store.metrics.RaftSnapshotQueueFailures,
+			pending:         store.metrics.RaftSnapshotQueuePending,
+			processingNanos: store.metrics.RaftSnapshotQueueProcessingNanos,
 		},
 	)
 	return rq

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -248,7 +248,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 
 		log.VEventf(ctx, 1, "transferring r%d (%.2f qps) to s%d to better balance load",
 			replWithStats.repl.RangeID, replWithStats.qps, target.StoreID)
-		if err := contextutil.RunWithTimeout(ctx, "transfer lease", sr.rq.processTimeout, func(ctx context.Context) error {
+		if err := contextutil.RunWithTimeout(ctx, "transfer lease", sr.rq.processTimeoutFunc(replWithStats.repl), func(ctx context.Context) error {
 			return sr.rq.transferLease(ctx, replWithStats.repl, target, replWithStats.qps)
 		}); err != nil {
 			log.Errorf(ctx, "unable to transfer lease to s%d: %+v", target.StoreID, err)
@@ -307,7 +307,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 		descBeforeRebalance := replWithStats.repl.Desc()
 		log.VEventf(ctx, 1, "rebalancing r%d (%.2f qps) from %v to %v to better balance load",
 			replWithStats.repl.RangeID, replWithStats.qps, descBeforeRebalance.Replicas(), targets)
-		if err := contextutil.RunWithTimeout(ctx, "relocate range", sr.rq.processTimeout, func(ctx context.Context) error {
+		if err := contextutil.RunWithTimeout(ctx, "relocate range", sr.rq.processTimeoutFunc(replWithStats.repl), func(ctx context.Context) error {
 			return sr.rq.store.AdminRelocateRange(ctx, *descBeforeRebalance, targets)
 		}); err != nil {
 			log.Errorf(ctx, "unable to relocate range to %v: %+v", targets, err)


### PR DESCRIPTION
The background storage queues each carry a timeout. This timeout seems like a
good idea to unstick a potentially stuck queue. I'm not going to speculate as
to why these queues might find themselves getting stuck but let's just say maybe
it happens and maybe having a timeout is a good idea. Unfortunately sometimes
these timeouts can come to bite us, especially when things are unexpectedly slow
or data sizes are unexpectedly large. Failure to make progress before a timeout
expires in queue processing is a common cause of long-term outages. In those
cases it's good to have an escape hatch.

Another concern on the horizon is the desire to have larger range sizes. Today
our default queue processing timeout is 1m. The raft snapshot queue does not
override this. The default snapshot rate is 8 MB/s.

```
 (512MB / 8MB/s) = 64s
                 > 1m
```

This unfortunate fact means that ranges larger than 512 MB can never
successfully receive a snapshot from the raft snapshot queue. The next
commit will utilize this fact by adding a cluster setting to control the
timeout of the raft snapshot queue.

The second commit adds a hidden setting to control the timeout of raftSnapshotQueue
processing. It was added as an escape hatch to deal with snapshots for large
ranges. At the default send rate of 8MB/s a range must stay smaller than 500MB
to be successfully sent before the default 1m timeout. When this has been hit
traditionally it is has been mitigated by increasing the send rate. This may
not always be desirable. Additionally this commit and PR more generally paves
the way to move to a higher timeout for the snapshot queue. A later PR will
adjust the default value in anticipation of larger default ranges.
