### PR TITLE
cli: temporarily disable test_demo_node_cmds

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl.disabled
@@ -1,5 +1,7 @@
 #! /usr/bin/env expect -f
 
+# Tests are temporarily disabled due to #42634
+
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check \\demo_node commands work as expected"


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/cockroach/issues/42634

Putting `disabled` in the name should stop it (https://sourcegraph.com/github.com/cockroachdb/cockroach@d905be8bb242dd4ad723fbbca12dee39c7d2aa7c/-/blob/pkg/acceptance/cli_test.go#L59:33)

Seems to be failing due to grpc not having the correct encoding.
Investigation to come.

Release note: None