### PR TITLE
coldata: expose a modifier for batchSize variable

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -58,14 +58,37 @@ type Batch interface {
 
 var _ Batch = &MemBatch{}
 
-const maxBatchSize = 1024
+const (
+	// MinBatchSize is the minimum acceptable size of batches.
+	MinBatchSize = 3
+	// MaxBatchSize is the maximum acceptable size of batches.
+	MaxBatchSize = 4096
+)
 
+// TODO(jordan): tune.
 var batchSize = uint16(1024)
 
 // BatchSize is the maximum number of tuples that fit in a column batch.
-// TODO(jordan): tune
 func BatchSize() uint16 {
 	return batchSize
+}
+
+// SetBatchSizeForTests modifies batchSize variable. It should only be used in
+// tests.
+func SetBatchSizeForTests(newBatchSize uint16) {
+	if newBatchSize > MaxBatchSize {
+		panic(
+			fmt.Sprintf("requested batch size %d is greater than MaxBatchSize %d",
+				newBatchSize, MaxBatchSize),
+		)
+	}
+	if newBatchSize < MinBatchSize {
+		panic(
+			fmt.Sprintf("requested batch size %d is smaller than MinBatchSize %d",
+				newBatchSize, MinBatchSize),
+		)
+	}
+	batchSize = newBatchSize
 }
 
 // NewMemBatch allocates a new in-memory Batch. A coltypes.Unknown type

--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -10,13 +10,13 @@
 
 package coldata
 
-// zeroedNulls is a zeroed out slice representing a bitmap of size maxBatchSize.
+// zeroedNulls is a zeroed out slice representing a bitmap of size MaxBatchSize.
 // This is copied to efficiently set all nulls.
-var zeroedNulls [(maxBatchSize-1)/8 + 1]byte
+var zeroedNulls [(MaxBatchSize-1)/8 + 1]byte
 
-// filledNulls is a slice representing a bitmap of size maxBatchSize with every
+// filledNulls is a slice representing a bitmap of size MaxBatchSize with every
 // single bit set.
-var filledNulls [(maxBatchSize-1)/8 + 1]byte
+var filledNulls [(MaxBatchSize-1)/8 + 1]byte
 
 // bitMask[i] is a byte with a single bit set at i.
 var bitMask = [8]byte{0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -912,6 +912,12 @@ func TestHashJoiner(t *testing.T) {
 	}
 
 	for _, outputBatchSize := range []uint16{1, 17, coldata.BatchSize()} {
+		if outputBatchSize > coldata.BatchSize() {
+			// It is possible for varied coldata.BatchSize() to be smaller than
+			// requested outputBatchSize. Such configuration is invalid, and we skip
+			// it.
+			continue
+		}
 		for _, tc := range tcs {
 			inputs := []tuples{tc.leftTuples, tc.rightTuples}
 			typs := [][]coltypes.T{tc.leftTypes, tc.rightTypes}

--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -12,9 +12,11 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -43,6 +45,13 @@ func TestMain(m *testing.M) {
 		testMemAcc = &memAcc
 		testAllocator = NewAllocator(ctx, testMemAcc)
 		defer testMemAcc.Close(ctx)
+		rng, _ := randutil.NewPseudoRand()
+		// Pick a random batch size in [coldata.MinBatchSize, coldata.MaxBatchSize]
+		// range.
+		randomBatchSize := uint16(coldata.MinBatchSize +
+			rng.Intn(coldata.MaxBatchSize-coldata.MinBatchSize))
+		fmt.Printf("coldata.BatchSize() is set to %d\n", randomBatchSize)
+		coldata.SetBatchSizeForTests(randomBatchSize)
 		return m.Run()
 	}())
 }

--- a/pkg/sql/colexec/orderedsynchronizer_test.go
+++ b/pkg/sql/colexec/orderedsynchronizer_test.go
@@ -157,6 +157,9 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 	numInputs := 3
 	inputLen := 1024
 	batchSize := uint16(16)
+	if batchSize > coldata.BatchSize() {
+		batchSize = coldata.BatchSize()
+	}
 
 	// Generate a random slice of sorted ints.
 	randInts := make([]int, inputLen)

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -35,9 +35,14 @@ type routerOutput interface {
 	cancel()
 }
 
-// defaultRouterOutputBlockedThreshold is the number of unread values buffered
-// by the routerOutputOp after which the output is considered blocked.
-var defaultRouterOutputBlockedThreshold = int(coldata.BatchSize() * 2)
+// getDefaultRouterOutputBlockedThreshold returns the number of unread values
+// buffered by the routerOutputOp after which the output is considered blocked.
+// It is a function rather than a variable so that in tests we could modify
+// coldata.BatchSize() (if it were a variable, then its value would be
+// evaluated before we set the desired batch size).
+func getDefaultRouterOutputBlockedThreshold() int {
+	return int(coldata.BatchSize()) * 2
+}
 
 type routerOutputOp struct {
 	// input is a reference to our router.
@@ -90,7 +95,7 @@ func newRouterOutputOp(
 	allocator *Allocator, types []coltypes.T, unblockedEventsChan chan<- struct{},
 ) *routerOutputOp {
 	return newRouterOutputOpWithBlockedThresholdAndBatchSize(
-		allocator, types, unblockedEventsChan, defaultRouterOutputBlockedThreshold, int(coldata.BatchSize()),
+		allocator, types, unblockedEventsChan, getDefaultRouterOutputBlockedThreshold(), int(coldata.BatchSize()),
 	)
 }
 

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -15,14 +15,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 )
 
-var zeroBoolColumn = make([]bool, coldata.BatchSize())
+var zeroBoolColumn = make([]bool, coldata.MaxBatchSize)
 
-var zeroDecimalColumn = make([]apd.Decimal, coldata.BatchSize())
+var zeroDecimalColumn = make([]apd.Decimal, coldata.MaxBatchSize)
 
-var zeroInt16Column = make([]int16, coldata.BatchSize())
+var zeroInt16Column = make([]int16, coldata.MaxBatchSize)
 
-var zeroInt32Column = make([]int32, coldata.BatchSize())
+var zeroInt32Column = make([]int32, coldata.MaxBatchSize)
 
-var zeroInt64Column = make([]int64, coldata.BatchSize())
+var zeroInt64Column = make([]int64, coldata.MaxBatchSize)
 
-var zeroFloat64Column = make([]float64, coldata.BatchSize())
+var zeroFloat64Column = make([]float64, coldata.MaxBatchSize)


### PR DESCRIPTION
This commit exposes a setter for batchSize private variable to be
modified in tests and runs all tests in sql/colexec with a random
batch size in [3, 4096] range.

The tests in several places needed to be adjusted because their
assumptions might no longer hold when batch size is modified.

Fixes: #40791.

Release note: None