### PR TITLE
sql: Fix for invalid value for parameter "TimeZone": "GMT-08:00" #41776

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -192,3 +192,14 @@ query R
 SELECT extract(timezone FROM '2001-01-01 13:00:00+01:15'::timestamptz)
 ----
 10800
+
+
+subtest regression_41776
+
+statement ok
+SET TIME ZONE 'GMT+1'
+
+query T
+SELECT '2001-01-01 00:00:00'::TIMESTAMP::TIMESTAMPTZ
+----
+2001-01-01 00:00:00 +0100 +0100

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -222,8 +222,12 @@ func timeZoneVarGetStringVal(
 			if err1 != nil {
 				loc, err1 = timeutil.LoadLocation(strings.ToTitle(location))
 				if err1 != nil {
-					return "", wrapSetVarError("timezone", values[0].String(),
-						"cannot find time zone %q: %v", location, err)
+					var ok bool
+					offset, ok = timeutil.TimeZoneOffsetStringConversion(location)
+					if !ok {
+						return "", wrapSetVarError("timezone", values[0].String(),
+							"cannot find time zone %q: %v", location, err)
+					}
 				}
 			}
 		}

--- a/pkg/util/timeutil/time_zone_util_test.go
+++ b/pkg/util/timeutil/time_zone_util_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package timeutil
+
+import "testing"
+
+func TestTimeZoneOffsetStringConversion(t *testing.T) {
+	testCases := []struct {
+		timezone   string
+		offsetSecs int64
+		ok         bool
+	}{
+		{`GMT+00:00`, 0, true},
+		{`UTC-1:00:00`, -3600, true},
+		{`UTC-1:0:00`, -3600, true},
+		{`UTC+15:59:0`, 57540, true},
+		{` GMT +167:59:00  `, 604740, true},
+		{`GMT-15:59:59`, -57599, true},
+		{`GMT-06:59`, -25140, true},
+		{`GMT+167:59:00`, 604740, true},
+		{`GMT+ 167: 59:0`, 604740, true},
+		{`GMT+5`, 18000, true},
+		{`UTC+5:9`, 5*60*60 + 9*60, true},
+		{`UTC-5:9:1`, -(5*60*60 + 9*60 + 1), true},
+		{`GMT-15:59:5Z`, 0, false},
+		{`GMT-15:99:1`, 0, false},
+		{`GMT+6:`, 0, false},
+		{`GMT-6:00:`, 0, false},
+		{`GMT+168:00:00`, 0, false},
+		{`GMT-170:00:59`, 0, false},
+	}
+
+	for i, testCase := range testCases {
+		offset, ok := TimeZoneOffsetStringConversion(testCase.timezone)
+		if offset != testCase.offsetSecs || ok != testCase.ok {
+			t.Errorf("%d: Expected offset: %d, success: %v for time %s, but got offset: %d, success: %v",
+				i, testCase.offsetSecs, testCase.ok, testCase.timezone, offset, ok)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #41776

Previously, the inputs starting with `UTC` and `GMT` would cause error.
Postgres supports inputs like this. So adding support for
these inputs was necessary.
sql: Added a check to convert the strings to offset.
timeutil: added a function to convert input to offset seconds.
Added unit tests. Added a regex to accept the above inputs.
Cleaned the code.

Release note (sql change): `SET TIME ZONE` now accepts inputs
beginning with `GMT` and `UTC`, such as `GMT+5` and
`UTC-3:59`. This was previously unsupported.


@otan 