### PR TITLE
cli: promote the 5-character error codes in the error outputs

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -71,8 +71,7 @@ func exitWithError(cmdName string, err error) {
 	errCode := 0
 	if err != nil {
 		// Display the error and its details/hints.
-		fmt.Fprintln(stderr, "Error:", err.Error())
-		maybeShowErrorDetails(stderr, err, false /* printNewline */)
+		cliOutputError(stderr, err, true /*showSeverity*/, false /*verbose*/)
 
 		// Remind the user of which command was being run.
 		fmt.Fprintf(stderr, "Failed running %q\n", cmdName)

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	errBase := errors.New("woo")
+	file, line, fn, _ := errors.GetOneLineSource(errBase)
+	refLoc := fmt.Sprintf("%s, %s:%d", fn, file, line)
+	testData := []struct {
+		err                   error
+		showSeverity, verbose bool
+		exp                   string
+	}{
+		// Check the basic with/without severity.
+		{errBase, false, false, "woo"},
+		{errBase, true, false, "ERROR: woo"},
+		{pgerror.WithCandidateCode(errBase, pgcode.Syntax), false, false, "woo\nSQLSTATE: " + pgcode.Syntax},
+		// Check the verbose output. This includes the uncategorized sqlstate.
+		{errBase, false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nLOCATION: " + refLoc},
+		{errBase, true, true, "ERROR: woo\nSQLSTATE: " + pgcode.Uncategorized + "\nLOCATION: " + refLoc},
+		// Check the same over pq.Error objects.
+		{&pq.Error{Message: "woo"}, false, false, "woo"},
+		{&pq.Error{Message: "woo"}, true, false, "ERROR: woo"},
+		{&pq.Error{Message: "woo"}, false, true, "woo"},
+		{&pq.Error{Message: "woo"}, true, true, "ERROR: woo"},
+		{&pq.Error{Severity: "W", Message: "woo"}, false, false, "woo"},
+		{&pq.Error{Severity: "W", Message: "woo"}, true, false, "W: woo"},
+		// Check hint printed after message.
+		{errors.WithHint(errBase, "hello"), false, false, "woo\nHINT: hello"},
+		// Check sqlstate printed before hint, location after hint.
+		{errors.WithHint(errBase, "hello"), false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nHINT: hello\nLOCATION: " + refLoc},
+		// Check detail printed after message.
+		{errors.WithDetail(errBase, "hello"), false, false, "woo\nDETAIL: hello"},
+		// Check hint/detail collection, hint printed after detail.
+		{errors.WithHint(
+			errors.WithDetail(
+				errors.WithHint(errBase, "a"),
+				"b"),
+			"c"), false, false, "woo\nDETAIL: b\nHINT: a\n--\nc"},
+		{errors.WithDetail(
+			errors.WithHint(
+				errors.WithDetail(errBase, "a"),
+				"b"),
+			"c"), false, false, "woo\nDETAIL: a\n--\nc\nHINT: b"},
+		// Check sqlstate printed before detail, location after hint.
+		{errors.WithDetail(
+			errors.WithHint(errBase, "a"), "b"),
+			false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nDETAIL: b\nHINT: a\nLOCATION: " + refLoc},
+	}
+
+	for _, tc := range testData {
+		var buf strings.Builder
+		cliOutputError(&buf, tc.err, tc.showSeverity, tc.verbose)
+		assert.Equal(t, tc.exp+"\n", buf.String())
+	}
+}
+
+func TestFormatLocation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		file, line, fn string
+		exp            string
+	}{
+		{"", "", "", ""},
+		{"a.b", "", "", "a.b"},
+		{"", "123", "", "<unknown>:123"},
+		{"", "", "abc", "abc"},
+		{"a.b", "", "abc", "abc, a.b"},
+		{"a.b", "123", "", "a.b:123"},
+		{"", "123", "abc", "abc, <unknown>:123"},
+	}
+
+	for _, tc := range testData {
+		r := formatLocation(tc.file, tc.line, tc.fn)
+		assert.Equal(t, tc.exp, r)
+	}
+}

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -40,7 +40,7 @@ send "begin;\r"
 eexpect BEGIN
 
 send "select 3+;\r"
-eexpect "pq: at or near"
+eexpect "ERROR: at or near"
 eexpect "syntax error"
 eexpect root@
 

--- a/pkg/cli/interactive_tests/test_demo_locality_error.tcl
+++ b/pkg/cli/interactive_tests/test_demo_locality_error.tcl
@@ -7,13 +7,13 @@ start_test "Expect error with incorrect demo locality settings"
 # Test failure with less localities than expected.
 spawn $argv demo --nodes 3 --demo-locality=region=us-east1:region=us-east2
 # wait for the CLI to start up
-eexpect "Error: number of localities specified must equal number of nodes"
+eexpect "ERROR: number of localities specified must equal number of nodes"
 eexpect eof
 
 # Test failure with more localities than expected.
 spawn $argv demo --nodes 3 --demo-locality=region=us-east1:region=us-east2:region=us-east3:region=us-east4
 # wait for the CLI to start up
-eexpect "Error: number of localities specified must equal number of nodes"
+eexpect "ERROR: number of localities specified must equal number of nodes"
 eexpect eof
 
 end_test

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -97,7 +97,7 @@ start_test "Expect an error if geo-partitioning is requested and license acquisi
 set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
 spawn $argv demo --geo-partitioned-replicas
 # expect a failure
-eexpect Error
+eexpect ERROR:
 eexpect "enterprise features are needed for this demo"
 # clean up after the test
 eexpect eof

--- a/pkg/cli/interactive_tests/test_error_handling.tcl
+++ b/pkg/cli/interactive_tests/test_error_handling.tcl
@@ -10,7 +10,7 @@ eexpect ":/# "
 
 start_test "Check that by default, an error prevents subsequent statements from running."
 send "(echo 'select foo;'; echo 'select 1;') | $argv sql\r"
-eexpect "pq: column \"foo\" does not exist"
+eexpect "ERROR: column \"foo\" does not exist"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "1\r\n:/# "
@@ -18,7 +18,7 @@ end_test
 
 start_test "Check that a user can request to continue upon failures."
 send "(echo '\\unset errexit'; echo 'select foo;'; echo 'select 1;') | $argv sql\r"
-eexpect "pq: column \"foo\" does not exist"
+eexpect "ERROR: column \"foo\" does not exist"
 eexpect "1 row"
 eexpect ":/# "
 send "echo \$?\r"
@@ -30,7 +30,7 @@ end_test
 
 start_test "Check that by default, an error does not cause an interactive failure."
 send "select foo;\r"
-eexpect "pq: column \"foo\" does not exist"
+eexpect "ERROR: column \"foo\" does not exist"
 eexpect "root@"
 end_test
 
@@ -38,7 +38,7 @@ start_test "Check that the user can ask for errors to terminate the interactive 
 send "\\set errexit\r"
 eexpect "root@"
 send "select foo;\r"
-eexpect "Error: pq: column \"foo\" does not exist"
+eexpect "ERROR: column \"foo\" does not exist"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "1\r\n:/# "
@@ -46,7 +46,7 @@ end_test
 
 start_test "Check that unknown sub-commands report a non-zero exit status."
 send "$argv node wowowo\r"
-eexpect "Error: unknown sub-command"
+eexpect "ERROR: unknown sub-command"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "1\r\n:/# "

--- a/pkg/cli/interactive_tests/test_error_hints.tcl
+++ b/pkg/cli/interactive_tests/test_error_hints.tcl
@@ -18,24 +18,24 @@ eexpect ":/# "
 
 start_test "Connecting a RPC client to a non-started server"
 send "$argv quit\r"
-eexpect "Error: cannot load certificates.\r\nCheck your certificate settings"
+eexpect "ERROR: cannot load certificates.\r\nCheck your certificate settings"
 eexpect "or use --insecure"
 eexpect ":/# "
 
 send "$argv quit --certs-dir=$certs_dir\r"
-eexpect "Error: cannot dial server.\r\nIs the server running?"
+eexpect "ERROR: cannot dial server.\r\nIs the server running?"
 eexpect "connection refused"
 eexpect ":/# "
 end_test
 
 start_test "Connecting a SQL client to a non-started server"
 send "$argv sql -e 'select 1'\r"
-eexpect "Error: cannot load certificates.\r\nCheck your certificate settings"
+eexpect "ERROR: cannot load certificates.\r\nCheck your certificate settings"
 eexpect "or use --insecure"
 eexpect ":/# "
 
 send "$argv sql -e 'select 1' --certs-dir=$certs_dir\r"
-eexpect "Error: cannot dial server.\r\nIs the server running?"
+eexpect "ERROR: cannot dial server.\r\nIs the server running?"
 eexpect "connection refused"
 eexpect ":/# "
 end_test
@@ -54,14 +54,14 @@ eexpect ":/# "
 
 start_test "Connecting a secure RPC client to an insecure server"
 send "$argv quit --certs-dir=$certs_dir\r"
-eexpect "Error: cannot establish secure connection to insecure server."
+eexpect "ERROR: cannot establish secure connection to insecure server."
 eexpect "Maybe use --insecure?"
 eexpect ":/# "
 end_test
 
 start_test "Connecting a secure SQL client to an insecure server"
 send "$argv sql -e 'select 1' --certs-dir=$certs_dir\r"
-eexpect "Error: cannot establish secure connection to insecure server."
+eexpect "ERROR: cannot establish secure connection to insecure server."
 eexpect ":/# "
 end_test
 
@@ -80,14 +80,14 @@ set spawn_id $client_spawn_id
 
 start_test "Connecting an insecure RPC client to a secure server"
 send "$argv quit --insecure\r"
-eexpect "Error: server closed the connection."
+eexpect "ERROR: server closed the connection."
 eexpect "remove --insecure"
 eexpect ":/# "
 end_test
 
 start_test "Connecting an insecure SQL client to a secure server"
 send "$argv sql -e 'select 1' --insecure\r"
-eexpect "Error: SSL authentication error while connecting."
+eexpect "ERROR: SSL authentication error while connecting."
 eexpect "remove --insecure"
 eexpect ":/# "
 end_test
@@ -115,7 +115,7 @@ interrupt
 eexpect ":/# "
 # Check that cockroach quit becomes suitably confused.
 set spawn_id $client_spawn_id
-eexpect "Error: server closed the connection."
+eexpect "ERROR: server closed the connection."
 eexpect "Is this a CockroachDB node?"
 eexpect ":/# "
 set spawn_id $shell_spawn_id
@@ -138,7 +138,7 @@ interrupt
 eexpect ":/# "
 # Check that cockroach sql becomes suitably confused.
 set spawn_id $client_spawn_id
-eexpect "Error: server closed the connection."
+eexpect "ERROR: server closed the connection."
 eexpect "Is this a CockroachDB node?"
 eexpect "EOF"
 eexpect ":/# "

--- a/pkg/cli/interactive_tests/test_init_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_command.tcl
@@ -20,7 +20,7 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 send "$argv sql\r"
-eexpect "Error: cannot dial server"
+eexpect "ERROR: cannot dial server"
 send "exit\r"
 eexpect eof
 end_test
@@ -48,7 +48,7 @@ system "$argv init --insecure --host=localhost"
 expect {
     "pg_class" {}
     # Hopefully this broad regex will match any errors we log
-    # (Currently, everything I've seen begins with "Error:")
+    # (Currently, everything I've seen begins with "ERROR:")
     -re "(?i)err" {
         set prefix $expect_out(buffer)
         # Read next line to finish the error message.

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -245,7 +245,7 @@ eexpect "statement ignored"
 eexpect ":/# "
 
 send "(echo '\\unset check_syntax'; echo 'select '; echo '\\help'; echo '1;') | $argv sql\r"
-eexpect "pq: at or near"
+eexpect "ERROR: at or near"
 eexpect "syntax error"
 eexpect ":/# "
 end_test

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -92,7 +92,7 @@ end_test
 start_test "Check that root cannot use password."
 # Run as root but with a non-existent certs directory.
 send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full&sslrootcert=$certs_dir/ca.crt'\r"
-eexpect "Error: connections with user root must use a client certificate"
+eexpect "ERROR: connections with user root must use a client certificate"
 eexpect "Failed running \"sql\""
 end_test
 
@@ -119,7 +119,7 @@ eexpect $prompt
 send "$argv sql --certs-dir=$certs_dir --user=eisen\r"
 eexpect "Enter password:"
 send "*****\r"
-eexpect "Error: pq: password authentication failed for user eisen"
+eexpect "ERROR: password authentication failed for user eisen"
 eexpect "Failed running \"sql\""
 # Check that history is scrubbed.
 send "$argv sql --certs-dir=$certs_dir\r"

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -91,7 +91,7 @@ end_test
 
 start_test "Test that prompt becomes ERROR upon txn error."
 send "select a;\r"
-eexpect "pq: column \"a\" does not exist"
+eexpect "ERROR: column \"a\" does not exist"
 eexpect root@
 eexpect "ERROR>"
 end_test
@@ -121,7 +121,7 @@ send "BEGIN; SAVEPOINT cockroach_restart;\r\r"
 eexpect SAVEPOINT
 eexpect root@
 send "SELECT crdb_internal.force_retry('1s':::INTERVAL);\r"
-eexpect "pq: restart transaction"
+eexpect "ERROR: restart transaction"
 eexpect root@
 eexpect "RETRY>"
 end_test

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -229,7 +229,7 @@ FROM crdb_internal.gossip_liveness LEFT JOIN crdb_internal.gossip_nodes USING (n
 			return nil, nil, err
 		}
 		if len(rows) == 0 {
-			return nil, nil, fmt.Errorf("Error: node %d doesn't exist", nodeID)
+			return nil, nil, errors.Errorf("node %d doesn't exist", nodeID)
 		}
 		return headers, rows, nil
 	default:


### PR DESCRIPTION
tldr: This patch opens a new era in the relationship between
CockroachDB and its users by acknowledging the existence of SQLSTATE
in the error outputs produced by CLI commands.

Before:
```
root@127.0.0.1:61772/movr> select * from u;
pq: relation "u" does not exist
```

After:
```
root@127.0.0.1:61772/movr> select * from u;
ERROR: relation "u" does not exist
SQLSTATE: 42P01
```

Background:

The SQL standard specifies that servers should signal errors to
clients with both an explanatory text and a 5-character "SQLSTATE"
code. Certain of these codes are even standardized. The purpose of
these codes is to facilitate both troubleshooting by end-users and
easier searching for resources about what to do under certain
errors.

PostgreSQL makes consistent use of these 5-digit codes; they are
always communicated to clients as a special payload in the postgres
wire protocol. In fact, CockroachDB has started ever since version 2.0
to imitate PostgreSQL and try an produce similar codes in similar
circumstances.

Unfortunately, CockroachDB's own SQL shell does not show SQLSTATE
codes to the user and this fails to teach users about their existence.

Moreover, users who build automation without knowing about SQLSTATE
codes get tempted to rely on the text of the error message
instead. This is undesirable because we wish to be able to improve
error messages (to clarify them over time) and only promise more
stability guarantees on the SQLSTATE.

This patch improve supon this situation by promoting SQLSTATE
in the default output of CLI commands.

Additional reading resources:

- https://www.postgresql.org/docs/12/errcodes-appendix.html
- https://en.wikipedia.org/wiki/SQLSTATE

Additionally, in order to prepare for the upcoming `pgx` migration,
the `pq: ` prefix to error generated by `lib/pq` is stripped out. It
is replaced by the "Severity" field of the pgwire error packet, if
available.

Release note (cli change): the various CLI commands that use SQL now
display errors using a new display format that emphasizes the 5-digit
SQLSTATE code. Users are encouraged to combine these codes together
with the error message when seeking help or troubleshooting.