### PR TITLE
ui: [depends on #42817] Pagination on decommissioned nodes table

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -39,7 +39,7 @@ import RaftMessages from "src/views/devtools/containers/raftMessages";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
-import NodeHistory from "src/views/reports/containers/nodes/nodeHistory";
+import DecommissionedNodeHistory from "src/views/reports/containers/nodesHistory/decommissionedNodeHistory";
 import JobsPage from "src/views/jobs";
 import Certificates from "src/views/reports/containers/certificates";
 import CustomChart from "src/views/reports/containers/customChart";
@@ -166,7 +166,7 @@ ReactDOM.render(
           <Route path="network" component={ Network } />
           <Route path="nodes">
             <IndexRoute component={ Nodes } />
-            <Route path="history" component={ NodeHistory } />
+            <Route path="history" component={ DecommissionedNodeHistory } />
           </Route>
           <Route path="settings" component={ Settings } />
           <Route path={`certificates/:${nodeIDAttr}`} component={ Certificates } />

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -39,6 +39,7 @@ import RaftMessages from "src/views/devtools/containers/raftMessages";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
+import NodeHistory from "src/views/reports/containers/nodes/nodeHistory";
 import JobsPage from "src/views/jobs";
 import Certificates from "src/views/reports/containers/certificates";
 import CustomChart from "src/views/reports/containers/customChart";
@@ -163,7 +164,10 @@ ReactDOM.render(
           </Route>
           <Route path="localities" component={ Localities } />
           <Route path="network" component={ Network } />
-          <Route path="nodes" component={ Nodes } />
+          <Route path="nodes">
+            <IndexRoute component={ Nodes } />
+            <Route path="history" component={ NodeHistory } />
+          </Route>
           <Route path="settings" component={ Settings } />
           <Route path={`certificates/:${nodeIDAttr}`} component={ Certificates } />
           <Route path={`range/:${rangeIDAttr}`} component={ Range } />

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -297,3 +297,28 @@ export type NodesSummary = typeof nodesSummaryType;
 export function selectNodesSummaryValid(state: AdminUIState) {
   return state.cachedData.nodes.valid && state.cachedData.liveness.valid;
 }
+
+/**
+ * partitionedStatuses divides the list of node statuses into "live" and "dead".
+ */
+export const partitionedStatuses = createSelector(
+  nodesSummarySelector,
+  (summary) => {
+    return _.groupBy(
+      summary.nodeStatuses,
+      (ns) => {
+        switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
+          case LivenessStatus.LIVE:
+          case LivenessStatus.UNAVAILABLE:
+          case LivenessStatus.DECOMMISSIONING:
+            return "live";
+          case LivenessStatus.DECOMMISSIONED:
+            return "decommissioned";
+          case LivenessStatus.DEAD:
+          default:
+            return "dead";
+        }
+      },
+    );
+  },
+);

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 import moment from "moment";
-import { createSelector } from "reselect";
 import _ from "lodash";
 
 import {
@@ -20,6 +19,7 @@ import {
   nodeCapacityStats,
   NodesSummary,
   nodesSummarySelector,
+  partitionedStatuses,
   selectNodesSummaryValid,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
@@ -284,31 +284,6 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     );
   }
 }
-
-/**
- * partitionedStatuses divides the list of node statuses into "live" and "dead".
- */
-const partitionedStatuses = createSelector(
-  nodesSummarySelector,
-  (summary) => {
-    return _.groupBy(
-      summary.nodeStatuses,
-      (ns) => {
-        switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
-          case LivenessStatus.LIVE:
-          case LivenessStatus.UNAVAILABLE:
-          case LivenessStatus.DECOMMISSIONING:
-            return "live";
-          case LivenessStatus.DECOMMISSIONED:
-            return "decommissioned";
-          case LivenessStatus.DEAD:
-          default:
-            return "dead";
-        }
-      },
-    );
-  },
-);
 
 /**
  * LiveNodesConnected is a redux-connected HOC of LiveNodeList.

--- a/pkg/ui/src/views/reports/containers/nodes/nodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/nodeHistory.tsx
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { Helmet } from "react-helmet";
+
+export interface NodeHistoryProps {
+
+}
+
+export default function NodeHistory(_props: NodeHistoryProps) {
+  return (
+    <section className="section">
+      <Helmet>
+        <title>Decommissioned Node History | Debug</title>
+      </Helmet>
+      <h1>Decommissioned Node History</h1>
+    </section>
+  );
+}

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
@@ -8,20 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as React from "react";
-import { Helmet } from "react-helmet";
-
-export interface NodeHistoryProps {
-
-}
-
-export default function NodeHistory(_props: NodeHistoryProps) {
-  return (
-    <section className="section">
-      <Helmet>
-        <title>Decommissioned Node History | Debug</title>
-      </Helmet>
-      <h1>Decommissioned Node History</h1>
-    </section>
-  );
-}
+.title
+  margin 8px 0 26px

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
@@ -10,3 +10,6 @@
 
 .title
   margin 8px 0 26px
+
+.info-message
+  margin-bottom 16px

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -15,20 +15,20 @@ import { Link } from "react-router";
 import moment from "moment";
 import _ from "lodash";
 
-import { AdminUIState } from "oss/src/redux/state";
+import { AdminUIState } from "src/redux/state";
 import {
   LivenessStatus,
   NodesSummary,
   nodesSummarySelector,
   partitionedStatuses,
   selectNodesSummaryValid,
-} from "oss/src/redux/nodes";
-import { refreshLiveness, refreshNodes } from "oss/src/redux/apiReducers";
-import { SortedTable } from "oss/src/views/shared/components/sortedtable";
-import { INodeStatus } from "oss/src/util/proto";
-import { LongToMoment } from "oss/src/util/convert";
-import { SortSetting } from "oss/src/views/shared/components/sortabletable";
-import { LocalSetting } from "oss/src/redux/localsettings";
+} from "src/redux/nodes";
+import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
+import { SortedTable } from "src/views/shared/components/sortedtable";
+import { INodeStatus } from "src/util/proto";
+import { LongToMoment } from "src/util/convert";
+import { SortSetting } from "src/views/shared/components/sortabletable";
+import { LocalSetting } from "src/redux/localsettings";
 
 import "./decommissionedNodeHistory.styl";
 

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -1,0 +1,138 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { Helmet } from "react-helmet";
+import { connect } from "react-redux";
+import { Link } from "react-router";
+import moment from "moment";
+import _ from "lodash";
+
+import { AdminUIState } from "oss/src/redux/state";
+import {
+  LivenessStatus,
+  NodesSummary,
+  nodesSummarySelector,
+  partitionedStatuses,
+  selectNodesSummaryValid,
+} from "oss/src/redux/nodes";
+import { refreshLiveness, refreshNodes } from "oss/src/redux/apiReducers";
+import { SortedTable } from "oss/src/views/shared/components/sortedtable";
+import { INodeStatus } from "oss/src/util/proto";
+import { LongToMoment } from "oss/src/util/convert";
+import { SortSetting } from "oss/src/views/shared/components/sortabletable";
+import { LocalSetting } from "oss/src/redux/localsettings";
+
+import "./decommissionedNodeHistory.styl";
+
+const decommissionedNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "nodes/decommissioned_sort_setting", (s) => s.localSettings,
+);
+
+class NodeSortedTable extends SortedTable<INodeStatus> {}
+
+export interface DecommissionedNodeHistoryProps {
+  refreshNodes: typeof refreshNodes;
+  refreshLiveness: typeof refreshLiveness;
+  nodesSummaryValid: boolean;
+  status: LivenessStatus.DECOMMISSIONED;
+  sortSetting: SortSetting;
+  setSort: typeof decommissionedNodesSortSetting.set;
+  statuses: INodeStatus[];
+  nodesSummary: NodesSummary;
+}
+
+class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps> {
+  componentWillMount() {
+    this.props.refreshNodes();
+    this.props.refreshLiveness();
+  }
+
+  componentWillReceiveProps(props: DecommissionedNodeHistoryProps) {
+    props.refreshNodes();
+    props.refreshLiveness();
+  }
+
+  render() {
+    const { status, statuses, nodesSummary, sortSetting, setSort } = this.props;
+    if (!statuses || statuses.length === 0) {
+      return null;
+    }
+
+    const statusName = _.capitalize(LivenessStatus[status]);
+
+    return (
+      <section className="section">
+        <Helmet>
+          <title>Decommissioned Node History | Debug</title>
+        </Helmet>
+        <h1 className="title">Decommissioned Node History</h1>
+        <div>
+          <NodeSortedTable
+            data={statuses}
+            sortSetting={sortSetting}
+            onChangeSortSetting={(setting) => setSort(setting)}
+            columns={[
+              {
+                title: "ID",
+                cell: (ns) => `n${ns.desc.node_id}`,
+                sort: (ns) => ns.desc.node_id,
+              },
+              {
+                title: "Address",
+                cell: (ns) => {
+                  return (
+                    <div>
+                      <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                    </div>
+                  );
+                },
+                sort: (ns) => ns.desc.node_id,
+                className: "sort-table__cell--link",
+              },
+              {
+                title: `${statusName} Since`,
+                cell: (ns) => {
+                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                  if (!liveness) {
+                    return "no information";
+                  }
+
+                  const deadTime = liveness.expiration.wall_time;
+                  const deadMoment = LongToMoment(deadTime);
+                  return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;
+                },
+                sort: (ns) => {
+                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                  return liveness.expiration.wall_time;
+                },
+              },
+            ]} />
+        </div>
+      </section>
+    );
+  }
+}
+
+const mapStateToProps = (state: AdminUIState) => ({
+  nodesSummaryValid: selectNodesSummaryValid(state),
+  sortSetting: decommissionedNodesSortSetting.selector(state),
+  status: LivenessStatus.DECOMMISSIONED,
+  statuses: partitionedStatuses(state).decommissioned,
+  nodesSummary: nodesSummarySelector(state),
+});
+
+const mapDispatchToProps = {
+  refreshNodes,
+  refreshLiveness,
+  setSort: decommissionedNodesSortSetting.set,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DecommissionedNodeHistory);

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -11,7 +11,7 @@
 import * as React from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
-import { Link } from "react-router";
+import { Link, withRouter, WithRouterProps } from "react-router";
 import moment from "moment";
 import _ from "lodash";
 
@@ -49,7 +49,7 @@ export interface DecommissionedNodeHistoryProps {
   nodesSummary: NodesSummary;
 }
 
-class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps> {
+class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps & WithRouterProps> {
   componentWillMount() {
     this.props.refreshNodes();
     this.props.refreshLiveness();
@@ -60,8 +60,23 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
     props.refreshLiveness();
   }
 
+  onPageChange = (page: number) => {
+    // Set 'page' search param with selected page so
+    // current page is preserved when page is reloaded.
+    this.props.router.push({
+      pathname: this.props.location.pathname,
+      query: {
+        ...this.props.location.query,
+        page,
+      },
+    });
+  }
+
   render() {
-    const { status, statuses, nodesSummary, sortSetting, setSort } = this.props;
+    const { status, statuses, nodesSummary, sortSetting, setSort, location } = this.props;
+    const query = location.query;
+    const page = query.page ? Number(query.page) : 1;
+
     if (!statuses || statuses.length === 0) {
       return null;
     }
@@ -78,7 +93,11 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
           <NodeSortedTable
             data={statuses}
             sortSetting={sortSetting}
-            onChangeSortSetting={(setting) => setSort(setting)}
+            onChangeSortSetting={setSort}
+            pagination
+            pageSize={15}
+            selectedPage={page}
+            onPageChange={this.onPageChange}
             columns={[
               {
                 title: "ID",
@@ -135,4 +154,4 @@ const mapDispatchToProps = {
   setSort: decommissionedNodesSortSetting.set,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(DecommissionedNodeHistory);
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(DecommissionedNodeHistory));

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -50,6 +50,14 @@ export interface DecommissionedNodeHistoryProps {
 }
 
 class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps & WithRouterProps> {
+  static defaultProps: Partial<DecommissionedNodeHistoryProps> = {
+    statuses: [],
+  };
+
+  state = {
+    rowsOnPage: this.props.statuses.length,
+  };
+
   componentWillMount() {
     this.props.refreshNodes();
     this.props.refreshLiveness();
@@ -72,12 +80,34 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
     });
   }
 
+  onPageRendered = (rowsOnPage: number) => {
+    if (rowsOnPage !== this.state.rowsOnPage) {
+      this.setState({
+        rowsOnPage,
+      });
+    }
+  }
+
+  getNodesCountMessage = () => {
+    const { rowsOnPage } = this.state;
+    const { statuses } = this.props;
+    const isEmptyTable = statuses.length === 0;
+
+    if (isEmptyTable) {
+      return `0 decommissioned nodes`;
+    } else {
+      return `${rowsOnPage} of ${statuses.length} decommissioned nodes`;
+    }
+  }
+
   render() {
-    const { status, statuses = [], nodesSummary, sortSetting, setSort, location } = this.props;
+    const { status, statuses, nodesSummary, sortSetting, setSort, location } = this.props;
+
+    const pageSize = 10;
     const query = location.query;
     const page = query.page ? Number(query.page) : 1;
-
     const statusName = _.capitalize(LivenessStatus[status]);
+    const totalNumberOfNodesMessage = this.getNodesCountMessage();
 
     return (
       <section className="section">
@@ -85,15 +115,17 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
           <title>Decommissioned Node History | Debug</title>
         </Helmet>
         <h1 className="title">Decommissioned Node History</h1>
+        <div className="info-message">{totalNumberOfNodesMessage}</div>
         <div>
           <NodeSortedTable
             data={statuses}
             sortSetting={sortSetting}
             onChangeSortSetting={setSort}
             pagination
-            pageSize={15}
+            pageSize={pageSize}
             selectedPage={page}
             onPageChange={this.onPageChange}
+            onPageRendered={this.onPageRendered}
             columns={[
               {
                 title: "ID",

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -73,13 +73,9 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
   }
 
   render() {
-    const { status, statuses, nodesSummary, sortSetting, setSort, location } = this.props;
+    const { status, statuses = [], nodesSummary, sortSetting, setSort, location } = this.props;
     const query = location.query;
     const page = query.page ? Number(query.page) : 1;
-
-    if (!statuses || statuses.length === 0) {
-      return null;
-    }
 
     const statusName = _.capitalize(LivenessStatus[status]);
 
@@ -133,7 +129,8 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
                   return liveness.expiration.wall_time;
                 },
               },
-            ]} />
+            ]}
+            emptyTableMessage="There are no decommissioned nodes in this cluster."/>
         </div>
       </section>
     );

--- a/pkg/ui/src/views/reports/containers/nodesHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./decommissionedNodeHistory";

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -65,6 +65,10 @@ interface TableProps {
   // i.e. each row has an expand/collapse arrow on its left, and renders
   // a full-width area below it when expanded.
   expandableConfig?: ExpandableConfig;
+  // Render rows which start from 'startIndex' number
+  startIndex?: number;
+  // render particular number of rows instead of rendering entire dataset
+  renderItemsCount?: number;
 }
 
 export interface ExpandableConfig {
@@ -184,7 +188,23 @@ export class SortableTable extends React.Component<TableProps> {
   }
 
   render() {
-    const { sortSetting, columns, expandableConfig } = this.props;
+    const { count, sortSetting, columns, expandableConfig } = this.props;
+    // Render all rows for entire dataset.
+    let startIndex = 0;
+    let endIndex = count;
+
+    if (!_.isUndefined(this.props.startIndex) &&
+      !_.isUndefined(this.props.renderItemsCount)) {
+      const { renderItemsCount } = this.props;
+      startIndex = this.props.startIndex;
+
+      // If endIndex is greater then total count of items in dataset (is possible for last page),
+      // then keep endIndex equal to total count of items to avoid IndexOutOfRange exception.
+      if (startIndex + renderItemsCount < count) {
+        endIndex = startIndex + renderItemsCount;
+      }
+    }
+
     return (
       <table className={classNames("sort-table", this.props.className)}>
         <thead>
@@ -216,7 +236,8 @@ export class SortableTable extends React.Component<TableProps> {
           </tr>
         </thead>
         <tbody>
-          {_.times(this.props.count, this.renderRow)}
+          {_.range(startIndex, endIndex)
+            .map(idx => this.renderRow(idx))}
         </tbody>
       </table>
     );

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -65,10 +65,11 @@ interface TableProps {
   // i.e. each row has an expand/collapse arrow on its left, and renders
   // a full-width area below it when expanded.
   expandableConfig?: ExpandableConfig;
-  // Render rows which start from 'startIndex' number
+  // Index of first row to render. If not specified renders rows starting from
+  // first row.
   startIndex?: number;
-  // render particular number of rows instead of rendering entire dataset
-  renderItemsCount?: number;
+  // Index of last row to render. If not specified renders up to last row in dataset.
+  endIndex?: number;
   // Message to display in case of empty table
   emptyTableMessage?: string;
 }
@@ -191,24 +192,11 @@ export class SortableTable extends React.Component<TableProps> {
 
   render() {
     const { count, sortSetting, columns, expandableConfig, emptyTableMessage } = this.props;
-    // Render all rows for entire dataset.
-    let startIndex = 0;
-    let endIndex = count;
-    let isEmptyTable = count === 0;
-
-    if (!_.isUndefined(this.props.startIndex) &&
-      !_.isUndefined(this.props.renderItemsCount) &&
-        this.props.startIndex < count) {
-      const { renderItemsCount } = this.props;
-      startIndex = this.props.startIndex;
-
-      // If endIndex is greater then total count of items in dataset (is possible for last page),
-      // then keep endIndex equal to total count of items to avoid IndexOutOfRange exception.
-      if (startIndex + renderItemsCount < count) {
-        endIndex = startIndex + renderItemsCount;
-      }
-      isEmptyTable = endIndex - startIndex === 0;
-    }
+    // If startIndex and endIndex are specified - render custom subset of row,
+    // otherwise render all rows.
+    const startIndex = this.props.startIndex || 0;
+    const endIndex = this.props.endIndex || count;
+    const isEmptyTable = endIndex - startIndex === 0;
 
     return (
       <table className={classNames("sort-table", this.props.className)}>

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -197,7 +197,8 @@ export class SortableTable extends React.Component<TableProps> {
     let isEmptyTable = count === 0;
 
     if (!_.isUndefined(this.props.startIndex) &&
-      !_.isUndefined(this.props.renderItemsCount)) {
+      !_.isUndefined(this.props.renderItemsCount) &&
+        this.props.startIndex < count) {
       const { renderItemsCount } = this.props;
       startIndex = this.props.startIndex;
 

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -69,6 +69,8 @@ interface TableProps {
   startIndex?: number;
   // render particular number of rows instead of rendering entire dataset
   renderItemsCount?: number;
+  // Message to display in case of empty table
+  emptyTableMessage?: string;
 }
 
 export interface ExpandableConfig {
@@ -188,10 +190,11 @@ export class SortableTable extends React.Component<TableProps> {
   }
 
   render() {
-    const { count, sortSetting, columns, expandableConfig } = this.props;
+    const { count, sortSetting, columns, expandableConfig, emptyTableMessage } = this.props;
     // Render all rows for entire dataset.
     let startIndex = 0;
     let endIndex = count;
+    let isEmptyTable = count === 0;
 
     if (!_.isUndefined(this.props.startIndex) &&
       !_.isUndefined(this.props.renderItemsCount)) {
@@ -203,6 +206,7 @@ export class SortableTable extends React.Component<TableProps> {
       if (startIndex + renderItemsCount < count) {
         endIndex = startIndex + renderItemsCount;
       }
+      isEmptyTable = endIndex - startIndex === 0;
     }
 
     return (
@@ -236,8 +240,11 @@ export class SortableTable extends React.Component<TableProps> {
           </tr>
         </thead>
         <tbody>
-          {_.range(startIndex, endIndex)
-            .map(idx => this.renderRow(idx))}
+          {
+            isEmptyTable ?
+              <div className="sort-table__empty-table-message">{emptyTableMessage}</div> :
+              _.range(startIndex, endIndex).map(idx => this.renderRow(idx))
+          }
         </tbody>
       </table>
     );

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -57,3 +57,8 @@
 
     div
       width 15px
+  .sort-table__empty-table-message
+    font-size 14px
+    color $body-color
+    padding 16px
+

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -18,6 +18,8 @@ import { Pagination } from "antd";
 import { SortableTable, SortableColumn, SortSetting } from "src/views/shared/components/sortabletable";
 import { ExpandableConfig } from "src/views/shared/components/sortabletable";
 
+import "./sortedtabel.styl";
+
 /**
  * ColumnDescriptor is used to describe metadata about an individual column
  * in a SortedTable.
@@ -237,7 +239,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
 
     if (data) {
       return (
-        <React.Fragment>
+        <div>
           <SortableTable
             count={data.length}
             startIndex={startIndex}
@@ -251,13 +253,14 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
           />
           { pagination &&
             <Pagination
-              hideOnSinglePage
+              className="table-pagination"
               defaultCurrent={ selectedPage }
               total={ totalRecordsCount }
               onChange={ onPageChange }
-              pageSize={ pageSize }/>
+              pageSize={ pageSize }
+              size="small"/>
           }
-        </React.Fragment>
+        </div>
       );
     }
     return <div>No results.</div>;

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -83,6 +83,8 @@ interface SortedTableProps<T> {
   pageSize?: number;
   // What page should be selected by default
   selectedPage?: number;
+  // No items message
+  emptyTableMessage?: string;
 }
 
 interface SortedTableState {
@@ -213,6 +215,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
       pagination,
       selectedPage,
       pageSize,
+      emptyTableMessage,
     } = this.props;
 
     let expandableConfig: ExpandableConfig = null;
@@ -228,7 +231,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
     // page so basically there is no pagination if not specified.
     const totalRecordsCount = data.length;
     let startIndex = 0;
-    let displayItemsCount = data.length;
+    let displayItemsCount = totalRecordsCount;
 
     // if 'pagination' props is enabled, then calculate
     // offset for rows to display
@@ -241,7 +244,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
       return (
         <div>
           <SortableTable
-            count={data.length}
+            count={totalRecordsCount}
             startIndex={startIndex}
             renderItemsCount={displayItemsCount}
             sortSetting={sortSetting}
@@ -250,8 +253,9 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
             rowClass={this.rowClass(this.props)}
             className={this.props.className}
             expandableConfig={expandableConfig}
+            emptyTableMessage={emptyTableMessage}
           />
-          { pagination &&
+          { pagination && totalRecordsCount > 0 &&
             <Pagination
               className="table-pagination"
               defaultCurrent={ selectedPage }

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -240,7 +240,8 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
       displayItemsCount = pageSize;
     }
 
-    if (data) {
+    // Display table only if data is available or 'emptyTableMessage' is provided by user.
+    if (totalRecordsCount > 0 || emptyTableMessage) {
       return (
         <div>
           <SortableTable

--- a/pkg/ui/src/views/shared/components/sortedtable/sortedtabel.styl
+++ b/pkg/ui/src/views/shared/components/sortedtable/sortedtabel.styl
@@ -1,3 +1,13 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 .table-pagination
   text-align center
   margin-top 42px

--- a/pkg/ui/src/views/shared/components/sortedtable/sortedtabel.styl
+++ b/pkg/ui/src/views/shared/components/sortedtable/sortedtabel.styl
@@ -1,0 +1,3 @@
+.table-pagination
+  text-align center
+  margin-top 42px


### PR DESCRIPTION
Pagination is implemented as a common solution for the `SortedTable` component, it is optional so does not affect components that do not require it. Components 
- Table page (selected with pagination) on `Decommissioned node history` view is set in URL search params so it is preserved its state after the page is refreshed;
- Additional (optional) `emptyTableMessage` property is added to the `SortedTable` component which allows show custom message as a single row inside of the table.
- The logic of rendering rows in the `SortableTable` component is changed. Before the total number of rows was provided and the component called rendering callback functions n-times and passed row index number to the rendering function (strictly starting from 0). 
With the current implementation, the `SortableTable` component accepts additional optional properties that can specify the subset of indexes we need to render rows (`'startIndex` and `renderItemsCount`).