### PR TITLE
types: modify upgradeType to account for pre-20.1 precisions for Time

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1484,6 +1484,18 @@ func (t *T) upgradeType() error {
 		// Precision should always be set to 0 going forward.
 		t.InternalType.Precision = 0
 
+	case TimestampFamily, TimestampTZFamily, TimeFamily, TimeTZFamily:
+		// Some bad/experimental versions of master had precision stored as `-1`.
+		// This represented a default - so upgrade this to 0 with TimePrecisionIsSet = false.
+		if t.InternalType.Precision == -1 {
+			t.InternalType.Precision = 0
+			t.InternalType.TimePrecisionIsSet = false
+		}
+		// Going forwards after 19.2, we want `TimePrecisionIsSet` to be explicitly set
+		// if Precision is > 0.
+		if t.InternalType.Precision > 0 {
+			t.InternalType.TimePrecisionIsSet = true
+		}
 	case StringFamily, CollatedStringFamily:
 		// Map string-related visible types to corresponding Oid values.
 		switch t.InternalType.VisibleType {


### PR DESCRIPTION
`upgradeType` has been modified to do the following:
* for precisions set as `-1`, which may exist in some data from before,
upgrade so that the precision is `0`/unset, which means "default
precision".
* for precisions which are set > 0, make sure it has
`TimePrecisionIsSet` to true, to avoid confusion in future.

Release note: None