### PR TITLE
opt: fold ANY when the array is NULL

### DIFF
--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -178,3 +178,14 @@ $result
 )
 =>
 $result
+
+# FoldEqualsAnyNull, conversts a scalar ANY operation to NULL if the right-hand
+# side tuple is NULL, e.g. x = ANY(NULL::int[]). See #42562.
+[FoldEqualsAnyNull, Normalize]
+(AnyScalar
+    *
+    (Null)
+    *
+)
+=>
+(Null (BoolType))

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -891,3 +891,15 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── ('foo',) [type=tuple{string}]
+
+# --------------------------------------------------
+# FoldEqualsAnyNull
+# --------------------------------------------------
+norm expect=FoldEqualsAnyNull
+SELECT * FROM a WHERE i = ANY (NULL::int[])
+----
+values
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) arr:6(int[]!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-6)


### PR DESCRIPTION
Detect when the right-hand-side of ANY is a Null array, and fold to
NULL. The usecase seems a little strange, but it makes sense if the
array is passed as a parameter.

Fixes #42562.

Release note (performance improvement): we now detect the case when
the right-hand side of an ANY expression is a NULL array (and
determine that the expression is always false).