### PR TITLE
workload, roachtest: skip TPCH Q4 for vec on

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -37,6 +37,7 @@ func registerTPCHVec(r *testRegistry) {
 		// TODO(yuzefovich): remove this once we have disk spilling.
 		1:  "needs disk spilling",
 		3:  "needs disk spilling",
+		4:  "needs disk spilling",
 		8:  "needs disk spilling",
 		9:  "needs disk spilling",
 		19: "needs disk spilling",
@@ -47,6 +48,7 @@ func registerTPCHVec(r *testRegistry) {
 		// vec on.
 		1:  "skipped with vec on",
 		3:  "skipped with vec on",
+		4:  "skipped with vec on",
 		8:  "skipped with vec on",
 		9:  "skipped with vec on",
 		19: "skipped with vec on",

--- a/pkg/workload/querybench/tpch-queries-vec
+++ b/pkg/workload/querybench/tpch-queries-vec
@@ -2,7 +2,7 @@
 -- understands. It is a subset of TPCH queries that is currently supported by
 -- vectorized execution engine.
 
--- TODO(yuzefovich): we skip queries 1, 3, 9 because they need disk spilling.
+-- TODO(yuzefovich): we skip queries 1, 3, 4, 9 because they need disk spilling.
 
 -- query 1
 -- SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum(l_extendedprice) AS sum_base_price, sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge, avg(l_quantity) AS avg_qty, avg(l_extendedprice) AS avg_price, avg(l_discount) AS avg_disc, count(*) AS count_order FROM lineitem WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY GROUP BY l_returnflag, l_linestatus ORDER BY l_returnflag, l_linestatus
@@ -11,7 +11,7 @@
 -- SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS revenue, o_orderdate, o_shippriority FROM customer, orders, lineitem WHERE c_mktsegment = 'BUILDING' AND c_custkey = o_custkey AND l_orderkey = o_orderkey AND o_orderDATE < DATE '1995-03-15' AND l_shipdate > DATE '1995-03-15' GROUP BY l_orderkey, o_orderdate, o_shippriority ORDER BY revenue DESC, o_orderdate LIMIT 10
 
 -- query 4
-SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE o_orderdate >= DATE '1993-07-01' AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitDATE < l_receiptdate) GROUP BY o_orderpriority ORDER BY o_orderpriority
+-- SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE o_orderdate >= DATE '1993-07-01' AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitDATE < l_receiptdate) GROUP BY o_orderpriority ORDER BY o_orderpriority
 
 -- query 5
 SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue FROM customer, orders, lineitem, supplier, nation, region WHERE c_custkey = o_custkey AND l_orderkey = o_orderkey AND l_suppkey = s_suppkey AND c_nationkey = s_nationkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'ASIA' AND o_orderDATE >= DATE '1994-01-01' AND o_orderDATE < DATE '1994-01-01' + INTERVAL '1' YEAR GROUP BY n_name ORDER BY revenue DESC


### PR DESCRIPTION
TPCH query 4 in some cases can hit a memory limit error, so we will skip
it for now (until the disk spilling is put in place).

Release note: None