### PR TITLE
release-19.2: backupccl: allow restoration of empty db

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -214,15 +214,8 @@ func selectTargets(
 		return nil, nil, err
 	}
 
-	seenTable := false
-	for _, desc := range matched.descs {
-		if desc.Table(hlc.Timestamp{}) != nil {
-			seenTable = true
-			break
-		}
-	}
-	if !seenTable {
-		return nil, nil, errors.Errorf("no tables found: %s", tree.ErrString(&targets))
+	if len(matched.descs) == 0 {
+		return nil, nil, errors.Errorf("no tables or databases matched the given targets: %s", tree.ErrString(&targets))
 	}
 
 	if lastBackupDesc.FormatVersion >= BackupFormatDescriptorTrackingVersion {
@@ -1546,9 +1539,6 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
-	if len(filteredTablesByID) == 0 {
-		return errors.Errorf("no tables to restore: %s", tree.ErrString(&restoreStmt.Targets))
-	}
 	tableRewrites, err := allocateTableRewrites(ctx, p, databasesByID, filteredTablesByID, restoreDBs, opts)
 	if err != nil {
 		return err
@@ -1761,6 +1751,17 @@ func (r *restoreResumer) Resume(
 	}
 	r.tables = tables
 	r.databases = databases
+	r.exec = p.ExecCfg().InternalExecutor
+	r.statsRefresher = p.ExecCfg().StatsRefresher
+	r.latestStats = remapRelevantStatistics(latestBackupDesc, details.TableRewrites)
+
+	if len(r.tables) == 0 {
+		// We have no tables to restore (we are restoring an empty DB).
+		// Since we have already created any new databases that we needed,
+		// we can return without importing any data.
+		log.Warning(ctx, "no tables to restore")
+		return nil
+	}
 
 	res, err := restore(
 		ctx,
@@ -1776,9 +1777,6 @@ func (r *restoreResumer) Resume(
 		r.job,
 	)
 	r.res = res
-	r.exec = p.ExecCfg().InternalExecutor
-	r.statsRefresher = p.ExecCfg().StatsRefresher
-	r.latestStats = remapRelevantStatistics(latestBackupDesc, details.TableRewrites)
 	return err
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #42005.

/cc @cockroachdb/release

---

Previously, RESTORE did not support restoring empty databases. However,
there are use cases in which scripts perform the backup and restore
process and they have run into issues since when they go to RESTORE all
of their databases, if any are empty the script will fail.

Since BACKUP supports the backing up of empty databases, it makes sense
to allow RESTORE to restore those databases that were backed up.

Fixes #41962.

Release note (enterprise change): RESTORE now supports the restoration
of empty databases.
