### PR TITLE
roachtest: force timeout differently in sqlsmith test

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -103,6 +103,15 @@ func registerSQLSmith(r *testRegistry) {
 		}
 		logStmt(setup)
 
+		const timeout = time.Minute
+		setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", timeout.String())
+		t.Status("setting statement_timeout")
+		c.l.Printf("statement timeout:\n%s", setStmtTimeout)
+		if _, err := conn.Exec(setStmtTimeout); err != nil {
+			t.Fatal(err)
+		}
+		logStmt(setStmtTimeout)
+
 		smither, err := sqlsmith.NewSmither(conn, rng, setting.Options...)
 		if err != nil {
 			t.Fatal(err)
@@ -125,11 +134,14 @@ func registerSQLSmith(r *testRegistry) {
 			stmt := smither.Generate()
 			err := func() error {
 				done := make(chan error, 1)
-				const timeout = time.Minute
-				go func(ctx context.Context) {
-					ctx, cancel := context.WithTimeout(ctx, timeout)
-					defer cancel()
-					_, err := conn.ExecContext(ctx, stmt)
+				go func(context.Context) {
+					// At the moment, CockroachDB doesn't support pgwire query
+					// cancellation which is needed for correct handling of context
+					// cancellation, so instead of using a context with timeout, we opt
+					// in for using CRDB's 'statement_timeout'.
+					// TODO(yuzefovich): once #41335 is implemented, go back to using a
+					// context with timeout.
+					_, err := conn.Exec(stmt)
 					if err != nil {
 						logStmt(stmt)
 					}


### PR DESCRIPTION
Previously, sqlsmith roachtest would use a context with timeout to
force the query cancellation. However, CockroachDB currently doesn't
implement pgwire cancellation protocol, so canceling a context would not
actually propagate to the database. Instead, we will use
'statement_timeout' session variable to specify the timeout.

Addresses: #42212.
Addresses: #42217.

Release note: None