### PR TITLE
Makefile: fix broken kerberos build in linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,7 @@ $(KRB5_DIR)/Makefile: $(C_DEPS_DIR)/krb5-rebuild $(KRB5_SRC_DIR)/src/configure
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/krb5-rebuild. See above for rationale.
 	@# If CFLAGS is set to -g1 then make will fail. Use "env -" to clear the environment.
-	cd $(KRB5_DIR) && env -u CFLAGS -u CXXFLAGS $(KRB5_SRC_DIR)/src/configure $(xconfigure-flags) --enable-static --disable-shared
+	cd $(KRB5_DIR) && env -u CFLAGS -u CXXFLAGS $(KRB5_SRC_DIR)/src/configure $(xconfigure-flags) --enable-shared
 
 $(PROTOBUF_DIR)/Makefile: $(C_DEPS_DIR)/protobuf-rebuild | bin/.submodules-initialized
 	rm -rf $(PROTOBUF_DIR)


### PR DESCRIPTION
Possibly related to issues:  #38841 and #39480.
I have enabled building of shared libraries for kerberos in linux(ubuntu 18.04) to avoid this kind of errors:

```
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:791: Error: junk at end of line, first unrecognized character is `%'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:792: Error: no such instruction: `section .note.GNU-stack noalloc noexec nowrite progbits'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:793: Error: junk at end of line, first unrecognized character is `%'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:794: Error: junk at end of line, first unrecognized character is `%'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:795: Error: no such instruction: `section .note.GNU-stack noalloc noexec nowrite progbits'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:796: Error: junk at end of line, first unrecognized character is `%'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:797: Error: junk at end of line, first unrecognized character is `%'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:798: Error: no such instruction: `section .note.GNU-stack noalloc noexec nowrite progbits'
/home/badis/go/src/github.com/cockroachdb/cockroach/c-deps/krb5/src/lib/crypto/builtin/aes/iaesx64.s:799: Error: junk at end of line, first unrecognized character is `%'
<builtin>: recipe for target 'iaesx64.o' failed
make[5]: *** [iaesx64.o] Error 1
Makefile:1139: recipe for target 'all-recurse' failed
make[4]: *** [all-recurse] Error 1
Makefile:1107: recipe for target 'all-recurse' failed
make[3]: *** [all-recurse] Error 1
Makefile:992: recipe for target 'all-recurse' failed
make[2]: *** [all-recurse] Error 1
Makefile:1533: recipe for target 'all-recurse' failed
make[1]: *** [all-recurse] Error 1
Makefile:719: recipe for target '/home/badis/go/native/x86_64-linux-gnu/krb5/lib/libgssapi_krb5.a' failed
make: *** [/home/badis/go/native/x86_64-linux-gnu/krb5/lib/libgssapi_krb5.a] Error 2

```

Release note (bug fix): Fixed a Makefile bug that would prevent building shared libraries of kerberos in linux and thus prevent building CockroachDB from sources.
