### PR TITLE
[19.1 backport] engine, libroach: Change type of len in DB{Slice,String} to size_t

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -25,14 +25,14 @@ extern "C" {
 // A DBSlice contains read-only data that does not need to be freed.
 typedef struct {
   char* data;
-  int len;
+  size_t len;
 } DBSlice;
 
 // A DBString is structurally identical to a DBSlice, but the data it
 // contains must be freed via a call to free().
 typedef struct {
   char* data;
-  int len;
+  size_t len;
 } DBString;
 
 // A DBStatus is an alias for DBString and is used to indicate that

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1248,7 +1248,7 @@ func (r *RocksDB) GetTickersAndHistograms() (*enginepb.TickersAndHistograms, err
 		return nil, err
 	}
 
-	tickers := (*[maxArrayLen / C.sizeof_TickerInfo]C.TickerInfo)(
+	tickers := (*[MaxArrayLen / C.sizeof_TickerInfo]C.TickerInfo)(
 		unsafe.Pointer(s.tickers))[:s.tickers_len:s.tickers_len]
 	res.Tickers = make(map[string]uint64)
 	for _, ticker := range tickers {
@@ -1259,7 +1259,7 @@ func (r *RocksDB) GetTickersAndHistograms() (*enginepb.TickersAndHistograms, err
 	C.free(unsafe.Pointer(s.tickers))
 
 	res.Histograms = make(map[string]enginepb.HistogramData)
-	histograms := (*[maxArrayLen / C.sizeof_HistogramInfo]C.HistogramInfo)(
+	histograms := (*[MaxArrayLen / C.sizeof_HistogramInfo]C.HistogramInfo)(
 		unsafe.Pointer(s.histograms))[:s.histograms_len:s.histograms_len]
 	for _, histogram := range histograms {
 		name := cStringToGoString(histogram.name)
@@ -2282,7 +2282,7 @@ func (r *rocksDBIterator) Value() []byte {
 }
 
 func (r *rocksDBIterator) ValueProto(msg protoutil.Message) error {
-	if r.value.len <= 0 {
+	if r.value.len == 0 {
 		return nil
 	}
 	return protoutil.Unmarshal(r.UnsafeValue(), msg)
@@ -2523,7 +2523,7 @@ func goToCSlice(b []byte) C.DBSlice {
 	}
 	return C.DBSlice{
 		data: (*C.char)(unsafe.Pointer(&b[0])),
-		len:  C.int(len(b)),
+		len:  C.size_t(len(b)),
 	}
 }
 
@@ -2570,7 +2570,8 @@ func cStringToGoString(s C.DBString) string {
 	if s.data == nil {
 		return ""
 	}
-	result := C.GoStringN(s.data, s.len)
+	// Reinterpret the string as a slice, then cast to string which does a copy.
+	result := string(cSliceToUnsafeGoBytes(C.DBSlice{s.data, s.len}))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }
@@ -2596,7 +2597,7 @@ func cSliceToUnsafeGoBytes(s C.DBSlice) []byte {
 		return nil
 	}
 	// Interpret the C pointer as a pointer to a Go array, then slice.
-	return (*[maxArrayLen]byte)(unsafe.Pointer(s.data))[:s.len:s.len]
+	return (*[MaxArrayLen]byte)(unsafe.Pointer(s.data))[:s.len:s.len]
 }
 
 func goToCTimestamp(ts hlc.Timestamp) C.DBTimestamp {
@@ -2729,7 +2730,7 @@ func dbGetProto(
 	if err = statusToError(C.DBGet(rdb, goToCKey(key), &result)); err != nil {
 		return
 	}
-	if result.len <= 0 {
+	if result.len == 0 {
 		msg.Reset()
 		return
 	}

--- a/pkg/storage/engine/rocksdb_32bit.go
+++ b/pkg/storage/engine/rocksdb_32bit.go
@@ -17,5 +17,6 @@
 package engine
 
 const (
-	maxArrayLen = 1<<31 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<31 - 1
 )

--- a/pkg/storage/engine/rocksdb_64bit.go
+++ b/pkg/storage/engine/rocksdb_64bit.go
@@ -17,5 +17,6 @@
 package engine
 
 const (
-	maxArrayLen = 1<<50 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<50 - 1
 )

--- a/pkg/storage/engine/slice.go
+++ b/pkg/storage/engine/slice.go
@@ -18,7 +18,7 @@ import "unsafe"
 
 func nonZeroingMakeByteSlice(len int) []byte {
 	ptr := mallocgc(uintptr(len), nil, false)
-	return (*[maxArrayLen]byte)(ptr)[:len:len]
+	return (*[MaxArrayLen]byte)(ptr)[:len:len]
 }
 
 // Replacement for C.GoBytes which does not zero initialize the returned slice
@@ -31,7 +31,7 @@ func gobytes(ptr unsafe.Pointer, len int) []byte {
 		return make([]byte, 0)
 	}
 	x := nonZeroingMakeByteSlice(len)
-	src := (*[maxArrayLen]byte)(ptr)[:len:len]
+	src := (*[MaxArrayLen]byte)(ptr)[:len:len]
 	copy(x, src)
 	return x
 }


### PR DESCRIPTION
This change updates the type of the DBSlice struct in libroach to
use a size_t to denote length, to match rocksdb::Slice. Since DBString
is a sister struct with similar functionality, it also updates that
struct with the same change.

size_t is guaranteed to be unsigned and at least 32 bits.

Fixes #42720. Backport of #42721.

Release note: None