### PR TITLE
ui: Show notification alert when decommissioned nodes are cleared

### DIFF
--- a/pkg/ui/src/redux/uiData.spec.ts
+++ b/pkg/ui/src/redux/uiData.spec.ts
@@ -323,8 +323,9 @@ describe("UIData reducer", function() {
     const uiKey2 = "another_key";
     const uiObj2 = 1234;
 
-    const saveUIData = function(...values: uidata.KeyValue[]): Promise<void> {
-      return uidata.saveUIData.apply(this, values)(dispatch, () => { return { uiData: state }; });
+    const saveUIData = function(values: uidata.KeyValue[] | uidata.KeyValue): Promise<void> {
+      console.log(values);
+      return uidata.saveUIData.call(this, values)(dispatch, () => { return { uiData: state }; });
     };
 
     const loadUIData = function(...keys: string[]): Promise<void> {
@@ -363,16 +364,16 @@ describe("UIData reducer", function() {
         },
       });
 
-      const p = saveUIData(
+      const p = saveUIData([
         {key: uiKey1, value: uiObj1},
         {key: uiKey2, value: uiObj2},
-      );
+      ]);
 
       // Second save should be ignored.
-      const p2 = saveUIData(
+      const p2 = saveUIData([
         {key: uiKey1, value: uiObj1},
         {key: uiKey2, value: uiObj2},
-      );
+      ]);
 
       return Promise.all([p, p2]).then(() => {
         assert.lengthOf(fetchMock.calls(`${api.API_PREFIX}/uidata`), 1);
@@ -396,10 +397,10 @@ describe("UIData reducer", function() {
         },
       });
 
-      const p = saveUIData(
+      const p = saveUIData([
         {key: uiKey1, value: uiObj1},
         {key: uiKey2, value: uiObj2},
-      );
+      ]);
 
       p.then(() => {
         assert.lengthOf(fetchMock.calls(`${api.API_PREFIX}/uidata`), 1);

--- a/pkg/ui/src/redux/uiData.spec.ts
+++ b/pkg/ui/src/redux/uiData.spec.ts
@@ -324,7 +324,6 @@ describe("UIData reducer", function() {
     const uiObj2 = 1234;
 
     const saveUIData = function(values: uidata.KeyValue[] | uidata.KeyValue): Promise<void> {
-      console.log(values);
       return uidata.saveUIData.call(this, values)(dispatch, () => { return { uiData: state }; });
     };
 

--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -10,6 +10,7 @@
 
 import _ from "lodash";
 import { Action, Dispatch } from "redux";
+import { createSelector } from "reselect";
 import * as protobuf from "protobufjs/minimal";
 
 import * as protos from  "src/js/protos";
@@ -59,6 +60,11 @@ export const VERSION_DISMISSED_KEY = "version_dismissed";
 // INSTRUCTIONS_BOX_COLLAPSED_KEY is the uiData key on the server that tracks whether the
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY = "clusterviz_instructions_box_collapsed";
+
+// HIDE_DECOMMISSIONED_NODE_LIST key that contains list of all decommissioned nodes which have to be hidden from
+// Decommissioned nodes table on Node Overview page.
+// Values are the list of node ids which have to be filtered out.
+export const HIDE_DECOMMISSIONED_NODE_LIST = "node_overview_hide_decommissioned_node_list";
 
 export enum UIDataStatus {
   UNINITIALIZED, // Data has not been loaded yet.
@@ -318,3 +324,8 @@ export function loadUIData(...keys: string[]) {
     });
   };
 }
+
+export const hiddenDecommissionedNodes = createSelector(
+  (state: AdminUIState) => getData(state, HIDE_DECOMMISSIONED_NODE_LIST),
+  (hiddenNodes: Array<number>) => hiddenNodes,
+);

--- a/pkg/ui/src/util/types.ts
+++ b/pkg/ui/src/util/types.ts
@@ -38,3 +38,13 @@
 export function nullOfReturnType<R> (_: (...args: any[]) => R): R {
     return null;
 }
+
+/**
+ * Json type represents the possible structure of arbitrary JSON structure.
+ */
+export type JsonValue = string | number | null | boolean;
+export type JsonObject = {
+  [key: string]: JsonValue | JsonArray | JsonObject,
+};
+export type JsonArray = Array<JsonValue | JsonObject | JsonArray>;
+export type JsonLike = JsonValue | JsonObject | JsonArray;

--- a/pkg/ui/src/views/app/containers/alertBanner/index.tsx
+++ b/pkg/ui/src/views/app/containers/alertBanner/index.tsx
@@ -15,6 +15,7 @@ import { connect } from "react-redux";
 import "./alertbanner.styl";
 
 import { AlertBox } from "src/views/shared/components/alertBox";
+import { AlertMessage } from "src/views/shared/components/alertMessage";
 import { Alert, bannerAlertsSelector } from "src/redux/alerts";
 import { AdminUIState } from "src/redux/state";
 
@@ -45,9 +46,14 @@ class AlertBanner extends React.Component<AlertBannerProps, {}> {
     // Display only the first visible component.
     const { dismiss, ...alertProps } = alerts[0];
     const boundDismiss = bindActionCreators(() => dismiss, dispatch);
-    return  <div className="alert-banner">
-      <AlertBox dismiss={boundDismiss} {...alertProps} />
-    </div>;
+    // tslint:disable-next-line:variable-name
+    const AlertComponent = alertProps.showAsAlert ? AlertMessage : AlertBox;
+
+    return (
+      <div className="alert-banner">
+        <AlertComponent dismiss={boundDismiss} {...alertProps} />
+      </div>
+    );
   }
 }
 

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -318,6 +318,7 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
   columns: ColumnDescriptor<INodeStatus>[] = [
     {
       title: (<a
+        className="sort-table__action-link"
         onClick={() => this.onClearNodesHandler(this.props.statuses)}>Clear All</a>),
       cell: (ns) => {
         return (

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -14,6 +14,7 @@ import { connect } from "react-redux";
 import moment from "moment";
 import { createSelector } from "reselect";
 import _ from "lodash";
+import { Dispatch } from "redux";
 
 import {
   LivenessStatus,
@@ -41,6 +42,7 @@ import {
   loadUIData,
   saveUIData,
 } from "src/redux/uiData";
+import { showDecommissionedNodesAlertAction } from "src/redux/alerts";
 
 import { BytesBarChart } from "./barChart";
 import "./nodes.styl";
@@ -329,8 +331,8 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
   ];
 
   onClearNodesHandler(nodeStatuses: INodeStatus[]) {
-    const { clearDecommissionedNodes, hiddenNodes } = this.props;
-    clearDecommissionedNodes(_.union(hiddenNodes, nodeStatuses.map(ns => ns.desc.node_id)));
+    const { clearDecommissionedNodes } = this.props;
+    clearDecommissionedNodes(nodeStatuses.map(ns => ns.desc.node_id));
   }
 
   componentWillMount() {
@@ -430,10 +432,11 @@ const DecommissionedNodesConnected = connect(
   {
     setSort: decommissionedNodesSortSetting.set,
     clearDecommissionedNodes: (nodeIds: Array<number>) => {
-      return saveUIData({
-        key: HIDE_DECOMMISSIONED_NODE_LIST,
-        value: nodeIds,
-      });
+      return (dispatch: Dispatch<AdminUIState>) => {
+        const saveUiDataPayload = { key: HIDE_DECOMMISSIONED_NODE_LIST, value: nodeIds};
+        return dispatch(saveUIData(saveUiDataPayload, true))
+          .then(() => dispatch(showDecommissionedNodesAlertAction(nodeIds)));
+      };
     },
     getClearedNodes: () => loadUIData(HIDE_DECOMMISSIONED_NODE_LIST),
   },

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -44,3 +44,11 @@
 .node-status-icon > svg
   width 16px
   height 16px
+
+.sort-table__action-link
+  text-transform none
+  font-size: 14px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  letter-spacing: 0.1px;

--- a/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
+++ b/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
@@ -1,0 +1,34 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+.alert-massage
+  max-width 470px
+  font-size 12px
+  margin 0 0 0 auto
+  padding-left 48px
+  border-radius 3px
+  box-shadow 0 0 10px 0 rgba(71, 88, 114, 0.47)
+  background-color #ffffff
+  border-color #ffffff
+  .alert-massage__icon
+    font-size 20px
+    left 16px
+  .ant-alert-close-icon
+    margin unset
+    right 0
+    top 0
+    padding-right 16px
+  .ant-alert-message
+    font-size 14px
+    color #242a35
+    font-weight 600
+
+.ant-alert-success .alert-massage__icon
+  color #37a806

--- a/pkg/ui/src/views/shared/components/alertMessage/index.tsx
+++ b/pkg/ui/src/views/shared/components/alertMessage/index.tsx
@@ -1,0 +1,99 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { Alert, Icon } from "antd";
+import { Link } from "react-router";
+
+import { AlertInfo, AlertLevel } from "src/redux/alerts";
+
+import "./alertMessage.styl";
+
+interface AlertMessageProps extends AlertInfo {
+  dismiss(): void;
+}
+
+type AlertType = "success" | "info" | "warning" | "error";
+
+const mapAlertLevelToType = (alertLevel: AlertLevel): AlertType => {
+  switch (alertLevel) {
+    case AlertLevel.SUCCESS:
+      return "success";
+    case AlertLevel.NOTIFICATION:
+      return "info";
+    case AlertLevel.WARNING:
+      return "warning";
+    case AlertLevel.CRITICAL:
+      return "error";
+    default:
+      return "info";
+  }
+};
+
+const getIconType = (alertLevel: AlertLevel): string => {
+  switch (alertLevel) {
+    case AlertLevel.SUCCESS:
+      return "check-circle";
+    case AlertLevel.NOTIFICATION:
+      return "info-circle";
+    case AlertLevel.WARNING:
+      return "warning";
+    case AlertLevel.CRITICAL:
+      return "close-circle";
+    default:
+      return "info-circle";
+  }
+};
+
+export class AlertMessage extends React.Component<AlertMessageProps> {
+  static defaultProps: Partial<AlertMessageProps> = {
+    link: undefined,
+    text: undefined,
+    wrapTextWithLink: undefined,
+  };
+
+  render() {
+    const {
+      level,
+      dismiss,
+      link,
+      title,
+      text,
+      wrapTextWithLink,
+    } = this.props;
+
+    let description: React.ReactNode = text;
+
+    if (link && wrapTextWithLink && text.includes(wrapTextWithLink)) {
+      const [beforeLinkSubstring, afterLinkSubstring] = text.split(wrapTextWithLink, 2);
+
+      description = (
+        <React.Fragment>
+          <span>{beforeLinkSubstring}</span>
+          <Link to={link} onClick={dismiss}>{wrapTextWithLink}</Link>
+          <span>{afterLinkSubstring}</span>
+        </React.Fragment>);
+    }
+
+    const type = mapAlertLevelToType(level);
+    const iconType = getIconType(level);
+    return (
+      <Alert
+        className="alert-massage"
+        message={title}
+        description={description}
+        showIcon
+        icon={<Icon type={iconType} theme="filled" className="alert-massage__icon" />}
+        closable
+        onClose={dismiss}
+        type={type} />
+    );
+  }
+}


### PR DESCRIPTION
According to new designs we need to display an alert on the top left corner
of the screen with different styles than the existing one (AlertBox component)
Current implementation inherits the same properties (with some new props)
as old one so it is compatible with LocalSettings actions and reducers.
In addition, this implementation allows us easily migrate all existing
alerts (which use old AlertBox component) to this one.

Following changes were introduced in existing functionality:
- KeyValue.value type is changed to 'JsonLike' type which complies with a
JSON arbitrary structure. It is a more accurate way to describe this field.
- 'saveUIData' action creator is extended with an additional input parameter
to allow not only replacing values but merging if value type supports it.