### PR TITLE
roachtest: update gopg blacklist

### DIFF
--- a/pkg/cmd/roachtest/gopg_blacklist.go
+++ b/pkg/cmd/roachtest/gopg_blacklist.go
@@ -75,7 +75,6 @@ var gopgBlackList19_2 = blacklist{
 	"pg | DB nulls | nil ptr inserts null value":                               "5807",
 	"pg | DB nulls | sql.NullInt64 inserts non-null value":                     "5807",
 	"pg | DB nulls | sql.NullInt64 inserts null value":                         "5807",
-	"pg | DB race | SelectOrInsert without OnConflict is race free":            "unknown",
 	"pg | DB uint64 in struct field | is appended and scanned as int64":        "5807",
 	"pg | DB.Select | selects bytea":                                           "5807",
 	"pg | DB.Select | selects into embedded struct pointer":                    "5807",


### PR DESCRIPTION
When the blacklist was last updated, it accidentally marked a flaky test
as "expected fail." We can diagnose the flakiness if it becomes a
problem, but for now, the test is expected to pass.

Fixes #42776

Release note: None