### PR TITLE
sql: More strict parsing of intervals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -58,11 +58,8 @@ SELECT * FROM (SELECT now()) AS OF SYSTEM TIME '2018-01-01'
 statement error pq: AS OF SYSTEM TIME: interval value '0.1us' too small, absolute value must be >= 1µs
 SELECT * FROM t AS OF SYSTEM TIME '0.1us'
 
-statement error pq: AS OF SYSTEM TIME: interval value '0,0' too small, absolute value must be >= 1µs
-SELECT * FROM t AS OF SYSTEM TIME '0,0'
-
-statement error pq: AS OF SYSTEM TIME: interval value '0.000000000,0' too small, absolute value must be >= 1µs
-SELECT * FROM t AS OF SYSTEM TIME '0.000000000,0'
+statement error pq: AS OF SYSTEM TIME: interval value '0-0' too small, absolute value must be >= 1µs
+SELECT * FROM t AS OF SYSTEM TIME '0-0'
 
 statement error pq: AS OF SYSTEM TIME: interval value '-0.1us' too small, absolute value must be >= 1µs
 SELECT * FROM t AS OF SYSTEM TIME '-0.1us'

--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -329,6 +329,8 @@ func sqlStdToDuration(s string) (duration.Duration, error) {
 			} else {
 				return d, newInvalidSQLDurationError(s)
 			}
+		} else {
+			return d, newInvalidSQLDurationError(s)
 		}
 	}
 	return d, nil

--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -122,6 +122,9 @@ func TestInvalidSQLIntervalSyntax(t *testing.T) {
 		{`+`, ``, `invalid input syntax for type interval +`},
 		{`++`, ``, `invalid input syntax for type interval ++`},
 		{`--`, ``, `invalid input syntax for type interval --`},
+		{`{1,2}`, ``, `invalid input syntax for type interval {1,2}`},
+		{`0.000,0`, ``, `invalid input syntax for type interval 0.000,0`},
+		{`0,0`, ``, `invalid input syntax for type interval 0,0`},
 	}
 	for i, test := range testData {
 		dur, err := sqlStdToDuration(test.input)


### PR DESCRIPTION
Previously a larger class of strings could be parsed as the 00:00 interval.
Fixes #42709

Release note (sql change): String to interval conversion is more strict