### PR TITLE
release-19.2: sql: fix ALTER INDEX IF EXISTS for non-existing index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -13,7 +13,9 @@ CREATE TABLE users (
 statement ok
 CREATE TABLE othertable (
    x INT,
-   INDEX baw (x)
+   y INT,
+   INDEX baw (x),
+   INDEX yak (y, x)
 )
 
 statement error index name "baw" is ambiguous
@@ -21,6 +23,27 @@ DROP INDEX baw
 
 statement error index name "baw" is ambiguous
 DROP INDEX IF EXISTS baw
+
+statement error index "ark" does not exist
+DROP INDEX ark
+
+statement ok
+DROP INDEX IF EXISTS ark
+
+statement error index "ark" does not exist
+DROP INDEX users@ark
+
+statement ok
+DROP INDEX IF EXISTS users@ark
+
+statement ok
+DROP INDEX yak
+
+statement ok
+CREATE INDEX yak ON othertable (y, x)
+
+statement ok
+DROP INDEX IF EXISTS yak
 
 statement ok
 DROP TABLE othertable

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -8,7 +8,19 @@ CREATE TABLE users (
 )
 
 statement ok
+CREATE TABLE users_dupe (
+  id    INT PRIMARY KEY,
+  name  VARCHAR NOT NULL,
+  title VARCHAR,
+  INDEX foo (name),
+  UNIQUE INDEX bar (id, name)
+)
+
+statement ok
 INSERT INTO users VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
+
+statement ok
+INSERT INTO users_dupe VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users
@@ -20,6 +32,16 @@ users       foo         true        2             id           ASC        false 
 users       bar         false       1             id           ASC        false    false
 users       bar         false       2             name         ASC        false    false
 
+query TTBITTBB colnames
+SHOW INDEXES FROM users_dupe
+----
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
+users_dupe  primary     false       1             id           ASC        false    false
+users_dupe  foo         true        1             name         ASC        false    false
+users_dupe  foo         true        2             id           ASC        false    true
+users_dupe  bar         false       1             id           ASC        false    false
+users_dupe  bar         false       2             name         ASC        false    false
+
 statement error index name "bar" already exists
 ALTER INDEX users@foo RENAME TO bar
 
@@ -29,11 +51,27 @@ ALTER INDEX users@foo RENAME TO ""
 statement error index "ffo" does not exist
 ALTER INDEX users@ffo RENAME TO ufo
 
+statement error index "ffo" does not exist
+ALTER INDEX ffo RENAME TO ufo
+
+statement error index name "foo" is ambiguous
+ALTER INDEX foo RENAME TO ufo
+
+statement error index name "foo" is ambiguous
+ALTER INDEX IF EXISTS foo RENAME TO ufo
+
 statement ok
 ALTER INDEX IF EXISTS users@ffo RENAME TO ufo
 
+# Regression test for #42399.
 statement ok
-ALTER INDEX users@foo RENAME TO ufoo
+ALTER INDEX IF EXISTS ffo RENAME TO ufo
+
+statement ok
+ALTER INDEX users@foo RENAME TO ufooo
+
+statement ok
+ALTER INDEX IF EXISTS ufooo RENAME TO ufoo
 
 statement ok
 ALTER INDEX ufoo RENAME TO ufo

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1085,6 +1085,7 @@ func TestParse(t *testing.T) {
 		{`EXPLAIN ALTER INDEX b RENAME TO b`},
 		{`ALTER INDEX a@b RENAME TO b`},
 		{`ALTER INDEX a@primary RENAME TO like`},
+		{`ALTER INDEX IF EXISTS b RENAME TO b`},
 		{`ALTER INDEX IF EXISTS a@b RENAME TO b`},
 		{`ALTER INDEX IF EXISTS a@primary RENAME TO like`},
 

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -34,9 +34,13 @@ type renameIndexNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNode, error) {
-	_, tableDesc, err := expandMutableIndexName(ctx, p, n.Index, true /* requireTable */)
+	_, tableDesc, err := expandMutableIndexName(ctx, p, n.Index, !n.IfExists /* requireTable */)
 	if err != nil {
 		return nil, err
+	}
+	if tableDesc == nil {
+		// IfExists specified and table did not exist -- noop.
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	idx, _, err := tableDesc.FindIndexByName(string(n.Index.Index))


### PR DESCRIPTION
Backport 2/2 commits from #42797.

/cc @cockroachdb/release

---

Previously, if ALTER INDEX IF EXISTS was used on an
unqualified index name that did not match any index, the database would
return an "index does not exist" error.

Now, the statement succeeds, but does nothing.

Also, test edge cases around ambiguous, non-existing, and/or unqualified
index names, in both alter_index and drop_index logic tests.

Fixes #42399 

Release note (bug fix): ALTER INDEX IF EXISTS no longer fails
when using an unqualified index name that does not match any existing
index. Now it is a no-op.
