### PR TITLE
use Pebble EstimateDiskUsage API

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -646,13 +646,10 @@ func (p *Pebble) PreIngestDelay(ctx context.Context) {
 
 // ApproximateDiskBytes implements the Engine interface.
 func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
-	// TODO(itsbilal): Add functionality in Pebble to do this count internally,
-	// instead of iterating over the range.
-	count := uint64(0)
-	_ = p.Iterate(from, to, func(kv MVCCKeyValue) (bool, error) {
-		count += uint64(kv.Key.Len() + len(kv.Value))
-		return false, nil
-	})
+	count, err := p.db.EstimateDiskUsage(from, to)
+	if err != nil {
+		return 0, err
+	}
 	return count, nil
 }
 


### PR DESCRIPTION
The admin UI uses `Pebble.ApproximateDiskBytes()` to estimate each
table's size. Previously it was doing an iteration over all keys/values,
which is slow and inaccurate in case of overwrites. This PR changes it
to use Pebble's native `EstimateDiskUsage()` API introduced in
https://github.com/cockroachdb/pebble/pull/415.

Test Plan: ran kv workloads with `--storage-engine pebble` and rocksdb,
and watched the kv table size in admin UI. Switched back and forth
between storage engines to make sure estimates were similar. They were
always within 1MB.

Release note: None