### PR TITLE
colexec: add mechanism to fallback to disk on OOM error

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -73,11 +73,11 @@ func New_OP_TITLEProjOp(
 	}
 }
 
-func (o *_OP_LOWERProjOp) ChildCount() int {
+func (o *_OP_LOWERProjOp) ChildCount(verbose bool) int {
 	return 3
 }
 
-func (o *_OP_LOWERProjOp) Child(nth int) execinfra.OpNode {
+func (o *_OP_LOWERProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	switch nth {
 	case 0:
 		return o.input

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -39,11 +39,11 @@ type caseOp struct {
 
 var _ InternalMemoryOperator = &caseOp{}
 
-func (c *caseOp) ChildCount() int {
+func (c *caseOp) ChildCount(verbose bool) int {
 	return 1 + len(c.caseOps) + 1
 }
 
-func (c *caseOp) Child(nth int) execinfra.OpNode {
+func (c *caseOp) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return c.buffer
 	} else if nth < len(c.caseOps)+1 {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -142,7 +142,7 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 }
 
 // ChildCount is part of the Operator interface.
-func (c *Columnarizer) ChildCount() int {
+func (c *Columnarizer) ChildCount(verbose bool) int {
 	if _, ok := c.input.(execinfra.OpNode); ok {
 		return 1
 	}
@@ -150,7 +150,7 @@ func (c *Columnarizer) ChildCount() int {
 }
 
 // Child is part of the Operator interface.
-func (c *Columnarizer) Child(nth int) execinfra.OpNode {
+func (c *Columnarizer) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		if n, ok := c.input.(execinfra.OpNode); ok {
 			return n

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -1,0 +1,218 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// bufferingInMemoryOperator is an Operator that buffers up intermediate tuples
+// in memory and knows how to export them once the memory limit has been
+// reached.
+type bufferingInMemoryOperator interface {
+	Operator
+
+	// ExportBuffered returns all the batches that have been buffered up and have
+	// not yet been processed by the operator. It needs to be called once the
+	// memory limit has been reached in order to "dump" the buffered tuples into
+	// a disk-backed operator. It will return a zero-length batch once the buffer
+	// has been emptied.
+	//
+	// Calling ExportBuffered may invalidate the contents of the last batch
+	// returned by ExportBuffered.
+	// TODO(yuzefovich): it might be possible to avoid the need for an Allocator
+	// when exporting buffered tuples. This will require the refactor of the
+	// buffering in-memory operators.
+	ExportBuffered(*Allocator) coldata.Batch
+}
+
+// oneInputDiskSpiller is an Operator that manages the fallback from an
+// in-memory buffering operator to a disk-backed one when the former hits the
+// memory limit.
+//
+// NOTE: if an out of memory error occurs during initialization, this operator
+// simply propagates the error further.
+//
+// The diagram of the components involved is as follows:
+//
+//        -------------  input  -----------
+//       |                ||                | (2nd src)
+//       |                ||   (1st src)    ↓
+//       |            ----||---> bufferExportingOperator
+//       ↓           |    ||                |
+//    inMemoryOp ----     ||                ↓
+//       |                ||           diskBackedOp
+//       |                ||                |
+//       |                ↓↓                |
+//        ---------> disk spiller <--------
+//                        ||
+//                        ||
+//                        ↓↓
+//                      output
+//
+// Here is the explanation:
+// - the main chain of Operators is input -> disk spiller -> output
+// - the dist spiller will first try running everything through the left side
+//   chain of input -> inMemoryOp. If that succeeds, great! The disk spiller
+//   will simply propagate the batch to the output. If that fails with an OOM
+//   error, the disk spiller will then initialize the right side chain and will
+//   proceed to emit from there
+// - the right side chain is bufferExportingOperator -> diskBackedOp. The
+//   former will first export all the buffered tuples from inMemoryOp and then
+//   will proceed on emitting from input.
+type oneInputDiskSpiller struct {
+	NonExplainable
+
+	allocator   *Allocator
+	initialized bool
+	spilled     bool
+
+	input        Operator
+	inMemoryOp   bufferingInMemoryOperator
+	diskBackedOp Operator
+}
+
+var _ Operator = &oneInputDiskSpiller{}
+
+// newOneInputDiskSpiller returns a new oneInputDiskSpiller. It takes the
+// following arguments:
+// - allocator - this Allocator is used (if spilling occurs) when copying the
+//   buffered tuples from the in-memory operator into the disk-backed one.
+// - inMemoryOp - the in-memory operator that will be consuming input and doing
+//   computations until it either successfully processes the whole input or
+//   reaches its memory limit.
+// - diskBackedOpConstructor - the function to construct the disk-backed
+//   operator when given an input operator. We take in a constructor rather
+//   than an already created operator in order to hide the complexity of buffer
+//   exporting operator that serves as the input to the disk-backed operator.
+func newOneInputDiskSpiller(
+	allocator *Allocator,
+	input Operator,
+	inMemoryOp bufferingInMemoryOperator,
+	diskBackedOpConstructor func(input Operator) Operator,
+) Operator {
+	diskBackedOpInput := newBufferExportingOperator(allocator, inMemoryOp, input)
+	return &oneInputDiskSpiller{
+		allocator:    allocator,
+		input:        input,
+		inMemoryOp:   inMemoryOp,
+		diskBackedOp: diskBackedOpConstructor(diskBackedOpInput),
+	}
+}
+
+func (d *oneInputDiskSpiller) Init() {
+	if d.initialized {
+		return
+	}
+	d.initialized = true
+	// It is possible that Init() call below will hit an out of memory error,
+	// but we decide to bail on this query, so we do not catch internal panics.
+	//
+	// Also note that d.input is the input to d.inMemoryOp, so calling Init()
+	// only on the latter is sufficient.
+	d.inMemoryOp.Init()
+}
+
+func (d *oneInputDiskSpiller) Next(ctx context.Context) coldata.Batch {
+	if d.spilled {
+		return d.diskBackedOp.Next(ctx)
+	}
+	var batch coldata.Batch
+	if err := execerror.CatchVectorizedRuntimeError(
+		func() {
+			batch = d.inMemoryOp.Next(ctx)
+		},
+	); err != nil {
+		if sqlbase.IsOutOfMemoryError(err) {
+			d.spilled = true
+			d.diskBackedOp.Init()
+			return d.Next(ctx)
+		}
+		// Not an out of memory error, so we propagate it further.
+		execerror.VectorizedInternalPanic(err)
+	}
+	return batch
+}
+
+func (d *oneInputDiskSpiller) ChildCount() int {
+	// TODO(yuzefovich): this should be 1 in non-verbose case.
+	return 3
+}
+
+func (d *oneInputDiskSpiller) Child(nth int) execinfra.OpNode {
+	switch nth {
+	// Note: although the main chain is d.input -> diskSpiller -> output (and the
+	// main chain should be under nth == 0), in order to make the output of
+	// EXPLAIN (VEC) less confusing we return the in-memory operator as being on
+	// the main chain.
+	case 0:
+		return d.inMemoryOp
+	case 1:
+		return d.input
+	case 2:
+		return d.diskBackedOp
+	default:
+		execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
+	}
+}
+
+// bufferExportingOperator is an Operator that first returns all batches from
+// firstSource, and once firstSource is exhausted, it proceeds on returning all
+// batches from the second source.
+//
+// NOTE: bufferExportingOperator assumes that both sources will have been
+// initialized when bufferExportingOperator.Init() is called.
+type bufferExportingOperator struct {
+	ZeroInputNode
+	NonExplainable
+
+	allocator       *Allocator
+	firstSource     bufferingInMemoryOperator
+	secondSource    Operator
+	firstSourceDone bool
+}
+
+var _ Operator = &bufferExportingOperator{}
+
+func newBufferExportingOperator(
+	allocator *Allocator, firstSource bufferingInMemoryOperator, secondSource Operator,
+) Operator {
+	return &bufferExportingOperator{
+		allocator:    allocator,
+		firstSource:  firstSource,
+		secondSource: secondSource,
+	}
+}
+
+func (b *bufferExportingOperator) Init() {
+	// Init here is a noop because the operator assumes that both sources have
+	// already been initialized.
+}
+
+func (b *bufferExportingOperator) Next(ctx context.Context) coldata.Batch {
+	if b.firstSourceDone {
+		return b.secondSource.Next(ctx)
+	}
+	batch := b.firstSource.ExportBuffered(b.allocator)
+	if batch.Length() == 0 {
+		b.firstSourceDone = true
+		return b.Next(ctx)
+	}
+	return batch
+}

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+)
+
+// TODO(yuzefovich): add actual implementation.
+
+// newExternalSorter returns a disk-backed general sort operator.
+func newExternalSorter(
+	allocator *Allocator,
+	input Operator,
+	inputTypes []coltypes.T,
+	orderingCols []execinfrapb.Ordering_Column,
+) Operator {
+	inMemSorter, err := newSorter(
+		allocator, newAllSpooler(allocator, input, inputTypes),
+		inputTypes, orderingCols,
+	)
+	if err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	return &externalSorter{OneInputNode: NewOneInputNode(inMemSorter)}
+}
+
+type externalSorter struct {
+	OneInputNode
+}
+
+var _ Operator = &externalSorter{}
+
+func (s *externalSorter) Init() {
+	s.input.Init()
+}
+
+func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
+	return s.input.Next(ctx)
+}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -175,11 +175,11 @@ type hashGrouper struct {
 
 var _ execinfra.OpNode = &hashGrouper{}
 
-func (op *hashGrouper) ChildCount() int {
+func (op *hashGrouper) ChildCount(verbose bool) int {
 	return 1
 }
 
-func (op *hashGrouper) Child(nth int) execinfra.OpNode {
+func (op *hashGrouper) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return op.builder.spec.source
 	}

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -198,11 +198,11 @@ type hashJoinEqOp struct {
 	}
 }
 
-func (hj *hashJoinEqOp) ChildCount() int {
+func (hj *hashJoinEqOp) ChildCount(verbose bool) int {
 	return 2
 }
 
-func (hj *hashJoinEqOp) Child(nth int) execinfra.OpNode {
+func (hj *hashJoinEqOp) Child(nth int, verbose bool) execinfra.OpNode {
 	switch nth {
 	case 0:
 		return hj.spec.left.source

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -113,12 +113,12 @@ func NewMaterializer(
 var _ execinfra.OpNode = &Materializer{}
 
 // ChildCount is part of the exec.OpNode interface.
-func (m *Materializer) ChildCount() int {
+func (m *Materializer) ChildCount(verbose bool) int {
 	return 1
 }
 
 // Child is part of the exec.OpNode interface.
-func (m *Materializer) Child(nth int) execinfra.OpNode {
+func (m *Materializer) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return m.input
 	}

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -65,12 +65,12 @@ type OneInputNode struct {
 }
 
 // ChildCount implements the execinfra.OpNode interface.
-func (OneInputNode) ChildCount() int {
+func (OneInputNode) ChildCount(verbose bool) int {
 	return 1
 }
 
 // Child implements the execinfra.OpNode interface.
-func (n OneInputNode) Child(nth int) execinfra.OpNode {
+func (n OneInputNode) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return n.input
 	}
@@ -88,12 +88,12 @@ func (n OneInputNode) Input() Operator {
 type ZeroInputNode struct{}
 
 // ChildCount implements the execinfra.OpNode interface.
-func (ZeroInputNode) ChildCount() int {
+func (ZeroInputNode) ChildCount(verbose bool) int {
 	return 0
 }
 
 // Child implements the execinfra.OpNode interface.
-func (ZeroInputNode) Child(nth int) execinfra.OpNode {
+func (ZeroInputNode) Child(nth int, verbose bool) execinfra.OpNode {
 	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
@@ -109,11 +109,11 @@ type twoInputNode struct {
 	inputTwo Operator
 }
 
-func (twoInputNode) ChildCount() int {
+func (twoInputNode) ChildCount(verbose bool) int {
 	return 2
 }
 
-func (n *twoInputNode) Child(nth int) execinfra.OpNode {
+func (n *twoInputNode) Child(nth int, verbose bool) execinfra.OpNode {
 	switch nth {
 	case 0:
 		return n.inputOne

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -24,6 +24,13 @@ type Operator interface {
 	// Init initializes this operator. Will be called once at operator setup
 	// time. If an operator has an input operator, it's responsible for calling
 	// Init on that input operator as well.
+	// TODO(yuzefovich): we might need to clarify whether it is ok to call
+	// Init() multiple times before the first call to Next(). It is possible to
+	// hit the memory limit during Init(), and a disk-backed operator needs to
+	// make sure that the input has been initialized. We could also in case that
+	// Init() doesn't succeed for bufferingInMemoryOperator - which should only
+	// happen when 'workmem' setting is too low - just bail, even if we have
+	// disk spilling for that operator.
 	Init()
 
 	// Next returns the next Batch from this operator. Once the operator is

--- a/pkg/sql/colexec/orderedsynchronizer.go
+++ b/pkg/sql/colexec/orderedsynchronizer.go
@@ -43,12 +43,12 @@ type OrderedSynchronizer struct {
 var _ Operator = &OrderedSynchronizer{}
 
 // ChildCount implements the execinfrapb.OpNode interface.
-func (o *OrderedSynchronizer) ChildCount() int {
+func (o *OrderedSynchronizer) ChildCount(verbose bool) int {
 	return len(o.inputs)
 }
 
 // Child implements the execinfrapb.OpNode interface.
-func (o *OrderedSynchronizer) Child(nth int) execinfra.OpNode {
+func (o *OrderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
 	return o.inputs[nth]
 }
 

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -74,12 +74,12 @@ type ParallelUnorderedSynchronizer struct {
 }
 
 // ChildCount implements the execinfra.OpNode interface.
-func (s *ParallelUnorderedSynchronizer) ChildCount() int {
+func (s *ParallelUnorderedSynchronizer) ChildCount(verbose bool) int {
 	return len(s.inputs)
 }
 
 // Child implements the execinfra.OpNode interface.
-func (s *ParallelUnorderedSynchronizer) Child(nth int) execinfra.OpNode {
+func (s *ParallelUnorderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
 	return s.inputs[nth]
 }
 

--- a/pkg/sql/colexec/partitioner.go
+++ b/pkg/sql/colexec/partitioner.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
@@ -75,8 +74,6 @@ func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
 	b := p.input.Next(ctx)
 	if p.partitionColIdx == b.Width() {
 		p.allocator.AppendColumn(b, coltypes.Bool)
-	} else if p.partitionColIdx > b.Width() {
-		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
 	if b.Length() == 0 {
 		return b

--- a/pkg/sql/colexec/rank_tmpl.go
+++ b/pkg/sql/colexec/rank_tmpl.go
@@ -27,6 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 )
 
+// Use execerror package to remove unused import warning.
+var _ = execerror.VectorizedInternalPanic
+
 // TODO(yuzefovich): add benchmarks.
 
 // NewRankOperator creates a new Operator that computes window function RANK or
@@ -125,22 +128,18 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	// {{ if .HasPartition }}
 	if r.partitionColIdx == batch.Width() {
 		r.allocator.AppendColumn(batch, coltypes.Bool)
-	} else if r.partitionColIdx > batch.Width() {
-		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
-	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{ end }}
-
 	if r.outputColIdx == batch.Width() {
 		r.allocator.AppendColumn(batch, coltypes.Int64)
-	} else if r.outputColIdx > batch.Width() {
-		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
 	}
-
 	if batch.Length() == 0 {
 		return batch
 	}
 
+	// {{ if .HasPartition }}
+	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
+	// {{ end }}
 	rankCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()
 	// TODO(yuzefovich): template out sel vs non-sel cases.

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -68,11 +68,11 @@ type routerOutputOp struct {
 	outputBatchSize  int
 }
 
-func (o *routerOutputOp) ChildCount() int {
+func (o *routerOutputOp) ChildCount(verbose bool) int {
 	return 1
 }
 
-func (o *routerOutputOp) Child(nth int) execinfra.OpNode {
+func (o *routerOutputOp) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return o.input
 	}

--- a/pkg/sql/colexec/row_number_tmpl.go
+++ b/pkg/sql/colexec/row_number_tmpl.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 )
 
 // TODO(yuzefovich): add benchmarks.
@@ -76,20 +75,18 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	// {{ if .HasPartition }}
 	if r.partitionColIdx == batch.Width() {
 		r.allocator.AppendColumn(batch, coltypes.Bool)
-	} else if r.partitionColIdx > batch.Width() {
-		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
-	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{ end }}
-
 	if r.outputColIdx == batch.Width() {
 		r.allocator.AppendColumn(batch, coltypes.Int64)
-	} else if r.outputColIdx > batch.Width() {
-		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
 	}
 	if batch.Length() == 0 {
 		return batch
 	}
+
+	// {{ if .HasPartition }}
+	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
+	// {{ end }}
 	rowNumberCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()
 	if sel != nil {

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -34,12 +34,12 @@ var _ Operator = &SerialUnorderedSynchronizer{}
 var _ execinfra.OpNode = &SerialUnorderedSynchronizer{}
 
 // ChildCount implements the execinfra.OpNode interface.
-func (s *SerialUnorderedSynchronizer) ChildCount() int {
+func (s *SerialUnorderedSynchronizer) ChildCount(verbose bool) int {
 	return len(s.inputs)
 }
 
 // Child implements the execinfra.OpNode interface.
-func (s *SerialUnorderedSynchronizer) Child(nth int) execinfra.OpNode {
+func (s *SerialUnorderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
 	return s.inputs[nth]
 }
 

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -203,9 +203,11 @@ type sortOp struct {
 	state sortState
 
 	output coldata.Batch
+
+	exported uint64
 }
 
-var _ Operator = &sortOp{}
+var _ bufferingInMemoryOperator = &sortOp{}
 
 // colSorter is a single-column sorter, specialized on a particular type.
 type colSorter interface {
@@ -256,12 +258,17 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 			newEmitted = p.input.getNumTuples()
 		}
 		p.output.ResetInternalBatch()
-		p.output.SetLength(uint16(newEmitted - p.emitted))
-		if p.output.Length() == 0 {
-			return p.output
+		if newEmitted == p.emitted {
+			return coldata.ZeroBatch
 		}
 
 		for j := 0; j < len(p.inputTypes); j++ {
+			// TODO(yuzefovich): at this point, we have already fully sorted the
+			// input. I think it is ok if we do this Copy outside of the Allocator -
+			// the work has been done, but theoretically it is possible to hit the
+			// limit here (mainly with variable-sized types like Bytes). Nonetheless,
+			// for performance reasons it would be sad to fallback to disk at this
+			// point.
 			p.allocator.Copy(
 				p.output.ColVec(j),
 				coldata.CopySliceArgs{
@@ -269,12 +276,13 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 						ColType:     p.inputTypes[j],
 						Src:         p.input.getValues(j),
 						SrcStartIdx: p.emitted,
-						SrcEndIdx:   p.emitted + uint64(p.output.Length()),
+						SrcEndIdx:   newEmitted,
 					},
 					Sel64: p.order,
 				},
 			)
 		}
+		p.output.SetLength(uint16(newEmitted - p.emitted))
 		p.emitted = newEmitted
 		return p.output
 	}
@@ -385,6 +393,7 @@ func (p *sortOp) reset() {
 		r.reset()
 	}
 	p.emitted = 0
+	p.exported = 0
 	p.state = sortSpooling
 }
 
@@ -399,4 +408,34 @@ func (p *sortOp) Child(nth int) execinfra.OpNode {
 	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
+}
+
+func (p *sortOp) ExportBuffered(allocator *Allocator) coldata.Batch {
+	if p.exported == p.input.getNumTuples() {
+		return coldata.ZeroBatch
+	}
+	p.output.ResetInternalBatch()
+	newExported := p.exported + uint64(coldata.BatchSize())
+	if newExported > p.input.getNumTuples() {
+		newExported = p.input.getNumTuples()
+	}
+	for j := 0; j < len(p.inputTypes); j++ {
+		// TODO(yuzefovich): refactor spooler interface so that the spooler could
+		// return buffered tuples as batches and we didn't need to copy the data.
+		// We're using the provided Allocator.
+		allocator.Copy(
+			p.output.ColVec(j),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:     p.inputTypes[j],
+					Src:         p.input.getValues(j),
+					SrcStartIdx: p.exported,
+					SrcEndIdx:   newExported,
+				},
+			},
+		)
+	}
+	p.output.SetLength(uint16(newExported - p.exported))
+	p.exported = newExported
+	return p.output
 }

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -397,11 +397,11 @@ func (p *sortOp) reset() {
 	p.state = sortSpooling
 }
 
-func (p *sortOp) ChildCount() int {
+func (p *sortOp) ChildCount(verbose bool) int {
 	return 1
 }
 
-func (p *sortOp) Child(nth int) execinfra.OpNode {
+func (p *sortOp) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return p.input
 	}

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -58,11 +58,11 @@ type sortChunksOp struct {
 	sorter resettableOperator
 }
 
-func (c *sortChunksOp) ChildCount() int {
+func (c *sortChunksOp) ChildCount(verbose bool) int {
 	return 0
 }
 
-func (c *sortChunksOp) Child(nth int) execinfra.OpNode {
+func (c *sortChunksOp) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		return c.input
 	}

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -69,6 +69,9 @@ var unorderedVerifier verifier = (*opTestOutput).VerifyAnyOrder
 // maybeHasNulls is a helper function that returns whether any of the columns in b
 // (maybe) have nulls.
 func maybeHasNulls(b coldata.Batch) bool {
+	if b.Length() == 0 {
+		return false
+	}
 	for i := 0; i < b.Width(); i++ {
 		if b.ColVec(i).MaybeHasNulls() {
 			return true

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -714,10 +714,8 @@ func (s *vectorizedFlowCreator) setupFlow(
 		// Even when err is non-nil, it is possible that the buffering memory
 		// monitor and account have been created, so we always want to accumulate
 		// them for a proper cleanup.
-		if result.BufferingOpMemMonitor != nil {
-			s.bufferingMemMonitors = append(s.bufferingMemMonitors, result.BufferingOpMemMonitor)
-			s.bufferingMemAccounts = append(s.bufferingMemAccounts, result.BufferingOpMemAccount)
-		}
+		s.bufferingMemMonitors = append(s.bufferingMemMonitors, result.BufferingOpMemMonitors...)
+		s.bufferingMemAccounts = append(s.bufferingMemAccounts, result.BufferingOpMemAccounts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to vectorize execution plan")
 		}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -94,10 +94,14 @@ func verifyColOperator(
 	if err != nil {
 		return err
 	}
-	if result.BufferingOpMemMonitor != nil {
-		defer result.BufferingOpMemMonitor.Stop(ctx)
-		defer result.BufferingOpMemAccount.Close(ctx)
-	}
+	defer func() {
+		for _, memAccount := range result.BufferingOpMemAccounts {
+			memAccount.Close(ctx)
+		}
+		for _, memMonitor := range result.BufferingOpMemMonitors {
+			memMonitor.Stop(ctx)
+		}
+	}()
 
 	outColOp, err := colexec.NewMaterializer(
 		flowCtx,

--- a/pkg/sql/execinfra/indexjoiner.go
+++ b/pkg/sql/execinfra/indexjoiner.go
@@ -263,12 +263,12 @@ func (ij *IndexJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 }
 
 // ChildCount is part of the OpNode interface.
-func (ij *IndexJoiner) ChildCount() int {
+func (ij *IndexJoiner) ChildCount(verbose bool) int {
 	return 1
 }
 
 // Child is part of the OpNode interface.
-func (ij *IndexJoiner) Child(nth int) OpNode {
+func (ij *IndexJoiner) Child(nth int, verbose bool) OpNode {
 	if nth == 0 {
 		if n, ok := ij.input.(OpNode); ok {
 			return n

--- a/pkg/sql/execinfra/joinreader.go
+++ b/pkg/sql/execinfra/joinreader.go
@@ -720,12 +720,12 @@ func (jr *JoinReader) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetad
 }
 
 // ChildCount is part of the OpNode interface.
-func (jr *JoinReader) ChildCount() int {
+func (jr *JoinReader) ChildCount(verbose bool) int {
 	return 1
 }
 
 // Child is part of the OpNode interface.
-func (jr *JoinReader) Child(nth int) OpNode {
+func (jr *JoinReader) Child(nth int, verbose bool) OpNode {
 	if nth == 0 {
 		if n, ok := jr.input.(OpNode); ok {
 			return n

--- a/pkg/sql/execinfra/operator.go
+++ b/pkg/sql/execinfra/operator.go
@@ -12,6 +12,8 @@ package execinfra
 
 // OpNode is an interface to operator-like structures with children.
 type OpNode interface {
+	// TODO(yuzefovich): modify the interface so that a boolean is passed in to
+	// distinguish between verbose and non-verbose outputs.
 	// ChildCount returns the number of children (inputs) of the operator.
 	ChildCount() int
 

--- a/pkg/sql/execinfra/operator.go
+++ b/pkg/sql/execinfra/operator.go
@@ -12,11 +12,9 @@ package execinfra
 
 // OpNode is an interface to operator-like structures with children.
 type OpNode interface {
-	// TODO(yuzefovich): modify the interface so that a boolean is passed in to
-	// distinguish between verbose and non-verbose outputs.
 	// ChildCount returns the number of children (inputs) of the operator.
-	ChildCount() int
+	ChildCount(verbose bool) int
 
 	// Child returns the nth child (input) of the operator.
-	Child(nth int) OpNode
+	Child(nth int, verbose bool) OpNode
 }

--- a/pkg/sql/execinfra/stats.go
+++ b/pkg/sql/execinfra/stats.go
@@ -41,12 +41,12 @@ func NewInputStatCollector(input RowSource) *InputStatCollector {
 }
 
 // ChildCount is part of the OpNode interface.
-func (isc *InputStatCollector) ChildCount() int {
+func (isc *InputStatCollector) ChildCount(verbose bool) int {
 	return 1
 }
 
 // Child is part of the OpNode interface.
-func (isc *InputStatCollector) Child(nth int) OpNode {
+func (isc *InputStatCollector) Child(nth int, verbose bool) OpNode {
 	if nth == 0 {
 		return isc.RowSource.(OpNode)
 	}

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -160,8 +160,8 @@ func doFormatOpChain(
 	verbose bool,
 	seenOps map[reflect.Value]struct{},
 ) {
-	for i := 0; i < operator.ChildCount(); i++ {
-		child := operator.Child(i)
+	for i := 0; i < operator.ChildCount(verbose); i++ {
+		child := operator.Child(i, verbose)
 		childOpValue := reflect.ValueOf(child)
 		childOpName := reflect.TypeOf(child).String()
 		if _, seenOp := seenOps[childOpValue]; seenOp {

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -532,17 +532,20 @@ EXPLAIN (VEC) SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projPlusFloat64Float64ConstOp
-            └ *colexec.projMultFloat64Float64Op
-              └ *colexec.projMinusFloat64ConstFloat64Op
-                └ *colexec.projMultFloat64Float64Op
-                  └ *colexec.projMinusFloat64ConstFloat64Op
-                    └ *colexec.selLEInt64Int64ConstOp
-                      └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *colexec.projMultFloat64Float64Op
+  │       └ *colexec.projPlusFloat64Float64ConstOp
+  │         └ *colexec.projMultFloat64Float64Op
+  │           └ *colexec.projMinusFloat64ConstFloat64Op
+  │             └ *colexec.projMultFloat64Float64Op
+  │               └ *colexec.projMinusFloat64ConstFloat64Op
+  │                 └ *colexec.selLEInt64Int64ConstOp
+  │                   └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 2
 query T
@@ -598,14 +601,17 @@ EXPLAIN (VEC) SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE 
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.hashJoinEqOp
-          ├ *execinfra.IndexJoiner
-          │ └ *colexec.colBatchScan
-          └ *colexec.selLTInt64Int64Op
-            └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *colexec.hashJoinEqOp
+  │       ├ *execinfra.IndexJoiner
+  │       │ └ *colexec.colBatchScan
+  │       └ *colexec.selLTInt64Int64Op
+  │         └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 5
 query T
@@ -613,23 +619,26 @@ EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue 
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projMinusFloat64ConstFloat64Op
-            └ *colexec.hashJoinEqOp
-              ├ *colexec.hashJoinEqOp
-              │ ├ *colexec.hashJoinEqOp
-              │ │ ├ *colexec.colBatchScan
-              │ │ └ *execinfra.JoinReader
-              │ │   └ *colexec.hashJoinEqOp
-              │ │     ├ *colexec.colBatchScan
-              │ │     └ *colexec.selEQBytesBytesConstOp
-              │ │       └ *colexec.colBatchScan
-              │ └ *execinfra.IndexJoiner
-              │   └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *colexec.projMultFloat64Float64Op
+  │       └ *colexec.projMinusFloat64ConstFloat64Op
+  │         └ *colexec.hashJoinEqOp
+  │           ├ *colexec.hashJoinEqOp
+  │           │ ├ *colexec.hashJoinEqOp
+  │           │ │ ├ *colexec.colBatchScan
+  │           │ │ └ *execinfra.JoinReader
+  │           │ │   └ *colexec.hashJoinEqOp
+  │           │ │     ├ *colexec.colBatchScan
+  │           │ │     └ *colexec.selEQBytesBytesConstOp
+  │           │ │       └ *colexec.colBatchScan
+  │           │ └ *execinfra.IndexJoiner
+  │           │   └ *colexec.colBatchScan
+  │           └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 6
 query T
@@ -649,35 +658,38 @@ EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FR
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projMinusFloat64ConstFloat64Op
-            └ *colexec.defaultBuiltinFuncOperator
-              └ *colexec.constBytesOp
-                └ *colexec.hashJoinEqOp
-                  ├ *execinfra.JoinReader
-                  │ └ *execinfra.JoinReader
-                  │   └ *execinfra.JoinReader
-                  │     └ *colexec.caseOp
-                  │       ├ *colexec.bufferOp
-                  │       │ └ *colexec.hashJoinEqOp
-                  │       │   ├ *colexec.colBatchScan
-                  │       │   └ *colexec.colBatchScan
-                  │       ├ *colexec.constBoolOp
-                  │       │ └ *colexec.andProjOp
-                  │       │   ├ *colexec.bufferOp
-                  │       │   ├ *colexec.projEQBytesBytesConstOp
-                  │       │   └ *colexec.projEQBytesBytesConstOp
-                  │       ├ *colexec.constBoolOp
-                  │       │ └ *colexec.andProjOp
-                  │       │   ├ *colexec.bufferOp
-                  │       │   ├ *colexec.projEQBytesBytesConstOp
-                  │       │   └ *colexec.projEQBytesBytesConstOp
-                  │       └ *colexec.constBoolOp
-                  │         └ *colexec.bufferOp
-                  └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *colexec.projMultFloat64Float64Op
+  │       └ *colexec.projMinusFloat64ConstFloat64Op
+  │         └ *colexec.defaultBuiltinFuncOperator
+  │           └ *colexec.constBytesOp
+  │             └ *colexec.hashJoinEqOp
+  │               ├ *execinfra.JoinReader
+  │               │ └ *execinfra.JoinReader
+  │               │   └ *execinfra.JoinReader
+  │               │     └ *colexec.caseOp
+  │               │       ├ *colexec.bufferOp
+  │               │       │ └ *colexec.hashJoinEqOp
+  │               │       │   ├ *colexec.colBatchScan
+  │               │       │   └ *colexec.colBatchScan
+  │               │       ├ *colexec.constBoolOp
+  │               │       │ └ *colexec.andProjOp
+  │               │       │   ├ *colexec.bufferOp
+  │               │       │   ├ *colexec.projEQBytesBytesConstOp
+  │               │       │   └ *colexec.projEQBytesBytesConstOp
+  │               │       ├ *colexec.constBoolOp
+  │               │       │ └ *colexec.andProjOp
+  │               │       │   ├ *colexec.bufferOp
+  │               │       │   ├ *colexec.projEQBytesBytesConstOp
+  │               │       │   └ *colexec.projEQBytesBytesConstOp
+  │               │       └ *colexec.constBoolOp
+  │               │         └ *colexec.bufferOp
+  │               └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 8
 query T
@@ -685,37 +697,40 @@ EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.projDivFloat64Float64Op
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
-          └ *colexec.caseOp
-            ├ *colexec.bufferOp
-            │ └ *colexec.projMultFloat64Float64Op
-            │   └ *colexec.projMinusFloat64ConstFloat64Op
-            │     └ *colexec.defaultBuiltinFuncOperator
-            │       └ *colexec.constBytesOp
-            │         └ *colexec.hashJoinEqOp
-            │           ├ *colexec.hashJoinEqOp
-            │           │ ├ *colexec.hashJoinEqOp
-            │           │ │ ├ *colexec.colBatchScan
-            │           │ │ └ *colexec.hashJoinEqOp
-            │           │ │   ├ *colexec.hashJoinEqOp
-            │           │ │   │ ├ *execinfra.JoinReader
-            │           │ │   │ │ └ *execinfra.JoinReader
-            │           │ │   │ │   └ *colexec.selEQBytesBytesConstOp
-            │           │ │   │ │     └ *colexec.colBatchScan
-            │           │ │   │ └ *colexec.colBatchScan
-            │           │ │   └ *colexec.selLEInt64Int64ConstOp
-            │           │ │     └ *colexec.selGEInt64Int64ConstOp
-            │           │ │       └ *colexec.colBatchScan
-            │           │ └ *colexec.colBatchScan
-            │           └ *colexec.selEQBytesBytesConstOp
-            │             └ *colexec.colBatchScan
-            ├ *colexec.projEQBytesBytesConstOp
-            │ └ *colexec.bufferOp
-            └ *colexec.constFloat64Op
-              └ *colexec.bufferOp
+  ├ *colexec.sortOp
+  │ └ *colexec.projDivFloat64Float64Op
+  │   └ *colexec.orderedAggregator
+  │     └ *colexec.hashGrouper
+  │       └ *colexec.caseOp
+  │         ├ *colexec.bufferOp
+  │         │ └ *colexec.projMultFloat64Float64Op
+  │         │   └ *colexec.projMinusFloat64ConstFloat64Op
+  │         │     └ *colexec.defaultBuiltinFuncOperator
+  │         │       └ *colexec.constBytesOp
+  │         │         └ *colexec.hashJoinEqOp
+  │         │           ├ *colexec.hashJoinEqOp
+  │         │           │ ├ *colexec.hashJoinEqOp
+  │         │           │ │ ├ *colexec.colBatchScan
+  │         │           │ │ └ *colexec.hashJoinEqOp
+  │         │           │ │   ├ *colexec.hashJoinEqOp
+  │         │           │ │   │ ├ *execinfra.JoinReader
+  │         │           │ │   │ │ └ *execinfra.JoinReader
+  │         │           │ │   │ │   └ *colexec.selEQBytesBytesConstOp
+  │         │           │ │   │ │     └ *colexec.colBatchScan
+  │         │           │ │   │ └ *colexec.colBatchScan
+  │         │           │ │   └ *colexec.selLEInt64Int64ConstOp
+  │         │           │ │     └ *colexec.selGEInt64Int64ConstOp
+  │         │           │ │       └ *colexec.colBatchScan
+  │         │           │ └ *colexec.colBatchScan
+  │         │           └ *colexec.selEQBytesBytesConstOp
+  │         │             └ *colexec.colBatchScan
+  │         ├ *colexec.projEQBytesBytesConstOp
+  │         │ └ *colexec.bufferOp
+  │         └ *colexec.constFloat64Op
+  │           └ *colexec.bufferOp
+  ├ *colexec.simpleProjectOp
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 9
 query T
@@ -723,18 +738,21 @@ EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_n
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *execinfra.JoinReader
-          └ *colexec.hashJoinEqOp
-            ├ *colexec.hashJoinEqOp
-            │ ├ *execinfra.JoinReader
-            │ │ └ *execinfra.JoinReader
-            │ │   └ *execinfra.JoinReader
-            │ │     └ *colexec.colBatchScan
-            │ └ *colexec.colBatchScan
-            └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *execinfra.JoinReader
+  │       └ *colexec.hashJoinEqOp
+  │         ├ *colexec.hashJoinEqOp
+  │         │ ├ *execinfra.JoinReader
+  │         │ │ └ *execinfra.JoinReader
+  │         │ │   └ *execinfra.JoinReader
+  │         │ │     └ *colexec.colBatchScan
+  │         │ └ *colexec.colBatchScan
+  │         └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 10
 query T
@@ -760,17 +778,20 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.selGTFloat64Float64Op
-      └ *colexec.castOpNullAny
-        └ *colexec.constNullOp
-          └ *colexec.orderedAggregator
-            └ *colexec.hashGrouper
-              └ *execinfra.JoinReader
-                └ *execinfra.JoinReader
-                  └ *execinfra.JoinReader
-                    └ *colexec.selEQBytesBytesConstOp
-                      └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.selGTFloat64Float64Op
+  │   └ *colexec.castOpNullAny
+  │     └ *colexec.constNullOp
+  │       └ *colexec.orderedAggregator
+  │         └ *colexec.hashGrouper
+  │           └ *execinfra.JoinReader
+  │             └ *execinfra.JoinReader
+  │               └ *execinfra.JoinReader
+  │                 └ *colexec.selEQBytesBytesConstOp
+  │                   └ *colexec.colBatchScan
+  ├ *colexec.simpleProjectOp
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 12
 query error unable to vectorize execution plan: sum on int cols not supported
@@ -782,15 +803,18 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.orderedAggregator
-          └ *colexec.hashGrouper
-            └ *colexec.hashJoinEqOp
-              ├ *colexec.selNotRegexpBytesBytesConstOp
-              │ └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *colexec.orderedAggregator
+  │       └ *colexec.hashGrouper
+  │         └ *colexec.hashJoinEqOp
+  │           ├ *colexec.selNotRegexpBytesBytesConstOp
+  │           │ └ *colexec.colBatchScan
+  │           └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 14
 query T
@@ -928,23 +952,26 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.hashJoinEqOp
-      ├ *colexec.hashJoinEqOp
-      │ ├ *colexec.colBatchScan
-      │ └ *colexec.hashJoinEqOp
-      │   ├ *colexec.selGTInt64Float64Op
-      │   │ └ *colexec.projMultFloat64Float64ConstOp
-      │   │   └ *colexec.orderedAggregator
-      │   │     └ *colexec.hashGrouper
-      │   │       └ *colexec.hashJoinEqOp
-      │   │         ├ *execinfra.IndexJoiner
-      │   │         │ └ *colexec.colBatchScan
-      │   │         └ *colexec.colBatchScan
-      │   └ *colexec.selPrefixBytesBytesConstOp
-      │     └ *colexec.colBatchScan
-      └ *colexec.selEQBytesBytesConstOp
-        └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.hashJoinEqOp
+  │   ├ *colexec.hashJoinEqOp
+  │   │ ├ *colexec.colBatchScan
+  │   │ └ *colexec.hashJoinEqOp
+  │   │   ├ *colexec.selGTInt64Float64Op
+  │   │   │ └ *colexec.projMultFloat64Float64ConstOp
+  │   │   │   └ *colexec.orderedAggregator
+  │   │   │     └ *colexec.hashGrouper
+  │   │   │       └ *colexec.hashJoinEqOp
+  │   │   │         ├ *execinfra.IndexJoiner
+  │   │   │         │ └ *colexec.colBatchScan
+  │   │   │         └ *colexec.colBatchScan
+  │   │   └ *colexec.selPrefixBytesBytesConstOp
+  │   │     └ *colexec.colBatchScan
+  │   └ *colexec.selEQBytesBytesConstOp
+  │     └ *colexec.colBatchScan
+  ├ *colexec.hashJoinEqOp
+  └ *colexec.externalSorter
+    └ *colexec.sortOp
 
 # Query 21
 query error can't plan non-inner hash join with on expressions
@@ -956,15 +983,18 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *execinfra.JoinReader
-          └ *colexec.selGTFloat64Float64Op
-            └ *colexec.castOpNullAny
-              └ *colexec.constNullOp
-                └ *colexec.selectInOpBytes
-                  └ *colexec.substringFunctionOperator
-                    └ *colexec.constInt64Op
-                      └ *colexec.constInt64Op
-                        └ *colexec.colBatchScan
+  ├ *colexec.sortOp
+  │ └ *colexec.orderedAggregator
+  │   └ *colexec.hashGrouper
+  │     └ *execinfra.JoinReader
+  │       └ *colexec.selGTFloat64Float64Op
+  │         └ *colexec.castOpNullAny
+  │           └ *colexec.constNullOp
+  │             └ *colexec.selectInOpBytes
+  │               └ *colexec.substringFunctionOperator
+  │                 └ *colexec.constInt64Op
+  │                   └ *colexec.constInt64Op
+  │                     └ *colexec.colBatchScan
+  ├ *colexec.orderedAggregator
+  └ *colexec.externalSorter
+    └ *colexec.sortOp

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -532,20 +532,17 @@ EXPLAIN (VEC) SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *colexec.projMultFloat64Float64Op
-  │       └ *colexec.projPlusFloat64Float64ConstOp
-  │         └ *colexec.projMultFloat64Float64Op
-  │           └ *colexec.projMinusFloat64ConstFloat64Op
-  │             └ *colexec.projMultFloat64Float64Op
-  │               └ *colexec.projMinusFloat64ConstFloat64Op
-  │                 └ *colexec.selLEInt64Int64ConstOp
-  │                   └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *colexec.projMultFloat64Float64Op
+          └ *colexec.projPlusFloat64Float64ConstOp
+            └ *colexec.projMultFloat64Float64Op
+              └ *colexec.projMinusFloat64ConstFloat64Op
+                └ *colexec.projMultFloat64Float64Op
+                  └ *colexec.projMinusFloat64ConstFloat64Op
+                    └ *colexec.selLEInt64Int64ConstOp
+                      └ *colexec.colBatchScan
 
 # Query 2
 query T
@@ -601,17 +598,14 @@ EXPLAIN (VEC) SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE 
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *colexec.hashJoinEqOp
-  │       ├ *execinfra.IndexJoiner
-  │       │ └ *colexec.colBatchScan
-  │       └ *colexec.selLTInt64Int64Op
-  │         └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *colexec.hashJoinEqOp
+          ├ *execinfra.IndexJoiner
+          │ └ *colexec.colBatchScan
+          └ *colexec.selLTInt64Int64Op
+            └ *colexec.colBatchScan
 
 # Query 5
 query T
@@ -619,26 +613,23 @@ EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue 
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *colexec.projMultFloat64Float64Op
-  │       └ *colexec.projMinusFloat64ConstFloat64Op
-  │         └ *colexec.hashJoinEqOp
-  │           ├ *colexec.hashJoinEqOp
-  │           │ ├ *colexec.hashJoinEqOp
-  │           │ │ ├ *colexec.colBatchScan
-  │           │ │ └ *execinfra.JoinReader
-  │           │ │   └ *colexec.hashJoinEqOp
-  │           │ │     ├ *colexec.colBatchScan
-  │           │ │     └ *colexec.selEQBytesBytesConstOp
-  │           │ │       └ *colexec.colBatchScan
-  │           │ └ *execinfra.IndexJoiner
-  │           │   └ *colexec.colBatchScan
-  │           └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *colexec.projMultFloat64Float64Op
+          └ *colexec.projMinusFloat64ConstFloat64Op
+            └ *colexec.hashJoinEqOp
+              ├ *colexec.hashJoinEqOp
+              │ ├ *colexec.hashJoinEqOp
+              │ │ ├ *colexec.colBatchScan
+              │ │ └ *execinfra.JoinReader
+              │ │   └ *colexec.hashJoinEqOp
+              │ │     ├ *colexec.colBatchScan
+              │ │     └ *colexec.selEQBytesBytesConstOp
+              │ │       └ *colexec.colBatchScan
+              │ └ *execinfra.IndexJoiner
+              │   └ *colexec.colBatchScan
+              └ *colexec.colBatchScan
 
 # Query 6
 query T
@@ -658,38 +649,35 @@ EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FR
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *colexec.projMultFloat64Float64Op
-  │       └ *colexec.projMinusFloat64ConstFloat64Op
-  │         └ *colexec.defaultBuiltinFuncOperator
-  │           └ *colexec.constBytesOp
-  │             └ *colexec.hashJoinEqOp
-  │               ├ *execinfra.JoinReader
-  │               │ └ *execinfra.JoinReader
-  │               │   └ *execinfra.JoinReader
-  │               │     └ *colexec.caseOp
-  │               │       ├ *colexec.bufferOp
-  │               │       │ └ *colexec.hashJoinEqOp
-  │               │       │   ├ *colexec.colBatchScan
-  │               │       │   └ *colexec.colBatchScan
-  │               │       ├ *colexec.constBoolOp
-  │               │       │ └ *colexec.andProjOp
-  │               │       │   ├ *colexec.bufferOp
-  │               │       │   ├ *colexec.projEQBytesBytesConstOp
-  │               │       │   └ *colexec.projEQBytesBytesConstOp
-  │               │       ├ *colexec.constBoolOp
-  │               │       │ └ *colexec.andProjOp
-  │               │       │   ├ *colexec.bufferOp
-  │               │       │   ├ *colexec.projEQBytesBytesConstOp
-  │               │       │   └ *colexec.projEQBytesBytesConstOp
-  │               │       └ *colexec.constBoolOp
-  │               │         └ *colexec.bufferOp
-  │               └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *colexec.projMultFloat64Float64Op
+          └ *colexec.projMinusFloat64ConstFloat64Op
+            └ *colexec.defaultBuiltinFuncOperator
+              └ *colexec.constBytesOp
+                └ *colexec.hashJoinEqOp
+                  ├ *execinfra.JoinReader
+                  │ └ *execinfra.JoinReader
+                  │   └ *execinfra.JoinReader
+                  │     └ *colexec.caseOp
+                  │       ├ *colexec.bufferOp
+                  │       │ └ *colexec.hashJoinEqOp
+                  │       │   ├ *colexec.colBatchScan
+                  │       │   └ *colexec.colBatchScan
+                  │       ├ *colexec.constBoolOp
+                  │       │ └ *colexec.andProjOp
+                  │       │   ├ *colexec.bufferOp
+                  │       │   ├ *colexec.projEQBytesBytesConstOp
+                  │       │   └ *colexec.projEQBytesBytesConstOp
+                  │       ├ *colexec.constBoolOp
+                  │       │ └ *colexec.andProjOp
+                  │       │   ├ *colexec.bufferOp
+                  │       │   ├ *colexec.projEQBytesBytesConstOp
+                  │       │   └ *colexec.projEQBytesBytesConstOp
+                  │       └ *colexec.constBoolOp
+                  │         └ *colexec.bufferOp
+                  └ *colexec.colBatchScan
 
 # Query 8
 query T
@@ -697,40 +685,37 @@ EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.projDivFloat64Float64Op
-  │   └ *colexec.orderedAggregator
-  │     └ *colexec.hashGrouper
-  │       └ *colexec.caseOp
-  │         ├ *colexec.bufferOp
-  │         │ └ *colexec.projMultFloat64Float64Op
-  │         │   └ *colexec.projMinusFloat64ConstFloat64Op
-  │         │     └ *colexec.defaultBuiltinFuncOperator
-  │         │       └ *colexec.constBytesOp
-  │         │         └ *colexec.hashJoinEqOp
-  │         │           ├ *colexec.hashJoinEqOp
-  │         │           │ ├ *colexec.hashJoinEqOp
-  │         │           │ │ ├ *colexec.colBatchScan
-  │         │           │ │ └ *colexec.hashJoinEqOp
-  │         │           │ │   ├ *colexec.hashJoinEqOp
-  │         │           │ │   │ ├ *execinfra.JoinReader
-  │         │           │ │   │ │ └ *execinfra.JoinReader
-  │         │           │ │   │ │   └ *colexec.selEQBytesBytesConstOp
-  │         │           │ │   │ │     └ *colexec.colBatchScan
-  │         │           │ │   │ └ *colexec.colBatchScan
-  │         │           │ │   └ *colexec.selLEInt64Int64ConstOp
-  │         │           │ │     └ *colexec.selGEInt64Int64ConstOp
-  │         │           │ │       └ *colexec.colBatchScan
-  │         │           │ └ *colexec.colBatchScan
-  │         │           └ *colexec.selEQBytesBytesConstOp
-  │         │             └ *colexec.colBatchScan
-  │         ├ *colexec.projEQBytesBytesConstOp
-  │         │ └ *colexec.bufferOp
-  │         └ *colexec.constFloat64Op
-  │           └ *colexec.bufferOp
-  ├ *colexec.simpleProjectOp
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.projDivFloat64Float64Op
+      └ *colexec.orderedAggregator
+        └ *colexec.hashGrouper
+          └ *colexec.caseOp
+            ├ *colexec.bufferOp
+            │ └ *colexec.projMultFloat64Float64Op
+            │   └ *colexec.projMinusFloat64ConstFloat64Op
+            │     └ *colexec.defaultBuiltinFuncOperator
+            │       └ *colexec.constBytesOp
+            │         └ *colexec.hashJoinEqOp
+            │           ├ *colexec.hashJoinEqOp
+            │           │ ├ *colexec.hashJoinEqOp
+            │           │ │ ├ *colexec.colBatchScan
+            │           │ │ └ *colexec.hashJoinEqOp
+            │           │ │   ├ *colexec.hashJoinEqOp
+            │           │ │   │ ├ *execinfra.JoinReader
+            │           │ │   │ │ └ *execinfra.JoinReader
+            │           │ │   │ │   └ *colexec.selEQBytesBytesConstOp
+            │           │ │   │ │     └ *colexec.colBatchScan
+            │           │ │   │ └ *colexec.colBatchScan
+            │           │ │   └ *colexec.selLEInt64Int64ConstOp
+            │           │ │     └ *colexec.selGEInt64Int64ConstOp
+            │           │ │       └ *colexec.colBatchScan
+            │           │ └ *colexec.colBatchScan
+            │           └ *colexec.selEQBytesBytesConstOp
+            │             └ *colexec.colBatchScan
+            ├ *colexec.projEQBytesBytesConstOp
+            │ └ *colexec.bufferOp
+            └ *colexec.constFloat64Op
+              └ *colexec.bufferOp
 
 # Query 9
 query T
@@ -738,21 +723,18 @@ EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_n
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *execinfra.JoinReader
-  │       └ *colexec.hashJoinEqOp
-  │         ├ *colexec.hashJoinEqOp
-  │         │ ├ *execinfra.JoinReader
-  │         │ │ └ *execinfra.JoinReader
-  │         │ │   └ *execinfra.JoinReader
-  │         │ │     └ *colexec.colBatchScan
-  │         │ └ *colexec.colBatchScan
-  │         └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *execinfra.JoinReader
+          └ *colexec.hashJoinEqOp
+            ├ *colexec.hashJoinEqOp
+            │ ├ *execinfra.JoinReader
+            │ │ └ *execinfra.JoinReader
+            │ │   └ *execinfra.JoinReader
+            │ │     └ *colexec.colBatchScan
+            │ └ *colexec.colBatchScan
+            └ *colexec.colBatchScan
 
 # Query 10
 query T
@@ -778,20 +760,17 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.selGTFloat64Float64Op
-  │   └ *colexec.castOpNullAny
-  │     └ *colexec.constNullOp
-  │       └ *colexec.orderedAggregator
-  │         └ *colexec.hashGrouper
-  │           └ *execinfra.JoinReader
-  │             └ *execinfra.JoinReader
-  │               └ *execinfra.JoinReader
-  │                 └ *colexec.selEQBytesBytesConstOp
-  │                   └ *colexec.colBatchScan
-  ├ *colexec.simpleProjectOp
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.selGTFloat64Float64Op
+      └ *colexec.castOpNullAny
+        └ *colexec.constNullOp
+          └ *colexec.orderedAggregator
+            └ *colexec.hashGrouper
+              └ *execinfra.JoinReader
+                └ *execinfra.JoinReader
+                  └ *execinfra.JoinReader
+                    └ *colexec.selEQBytesBytesConstOp
+                      └ *colexec.colBatchScan
 
 # Query 12
 query error unable to vectorize execution plan: sum on int cols not supported
@@ -803,18 +782,15 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *colexec.orderedAggregator
-  │       └ *colexec.hashGrouper
-  │         └ *colexec.hashJoinEqOp
-  │           ├ *colexec.selNotRegexpBytesBytesConstOp
-  │           │ └ *colexec.colBatchScan
-  │           └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *colexec.orderedAggregator
+          └ *colexec.hashGrouper
+            └ *colexec.hashJoinEqOp
+              ├ *colexec.selNotRegexpBytesBytesConstOp
+              │ └ *colexec.colBatchScan
+              └ *colexec.colBatchScan
 
 # Query 14
 query T
@@ -952,26 +928,23 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.hashJoinEqOp
-  │   ├ *colexec.hashJoinEqOp
-  │   │ ├ *colexec.colBatchScan
-  │   │ └ *colexec.hashJoinEqOp
-  │   │   ├ *colexec.selGTInt64Float64Op
-  │   │   │ └ *colexec.projMultFloat64Float64ConstOp
-  │   │   │   └ *colexec.orderedAggregator
-  │   │   │     └ *colexec.hashGrouper
-  │   │   │       └ *colexec.hashJoinEqOp
-  │   │   │         ├ *execinfra.IndexJoiner
-  │   │   │         │ └ *colexec.colBatchScan
-  │   │   │         └ *colexec.colBatchScan
-  │   │   └ *colexec.selPrefixBytesBytesConstOp
-  │   │     └ *colexec.colBatchScan
-  │   └ *colexec.selEQBytesBytesConstOp
-  │     └ *colexec.colBatchScan
-  ├ *colexec.hashJoinEqOp
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.hashJoinEqOp
+      ├ *colexec.hashJoinEqOp
+      │ ├ *colexec.colBatchScan
+      │ └ *colexec.hashJoinEqOp
+      │   ├ *colexec.selGTInt64Float64Op
+      │   │ └ *colexec.projMultFloat64Float64ConstOp
+      │   │   └ *colexec.orderedAggregator
+      │   │     └ *colexec.hashGrouper
+      │   │       └ *colexec.hashJoinEqOp
+      │   │         ├ *execinfra.IndexJoiner
+      │   │         │ └ *colexec.colBatchScan
+      │   │         └ *colexec.colBatchScan
+      │   └ *colexec.selPrefixBytesBytesConstOp
+      │     └ *colexec.colBatchScan
+      └ *colexec.selEQBytesBytesConstOp
+        └ *colexec.colBatchScan
 
 # Query 21
 query error can't plan non-inner hash join with on expressions
@@ -983,18 +956,15 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 ----
 │
 └ Node 1
-  ├ *colexec.sortOp
-  │ └ *colexec.orderedAggregator
-  │   └ *colexec.hashGrouper
-  │     └ *execinfra.JoinReader
-  │       └ *colexec.selGTFloat64Float64Op
-  │         └ *colexec.castOpNullAny
-  │           └ *colexec.constNullOp
-  │             └ *colexec.selectInOpBytes
-  │               └ *colexec.substringFunctionOperator
-  │                 └ *colexec.constInt64Op
-  │                   └ *colexec.constInt64Op
-  │                     └ *colexec.colBatchScan
-  ├ *colexec.orderedAggregator
-  └ *colexec.externalSorter
-    └ *colexec.sortOp
+  └ *colexec.sortOp
+    └ *colexec.orderedAggregator
+      └ *colexec.hashGrouper
+        └ *execinfra.JoinReader
+          └ *colexec.selGTFloat64Float64Op
+            └ *colexec.castOpNullAny
+              └ *colexec.constNullOp
+                └ *colexec.selectInOpBytes
+                  └ *colexec.substringFunctionOperator
+                    └ *colexec.constInt64Op
+                      └ *colexec.constInt64Op
+                        └ *colexec.colBatchScan


### PR DESCRIPTION
**colexec: add mechanism to fallback to disk on OOM error**

This commit adds the infrastructure to be able to fallback from the
in-memory buffering operator to a disk-backed one. A new interface
'bufferingInMemoryOperator' is introduced that allows for exporting the
already buffered tuples from the in-memory operator to the disk-backed
implementation. The commit also introduces 'diskSpiller' operator that
performs the fallback by catching OOM errors and facilitating the
transfer of already buffered tuples and continuing to exhaust the input
via a newly created 'bufferExportingOperator' (which is responsible for
providing the continuous stream of batches from the two sources).

diskSpiller assumes that if an OOM error is occurred during
initialization, then it cannot fallback and bails on the query.

Here is the diagram of the components involved:

        -------------  input  -----------
       |                ||                | (2nd src)
       |                ||   (1st src)    ↓
       |            ----||---> bufferExportingOperator
       ↓           |    ||                |
    inMemoryOp ----     ||                ↓
       |                ||           diskBackedOp
       |                ||                |
       |                ↓↓                |
        ---------> disk spiller <--------
                        ||
                        ||
                        ↓↓
                      output

Fixes: #42408.

Release note: None

**execinfra: modify OpNode interface**

This commit adds 'verbose' argument to two methods of OpNode interface.
The only operator that currently uses it is diskSpiller which in
non-verbose setting hides its side chains.

Release note: None

**colexec: remove assertions from window functions that are no longer true**

We recently merged a change to use a schema-less zero-length batch to
indicate that an operator is done emitting batches. Previously, window
functions had an assertion that always checked that there are enough
columns so that the window function operator could write into it. It no
longer holds for coldata.ZeroBatch, so it was removed.

Release note: None