### PR TITLE
release-19.2: opt: fix incorrect lax key calculation

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/index-join
+++ b/pkg/sql/opt/memo/testdata/logprops/index-join
@@ -55,7 +55,6 @@ SELECT y FROM a WHERE s = 'foo' AND x + y = 10
 ----
 project
  ├── columns: y:2(int)
- ├── lax-key: (2)
  ├── prune: (2)
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -175,3 +175,32 @@ select
            └── lt [type=bool]
                 ├── variable: d [type=date]
                 └── const: '2017-01-05' [type=date]
+
+
+# Regression test for #42731: we were incorrectly setting cardinality [0 - 1].
+exec-ddl
+CREATE TABLE t42731 (id INT PRIMARY KEY, unique_value INT UNIQUE, notnull_value INT NOT NULL)
+----
+
+norm
+SELECT * FROM t42731 WHERE unique_value IS NULL AND notnull_value = 2000
+----
+select
+ ├── columns: id:1(int!null) unique_value:2(int) notnull_value:3(int!null)
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (2)~~>(1)
+ ├── prune: (1)
+ ├── interesting orderings: (+1) (+2,+1)
+ ├── scan t42731
+ │    ├── columns: id:1(int!null) unique_value:2(int) notnull_value:3(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3), (2)~~>(1,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1) (+2,+1)
+ └── filters
+      ├── is [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
+      │    ├── variable: unique_value [type=int]
+      │    └── null [type=unknown]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/2000 - /2000]; tight), fd=()-->(3)]
+           ├── variable: notnull_value [type=int]
+           └── const: 2000 [type=int]

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -1371,8 +1371,8 @@ func (f *FuncDepSet) inClosureOf(cols, in opt.ColSet, strict bool) bool {
 			if fd.from.SubsetOf(in) && !fd.to.SubsetOf(in) {
 				laxIn.UnionWith(fd.to)
 
-				// Equivalencies and constants are always transitive.
-				if fd.equiv || fd.from.Empty() {
+				// Equivalencies are always transitive.
+				if fd.equiv {
 					in.UnionWith(fd.to)
 
 					// Restart iteration to get transitive closure.

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -46,7 +46,13 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 		{cols: c(10), strict: false, lax: false},
 		{cols: c(11), strict: false, lax: false},
 		{cols: c(), strict: false, lax: false},
-		{cols: c(2, 11), strict: false, lax: true},
+
+		// This case is interesting: if we take into account that 3 is a constant,
+		// we could put 2 and 3 together and use (2,3)~~>(1,4,5) and (1)==(10) to
+		// prove that (2,3) is a lax key. But this is only true when that constant
+		// value for 3 is not NULL. We would have to pass non-null information to
+		// the check. See #42731.
+		{cols: c(2, 11), strict: false, lax: false},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Backport 1/1 commits from #42760.

/cc @cockroachdb/release

---

There is an interesting case where we incorrectly return a column as a
lax key because we think it's ok to combine it with other constant
columns. This would be ok in most cases, except when the constant
value for one of the other columns is NULL.

The specific example is when we have a unique index on column 2
constrained to NULL and a non-unique index on column 3 constrained to
some value. The FDs are `key(1); ()-->(2,3), (2)~~>(1)`. We
incorrectly determine `(3)` to be a lax key because we extend the set
to include `2`.

The fix is to not extend the left-hand-side set with constants when
getting the lax closure. If we really cared about this case we would
need to pass in non-null column information, and extend the set with
constants that are also known to be non-null.

Fixes #42731.

Release note (bug fix): fixed a case where we incorrectly determine
that a query (or part of a query) which contains an `IS NULL`
constraint on a unique index column returns at most one row, possibly
ignoring a `LIMIT 1` clause.

