### PR TITLE
norm: add missing fold rule for OVERLAPS

### DIFF
--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -120,7 +120,7 @@
 [FoldNullComparisonLeft, Normalize]
 (Eq | Ne | Ge | Gt | Le | Lt | Like | NotLike | ILike | NotILike | SimilarTo |
     NotSimilarTo | RegMatch | NotRegMatch | RegIMatch | NotRegIMatch |
-    Contains | JsonExists | JsonSomeExists | JsonAllExists
+    Contains | Overlaps | JsonExists | JsonSomeExists | JsonAllExists
     $left:(Null)
     *
 )
@@ -132,7 +132,7 @@
 [FoldNullComparisonRight, Normalize]
 (Eq | Ne | Ge | Gt | Le | Lt | Like | NotLike | ILike | NotILike | SimilarTo |
     NotSimilarTo | RegMatch | NotRegMatch | RegIMatch | NotRegIMatch |
-    Contains | JsonExists | JsonSomeExists | JsonAllExists
+    Contains | Overlaps | JsonExists | JsonSomeExists | JsonAllExists
     *
     $right:(Null)
 )

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -287,6 +287,7 @@ WHERE
     null::string !~ 'foo' OR 'foo' !~ null::string OR
     null::string ~* 'foo' OR 'foo' ~* null::string OR
     null::string !~* 'foo' OR 'foo' !~* null::string OR
+    null::string[] && ARRAY['foo'] OR ARRAY['foo'] && null::string[] OR
     null::jsonb @> '"foo"' OR '"foo"' <@ null::jsonb OR
     null::jsonb ? 'foo' OR '{}' ? null::string OR
     null::jsonb ?| ARRAY['foo'] OR '{}' ?| null::string[] OR


### PR DESCRIPTION
Fixes #42874.
Fixes #42872 

Previously, there was no constant folding rule for NULL arguments to
the OVERLAPS operator. This could lead to crashes.

Release note (bug fix): prevent internal error in some cases when a NULL
literal is passed to the OVERLAPS operator