### PR TITLE
opt: scale DISTINCT and SELECT limit hints based on statistics

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -676,7 +676,7 @@ semi-join-apply
  │    │    ├── limit hint: 5.00
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int)
- │    │    │    ├── limit hint: 5.00
+ │    │    │    ├── limit hint: 5.05
  │    │    │    └── prune: (5)
  │    │    └── filters
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
@@ -738,7 +738,7 @@ anti-join-apply
  │    │    ├── limit hint: 5.00
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int)
- │    │    │    ├── limit hint: 5.00
+ │    │    │    ├── limit hint: 5.05
  │    │    │    └── prune: (5)
  │    │    └── filters
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -51,7 +51,7 @@ limit
  │    │    ├── stats: [rows=2000, distinct(1)=2000, null(1)=0, distinct(3)=10, null(3)=0, distinct(4)=200, null(4)=0]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │    │    └── limit hint: 5.00
+ │    │    └── limit hint: 50.00
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
  └── const: 5 [type=int]
@@ -200,7 +200,7 @@ limit
  │    │    ├── stats: [rows=2000, distinct(1)=2000, null(1)=0, distinct(2)=501, null(2)=1000, distinct(3)=11, null(3)=1000, distinct(4)=200, null(4)=0, distinct(2,3)=2000, null(2,3)=1500]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │    │    └── limit hint: 5.00
+ │    │    └── limit hint: 100.00
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
  └── const: 5 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -706,7 +706,7 @@ semi-join-apply
  │    │    ├── limit hint: 1.00
  │    │    ├── scan xy
  │    │    │    ├── columns: y:7(int)
- │    │    │    └── limit hint: 1.00
+ │    │    │    └── limit hint: 1.01
  │    │    └── filters
  │    │         └── y = k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    └── const: 1 [type=int]
@@ -738,7 +738,7 @@ anti-join-apply
  │    │    ├── limit hint: 1.00
  │    │    ├── scan xy
  │    │    │    ├── columns: y:7(int)
- │    │    │    └── limit hint: 1.00
+ │    │    │    └── limit hint: 1.01
  │    │    └── filters
  │    │         └── y = k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    └── const: 1 [type=int]
@@ -5003,7 +5003,7 @@ select
                 │    ├── limit hint: 1.00
                 │    ├── scan xy
                 │    │    ├── columns: y:7(int)
-                │    │    └── limit hint: 1.00
+                │    │    └── limit hint: 100.00
                 │    └── filters
                 │         └── y = 5 [type=bool, outer=(7), constraints=(/7: [/5 - /5]; tight), fd=()-->(7)]
                 └── const: 1 [type=int]
@@ -5134,7 +5134,7 @@ select
                      │    ├── limit hint: 1.00
                      │    ├── scan xy
                      │    │    ├── columns: y:7(int)
-                     │    │    └── limit hint: 1.00
+                     │    │    └── limit hint: 3.00
                      │    └── filters
                      │         └── (y = 5) IS NOT false [type=bool, outer=(7)]
                      └── const: 1 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -567,7 +567,7 @@ limit
  │    ├── limit hint: 1.00
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null)
- │    │    └── limit hint: 1.00
+ │    │    └── limit hint: 100.00
  │    └── filters
  │         └── a = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  └── const: 1 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -444,10 +444,10 @@ project
       │    ├── limit hint: 107.00
       │    ├── project
       │    │    ├── columns: c0:6(int) c1:7(int)
-      │    │    ├── limit hint: 107.00
+      │    │    ├── limit hint: 321.00
       │    │    ├── scan crdb_internal.public.zones
       │    │    │    ├── columns: crdb_internal.public.zones.zone_id:1(int!null)
-      │    │    │    └── limit hint: 107.00
+      │    │    │    └── limit hint: 321.00
       │    │    └── projections
       │    │         ├── crdb_internal.public.zones.zone_id + 1 [type=int, outer=(1)]
       │    │         └── crdb_internal.public.zones.zone_id + 2 [type=int, outer=(1)]
@@ -590,8 +590,7 @@ project
       │         │    ├── scan xy
       │         │    │    ├── columns: x:7(int!null) y:8(int)
       │         │    │    ├── key: (7)
-      │         │    │    ├── fd: (7)-->(8)
-      │         │    │    └── limit hint: 1.00
+      │         │    │    └── fd: (7)-->(8)
       │         │    └── filters
       │         │         └── (x = 1) OR (x = 2) [type=bool, outer=(7), constraints=(/7: [/1 - /1] [/2 - /2])]
       │         └── const: 1 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -974,7 +974,7 @@ project
  │         │    │    │    │    │    │    ├── outer: (4)
  │         │    │    │    │    │    │    ├── limit hint: 10.00
  │         │    │    │    │    │    │    ├── scan b
- │         │    │    │    │    │    │    │    └── limit hint: 10.00
+ │         │    │    │    │    │    │    │    └── limit hint: 30.00
  │         │    │    │    │    │    │    └── filters
  │         │    │    │    │    │    │         └── s >= 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - ]; tight)]
  │         │    │    │    │    │    └── const: 10 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -261,7 +261,7 @@ project
  │    │    └── sort
  │    │         ├── columns: i:2(int) f:3(float)
  │    │         ├── ordering: +3
- │    │         ├── limit hint: 5.00
+ │    │         ├── limit hint: 6.02
  │    │         └── scan a
  │    │              └── columns: i:2(int) f:3(float)
  │    └── const: 5 [type=int]
@@ -443,7 +443,7 @@ project
  │    │    │    └── sort
  │    │    │         ├── columns: i:2(int) f:3(float)
  │    │    │         ├── ordering: +3
- │    │    │         ├── limit hint: 15.00
+ │    │    │         ├── limit hint: 18.16
  │    │    │         └── scan a
  │    │    │              └── columns: i:2(int) f:3(float)
  │    │    └── const: 15 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -423,7 +423,7 @@ project
  │    │    ├── limit hint: 5.00
  │    │    └── scan a
  │    │         ├── columns: f:3(float) s:4(string)
- │    │         └── limit hint: 5.00
+ │    │         └── limit hint: 6.02
  │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
@@ -668,7 +668,7 @@ project
  │    │    │    ├── limit hint: 10.00
  │    │    │    └── scan a
  │    │    │         ├── columns: f:3(float) s:4(string)
- │    │    │         └── limit hint: 10.00
+ │    │    │         └── limit hint: 12.07
  │    │    └── const: 10 [type=int]
  │    └── const: 5 [type=int]
  └── projections

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1106,7 +1106,7 @@ limit
  │    ├── limit hint: 1.00
  │    ├── scan a
  │    │    ├── columns: i:2(int)
- │    │    └── limit hint: 1.00
+ │    │    └── limit hint: 100.00
  │    └── filters
  │         └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
  └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -312,7 +312,7 @@ limit
  │         ├── columns: w:3(int)
  │         ├── internal-ordering: +3
  │         ├── ordering: +3
- │         ├── limit hint: 25.00
+ │         ├── limit hint: 40.39
  │         ├── sort
  │         │    ├── columns: w:3(int)
  │         │    ├── ordering: +3

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -111,7 +111,7 @@ project
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
       │         │    ├── ordering: +1 opt(9) [actual: +1]
-      │         │    └── limit hint: 50.00
+      │         │    └── limit hint: 101.01
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -154,7 +154,7 @@ project
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
       │         │    ├── ordering: +1 opt(9) [actual: +1]
-      │         │    └── limit hint: 50.00
+      │         │    └── limit hint: 101.01
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -182,7 +182,7 @@ limit
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    ├── ordering: +1 opt(9) [actual: +1]
- │    │    └── limit hint: 5.00
+ │    │    └── limit hint: 10.10
  │    └── filters
  │         └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
  └── const: 5 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -2,6 +2,43 @@ exec-ddl
 CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, index y_idx (y))
 ----
 
+# t has 200 rows where z=0, 200 where z=1, and 600 where z=2.
+exec-ddl
+ALTER TABLE t INJECT STATISTICS ' [
+   {
+      "columns":[
+         "z"
+      ],
+      "created_at":"2019-11-11 22:16:04.314619+00:00",
+      "distinct_count":3,
+      "histo_buckets":[
+         {
+            "distinct_range":0,
+            "num_eq":200,
+            "num_range":0,
+            "upper_bound":"0"
+         },
+         {
+            "distinct_range":0,
+            "num_eq":200,
+            "num_range":0,
+            "upper_bound":"1"
+         },
+         {
+            "distinct_range":0,
+            "num_eq":600,
+            "num_range":0,
+            "upper_bound":"2"
+         }
+      ],
+      "histo_col_type":"INT8",
+      "name":"statistics",
+      "null_count":0,
+      "row_count":1000
+   }
+]'
+----
+
 # In order to test how limit hints are propagated through a particular operator,
 # a limit operator must exist higher in the tree, and all operators between the
 # limit and the operator targeted by the test must pass a limit hint to their
@@ -148,6 +185,70 @@ limit
  └── const: 10 [type=int]
 
 # --------------------------------------------------
+# Limit hint depends on statistics.
+# --------------------------------------------------
+
+# Select operator.
+opt
+SELECT * FROM t WHERE z=1 LIMIT 10
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ ├── select
+ │    ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ │    ├── limit hint: 10.00
+ │    ├── scan t
+ │    │    ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │    │    └── limit hint: 50.00
+ │    └── filters
+ │         └── z = 1 [type=bool]
+ └── const: 10 [type=int]
+
+# DistinctOn operator.
+opt
+SELECT DISTINCT z FROM t LIMIT 2
+----
+limit
+ ├── columns: z:3(int)
+ ├── distinct-on
+ │    ├── columns: z:3(int)
+ │    ├── grouping columns: z:3(int)
+ │    ├── limit hint: 2.00
+ │    └── scan t
+ │         ├── columns: z:3(int)
+ │         └── limit hint: 3.44
+ └── const: 2 [type=int]
+
+# No limit hint propagation if number of distinct rows < required number of rows.
+opt
+SELECT DISTINCT z FROM t LIMIT 10
+----
+limit
+ ├── columns: z:3(int)
+ ├── distinct-on
+ │    ├── columns: z:3(int)
+ │    ├── grouping columns: z:3(int)
+ │    ├── limit hint: 10.00
+ │    └── scan t
+ │         └── columns: z:3(int)
+ └── const: 10 [type=int]
+
+opt
+SELECT * FROM t WHERE z=4 LIMIT 10
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ ├── select
+ │    ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ │    ├── limit hint: 10.00
+ │    ├── scan t
+ │    │    └── columns: x:1(int!null) y:2(int) z:3(int)
+ │    └── filters
+ │         └── z = 4 [type=bool]
+ └── const: 10 [type=int]
+
+
+# --------------------------------------------------
 # Passing limit hint through unchanged.
 # --------------------------------------------------
 
@@ -170,37 +271,6 @@ limit
  │              ├── columns: x:1(int!null)
  │              ├── flags: force-index=y_idx
  │              └── limit hint: 10.00
- └── const: 10 [type=int]
-
-# Select operator.
-opt
-SELECT * FROM t WHERE z=1 LIMIT 10
-----
-limit
- ├── columns: x:1(int!null) y:2(int) z:3(int!null)
- ├── select
- │    ├── columns: x:1(int!null) y:2(int) z:3(int!null)
- │    ├── limit hint: 10.00
- │    ├── scan t
- │    │    ├── columns: x:1(int!null) y:2(int) z:3(int)
- │    │    └── limit hint: 10.00
- │    └── filters
- │         └── z = 1 [type=bool]
- └── const: 10 [type=int]
-
-# DistinctOn operator.
-opt
-SELECT DISTINCT z FROM t LIMIT 10
-----
-limit
- ├── columns: z:3(int)
- ├── distinct-on
- │    ├── columns: z:3(int)
- │    ├── grouping columns: z:3(int)
- │    ├── limit hint: 10.00
- │    └── scan t
- │         ├── columns: z:3(int)
- │         └── limit hint: 10.00
  └── const: 10 [type=int]
 
 # Ordinality operator.

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -820,7 +820,7 @@ limit
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    │    ├── ordering: +1,+2
- │    │    └── limit hint: 10.00
+ │    │    └── limit hint: 30.00
  │    └── filters
  │         └── c < (a + b) [type=bool]
  └── const: 10 [type=int]
@@ -867,7 +867,7 @@ sort
       │    ├── scan abc
       │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    │    ├── ordering: +1,+2
-      │    │    └── limit hint: 10.00
+      │    │    └── limit hint: 30.00
       │    └── filters
       │         └── c < (a + b) [type=bool]
       └── const: 10 [type=int]
@@ -912,7 +912,7 @@ limit
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    │    ├── ordering: +1,+2
- │    │    └── limit hint: 10.00
+ │    │    └── limit hint: 30.00
  │    └── filters
  │         └── c < (a + b) [type=bool]
  └── const: 10 [type=int]
@@ -954,7 +954,7 @@ limit
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    │    ├── ordering: +1,+2,+3
- │    │    └── limit hint: 10.00
+ │    │    └── limit hint: 30.00
  │    └── filters
  │         └── c < (a + b) [type=bool]
  └── const: 10 [type=int]

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -495,7 +495,7 @@ memo (optimized, ~5KB, required=[presentation: min:5])
  │         ├── best: (scalar-group-by G2 G3 cols=())
  │         └── cost: 1060.04
  ├── G2: (scan abc,cols=(2))
- │    ├── [ordering: +2] [limit hint: 1.00]
+ │    ├── [ordering: +2] [limit hint: 1.01]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1269.35
  │    └── []
@@ -557,7 +557,7 @@ memo (optimized, ~5KB, required=[presentation: max:5])
  │         ├── best: (scalar-group-by G2 G3 cols=())
  │         └── cost: 1060.04
  ├── G2: (scan abc,cols=(2))
- │    ├── [ordering: -2] [limit hint: 1.00]
+ │    ├── [ordering: -2] [limit hint: 1.01]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1269.35
  │    └── []
@@ -646,7 +646,7 @@ memo (optimized, ~5KB, required=[presentation: max:5])
  │         ├── best: (scalar-group-by G2 G3 cols=())
  │         └── cost: 1060.04
  ├── G2: (scan abc,cols=(2))
- │    ├── [ordering: -2] [limit hint: 1.00]
+ │    ├── [ordering: -2] [limit hint: 1.01]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1269.35
  │    └── []

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -114,7 +114,7 @@ memo (optimized, ~6KB, required=[presentation: s:4])
  │         └── cost: 10.51
  ├── G3: (const 1)
  ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
- │    └── [limit hint: 1.00]
+ │    └── [limit hint: 100.00]
  │         ├── best: (scan a@s_idx,cols=(4))
  │         └── cost: 1050.02
  ├── G5: (filters G6)


### PR DESCRIPTION
This commit multiplies the limit hint of child operations to Select and
DistinctOn operations based on statistics known about the distribution
of the input.

The multiplier for Select is simply based on the selectivity of the
filter (# output rows / # input rows) and assumes a uniform
distribution of values, which is a good estimate in the average case.

The DistinctOn case is more complicated, since an estimate based on a
uniform distribution (the coupon collector's problem:
https://en.wikipedia.org/wiki/Coupon_collector%27s_problem) ends up
being an underestimate in most cases, and the inaccuracy is correlated
with the difference between the target number of rows and the number of
distinct values. I performed some simulations of different tables and
settled on a calculation that errs towards overestimation of the limit
hint, but not by too much.

Release note (sql change): Better estimates for the number of rows
needed by SELECT and DISTINCT operations may result in faster queries
when the results of these queries are limited (for instance, `SELECT
DISTINCT * FROM t LIMIT 10`).