### PR TITLE
storage: fix rangefeed filter update on stopper quiescence race

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -640,8 +640,8 @@ func rebalanceCandidates(
 
 	// 3. Decide whether we should try to rebalance. Note that for each existing
 	// store, we only compare its fullness stats to the stats of "comparable"
-	// stores, i.e. those stores that at least as valid, necessary, and diverse
-	// as the existing store.
+	// stores, i.e. those stores that are at least as valid, necessary, and
+	// diverse as the existing store.
 	needRebalance := needRebalanceFrom || needRebalanceTo
 	var shouldRebalanceCheck bool
 	if !needRebalance {


### PR DESCRIPTION
Fixes #42834.
Fixes #42812.
Fixes #42870.
Fixes #42811.
Fixes #42879.

The fix in #42754 made the assumption that a rangefeed processor could not be stopped between the time that the processor was first started and when it first requested its operation filter. This assumption was invalid during stopper quiescence, which we [already handled correctly during the first registration](https://github.com/cockroachdb/cockroach/blob/b29922628e8d52fcd38df510a7fb79597be5e64e/pkg/storage/replica_rangefeed.go#L369-L371). This change removes this assumption and couples the process of creating a new registration with updating the operation filter. This avoids these kinds of issues without having to handle new lifetime states and is generally cleaner.

Release note: None