### PR TITLE
[wip] sql: add pushdown to virtual tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1378,10 +1378,12 @@ func showAlterStatementWithInterleave(
 
 			var tableName tree.TableName
 			if lCtx != nil {
-				tableName, err = lCtx.getTableAsTableName(table, contextName)
+				tableDbDesc, err := lCtx.getDatabaseByID(table.ParentID)
 				if err != nil {
 					return err
 				}
+				tableName = tree.MakeTableName(tree.Name(tableDbDesc.Name), tree.Name(table.Name))
+				tableName.ExplicitSchema = tableDbDesc.Name != contextName
 			} else {
 				tableName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as parent]", table.ID)))
 				tableName.ExplicitCatalog = false

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1136,6 +1136,7 @@ func MakeTableDesc(
 			if d.Interleave != nil {
 				return desc, unimplemented.NewWithIssue(9148, "use CREATE INDEX to make interleaved indexes")
 			}
+			fmt.Printf("%+v\n", idx)
 		case *tree.CheckConstraintTableDef, *tree.ForeignKeyConstraintTableDef, *tree.FamilyTableDef:
 			// pass, handled below.
 

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -47,7 +47,9 @@ func (f *stubFactory) ConstructScan(
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructVirtualScan(table cat.Table) (exec.Node, error) {
+func (f *stubFactory) ConstructVirtualScan(
+	table cat.Table, index cat.Index, indexConstraint *constraint.Constraint,
+) (exec.Node, error) {
 	return struct{}{}, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -509,7 +509,7 @@ func (b *Builder) buildVirtualScan(scan *memo.VirtualScanExpr) (execPlan, error)
 	_, output := b.getColumns(scan.Cols, scan.Table)
 	res := execPlan{outputCols: output}
 
-	root, err := b.factory.ConstructVirtualScan(tab)
+	root, err := b.factory.ConstructVirtualScan(tab, tab.Index(scan.Index), scan.Constraint)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -74,7 +74,7 @@ type Factory interface {
 	// ConstructVirtualScan returns a node that represents the scan of a virtual
 	// table. Virtual tables are system tables that are populated "on the fly"
 	// with rows synthesized from system metadata and other state.
-	ConstructVirtualScan(table cat.Table) (Node, error)
+	ConstructVirtualScan(table cat.Table, index cat.Index, indexConstraint *constraint.Constraint) (Node, error)
 
 	// ConstructFilter returns a node that applies a filter on the results of
 	// the given input node.

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -94,6 +94,15 @@ define VirtualScanPrivate {
     # cat.Table metadata.
     Table TableID
 
+    # Index identifies the index to scan (whether primary or secondary). It
+    # can be passed to the cat.Table.Index() method in order to fetch the
+    # cat.Index metadata.
+    Index IndexOrdinal
+
+    # If set, the virtual scan is constrained; the constraint contains the
+    # logical spans that need to be scanned.
+    Constraint Constraint
+
     # Cols specifies the set of columns that the VirtualScan operator projects.
     # This is always every column in the virtual table (i.e. never a subset even
     # if all columns are not needed).

--- a/pkg/sql/opt/xform/rules/scan.opt
+++ b/pkg/sql/opt/xform/rules/scan.opt
@@ -7,3 +7,8 @@
 # on the scanned table.
 [GenerateIndexScans, Explore]
 (Scan $scanPrivate:* & (IsCanonicalScan $scanPrivate)) => (GenerateIndexScans $scanPrivate)
+
+# GenerateVirtualTableIndexScans creates alternate VirtualScan expressions for
+# each virtual secondary index on the scanned virtual table.
+[GenerateVirtualTableIndexScans, Explore]
+(VirtualScan $scanPrivate:* & (IsCanonicalVirtualScan $scanPrivate)) => (GenerateVirtualTableIndexScans $scanPrivate)

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -18,6 +18,18 @@
 =>
 (GenerateConstrainedScans $scanPrivate $filters)
 
+# GenerateConstrainedVirtualScans generates a set of constrained VirtualScan expressions, one
+# for each matching index on the scanned table. The expressions consist of
+# either a standalone VirtualScan operator (if no remaining filter), or else a VirtualScan
+# wrapped by a Select (with a remaining filter).
+[GenerateConstrainedVirtualScans, Explore]
+(Select
+  (VirtualScan $virtualScanPrivate:* & (IsCanonicalVirtualScan $virtualScanPrivate))
+  $filters:*
+)
+=>
+(GenerateConstrainedVirtualScans $virtualScanPrivate $filters)
+
 # GenerateInvertedIndexScans creates alternate expressions for filters that can
 # be serviced by an inverted index.
 [GenerateInvertedIndexScans, Explore]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -510,3 +510,7 @@ offset
  │         ├── fd: (1)-->(2,4,5)
  │         └── ordering: -4
  └── const: 10 [type=int]
+
+optsteps
+SELECT * FROM pg_constraint WHERE conrelid = 5
+----

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -130,13 +130,17 @@ func (ef *execFactory) ConstructScan(
 }
 
 // ConstructVirtualScan is part of the exec.Factory interface.
-func (ef *execFactory) ConstructVirtualScan(table cat.Table) (exec.Node, error) {
-	tn := &table.(*optVirtualTable).name
+func (ef *execFactory) ConstructVirtualScan(
+	table cat.Table, index cat.Index, indexConstraint *constraint.Constraint,
+) (exec.Node, error) {
+	t := table.(*optVirtualTable)
+	tn := &t.name
+	indexDesc := index.(*optVirtualIndex).desc
 	virtual, err := ef.planner.getVirtualTabler().getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err
 	}
-	columns, constructor := virtual.getPlanInfo()
+	columns, constructor := virtual.getPlanInfo(indexDesc, indexConstraint)
 
 	return &delayedNode{
 		columns: columns,

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -669,20 +669,6 @@ func (l *internalLookupCtx) getParentAsTableName(
 	return parentName, nil
 }
 
-// getTableAsTableName returns a TableName object fot a given TableDescriptor.
-func (l *internalLookupCtx) getTableAsTableName(
-	table *sqlbase.TableDescriptor, dbPrefix string,
-) (tree.TableName, error) {
-	var tableName tree.TableName
-	tableDbDesc, err := l.getDatabaseByID(table.ParentID)
-	if err != nil {
-		return tree.TableName{}, err
-	}
-	tableName = tree.MakeTableName(tree.Name(tableDbDesc.Name), tree.Name(table.Name))
-	tableName.ExplicitSchema = tableDbDesc.Name != dbPrefix
-	return tableName, nil
-}
-
 // The versions below are part of the work for #34240.
 // TODO(radu): clean these up when everything is switched over.
 
@@ -735,4 +721,9 @@ func (p *planner) ResolveExistingObjectEx(
 // ResolvedName is a convenience wrapper for UnresolvedObjectName.Resolved.
 func (p *planner) ResolvedName(u *tree.UnresolvedObjectName) *tree.TableName {
 	return u.Resolved(&p.semaCtx.Annotations)
+}
+
+type simpleSchemaResolver interface {
+	getDatabaseByID(id sqlbase.ID) (*DatabaseDescriptor, error)
+	getTableByID(id sqlbase.ID) (*TableDescriptor, error)
 }

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -68,7 +68,7 @@ func ShowCreateTable(
 		}
 		f.WriteString("\n\t")
 		f.WriteString(col.SQLString())
-		if desc.IsPhysicalTable() && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
+		if desc.PrimaryIndex.ColumnIDs[0] == col.ID {
 			// Only set primaryKeyIsOnVisibleColumn to true if the primary key
 			// is on a visible column (not rowid).
 			primaryKeyIsOnVisibleColumn = true

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -49,7 +49,7 @@ func showForeignKeyConstraint(
 	dbPrefix string,
 	originTable *sqlbase.TableDescriptor,
 	fk *sqlbase.ForeignKeyConstraint,
-	lCtx *internalLookupCtx,
+	lCtx simpleSchemaResolver,
 ) error {
 	var refNames []string
 	var originNames []string

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1083,11 +1083,11 @@ func (desc *MutableTableDescriptor) AllocateIDs() error {
 		}
 	}
 
-	// Only physical tables can have / need indexes and column families.
+	if err := desc.allocateIndexIDs(columnNames); err != nil {
+		return err
+	}
+	// Only physical tables can have / need column families.
 	if desc.IsPhysicalTable() {
-		if err := desc.allocateIndexIDs(columnNames); err != nil {
-			return err
-		}
 		desc.allocateColumnFamilyIDs(columnNames)
 	}
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1047,7 +1047,6 @@ func (desc *TableDescriptor) maybeUpgradeToFamilyFormatVersion() bool {
 // AllocateIDs allocates column, family, and index ids for any column, family,
 // or index which has an ID of 0.
 func (desc *MutableTableDescriptor) AllocateIDs() error {
-	// Only physical tables can have / need a primary key.
 	if desc.IsPhysicalTable() {
 		if err := desc.ensurePrimaryKey(); err != nil {
 			return err

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -32,7 +32,7 @@ type virtualTableNode struct {
 	currentRow tree.Datums
 }
 
-func (p *planner) newContainerVirtualTableNode(
+func (p *planner) newVirtualTableNode(
 	columns sqlbase.ResultColumns, capacity int, next virtualTableGenerator,
 ) *virtualTableNode {
 	return &virtualTableNode{
@@ -59,4 +59,10 @@ func (n *virtualTableNode) Values() tree.Datums {
 }
 
 func (n *virtualTableNode) Close(ctx context.Context) {
+}
+
+type containerVirtualTableNode struct {
+	columns    sqlbase.ResultColumns
+	next       virtualTableGenerator
+	currentRow tree.Datums
 }


### PR DESCRIPTION
This commit adds the capability to push filters down into virtual
tables, by exposing "indexes" on virtual tables that are implemented by
populate functions that take exact constraints on the index's prefix.

It also has an example of what you'd have to do per-table on the execution 
side, in the pg_constraint table.

This is a work in progress, I'm looking for feedback. It adds a prototype of the execution capabilities, as well as some infrastructure within the optimizer, but it's missing the exploration rule that turns filters into constraints.

The reason I stopped working on it here was that I was about to introduce a whole bunch of code duplication for that exploration rule, and I've already introduced a decent chunk, so I wanted to step back and ask for feedback. Do you think we should try to unify some things between VirtualScanExpr and ScanExpr? I wasn't exactly sure how to do it, but I think we could probably get pretty far by having the virtual tables and indexes pretend to be ordinary tables and indexes in most respects.