### PR TITLE
roachtest: skip acceptance/version-upgrade on 19.1 

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -44,7 +44,16 @@ func registerAcceptance(r *testRegistry) {
 		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
 		{name: "rapid-restart", fn: runRapidRestart},
 		{name: "status-server", fn: runStatusServer},
-		{name: "version-upgrade", fn: runVersionUpgrade, minVersion: "v19.1.0", timeout: 30 * time.Minute},
+		{
+			name: "version-upgrade",
+			fn:   runVersionUpgrade,
+			// This test doesn't like running on old versions because it upgrades to
+			// the latest released version and then it tries to "head", where head is
+			// the cockroach binary built from the branch on which the test is
+			// running. If that branch corresponds to an older release, then upgrading
+			// to head after 19.2 fails.
+			minVersion: "v19.2.0",
+			timeout:    30 * time.Minute},
 	}
 	tags := []string{"default", "quick"}
 	const numNodes = 4

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -477,8 +477,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		binaryVersionUpgrade("v19.1.5", nodes),
 		clusterVersionUpgrade(""),
 
-		// TODO(andrei): Change to the final 19.2 version once released.
-		binaryVersionUpgrade("v19.2.0-rc.2", nodes),
+		binaryVersionUpgrade("v19.2.1", nodes),
 		clusterVersionUpgrade(""),
 
 		// Each new release has to be added here. When adding a new release, you'll


### PR DESCRIPTION
This test doesn't work on branches corresponding on older releases.

Fixes #42374

Release note: None