### PR TITLE
sql, bulkio: Support file upload using COPY

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -42,7 +42,7 @@ preparable_stmt ::=
 	| upsert_stmt
 
 copy_from_stmt ::=
-	'COPY' table_name opt_column_list 'FROM' 'STDIN'
+	'COPY' table_name opt_column_list 'FROM' 'STDIN' opt_with_options
 
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
@@ -208,6 +208,11 @@ opt_column_list ::=
 	'(' name_list ')'
 	| 
 
+opt_with_options ::=
+	'WITH' kv_option_list
+	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 
+
 database_name ::=
 	name
 
@@ -302,11 +307,6 @@ opt_as_of_clause ::=
 
 opt_incremental ::=
 	'INCREMENTAL' 'FROM' string_or_placeholder_list
-	| 
-
-opt_with_options ::=
-	'WITH' kv_option_list
-	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 
 
 cancel_jobs_stmt ::=
@@ -588,6 +588,9 @@ opt_from_list ::=
 db_object_name ::=
 	simple_db_object_name
 	| complex_db_object_name
+
+kv_option_list ::=
+	( kv_option ) ( ( ',' kv_option ) )*
 
 prefixed_column_path ::=
 	db_object_name_component '.' unrestricted_name
@@ -997,9 +1000,6 @@ alter_user_password_stmt ::=
 as_of_clause ::=
 	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
 
-kv_option_list ::=
-	( kv_option ) ( ( ',' kv_option ) )*
-
 opt_password ::=
 	opt_with 'PASSWORD' string_or_placeholder
 	| 
@@ -1245,6 +1245,12 @@ complex_db_object_name ::=
 	db_object_name_component '.' unrestricted_name
 	| db_object_name_component '.' unrestricted_name '.' unrestricted_name
 
+kv_option ::=
+	name '=' string_or_placeholder
+	| name
+	| 'SCONST' '=' string_or_placeholder
+	| 'SCONST'
+
 db_object_name_component ::=
 	name
 	| cockroachdb_extra_type_func_name_keyword
@@ -1337,12 +1343,6 @@ alter_zone_partition_stmt ::=
 	'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_index_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_name '@' '*' set_zone_config
-
-kv_option ::=
-	name '=' string_or_placeholder
-	| name
-	| 'SCONST' '=' string_or_placeholder
-	| 'SCONST'
 
 opt_with ::=
 	'WITH'

--- a/pkg/blobs/bench_test.go
+++ b/pkg/blobs/bench_test.go
@@ -76,7 +76,7 @@ func BenchmarkStreamingReadFile(b *testing.B) {
 
 func benchmarkStreamingReadFile(b *testing.B, tc *benchmarkTestCase) {
 	writeLargeFile(b, filepath.Join(tc.remoteExternalDir, tc.fileName), tc.fileSize)
-	writeTo := localStorage{externalIODir: tc.localExternalDir}
+	writeTo := LocalStorage{externalIODir: tc.localExternalDir}
 	b.ResetTimer()
 	b.SetBytes(tc.fileSize)
 	for i := 0; i < b.N; i++ {

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -122,12 +122,12 @@ var _ BlobClient = &localClient{}
 // localClient executes the local blob service's code
 // to Read or Write bulk files on the current node.
 type localClient struct {
-	localStorage *localStorage
+	localStorage *LocalStorage
 }
 
 // newLocalClient instantiates a local blob service client.
 func newLocalClient(externalIODir string) (BlobClient, error) {
-	storage, err := newLocalStorage(externalIODir)
+	storage, err := NewLocalStorage(externalIODir)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating local client")
 	}

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -21,23 +21,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-// localStorage wraps all operations with the local file system
+// LocalStorage wraps all operations with the local file system
 // that the blob service makes.
-type localStorage struct {
+type LocalStorage struct {
 	externalIODir string
 }
 
-// newLocalStorage creates a new localStorage object and returns
+// NewLocalStorage creates a new LocalStorage object and returns
 // an error when we cannot take the absolute path of `externalIODir`.
-func newLocalStorage(externalIODir string) (*localStorage, error) {
+func NewLocalStorage(externalIODir string) (*LocalStorage, error) {
 	absPath, err := filepath.Abs(externalIODir)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating localStorage object")
+		return nil, errors.Wrap(err, "creating LocalStorage object")
 	}
-	return &localStorage{externalIODir: absPath}, nil
+	return &LocalStorage{externalIODir: absPath}, nil
 }
 
-func (l *localStorage) prependExternalIODir(path string) (string, error) {
+func (l *LocalStorage) prependExternalIODir(path string) (string, error) {
 	localBase := filepath.Join(l.externalIODir, path)
 	// Make sure we didn't ../ our way back out.
 	if !strings.HasPrefix(localBase, l.externalIODir) {
@@ -47,7 +47,7 @@ func (l *localStorage) prependExternalIODir(path string) (string, error) {
 }
 
 // WriteFile prepends IO dir to filename and writes the content to that local file.
-func (l *localStorage) WriteFile(filename string, content io.Reader) error {
+func (l *LocalStorage) WriteFile(filename string, content io.Reader) error {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func (l *localStorage) WriteFile(filename string, content io.Reader) error {
 }
 
 // ReadFile prepends IO dir to filename and reads the content of that local file.
-func (l *localStorage) ReadFile(filename string) (io.ReadCloser, error) {
+func (l *LocalStorage) ReadFile(filename string) (io.ReadCloser, error) {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (l *localStorage) ReadFile(filename string) (io.ReadCloser, error) {
 }
 
 // List prepends IO dir to pattern and glob matches all local files against that pattern.
-func (l *localStorage) List(pattern string) ([]string, error) {
+func (l *LocalStorage) List(pattern string) ([]string, error) {
 	if pattern == "" {
 		return nil, errors.New("pattern cannot be empty")
 	}
@@ -102,7 +102,7 @@ func (l *localStorage) List(pattern string) ([]string, error) {
 }
 
 // Delete prepends IO dir to filename and deletes that local file.
-func (l *localStorage) Delete(filename string) error {
+func (l *LocalStorage) Delete(filename string) error {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
 		return errors.Wrap(err, "deleting file")
@@ -111,7 +111,7 @@ func (l *localStorage) Delete(filename string) error {
 }
 
 // Stat prepends IO dir to filename and gets the Stat() of that local file.
-func (l *localStorage) Stat(filename string) (*blobspb.BlobStat, error) {
+func (l *LocalStorage) Stat(filename string) (*blobspb.BlobStat, error) {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting stat of file")

--- a/pkg/blobs/service.go
+++ b/pkg/blobs/service.go
@@ -35,14 +35,14 @@ import (
 
 // Service implements the gRPC BlobService which exchanges bulk files between different nodes.
 type Service struct {
-	localStorage *localStorage
+	localStorage *LocalStorage
 }
 
 var _ blobspb.BlobServer = &Service{}
 
 // NewBlobService instantiates a blob service server.
 func NewBlobService(externalIODir string) (*Service, error) {
-	localStorage, err := newLocalStorage(externalIODir)
+	localStorage, err := NewLocalStorage(externalIODir)
 	return &Service{localStorage: localStorage}, err
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1632,28 +1632,31 @@ func (ex *connExecutor) execCopyIn(
 		ex.state.mon.Start(ctx, ex.sessionMon, mon.BoundAccount{} /* reserved */)
 		monToStop = ex.state.mon
 	}
-	cm, err := newCopyMachine(
-		ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg,
-
-		// resetPlanner
-		func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time) {
-			// HACK: We're reaching inside ex.state and changing sqlTimestamp by hand.
-			// It is used by resetPlanner. Normally sqlTimestamp is updated by the
-			// state machine, but the copyMachine manages its own transactions without
-			// going through the state machine.
-			ex.state.sqlTimestamp = txnTS
-			ex.statsCollector = ex.newStatsCollector()
-			ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
-			ex.initPlanner(ctx, p)
-			ex.resetPlanner(ctx, p, txn, stmtTS, 0 /* numAnnotations */)
-		},
-
-		// execInsertPlan
-		func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
-			_, _, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, false /* distribute */)
-			return err
-		},
-	)
+	var cm copyMachineInterface
+	var err error
+	resetPlanner := func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time) {
+		// HACK: We're reaching inside ex.state and changing sqlTimestamp by hand.
+		// It is used by resetPlanner. Normally sqlTimestamp is updated by the
+		// state machine, but the copyMachine manages its own transactions without
+		// going through the state machine.
+		ex.state.sqlTimestamp = txnTS
+		ex.statsCollector = ex.newStatsCollector()
+		ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
+		ex.initPlanner(ctx, p)
+		ex.resetPlanner(ctx, p, txn, stmtTS, 0 /* numAnnotations */)
+	}
+	if cmd.Stmt.Table.TableName == fileUploadTable {
+		cm, err = newFileUploadMachine(cmd.Conn, cmd.Stmt, ex.server.cfg, resetPlanner)
+	} else {
+		cm, err = newCopyMachine(
+			ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg, resetPlanner,
+			// execInsertPlan
+			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
+				_, _, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, false /* distribute */)
+				return err
+			},
+		)
+	}
 	if err != nil {
 		ev := eventNonRetriableErr{IsCommit: fsm.False}
 		payload := eventNonRetriableErrPayload{err: err}

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -1,0 +1,132 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/lib/pq"
+)
+
+const (
+	fileUploadTable = "crdb_internal.file_upload"
+	copyOptionDest  = "destination"
+)
+
+var copyFileOptionExpectValues = map[string]KVStringOptValidate{
+	copyOptionDest: KVStringOptRequireValue,
+}
+
+var _ copyMachineInterface = &fileUploadMachine{}
+
+type fileUploadMachine struct {
+	c           *copyMachine
+	writeToFile *io.PipeWriter
+	writeError  chan error
+}
+
+func newFileUploadMachine(
+	conn pgwirebase.Conn,
+	n *tree.CopyFrom,
+	execCfg *ExecutorConfig,
+	resetPlanner func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time),
+) (f *fileUploadMachine, retErr error) {
+	if len(n.Columns) != 0 {
+		return nil, errors.New("expected 0 columns specified for file uploads")
+	}
+	c := &copyMachine{
+		conn: conn,
+		// The planner will be prepared before use.
+		p:            planner{execCfg: execCfg},
+		resetPlanner: resetPlanner,
+	}
+	f = &fileUploadMachine{c: c}
+
+	optsFn, err := f.c.p.TypeAsStringOpts(n.Options, copyFileOptionExpectValues)
+	if err != nil {
+		return nil, err
+	}
+	opts, err := optsFn()
+	if err != nil {
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	localStorage, err := blobs.NewLocalStorage(c.p.execCfg.Settings.ExternalIODir)
+	if err != nil {
+		return nil, err
+	}
+	// Check that the file does not already exist
+	_, err = localStorage.Stat(opts[copyOptionDest])
+	if err == nil {
+		return nil, fmt.Errorf("destination file already exists for %s", opts[copyOptionDest])
+	}
+	f.writeError = make(chan error, 1)
+	go func() {
+		f.writeError <- localStorage.WriteFile(opts[copyOptionDest], pr)
+		close(f.writeError)
+	}()
+	f.writeToFile = pw
+
+	c.resetPlanner(&c.p, nil /* txn */, time.Time{} /* txnTS */, time.Time{} /* stmtTS */)
+	c.resultColumns = make(sqlbase.ResultColumns, 1)
+	c.resultColumns[0] = sqlbase.ResultColumn{Typ: types.Bytes}
+	c.parsingEvalCtx = c.p.EvalContext()
+	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
+	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
+	c.processRows = f.writeFile
+	return
+}
+
+// CopyInFileStmt creates a COPY FROM statement which can be used
+// to upload files, and be prepared with Tx.Prepare().
+func CopyInFileStmt(destination, schema, table string) string {
+	return fmt.Sprintf(
+		`COPY %s.%s FROM STDIN WITH destination = %s`,
+		pq.QuoteIdentifier(schema),
+		pq.QuoteIdentifier(table),
+		lex.EscapeSQLString(destination),
+	)
+}
+
+func (f *fileUploadMachine) run(ctx context.Context) error {
+	err := f.c.run(ctx)
+	_ = f.writeToFile.Close()
+	if err != nil {
+		return err
+	}
+	return <-f.writeError
+}
+
+func (f *fileUploadMachine) writeFile(ctx context.Context) error {
+	for _, r := range f.c.rows {
+		b := []byte(*r[0].(*tree.DBytes))
+		n, err := f.writeToFile.Write(b)
+		if err != nil || n < len(b) {
+			return err
+		}
+	}
+	f.c.insertedRows += len(f.c.rows)
+	f.c.rows = f.c.rows[:0]
+	f.c.rowsMemAcc.Clear(ctx)
+	return nil
+}

--- a/pkg/sql/copy_file_upload_test.go
+++ b/pkg/sql/copy_file_upload_test.go
@@ -1,0 +1,179 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+const filename = "/test/test_file_upload.csv"
+
+func writeFile(t *testing.T, testSendFile string, fileContent []byte) {
+	err := os.MkdirAll(filepath.Dir(testSendFile), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(testSendFile, fileContent, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runCopyFile(t *testing.T, serverParams base.TestServerArgs, testSendFile string) error {
+	// Make sure we can open this file first
+	reader, err := os.Open(testSendFile)
+	if err != nil {
+		return err
+	}
+
+	s, db, _ := serverutils.StartServer(t, serverParams)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`CREATE DATABASE d;`); err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if newErr := txn.Commit(); err == nil && newErr != nil {
+			t.Fatal(newErr)
+		}
+	}()
+
+	stmt, err := txn.Prepare(CopyInFileStmt(filename, "d", fileUploadTable))
+	if err != nil {
+		return err
+	}
+
+	for {
+		send := make([]byte, 1024)
+		n, err := reader.Read(send)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = stmt.Exec(string(send[:n]))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nil
+}
+
+func TestFileUpload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	localExternalDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	params.ExternalIODir = localExternalDir
+
+	testFileDir, cleanup2 := testutils.TempDir(t)
+	defer cleanup2()
+	testSendFile := filepath.Join(testFileDir, filename)
+	fileContent := []byte("hello \n blah 1@#% some data hello \n @#%^&&*")
+	writeFile(t, testSendFile, fileContent)
+
+	err := runCopyFile(t, params, testSendFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := ioutil.ReadFile(filepath.Join(localExternalDir, filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fileContent, content) {
+		t.Fatalf("content not the same. expected: %s got: %s", fileContent, content)
+	}
+}
+
+func TestUploadEmptyFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	localExternalDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	params.ExternalIODir = localExternalDir
+
+	testFileDir, cleanup2 := testutils.TempDir(t)
+	defer cleanup2()
+	testSendFile := filepath.Join(testFileDir, filename)
+	fileContent := []byte("")
+	writeFile(t, testSendFile, fileContent)
+
+	err := runCopyFile(t, params, testSendFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := ioutil.ReadFile(filepath.Join(localExternalDir, filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fileContent, content) {
+		t.Fatalf("content not the same. expected: %s got: %s", fileContent, content)
+	}
+}
+
+func TestFileNotExist(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	localExternalDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	params.ExternalIODir = localExternalDir
+
+	err := runCopyFile(t, params, filepath.Join(localExternalDir, filename))
+	expectedErr := "no such file"
+	if !testutils.IsError(err, expectedErr) {
+		t.Fatalf(`expected error: %s, got: %s`, expectedErr, err)
+	}
+}
+
+func TestFileExist(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	localExternalDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	params.ExternalIODir = localExternalDir
+	destination := filepath.Join(localExternalDir, filename)
+	writeFile(t, destination, []byte("file exists"))
+
+	err := runCopyFile(t, params, destination)
+	expectedErr := "file already exists"
+	if !testutils.IsError(err, expectedErr) {
+		t.Fatalf(`expected error: %s, got: %s`, expectedErr, err)
+	}
+}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1167,6 +1167,7 @@ func TestParse(t *testing.T) {
 
 		{`COPY t FROM STDIN`},
 		{`COPY t (a, b, c) FROM STDIN`},
+		{`COPY crdb_internal.file_upload FROM STDIN WITH destination = 'filename'`},
 
 		{`ALTER TABLE a SPLIT AT VALUES (1)`},
 		{`EXPLAIN ALTER TABLE a SPLIT AT VALUES (1)`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2051,13 +2051,14 @@ opt_with_options:
   }
 
 copy_from_stmt:
-  COPY table_name opt_column_list FROM STDIN
+  COPY table_name opt_column_list FROM STDIN opt_with_options
   {
     name := $2.unresolvedObjectName().ToTableName()
     $$.val = &tree.CopyFrom{
        Table: name,
        Columns: $3.nameList(),
        Stdin: true,
+       Options: $6.kvOptions(),
     }
   }
 

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -15,6 +15,7 @@ type CopyFrom struct {
 	Table   TableName
 	Columns NameList
 	Stdin   bool
+	Options KVOptions
 }
 
 // Format implements the NodeFormatter interface.
@@ -29,5 +30,9 @@ func (node *CopyFrom) Format(ctx *FmtCtx) {
 	ctx.WriteString(" FROM ")
 	if node.Stdin {
 		ctx.WriteString("STDIN")
+	}
+	if node.Options != nil {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
 	}
 }


### PR DESCRIPTION
We are currently unable to upload a bulk file to a node's
local file system using a SQL connectiong. This feature
will allow users to upload files so that they can take
advantage of our `IMPORT`'s support for nodelocal, all
through a SQL connection.

We are giving `COPY` the capability to upload when copying
to a specific table. We also expect a destination filename
to be passed in using options. The copying functionality
piggybacks off the current `copyMachine` and changes the path
of execution based on the table name. The unit test `TestFileUpload`
imitates what the client would do to use this feature. This
functionality will later be added to the cockroach CLI.

In order to fit the destination filename into the syntax of
`COPY`, we had to manually build the query on the client side,
as well as change the parsing of COPY queries on the server
side. The `COPY` now accepts statements like:

`COPY table FROM stdin WITH destination = "destination/file"`

We initially intended for this added feature of COPY to be
free of grammar changes. However, there was no good way of
specifying the file destination of the uploaded file. One
potential alternative to this change was to specify this as
the column name of the table to which we are uploading. This
causes concerns with the handling of special characters as well
as placeholders support. We therefore decided that the syntax
change might be worthwhile.

Within this PR, there are no user facing changes (users should
not be running this query manually) and therefore should not be
added to our documentation.

Release note: None