### PR TITLE
colexec: use global zeroBatch in a few places

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -91,6 +91,13 @@ func NewMemBatchWithSize(types []coltypes.T, size int) Batch {
 	return b
 }
 
+// ZeroBatch is a schema-less Batch of length 0.
+var ZeroBatch = NewMemBatchWithSize(nil /* types */, 0 /* size */)
+
+func init() {
+	ZeroBatch.SetLength(0)
+}
+
 // MemBatch is an in-memory implementation of Batch.
 type MemBatch struct {
 	// length of batch or sel in tuples

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -22,12 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
-var zeroBatch = coldata.NewMemBatchWithSize(nil /* types */, 0 /* size */)
-
-func init() {
-	zeroBatch.SetLength(0)
-}
-
 // Allocator is a memory management tool for vectorized components. It provides
 // new batches (and appends to existing ones) within a fixed memory budget. If
 // the budget is exceeded, it will panic with an error.

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -70,6 +70,7 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	s := string(d)
 
 	// Replace the template variables.
+	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -822,7 +822,7 @@ func NewColOperator(
 		result.Op = NewOffsetOp(result.Op, post.Offset)
 	}
 	if post.Limit != 0 {
-		result.Op = NewLimitOp(NewAllocator(ctx, streamingMemAccount), result.Op, post.Limit)
+		result.Op = NewLimitOp(result.Op, post.Limit)
 	}
 	return result, err
 }

--- a/pkg/sql/colexec/joiner_util.go
+++ b/pkg/sql/colexec/joiner_util.go
@@ -42,7 +42,7 @@ func (o *filterFeedOperator) Next(context.Context) coldata.Batch {
 		o.nexted = true
 		return o.batch
 	}
-	return zeroBatch
+	return coldata.ZeroBatch
 }
 
 func (o *filterFeedOperator) reset() {

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -21,9 +21,7 @@ import (
 type limitOp struct {
 	OneInputNode
 
-	allocator *Allocator
-	zeroBatch coldata.Batch
-	limit     uint64
+	limit uint64
 
 	// seen is the number of tuples seen so far.
 	seen uint64
@@ -34,24 +32,21 @@ type limitOp struct {
 var _ Operator = &limitOp{}
 
 // NewLimitOp returns a new limit operator with the given limit.
-func NewLimitOp(allocator *Allocator, input Operator, limit uint64) Operator {
+func NewLimitOp(input Operator, limit uint64) Operator {
 	c := &limitOp{
 		OneInputNode: NewOneInputNode(input),
-		allocator:    allocator,
 		limit:        limit,
 	}
 	return c
 }
 
 func (c *limitOp) Init() {
-	c.zeroBatch = c.allocator.NewMemBatchWithSize(nil /* types */, 0 /* size */)
 	c.input.Init()
 }
 
 func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 	if c.done {
-		c.zeroBatch.SetLength(0)
-		return c.zeroBatch
+		return coldata.ZeroBatch
 	}
 	bat := c.input.Next(ctx)
 	length := bat.Length()

--- a/pkg/sql/colexec/limit_test.go
+++ b/pkg/sql/colexec/limit_test.go
@@ -64,7 +64,7 @@ func TestLimit(t *testing.T) {
 		// The tuples consisting of all nulls still count as separate rows, so if
 		// we replace all values with nulls, we should get the same output.
 		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, orderedVerifier, func(input []Operator) (Operator, error) {
-			return NewLimitOp(testAllocator, input[0], tc.limit), nil
+			return NewLimitOp(input[0], tc.limit), nil
 		})
 	}
 }

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -618,7 +618,10 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 	switch colType {
 	// {{ range $.Global.MJOverloads }}
 	case _TYPES_T:
-		srcCol := src._TemplateType()
+		var srcCol _GOTYPESLICE
+		if src != nil {
+			srcCol = src._TemplateType()
+		}
 		outCol := out._TemplateType()
 		var val _GOTYPE
 		var srcStartIdx int
@@ -748,17 +751,20 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildLeftGroups(
 			for outColIdx, inColIdx := range input.outCols {
 				outStartIdx := int(destStartIdx)
 				out := o.output.ColVec(outColIdx)
-				src := batch.ColVec(int(inColIdx))
+				var src coldata.Vec
+				if batch.Width() > int(inColIdx) {
+					src = batch.ColVec(int(inColIdx))
+				}
 				colType := input.sourceTypes[inColIdx]
 
 				if sel != nil {
-					if src.MaybeHasNulls() {
+					if src != nil && src.MaybeHasNulls() {
 						_LEFT_SWITCH(_JOIN_TYPE, true, true)
 					} else {
 						_LEFT_SWITCH(_JOIN_TYPE, true, false)
 					}
 				} else {
-					if src.MaybeHasNulls() {
+					if src != nil && src.MaybeHasNulls() {
 						_LEFT_SWITCH(_JOIN_TYPE, false, true)
 					} else {
 						_LEFT_SWITCH(_JOIN_TYPE, false, false)
@@ -783,7 +789,10 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 	switch colType {
 	// {{range $.Global.MJOverloads }}
 	case _TYPES_T:
-		srcCol := src._TemplateType()
+		var srcCol _GOTYPESLICE
+		if src != nil {
+			srcCol = src._TemplateType()
+		}
 		outCol := out._TemplateType()
 
 		// Loop over every group.
@@ -944,17 +953,20 @@ RightColLoop:
 	for outColIdx, inColIdx := range input.outCols {
 		outStartIdx := int(destStartIdx)
 		out := o.output.ColVec(outColIdx + colOffset)
-		src := batch.ColVec(int(inColIdx))
+		var src coldata.Vec
+		if batch.Width() > int(inColIdx) {
+			src = batch.ColVec(int(inColIdx))
+		}
 		colType := input.sourceTypes[inColIdx]
 
 		if sel != nil {
-			if src.MaybeHasNulls() {
+			if src != nil && src.MaybeHasNulls() {
 				_RIGHT_SWITCH(_JOIN_TYPE, true, true)
 			} else {
 				_RIGHT_SWITCH(_JOIN_TYPE, true, false)
 			}
 		} else {
-			if src.MaybeHasNulls() {
+			if src != nil && src.MaybeHasNulls() {
 				_RIGHT_SWITCH(_JOIN_TYPE, false, true)
 			} else {
 				_RIGHT_SWITCH(_JOIN_TYPE, false, false)

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -199,7 +199,7 @@ func (s *ParallelUnorderedSynchronizer) init(ctx context.Context) {
 // Next is part of the Operator interface.
 func (s *ParallelUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	if s.done {
-		return zeroBatch
+		return coldata.ZeroBatch
 	}
 	if !s.initialized {
 		s.init(ctx)
@@ -231,7 +231,7 @@ func (s *ParallelUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch 
 			default:
 			}
 			s.done = true
-			return zeroBatch
+			return coldata.ZeroBatch
 		}
 		s.lastReadInputIdx = msg.inputIdx
 		return msg.b

--- a/pkg/sql/colexec/random_testutils.go
+++ b/pkg/sql/colexec/random_testutils.go
@@ -306,7 +306,7 @@ func (o *RandomDataOp) Init() {}
 func (o *RandomDataOp) Next(ctx context.Context) coldata.Batch {
 	if o.numReturned == o.numBatches {
 		// Done.
-		b := zeroBatch
+		b := coldata.ZeroBatch
 		if o.batchAccumulator != nil {
 			o.batchAccumulator(b)
 		}

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -152,7 +152,7 @@ func TestRouterOutputNext(t *testing.T) {
 			// ReaderWaitsForZeroBatch verifies that a reader blocking on Next will
 			// also get unblocked with no data other than the zero batch.
 			unblockEvent: func(_ Operator, o *routerOutputOp) {
-				o.addBatch(o.zeroBatch, nil /* selection */)
+				o.addBatch(coldata.ZeroBatch, nil /* selection */)
 			},
 			expected: tuples{},
 			name:     "ReaderWaitsForZeroBatch",
@@ -227,7 +227,7 @@ func TestRouterOutputNext(t *testing.T) {
 
 	t.Run("NextAfterZeroBatchDoesntBlock", func(t *testing.T) {
 		o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan)
-		o.addBatch(o.zeroBatch, fullSelection)
+		o.addBatch(coldata.ZeroBatch, fullSelection)
 		o.Next(ctx)
 		o.Next(ctx)
 		select {

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -64,7 +64,7 @@ func (s *SerialUnorderedSynchronizer) Init() {
 func (s *SerialUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	for {
 		if s.curSerialInputIdx == len(s.inputs) {
-			return zeroBatch
+			return coldata.ZeroBatch
 		}
 		b := s.inputs[s.curSerialInputIdx].Next(ctx)
 		if b.Length() == 0 {

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -932,7 +932,7 @@ func (f *finiteBatchSource) Next(ctx context.Context) coldata.Batch {
 		f.usableCount--
 		return f.repeatableBatch.Next(ctx)
 	}
-	return zeroBatch
+	return coldata.ZeroBatch
 }
 
 // finiteChunksSource is an Operator that returns a batch specified number of
@@ -987,7 +987,7 @@ func (f *finiteChunksSource) Next(ctx context.Context) coldata.Batch {
 		}
 		return batch
 	}
-	return zeroBatch
+	return coldata.ZeroBatch
 }
 
 func TestOpTestInputOutput(t *testing.T) {


### PR DESCRIPTION
This commit performs a minor refactor of merge joiner logic so that it
no longer requires the zero length batch to have a particular schema.
This allows us to use the global zeroBatch in hash router, inbox, and limit
operator. ZeroBatch itself is moved into coldata package.

Release note: None