### PR TITLE
storage, ccl: Use RocksDBv2 format for SSTs meant for ingestion

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -350,7 +350,7 @@ func writeSST(
 	log.Info(ctx, "writesst ", filename)
 
 	sstFile := &engine.MemFile{}
-	sst := engine.MakeSSTWriter(sstFile)
+	sst := engine.MakeBackupSSTWriter(sstFile)
 	defer sst.Close()
 	for _, kv := range kvs {
 		kv.Key.Timestamp = ts

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkAddSSTable(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				sstFile := &engine.MemFile{}
-				sst := engine.MakeSSTWriter(sstFile)
+				sst := engine.MakeBackupSSTWriter(sstFile)
 
 				id++
 				backup.ResetKeyValueIteration()

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -171,7 +171,7 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 		path := strconv.FormatInt(hlc.UnixNano(), 10)
 
 		sstFile := &engine.MemFile{}
-		sst := engine.MakeSSTWriter(sstFile)
+		sst := engine.MakeBackupSSTWriter(sstFile)
 		defer sst.Close()
 		ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
 		value := roachpb.MakeValueFromString("bar")

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -76,7 +76,7 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 	g.GoCtx(func(ctx context.Context) error {
 		sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
 		sstFile := &engine.MemFile{}
-		sw := engine.MakeSSTWriter(sstFile)
+		sw := engine.MakeIngestionSSTWriter(sstFile)
 		defer sw.Close()
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -58,7 +58,7 @@ var engineImpls = []struct {
 
 func singleKVSSTable(key engine.MVCCKey, value []byte) ([]byte, error) {
 	sstFile := &engine.MemFile{}
-	sst := engine.MakeSSTWriter(sstFile)
+	sst := engine.MakeBackupSSTWriter(sstFile)
 	defer sst.Close()
 	if err := sst.Put(key, value); err != nil {
 		return nil, err
@@ -406,7 +406,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 
 			mkSST := func(kvs []engine.MVCCKeyValue) []byte {
 				sstFile := &engine.MemFile{}
-				sst := engine.MakeSSTWriter(sstFile)
+				sst := engine.MakeBackupSSTWriter(sstFile)
 				defer sst.Close()
 				for _, kv := range kvs {
 					if err := sst.Put(kv.Key, kv.Value); err != nil {
@@ -510,7 +510,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 			getSSTBytes := func(sstKVs []engine.MVCCKeyValue) []byte {
 				sstFile := &engine.MemFile{}
-				sst := engine.MakeSSTWriter(sstFile)
+				sst := engine.MakeBackupSSTWriter(sstFile)
 				defer sst.Close()
 				for _, kv := range sstKVs {
 					if err := sst.Put(kv.Key, kv.Value); err != nil {

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -177,7 +177,7 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value [
 func (b *SSTBatcher) Reset() error {
 	b.sstWriter.Close()
 	b.sstFile = &engine.MemFile{}
-	b.sstWriter = engine.MakeSSTWriter(b.sstFile)
+	b.sstWriter = engine.MakeIngestionSSTWriter(b.sstFile)
 	b.batchStartKey = b.batchStartKey[:0]
 	b.batchEndKey = b.batchEndKey[:0]
 	b.batchEndValue = b.batchEndValue[:0]
@@ -471,7 +471,7 @@ func createSplitSSTable(
 	iter engine.SimpleIterator,
 ) (*sstSpan, *sstSpan, error) {
 	sstFile := &engine.MemFile{}
-	w := engine.MakeSSTWriter(sstFile)
+	w := engine.MakeIngestionSSTWriter(sstFile)
 	defer w.Close()
 
 	split := false
@@ -501,7 +501,7 @@ func createSplitSSTable(
 				disallowShadowing: disallowShadowing,
 			}
 			*sstFile = engine.MemFile{}
-			w = engine.MakeSSTWriter(sstFile)
+			w = engine.MakeIngestionSSTWriter(sstFile)
 			split = true
 			first = nil
 			last = nil

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2891,7 +2891,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// Range-id local range of subsumed replicas.
 		for _, rangeID := range []roachpb.RangeID{roachpb.RangeID(3), roachpb.RangeID(4)} {
 			sstFile := &engine.MemFile{}
-			sst := engine.MakeSSTWriter(sstFile)
+			sst := engine.MakeIngestionSSTWriter(sstFile)
 			defer sst.Close()
 			r := rditer.MakeRangeIDLocalKeyRange(rangeID, false)
 			if err := sst.ClearRange(r.Start, r.End); err != nil {
@@ -2911,7 +2911,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 		// User key range of subsumed replicas.
 		sstFile := &engine.MemFile{}
-		sst := engine.MakeSSTWriter(sstFile)
+		sst := engine.MakeIngestionSSTWriter(sstFile)
 		defer sst.Close()
 		desc := roachpb.RangeDescriptor{
 			StartKey: roachpb.RKey("d"),

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -977,7 +977,7 @@ func pebbleExportToSst(
 	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, error) {
 	sstFile := &MemFile{}
-	sstWriter := MakeSSTWriter(sstFile)
+	sstWriter := MakeBackupSSTWriter(sstFile)
 	defer sstWriter.Close()
 
 	var rows RowCounter

--- a/pkg/storage/engine/sst_iterator_test.go
+++ b/pkg/storage/engine/sst_iterator_test.go
@@ -73,7 +73,7 @@ func TestSSTIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sstFile := &MemFile{}
-	sst := MakeSSTWriter(sstFile)
+	sst := MakeIngestionSSTWriter(sstFile)
 	defer sst.Close()
 	var allKVs []MVCCKeyValue
 	for i := 0; i < 10; i++ {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -375,7 +375,7 @@ func (r *Replica) SideloadedRaftMuLocked() SideloadStorage {
 
 func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, engine.MVCCKeyValue) {
 	sstFile := &engine.MemFile{}
-	sst := engine.MakeSSTWriter(sstFile)
+	sst := engine.MakeIngestionSSTWriter(sstFile)
 	defer sst.Close()
 
 	v := roachpb.MakeValueFromBytes([]byte(value))

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -822,7 +822,7 @@ func (r *Replica) applySnapshot(
 	}(timeutil.Now())
 
 	unreplicatedSSTFile := &engine.MemFile{}
-	unreplicatedSST := engine.MakeSSTWriter(unreplicatedSSTFile)
+	unreplicatedSST := engine.MakeIngestionSSTWriter(unreplicatedSSTFile)
 	defer unreplicatedSST.Close()
 
 	// Clearing the unreplicated state.
@@ -1029,7 +1029,7 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	for _, sr := range subsumedRepls {
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		subsumedReplSSTFile := &engine.MemFile{}
-		subsumedReplSST := engine.MakeSSTWriter(subsumedReplSSTFile)
+		subsumedReplSST := engine.MakeIngestionSSTWriter(subsumedReplSSTFile)
 		defer subsumedReplSST.Close()
 		// NOTE: We set mustClearRange to true because we are setting
 		// RaftTombstoneKey. Since Clears and Puts need to be done in increasing
@@ -1085,7 +1085,7 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	for i := range keyRanges {
 		if totalKeyRanges[i].End.Key.Compare(keyRanges[i].End.Key) > 0 {
 			subsumedReplSSTFile := &engine.MemFile{}
-			subsumedReplSST := engine.MakeSSTWriter(subsumedReplSSTFile)
+			subsumedReplSST := engine.MakeIngestionSSTWriter(subsumedReplSSTFile)
 			defer subsumedReplSST.Close()
 			if err := engine.ClearRangeWithHeuristic(
 				r.store.Engine(),

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -148,7 +148,7 @@ func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create new sst file")
 	}
-	newSST := engine.MakeSSTWriter(newSSTFile)
+	newSST := engine.MakeIngestionSSTWriter(newSSTFile)
 	msstw.currSST = newSST
 	if err := msstw.currSST.ClearRange(msstw.keyRanges[msstw.currRange].Start, msstw.keyRanges[msstw.currRange].End); err != nil {
 		msstw.currSST.Close()


### PR DESCRIPTION
This change updates SSTWriter to use the RocksDBv2 format and to
re-enable bloom filters on all SSTs written for ingestion (eg.
snapshots). SSTs written for backup are still written in the
leveldb format, and TestPebbleWritesSameSSTables still uses
the leveldb format for comparison with those produced by
RocksDBSstFileWriter.

Fixes #41814.

Release note: None.