### PR TITLE
cli: Handle *cliError when logging command failure

### DIFF
--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -342,15 +342,22 @@ func maybeShoutError(
 }
 
 func checkAndMaybeShout(err error) error {
+	return checkAndMaybeShoutTo(err, log.Shout)
+}
+
+func checkAndMaybeShoutTo(
+	err error, logger func(context.Context, log.Severity, ...interface{}),
+) error {
 	if err == nil {
 		return nil
 	}
 	severity := log.Severity_ERROR
 	cause := err
-	if ec, ok := errors.Cause(err).(*cliError); ok {
+	var ec *cliError
+	if errors.As(err, &ec) {
 		severity = ec.severity
 		cause = ec.cause
 	}
-	log.Shout(context.Background(), severity, cause)
+	logger(context.Background(), severity, cause)
 	return err
 }


### PR DESCRIPTION
To correctly unwrap errors returned by commands and log their severity,
we should use `errors.As` instead of `errors.Cause`. The latter will
unwrap `*cliError`, which discards the log severity and exit code. (In
`exitWithError`, where we're also unwrapping to look for a `*cliError`,
we're already using `errors.As`.)

Fixes #42832.