### PR TITLE
*: bump the `datadriven` dependency and update the calls

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,11 +406,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0bfb531e077e1f287ed41f059dc5a8f2bde8827d02890d3aadea88f9ccba1b33"
+  digest = "1:9c071ae52ffbdc073585b61aced5dfd0d5aa658815c36bbb51362993a00353a8"
   name = "github.com/cockroachdb/datadriven"
   packages = ["."]
   pruneopts = "UT"
-  revision = "474fb724652d5548aed79577a2280abee1e9302e"
+  revision = "1cff7050b0ae084e5178fc82da15995d8a32761d"
 
 [[projects]]
   digest = "1:35ff61e02c035785971ac6ec04d54428307a986412e5d0aea86b8b7f45677d09"

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
@@ -245,7 +245,7 @@ func TestDataKeyManager(t *testing.T) {
 	}
 
 	datadriven.RunTest(t, "testdata/data_key_manager",
-		func(d *datadriven.TestData) string {
+		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
 				data := strings.Split(d.Input, "\n")

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -60,7 +60,7 @@ func TestDumpData(t *testing.T) {
 		c.omitArgs = true
 		defer c.cleanup()
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			args := []string{d.Cmd}
 			switch d.Cmd {
 			case "sql":

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -40,7 +40,7 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 		USE t;
 	`)
 
-	datadriven.RunTest(t, "testdata/explain_tree", func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/explain_tree", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "exec":
 			r.Exec(t, d.Input)

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -71,7 +71,7 @@ func TestIndexConstraints(t *testing.T) {
 		semaCtx := tree.MakeSemaContext()
 		evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var varTypes []*types.T
 			var indexCols []opt.OrderingColumn
 			var notNullCols opt.ColSet

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -59,7 +59,7 @@ func TestExprIsNeverNull(t *testing.T) {
 	datadriven.Walk(t, "testdata/expr", func(t *testing.T, path string) {
 		catalog := testcat.New()
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var varTypes []*types.T
 			var iVarHelper tree.IndexedVarHelper
 			var err error

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -310,7 +310,7 @@ func traverseExpr(expr memo.RelExpr, f func(memo.RelExpr)) {
 func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -42,7 +42,7 @@ func TestNormRules(t *testing.T) {
 		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars
 	datadriven.Walk(t, "testdata/rules", func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -57,7 +57,7 @@ func TestBuilder(t *testing.T) {
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testcat.New()
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var varTypes []*types.T
 			var iVarHelper tree.IndexedVarHelper
 			var err error

--- a/pkg/sql/opt/optgen/cmd/optgen/main_test.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/main_test.go
@@ -37,7 +37,7 @@ func TestOptgen(t *testing.T) {
 
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 				var buf bytes.Buffer
 
 				gen := optgen{useGoFmt: true, maxErrors: 2, stdErr: &buf}

--- a/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
@@ -21,7 +21,7 @@ import (
 func TestExprGen(t *testing.T) {
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			return tester.RunCommand(t, d)
 		})

--- a/pkg/sql/opt/optgen/lang/compiler_test.go
+++ b/pkg/sql/opt/optgen/lang/compiler_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestCompiler(t *testing.T) {
-	datadriven.RunTest(t, "testdata/compiler", func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/compiler", func(t *testing.T, d *datadriven.TestData) string {
 		// Only compile command supported.
 		if d.Cmd != "compile" {
 			t.FailNow()

--- a/pkg/sql/opt/optgen/lang/parser_test.go
+++ b/pkg/sql/opt/optgen/lang/parser_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestParser(t *testing.T) {
-	datadriven.RunTest(t, "testdata/parser", func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/parser", func(t *testing.T, d *datadriven.TestData) string {
 		// Only parse command supported.
 		if d.Cmd != "parse" {
 			t.FailNow()

--- a/pkg/sql/opt/optgen/lang/scanner_test.go
+++ b/pkg/sql/opt/optgen/lang/scanner_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestScanner(t *testing.T) {
-	datadriven.RunTest(t, "testdata/scanner", func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/scanner", func(t *testing.T, d *datadriven.TestData) string {
 		// Only scan command supported.
 		if d.Cmd != "scan" {
 			t.FailNow()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1069,9 +1069,9 @@ func (ot *OptTester) Import(tb testing.TB) {
 		tb.Fatalf("unable to find file %s", ot.Flags.File)
 	}
 	path := filepath.Join(filepath.Dir(optTesterFile), "testfixtures", ot.Flags.File)
-	datadriven.RunTest(tb.(*testing.T), path, func(d *datadriven.TestData) string {
+	datadriven.RunTest(tb.(*testing.T), path, func(t *testing.T, d *datadriven.TestData) string {
 		tester := New(ot.catalog, d.Input)
-		return tester.RunCommand(tb.(*testing.T), d)
+		return tester.RunCommand(t, d)
 	})
 }
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester_test.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester_test.go
@@ -25,7 +25,7 @@ func TestOptTester(t *testing.T) {
 
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)

--- a/pkg/sql/opt/testutils/testcat/test_catalog_test.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog_test.go
@@ -25,7 +25,7 @@ func TestCatalog(t *testing.T) {
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testcat.New()
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			return tester.RunCommand(t, d)
 		})

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -164,7 +164,7 @@ func TestRuleProps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	datadriven.Walk(t, "testdata/ruleprops", func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = memo.ExprFmtHideStats | memo.ExprFmtHideCost |
 				memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars
@@ -222,7 +222,7 @@ func TestExternal(t *testing.T) {
 func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testcat.New()
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)

--- a/pkg/sql/pgwire/hba/hba_test.go
+++ b/pkg/sql/pgwire/hba/hba_test.go
@@ -19,13 +19,14 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	datadriven.RunTest(t, filepath.Join("testdata", "parse"), func(d *datadriven.TestData) string {
-		conf, err := Parse(d.Input)
-		if err != nil {
-			return fmt.Sprintf("error: %v\n", err)
-		}
-		return conf.String()
-	})
+	datadriven.RunTest(t, filepath.Join("testdata", "parse"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			conf, err := Parse(d.Input)
+			if err != nil {
+				return fmt.Sprintf("error: %v\n", err)
+			}
+			return conf.String()
+		})
 }
 
 // TODO(mjibson): these are untested outside ccl +gss builds.

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -41,8 +41,7 @@ func (r *rocksDBMap) put(k []byte, v []byte) error {
 func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine diskmap.Factory) {
 	diskMaps := make(map[string]diskmap.SortedDiskMap)
 
-	datadriven.RunTest(t, filename, func(d *datadriven.TestData) string {
-
+	datadriven.RunTest(t, filename, func(t *testing.T, d *datadriven.TestData) string {
 		if d.Cmd == "raw-count" {
 			var keyCount int
 			// Trying to build a common interface to RocksDB and Pebble's iterator

--- a/pkg/storage/engine/pebble_test.go
+++ b/pkg/storage/engine/pebble_test.go
@@ -29,7 +29,7 @@ import (
 func TestPebbleTimeBoundPropCollector(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	datadriven.RunTest(t, "testdata/time_bound_props", func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/time_bound_props", func(t *testing.T, d *datadriven.TestData) string {
 		c := &pebbleTimeBoundPropCollector{}
 		switch d.Cmd {
 		case "build":

--- a/pkg/storage/replica_raft_truncation_test.go
+++ b/pkg/storage/replica_raft_truncation_test.go
@@ -47,7 +47,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 		eng := engine.NewDefaultInMem()
 		defer eng.Close()
 
-		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "prev":
 				d.ScanArgs(t, "index", &prevTruncatedState.Index)

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -50,7 +50,7 @@ func RunTest(t *testing.T, path, addr, user string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "send":
 			for _, line := range strings.Split(d.Input, "\n") {

--- a/pkg/testutils/reduce/datadriven.go
+++ b/pkg/testutils/reduce/datadriven.go
@@ -55,7 +55,7 @@ func RunTest(
 	if testing.Verbose() {
 		log = os.Stderr
 	}
-	datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "contains":
 			contains = d.Input


### PR DESCRIPTION
For use with https://github.com/cockroachdb/datadriven/pull/7.

The `datadriven.RunTest` function uses sub-tests for each directive in
the input file. Since it's not valid to use `t.Fatal`, `t.Skip` etc on
a parent test while there is a sub-test `testing.T` active, the
`RunTest` interface has been updated so that the callback function
gets the sub-test as argument.

This patch bumps the dependency and updates the calls to `RunTest`
accordingly.

Release note: None