### PR TITLE
sql: add CREATE SCHEMA IF NOT EXISTS for existing schemas

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -348,6 +348,7 @@ create_ddl_stmt ::=
 	create_changefeed_stmt
 	| create_database_stmt
 	| create_index_stmt
+	| create_schema_stmt
 	| create_table_stmt
 	| create_table_as_stmt
 	| create_view_stmt
@@ -1033,6 +1034,10 @@ create_index_stmt ::=
 	| 'CREATE' opt_unique 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by
 	| 'CREATE' opt_unique 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by
 
+create_schema_stmt ::=
+	'CREATE' 'SCHEMA' schema_name
+	| 'CREATE' 'SCHEMA' 'IF' 'NOT' 'EXISTS' schema_name
+
 create_table_stmt ::=
 	'CREATE' opt_temp_create_table 'TABLE' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
 	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
@@ -1427,6 +1432,9 @@ opt_interleave ::=
 opt_partition_by ::=
 	partition_by
 	| 
+
+schema_name ::=
+	name
 
 opt_temp_create_table ::=
 	opt_temp

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -1,0 +1,58 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+type createSchemaNode struct {
+	n *tree.CreateSchema
+}
+
+func (n *createSchemaNode) startExec(params runParams) error {
+	var schemaExists bool
+	if n.n.Schema == tree.PublicSchema {
+		schemaExists = true
+	} else {
+		for _, virtualSchema := range virtualSchemas {
+			if n.n.Schema == virtualSchema.name {
+				schemaExists = true
+				break
+			}
+		}
+	}
+	if !schemaExists {
+		return unimplemented.NewWithIssuef(26443,
+			"new schemas are unsupported")
+	}
+	if n.n.IfNotExists {
+		return nil
+	}
+	return pgerror.Newf(pgcode.DuplicateSchema, "schema %q already exists", n.n.Schema)
+}
+
+func (*createSchemaNode) Next(runParams) (bool, error) { return false, nil }
+func (*createSchemaNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *createSchemaNode) Close(ctx context.Context)  {}
+
+// CreateSchema creates a schema. Currently only works in IF NOT EXISTS mode,
+// for schemas that do in fact already exist.
+func (p *planner) CreateSchema(ctx context.Context, n *tree.CreateSchema) (planNode, error) {
+	return &createSchemaNode{
+		n: n,
+	}, nil
+}

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1,0 +1,29 @@
+statement ok
+CREATE SCHEMA IF NOT EXISTS public
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS crdb_internal
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS pg_catalog
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS information_schema
+
+statement error unimplemented: new schemas are unsupported
+CREATE SCHEMA IF NOT EXISTS derp
+
+statement error unimplemented: new schemas are unsupported
+CREATE SCHEMA derp
+
+statement error schema .* already exists
+CREATE SCHEMA public
+
+statement error schema .* already exists
+CREATE SCHEMA crdb_internal
+
+statement error schema .* already exists
+CREATE SCHEMA pg_catalog
+
+statement error schema .* already exists
+CREATE SCHEMA information_schema

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -69,6 +69,8 @@ func buildOpaque(
 		plan, err = p.CreateIndex(ctx, n)
 	case *tree.CreateUser:
 		plan, err = p.CreateUser(ctx, n)
+	case *tree.CreateSchema:
+		plan, err = p.CreateSchema(ctx, n)
 	case *tree.CreateSequence:
 		plan, err = p.CreateSequence(ctx, n)
 	case *tree.CreateStats:
@@ -162,6 +164,7 @@ func init() {
 		&tree.CommentOnTable{},
 		&tree.CreateDatabase{},
 		&tree.CreateIndex{},
+		&tree.CreateSchema{},
 		&tree.CreateSequence{},
 		&tree.CreateStats{},
 		&tree.CreateUser{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -125,6 +125,10 @@ func TestContextualHelp(t *testing.T) {
 		{`CREATE TABLE blah AS (SELECT 1) ??`, `CREATE TABLE`},
 		{`CREATE TABLE blah AS SELECT 1 ??`, `SELECT`},
 
+		{`CREATE SCHEMA IF ??`, `CREATE SCHEMA`},
+		{`CREATE SCHEMA IF NOT ??`, `CREATE SCHEMA`},
+		{`CREATE SCHEMA bli ??`, `CREATE SCHEMA`},
+
 		{`DELETE FROM ??`, `DELETE`},
 		{`DELETE FROM blah ??`, `DELETE`},
 		{`DELETE FROM blah WHERE ??`, `DELETE`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -76,6 +76,8 @@ func TestParse(t *testing.T) {
 		{`CREATE DATABASE IF NOT EXISTS a LC_CTYPE = 'C.UTF-8'`},
 		{`CREATE DATABASE IF NOT EXISTS a LC_CTYPE = 'INVALID'`},
 		{`CREATE DATABASE IF NOT EXISTS a TEMPLATE = 'template0' ENCODING = 'UTF8' LC_COLLATE = 'C.UTF-8' LC_CTYPE = 'INVALID'`},
+		{`CREATE SCHEMA IF NOT EXISTS foo`},
+		{`CREATE SCHEMA foo`},
 
 		{`CREATE INDEX a ON b (c)`},
 		{`EXPLAIN CREATE INDEX a ON b (c)`},
@@ -3132,7 +3134,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE OPERATOR a`, 0, `create operator`},
 		{`CREATE PUBLICATION a`, 0, `create publication`},
 		{`CREATE RULE a`, 0, `create rule`},
-		{`CREATE SCHEMA a`, 26443, `create`},
 		{`CREATE SERVER a`, 0, `create server`},
 		{`CREATE SUBSCRIPTION a`, 0, `create subscription`},
 		{`CREATE TEXT SEARCH a`, 7821, `create text`},

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1125,6 +1125,23 @@ func (node *CreateTable) HoistConstraints() {
 	}
 }
 
+// CreateSchema represents a CREATE SCHEMA statement.
+type CreateSchema struct {
+	IfNotExists bool
+	Schema      string
+}
+
+// Format implements the NodeFormatter interface.
+func (node *CreateSchema) Format(ctx *FmtCtx) {
+	ctx.WriteString("CREATE SCHEMA ")
+
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
+
+	ctx.WriteString(node.Schema)
+}
+
 // CreateSequence represents a CREATE SEQUENCE statement.
 type CreateSequence struct {
 	IfNotExists bool

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -316,6 +316,17 @@ func (*CreateIndex) StatementType() StatementType { return DDL }
 func (*CreateIndex) StatementTag() string { return "CREATE INDEX" }
 
 // StatementType implements the Statement interface.
+func (n *CreateSchema) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (n *CreateSchema) StatementTag() string {
+	return "CREATE SCHEMA"
+}
+
+// modifiesSchema implements the canModifySchema interface.
+func (*CreateSchema) modifiesSchema() bool { return true }
+
+// StatementType implements the Statement interface.
 func (n *CreateTable) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -928,6 +939,7 @@ func (n *CreateIndex) String() string                    { return AsString(n) }
 func (n *CreateRole) String() string                     { return AsString(n) }
 func (n *CreateUser) String() string                     { return AsString(n) }
 func (n *CreateTable) String() string                    { return AsString(n) }
+func (n *CreateSchema) String() string                   { return AsString(n) }
 func (n *CreateSequence) String() string                 { return AsString(n) }
 func (n *CreateStats) String() string                    { return AsString(n) }
 func (n *CreateView) String() string                     { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -852,6 +852,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&createDatabaseNode{}):    "create database",
 	reflect.TypeOf(&createIndexNode{}):       "create index",
 	reflect.TypeOf(&createSequenceNode{}):    "create sequence",
+	reflect.TypeOf(&createSchemaNode{}):      "create schema",
 	reflect.TypeOf(&createStatsNode{}):       "create statistics",
 	reflect.TypeOf(&createTableNode{}):       "create table",
 	reflect.TypeOf(&CreateRoleNode{}):        "create user/role",


### PR DESCRIPTION
This helps compatibility a bit.

Release note (sql change): allow no-op CREATE SCHEMA IF NOT EXISTS
statements.
Release justification: low-risk, high benefit changes to existing
functionality (compatibility improvement with no new functionality)