### PR TITLE
release-19.1: changefeedccl: fix violation of CDC's ordering guarantees

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -208,8 +208,9 @@ func createBenchmarkChangefeed(
 		m:        th,
 	}
 	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), details, buf.Get)
+	sf := makeSpanFrontier(spans...)
 	tickFn := emitEntries(
-		s.ClusterSettings(), details, spans, encoder, sink, rowsFn, TestingKnobs{}, metrics)
+		s.ClusterSettings(), details, sf, encoder, sink, rowsFn, TestingKnobs{}, metrics)
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() { _ = poller.Run(ctx) }()

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -29,7 +29,7 @@ import (
 // duplicates, which the two cdctest.Validator implementations verify for the
 // real output of a changefeed. The output rows and resolved timestamps of the
 // tested feed are fed into them to check for anomalies.
-func RunNemesis(f TestFeedFactory, db *gosql.DB, isSinkless bool) (Validator, error) {
+func RunNemesis(f TestFeedFactory, db *gosql.DB, omitPause bool) (Validator, error) {
 	// possible additional nemeses:
 	// - schema changes
 	// - merges
@@ -51,12 +51,7 @@ func RunNemesis(f TestFeedFactory, db *gosql.DB, isSinkless bool) (Validator, er
 	}
 
 	eventPauseCount := 10
-	if isSinkless {
-		// Disable eventPause for sinkless changefeeds because we currently do not
-		// have "correct" pause and unpause mechanisms for changefeeds that aren't
-		// based on the jobs infrastructure. Enabling it for sinkless might require
-		// using "AS OF SYSTEM TIME" for sinkless changefeeds. See #41006 for more
-		// details.
+	if omitPause {
 		eventPauseCount = 0
 	}
 	ns := &nemeses{

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -432,7 +432,7 @@ func (c *TableFeed) Close() error {
 	return c.db.Close()
 }
 
-var cloudFeedFileRE = regexp.MustCompile(`^\d{33}-(.+?)-(\d+)-`)
+var cloudFeedFileRE = regexp.MustCompile(`^\d{33}-(.+?)-(\d+)-(\d+)-([0-9a-fA-F]{8})-(.+?)-`)
 
 type cloudFeedFactory struct {
 	s       serverutils.TestServerInterface
@@ -637,7 +637,7 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, _ error) error {
 	if subs == nil {
 		return errors.Errorf(`unexpected file: %s`, path)
 	}
-	topic = subs[1]
+	topic = subs[5]
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -432,7 +432,7 @@ func (c *TableFeed) Close() error {
 	return c.db.Close()
 }
 
-var cloudFeedFileRE = regexp.MustCompile(`^\d{33}-(.+?)-(\d+)-(\d+)-([0-9a-fA-F]{8})-(.+?)-`)
+var cloudFeedFileRE = regexp.MustCompile(`^\d{33}-(.+?)-(\d+)-`)
 
 type cloudFeedFactory struct {
 	s       serverutils.TestServerInterface
@@ -637,7 +637,7 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, _ error) error {
 	if subs == nil {
 		return errors.Errorf(`unexpected file: %s`, path)
 	}
-	topic = subs[5]
+	topic = subs[1]
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -10,6 +10,8 @@ package changefeedccl
 
 import (
 	"context"
+	"encoding/hex"
+	"math/rand"
 	"net/url"
 	"sort"
 	"time"
@@ -290,7 +292,8 @@ func changefeedPlanHook(
 		// which will be immediately closed, only to check for errors.
 		{
 			nodeID := p.ExtendedEvalContext().NodeID
-			canarySink, err := getSink(details.SinkURI, nodeID, details.Opts, details.Targets, settings)
+			var nilOracle timestampLowerBoundOracle
+			canarySink, err := getSink(details.SinkURI, nodeID, details.Opts, details.Targets, settings, nilOracle)
 			if err != nil {
 				return MaybeStripRetryableErrorMarker(err)
 			}
@@ -446,8 +449,37 @@ func validateChangefeedTable(
 	return nil
 }
 
+// generateChangefeedSessionID generates a unique string that is used to
+// prevent overwriting of output files by the cloudStorageSink.
+func generateChangefeedSessionID() string {
+	// We read exactly 8 random bytes. 8 bytes should be enough because:
+	// Consider that each new session for a changefeed job can occur at the
+	// same highWater timestamp for its catch up scan. This session ID is
+	// used to ensure that a session emitting files with the same timestamp
+	// as the session before doesn't clobber existing files. Let's assume that
+	// each of these runs for 0 seconds. Our node liveness duration is currently
+	// 9 seconds, but let's go with a conservative duration of 1 second.
+	// With 8 bytes using the rough approximation for the birthday problem
+	// https://en.wikipedia.org/wiki/Birthday_problem#Square_approximation, we
+	// will have a 50% chance of a single collision after sqrt(2^64) = 2^32
+	// sessions. So if we start a new job every second, we get a coin flip chance of
+	// single collision after 136 years. With this same approximation, we get
+	// something like 220 days to have a 0.001% chance of a collision. In practice,
+	// jobs are likely to run for longer and it's likely to take longer for
+	// job adoption, so we should be good with 8 bytes. Similarly, it's clear that
+	// 16 would be way overkill. 4 bytes gives us a 50% chance of collision after
+	// 65K sessions at the same timestamp.
+	const size = 8
+	p := make([]byte, size)
+	buf := make([]byte, hex.EncodedLen(size))
+	rand.Read(p)
+	hex.Encode(buf, p)
+	return string(buf)
+}
+
 type changefeedResumer struct{}
 
+// Resume is part of the jobs.Resumer interface.
 func (b *changefeedResumer) Resume(
 	ctx context.Context, job *jobs.Job, planHookState interface{}, startedCh chan<- tree.Datums,
 ) error {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -10,8 +10,6 @@ package changefeedccl
 
 import (
 	"context"
-	"encoding/hex"
-	"math/rand"
 	"net/url"
 	"sort"
 	"time"
@@ -447,34 +445,6 @@ func validateChangefeedTable(
 	// }
 
 	return nil
-}
-
-// generateChangefeedSessionID generates a unique string that is used to
-// prevent overwriting of output files by the cloudStorageSink.
-func generateChangefeedSessionID() string {
-	// We read exactly 8 random bytes. 8 bytes should be enough because:
-	// Consider that each new session for a changefeed job can occur at the
-	// same highWater timestamp for its catch up scan. This session ID is
-	// used to ensure that a session emitting files with the same timestamp
-	// as the session before doesn't clobber existing files. Let's assume that
-	// each of these runs for 0 seconds. Our node liveness duration is currently
-	// 9 seconds, but let's go with a conservative duration of 1 second.
-	// With 8 bytes using the rough approximation for the birthday problem
-	// https://en.wikipedia.org/wiki/Birthday_problem#Square_approximation, we
-	// will have a 50% chance of a single collision after sqrt(2^64) = 2^32
-	// sessions. So if we start a new job every second, we get a coin flip chance of
-	// single collision after 136 years. With this same approximation, we get
-	// something like 220 days to have a 0.001% chance of a collision. In practice,
-	// jobs are likely to run for longer and it's likely to take longer for
-	// job adoption, so we should be good with 8 bytes. Similarly, it's clear that
-	// 16 would be way overkill. 4 bytes gives us a 50% chance of collision after
-	// 65K sessions at the same timestamp.
-	const size = 8
-	p := make([]byte, size)
-	buf := make([]byte, hex.EncodedLen(size))
-	rand.Read(p)
-	hex.Encode(buf, p)
-	return string(buf)
 }
 
 type changefeedResumer struct{}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -312,6 +312,7 @@ func cloudStorageTest(
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 
 		f := cdctest.MakeCloudFeedFactory(s, db, dir, flushCh)

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -25,10 +25,22 @@ func TestChangefeedNemeses(t *testing.T) {
 	jobs.DefaultAdoptInterval = 10 * time.Millisecond
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		// TODO(aayush,dan): Ugly hack to disable `eventPause` in sinkless
-		// feeds. See comment in `RunNemesis` for details.
-		isSinkless := strings.Contains(t.Name(), "sinkless")
-		v, err := cdctest.RunNemesis(f, db, isSinkless)
+		// Disable eventPause for sinkless changefeeds because we currently do not
+		// have "correct" pause and unpause mechanisms for changefeeds that aren't
+		// based on the jobs infrastructure. Enabling it for sinkless might require
+		// using "AS OF SYSTEM TIME" for sinkless changefeeds. See #41006 for more
+		// details.
+		omitPause := strings.Contains(t.Name(), "sinkless")
+		// TODO(dan): Figure out why this doesn't work for poller. I suspect one of
+		// the later cherry-picks will fix this, so waiting until we have those to
+		// investigate.
+		omitPause = omitPause || strings.Contains(t.Name(), "poller")
+		// The cloudstorage sink has known changefeed invariant violations around
+		// restarts. This cannot be fixed without changing the format of filenames
+		// it uses, which was deemed too invasive to backport. Users of the
+		// cloudstorage should upgrade to 19.2+.
+		omitPause = omitPause || strings.Contains(t.Name(), "cloudstorage")
+		v, err := cdctest.RunNemesis(f, db, omitPause)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	gosql "database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +25,10 @@ func TestChangefeedNemeses(t *testing.T) {
 	jobs.DefaultAdoptInterval = 10 * time.Millisecond
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		v, err := cdctest.RunNemesis(f, db)
+		// TODO(aayush,dan): Ugly hack to disable `eventPause` in sinkless
+		// feeds. See comment in `RunNemesis` for details.
+		isSinkless := strings.Contains(t.Name(), "sinkless")
+		v, err := cdctest.RunNemesis(f, db, isSinkless)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -69,6 +69,7 @@ func getSink(
 	opts map[string]string,
 	targets jobspb.ChangefeedTargets,
 	settings *cluster.Settings,
+	timestampOracle timestampLowerBoundOracle,
 ) (Sink, error) {
 	u, err := url.Parse(sinkURI)
 	if err != nil {
@@ -170,7 +171,7 @@ func getSink(
 		u.RawQuery = q.Encode()
 		q = url.Values{}
 		makeSink = func() (Sink, error) {
-			return makeCloudStorageSink(u.String(), nodeID, fileSize, settings, opts)
+			return makeCloudStorageSink(u.String(), nodeID, fileSize, settings, opts, timestampOracle)
 		}
 	case u.Scheme == sinkSchemeExperimentalSQL:
 		// Swap the changefeed prefix for the sql connection one that sqlSink

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
+	"github.com/pkg/errors"
 )
 
 func isCloudStorageSink(u *url.URL) bool {
@@ -55,81 +55,20 @@ type cloudStorageSinkFile struct {
 	buf bytes.Buffer
 }
 
-// cloudStorageSink writes changefeed output to files in a cloud storage bucket
-// (S3/GCS/HTTP) maintaining CDC's ordering guarantees (see below) for each
-// row through lexicographical filename ordering.
+// cloudStorageSink emits to files on cloud storage.
 //
-// Changefeeds offer the following two ordering guarantees to external clients:
-//
-// 1. Rows are emitted with a timestamp. Individual rows are emitted in
-// timestamp order. There may be duplicates, but once a row is seen at a given
-// timestamp no previously unseen version of that row will be emitted at a less
-// (or equal) timestamp. For example, you may see 1 2 1 2, or even 1 2 1, but
-// never simply 2 1.
-// 2. Periodically, a resolved timestamp is emitted. This is a changefeed-wide
-// guarantee that no previously unseen row will later be seen with a timestamp
-// less (or equal) to the resolved one. The cloud storage sink is structured as
-// a number of distsql processors that each emit some part of the total changefeed.
-// These processors only write files containing row data (initially only in ndjson
-// format in this cloudStorageSink). This mapping is stable for a given distsql
-// flow of a changefeed (meaning any given row is always emitted by the same
-// processor), but it's not stable across restarts (pause/unpause). Each of these
-// processors report partial progress information to a central coordinator
-// (changeFrontier), which is responsible for writing the resolved timestamp files.
-//
-// In addition to the guarantees required of any changefeed, the cloud storage
-// sink adds some quality of life guarantees of its own.
-// 3. All rows in a file are from the same table. Further, all rows in a file are
-// from the same schema version of that table, and so all have the same schema.
-// 4. All files are partitioned into folders by the date part of the filename.
-//
-// Two methods of the cloudStorageSink on each data emitting processor are
-// called. EmitRow is called with each row change and Flush is called before
-// sending partial progress information to the coordinator. This happens with no
-// concurrency, all EmitRow and Flush calls for a sink are serialized.
-// EmitResolvedTimestamp is only called by the `changeFrontier`.
-//
-// The rows handed to EmitRow by the changefeed are guaranteed to satisfy
-// condition (1). Further, as long as the sink has written every EmitRow it's
-// gotten before returning from Flush, condition (2) is upheld.
-//
-// The cloudStorageSink uses lexicographic filename ordering to provide a total
-// ordering for the output of this sink. Guarantees (1) and (2) depend on this
-// ordering. Specifically, at any given time, the order of the data written by
-// the sink is by lexicographic filename and then by order within the file.
-//
-// Batching these row updates into files is complicated because:
-// a) We need to pick a representative timestamp for the file. This is required
-// for comparison with resolved timestamp filenames as part of guarantee (2).
-// b) For each topic, the row ordering guarantees must be preserved.
-// One intuitive way of solving (b) is to ensure that filenames are emitted in
-// strictly lexically increasing order (see assertion in `flushFile()`). This
-// guarantees correctness as long as the underlying system is correct.
-//
-// Before the local progress is sent to the coordinator (called the "local frontier" as
-// opposed to the resolved timestamp which is exactly a "global frontier" or
-// "changefeed-level frontier"), all buffered data which preceded that update is flushed.
-// To accomplish (a), we need two invariants. (a1) is that once Flush is called, we can
-// never write a file with a timestamp that is less than or equal to the local frontier.
-// This is because the local progress update could indeed cause a resolved timestamp file
-// to be written with that timestamp. We cannot break this invariant because the client is
-// free to ignore any files with a lexically lesser filename. Additionally, because we
-// picked the resolved timestamp filename to sort after a data file with the same
-// timestamp, a data file can't even be emitted at the same timestamp, it must be emitted
-// at a timestamp that is strictly greater than the last globally resolved timestamp. Note
-// that the local frontier is a guarantee that the sink will never get an EmitRow with
-// that timestamp or lower. (NOTE: there is a known bug in the poller which can cause row
-// updates to be emitted with a timestamp that is equal to the local frontier, during a
-// schema change with backfill. See #41415 for more details) (a2) is that whenever Flush
-// is called, all files written by the sink must be named using timestamps less than or
-// equal to the one for the local frontier at the time Flush is called. This is again
-// because our local progress update could cause the global progress to be updated and we
-// need everything written so far to lexically compare as less than the new resolved
-// timestamp.
+// WARNING: We found correctness bugs with the cloud storage sink that would
+// violate changefeed invariants. Some of these have been backported into
+// release-19.1, but others require changes to the format of filenames created,
+// which was deemed too disruptive for a patch release. As a result, this is a
+// hybrid of what it was previously and what's in release-19.2. It does provide
+// our guarantees within a session, but there are buggy edge cases around
+// changefeed restarts. See the cloudStorageSink godoc in release-19.2 for a
+// much better explanation of how this all fits together.
 //
 // The data files written by this sink are named according to the pattern
-// `<timestamp>-<uniquer>-<topic_id>-<schema_id>.<ext>`, each component of which is as
-// follows:
+// `<timestamp>_<topic>_<schema_id>_<uniquer>.<ext>`, each component of which is
+// as follows:
 //
 // `<timestamp>` is the smallest resolved timestamp being tracked by this sink's
 // `changeAggregator`, as of the time the last `Flush()` call was made (or `StatementTime`
@@ -144,30 +83,22 @@ type cloudStorageSinkFile struct {
 // to guarantee to users that _all entries in a given file have the same
 // schema_.
 //
-// `<uniquer>` is used to keep nodes in a cluster from overwriting each other's data and
-// should be ignored by external users. It also keeps a single node from overwriting its
-// own data if there are multiple changefeeds, or if a changefeed gets
-// canceled/restarted/zombied. Internally, it's generated by
-// `<session_id>-<node_id>-<sink_id>-<file_id>` where `<sink_id>` is a unique id for each
-// cloudStorageSink in a running process, `<file_id>` is a unique id for each file written
-// by a given `<sink_id>` and <session_id> is a unique identifying string for the job
-// session running the `changeAggregator` that owns this sink.
+// `<uniquer>` is used to keep nodes in a cluster from overwriting each other's
+// data and should be ignored by external users. It also keeps a single node
+// from overwriting its own data if there are multiple changefeeds, or if a
+// changefeed gets canceled/restarted/zombied. Internally, it's generated by
+// `<node_id>-<sink_id>-<file_id>` where `<sink_id>` is a unique id for each
+// cloudStorageSink in a running process and `<file_id>` is a unique id for each
+// file written by a given `<sink_id>`.
 //
 // `<ext>` implies the format of the file: currently the only option is
 // `ndjson`, which means a text file conforming to the "Newline Delimited JSON"
 // spec.
 //
-// This naming convention of data files is carefully chosen in order to preserve
-// the external ordering guarantees of CDC. Naming output files in this fashion
-// provides monotonicity among files emitted by a given sink for a given table
-// name, table schema version pair within a given job session. This ensures that
-// all row updates for a given span are read in an order that preserves the CDC
-// ordering guarantees, even in the presence of job restarts (see proof below).
 // Each record in the data files is a value, keys are not included, so the
 // `envelope` option must be set to `value_only`. Within a file, records are not
 // guaranteed to be sorted by timestamp. A duplicate of some records might exist
 // in a different file or even in the same file.
-//
 //
 // The resolved timestamp files are named `<timestamp>.RESOLVED`. This is
 // carefully done so that we can offer the following external guarantee: At any
@@ -178,86 +109,6 @@ type cloudStorageSinkFile struct {
 // would periodically do exactly this.
 //
 // Still TODO is writing out data schemas, Avro support, bounding memory usage.
-//
-// Now what follows is a proof of why the above is correct even in the presence
-// of multiple job restarts. We begin by establishing some terminology and by
-// formally (re)stating some invariants about the underlying system.
-//
-// Terminology
-// 1. Characters A,B...Z refer to job sessions.
-// 2. Ai, for i in Nat, refers to `the filename of the i'th data file
-// emitted by session A`. Note that because of the invariants we will state,
-// this can also be taken to mean "the filename of lexically the i'th data
-// file emitted by session A". This is a notation simply used for convenience.
-// 3. Ae > Bf refers to a lexical comparison of Ae and Bf.
-// 4. ts(Xi) refers to the <timestamp> part of Xi.
-//
-// Invariants
-// 1. We assume that the ordering guarantee (1) stated at the beginning of this
-// comment blob is upheld by the underlying system. More specifically, this proof
-// only proves correctness of the cloudStorageSink, not the entire system.
-// To re-state, if the rows are read in the order they are emitted by the underlying
-// system, it is impossible to see a previously unseen timestamp that is lower
-// than some timestamp we've seen before.
-// 2. Data files emitted by a single session of a changefeed job are lexically
-// ordered exactly as they were emitted. Xi lexically precedes X(i-1), for i in
-// Nat, for all job sessions X. The naming convention described above guarantees
-// this.
-// 3. Data files are named using the successor of the "local frontier" timestamp as of the
-// time the last `Flush()` call was made (or StatementTime in case `Flush()` hasn't been
-// called yet). Since all EmitRow calls are guaranteed to be for rows that equal or
-// succeed this timestamp, ts(Xi) is an inclusive lower bound for the rows contained
-// inside Xi. NOTE: There is a known bug in the poller which causes this guarantee to be
-// violated in case of a schema change that causes a backfill. See issue #41415 for more
-// details.
-// 4. When a job restarts, the new job session starts with a catch-up scan
-// from the last globally resolved timestamp of the changefeed. This catch-up
-// scan replays all rows since this resolved timestamp preserving invariant 1.
-//
-// Corollary 1: It is impossible to see a previously unseen timestamp that is
-// lower than any timestamp seen thus far, in a lexical ordering of files if the
-// files satisfy invariant 2 and the underlying system satisfies invariant 1.
-//
-// Note that correctness does not necessarily imply invariants 1 and 2.
-//
-// Lemma 1: Given two totally ordered sets of files X and Y that preserve CDC's ordering
-// guarantee along with invariants 3 and 4, their union produces a totally ordered set of
-// files that preserves this guarantee.
-// Proof of lemma: Lets refer to the data filenames emitted by these sessions as X1,X2....
-// and similarly for session Y. Additionally, lets refer to the last file ever emitted by
-// session X as Xn, for some n in Nat. Now lexically speaking there are 2 cases here: 1.
-// Y1 < Xn: For the sake of contradiction, let's assume there is a violation here. Since
-// there is a total lexical ordering among files in each set individually, we must have
-// read Y(e-1) before Ye, for all e in Nat. Similarly for X. Without loss of generality,
-// lets say there are 2 files Ye and Xf such that (1.1) Ye < Xf and Xf contains an unseen
-// timestamp that is lower than at least one timestamp seen in Ye. call this timestamp t.
-// More explicitly, it must be the case that this timestamp t does not exist in any files
-// Y1...Ye. This must mean that timestamp t lies before the starting point of session Y's
-// catch-up scan (again from invariant 4). Thus it must be the case that (1.2) ts(Y1) > t.
-// Now, due to invariant 3, we know that we won't see any rows in a file Xi with a
-// timestamp that is lower than ts(Xi). This must mean that (1.3) ts(Xf) <= t. Statements
-// 1.1, 1.2 and 1.3 together give us a contradiction. 2. Y1 > Xn. This case means that all
-// data files of session Y lexically succeed all the data files of session X. This means
-// that all data files are ordered monotonically relative to when they were emitted, this
-// gives us invariant 2 (but for 2 sessions). Correctness follows from this and invariant
-// 1. Note that Y1 == Xn is not possible because sessions are assigned unique session IDs.
-// QED.
-//
-// Proof of correctness: It is impossible to see a previously unseen timestamp that is
-// lower than any timestamp seen thus far, across n job sessions for all n, n in Nat. We
-// do this by induction, let k be the number of job sessions a changefeed job goes
-// through:
-// Case k = 1: Correctness for this case follows from corollary 1.
-// Case k = 2: This follows from lemma 1 stated above.
-// Case k > 2 (induction case): Assume that the statement of the proof is true for the
-// output of a changefeed job with k sessions. We will show that it must also be true for
-// the output of a changefeed job with k+1 sessions. Let's refer to the first k jobs as
-// P1,P2,..PK, and the k+1st job as Q. Now, since we assumed the statement is true for
-// P1,P2...PK, it must produce a totally ordered (lexical ordering) set of files that
-// satisfies requirements of lemma 1. So we can consider these k jobs conceptually as one
-// job (call it P). Now, we're back to the case where k = 2 with jobs P and Q. Thus, by
-// induction we have the required proof.
-//
 type cloudStorageSink struct {
 	nodeID            roachpb.NodeID
 	sinkID            int64
@@ -275,13 +126,11 @@ type cloudStorageSink struct {
 	fileID          int64
 	files           map[cloudStorageSinkKey]*cloudStorageSinkFile
 	timestampOracle timestampLowerBoundOracle
-	jobSessionID    string
 	// We keep track of the successor of the least resolved timestamp in the local
 	// frontier as of the time of the last `Flush()` call. If `Flush()` hasn't been
 	// called, these fields are based on the statement time of the changefeed.
 	dataFileTs        string
 	dataFilePartition string
-	prevFilename      string
 }
 
 var cloudStorageSinkIDAtomic int64
@@ -307,8 +156,6 @@ func makeCloudStorageSink(
 		files:             make(map[cloudStorageSinkKey]*cloudStorageSinkFile),
 		partitionFormat:   defaultPartitionFormat,
 		timestampOracle:   timestampOracle,
-		// TODO(aayush): Use the jobs framework's session ID once that's available.
-		jobSessionID: generateChangefeedSessionID(),
 	}
 	if timestampOracle != nil {
 		s.dataFileTs = cloudStorageFormatTime(timestampOracle.inclusiveLowerBoundTS())
@@ -448,13 +295,8 @@ func (s *cloudStorageSink) flushFile(
 	// Note that we use `-` here to delimit the filename because we want
 	// `%d.RESOLVED` files to lexicographically succeed data files that have the
 	// same timestamp. This works because ascii `-` < ascii '.'.
-	filename := fmt.Sprintf(`%s-%s-%d-%d-%08x-%s-%x%s`, s.dataFileTs,
-		s.jobSessionID, s.nodeID, s.sinkID, fileID, key.Topic, key.SchemaID, s.ext)
-	if s.prevFilename != "" && filename < s.prevFilename {
-		return errors.AssertionFailedf("error: detected a filename %s that lexically "+
-			"precedes a file emitted before: %s", filename, s.prevFilename)
-	}
-	s.prevFilename = filename
+	filename := fmt.Sprintf(`%s-%s-%d-%d-%d-%08d%s`, s.dataFileTs,
+		key.Topic, key.SchemaID, s.nodeID, s.sinkID, fileID, s.ext)
 	return s.es.WriteFile(ctx, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes()))
 }
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 func isCloudStorageSink(u *url.URL) bool {
@@ -52,17 +52,91 @@ type cloudStorageSinkKey struct {
 }
 
 type cloudStorageSinkFile struct {
-	earliestTs hlc.Timestamp
-	buf        bytes.Buffer
+	buf bytes.Buffer
 }
 
-// cloudStorageSink emits to files on cloud storage.
+// cloudStorageSink writes changefeed output to files in a cloud storage bucket
+// (S3/GCS/HTTP) maintaining CDC's ordering guarantees (see below) for each
+// row through lexicographical filename ordering.
+//
+// Changefeeds offer the following two ordering guarantees to external clients:
+//
+// 1. Rows are emitted with a timestamp. Individual rows are emitted in
+// timestamp order. There may be duplicates, but once a row is seen at a given
+// timestamp no previously unseen version of that row will be emitted at a less
+// (or equal) timestamp. For example, you may see 1 2 1 2, or even 1 2 1, but
+// never simply 2 1.
+// 2. Periodically, a resolved timestamp is emitted. This is a changefeed-wide
+// guarantee that no previously unseen row will later be seen with a timestamp
+// less (or equal) to the resolved one. The cloud storage sink is structured as
+// a number of distsql processors that each emit some part of the total changefeed.
+// These processors only write files containing row data (initially only in ndjson
+// format in this cloudStorageSink). This mapping is stable for a given distsql
+// flow of a changefeed (meaning any given row is always emitted by the same
+// processor), but it's not stable across restarts (pause/unpause). Each of these
+// processors report partial progress information to a central coordinator
+// (changeFrontier), which is responsible for writing the resolved timestamp files.
+//
+// In addition to the guarantees required of any changefeed, the cloud storage
+// sink adds some quality of life guarantees of its own.
+// 3. All rows in a file are from the same table. Further, all rows in a file are
+// from the same schema version of that table, and so all have the same schema.
+// 4. All files are partitioned into folders by the date part of the filename.
+//
+// Two methods of the cloudStorageSink on each data emitting processor are
+// called. EmitRow is called with each row change and Flush is called before
+// sending partial progress information to the coordinator. This happens with no
+// concurrency, all EmitRow and Flush calls for a sink are serialized.
+// EmitResolvedTimestamp is only called by the `changeFrontier`.
+//
+// The rows handed to EmitRow by the changefeed are guaranteed to satisfy
+// condition (1). Further, as long as the sink has written every EmitRow it's
+// gotten before returning from Flush, condition (2) is upheld.
+//
+// The cloudStorageSink uses lexicographic filename ordering to provide a total
+// ordering for the output of this sink. Guarantees (1) and (2) depend on this
+// ordering. Specifically, at any given time, the order of the data written by
+// the sink is by lexicographic filename and then by order within the file.
+//
+// Batching these row updates into files is complicated because:
+// a) We need to pick a representative timestamp for the file. This is required
+// for comparison with resolved timestamp filenames as part of guarantee (2).
+// b) For each topic, the row ordering guarantees must be preserved.
+// One intuitive way of solving (b) is to ensure that filenames are emitted in
+// strictly lexically increasing order (see assertion in `flushFile()`). This
+// guarantees correctness as long as the underlying system is correct.
+//
+// Before the local progress is sent to the coordinator (called the "local frontier" as
+// opposed to the resolved timestamp which is exactly a "global frontier" or
+// "changefeed-level frontier"), all buffered data which preceded that update is flushed.
+// To accomplish (a), we need two invariants. (a1) is that once Flush is called, we can
+// never write a file with a timestamp that is less than or equal to the local frontier.
+// This is because the local progress update could indeed cause a resolved timestamp file
+// to be written with that timestamp. We cannot break this invariant because the client is
+// free to ignore any files with a lexically lesser filename. Additionally, because we
+// picked the resolved timestamp filename to sort after a data file with the same
+// timestamp, a data file can't even be emitted at the same timestamp, it must be emitted
+// at a timestamp that is strictly greater than the last globally resolved timestamp. Note
+// that the local frontier is a guarantee that the sink will never get an EmitRow with
+// that timestamp or lower. (NOTE: there is a known bug in the poller which can cause row
+// updates to be emitted with a timestamp that is equal to the local frontier, during a
+// schema change with backfill. See #41415 for more details) (a2) is that whenever Flush
+// is called, all files written by the sink must be named using timestamps less than or
+// equal to the one for the local frontier at the time Flush is called. This is again
+// because our local progress update could cause the global progress to be updated and we
+// need everything written so far to lexically compare as less than the new resolved
+// timestamp.
 //
 // The data files written by this sink are named according to the pattern
-// `<timestamp>_<topic>_<schema_id>_<uniquer>.<ext>`, each component of which is
-// as follows:
+// `<timestamp>-<uniquer>-<topic_id>-<schema_id>.<ext>`, each component of which is as
+// follows:
 //
-// `<timestamp>` is the smallest timestamp of any entries in the file.
+// `<timestamp>` is the smallest resolved timestamp being tracked by this sink's
+// `changeAggregator`, as of the time the last `Flush()` call was made (or `StatementTime`
+// if `Flush()` hasn't been called yet). Intuitively, this can be thought of as an
+// inclusive lower bound on the timestamps of updates that can be seen in a given file.
+// NOTE: Due to a bug in the poller, this is not always true when there's a schema change
+// that causes a backfill. See issue #41415 for more details.
 //
 // `<topic>` corresponds to one SQL table.
 //
@@ -70,22 +144,30 @@ type cloudStorageSinkFile struct {
 // to guarantee to users that _all entries in a given file have the same
 // schema_.
 //
-// `<uniquer>` is used to keep nodes in a cluster from overwriting each other's
-// data and should be ignored by external users. It also keeps a single node
-// from overwriting its own data if there are multiple changefeeds, or if a
-// changefeed gets canceled/restarted/zombied. Internally, it's generated by
-// `<node_id>-<sink_id>-<file_id>` where `<sink_id>` is a unique id for each
-// cloudStorageSink in a running process and `<file_id>` is a unique id for each
-// file written by a given `<sink_id>`.
+// `<uniquer>` is used to keep nodes in a cluster from overwriting each other's data and
+// should be ignored by external users. It also keeps a single node from overwriting its
+// own data if there are multiple changefeeds, or if a changefeed gets
+// canceled/restarted/zombied. Internally, it's generated by
+// `<session_id>-<node_id>-<sink_id>-<file_id>` where `<sink_id>` is a unique id for each
+// cloudStorageSink in a running process, `<file_id>` is a unique id for each file written
+// by a given `<sink_id>` and <session_id> is a unique identifying string for the job
+// session running the `changeAggregator` that owns this sink.
 //
 // `<ext>` implies the format of the file: currently the only option is
 // `ndjson`, which means a text file conforming to the "Newline Delimited JSON"
 // spec.
 //
+// This naming convention of data files is carefully chosen in order to preserve
+// the external ordering guarantees of CDC. Naming output files in this fashion
+// provides monotonicity among files emitted by a given sink for a given table
+// name, table schema version pair within a given job session. This ensures that
+// all row updates for a given span are read in an order that preserves the CDC
+// ordering guarantees, even in the presence of job restarts (see proof below).
 // Each record in the data files is a value, keys are not included, so the
 // `envelope` option must be set to `value_only`. Within a file, records are not
 // guaranteed to be sorted by timestamp. A duplicate of some records might exist
 // in a different file or even in the same file.
+//
 //
 // The resolved timestamp files are named `<timestamp>.RESOLVED`. This is
 // carefully done so that we can offer the following external guarantee: At any
@@ -96,6 +178,86 @@ type cloudStorageSinkFile struct {
 // would periodically do exactly this.
 //
 // Still TODO is writing out data schemas, Avro support, bounding memory usage.
+//
+// Now what follows is a proof of why the above is correct even in the presence
+// of multiple job restarts. We begin by establishing some terminology and by
+// formally (re)stating some invariants about the underlying system.
+//
+// Terminology
+// 1. Characters A,B...Z refer to job sessions.
+// 2. Ai, for i in Nat, refers to `the filename of the i'th data file
+// emitted by session A`. Note that because of the invariants we will state,
+// this can also be taken to mean "the filename of lexically the i'th data
+// file emitted by session A". This is a notation simply used for convenience.
+// 3. Ae > Bf refers to a lexical comparison of Ae and Bf.
+// 4. ts(Xi) refers to the <timestamp> part of Xi.
+//
+// Invariants
+// 1. We assume that the ordering guarantee (1) stated at the beginning of this
+// comment blob is upheld by the underlying system. More specifically, this proof
+// only proves correctness of the cloudStorageSink, not the entire system.
+// To re-state, if the rows are read in the order they are emitted by the underlying
+// system, it is impossible to see a previously unseen timestamp that is lower
+// than some timestamp we've seen before.
+// 2. Data files emitted by a single session of a changefeed job are lexically
+// ordered exactly as they were emitted. Xi lexically precedes X(i-1), for i in
+// Nat, for all job sessions X. The naming convention described above guarantees
+// this.
+// 3. Data files are named using the successor of the "local frontier" timestamp as of the
+// time the last `Flush()` call was made (or StatementTime in case `Flush()` hasn't been
+// called yet). Since all EmitRow calls are guaranteed to be for rows that equal or
+// succeed this timestamp, ts(Xi) is an inclusive lower bound for the rows contained
+// inside Xi. NOTE: There is a known bug in the poller which causes this guarantee to be
+// violated in case of a schema change that causes a backfill. See issue #41415 for more
+// details.
+// 4. When a job restarts, the new job session starts with a catch-up scan
+// from the last globally resolved timestamp of the changefeed. This catch-up
+// scan replays all rows since this resolved timestamp preserving invariant 1.
+//
+// Corollary 1: It is impossible to see a previously unseen timestamp that is
+// lower than any timestamp seen thus far, in a lexical ordering of files if the
+// files satisfy invariant 2 and the underlying system satisfies invariant 1.
+//
+// Note that correctness does not necessarily imply invariants 1 and 2.
+//
+// Lemma 1: Given two totally ordered sets of files X and Y that preserve CDC's ordering
+// guarantee along with invariants 3 and 4, their union produces a totally ordered set of
+// files that preserves this guarantee.
+// Proof of lemma: Lets refer to the data filenames emitted by these sessions as X1,X2....
+// and similarly for session Y. Additionally, lets refer to the last file ever emitted by
+// session X as Xn, for some n in Nat. Now lexically speaking there are 2 cases here: 1.
+// Y1 < Xn: For the sake of contradiction, let's assume there is a violation here. Since
+// there is a total lexical ordering among files in each set individually, we must have
+// read Y(e-1) before Ye, for all e in Nat. Similarly for X. Without loss of generality,
+// lets say there are 2 files Ye and Xf such that (1.1) Ye < Xf and Xf contains an unseen
+// timestamp that is lower than at least one timestamp seen in Ye. call this timestamp t.
+// More explicitly, it must be the case that this timestamp t does not exist in any files
+// Y1...Ye. This must mean that timestamp t lies before the starting point of session Y's
+// catch-up scan (again from invariant 4). Thus it must be the case that (1.2) ts(Y1) > t.
+// Now, due to invariant 3, we know that we won't see any rows in a file Xi with a
+// timestamp that is lower than ts(Xi). This must mean that (1.3) ts(Xf) <= t. Statements
+// 1.1, 1.2 and 1.3 together give us a contradiction. 2. Y1 > Xn. This case means that all
+// data files of session Y lexically succeed all the data files of session X. This means
+// that all data files are ordered monotonically relative to when they were emitted, this
+// gives us invariant 2 (but for 2 sessions). Correctness follows from this and invariant
+// 1. Note that Y1 == Xn is not possible because sessions are assigned unique session IDs.
+// QED.
+//
+// Proof of correctness: It is impossible to see a previously unseen timestamp that is
+// lower than any timestamp seen thus far, across n job sessions for all n, n in Nat. We
+// do this by induction, let k be the number of job sessions a changefeed job goes
+// through:
+// Case k = 1: Correctness for this case follows from corollary 1.
+// Case k = 2: This follows from lemma 1 stated above.
+// Case k > 2 (induction case): Assume that the statement of the proof is true for the
+// output of a changefeed job with k sessions. We will show that it must also be true for
+// the output of a changefeed job with k+1 sessions. Let's refer to the first k jobs as
+// P1,P2,..PK, and the k+1st job as Q. Now, since we assumed the statement is true for
+// P1,P2...PK, it must produce a totally ordered (lexical ordering) set of files that
+// satisfies requirements of lemma 1. So we can consider these k jobs conceptually as one
+// job (call it P). Now, we're back to the case where k = 2 with jobs P and Q. Thus, by
+// induction we have the required proof.
+//
 type cloudStorageSink struct {
 	nodeID            roachpb.NodeID
 	sinkID            int64
@@ -106,9 +268,20 @@ type cloudStorageSink struct {
 	ext           string
 	recordDelimFn func(io.Writer) error
 
-	es     storageccl.ExportStorage
-	fileID int64
-	files  map[cloudStorageSinkKey]*cloudStorageSinkFile
+	es storageccl.ExportStorage
+
+	// These are fields to track information needed to output files based on the naming
+	// convention described above. See comment on cloudStorageSink above for more details.
+	fileID          int64
+	files           map[cloudStorageSinkKey]*cloudStorageSinkFile
+	timestampOracle timestampLowerBoundOracle
+	jobSessionID    string
+	// We keep track of the successor of the least resolved timestamp in the local
+	// frontier as of the time of the last `Flush()` call. If `Flush()` hasn't been
+	// called, these fields are based on the statement time of the changefeed.
+	dataFileTs        string
+	dataFilePartition string
+	prevFilename      string
 }
 
 var cloudStorageSinkIDAtomic int64
@@ -119,6 +292,7 @@ func makeCloudStorageSink(
 	targetMaxFileSize int64,
 	settings *cluster.Settings,
 	opts map[string]string,
+	timestampOracle timestampLowerBoundOracle,
 ) (Sink, error) {
 	// Date partitioning is pretty standard, so no override for now, but we could
 	// plumb one down if someone needs it.
@@ -132,6 +306,13 @@ func makeCloudStorageSink(
 		targetMaxFileSize: targetMaxFileSize,
 		files:             make(map[cloudStorageSinkKey]*cloudStorageSinkFile),
 		partitionFormat:   defaultPartitionFormat,
+		timestampOracle:   timestampOracle,
+		// TODO(aayush): Use the jobs framework's session ID once that's available.
+		jobSessionID: generateChangefeedSessionID(),
+	}
+	if timestampOracle != nil {
+		s.dataFileTs = cloudStorageFormatTime(timestampOracle.inclusiveLowerBoundTS())
+		s.dataFilePartition = timestampOracle.inclusiveLowerBoundTS().GoTime().Format(s.partitionFormat)
 	}
 
 	switch formatType(opts[optFormat]) {
@@ -186,9 +367,6 @@ func (s *cloudStorageSink) EmitRow(
 		// careful to bound the size of the memory held by the pool.
 		file = &cloudStorageSinkFile{}
 		s.files[key] = file
-	}
-	if file.earliestTs.IsEmpty() || updated.Less(file.earliestTs) {
-		file.earliestTs = updated
 	}
 
 	// TODO(dan): Memory monitoring for this
@@ -245,6 +423,11 @@ func (s *cloudStorageSink) Flush(ctx context.Context) error {
 	for key := range s.files {
 		delete(s.files, key)
 	}
+	// Record the least resolved timestamp being tracked in the frontier as of this point,
+	// to use for naming files until the next `Flush()`. See comment on cloudStorageSink
+	// for an overview of the naming convention and proof of correctness.
+	s.dataFileTs = cloudStorageFormatTime(s.timestampOracle.inclusiveLowerBoundTS())
+	s.dataFilePartition = s.timestampOracle.inclusiveLowerBoundTS().GoTime().Format(s.partitionFormat)
 	return nil
 }
 
@@ -257,16 +440,22 @@ func (s *cloudStorageSink) flushFile(
 		return nil
 	}
 
-	part := file.earliestTs.GoTime().Format(s.partitionFormat)
-	ts := cloudStorageFormatTime(file.earliestTs)
+	// We use this monotonically increasing fileID to ensure correct ordering
+	// among files emitted at the same timestamp during the same job session.
 	fileID := s.fileID
 	s.fileID++
-	filename := fmt.Sprintf(`%s-%s-%d-%d-%d-%d%s`,
-		ts, key.Topic, key.SchemaID, s.nodeID, s.sinkID, fileID, s.ext)
-	if log.V(1) {
-		log.Info(ctx, "writing ", filename)
+	// Pad file ID to maintain lexical ordering among files from the same sink.
+	// Note that we use `-` here to delimit the filename because we want
+	// `%d.RESOLVED` files to lexicographically succeed data files that have the
+	// same timestamp. This works because ascii `-` < ascii '.'.
+	filename := fmt.Sprintf(`%s-%s-%d-%d-%08x-%s-%x%s`, s.dataFileTs,
+		s.jobSessionID, s.nodeID, s.sinkID, fileID, key.Topic, key.SchemaID, s.ext)
+	if s.prevFilename != "" && filename < s.prevFilename {
+		return errors.AssertionFailedf("error: detected a filename %s that lexically "+
+			"precedes a file emitted before: %s", filename, s.prevFilename)
 	}
-	return s.es.WriteFile(ctx, filepath.Join(part, filename), bytes.NewReader(file.buf.Bytes()))
+	s.prevFilename = filename
+	return s.es.WriteFile(ctx, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes()))
 }
 
 // Close implements the Sink interface.

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -15,8 +15,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -71,21 +73,22 @@ func TestCloudStorageSink(t *testing.T) {
 
 	t.Run(`golden`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
-
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		sinkDir := `golden`
-		s, err := makeCloudStorageSink(`nodelocal:///`+sinkDir, 1, unlimitedFileSize, settings, opts)
+		s, err := makeCloudStorageSink(`nodelocal:///`+sinkDir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s.Flush(ctx))
+
+		require.Equal(t, []string{
+			"v1\n",
+		}, slurpDir(t, sinkDir))
+
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(5)))
-
-		dataFile, err := ioutil.ReadFile(filepath.Join(
-			dir, sinkDir, `1970-01-01`, `197001010000000000000010000000000-t1-0-1-7-0.ndjson`))
-		require.NoError(t, err)
-		require.Equal(t, "v1\n", string(dataFile))
-
 		resolvedFile, err := ioutil.ReadFile(filepath.Join(
 			dir, sinkDir, `1970-01-01`, `197001010000000000000050000000000.RESOLVED`))
 		require.NoError(t, err)
@@ -95,8 +98,11 @@ func TestCloudStorageSink(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
 		t2 := &sqlbase.TableDescriptor{Name: `t2`}
 
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `single-node`
-		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
@@ -104,69 +110,84 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string(nil), slurpDir(t, dir))
 
-		// Emitting rows and flushing should write them out in one file per table.
+		// Emitting rows and flushing should write them out in one file per table. Note
+		// the ordering among these two files is non deterministic as either of them could
+		// be flushed first (and thus be assigned fileID 0).
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1)))
-		require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(1)))
+		require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3)))
 		require.NoError(t, s.Flush(ctx))
-		require.Equal(t, []string{
+		expected := []string{
 			"v1\nv2\n",
 			"w1\n",
-		}, slurpDir(t, dir))
+		}
+		actual := slurpDir(t, dir)
+		sort.Strings(actual)
+		require.Equal(t, expected, actual)
 
 		// Flushing with no new emits writes nothing new.
 		require.NoError(t, s.Flush(ctx))
-		require.Equal(t, []string{
-			"v1\nv2\n",
-			"w1\n",
-		}, slurpDir(t, dir))
+		actual = slurpDir(t, dir)
+		sort.Strings(actual)
+		require.Equal(t, expected, actual)
 
 		// Without a flush, nothing new shows up.
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3)))
-		require.Equal(t, []string{
-			"v1\nv2\n",
-			"w1\n",
-		}, slurpDir(t, dir))
+		actual = slurpDir(t, dir)
+		sort.Strings(actual)
+		require.Equal(t, expected, actual)
 
-		// Flush and now it does.
+		// Note that since we haven't forwarded `testSpan` yet, all files initiated until
+		// this point must have the same `frontier` timestamp. Since fileID increases
+		// monotonically, the last file emitted should be ordered as such.
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string{
-			"v1\nv2\n",
-			"w1\n",
 			"v3\n",
-		}, slurpDir(t, dir))
+		}, slurpDir(t, dir)[2:])
 
-		// Data from different versions of a table is put in different files, so
-		// that we can guarantee that all rows in any given file have the same
-		// schema.
+		// Data from different versions of a table is put in different files, so that we
+		// can guarantee that all rows in any given file have the same schema.
+		// We also advance `testSpan` and `Flush` to make sure these new rows are read
+		// after the rows emitted above.
+		require.True(t, sf.Forward(testSpan, ts(4)))
+		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4)))
 		t1.Version = 2
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5)))
 		require.NoError(t, s.Flush(ctx))
-		require.Equal(t, []string{
-			"v1\nv2\n",
-			"w1\n",
-			"v3\n",
+		expected = []string{
 			"v4\n",
 			"v5\n",
-		}, slurpDir(t, dir))
+		}
+		actual = slurpDir(t, dir)
+		actual = actual[len(actual)-2:]
+		sort.Strings(actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run(`multi-node`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
 
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `multi-node`
-		s1, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		s1, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
-		s2, err := makeCloudStorageSink(`nodelocal:///`+dir, 2, unlimitedFileSize, settings, opts)
+		s2, err := makeCloudStorageSink(`nodelocal:///`+dir, 2, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		// Hack into the sinks to pretend each is the first sink created on two
 		// different nodes, which is the worst case for them conflicting.
 		s1.(*cloudStorageSink).sinkID = 0
 		s2.(*cloudStorageSink).sinkID = 0
 
+		// Force deterministic job session IDs to force ordering of output files.
+		s1.(*cloudStorageSink).jobSessionID = "a"
+		s2.(*cloudStorageSink).jobSessionID = "b"
+
 		// Each node writes some data at the same timestamp. When this data is
-		// written out, the files have different names and don't conflict.
+		// written out, the files have different names and don't conflict because
+		// the sinks have different job session IDs.
 		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1)))
 		require.NoError(t, s1.Flush(ctx))
@@ -178,23 +199,27 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// If a node restarts then the entire distsql flow has to restart. If
 		// this happens before checkpointing, some data is written again but
-		// this is unavoidable. It may overwrite the old data if the sink id and
-		// file id line up just so, but it's much more likely that they don't.
-		// Either way is fine.
-		s1R, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		// this is unavoidable.
+		s1R, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
-		s2R, err := makeCloudStorageSink(`nodelocal:///`+dir, 2, unlimitedFileSize, settings, opts)
+		s2R, err := makeCloudStorageSink(`nodelocal:///`+dir, 2, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		// Nodes restart. s1 gets the same sink id it had last time but s2
 		// doesn't.
 		s1R.(*cloudStorageSink).sinkID = 0
 		s2R.(*cloudStorageSink).sinkID = 7
+
+		// Again, force deterministic job session IDs to force ordering of output
+		// files. Note that making s1R have the same job session ID as s1 should make
+		// its output overwrite s1's output.
+		s1R.(*cloudStorageSink).jobSessionID = "a"
+		s2R.(*cloudStorageSink).jobSessionID = "b"
 		// Each resends the data it did before.
 		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1)))
 		require.NoError(t, s1R.Flush(ctx))
 		require.NoError(t, s2R.Flush(ctx))
-		// The s1 data overwrites the old file, the s2 data ends up duplicated.
+		// s1 data ends up being overwritten, s2 data ends up duplicated.
 		require.Equal(t, []string{
 			"v1\n",
 			"w1\n",
@@ -211,14 +236,18 @@ func TestCloudStorageSink(t *testing.T) {
 	// changefeed using this sink. Ditto job restarts.
 	t.Run(`zombie`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
-
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `zombie`
-		s1, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		s1, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
-		s1.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
-		s2, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		s1.(*cloudStorageSink).sinkID = 7         // Force a deterministic sinkID.
+		s1.(*cloudStorageSink).jobSessionID = "a" // Force deterministic job session ID.
+		s2, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
-		s2.(*cloudStorageSink).sinkID = 8 // Force a deterministic sinkID.
+		s2.(*cloudStorageSink).sinkID = 8         // Force a deterministic sinkID.
+		s2.(*cloudStorageSink).jobSessionID = "b" // Force deterministic job session ID.
 
 		// Good job writes
 		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
@@ -235,17 +264,19 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, s1.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\nv2\n",
-			"v1\n",
 			"v3\n",
+			"v1\n",
 		}, slurpDir(t, dir))
 	})
 
 	t.Run(`bucketing`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
-
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `bucketing`
 		const targetMaxFileSize = 6
-		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, targetMaxFileSize, settings, opts)
+		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, targetMaxFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
@@ -265,6 +296,11 @@ func TestCloudStorageSink(t *testing.T) {
 			"v4\nv5\n",
 		}, slurpDir(t, dir))
 
+		// Forward the spanFrontier here and trigger an empty flush to update
+		// the sink's `inclusiveLowerBoundTs`
+		sf.Forward(testSpan, ts(5))
+		require.NoError(t, s.Flush(ctx))
+
 		// Some more data is written. Some of it flushed out because of the max
 		// file size.
 		for i := int64(6); i < 10; i++ {
@@ -282,7 +318,8 @@ func TestCloudStorageSink(t *testing.T) {
 		// guarantees that Flush been called (and returned without error) with a
 		// ts at >= this one before this call starts.
 		//
-		// The resolved timestamp file sorts after all data with that timestamp.
+		// The resolved timestamp file should precede the data files that were
+		// started after the spanFrontier was forwarded to ts(5).
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(5)))
 		require.Equal(t, []string{
 			"v1\nv2\nv3\n",
@@ -291,7 +328,10 @@ func TestCloudStorageSink(t *testing.T) {
 			"v6\nv7\nv8\n",
 		}, slurpDir(t, dir))
 
-		// Flush then writes the rest.
+		// Flush then writes the rest. Since we use the time of the EmitRow
+		// or EmitResolvedTimestamp calls to order files, the resolved timestamp
+		// file should precede the last couple files since they started buffering
+		// after the spanFrontier was forwarded to ts(5).
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\nv2\nv3\n",
@@ -300,13 +340,27 @@ func TestCloudStorageSink(t *testing.T) {
 			"v6\nv7\nv8\n",
 			"v9\n",
 		}, slurpDir(t, dir))
+
+		// A resolved timestamp emitted with ts > 5 should follow everything
+		// emitted thus far.
+		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(6)))
+		require.Equal(t, []string{
+			"v1\nv2\nv3\n",
+			"v4\nv5\n",
+			`{"resolved":"5.0000000000"}`,
+			"v6\nv7\nv8\n",
+			"v9\n",
+			`{"resolved":"6.0000000000"}`,
+		}, slurpDir(t, dir))
 	})
 
 	t.Run(`file-ordering`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
-
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `file-ordering`
-		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts)
+		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, unlimitedFileSize, settings, opts, timestampOracle)
 		require.NoError(t, err)
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
@@ -318,15 +372,33 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(1)))
 
 		// Test some edge cases.
+
+		// Forward the testSpan and trigger an empty `Flush` to have new rows
+		// be after the resolved timestamp emitted above.
+		require.True(t, sf.Forward(testSpan, ts(2)))
+		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), ts(2)))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), ts(3).Prev()))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), ts(3)))
+		require.True(t, sf.Forward(testSpan, ts(3)))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(3)))
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), ts(3).Next()))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(4)))
 
+		require.Equal(t, []string{
+			"is1\nis2\n",
+			`{"resolved":"1.0000000000"}`,
+			"e2\ne3prev\ne3\n",
+			`{"resolved":"3.0000000000"}`,
+			"e3next\n",
+			`{"resolved":"4.0000000000"}`,
+		}, slurpDir(t, dir))
+
+		// Test that files with timestamp lower than the least resolved timestamp
+		// as of file creation time are ignored.
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), ts(1).Next()))
 		require.Equal(t, []string{
 			"is1\nis2\n",
 			`{"resolved":"1.0000000000"}`,


### PR DESCRIPTION
Backport 1/1 commits from #40696.

/cc @cockroachdb/release

---

In cloudStorageSink, we currently name output files based on the earliest
timestamps inside those files. This can sometimes muddle the ordering
of output files, leading to a violation of CDC's ordering properties

This change fixes this violation by instead using the times of the 
last `EmitRow` and `EmitResolvedTimestamp` calls to order files. This ensures
that timestamps within the output files are consumed in the same order
that they're emitted in.

Fixes: #38368

Release justification: Fixes limitation of changefeeds when using cloud storage sinks.

Release note: None
