### PR TITLE
sql/rowexec: select only required cols for interleaved_reader_joiner

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -359,7 +359,7 @@ func (rf *cFetcher) Init(
 		if table.isSecondaryIndex {
 			for i := range table.cols {
 				if neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+					return errors.Errorf("requested column %s not in index", table.cols[i].Name)
 				}
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -589,3 +589,37 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.plan.interleaved-table-join' AND usage_count > 0
 ----
 sql.plan.interleaved-table-join
+
+subtest regression_42609
+
+statement ok
+CREATE TABLE parent (
+  a STRING,
+  b STRING,
+  extraParent STRING,
+  PRIMARY KEY (a, b)
+)
+
+statement ok
+CREATE TABLE child (
+  a STRING,
+  b STRING,
+  c STRING,
+  extra STRING,
+  PRIMARY KEY (a,b,c)
+) INTERLEAVE IN PARENT "parent" (a, b)
+
+statement ok
+INSERT INTO parent VALUES ('a', 'b', 'ccc')
+
+statement ok
+INSERT INTO child VALUES ('a', 'b', '1', 'extra')
+
+statement ok
+CREATE INDEX idx_parent_child on child(a,b) INTERLEAVE IN PARENT parent(a,b)
+
+# This query strictly uses the interleave index on the child to merge with the parent.
+query TTT
+select parent.a, parent.b, child.c from child@{force_index=idx_parent_child} left outer join parent on (parent.a=child.a and parent.b = child.b)
+----
+a  b  1

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -390,7 +390,7 @@ func (rf *Fetcher) Init(
 		if table.isSecondaryIndex {
 			for i := range table.cols {
 				if table.neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
-					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+					return errors.Errorf("requested column %s not in index", table.cols[i].Name)
 				}
 			}
 		}

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -364,7 +364,7 @@ func newInterleavedReaderJoiner(
 	}
 
 	if err := irj.initRowFetcher(
-		spec.Tables, spec.Reverse, &irj.alloc,
+		spec.Tables, tables, spec.Reverse, &irj.alloc,
 	); err != nil {
 		return nil, err
 	}
@@ -398,6 +398,7 @@ func newInterleavedReaderJoiner(
 
 func (irj *interleavedReaderJoiner) initRowFetcher(
 	tables []execinfrapb.InterleavedReaderJoinerSpec_Table,
+	tableInfos []tableInfo,
 	reverseScan bool,
 	alloc *sqlbase.DatumAlloc,
 ) error {
@@ -411,10 +412,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 			return err
 		}
 
-		// We require all values from the tables being read
-		// since we do not expect any projections or rendering
-		// on a scan before a join.
-		args[i].ValNeededForCol.AddRange(0, len(desc.Columns)-1)
+		args[i].ValNeededForCol = tableInfos[i].post.NeededColumns()
 		args[i].ColIdxMap = desc.ColumnIdxMap()
 		args[i].Desc = desc
 		args[i].Cols = desc.Columns


### PR DESCRIPTION
Resolves: #42609 (the right way this time! - RIP #42794 and #42767)

interleaved_reader_joiner seems to have an out of date comment that it
needed to select every column when doing a join when we can be more
selective about the rows being picked from `PostProcessSpec`.

This comment seems two years old and outdated; furthermore, it causes
a bug when trying to select every column but trips up because it does
not have permission to do so.

Release note (bug fix): Fix a bug where selecting cols by forcing an
INTERLEAVING index would error instead of returning the correct results.