### PR TITLE
engine, libroach: Change type of len in DB{Slice,String} to size_t

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -21,14 +21,14 @@ extern "C" {
 // A DBSlice contains read-only data that does not need to be freed.
 typedef struct {
   char* data;
-  int len;
+  size_t len;
 } DBSlice;
 
 // A DBString is structurally identical to a DBSlice, but the data it
 // contains must be freed via a call to free().
 typedef struct {
   char* data;
-  int len;
+  size_t len;
 } DBString;
 
 // A DBStatus is an alias for DBString and is used to indicate that

--- a/pkg/storage/engine/rocksdb_32bit.go
+++ b/pkg/storage/engine/rocksdb_32bit.go
@@ -13,5 +13,6 @@
 package engine
 
 const (
-	maxArrayLen = 1<<31 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<31 - 1
 )

--- a/pkg/storage/engine/rocksdb_64bit.go
+++ b/pkg/storage/engine/rocksdb_64bit.go
@@ -13,5 +13,6 @@
 package engine
 
 const (
-	maxArrayLen = 1<<50 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<50 - 1
 )

--- a/pkg/storage/engine/slice.go
+++ b/pkg/storage/engine/slice.go
@@ -14,7 +14,7 @@ import "unsafe"
 
 func nonZeroingMakeByteSlice(len int) []byte {
 	ptr := mallocgc(uintptr(len), nil, false)
-	return (*[maxArrayLen]byte)(ptr)[:len:len]
+	return (*[MaxArrayLen]byte)(ptr)[:len:len]
 }
 
 // Replacement for C.GoBytes which does not zero initialize the returned slice
@@ -27,7 +27,7 @@ func gobytes(ptr unsafe.Pointer, len int) []byte {
 		return make([]byte, 0)
 	}
 	x := nonZeroingMakeByteSlice(len)
-	src := (*[maxArrayLen]byte)(ptr)[:len:len]
+	src := (*[MaxArrayLen]byte)(ptr)[:len:len]
 	copy(x, src)
 	return x
 }


### PR DESCRIPTION
This change updates the type of the DBSlice struct in libroach to
use a size_t to denote length, to match rocksdb::Slice. Since DBString
is a sister struct with similar functionality, it also updates that
struct with the same change.

size_t is guaranteed to be unsigned and at least 32 bits.

Fixes #42720.

Release note: None.