### PR TITLE
Ui styling decommissioned nodes

### DIFF
--- a/pkg/ui/assets/livenessIcons/decommissioning.svg
+++ b/pkg/ui/assets/livenessIcons/decommissioning.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+  <circle fill="#54B30E" cx="9" cy="9" r="6" stroke="white" stroke-width="1px" />
+  <g transform="translate(1 1)">
+    <circle fill="#5F6C87" cx="8" cy="8" r="8" stroke="white" stroke-width="1px" />
+    <rect width="1.333" height="5.333" x="8.667" y="12" fill="#fff" rx=".667" transform="rotate(180 8.667 12)"/>
+    <ellipse cx="8" cy="4.667" fill="#fff" rx=".667" ry=".667" transform="rotate(180 8 4.667)"/>
+  </g>
+</svg>

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -29,6 +29,7 @@ import { LongToMoment } from "src/util/convert";
 import {
   SummaryBar, SummaryLabel, SummaryValue,
 } from "src/views/shared/components/summaryBar";
+import { getLivenessStatusDescription } from "src/views/cluster/util/nodes";
 
 /**
  * TableRow is a small stateless component that renders a single row in the node
@@ -88,7 +89,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
 
     const liveness = nodesSummary.livenessStatusByNodeID[node.desc.node_id] || LivenessStatus.LIVE;
     const livenessString = livenessNomenclature(liveness);
-
+    const tooltip = getLivenessStatusDescription(liveness);
     return (
       <div>
         <Helmet>
@@ -166,6 +167,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
                 title="Health"
                 value={livenessString}
                 classModifier={livenessString}
+                tooltip={tooltip}
               />
               <SummaryValue title="Last Update" value={LongToMoment(node.updated_at).fromNow()} />
               <SummaryValue title="Build" value={node.build_info.tag} />

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -176,7 +176,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
  * NotLiveNodeListProps are the properties of NotLiveNodeList.
  */
 interface NotLiveNodeListProps extends NodeCategoryListProps {
-  status: LivenessStatus.DECOMMISSIONING | LivenessStatus.DEAD;
+  status: LivenessStatus.DECOMMISSIONED | LivenessStatus.DEAD;
 }
 
 /**
@@ -191,8 +191,8 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     }
 
     const statusName = _.capitalize(LivenessStatus[status]);
-    const icon = getLivenessIcon(status);
     const tooltip = getLivenessStatusDescription(status);
+    const icon = getLivenessIcon(status);
 
     return (
       <div className="embedded-table">
@@ -217,9 +217,13 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
               cell: (ns) => {
                 return (
                   <div>
-                    <span className="node-status-icon"
-                      title={tooltip}
-                      dangerouslySetInnerHTML={ trustIcon(icon) } />
+                    {
+                      icon && (
+                        <span className="node-status-icon"
+                              title={tooltip}
+                              dangerouslySetInnerHTML={ trustIcon(icon) } />
+                      )
+                    }
                     <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
                   </div>
                 );

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -36,6 +36,7 @@ import suspectIcon from "!!raw-loader!assets/livenessIcons/suspect.svg";
 import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
 import decommissioningIcon from "!!raw-loader!assets/livenessIcons/decommissioning.svg";
 import { cockroach } from "src/js/protos";
+import { getLivenessStatusDescription } from "src/views/cluster/util/nodes";
 
 import { BytesBarChart } from "./barChart";
 import "./nodes.styl";
@@ -115,19 +116,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               cell: (ns) => {
                 const status = nodesSummary.livenessStatusByNodeID[ns.desc.node_id] || LivenessStatus.LIVE;
                 const icon = this.getLivenessIcon(status);
-                let tooltip: string;
-                switch (status) {
-                  case LivenessStatus.LIVE:
-                    tooltip = "This node is currently healthy.";
-                    break;
-                  case LivenessStatus.DECOMMISSIONING:
-                    tooltip = "This node is in the process of being decommissioned. It may take some time to transfer" +
-                      " the data to other nodes. When finished, it will appear below as a decommissioned node.";
-                    break;
-                  default:
-                    tooltip = "This node has not recently reported as being live. " +
-                      "It may not be functioning correctly, but no automatic action has yet been taken.";
-                }
+                const tooltip = getLivenessStatusDescription(status);
                 return (
                   <div className="sort-table__unbounded-column">
                     <span className="node-status-icon" title={tooltip} dangerouslySetInnerHTML={ trustIcon(icon) } />

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -31,17 +31,10 @@ import { LongToMoment } from "src/util/convert";
 import { BytesUsed, INodeStatus, MetricConstants } from "src/util/proto";
 import { FixLong } from "src/util/fixLong";
 import { trustIcon } from "src/util/trust";
-import liveIcon from "!!raw-loader!assets/livenessIcons/live.svg";
-import suspectIcon from "!!raw-loader!assets/livenessIcons/suspect.svg";
-import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
-import decommissioningIcon from "!!raw-loader!assets/livenessIcons/decommissioning.svg";
-import { cockroach } from "src/js/protos";
-import { getLivenessStatusDescription } from "src/views/cluster/util/nodes";
+import { getLivenessStatusDescription, getLivenessIcon } from "src/views/cluster/util/nodes";
 
 import { BytesBarChart } from "./barChart";
 import "./nodes.styl";
-
-import NodeLivenessStatus = cockroach.storage.NodeLivenessStatus;
 
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/live_sort_setting", (s) => s.localSettings,
@@ -74,19 +67,6 @@ interface NodeCategoryListProps {
  * statistics for these nodes.
  */
 class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
-  getLivenessIcon(livenessStatus: NodeLivenessStatus) {
-    switch (livenessStatus) {
-      case NodeLivenessStatus.LIVE:
-        return liveIcon;
-      case NodeLivenessStatus.DECOMMISSIONING:
-        return decommissioningIcon;
-      case NodeLivenessStatus.DEAD:
-        return deadIcon;
-      default:
-        return suspectIcon;
-    }
-  }
-
   render() {
     const { statuses, nodesSummary, sortSetting } = this.props;
     if (!statuses || statuses.length === 0) {
@@ -115,7 +95,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               title: "Address",
               cell: (ns) => {
                 const status = nodesSummary.livenessStatusByNodeID[ns.desc.node_id] || LivenessStatus.LIVE;
-                const icon = this.getLivenessIcon(status);
+                const icon = getLivenessIcon(status);
                 const tooltip = getLivenessStatusDescription(status);
                 return (
                   <div className="sort-table__unbounded-column">
@@ -211,6 +191,8 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     }
 
     const statusName = _.capitalize(LivenessStatus[status]);
+    const icon = getLivenessIcon(status);
+    const tooltip = getLivenessStatusDescription(status);
 
     return (
       <div className="embedded-table">
@@ -235,6 +217,9 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
               cell: (ns) => {
                 return (
                   <div>
+                    <span className="node-status-icon"
+                      title={tooltip}
+                      dangerouslySetInnerHTML={ trustIcon(icon) } />
                     <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
                   </div>
                 );

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -23,17 +23,18 @@ import {
   selectNodesSummaryValid,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
-import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
 import { LongToMoment } from "src/util/convert";
-import { INodeStatus, MetricConstants, BytesUsed } from "src/util/proto";
+import { BytesUsed, INodeStatus, MetricConstants } from "src/util/proto";
 import { FixLong } from "src/util/fixLong";
 import { trustIcon } from "src/util/trust";
 import liveIcon from "!!raw-loader!assets/livenessIcons/live.svg";
 import suspectIcon from "!!raw-loader!assets/livenessIcons/suspect.svg";
 import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
+import decommissioningIcon from "!!raw-loader!assets/livenessIcons/decommissioning.svg";
 import { cockroach } from "src/js/protos";
 
 import { BytesBarChart } from "./barChart";
@@ -76,6 +77,8 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
     switch (livenessStatus) {
       case NodeLivenessStatus.LIVE:
         return liveIcon;
+      case NodeLivenessStatus.DECOMMISSIONING:
+        return decommissioningIcon;
       case NodeLivenessStatus.DEAD:
         return deadIcon;
       default:
@@ -118,7 +121,8 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                     tooltip = "This node is currently healthy.";
                     break;
                   case LivenessStatus.DECOMMISSIONING:
-                    tooltip = "This node is currently being decommissioned.";
+                    tooltip = "This node is in the process of being decommissioned. It may take some time to transfer" +
+                      " the data to other nodes. When finished, it will appear below as a decommissioned node.";
                     break;
                   default:
                     tooltip = "This node has not recently reported as being live. " +
@@ -242,13 +246,6 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
               cell: (ns) => {
                 return (
                   <div>
-                    <span className="node-status-icon"
-                      title={
-                        "This node has not reported as live for a significant period and is considered dead. " +
-                        "The cut-off period for dead nodes is configurable as cluster setting " +
-                        "'server.time_until_store_dead'"
-                      }
-                      dangerouslySetInnerHTML={ trustIcon(deadIcon) } />
                     <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
                   </div>
                 );

--- a/pkg/ui/src/views/cluster/util/nodes.ts
+++ b/pkg/ui/src/views/cluster/util/nodes.ts
@@ -15,7 +15,6 @@ import liveIcon from "!!raw-loader!assets/livenessIcons/live.svg";
 import suspectIcon from "!!raw-loader!assets/livenessIcons/suspect.svg";
 import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
 import decommissioningIcon from "!!raw-loader!assets/livenessIcons/decommissioning.svg";
-
 import NodeLivenessStatus = cockroach.storage.NodeLivenessStatus;
 
 export const getLivenessStatusDescription = (status: LivenessStatus) => {
@@ -41,6 +40,8 @@ export const getLivenessIcon = (livenessStatus: NodeLivenessStatus) => {
       return liveIcon;
     case NodeLivenessStatus.DECOMMISSIONING:
       return decommissioningIcon;
+    case NodeLivenessStatus.DECOMMISSIONED:
+      return null;
     case NodeLivenessStatus.DEAD:
       return deadIcon;
     default:

--- a/pkg/ui/src/views/cluster/util/nodes.ts
+++ b/pkg/ui/src/views/cluster/util/nodes.ts
@@ -9,6 +9,14 @@
 // licenses/APL.txt.
 
 import { LivenessStatus } from "src/redux/nodes";
+import { cockroach } from "src/js/protos";
+
+import liveIcon from "!!raw-loader!assets/livenessIcons/live.svg";
+import suspectIcon from "!!raw-loader!assets/livenessIcons/suspect.svg";
+import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
+import decommissioningIcon from "!!raw-loader!assets/livenessIcons/decommissioning.svg";
+
+import NodeLivenessStatus = cockroach.storage.NodeLivenessStatus;
 
 export const getLivenessStatusDescription = (status: LivenessStatus) => {
   switch (status) {
@@ -17,8 +25,25 @@ export const getLivenessStatusDescription = (status: LivenessStatus) => {
     case LivenessStatus.DECOMMISSIONING:
       return  "This node is in the process of being decommissioned. It may take some time to transfer" +
         " the data to other nodes. When finished, it will appear below as a decommissioned node.";
+    case LivenessStatus.DEAD:
+      return "This node has not reported as live for a significant period and is considered dead. " +
+        "The cut-off period for dead nodes is configurable as cluster setting " +
+        "'server.time_until_store_dead'";
     default:
       return "This node has not recently reported as being live. " +
         "It may not be functioning correctly, but no automatic action has yet been taken.";
+  }
+};
+
+export const getLivenessIcon = (livenessStatus: NodeLivenessStatus) => {
+  switch (livenessStatus) {
+    case NodeLivenessStatus.LIVE:
+      return liveIcon;
+    case NodeLivenessStatus.DECOMMISSIONING:
+      return decommissioningIcon;
+    case NodeLivenessStatus.DEAD:
+      return deadIcon;
+    default:
+      return suspectIcon;
   }
 };

--- a/pkg/ui/src/views/cluster/util/nodes.ts
+++ b/pkg/ui/src/views/cluster/util/nodes.ts
@@ -1,0 +1,24 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { LivenessStatus } from "src/redux/nodes";
+
+export const getLivenessStatusDescription = (status: LivenessStatus) => {
+  switch (status) {
+    case LivenessStatus.LIVE:
+      return "This node is currently healthy.";
+    case LivenessStatus.DECOMMISSIONING:
+      return  "This node is in the process of being decommissioned. It may take some time to transfer" +
+        " the data to other nodes. When finished, it will appear below as a decommissioned node.";
+    default:
+      return "This node has not recently reported as being live. " +
+        "It may not be functioning correctly, but no automatic action has yet been taken.";
+  }
+};

--- a/pkg/ui/src/views/shared/components/summaryBar/index.tsx
+++ b/pkg/ui/src/views/shared/components/summaryBar/index.tsx
@@ -29,6 +29,7 @@ interface SummaryValueProps {
   title: React.ReactNode;
   value: React.ReactNode;
   classModifier?: string;
+  tooltip?: string;
 }
 
 interface SummaryStatProps {
@@ -82,21 +83,22 @@ export function SummaryBar(props: { children?: React.ReactNode }) {
  * as messages and breakdowns.
  */
 export function SummaryValue(props: SummaryValueProps & {children?: React.ReactNode}) {
+  const { classModifier, children, title, tooltip, value } = props;
   const topClasses = classNames(
     "summary-stat",
-    props.classModifier ? `summary-stat--${props.classModifier}` : null,
+    classModifier ? `summary-stat--${classModifier}` : null,
   );
   return (
     <div className={topClasses}>
       <div className="summary-stat__body">
         <span className="summary-stat__title">
-          { props.title }
+          { title }
         </span>
-        <span className="summary-stat__value">
-          { props.value }
+        <span className="summary-stat__value" title={tooltip}>
+          { value }
         </span>
       </div>
-      { props.children }
+      { children }
     </div>
   );
 }

--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -88,8 +88,9 @@
     color $warning-color
     text-transform capitalize
 
-  &--decommissioning &__value
-    color $warning-color
+  &--decommissioning &__value,
+  &--decommissioned &__value
+    color $body-color
     text-transform capitalize
 
   &--healthy &__value


### PR DESCRIPTION
- Show icon (greyed info icon) for decommissioned nodes on Nodes Overview page;
- Do not show Dead icon for already decommissioned nodes;
- Display tooltips for liveness statuses on Node overview page;
- Refactor to external function logic with composing tooltip for liveness statuses;

Changes made regarding this designs: https://app.zeplin.io/project/5ddc251005378993e4be872c/screen/5ddc3ec1a425aa9499596250

![Screenshot 2019-11-26 at 17 07 03](https://user-images.githubusercontent.com/3106437/69645833-7cd57680-106f-11ea-839e-59af8b5fc0ea.png)
