### PR TITLE
sql/execinfra: delete wrong TODO

### DIFF
--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -197,9 +197,6 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 //
 // It is OK to call DrainAndForwardMetadata() multiple times concurrently on the
 // same dst (as RowReceiver.Push() is guaranteed to be thread safe).
-//
-// TODO(andrei): errors seen while draining should be reported to the gateway,
-// but they shouldn't fail a SQL query.
 func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver) {
 	src.ConsumerDone()
 	for {


### PR DESCRIPTION
A TODO was calling on DistSQL to be more lenient with errors encountered
during draining. That's not admissible any more since we started
including txn read spans in the metadata. Failing to collect all of
these can lead to incomplete refreshes later in the life of a txn.

Release note: None