### PR TITLE
githooks: avoid depending on git 2.24

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -38,7 +38,7 @@ sed_script=''
 # true, all the template recommendations will be commented out as
 # opposed to be filled in.
 tchar=''
-tdisable=$(git config --bool --default false --get cockroachdb.disable-commit-template)
+tdisable=$(git config --bool --get cockroachdb.disable-commit-template || echo false)
 if test x"$tdisable" != xfalse; then
 	tchar="$cchar "
 fi


### PR DESCRIPTION
The previous changes to the git commit template were using the new
`git config --default` flag introduced in a recent version of
Git (presumably 2.24).

Unfortunately certain GNU/Linux distributions and other platforms do
not provide this version of Git yet, most notably the latest Ubuntu
LTS.

Without the newer Git, the `git commit` command fails without a clear
path forward. This constitutes an inconvenient obstacle to external
contributors.

To facilitate external contributions, this commit drops this
dependency by avoiding to rely on the `--default` argument.

Release note: None