### PR TITLE
release-19.2: changefeedccl: fix bug which leaves a dangling table lease after job restart

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 )
 
 var errRenewLease = errors.New("renew lease on id")
@@ -981,6 +982,12 @@ func (t *tableState) removeInactiveVersions() []*storedTableLease {
 func acquireNodeLease(ctx context.Context, m *LeaseManager, id sqlbase.ID) (bool, error) {
 	var toRelease *storedTableLease
 	resultChan, didAcquire := m.group.DoChan(fmt.Sprintf("acquire%d", id), func() (interface{}, error) {
+		// Note that we use a new `context` here to avoid a situation where a cancellation
+		// of the first context cancels other callers to the `acquireNodeLease()` method,
+		// because of its use of `singleflight.Group`. See issue #41780 for how this has
+		// happened.
+		newCtx, cancel := m.stopper.WithCancelOnQuiesce(logtags.WithTags(context.Background(), logtags.FromContext(ctx)))
+		defer cancel()
 		if m.isDraining() {
 			return nil, errors.New("cannot acquire lease when draining")
 		}
@@ -989,26 +996,30 @@ func acquireNodeLease(ctx context.Context, m *LeaseManager, id sqlbase.ID) (bool
 		if newest != nil {
 			minExpiration = newest.expiration
 		}
-		table, err := m.LeaseStore.acquire(ctx, minExpiration, id)
+		table, err := m.LeaseStore.acquire(newCtx, minExpiration, id)
 		if err != nil {
 			return nil, err
 		}
 		t := m.findTableState(id, false /* create */)
 		t.mu.Lock()
 		defer t.mu.Unlock()
-		toRelease, err = t.upsertLocked(ctx, table)
+		toRelease, err = t.upsertLocked(newCtx, table)
 		if err != nil {
 			return nil, err
 		}
 		m.tableNames.insert(table)
+		if toRelease != nil {
+			releaseLease(toRelease, m)
+		}
 		return leaseToken(table), nil
 	})
-	result := <-resultChan
-	if result.Err != nil {
-		return false, result.Err
-	}
-	if toRelease != nil {
-		releaseLease(toRelease, m)
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case result := <-resultChan:
+		if result.Err != nil {
+			return false, result.Err
+		}
 	}
 	return didAcquire, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -139,7 +139,6 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-[async] kv.DistSender: sending pre-commit query intents  r7: sending batch 1 QueryIntent to (n1,s1):1
 table reader                                             Scan /Table/55/{1-2}
 table reader                                             fetched: /kv2/primary/-9222809086901354496/k/v -> /1/2
 flow                                                     Put /Table/55/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
@@ -297,7 +296,6 @@ SELECT DISTINCT node_id, store_id, replica_id
 ----
 node_id  store_id  replica_id
 1        1         6
-1        1         7
 1        1         25
 
 subtest system_table_lookup


### PR DESCRIPTION
Backport 1/1 commits from #41785.

/cc @cockroachdb/release

---

Fixes #41780

Currently, any call to `acquireNodeLease()` in `lease.go` goes through
a `singleflight.Group`. The group uses the `context.Context` of its first
caller. The method `AcquireFreshestFromStore()` calls `acquireNodeLease()`.

Now, in `poller.go` and `table_history.go` we repeatedly call
`leaseManager.AcquireFreshestFromStore()` in order to make sure the table
descriptor is up to date with respect to a certain timestamp.
Additionally, we also call `leaseManager.AcquireFreshestFromStore()`
periodically inside `leaseManager.RefreshLeases()`.

Now consider the case where there is a job cancellation around the same
time as a `RefreshLeases` call. Since the single flight group simply uses
the `context` of its first caller, it's possible that it's using the
changefeed job's context that's passed down into this call from the `poller`.
Due to the job cancellation and because the single flight group is using
the changefeed job's context, the `purgeOldVersions` call
(called by `RefreshLeases`) also gets cancelled; this leaves a dangling table
lease that doesn't get purged at the end of the call.

This PR fixes this problem by having `acquireNodeLease` create a new context
inside of its single flight closure to make sure that this closure doesn't
get cancelled, after copying the tags from the context it's handed.

Release note (bug fix): Other callers to `acquireNodeLease` will not get
erroneously cancelled just because the context of the first caller was
cancelled.
