### PR TITLE
Allow implicit casting to int[], decimal[]

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -227,7 +227,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1, 2, 3)
 statement error could not parse "foo" as type int
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[4], 'foo')
 
-statement error EXPERIMENTAL_RELOCATE data column 1 \(relocation array\) must be of type int\[\], not type string
+statement error pq: could not parse "foo" as type int\[\]: array must be enclosed in \{ and \}
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES ('foo', 1)
 
 statement error too many columns in EXPERIMENTAL_RELOCATE LEASE data

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1016,13 +1016,28 @@ SELECT 0, information_schema._pg_expandarray(ARRAY[0]) GROUP BY 1
 error (42803): column "x" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Regression test for #31755.
+exec-ddl
+CREATE TABLE tab31755 (a STRING)
+----
+
 build
-SELECT * FROM ROWS FROM (CAST('string' AS SERIAL2[])) AS ident
+SELECT * FROM ROWS FROM (CAST((SELECT a FROM tab31755 LIMIT 1) AS SERIAL2[])) AS ident
 ----
 project-set
- ├── columns: ident:1(int2[])
+ ├── columns: ident:3(int2[])
  ├── values
  │    └── tuple [type=tuple]
  └── zip
       └── cast: INT2[] [type=int2[]]
-           └── const: 'string' [type=string]
+           └── subquery [type=string]
+                └── max1-row
+                     ├── columns: tab31755.a:1(string)
+                     └── limit
+                          ├── columns: tab31755.a:1(string)
+                          ├── project
+                          │    ├── columns: tab31755.a:1(string)
+                          │    ├── limit hint: 1.00
+                          │    └── scan tab31755
+                          │         ├── columns: tab31755.a:1(string) rowid:2(int!null)
+                          │         └── limit hint: 1.00
+                          └── const: 1 [type=int]

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -453,6 +453,8 @@ var (
 		types.Decimal,
 		types.Date,
 		types.StringArray,
+		types.IntArray,
+		types.DecimalArray,
 		types.Time,
 		types.TimeTZ,
 		types.Timestamp,


### PR DESCRIPTION
Fixes #41405

Release note (sql change): Cast string to int[] or decimal[] when appropriate