### PR TITLE
colexec: fix a bug with top K sort not handling K > 1024

### DIFF
--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -147,9 +147,9 @@ func TestSort(t *testing.T) {
 func TestSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
-	nTups := 1025
-	k := uint16(4)
-	maxCols := 5
+	nTups := coldata.BatchSize()*2 + 1
+	k := uint16(rng.Intn(int(nTups))) + 1
+	maxCols := 3
 	// TODO(yuzefovich): randomize types as well.
 	typs := make([]coltypes.T, maxCols)
 	for i := range typs {

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -214,10 +214,11 @@ func (t *topKSorter) emit() coldata.Batch {
 			vec,
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{
-					ColType:   t.inputTypes[i],
-					Src:       t.topK.ColVec(i),
-					Sel:       t.sel,
-					SrcEndIdx: uint64(toEmit),
+					ColType:     t.inputTypes[i],
+					Src:         t.topK.ColVec(i),
+					Sel:         t.sel,
+					SrcStartIdx: uint64(t.emitted),
+					SrcEndIdx:   uint64(t.emitted + toEmit),
 				},
 			},
 		)

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -991,3 +991,18 @@ NULL  NULL  1
 NULL  1     1
 1     NULL  0
 1     1     2
+
+# Regression test for #42816 - top K sort when K is greated than
+# coldata.BatchSize().
+statement ok
+CREATE TABLE t_42816 (a int); INSERT INTO t_42816 SELECT * FROM generate_series(0, 1025)
+
+query I
+SELECT * FROM t_42816 ORDER BY a OFFSET 1020 LIMIT 10
+----
+1020
+1021
+1022
+1023
+1024
+1025


### PR DESCRIPTION
Previously, top K sorter when emitting the data would copy always from
the beginning of the stored vectors. This is incorrect behavior when
K is greater than coldata.BatchSize(), and now this has been fixed.

Fixes: #42816.

Release note (bug fix): A bug with incorrect handling of Top K sort by
the vectorized engine when K is greater than 1024 has been fixed.