### PR TITLE
sql: fix typo in comment about settings table

### DIFF
--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -407,7 +407,9 @@ var (
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
-	// SettingsTable is the descriptor for the jobs table.
+
+	// SettingsTable is the descriptor for the settings table.
+	// It contains all cluster settings for which a value has been set.
 	SettingsTable = TableDescriptor{
 		Name:     "settings",
 		ID:       keys.SettingsTableID,


### PR DESCRIPTION
Fix a copy and paste error in comment about settings table. Also added a
short sentence spelling out what the settings table contains.

Release note: None