### PR TITLE
partitionccl: enhance partition test to use leaseholders and more nodes

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -283,7 +283,7 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 			continue
 		}
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.parse(); err != nil {
+			if err := test.parse(false /* useLeaseholderPrefs */); err != nil {
 				t.Fatalf("%+v", err)
 			}
 			clusterID := uuid.MakeV4()


### PR DESCRIPTION
Prior to this commit the partitioning tests worked by creating a 3 node cluster
and then expressed constraints over the three nodes. It then validates that
the cluster conforms to the constraints by querying data and examining the
trace to determine which node held the data.

This is problematic for one because it is susceptible to #40333. In rare
cases we'll down-replicate to the wrong single node (e.g. if the right one
is not live) and we won't ever fix it.

It also doesn't exercise leaseholder preferences.

This PR adds functionality to configure clusters with larger numbers of nodes
where each expectation in the config can now refer to a leaseholder_preference
rather than a constraint and we'll allocate the additional nodes to 3
datacenters.

This larger test creates dramatically more data movement and has been useful
when testing #40892.

The PR also adds a flag to control how many of these subtests to run.

Release justification: Only touches testing and is useful for testing a
release blocker.

Release note: None