### PR TITLE
roachtest: migrate uses of deprecated `workload run --init`

### DIFF
--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -39,8 +39,9 @@ func registerDiskFull(r *testRegistry) {
 			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))
 			m.Go(func(ctx context.Context) error {
+				c.Run(ctx, c.Node(nodes+1), "./workload init kv {pgurl:1}")
 				cmd := fmt.Sprintf(
-					"./workload run kv --tolerate-errors --init --read-percent=0"+
+					"./workload run kv --tolerate-errors --read-percent=0"+
 						" --concurrency=10 --duration=2m {pgurl:1-%d}",
 					nodes)
 				c.Run(ctx, c.Node(nodes+1), cmd)

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -36,7 +36,8 @@ func registerLedger(r *testRegistry) {
 				concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*32))
 				duration := " --duration=" + ifLocal("10s", "10m")
 
-				cmd := fmt.Sprintf("./workload run ledger --init --histograms="+perfArtifactsDir+"/stats.json"+
+				c.Run(ctx, loadNode, "./workload init ledger {pgurl:1}")
+				cmd := fmt.Sprintf("./workload run ledger --histograms="+perfArtifactsDir+"/stats.json"+
 					concurrency+duration+" {pgurl%s}", gatewayNodes)
 				c.Run(ctx, loadNode, cmd)
 				return nil

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -47,13 +47,11 @@ func runQueue(ctx context.Context, t *test, c *cluster) {
 			concurrency := ifLocal("", " --concurrency="+fmt.Sprint(dbNodeCount*64))
 			duration := fmt.Sprintf(" --duration=%s", duration.String())
 			batch := " --batch 100"
-			init := ""
 			if initTables {
-				init = " --init"
+				c.Run(ctx, c.Node(workloadNode), "./workload init queue {pgurl:1}")
 			}
 			cmd := fmt.Sprintf(
 				"./workload run queue --histograms="+perfArtifactsDir+"/stats.json"+
-					init+
 					concurrency+
 					duration+
 					batch+

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -66,7 +66,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRest
 		}
 	}()
 
-	c.Run(ctx, c.Node(1), "./workload run kv {pgurl:1} --init --max-ops=1 --splits 100")
+	c.Run(ctx, c.Node(1), "./workload init kv --splits 100 {pgurl:1}")
 
 	// Kill the third node so it won't know that all of its replicas are moved
 	// elsewhere. (We don't use the first because that's what roachprod will

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -190,8 +190,9 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 		if params.sequential {
 			extraFlags += "--sequential"
 		}
+		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init kv {pgurl:1}"))
 		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload run kv "+
-			"--init --concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl:1-%d} --duration='%s'",
+			"--concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl:1-%d} --duration='%s'",
 			params.concurrency, params.readPercent, params.spanPercent, extraFlags, c.spec.NodeCount,
 			params.waitDuration.String()))
 

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -28,8 +28,10 @@ func registerYCSB(r *testRegistry) {
 		m.Go(func(ctx context.Context) error {
 			ramp := " --ramp=" + ifLocal("0s", "1m")
 			duration := " --duration=" + ifLocal("10s", "10m")
+			c.Run(ctx, c.Node(nodes+1),
+				"./workload init ycsb --insert-count=1000000 --splits=100 {pgurl:1}")
 			cmd := fmt.Sprintf(
-				"./workload run ycsb --init --insert-count=1000000 --splits=100"+
+				"./workload run ycsb --insert-count=1000000 "+
 					" --workload=%s --concurrency=64 --histograms="+perfArtifactsDir+"/stats.json"+
 					ramp+duration+" {pgurl:1-%d}",
 				wl, nodes)


### PR DESCRIPTION
workload has always supported both an explicit `workload init` setup as
well as the convenience shorthand `workload run --init`. The `run
--init` version has turned out to be confusing enough to not be worth
the convenience, so it was deprecated. Migrate the existing uses of it
in roachtests.

Mostly mechanical, just copying the non-runtime-only flags into an
explicit `workload init` call. Intentional changes:
- "{pgurl:1}" everywhere because we don't need to load balance init
- Omit passing `--concurrency` to init because init doesn't do anything
  with it. (In the very distant past, --concurrency would also control
  split concurrency, but this hasn't been true for a while.)

Closes #42713

Release note: None