### PR TITLE
sql: make SQL statements operate on a read snapshot

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -104,7 +104,10 @@ func (cp *readImportDataProcessor) Run(ctx context.Context) {
 }
 
 func makeInputConverter(
-	spec *execinfrapb.ReadImportDataSpec, evalCtx *tree.EvalContext, kvCh chan row.KVBatch,
+	ctx context.Context,
+	spec *execinfrapb.ReadImportDataSpec,
+	evalCtx *tree.EvalContext,
+	kvCh chan row.KVBatch,
 ) (inputConverter, error) {
 
 	var singleTable *sqlbase.TableDescriptor
@@ -139,15 +142,15 @@ func makeInputConverter(
 			kvCh, spec.Format.Csv, spec.WalltimeNanos, int(spec.ReaderParallelism),
 			singleTable, singleTableTargetCols, evalCtx), nil
 	case roachpb.IOFileFormat_MysqlOutfile:
-		return newMysqloutfileReader(kvCh, spec.Format.MysqlOut, singleTable, evalCtx)
+		return newMysqloutfileReader(ctx, kvCh, spec.Format.MysqlOut, singleTable, evalCtx)
 	case roachpb.IOFileFormat_Mysqldump:
-		return newMysqldumpReader(kvCh, spec.Tables, evalCtx)
+		return newMysqldumpReader(ctx, kvCh, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_PgCopy:
-		return newPgCopyReader(kvCh, spec.Format.PgCopy, singleTable, evalCtx)
+		return newPgCopyReader(ctx, kvCh, spec.Format.PgCopy, singleTable, evalCtx)
 	case roachpb.IOFileFormat_PgDump:
-		return newPgDumpReader(kvCh, spec.Format.PgDump, spec.Tables, evalCtx)
+		return newPgDumpReader(ctx, kvCh, spec.Format.PgDump, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_Avro:
-		return newAvroInputReader(kvCh, singleTable, spec.Format.Avro, evalCtx)
+		return newAvroInputReader(ctx, kvCh, singleTable, spec.Format.Avro, evalCtx)
 	default:
 		return nil, errors.Errorf("Requested IMPORT format (%d) not supported by this node", spec.Format.Format)
 	}

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -110,7 +110,7 @@ func TestConverterFlushesBatches(t *testing.T) {
 				}
 
 				kvCh := make(chan row.KVBatch, batchSize)
-				conv, err := makeInputConverter(converterSpec, &evalCtx, kvCh)
+				conv, err := makeInputConverter(ctx, converterSpec, &evalCtx, kvCh)
 				if err != nil {
 					t.Fatalf("makeInputConverter() error = %v", err)
 				}

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -186,7 +186,7 @@ func Load(
 			}
 
 			ri, err = row.MakeInserter(
-				nil, tableDesc, tableDesc.Columns, row.SkipFKs, nil /* fkTables */, &sqlbase.DatumAlloc{},
+				ctx, nil, tableDesc, tableDesc.Columns, row.SkipFKs, nil /* fkTables */, &sqlbase.DatumAlloc{},
 			)
 			if err != nil {
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make row inserter")

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -428,12 +428,13 @@ type avroInputReader struct {
 var _ inputConverter = &avroInputReader{}
 
 func newAvroInputReader(
+	ctx context.Context,
 	kvCh chan row.KVBatch,
 	tableDesc *sqlbase.TableDescriptor,
 	avro roachpb.AvroOptions,
 	evalCtx *tree.EvalContext,
 ) (*avroInputReader, error) {
-	conv, err := row.NewDatumRowConverter(tableDesc, nil /* targetColNames */, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(ctx, tableDesc, nil /* targetColNames */, evalCtx, kvCh)
 
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -202,7 +202,7 @@ func (th *testHelper) newRecordStream(
 	// we're using nil kv channel for this test).
 	defer row.TestingSetDatumRowConverterBatchSize(numRecords + 1)()
 	evalCtx := tree.MakeTestingEvalContext(nil)
-	conv, err := row.NewDatumRowConverter(th.schemaTable, nil, &evalCtx, nil)
+	conv, err := row.NewDatumRowConverter(context.Background(), th.schemaTable, nil, &evalCtx, nil)
 	require.NoError(t, err)
 
 	opts := roachpb.AvroOptions{

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -41,7 +41,7 @@ func runImport(
 ) (*roachpb.BulkOpSummary, error) {
 	// Used to send ingested import rows to the KV layer.
 	kvCh := make(chan row.KVBatch, 10)
-	conv, err := makeInputConverter(spec, flowCtx.NewEvalCtx(), kvCh)
+	conv, err := makeInputConverter(ctx, spec, flowCtx.NewEvalCtx(), kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -213,7 +213,7 @@ func (c *csvInputReader) convertRecordWorker(ctx context.Context, workerID int) 
 	// Create a new evalCtx per converter so each go routine gets its own
 	// collationenv, which can't be accessed in parallel.
 	evalCtx := c.evalCtx.Copy()
-	conv, err := row.NewDatumRowConverter(c.tableDesc, c.targetCols, evalCtx, c.kvCh)
+	conv, err := row.NewDatumRowConverter(ctx, c.tableDesc, c.targetCols, evalCtx, c.kvCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -53,6 +53,7 @@ type mysqldumpReader struct {
 var _ inputConverter = &mysqldumpReader{}
 
 func newMysqldumpReader(
+	ctx context.Context,
 	kvCh chan row.KVBatch,
 	tables map[string]*execinfrapb.ReadImportDataSpec_ImportTable,
 	evalCtx *tree.EvalContext,
@@ -65,7 +66,7 @@ func newMysqldumpReader(
 			converters[name] = nil
 			continue
 		}
-		conv, err := row.NewDatumRowConverter(table.Desc, nil /* targetColNames */, evalCtx, kvCh)
+		conv, err := row.NewDatumRowConverter(ctx, table.Desc, nil /* targetColNames */, evalCtx, kvCh)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -42,7 +42,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	tables := map[string]*execinfrapb.ReadImportDataSpec_ImportTable{"simple": {Desc: table}}
 
 	kvCh := make(chan row.KVBatch, 10)
-	converter, err := newMysqldumpReader(kvCh, tables, testEvalCtx)
+	converter, err := newMysqldumpReader(ctx, kvCh, tables, testEvalCtx)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -32,12 +32,13 @@ type mysqloutfileReader struct {
 var _ inputConverter = &mysqloutfileReader{}
 
 func newMysqloutfileReader(
+	ctx context.Context,
 	kvCh chan row.KVBatch,
 	opts roachpb.MySQLOutfileOptions,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*mysqloutfileReader, error) {
-	conv, err := row.NewDatumRowConverter(tableDesc, nil /* targetColNames */, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(ctx, tableDesc, nil /* targetColNames */, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -39,12 +39,13 @@ type pgCopyReader struct {
 var _ inputConverter = &pgCopyReader{}
 
 func newPgCopyReader(
+	ctx context.Context,
 	kvCh chan row.KVBatch,
 	opts roachpb.PgCopyOptions,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*pgCopyReader, error) {
-	conv, err := row.NewDatumRowConverter(tableDesc, nil /* targetColNames */, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(ctx, tableDesc, nil /* targetColNames */, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -409,6 +409,7 @@ var _ inputConverter = &pgDumpReader{}
 
 // newPgDumpReader creates a new inputConverter for pg_dump files.
 func newPgDumpReader(
+	ctx context.Context,
 	kvCh chan row.KVBatch,
 	opts roachpb.PgDumpOptions,
 	descs map[string]*execinfrapb.ReadImportDataSpec_ImportTable,
@@ -417,7 +418,7 @@ func newPgDumpReader(
 	converters := make(map[string]*row.DatumRowConverter, len(descs))
 	for name, table := range descs {
 		if table.Desc.IsTable() {
-			conv, err := row.NewDatumRowConverter(table.Desc, nil /* targetColNames */, evalCtx, kvCh)
+			conv, err := row.NewDatumRowConverter(ctx, table.Desc, nil /* targetColNames */, evalCtx, kvCh)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -202,7 +202,7 @@ func NewWorkloadKVConverter(
 //
 // This worker needs its own EvalContext and DatumAlloc.
 func (w *WorkloadKVConverter) Worker(ctx context.Context, evalCtx *tree.EvalContext) error {
-	conv, err := row.NewDatumRowConverter(w.tableDesc, nil /* targetColNames */, evalCtx, w.kvCh)
+	conv, err := row.NewDatumRowConverter(ctx, w.tableDesc, nil /* targetColNames */, evalCtx, w.kvCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/client/mock_transactional_sender.go
+++ b/pkg/internal/client/mock_transactional_sender.go
@@ -164,10 +164,23 @@ func (m *MockTransactionalSender) PrepareRetryableError(ctx context.Context, msg
 }
 
 // Step is part of the TxnSender interface.
-func (m *MockTransactionalSender) Step() error { panic("unimplemented") }
+func (m *MockTransactionalSender) Step(_ context.Context) error {
+	// At least one test (e.g sql/TestPortalsDestroyedOnTxnFinish) requires
+	// the ability to run simple statements that do not access storage,
+	// and that requires a non-panicky Step().
+	return nil
+}
 
-// DisableStepping is part of the TxnSender interface.
-func (m *MockTransactionalSender) DisableStepping() error { panic("unimplemented") }
+// ConfigureStepping is part of the TxnSender interface.
+func (m *MockTransactionalSender) ConfigureStepping(context.Context, SteppingMode) SteppingMode {
+	// See Step() above.
+	return SteppingDisabled
+}
+
+// GetSteppingMode is part of the TxnSender interface.
+func (m *MockTransactionalSender) GetSteppingMode(context.Context) SteppingMode {
+	return SteppingDisabled
+}
 
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {

--- a/pkg/kv/txn_interceptor_seq_num_allocator_test.go
+++ b/pkg/kv/txn_interceptor_seq_num_allocator_test.go
@@ -117,8 +117,10 @@ func TestSequenceNumberAllocationWithStep(t *testing.T) {
 	txn := makeTxnProto()
 	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 
+	s.configureSteppingLocked(true /* enabled */)
+
 	for i := 1; i <= 3; i++ {
-		if err := s.stepLocked(); err != nil {
+		if err := s.stepLocked(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if s.writeSeq != s.readSeq {
@@ -195,8 +197,8 @@ func TestSequenceNumberAllocationWithStep(t *testing.T) {
 		})
 	}
 
-	// Check that step-wise execution is disabled by DisableStepping().
-	s.disableSteppingLocked()
+	// Check that step-wise execution is disabled by ConfigureStepping(SteppingDisabled).
+	s.configureSteppingLocked(false /* enabled */)
 	currentStepSeqNum := s.writeSeq
 
 	var ba roachpb.BatchRequest

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -44,6 +44,11 @@ func (p *planner) AlterIndex(ctx context.Context, n *tree.AlterIndex) (planNode,
 	return &alterIndexNode{n: n, tableDesc: tableDesc, indexDesc: indexDesc}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because ALTER INDEX performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *alterIndexNode) ReadingOwnWrites() {}
+
 func (n *alterIndexNode) startExec(params runParams) error {
 	// Commands can either change the descriptor directly (for
 	// alterations that don't require a backfill) or add a mutation to

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -42,6 +42,11 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 	return &alterSequenceNode{n: n, seqDesc: seqDesc}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because ALTER SEQUENCE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *alterSequenceNode) ReadingOwnWrites() {}
+
 func (n *alterSequenceNode) startExec(params runParams) error {
 	desc := n.seqDesc
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -92,6 +92,11 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 	}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because ALTER TABLE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *alterTableNode) ReadingOwnWrites() {}
+
 func (n *alterTableNode) startExec(params runParams) error {
 	// Commands can either change the descriptor directly (for
 	// alterations that don't require a backfill) or add a mutation to

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -615,7 +615,7 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				rd, err := row.MakeDeleter(
-					txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
+					ctx, txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
 				)
 				if err != nil {
 					return err
@@ -1660,7 +1660,7 @@ func indexTruncateInTxn(
 	var sp roachpb.Span
 	for done := false; !done; done = sp.Key == nil {
 		rd, err := row.MakeDeleter(
-			txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
+			ctx, txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -168,6 +168,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	requestedCols = append(requestedCols, tableDesc.Columns...)
 	requestedCols = append(requestedCols, cb.added...)
 	ru, err := row.MakeUpdater(
+		ctx,
 		txn,
 		tableDesc,
 		fkTables,

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -292,7 +292,7 @@ func (c *copyMachine) preparePlanner(ctx context.Context) func(context.Context, 
 	stmtTs := c.txnOpt.stmtTimestamp
 	autoCommit := false
 	if txn == nil {
-		txn = client.NewTxn(ctx, c.p.execCfg.DB, c.p.execCfg.NodeID.Get())
+		txn = client.NewTxnWithSteppingEnabled(ctx, c.p.execCfg.DB, c.p.execCfg.NodeID.Get())
 		txnTs = c.p.execCfg.Clock.PhysicalTime()
 		stmtTs = txnTs
 		autoCommit = true

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -79,6 +79,11 @@ func MakeIndexDescriptor(n *tree.CreateIndex) (*sqlbase.IndexDescriptor, error) 
 	return &indexDesc, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because CREATE INDEX performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *createIndexNode) ReadingOwnWrites() {}
+
 func (n *createIndexNode) startExec(params runParams) error {
 	_, dropped, err := n.tableDesc.FindIndexByName(string(n.n.Name))
 	if err == nil {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -44,6 +44,11 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 	}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because CREATE SEQUENCE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *createSequenceNode) ReadingOwnWrites() {}
+
 func (n *createSequenceNode) startExec(params runParams) error {
 	// TODO(arul): Allow temporary sequences once temp tables work for regular tables.
 	if n.n.Temporary {

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -37,6 +37,11 @@ type createViewNode struct {
 	planDeps planDependencies
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because CREATE VIEW performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *createViewNode) ReadingOwnWrites() {}
+
 func (n *createViewNode) startExec(params runParams) error {
 	// TODO(arul): Allow temporary views once temp tables work for regular tables.
 	if n.temporary {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -59,6 +59,11 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 	return &dropIndexNode{n: n, idxNames: idxNames}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because DROP INDEX performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *dropIndexNode) ReadingOwnWrites() {}
+
 func (n *dropIndexNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, index := range n.idxNames {

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -55,6 +55,11 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 	}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because DROP SEQUENCE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *dropSequenceNode) ReadingOwnWrites() {}
+
 func (n *dropSequenceNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -97,6 +97,11 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 	return &dropTableNode{n: n, td: td}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because DROP TABLE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *dropTableNode) ReadingOwnWrites() {}
+
 func (n *dropTableNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -69,6 +69,11 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 	return &dropViewNode{n: n, td: td}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because DROP VIEW performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *dropViewNode) ReadingOwnWrites() {}
+
 func (n *dropViewNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -63,6 +63,11 @@ type changePrivilegesNode struct {
 	changePrivilege func(*sqlbase.PrivilegeDescriptor, string)
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because GRANT/REVOKE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *changePrivilegesNode) ReadingOwnWrites() {}
+
 func (n *changePrivilegesNode) startExec(params runParams) error {
 	ctx := params.ctx
 	p := params.p

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -177,7 +177,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 // the insert operation (including secondary index updates, FK
 // cascading updates, etc), before the current KV batch is executed
 // and a new batch is started.
-const maxInsertBatchSize = 10000
+var maxInsertBatchSize = 10000
 
 func (n *insertNode) startExec(params runParams) error {
 	if err := params.p.maybeSetSystemConfig(n.run.ti.tableDesc().GetID()); err != nil {
@@ -293,4 +293,11 @@ func (n *insertNode) Close(ctx context.Context) {
 // See planner.autoCommit.
 func (n *insertNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()
+}
+
+// TestingSetInsertBatchSize exports a constant for testing only.
+func TestingSetInsertBatchSize(val int) func() {
+	oldVal := maxInsertBatchSize
+	maxInsertBatchSize = val
+	return func() { maxInsertBatchSize = oldVal }
 }

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -31,9 +31,13 @@ var insertFastPathNodePool = sync.Pool{
 	},
 }
 
-// Check that exec.InsertFastPathMaxRows does not exceed maxInsertBatchSize
-// (this is a compile error if the value is negative).
-const _ uint = maxInsertBatchSize - exec.InsertFastPathMaxRows
+// Check that exec.InsertFastPathMaxRows does not exceed the default
+// maxInsertBatchSize.
+func init() {
+	if maxInsertBatchSize < exec.InsertFastPathMaxRows {
+		panic("decrease exec.InsertFastPathMaxRows")
+	}
+}
 
 // insertFastPathNode is a faster implementation of inserting values in a table
 // and performing FK checks. It is used when all the foreign key checks can be

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1771,7 +1771,7 @@ func (t *logicTest) processSubtest(
 				return errors.Errorf("kv-batch-size needs an integer argument; %s", err)
 			}
 			t.outf("Setting kv batch size %d", batchSize)
-			defer row.SetKVBatchSize(int64(batchSize))()
+			defer row.TestingSetKVBatchSize(int64(batchSize))()
 
 		default:
 			return errors.Errorf("%s:%d: unknown command: %s",

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -72,10 +72,10 @@ SELECT * FROM a ORDER BY b
 # Regression for #30936: ensure that wrapped planNodes with non-needed columns work ok
 
 statement ok
-CREATE TABLE b (a int, b int)
+CREATE TABLE b (a int, b int);
 
 query II
-SELECT * FROM b WHERE EXISTS (SELECT * FROM [INSERT INTO b VALUES (1,2) RETURNING a,b]);
+SELECT * FROM (VALUES (1, 2)) WHERE EXISTS (SELECT * FROM [INSERT INTO b VALUES (1,2) RETURNING a,b]);
 ----
 1 2
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1200,6 +1200,8 @@ func (ef *execFactory) ConstructInsert(
 	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
+	ctx := ef.planner.extendedEvalCtx.Context
+
 	// Derive insert table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
@@ -1218,7 +1220,7 @@ func (ef *execFactory) ConstructInsert(
 	}
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ef.planner.txn, tabDesc, colDescs, checkFKs, fkTables, &ef.planner.alloc,
+		ctx, ef.planner.txn, tabDesc, colDescs, checkFKs, fkTables, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1270,6 +1272,8 @@ func (ef *execFactory) ConstructInsertFastPath(
 	checkOrdSet exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
 ) (exec.Node, error) {
+	ctx := ef.planner.extendedEvalCtx.Context
+
 	// Derive insert table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
@@ -1277,7 +1281,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ef.planner.txn, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, &ef.planner.alloc,
+		ctx, ef.planner.txn, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1345,6 +1349,8 @@ func (ef *execFactory) ConstructUpdate(
 	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
+	ctx := ef.planner.extendedEvalCtx.Context
+
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
@@ -1376,6 +1382,7 @@ func (ef *execFactory) ConstructUpdate(
 	// CBO will have already determined the set of fetch and update columns, and
 	// passes those sets into the updater (which will basically be a no-op).
 	ru, err := row.MakeUpdater(
+		ctx,
 		ef.planner.txn,
 		tabDesc,
 		fkTables,
@@ -1494,6 +1501,8 @@ func (ef *execFactory) ConstructUpsert(
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
 ) (exec.Node, error) {
+	ctx := ef.planner.extendedEvalCtx.Context
+
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
@@ -1509,7 +1518,7 @@ func (ef *execFactory) ConstructUpsert(
 
 	// Create the table inserter, which does the bulk of the insert-related work.
 	ri, err := row.MakeInserter(
-		ef.planner.txn, tabDesc, insertColDescs, row.CheckFKs, fkTables, &ef.planner.alloc,
+		ctx, ef.planner.txn, tabDesc, insertColDescs, row.CheckFKs, fkTables, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1521,6 +1530,7 @@ func (ef *execFactory) ConstructUpsert(
 	// columns, and passes those sets into the updater (which will basically be a
 	// no-op).
 	ru, err := row.MakeUpdater(
+		ctx,
 		ef.planner.txn,
 		tabDesc,
 		fkTables,
@@ -1603,6 +1613,8 @@ func (ef *execFactory) ConstructDelete(
 	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
+	ctx := ef.planner.extendedEvalCtx.Context
+
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
@@ -1629,6 +1641,7 @@ func (ef *execFactory) ConstructDelete(
 	// CBO will have already determined the set of fetch columns, and passes
 	// those sets into the deleter (which will basically be a no-op).
 	rd, err := row.MakeDeleter(
+		ctx,
 		ef.planner.txn,
 		tabDesc,
 		fkTables,

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -50,6 +50,11 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	return &renameColumnNode{n: n, tableDesc: tableDesc}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because RENAME COLUMN performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *renameColumnNode) ReadingOwnWrites() {}
+
 func (n *renameColumnNode) startExec(params runParams) error {
 	p := params.p
 	ctx := params.ctx

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -63,6 +63,11 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 	}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because RENAME DATABASE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *renameDatabaseNode) ReadingOwnWrites() {}
+
 func (n *renameDatabaseNode) startExec(params runParams) error {
 	p := params.p
 	ctx := params.ctx

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -60,6 +60,11 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 	return &renameIndexNode{n: n, idx: idx, tableDesc: tableDesc}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because RENAME DATABASE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *renameIndexNode) ReadingOwnWrites() {}
+
 func (n *renameIndexNode) startExec(params runParams) error {
 	p := params.p
 	ctx := params.ctx

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -71,6 +71,11 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	return &renameTableNode{n: n, oldTn: &oldTn, newTn: &newTn, tableDesc: tableDesc}, nil
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because RENAME DATABASE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *renameTableNode) ReadingOwnWrites() {}
+
 func (n *renameTableNode) startExec(params runParams) error {
 	p := params.p
 	ctx := params.ctx

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -38,6 +38,7 @@ type Deleter struct {
 // expectation of which values are passed as values to DeleteRow. Any column
 // passed in requestedCols will be included in FetchCols.
 func MakeDeleter(
+	ctx context.Context,
 	txn *client.Txn,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables FkTableMetadata,
@@ -47,14 +48,14 @@ func MakeDeleter(
 	alloc *sqlbase.DatumAlloc,
 ) (Deleter, error) {
 	rowDeleter, err := makeRowDeleterWithoutCascader(
-		txn, tableDesc, fkTables, requestedCols, checkFKs, alloc,
+		ctx, txn, tableDesc, fkTables, requestedCols, checkFKs, alloc,
 	)
 	if err != nil {
 		return Deleter{}, err
 	}
 	if checkFKs == CheckFKs {
 		var err error
-		rowDeleter.cascader, err = makeDeleteCascader(txn, tableDesc, fkTables, evalCtx, alloc)
+		rowDeleter.cascader, err = makeDeleteCascader(ctx, txn, tableDesc, fkTables, evalCtx, alloc)
 		if err != nil {
 			return Deleter{}, err
 		}
@@ -65,6 +66,7 @@ func MakeDeleter(
 // makeRowDeleterWithoutCascader creates a rowDeleter but does not create an
 // additional cascader.
 func makeRowDeleterWithoutCascader(
+	ctx context.Context,
 	txn *client.Txn,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables FkTableMetadata,
@@ -114,7 +116,7 @@ func makeRowDeleterWithoutCascader(
 	}
 	if checkFKs == CheckFKs {
 		var err error
-		if rd.Fks, err = makeFkExistenceCheckHelperForDelete(txn, tableDesc, fkTables,
+		if rd.Fks, err = makeFkExistenceCheckHelperForDelete(ctx, txn, tableDesc, fkTables,
 			fetchColIDtoRowIndex, alloc); err != nil {
 			return Deleter{}, err
 		}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -503,7 +503,7 @@ func (rf *Fetcher) StartInconsistentScan(
 			maxTimestampAge,
 		)
 	}
-	txn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */)
+	txn := client.NewTxnWithSteppingEnabled(ctx, db, 0 /* gatewayNodeID */)
 	txn.SetFixedTimestamp(ctx, txnTimestamp)
 	if log.V(1) {
 		log.Infof(ctx, "starting inconsistent scan at timestamp %v", txnTimestamp)
@@ -518,7 +518,7 @@ func (rf *Fetcher) StartInconsistentScan(
 			// Advance the timestamp by the time that passed.
 			txnTimestamp = txnTimestamp.Add(now.Sub(txnStartTime).Nanoseconds(), 0 /* logical */)
 			txnStartTime = now
-			txn = client.NewTxn(ctx, db, 0 /* gatewayNodeID */)
+			txn = client.NewTxnWithSteppingEnabled(ctx, db, 0 /* gatewayNodeID */)
 			txn.SetFixedTimestamp(ctx, txnTimestamp)
 
 			if log.V(1) {

--- a/pkg/sql/row/fk_existence_delete.go
+++ b/pkg/sql/row/fk_existence_delete.go
@@ -34,6 +34,7 @@ type fkExistenceCheckForDelete struct {
 
 // makeFkExistenceCheckHelperForDelete instantiates a delete helper.
 func makeFkExistenceCheckHelperForDelete(
+	ctx context.Context,
 	txn *client.Txn,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
@@ -94,6 +95,26 @@ func makeFkExistenceCheckHelperForDelete(
 			h.fks = make(map[sqlbase.IndexID][]fkExistenceCheckBaseHelper)
 		}
 		h.fks[mutatedIdx.ID] = append(h.fks[mutatedIdx.ID], fk)
+	}
+
+	if len(h.fks) > 0 {
+		// TODO(knz,radu): FK existence checks need to see the writes
+		// performed by the mutation.
+		//
+		// In order to make this true, we need to split the existence
+		// checks into a separate sequencing step, and have the first
+		// check happen no early than the end of all the "main" part of
+		// the statement. Unfortunately, the organization of the code does
+		// not allow this today.
+		//
+		// See: https://github.com/cockroachdb/cockroach/issues/33475
+		//
+		// In order to "make do" and preserve a modicum of FK semantics we
+		// thus need to disable step-wise execution here. The result is that
+		// it will also enable any interleaved read part to observe the
+		// mutation, and thus introduce the risk of a Halloween problem for
+		// any mutation that uses FK relationships.
+		_ = txn.ConfigureStepping(ctx, client.SteppingDisabled)
 	}
 
 	return h, nil

--- a/pkg/sql/row/fk_existence_insert.go
+++ b/pkg/sql/row/fk_existence_insert.go
@@ -43,6 +43,7 @@ type fkExistenceCheckForInsert struct {
 
 // makeFkExistenceCheckHelperForInsert instantiates an insert helper.
 func makeFkExistenceCheckHelperForInsert(
+	ctx context.Context,
 	txn *client.Txn,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
@@ -85,6 +86,26 @@ func makeFkExistenceCheckHelperForInsert(
 			h.fks = make(map[sqlbase.IndexID][]fkExistenceCheckBaseHelper)
 		}
 		h.fks[mutatedIdx.ID] = append(h.fks[mutatedIdx.ID], fk)
+	}
+
+	if len(h.fks) > 0 {
+		// TODO(knz,radu): FK existence checks need to see the writes
+		// performed by the mutation.
+		//
+		// In order to make this true, we need to split the existence
+		// checks into a separate sequencing step, and have the first
+		// check happen no early than the end of all the "main" part of
+		// the statement. Unfortunately, the organization of the code does
+		// not allow this today.
+		//
+		// See: https://github.com/cockroachdb/cockroach/issues/33475
+		//
+		// In order to "make do" and preserve a modicum of FK semantics we
+		// thus need to disable step-wise execution here. The result is that
+		// it will also enable any interleaved read part to observe the
+		// mutation, and thus introduce the risk of a Halloween problem for
+		// any mutation that uses FK relationships.
+		_ = txn.ConfigureStepping(ctx, client.SteppingDisabled)
 	}
 
 	return h, nil

--- a/pkg/sql/row/fk_existence_update.go
+++ b/pkg/sql/row/fk_existence_update.go
@@ -62,6 +62,7 @@ type fkExistenceCheckForUpdate struct {
 
 // makeFkExistenceCheckHelperForUpdate instantiates an update helper.
 func makeFkExistenceCheckHelperForUpdate(
+	ctx context.Context,
 	txn *client.Txn,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
@@ -75,13 +76,13 @@ func makeFkExistenceCheckHelperForUpdate(
 
 	// Instantiate a helper for the referencing tables.
 	var err error
-	if ret.inbound, err = makeFkExistenceCheckHelperForDelete(txn, table, otherTables, colMap,
+	if ret.inbound, err = makeFkExistenceCheckHelperForDelete(ctx, txn, table, otherTables, colMap,
 		alloc); err != nil {
 		return ret, err
 	}
 
 	// Instantiate a helper for the referenced table(s).
-	ret.outbound, err = makeFkExistenceCheckHelperForInsert(txn, table, otherTables, colMap, alloc)
+	ret.outbound, err = makeFkExistenceCheckHelperForInsert(ctx, txn, table, otherTables, colMap, alloc)
 	ret.outbound.checker = ret.inbound.checker
 
 	// We need *some* KV batch checker to perform the checks. It doesn't

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -40,6 +40,7 @@ type Inserter struct {
 //
 // insertCols must contain every column in the primary key.
 func MakeInserter(
+	ctx context.Context,
 	txn *client.Txn,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	insertCols []sqlbase.ColumnDescriptor,
@@ -62,7 +63,7 @@ func MakeInserter(
 
 	if checkFKs == CheckFKs {
 		var err error
-		if ri.Fks, err = makeFkExistenceCheckHelperForInsert(txn, tableDesc, fkTables,
+		if ri.Fks, err = makeFkExistenceCheckHelperForInsert(ctx, txn, tableDesc, fkTables,
 			ri.InsertColIDtoRowIndex, alloc); err != nil {
 			return ri, err
 		}

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -28,8 +28,9 @@ import (
 // TODO(radu): parameters like this should be configurable
 var kvBatchSize int64 = 10000
 
-// SetKVBatchSize changes the kvBatchFetcher batch size, and returns a function that restores it.
-func SetKVBatchSize(val int64) func() {
+// TestingSetKVBatchSize changes the kvBatchFetcher batch size, and returns a function that restores it.
+// This is to be used only in tests - we have no test coverage for arbitrary kv batch sizes at this time.
+func TestingSetKVBatchSize(val int64) func() {
 	oldVal := kvBatchSize
 	kvBatchSize = val
 	return func() { kvBatchSize = oldVal }

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -224,6 +224,7 @@ func TestingSetDatumRowConverterBatchSize(newSize int) func() {
 
 // NewDatumRowConverter returns an instance of a DatumRowConverter.
 func NewDatumRowConverter(
+	ctx context.Context,
 	tableDesc *sqlbase.TableDescriptor,
 	targetColNames tree.NameList,
 	evalCtx *tree.EvalContext,
@@ -274,6 +275,7 @@ func NewDatumRowConverter(
 	}
 
 	ri, err := MakeInserter(
+		ctx,
 		nil, /* txn */
 		immutDesc,
 		cols,

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -99,7 +99,8 @@ func (sp *bulkRowWriter) work(ctx context.Context) error {
 	kvCh := make(chan row.KVBatch, 10)
 	var g ctxgroup.Group
 
-	conv, err := row.NewDatumRowConverter(&sp.spec.Table, nil /* targetColNames */, sp.EvalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(ctx,
+		&sp.spec.Table, nil /* targetColNames */, sp.EvalCtx, kvCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -125,7 +125,7 @@ func TestScanBatches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// The test will screw around with KVBatchSize; make sure to restore it at the end.
-	restore := row.SetKVBatchSize(10)
+	restore := row.TestingSetKVBatchSize(10)
 	defer restore()
 
 	s, db, _ := serverutils.StartServer(
@@ -171,7 +171,7 @@ func TestScanBatches(t *testing.T) {
 	numSpanValues := []int{0, 1, 2, 3}
 
 	for _, batch := range batchSizes {
-		row.SetKVBatchSize(int64(batch))
+		row.TestingSetKVBatchSize(int64(batch))
 		for _, numSpans := range numSpanValues {
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, false)
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, true)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -222,6 +222,11 @@ type setZoneConfigRun struct {
 	numAffected int
 }
 
+// ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
+// This is because CONFIGURE ZONE performs multiple KV operations on descriptors
+// and expects to see its own writes.
+func (n *setZoneConfigNode) ReadingOwnWrites() {}
+
 func (n *setZoneConfigNode) startExec(params runParams) error {
 	var yamlConfig string
 	var setters []func(c *zonepb.ZoneConfig)

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -467,7 +467,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	}(rowexec.SamplerProgressInterval)
 	rowexec.SamplerProgressInterval = 10
 
-	resetKVBatchSize := row.SetKVBatchSize(10)
+	resetKVBatchSize := row.TestingSetKVBatchSize(10)
 	defer resetKVBatchSize()
 
 	var allowRequest chan struct{}

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -113,7 +113,9 @@ type optTableUpserter struct {
 }
 
 // init is part of the tableWriter interface.
-func (tu *optTableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error {
+func (tu *optTableUpserter) init(
+	ctx context.Context, txn *client.Txn, evalCtx *tree.EvalContext,
+) error {
 	tu.tableWriterBase.init(txn)
 	tableDesc := tu.tableDesc()
 
@@ -169,6 +171,7 @@ func (tu *optTableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) err
 
 	var err error
 	tu.ru, err = row.MakeUpdater(
+		ctx,
 		txn,
 		tu.tableDesc(),
 		tu.fkTables,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -543,6 +543,7 @@ func truncateTableInChunks(
 		}
 		if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			rd, err := row.MakeDeleter(
+				ctx,
 				txn,
 				sqlbase.NewImmutableTableDescriptor(*tableDesc),
 				nil,

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -203,7 +203,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	ts.mon.Start(ts.Ctx, tranCtx.connMon, mon.BoundAccount{} /* reserved */)
 	ts.mu.Lock()
 	if txn == nil {
-		ts.mu.txn = client.NewTxn(ts.Ctx, tranCtx.db, tranCtx.nodeID)
+		ts.mu.txn = client.NewTxnWithSteppingEnabled(ts.Ctx, tranCtx.db, tranCtx.nodeID)
 		ts.mu.txn.SetDebugName(opName)
 	} else {
 		ts.mu.txn = txn

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -60,7 +60,7 @@ func (n *upsertNode) startExec(params runParams) error {
 	// cache traceKV during execution, to avoid re-evaluating it for every row.
 	n.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
-	return n.run.tw.init(params.p.txn, params.EvalContext())
+	return n.run.tw.init(params.ctx, params.p.txn, params.EvalContext())
 }
 
 // Next is required because batchedPlanNode inherits from planNode, but


### PR DESCRIPTION
Fixes #33473.
Fixes #28842.
Informs #41569 and #42864.

Previously, all individual KV reads performed by a SQL statement were
able to observe the most recent KV writes that it performed itself.

This is in violation of PostgreSQL's dialect semantics, which mandate
that statements can only observe data as per a read snapshot taken at
the instant a statement begins execution.

Moreover, this invalid behavior causes a real observable bug: a
statement that reads and writes to the same table may never complete,
as the read part may become able to consume the rows that it itself
writes. Or worse, it could cause logical operations to be performed
multiple times: https://en.wikipedia.org/wiki/Halloween_Problem

This patch fixes it by exploiting the new KV `Step()` API which
decouples the read and write sequence numbers.

The fix is not complete however; additional sequence points must also
be introduced prior to FK existence checks and cascading actions. See
#42864 and #33475 for details.

For now, this patch excludes any mutation that involves a foreign key
from the new (fixed) semantics. When a mutation involves a FK, the
previous (broken) semantics still apply.

Release note (bug fix): SQL mutation statements that target tables
with no foreign key relationships now correctly read data as per the
state of the database when the statement started execution. This is
required for compatibility with PostgreSQL and to ensure deterministic
behavior when certain operations are parallelized. Prior to this fix,
a statement [could incorrectly operate multiple
times](https://en.wikipedia.org/wiki/Halloween_Problem) on data that
itself was writing, and potentially never terminate. This fix is
limited to tables without FK relationships, and for certain operations
on tables with FK relationships; in other cases, the fix is not
active and the bug is still present. A full fix will be provided
in a later release.
