### PR TITLE
ui: Clear decommissioned nodes from UI and preserve state in DB

### DIFF
--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -10,6 +10,7 @@
 
 import _ from "lodash";
 import { Action, Dispatch } from "redux";
+import { createSelector } from "reselect";
 import * as protobuf from "protobufjs/minimal";
 
 import * as protos from  "src/js/protos";
@@ -59,6 +60,11 @@ export const VERSION_DISMISSED_KEY = "version_dismissed";
 // INSTRUCTIONS_BOX_COLLAPSED_KEY is the uiData key on the server that tracks whether the
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY = "clusterviz_instructions_box_collapsed";
+
+// HIDE_DECOMMISSIONED_NODE_LIST key that contains list of all decommissioned nodes which have to be hidden from
+// Decommissioned nodes table on Node Overview page.
+// Values are the list of node ids which have to be filtered out.
+export const HIDE_DECOMMISSIONED_NODE_LIST = "node_overview_hide_decommissioned_node_list";
 
 export enum UIDataStatus {
   UNINITIALIZED, // Data has not been loaded yet.
@@ -318,3 +324,8 @@ export function loadUIData(...keys: string[]) {
     });
   };
 }
+
+export const hiddenDecommissionedNodes = createSelector(
+  (state: AdminUIState) => getData(state, HIDE_DECOMMISSIONED_NODE_LIST),
+  (hiddenNodes: Array<number>) => hiddenNodes,
+);

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -318,6 +318,7 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
   columns: ColumnDescriptor<INodeStatus>[] = [
     {
       title: (<a
+        className="sort-table__action-link"
         onClick={() => this.onClearNodesHandler(this.props.statuses)}>Clear All</a>),
       cell: (ns) => {
         return (

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -44,3 +44,11 @@
 .node-status-icon > svg
   width 16px
   height 16px
+
+.sort-table__action-link
+  text-transform none
+  font-size: 14px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  letter-spacing: 0.1px;


### PR DESCRIPTION
It is required to allow users clear decommissioned nodes from UI and
it has to be permanent globally for all users. To achieve this, cleared
node ids are stored in database ('ui' table) as a single key with
array of node ids as value.

Due to required custom action links for Decommissioned node table,
new DecommissionedNodeList component is added which basically extends
presentation and behavior of base component (NotLiveNodeList)

Release note: None