### PR TITLE
colflow: create separate memory accounts for streaming components

### DIFF
--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -40,7 +40,6 @@ type routerOutput interface {
 var defaultRouterOutputBlockedThreshold = int(coldata.BatchSize() * 2)
 
 type routerOutputOp struct {
-	allocator *Allocator
 	// input is a reference to our router.
 	input execinfra.OpNode
 
@@ -56,8 +55,9 @@ type routerOutputOp struct {
 
 	mu struct {
 		syncutil.Mutex
-		cond *sync.Cond
-		done bool
+		allocator *Allocator
+		cond      *sync.Cond
+		done      bool
 		// TODO(asubiotto): Use a ring buffer once we have disk spilling.
 		data      []coldata.Batch
 		numUnread int
@@ -106,13 +106,13 @@ func newRouterOutputOpWithBlockedThresholdAndBatchSize(
 	outputBatchSize int,
 ) *routerOutputOp {
 	o := &routerOutputOp{
-		allocator:           allocator,
 		types:               types,
 		zeroBatch:           allocator.NewMemBatchWithSize(types, 0 /* size */),
 		unblockedEventsChan: unblockedEventsChan,
 		blockedThreshold:    blockedThreshold,
 		outputBatchSize:     outputBatchSize,
 	}
+	o.mu.allocator = allocator
 	o.mu.cond = sync.NewCond(&o.mu)
 	o.mu.data = make([]coldata.Batch, 0, o.blockedThreshold/o.outputBatchSize)
 	return o
@@ -194,11 +194,11 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 	writeIdx := 0
 	if len(o.mu.data) == 0 {
 		// New output batch.
-		o.mu.data = append(o.mu.data, o.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
+		o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
 	} else {
 		if int(o.mu.data[len(o.mu.data)-1].Length()) == o.outputBatchSize {
 			// No space in last batch, append new output batch.
-			o.mu.data = append(o.mu.data, o.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
+			o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
 		}
 		writeIdx = len(o.mu.data) - 1
 	}
@@ -219,11 +219,11 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 			numAppended = available
 			// Need to create a new batch to append to in the next o.mu.data slot.
 			// This will be used in the next iteration.
-			o.mu.data = append(o.mu.data, o.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
+			o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
 		}
 
 		for i, t := range o.types {
-			o.allocator.Append(
+			o.mu.allocator.Append(
 				dst.ColVec(i),
 				coldata.SliceArgs{
 					ColType:   t,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -40,10 +40,10 @@ type vectorizedFlow struct {
 	// operatorConcurrency is set if any operators are executed in parallel.
 	operatorConcurrency bool
 
-	// streamingMemAccount is the memory account that is tracking the static
+	// streamingMemAccounts are the memory accounts that are tracking the static
 	// memory usage of the whole vectorized flow as well as all dynamic memory of
 	// the streaming components.
-	streamingMemAccount *mon.BoundAccount
+	streamingMemAccounts []*mon.BoundAccount
 
 	// bufferingMemMonitors are the memory monitors of the buffering components.
 	bufferingMemMonitors []*mon.BytesMonitor
@@ -73,8 +73,6 @@ func (f *vectorizedFlow) Setup(
 ) error {
 	f.SetSpec(spec)
 	log.VEventf(ctx, 1, "setting up vectorize flow %s", f.ID.Short())
-	streamingMemAccount := f.EvalCtx.Mon.MakeBoundAccount()
-	f.streamingMemAccount = &streamingMemAccount
 	recordingStats := false
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		recordingStats = true
@@ -89,18 +87,21 @@ func (f *vectorizedFlow) Setup(
 		f.GetFlowCtx().Cfg.NodeDialer,
 		f.GetID(),
 	)
-	_, err := creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, &streamingMemAccount, opt)
+	_, err := creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, opt)
 	if err == nil {
 		f.operatorConcurrency = creator.operatorConcurrency
+		f.streamingMemAccounts = append(f.streamingMemAccounts, creator.streamingMemAccounts...)
 		f.bufferingMemMonitors = append(f.bufferingMemMonitors, creator.bufferingMemMonitors...)
 		f.bufferingMemAccounts = append(f.bufferingMemAccounts, creator.bufferingMemAccounts...)
 		log.VEventf(ctx, 1, "vectorized flow setup succeeded")
 		return nil
 	}
-	f.streamingMemAccount.Close(ctx)
 	// It is (theoretically) possible that some of the memory monitoring
 	// infrastructure was created even in case of an error, and we need to clean
 	// that up.
+	for _, memAcc := range creator.streamingMemAccounts {
+		memAcc.Close(ctx)
+	}
 	for _, memAcc := range creator.bufferingMemAccounts {
 		memAcc.Close(ctx)
 	}
@@ -125,7 +126,9 @@ func (f *vectorizedFlow) Release() {
 // Cleanup is part of the Flow interface.
 func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	// This cleans up all the memory monitoring of the vectorized flow.
-	f.streamingMemAccount.Close(ctx)
+	for _, memAcc := range f.streamingMemAccounts {
+		memAcc.Close(ctx)
+	}
 	for _, memAcc := range f.bufferingMemAccounts {
 		memAcc.Close(ctx)
 	}
@@ -276,6 +279,9 @@ type vectorizedFlowCreator struct {
 	leaves []execinfra.OpNode
 	// operatorConcurrency is set if any operators are executed in parallel.
 	operatorConcurrency bool
+	// streamingMemAccounts contains all memory accounts of the non-buffering
+	// components in the vectorized flow.
+	streamingMemAccounts []*mon.BoundAccount
 	// bufferingMemMonitors contains all memory monitors of the buffering
 	// components in the vectorized flow.
 	bufferingMemMonitors []*mon.BytesMonitor
@@ -307,19 +313,29 @@ func newVectorizedFlowCreator(
 	}
 }
 
+// newStreamingMemAccount creates a new memory account bound to the monitor in
+// flowCtx and accumulates it into streamingMemAccounts slice.
+func (s *vectorizedFlowCreator) newStreamingMemAccount(
+	flowCtx *execinfra.FlowCtx,
+) *mon.BoundAccount {
+	streamingMemAccount := flowCtx.EvalCtx.Mon.MakeBoundAccount()
+	s.streamingMemAccounts = append(s.streamingMemAccounts, &streamingMemAccount)
+	return &streamingMemAccount
+}
+
 // setupRemoteOutputStream sets up an Outbox that will operate according to
 // the given StreamEndpointSpec. It will also drain all MetadataSources in the
 // metadataSourcesQueue.
 func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	op colexec.Operator,
 	outputTyps []coltypes.T,
 	stream *execinfrapb.StreamEndpointSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	streamingMemAccount *mon.BoundAccount,
 ) (execinfra.OpNode, error) {
 	outbox, err := s.remoteComponentCreator.newOutbox(
-		colexec.NewAllocator(ctx, streamingMemAccount),
+		colexec.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
 		op, outputTyps, metadataSourcesQueue,
 	)
 	if err != nil {
@@ -360,7 +376,6 @@ func (s *vectorizedFlowCreator) setupRouter(
 	outputTyps []coltypes.T,
 	output *execinfrapb.OutputRouterSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	streamingMemAccount *mon.BoundAccount,
 ) error {
 	if output.Type != execinfrapb.OutputRouterSpec_BY_HASH {
 		return errors.Errorf("vectorized output router type %s unsupported", output.Type)
@@ -397,7 +412,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 			return errors.Errorf("unexpected sync response output when setting up router")
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			if _, err := s.setupRemoteOutputStream(
-				ctx, op, outputTyps, stream, metadataSourcesQueue, streamingMemAccount,
+				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue,
 			); err != nil {
 				return err
 			}
@@ -438,9 +453,9 @@ func (s *vectorizedFlowCreator) setupRouter(
 // calling DrainMeta.
 func (s *vectorizedFlowCreator) setupInput(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
-	streamingMemAccount *mon.BoundAccount,
 ) (op colexec.Operator, _ []execinfrapb.MetadataSource, _ error) {
 	inputStreamOps := make([]colexec.Operator, 0, len(input.Streams))
 	metaSources := make([]execinfrapb.MetadataSource, 0, len(input.Streams))
@@ -460,7 +475,10 @@ func (s *vectorizedFlowCreator) setupInput(
 			if err != nil {
 				return nil, nil, err
 			}
-			inbox, err := s.remoteComponentCreator.newInbox(colexec.NewAllocator(ctx, streamingMemAccount), typs, inputStream.StreamID)
+			inbox, err := s.remoteComponentCreator.newInbox(
+				colexec.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
+				typs, inputStream.StreamID,
+			)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -496,7 +514,8 @@ func (s *vectorizedFlowCreator) setupInput(
 		}
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
 			op = colexec.NewOrderedSynchronizer(
-				colexec.NewAllocator(ctx, streamingMemAccount), inputStreamOps, typs, execinfrapb.ConvertToColumnOrdering(input.Ordering),
+				colexec.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
+				inputStreamOps, typs, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 		} else {
 			if opt == flowinfra.FuseAggressively {
@@ -536,7 +555,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 	op colexec.Operator,
 	opOutputTypes []coltypes.T,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	streamingMemAccount *mon.BoundAccount,
 ) error {
 	output := &pspec.Output[0]
 	if output.Type != execinfrapb.OutputRouterSpec_PASS_THROUGH {
@@ -549,7 +567,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 			// Pass in a copy of the queue to reset metadataSourcesQueue for
 			// further appends without overwriting.
 			metadataSourcesQueue,
-			streamingMemAccount,
 		)
 	}
 
@@ -583,7 +600,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 				},
 			)
 		}
-		outbox, err := s.setupRemoteOutputStream(ctx, op, opOutputTypes, outputStream, metadataSourcesQueue, streamingMemAccount)
+		outbox, err := s.setupRemoteOutputStream(ctx, flowCtx, op, opOutputTypes, outputStream, metadataSourcesQueue)
 		if err != nil {
 			return err
 		}
@@ -636,7 +653,6 @@ func (s *vectorizedFlowCreator) setupFlow(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorSpecs []execinfrapb.ProcessorSpec,
-	streamingMemAccount *mon.BoundAccount,
 	opt flowinfra.FuseOpt,
 ) (leaves []execinfra.OpNode, err error) {
 	streamIDToSpecIdx := make(map[execinfrapb.StreamID]int)
@@ -678,7 +694,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 		metadataSourcesQueue := make([]execinfrapb.MetadataSource, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
-			input, metadataSources, err := s.setupInput(ctx, pspec.Input[i], opt, streamingMemAccount)
+			input, metadataSources, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt)
 			if err != nil {
 				return nil, err
 			}
@@ -687,7 +703,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 		}
 
 		result, err := colexec.NewColOperator(
-			ctx, flowCtx, pspec, inputs, streamingMemAccount,
+			ctx, flowCtx, pspec, inputs, s.newStreamingMemAccount(flowCtx),
 			false, /* useStreamingMemAccountForBuffering */
 		)
 		// Even when err is non-nil, it is possible that the buffering memory
@@ -707,7 +723,10 @@ func (s *vectorizedFlowCreator) setupFlow(
 			!result.IsStreaming {
 			return nil, errors.Errorf("non-streaming operator encountered when vectorize=auto")
 		}
-		if err = streamingMemAccount.Grow(ctx, int64(result.InternalMemUsage)); err != nil {
+		// We created a streaming memory account when calling NewColOperator above,
+		// so there is definitely at least one memory account, and it doesn't
+		// matter which one we grow.
+		if err = s.streamingMemAccounts[0].Grow(ctx, int64(result.InternalMemUsage)); err != nil {
 			return nil, errors.Wrapf(err, "not enough memory to setup vectorized plan")
 		}
 		metadataSourcesQueue = append(metadataSourcesQueue, result.MetadataSources...)
@@ -735,7 +754,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, err
 		}
 		if err = s.setupOutput(
-			ctx, flowCtx, pspec, op, opOutputTypes, metadataSourcesQueue, streamingMemAccount,
+			ctx, flowCtx, pspec, op, opOutputTypes, metadataSourcesQueue,
 		); err != nil {
 			return nil, err
 		}
@@ -919,9 +938,10 @@ func SupportsVectorized(
 	)
 	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer memoryMonitor.Stop(ctx)
-	acc := memoryMonitor.MakeBoundAccount()
-	defer acc.Close(ctx)
 	defer func() {
+		for _, memAcc := range creator.streamingMemAccounts {
+			memAcc.Close(ctx)
+		}
 		for _, memAcc := range creator.bufferingMemAccounts {
 			memAcc.Close(ctx)
 		}
@@ -930,7 +950,7 @@ func SupportsVectorized(
 		}
 	}()
 	if vecErr := execerror.CatchVectorizedRuntimeError(func() {
-		leaves, err = creator.setupFlow(ctx, flowCtx, processorSpecs, &acc, fuseOpt)
+		leaves, err = creator.setupFlow(ctx, flowCtx, processorSpecs, fuseOpt)
 	}); vecErr != nil {
 		return leaves, vecErr
 	}

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -218,9 +218,12 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 		execinfrapb.FlowID{},
 	)
 
-	acc := evalCtx.Mon.MakeBoundAccount()
-	defer acc.Close(ctx)
-	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, &acc, flowinfra.FuseNormally)
+	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
+	defer func() {
+		for _, memAcc := range vfc.streamingMemAccounts {
+			memAcc.Close(ctx)
+		}
+	}()
 	require.NoError(t, err)
 
 	// Verify that an outbox was actually created.

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -632,10 +632,10 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 	if mm.mu.curAllocated < sz {
-		sz = mm.mu.curAllocated
 		log.ReportOrPanic(ctx, &mm.settings.SV,
 			"%s: no bytes to release, current %d, free %d",
 			mm.name, mm.mu.curAllocated, sz)
+		sz = mm.mu.curAllocated
 	}
 	mm.mu.curAllocated -= sz
 	if mm.curBytesCount != nil {
@@ -647,7 +647,7 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 		// We avoid VEventf here because we want to avoid computing the
 		// trace string if there is nothing to log.
 		log.Infof(ctx, "%s: now at %d bytes (-%d) - %s",
-			mm.name, mm.mu.curAllocated, sz, util.GetSmallTrace(3))
+			mm.name, mm.mu.curAllocated, sz, util.GetSmallTrace(5))
 	}
 }
 


### PR DESCRIPTION
**colexec: move Allocator in hash router output under the mutex**

The Allocator object is shared among the output of a hash router, so
access to it needs to be synchronized. It just so happens that it was
already the case (we acquire the lock in the beginning of 'addBatch' and
defer its release), and this commit moves the Allocator into 'mu' struct
to make it explicit.

Release note: None

**mon: minor tweaks to BytesMonitor**

It increases the number of lines from the stack trace when verbose
logging is enabled. Also, it correctly logs the amount of bytes requested
to release is greater than currently allocated.

Release note: None

**colflow: create separate memory accounts for streaming components**

Previously, all non-buffering vectorized components shared the same
memory account. However, those components can run concurrently (for
example, multiple Outboxes on the same node), and we could get into
a race situation because the access to the single memory account wasn't
synchronized (although different Allocator objects are used, they shared
the same account). Now this is fixed by creating separate memory
accounts for all streaming components.

Fixes: #41322.
Fixes: #42722.

Release note: None