### PR TITLE
sql/row: fix erroring column check for interleaved indexes in fetcher

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -356,10 +356,10 @@ func (rf *cFetcher) Init(
 			rf.mustDecodeIndexKey = true
 		}
 
-		if table.isSecondaryIndex {
+		if table.isSecondaryIndex && len(table.index.Interleave.Ancestors) == 0 {
 			for i := range table.cols {
 				if neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+					return errors.Errorf("requested column %s not in index", table.cols[i].Name)
 				}
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -589,3 +589,37 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.plan.interleaved-table-join' AND usage_count > 0
 ----
 sql.plan.interleaved-table-join
+
+subtest regression_42609
+
+statement ok
+CREATE TABLE parent (
+  a STRING,
+  b STRING,
+  extraParent STRING,
+  PRIMARY KEY (a, b)
+)
+
+statement ok
+CREATE TABLE child (
+  a STRING,
+  b STRING,
+  c STRING,
+  extra STRING,
+  PRIMARY KEY (a,b,c)
+) INTERLEAVE IN PARENT "parent" (a, b)
+
+statement ok
+INSERT INTO parent VALUES ('a', 'b', 'ccc')
+
+statement ok
+INSERT INTO child VALUES ('a', 'b', '1', 'extra')
+
+statement ok
+CREATE INDEX idx_parent_child on child(a,b) INTERLEAVE IN PARENT parent(a,b)
+
+# This query strictly uses the interleave index on the child to merge with the parent.
+query TTT
+select parent.a, parent.b, child.c from child@{force_index=idx_parent_child} left outer join parent on (parent.a=child.a and parent.b = child.b)
+----
+a  b  1

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -387,10 +387,10 @@ func (rf *Fetcher) Init(
 		// index key, except for composite columns.
 		table.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
 
-		if table.isSecondaryIndex {
+		if table.isSecondaryIndex && len(table.index.Interleave.Ancestors) == 0 {
 			for i := range table.cols {
 				if table.neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+					return errors.Errorf("requested column %s not in index", table.cols[i].Name)
 				}
 			}
 		}


### PR DESCRIPTION
Resolves #42609

Previously in both fetcher and cfetcher, we check that we are not
fetching columns that are not referenced by any secondary index.
However, for interleaving indexes, these columns will exist despite
being a secondary index. As such, make this check a little more
targeted.

Release note (bug fix): Fix a bug where selecting cols by forcing an
INTERLEAVING index would error instead of returning the correct results.