### PR TITLE
sql/row: remove extraneous secondary index check

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -356,14 +356,6 @@ func (rf *cFetcher) Init(
 			rf.mustDecodeIndexKey = true
 		}
 
-		if table.isSecondaryIndex {
-			for i := range table.cols {
-				if neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
-				}
-			}
-		}
-
 		// Prepare our index key vals slice.
 		table.keyValTypes, err = sqlbase.GetColumnTypes(table.desc.TableDesc(), indexColumnIDs)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -589,3 +589,37 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.plan.interleaved-table-join' AND usage_count > 0
 ----
 sql.plan.interleaved-table-join
+
+subtest regression_42609
+
+statement ok
+CREATE TABLE parent (
+  a STRING,
+  b STRING,
+  extraParent STRING,
+  PRIMARY KEY (a, b)
+)
+
+statement ok
+CREATE TABLE child (
+  a STRING,
+  b STRING,
+  c STRING,
+  extra STRING,
+  PRIMARY KEY (a,b,c)
+) INTERLEAVE IN PARENT "parent" (a, b)
+
+statement ok
+INSERT INTO parent VALUES ('a', 'b', 'ccc')
+
+statement ok
+INSERT INTO child VALUES ('a', 'b', '1', 'extra')
+
+statement ok
+CREATE INDEX idx_parent_child on child(a,b) INTERLEAVE IN PARENT parent(a,b)
+
+# This query strictly uses the interleave index on the child to merge with the parent.
+query TTT
+select parent.a, parent.b, child.c from child left outer join parent on (parent.a=child.a and parent.b = child.b)
+----
+a  b  1

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -387,14 +387,6 @@ func (rf *Fetcher) Init(
 		// index key, except for composite columns.
 		table.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
 
-		if table.isSecondaryIndex {
-			for i := range table.cols {
-				if table.neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
-				}
-			}
-		}
-
 		// Prepare our index key vals slice.
 		table.keyValTypes, err = sqlbase.GetColumnTypes(table.desc.TableDesc(), indexColumnIDs)
 		if err != nil {


### PR DESCRIPTION
Resolves #42609 - see how this bug causes the foreign key failure!

NOTE: I could be totally wrong on the fix.

We do a check on row fetcher / cfetcher that checks if we're using a
secondary index that the required columns from the table should all exist
in the secondary index. I'm not convinced this check is necessary
(certainly no tests in it - and doesn't lead to correctness concerns
from what I can gather), and has led to some bugs.

Release note (bug fix): Fix a bug where selecting cols by forcing an
INTERLEAVING index would error instead of returning the correct results.