### PR TITLE
sql: fix parsing of 0000-01-01 as Time/TimeTZ

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -406,3 +406,16 @@ select column_name, data_type FROM [SHOW COLUMNS FROM time_precision_test] ORDER
 ----
 id  INT8
 t   TIME(6)
+
+subtest regression_42749
+
+# cast to string to prove it is 24:00
+query T
+SELECT '0000-01-01 24:00:00'::time::string
+----
+24:00:00
+
+query T
+SELECT '2001-01-01 01:24:00'::time
+----
+0000-01-01 01:24:00 +0000 UTC

--- a/pkg/sql/logictest/testdata/logic_test/timetz
+++ b/pkg/sql/logictest/testdata/logic_test/timetz
@@ -153,3 +153,16 @@ select column_name, data_type FROM [SHOW COLUMNS FROM timetz_precision_test] ORD
 ----
 id  INT8
 t   TIMETZ(6)
+
+subtest regression_42749
+
+# cast to string to prove it is 24:00
+query T
+SELECT '0000-01-01 24:00:00'::timetz::string
+----
+24:00:00+00:00:00
+
+query T
+SELECT '2001-01-01 01:24:00+3'::timetz
+----
+0000-01-01 01:24:00 +0300 +0300

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -320,11 +320,11 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c:            tree.NewStrVal("2010-09-28 12:00:00.1"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.Timestamp, types.TimestampTZ, types.Date),
+			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp, types.TimestampTZ, types.Date),
 		},
 		{
 			c:            tree.NewStrVal("2006-07-08T00:00:00.000000123Z"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.Timestamp, types.TimestampTZ, types.Date),
+			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp, types.TimestampTZ, types.Date),
 		},
 		{
 			c:            tree.NewStrVal("PT12H2M"),

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -492,6 +492,8 @@ func TestParseDTime(t *testing.T) {
 		{"04:05:06.000001", time.Microsecond, timeofday.New(4, 5, 6, 1)},
 		{"04:05:06.000001", time.Second, timeofday.New(4, 5, 6, 0)},
 		{"04:05:06-07", time.Microsecond, timeofday.New(4, 5, 6, 0)},
+		{"0000-01-01 04:05:06", time.Microsecond, timeofday.New(4, 5, 6, 0)},
+		{"2001-01-01 04:05:06", time.Microsecond, timeofday.New(4, 5, 6, 0)},
 		{"4:5:6", time.Microsecond, timeofday.New(4, 5, 6, 0)},
 		{"24:00:00", time.Microsecond, timeofday.Time2400},
 		{"24:00:00.000", time.Microsecond, timeofday.Time2400},

--- a/pkg/util/timetz/timetz_test.go
+++ b/pkg/util/timetz/timetz_test.go
@@ -180,6 +180,13 @@ func TestParseTimeTZ(t *testing.T) {
 	}{
 		{str: "01:02:03", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
 		{str: "01:02:03.000123", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 123), 0)},
+		{str: "01:24:00", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 24, 0, 0), 0)},
+		{str: "01:03:24", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 3, 24, 0), 0)},
+		{str: "1970-01-01 01:02:03", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
+		{str: "1970-01-01T01:02:03", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
+		{str: "1970-01-01T01:02:03", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
+		{str: "0000-01-01  01:02:03", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
+		{str: "01:02:03.000123", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 123), 0)},
 		{str: "4:5:6", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(4, 5, 6, 0), 0)},
 		{str: "24:00", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, 0)},
 		{str: "24:00:00", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, 0)},
@@ -193,8 +200,11 @@ func TestParseTimeTZ(t *testing.T) {
 		{str: "24:00:00+4", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, -4*60*60)},
 		{str: "24:00:00.000-5", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, 5*60*60)},
 		{str: "24:00:00.000000+6", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, -6*60*60)},
+		{str: "24:00:00.000000+6", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, -6*60*60)},
+		{str: "1970-01-01T24:00:00.000000+6", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.Time2400, -6*60*60)},
 		{str: "00:00-1559", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(0, 0, 0, 0), MaxTimeTZOffsetSecs)},
 		{str: "00:00+1559", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(0, 0, 0, 0), MinTimeTZOffsetSecs)},
+		{str: " 01:03:24", precision: time.Microsecond, expected: MakeTimeTZ(timeofday.New(1, 3, 24, 0), 0)},
 
 		{str: "01:02:03.000123", precision: time.Millisecond, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 0), 0)},
 		{str: "01:02:03.000123", precision: time.Millisecond / 10, expected: MakeTimeTZ(timeofday.New(1, 2, 3, 100), 0)},
@@ -206,6 +216,9 @@ func TestParseTimeTZ(t *testing.T) {
 		{str: "01:00=wat", expectedError: true},
 		{str: "00:00-1600", expectedError: true},
 		{str: "00:00+1600", expectedError: true},
+		{str: "00:00+24:00", expectedError: true},
+		{str: "1970-01-01 00:00+24:00", expectedError: true},
+		{str: "2010-09-28", expectedError: true},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d: %s", i, tc.str), func(t *testing.T) {

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -12,6 +12,7 @@ package timeutil
 
 import (
 	"math"
+	"strings"
 	"time"
 )
 
@@ -19,6 +20,9 @@ import (
 // runs in "clockless" mode. In that (experimental) mode, we operate without
 // assuming any bound on the clock drift.
 const ClocklessMaxOffset = math.MaxInt64
+
+// LibPQTimePrefix is the prefix lib/pq prints time-type datatypes with.
+const LibPQTimePrefix = "0000-01-01"
 
 // Since returns the time elapsed since t.
 // It is shorthand for Now().Sub(t).
@@ -71,4 +75,13 @@ func SleepUntil(untilNanos int64, currentTimeNanos func() int64) {
 		}
 		time.Sleep(d)
 	}
+}
+
+// ReplaceLibPQTimePrefix replaces unparsable lib/pq dates used for timestamps
+// (0000-01-01) with timestamps that can be parsed by date libraries.
+func ReplaceLibPQTimePrefix(s string) string {
+	if strings.HasPrefix(s, LibPQTimePrefix) {
+		return "1970-01-01" + s[len(LibPQTimePrefix):]
+	}
+	return s
 }

--- a/pkg/util/timeutil/time_test.go
+++ b/pkg/util/timeutil/time_test.go
@@ -15,6 +15,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnixMicros(t *testing.T) {
@@ -62,4 +64,9 @@ func TestUnixMicrosRounding(t *testing.T) {
 			t.Errorf("%d:ToUnixMicro: expected %v, but got %v", i, e, a)
 		}
 	}
+}
+
+func TestReplaceLibPQTimePrefix(t *testing.T) {
+	assert.Equal(t, "1970-02-02 11:00", ReplaceLibPQTimePrefix("1970-02-02 11:00"))
+	assert.Equal(t, "1970-01-01 11:00", ReplaceLibPQTimePrefix("0000-01-01 11:00"))
 }


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/42749

Since `lib/pq` outputs `time.Time` for time datums as 0000-01-01, we
should be able to parse this in. However, `pgdate` library cannot do
that - so we hack around it for now by replacing the year for these
kinds of dates.

Release note (bug fix): Previously, attempting to parse `0000-01-01
00:00` when involving `time` did not work as `pgdate` does not
understand `0000` as a year. This PR will fix that behaviour.