### PR TITLE
release-19.2: sql: stop observing the CommitTimestamp in TRUNCATE

### DIFF
--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -73,7 +73,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{0}
 }
 
 type ForeignKeyReference_Action int32
@@ -118,7 +118,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{0, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -158,7 +158,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{0, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -195,7 +195,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{6, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{6, 0}
 }
 
 // The type of the index.
@@ -232,7 +232,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{6, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{6, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -275,7 +275,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{7, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{7, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -340,7 +340,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{8, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{8, 0}
 }
 
 // Direction of mutation.
@@ -383,7 +383,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{8, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{8, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -434,7 +434,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -471,7 +471,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 1}
 }
 
 type ForeignKeyReference struct {
@@ -493,7 +493,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -561,7 +561,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -606,7 +606,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{2}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -657,7 +657,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{3}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -703,7 +703,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{4}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -747,7 +747,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{4, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -792,7 +792,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{5}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{5}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -835,7 +835,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{5, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{5, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -880,7 +880,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{5, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{5, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1016,7 +1016,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{6}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{6}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1067,7 +1067,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{7}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{7}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1121,7 +1121,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{8}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{8}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1426,7 +1426,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1711,7 +1711,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 0}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1749,7 +1749,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 1}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1852,7 +1852,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 2}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1892,7 +1892,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 3}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1929,7 +1929,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 4}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1971,7 +1971,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 5}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1997,7 +1997,13 @@ func (m *TableDescriptor_SequenceOpts) XXX_DiscardUnknown() {
 var xxx_messageInfo_TableDescriptor_SequenceOpts proto.InternalMessageInfo
 
 type TableDescriptor_Replacement struct {
-	ID   ID            `protobuf:"varint,1,opt,name=id,casttype=ID" json:"id"`
+	ID ID `protobuf:"varint,1,opt,name=id,casttype=ID" json:"id"`
+	// Time is just used for debugging purposes. It is not used in business
+	// logic. It is an HLC rather than just wall time only for historical
+	// reasons. Prior to 19.2.2 it was populated with the commit timestamp of
+	// the transaction which created this replacement. In 19.2.2 and after it is
+	// populated with the read timestamp at which the descriptor being
+	// replaced was read.
 	Time hlc.Timestamp `protobuf:"bytes,2,opt,name=time" json:"time"`
 }
 
@@ -2005,7 +2011,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 6}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2042,7 +2048,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{9, 7}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{9, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2081,7 +2087,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{10}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{10}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2139,7 +2145,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_3c8be6f387ccaf5e, []int{11}
+	return fileDescriptor_structured_d4aef99d2b4f5a45, []int{11}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -10773,10 +10779,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_3c8be6f387ccaf5e)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_d4aef99d2b4f5a45)
 }
 
-var fileDescriptor_structured_3c8be6f387ccaf5e = []byte{
+var fileDescriptor_structured_d4aef99d2b4f5a45 = []byte{
 	// 3367 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5a, 0x4b, 0x6f, 0x23, 0xd7,
 	0x95, 0x56, 0xf1, 0xcd, 0xc3, 0x57, 0xe9, 0xaa, 0xbb, 0xcd, 0x96, 0xdb, 0x22, 0x9b, 0xed, 0xb6,

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -776,6 +776,12 @@ message TableDescriptor {
   message Replacement {
     option (gogoproto.equal) = true;
     optional uint32 id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "ID", (gogoproto.casttype) = "ID"];
+    // Time is just used for debugging purposes. It is not used in business
+    // logic. It is an HLC rather than just wall time only for historical
+    // reasons. Prior to 19.2.2 it was populated with the commit timestamp of
+    // the transaction which created this replacement. In 19.2.2 and after it is
+    // populated with the read timestamp at which the descriptor being
+    // replaced was read.
     optional util.hlc.Timestamp time = 2 [(gogoproto.nullable) = false];
   }
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -190,7 +190,10 @@ func (p *planner) truncateTable(
 	tableDesc.DropJobID = dropJobID
 	newTableDesc := sqlbase.NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
-		ID: id, Time: p.txn.CommitTimestamp(),
+		ID: id,
+		// NB: Time is just used for debugging purposes. See the comment on the
+		// field for more details.
+		Time: p.txn.OrigTimestamp(),
 	}
 	newTableDesc.SetID(0)
 	newTableDesc.Version = 1


### PR DESCRIPTION
Backport 1/1 commits from #42650.

/cc @cockroachdb/release

---

In #40581 we stopped observing the commit timestamp to write it into table
descriptors. In this change I overlooked (rather forgot) about this additional
place in the code where we observed the commit timestamp. As far as I can tell
we don't read this field anywhere ever. Furthermore we know that the the table
descriptor in question to which we are referring must be alive and equal to
the provided value at the timestamp at which it was read due to serializability.
In short, this minor change continues to populate the field with a sensible
value and will permit TRUNCATE to be pushed.

Fixes #41566.

Release note (bug fix): Long running transactions which attempt to TRUNCATE
can now be pushed and will commit in cases where they previously could fail
or retry forever.
