### PR TITLE
flowinfra: remove isVectorized field from FlowBase

### DIFF
--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -283,19 +283,23 @@ func TestOutboxInbox(t *testing.T) {
 			if cancellationScenario == noCancel {
 				// Accumulate batches to check for correctness.
 				// Copy batch since it's not safe to reuse after calling Next.
-				batchCopy := testAllocator.NewMemBatchWithSize(typs, int(outputBatch.Length()))
-				for i := range typs {
-					testAllocator.Append(
-						batchCopy.ColVec(i),
-						coldata.SliceArgs{
-							ColType:   typs[i],
-							Src:       outputBatch.ColVec(i),
-							SrcEndIdx: uint64(outputBatch.Length()),
-						},
-					)
+				if outputBatch == coldata.ZeroBatch {
+					outputBatches.Add(coldata.ZeroBatch)
+				} else {
+					batchCopy := testAllocator.NewMemBatchWithSize(typs, int(outputBatch.Length()))
+					for i := range typs {
+						testAllocator.Append(
+							batchCopy.ColVec(i),
+							coldata.SliceArgs{
+								ColType:   typs[i],
+								Src:       outputBatch.ColVec(i),
+								SrcEndIdx: uint64(outputBatch.Length()),
+							},
+						)
+					}
+					batchCopy.SetLength(outputBatch.Length())
+					outputBatches.Add(batchCopy)
 				}
-				batchCopy.SetLength(outputBatch.Length())
-				outputBatches.Add(batchCopy)
 			}
 			if outputBatch.Length() == 0 {
 				break

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -111,7 +111,12 @@ func (f *vectorizedFlow) Setup(
 	return err
 }
 
-// ConcurrentExecution is part of the Flow interface.
+// IsVectorized is part of the flowinfra.Flow interface.
+func (f *vectorizedFlow) IsVectorized() bool {
+	return true
+}
+
+// ConcurrentExecution is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) ConcurrentExecution() bool {
 	return f.operatorConcurrency || f.FlowBase.ConcurrentExecution()
 }
@@ -122,7 +127,7 @@ func (f *vectorizedFlow) Release() {
 	vectorizedFlowPool.Put(f)
 }
 
-// Cleanup is part of the Flow interface.
+// Cleanup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	// This cleans up all the memory monitoring of the vectorized flow.
 	f.streamingMemAccount.Close(ctx)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -400,7 +400,7 @@ func newFlow(
 	localProcessors []execinfra.LocalProcessor,
 	isVectorized bool,
 ) flowinfra.Flow {
-	base := flowinfra.NewFlowBase(flowCtx, flowReg, syncFlowConsumer, localProcessors, isVectorized)
+	base := flowinfra.NewFlowBase(flowCtx, flowReg, syncFlowConsumer, localProcessors)
 	if isVectorized {
 		return colflow.NewVectorizedFlow(base)
 	}

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -44,10 +44,9 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	}
 	base := flowinfra.NewFlowBase(
 		flowCtx,
-		nil,  /* flowReg */
-		nil,  /* syncFlowConsumer */
-		nil,  /* localProcessors */
-		true, /* isVectorized */
+		nil, /* flowReg */
+		nil, /* syncFlowConsumer */
+		nil, /* localProcessors */
 	)
 	flow := colflow.NewVectorizedFlow(base)
 

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -124,8 +124,6 @@ type FlowBase struct {
 	execinfra.FlowCtx
 
 	flowRegistry *FlowRegistry
-	// isVectorized indicates whether it is a vectorized flow.
-	isVectorized bool
 	// processors contains a subset of the processors in the flow - the ones that
 	// run in their own goroutines. Some processors that implement RowSource are
 	// scheduled to run in their consumer's goroutine; those are not present here.
@@ -193,12 +191,10 @@ func NewFlowBase(
 	flowReg *FlowRegistry,
 	syncFlowConsumer execinfra.RowReceiver,
 	localProcessors []execinfra.LocalProcessor,
-	isVectorized bool,
 ) *FlowBase {
 	base := &FlowBase{
 		FlowCtx:          flowCtx,
 		flowRegistry:     flowReg,
-		isVectorized:     isVectorized,
 		syncFlowConsumer: syncFlowConsumer,
 		localProcessors:  localProcessors,
 	}
@@ -335,7 +331,7 @@ func (f *FlowBase) IsLocal() bool {
 
 // IsVectorized returns whether this flow will run with vectorized execution.
 func (f *FlowBase) IsVectorized() bool {
-	return f.isVectorized
+	panic("IsVectorized should not be called on FlowBase")
 }
 
 // Start is part of the Flow interface.

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -394,13 +394,18 @@ func (f *rowBasedFlow) setupRouter(spec *execinfrapb.OutputRouterSpec) (router, 
 	return makeRouter(spec, streams)
 }
 
+// IsVectorized is part of the flowinfra.Flow interface.
+func (f *rowBasedFlow) IsVectorized() bool {
+	return false
+}
+
 // Release releases this rowBasedFlow back to the pool.
 func (f *rowBasedFlow) Release() {
 	*f = rowBasedFlow{}
 	rowBasedFlowPool.Put(f)
 }
 
-// Cleanup is part of the Flow interface.
+// Cleanup is part of the flowinfra.Flow interface.
 func (f *rowBasedFlow) Cleanup(ctx context.Context) {
 	f.FlowBase.Cleanup(ctx)
 	f.Release()


### PR DESCRIPTION
**flowinfra: remove isVectorized field from FlowBase**

Previously, FlowBase stored the boolean for whether it is a part of the
vectorized flow. This is not necessary since two kinds of flows can
implement Flow.IsVectorized method themselves.

Release note: None

**colrpc: adjust the test to use coldata.ZeroBatch**

Previously, one of the tests was accumulating all batches assuming that
they were schema-full. But it is no longer true when coldata.ZeroBatch
is emitted, and now this is fixed.

Release note: None