### PR TITLE
sql: pool some allocations during flow setup

### DIFF
--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -188,6 +188,14 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 	}
 }
 
+// Releasable is an interface for objects than can be Released back into a
+// memory pool when finished.
+type Releasable interface {
+	// Release allows this object to be returned to a memory pool. Objects must
+	// not be used after Release is called.
+	Release()
+}
+
 // DrainAndForwardMetadata calls src.ConsumerDone() (thus asking src for
 // draining metadata) and then forwards all the metadata to dst.
 //

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -60,18 +59,6 @@ type FlowCtx struct {
 
 	// Local is true if this flow is being run as part of a local-only query.
 	Local bool
-
-	// VectorizedStreamingMemAccount is the memory account that is tracking the
-	// static memory usage of the whole vectorized flow as well as all dynamic
-	// memory of the streaming vectorized components.
-	VectorizedStreamingMemAccount *mon.BoundAccount
-
-	// VectorizedBufferingMemMonitors are the memory monitors of the buffering
-	// vectorized components.
-	VectorizedBufferingMemMonitors []*mon.BytesMonitor
-	// VectorizedBufferingMemAccounts are the memory accounts that are tracking
-	// the dynamic memory usage of the buffering vectorized components.
-	VectorizedBufferingMemAccounts []*mon.BoundAccount
 }
 
 // NewEvalCtx returns a modifiable copy of the FlowCtx's EvalContext.

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -59,6 +59,7 @@ type tableReader struct {
 var _ execinfra.Processor = &tableReader{}
 var _ execinfra.RowSource = &tableReader{}
 var _ execinfrapb.MetadataSource = &tableReader{}
+var _ execinfra.Releasable = &tableReader{}
 
 const tableReaderProcName = "table reader"
 


### PR DESCRIPTION
**flowinfra: slightly tweak the setup of processors in the flow**

Previously, the last processor ('headProc') would be removed from
f.processors before flow.startInternal to be run in the same goroutine
as the one that is doing the setup. However, this was problematic
because if that processor implements 'Releasable' interface, it will not
be returned to the pool on the flow clean up. Now this is fixed.

Addresses: #42770.

Release note: None

**sql: pool flow allocations**

sql: pool flow allocations

Previously, new structs for rowBasedFlow and vectorizedFlow would be
allocated upon creation. This commit creates pools for both of them.
flowinfra.Releasable interface is moved into execinfra package because
now components from rowflow, rowexec, and colflow packages implement
that.

In order to actually be able to release the flow structs, I needed to
create separate Cleanup methods (which still share most of the logic)
which allows for removal of vectorized memory monitoring logic from
the shared FlowCtx.

Release note: None