### PR TITLE
sql: implement fast path for insert

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -153,8 +153,14 @@ var zigzagJoinClusterMode = settings.RegisterBoolSetting(
 
 var optDrivenFKClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_optimizer_foreign_keys.enabled",
-	"enables optimizer-driven foreign key checks by default",
+	"default value for experimental_optimizer_foreign_keys session setting; enables optimizer-driven foreign key checks by default",
 	false,
+)
+
+var insertFastPathClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.insert_fast_path.enabled",
+	"default value for enable_insert_fast_path session setting; enables a specialized insert path",
+	true,
 )
 
 // VectorizeClusterMode controls the cluster default for when automatic
@@ -1831,6 +1837,10 @@ func (m *sessionDataMutator) SetVectorizeRowCountThreshold(val uint64) {
 
 func (m *sessionDataMutator) SetOptimizerFKs(val bool) {
 	m.data.OptimizerFKs = val
+}
+
+func (m *sessionDataMutator) SetInsertFastPath(val bool) {
+	m.data.InsertFastPath = val
 }
 
 func (m *sessionDataMutator) SetSerialNormalizationMode(val sessiondata.SerialNormalizationMode) {

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -1,0 +1,336 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
+)
+
+var insertFastPathNodePool = sync.Pool{
+	New: func() interface{} {
+		return &insertFastPathNode{}
+	},
+}
+
+// Check that exec.InsertFastPathMaxRows does not exceed maxInsertBatchSize
+// (this is a compile error if the value is negative).
+const _ uint = maxInsertBatchSize - exec.InsertFastPathMaxRows
+
+// insertFastPathNode is a faster implementation of inserting values in a table
+// and performing FK checks. It is used when all the foreign key checks can be
+// performed via a direct lookup in an index, and when the input is VALUES of
+// limited size (at most exec.InsertFastPathMaxRows).
+type insertFastPathNode struct {
+	// input values, similar to a valuesNode.
+	input [][]tree.TypedExpr
+
+	// columns is set if this INSERT is returning any rows, to be
+	// consumed by a renderNode upstream. This occurs when there is a
+	// RETURNING clause with some scalar expressions.
+	columns sqlbase.ResultColumns
+
+	run insertFastPathRun
+}
+
+type insertFastPathRun struct {
+	insertRun
+
+	fkChecks []insertFastPathFKCheck
+
+	numInputCols int
+
+	// inputBuf stores the evaluation result of the input rows, linearized into a
+	// single slice; see inputRow(). Unfortunately we can't do everything one row
+	// at a time, because we need the datums for generating error messages in case
+	// an FK check fails.
+	inputBuf tree.Datums
+
+	// fkBatch accumulates the FK existence checks.
+	fkBatch roachpb.BatchRequest
+	// fkSpanInfo keeps track of information for each fkBatch.Request entry.
+	fkSpanInfo []insertFastPathFKSpanInfo
+
+	// fkSpanMap is used to de-duplicate FK existence checks. Only used if there
+	// is more than one input row.
+	fkSpanMap map[string]struct{}
+}
+
+// insertFastPathFKSpanInfo records information about each Request in the
+// fkBatch, associating it with a specific check and row index.
+type insertFastPathFKSpanInfo struct {
+	check  *insertFastPathFKCheck
+	rowIdx int
+}
+
+// insertFastPathFKCheck extends exec.InsertFastPathFKCheck with metadata that
+// is computed once and can be reused across rows.
+type insertFastPathFKCheck struct {
+	exec.InsertFastPathFKCheck
+
+	tabDesc   *sqlbase.ImmutableTableDescriptor
+	idxDesc   *sqlbase.IndexDescriptor
+	keyPrefix []byte
+	colMap    map[sqlbase.ColumnID]int
+}
+
+func (c *insertFastPathFKCheck) init() error {
+	c.tabDesc = c.ReferencedTable.(*optTable).desc
+	c.idxDesc = c.ReferencedIndex.(*optIndex).desc
+	c.keyPrefix = sqlbase.MakeIndexKeyPrefix(&c.tabDesc.TableDescriptor, c.idxDesc.ID)
+
+	if len(c.InsertCols) > len(c.idxDesc.ColumnIDs) {
+		return errors.AssertionFailedf(
+			"%d FK cols, only %d cols in index",
+			len(c.InsertCols), len(c.idxDesc.ColumnIDs),
+		)
+	}
+	c.colMap = make(map[sqlbase.ColumnID]int, len(c.InsertCols))
+	for i, ord := range c.InsertCols {
+		colID := c.idxDesc.ColumnIDs[i]
+		c.colMap[colID] = int(ord)
+	}
+	return nil
+}
+
+// generateSpan returns the span that we need to look up to confirm existence of
+// the referenced row.
+func (c *insertFastPathFKCheck) generateSpan(inputRow tree.Datums) (roachpb.Span, error) {
+	return row.FKCheckSpan(
+		&c.tabDesc.TableDescriptor, c.idxDesc, len(c.InsertCols), c.colMap, inputRow, c.keyPrefix,
+	)
+}
+
+// errorForRow returns an error indicating failure of this FK check for the
+// given row.
+func (c *insertFastPathFKCheck) errorForRow(inputRow tree.Datums) error {
+	values := make(tree.Datums, len(c.InsertCols))
+	for i, ord := range c.InsertCols {
+		values[i] = inputRow[ord]
+	}
+	return c.MkErr(values)
+}
+
+func (r *insertFastPathRun) inputRow(rowIdx int) tree.Datums {
+	start := rowIdx * r.numInputCols
+	end := start + r.numInputCols
+	return r.inputBuf[start:end:end]
+}
+
+// addFKChecks adds Requests to fkBatch and entries in fkSpanInfo / fkSpanMap as
+// needed for checking foreign keys for the given row.
+func (r *insertFastPathRun) addFKChecks(
+	ctx context.Context, rowIdx int, inputRow tree.Datums,
+) error {
+	for i := range r.fkChecks {
+		c := &r.fkChecks[i]
+
+		// See if we have any nulls.
+		numNulls := 0
+		for _, ord := range c.InsertCols {
+			if inputRow[ord] == tree.DNull {
+				numNulls++
+			}
+		}
+		if numNulls > 0 {
+			if c.MatchMethod == tree.MatchFull && numNulls != len(c.InsertCols) {
+				return c.errorForRow(inputRow)
+			}
+			// We have a row with only NULLS, or a row with some NULLs and match
+			// method PARTIAL. We can ignore this row.
+			return nil
+		}
+
+		span, err := c.generateSpan(inputRow)
+		if err != nil {
+			return err
+		}
+		if r.fkSpanMap != nil {
+			_, exists := r.fkSpanMap[string(span.Key)]
+			if exists {
+				// Duplicate span.
+				continue
+			}
+			r.fkSpanMap[string(span.Key)] = struct{}{}
+		}
+		if r.traceKV {
+			log.VEventf(ctx, 2, "FKScan %s", span)
+		}
+		reqIdx := len(r.fkBatch.Requests)
+		r.fkBatch.Requests = append(r.fkBatch.Requests, roachpb.RequestUnion{})
+		r.fkBatch.Requests[reqIdx].MustSetInner(&roachpb.ScanRequest{
+			RequestHeader: roachpb.RequestHeaderFromSpan(span),
+		})
+		r.fkSpanInfo = append(r.fkSpanInfo, insertFastPathFKSpanInfo{
+			check:  c,
+			rowIdx: rowIdx,
+		})
+	}
+	return nil
+}
+
+// runFKChecks runs the fkBatch and checks that all spans return at least one
+// key.
+func (n *insertFastPathNode) runFKChecks(params runParams) error {
+	if len(n.run.fkBatch.Requests) == 0 {
+		return nil
+	}
+	defer n.run.fkBatch.Reset()
+
+	// Run the FK checks batch.
+	br, err := params.p.txn.Send(params.ctx, n.run.fkBatch)
+	if err != nil {
+		return err.GoError()
+	}
+
+	for i := range br.Responses {
+		resp := br.Responses[i].GetInner().(*roachpb.ScanResponse)
+		if len(resp.Rows) == 0 {
+			// No results for lookup; generate the violation error.
+			info := n.run.fkSpanInfo[i]
+			return info.check.errorForRow(n.run.inputRow(info.rowIdx))
+		}
+	}
+
+	return nil
+}
+
+func (n *insertFastPathNode) startExec(params runParams) error {
+	if err := params.p.maybeSetSystemConfig(n.run.ti.tableDesc().GetID()); err != nil {
+		return err
+	}
+
+	// Cache traceKV during execution, to avoid re-evaluating it for every row.
+	n.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
+
+	n.run.initRowContainer(params, n.columns, 0 /* rowCapacity */)
+
+	n.run.numInputCols = len(n.input[0])
+	n.run.inputBuf = make(tree.Datums, len(n.input)*n.run.numInputCols)
+
+	if len(n.input) > 1 {
+		n.run.fkSpanMap = make(map[string]struct{})
+	}
+
+	if len(n.run.fkChecks) > 0 {
+		for i := range n.run.fkChecks {
+			if err := n.run.fkChecks[i].init(); err != nil {
+				return err
+			}
+		}
+		maxSpans := len(n.run.fkChecks) * len(n.input)
+		n.run.fkBatch.Requests = make([]roachpb.RequestUnion, 0, maxSpans)
+		n.run.fkSpanInfo = make([]insertFastPathFKSpanInfo, 0, maxSpans)
+		if len(n.input) > 1 {
+			n.run.fkSpanMap = make(map[string]struct{}, maxSpans)
+		}
+	}
+
+	return n.run.ti.init(params.p.txn, params.EvalContext())
+}
+
+// Next is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (n *insertFastPathNode) Next(params runParams) (bool, error) { panic("not valid") }
+
+// Values is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (n *insertFastPathNode) Values() tree.Datums { panic("not valid") }
+
+// BatchedNext implements the batchedPlanNode interface.
+func (n *insertFastPathNode) BatchedNext(params runParams) (bool, error) {
+	if n.run.done {
+		return false, nil
+	}
+
+	tracing.AnnotateTrace()
+
+	// The fast path node does everything in one batch.
+
+	for rowIdx, tupleRow := range n.input {
+		if err := params.p.cancelChecker.Check(); err != nil {
+			return false, err
+		}
+		inputRow := n.run.inputRow(rowIdx)
+		for col, typedExpr := range tupleRow {
+			var err error
+			inputRow[col], err = typedExpr.Eval(params.EvalContext())
+			if err != nil {
+				return false, err
+			}
+		}
+		// Process the insertion for the current source row, potentially
+		// accumulating the result row for later.
+		if err := n.run.processSourceRow(params, inputRow); err != nil {
+			return false, err
+		}
+
+		// Add FK existence checks.
+		if len(n.run.fkChecks) > 0 {
+			if err := n.run.addFKChecks(params.ctx, rowIdx, inputRow); err != nil {
+				return false, err
+			}
+		}
+	}
+
+	// Perform the FK checks.
+	// TODO(radu): we could run the FK batch in parallel with the main batch (if
+	// we aren't auto-committing).
+	if err := n.runFKChecks(params); err != nil {
+		return false, err
+	}
+
+	if err := n.run.ti.atBatchEnd(params.ctx, n.run.traceKV); err != nil {
+		return false, err
+	}
+
+	if _, err := n.run.ti.finalize(params.ctx, n.run.traceKV); err != nil {
+		return false, err
+	}
+	// Remember we're done for the next call to BatchedNext().
+	n.run.done = true
+
+	// Possibly initiate a run of CREATE STATISTICS.
+	params.ExecCfg().StatsRefresher.NotifyMutation(n.run.ti.tableDesc().ID, len(n.input))
+
+	return true, nil
+}
+
+// BatchedCount implements the batchedPlanNode interface.
+func (n *insertFastPathNode) BatchedCount() int { return len(n.input) }
+
+// BatchedCount implements the batchedPlanNode interface.
+func (n *insertFastPathNode) BatchedValues(rowIdx int) tree.Datums { return n.run.rows.At(rowIdx) }
+
+func (n *insertFastPathNode) Close(ctx context.Context) {
+	n.run.ti.close(ctx)
+	if n.run.rows != nil {
+		n.run.rows.Close(ctx)
+	}
+	*n = insertFastPathNode{}
+	insertFastPathNodePool.Put(n)
+}
+
+// See planner.autoCommit.
+func (n *insertFastPathNode) enableAutoCommit() {
+	n.run.ti.enableAutoCommit()
+}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -382,7 +382,7 @@ type testClusterConfig struct {
 	name                string
 	numNodes            int
 	useFakeSpanResolver bool
-	// if non-empty, overrides the default optimizer mode.
+	// if non-empty, overrides the default distsql mode.
 	overrideDistSQLMode string
 	// if non-empty, overrides the default vectorize mode.
 	overrideVectorize string
@@ -1690,6 +1690,7 @@ func (t *logicTest) processSubtest(
 			if rows.Next() {
 				return errors.Errorf("%s: more than one row returned by query  %s", stmt.pos, stmt.sql)
 			}
+			t.t().Logf("let %s = %s\n", varName, val)
 			t.varMap[varName] = val
 
 		case "halt", "hash-threshold":

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -5,6 +5,14 @@
 statement ok
 SET experimental_optimizer_foreign_keys = true
 
+# Randomize the use of insert fast path.
+# The let statement will also log the value.
+let $enable_insert_fast_path
+SELECT random() < 0.5
+
+statement ok
+SET enable_insert_fast_path = $enable_insert_fast_path
+
 # Insert
 # ------
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1562,6 +1562,7 @@ default_tablespace                   ·                   NULL      NULL        
 default_transaction_isolation        serializable        NULL      NULL        NULL        string
 default_transaction_read_only        off                 NULL      NULL        NULL        string
 distsql                              off                 NULL      NULL        NULL        string
+enable_insert_fast_path              on                  NULL      NULL        NULL        string
 enable_zigzag_join                   on                  NULL      NULL        NULL        string
 experimental_enable_temp_tables      off                 NULL      NULL        NULL        string
 experimental_force_split_at          off                 NULL      NULL        NULL        string
@@ -1618,6 +1619,7 @@ default_tablespace                   ·                   NULL  user     NULL   
 default_transaction_isolation        serializable        NULL  user     NULL      default             default
 default_transaction_read_only        off                 NULL  user     NULL      off                 off
 distsql                              off                 NULL  user     NULL      off                 off
+enable_insert_fast_path              on                  NULL  user     NULL      on                  on
 enable_zigzag_join                   on                  NULL  user     NULL      on                  on
 experimental_enable_temp_tables      off                 NULL  user     NULL      off                 off
 experimental_force_split_at          off                 NULL  user     NULL      off                 off
@@ -1670,6 +1672,7 @@ default_tablespace                   NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation        NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only        NULL    NULL     NULL     NULL        NULL
 distsql                              NULL    NULL     NULL     NULL        NULL
+enable_insert_fast_path              NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                   NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables      NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -37,6 +37,7 @@ default_tablespace                   ·
 default_transaction_isolation        serializable
 default_transaction_read_only        off
 distsql                              off
+enable_insert_fast_path              on
 enable_zigzag_join                   on
 experimental_enable_temp_tables      off
 experimental_force_split_at          off

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -239,6 +239,17 @@ func (f *stubFactory) ConstructInsert(
 	return struct{}{}, nil
 }
 
+func (f *stubFactory) ConstructInsertFastPath(
+	rows [][]tree.TypedExpr,
+	table cat.Table,
+	insertCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
+	checkCols exec.CheckOrdinalSet,
+	fkChecks []exec.InsertFastPathFKCheck,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
 func (f *stubFactory) ConstructUpdate(
 	input exec.Node,
 	table cat.Table,

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -118,9 +118,9 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 		// The auto commit flag should reflect what would happen if this statement
 		// was run without the explain, so recalculate it.
 		defer func(oldVal bool) {
-			b.autoCommit = oldVal
-		}(b.autoCommit)
-		b.autoCommit = b.canAutoCommit(explain.Input)
+			b.allowAutoCommit = oldVal
+		}(b.allowAutoCommit)
+		b.allowAutoCommit = b.canAutoCommit(explain.Input)
 
 		input, err := b.buildRelational(explain.Input)
 		if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -397,20 +397,19 @@ CREATE TABLE t (
 query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-·                 distributed  false
-·                 vectorized   false
-count             ·            ·
- └── insert       ·            ·
-      │           into         t(k, v)
-      │           strategy     inserter
-      │           auto commit  ·
-      └── values  ·            ·
-·                 size         2 columns, 1 row
+·                      distributed  false
+·                      vectorized   false
+count                  ·            ·
+ └── insert-fast-path  ·            ·
+·                      into         t(k, v)
+·                      strategy     inserter
+·                      auto commit  ·
+·                      size         2 columns, 1 row
 
 query I
 SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
 ----
-2
+1
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -546,18 +545,17 @@ sort             ·            ·           (a, b)              +b
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-tree              field          description       columns                     ordering
-·                 distributed    false             ·                           ·
-·                 vectorized     false             ·                           ·
-count             ·              ·                 ()                          ·
- └── insert       ·              ·                 ()                          ·
-      │           into           t(k, v)           ·                           ·
-      │           strategy       inserter          ·                           ·
-      │           auto commit    ·                 ·                           ·
-      └── values  ·              ·                 (column1 int, column2 int)  ·
-·                 size           2 columns, 1 row  ·                           ·
-·                 row 0, expr 0  (1)[int]          ·                           ·
-·                 row 0, expr 1  (2)[int]          ·                           ·
+tree                   field          description       columns  ordering
+·                      distributed    false             ·        ·
+·                      vectorized     false             ·        ·
+count                  ·              ·                 ()       ·
+ └── insert-fast-path  ·              ·                 ()       ·
+·                      into           t(k, v)           ·        ·
+·                      strategy       inserter          ·        ·
+·                      auto commit    ·                 ·        ·
+·                      size           2 columns, 1 row  ·        ·
+·                      row 0, expr 0  (1)[int]          ·        ·
+·                      row 0, expr 1  (2)[int]          ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT 42 AS a

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -3,6 +3,10 @@
 statement ok
 SET experimental_optimizer_foreign_keys = true
 
+# We will test the fast path later.
+statement ok
+SET enable_insert_fast_path = false
+
 # -- Tests with INSERT --
 
 statement ok
@@ -742,3 +746,69 @@ root                                                      ·                   �
                           └── scan                        ·                   ·
 ·                                                         table               self@self_auto_index_fk_y_ref_self
 ·                                                         spans               ALL
+
+# Tests for the insert fast path.
+statement ok
+SET enable_insert_fast_path = true
+
+# Simple insert with VALUES should use the fast path.
+query TTTTT
+EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
+----
+·                      distributed    false              ·   ·
+·                      vectorized     false              ·   ·
+count                  ·              ·                  ()  ·
+ └── insert-fast-path  ·              ·                  ()  ·
+·                      into           child(c, p)        ·   ·
+·                      strategy       inserter           ·   ·
+·                      auto commit    ·                  ·   ·
+·                      FK check       parent@primary     ·   ·
+·                      size           2 columns, 2 rows  ·   ·
+·                      row 0, expr 0  1                  ·   ·
+·                      row 0, expr 1  1                  ·   ·
+·                      row 1, expr 0  2                  ·   ·
+·                      row 1, expr 1  2                  ·   ·
+
+# We shouldn't use the fast path if the VALUES columns are not in order.
+query B 
+SELECT count(*) > 0 FROM [
+  EXPLAIN INSERT INTO child (SELECT b, a FROM (VALUES (1,2)) AS v(a,b))
+] WHERE tree LIKE '%insert-fast-path'
+----
+false
+
+# Multiple mutations shouldn't use the fast-path.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING p)
+  INSERT INTO parent VALUES (2, 3)
+] WHERE tree LIKE '%insert-fast-path'
+----
+false
+
+# Self-referencing FKs should not use the fast-path.
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN INSERT INTO self VALUES (1, 1)
+] WHERE tree LIKE '%insert-fast-path'
+----
+false
+
+# We should not use the fast path If the best FK check plan is not a lookup
+# join. We do this by adding statistics that make a hash join more desirable.
+statement ok
+ALTER TABLE parent INJECT STATISTICS '[
+  {
+    "columns": ["p"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+query B
+SELECT count(*) > 0 FROM [
+  EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2), (3,3), (4,4)
+] WHERE tree LIKE '%insert-fast-path'
+----
+false

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -462,19 +462,18 @@ BEGIN; ALTER TABLE mutation DROP COLUMN y
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
-·                      distributed    false                  ·                            ·
-·                      vectorized     false                  ·                            ·
-render                 ·              ·                      (x)                          ·
- │                     render 0       x                      ·                            ·
- └── run               ·              ·                      (x, rowid[hidden])           ·
-      └── insert       ·              ·                      (x, rowid[hidden])           ·
-           │           into           mutation(x, rowid, y)  ·                            ·
-           │           strategy       inserter               ·                            ·
-           └── values  ·              ·                      (column1, column5, column6)  ·
-·                      size           3 columns, 1 row       ·                            ·
-·                      row 0, expr 0  2                      ·                            ·
-·                      row 0, expr 1  unique_rowid()         ·                            ·
-·                      row 0, expr 2  10                     ·                            ·
+·                           distributed    false                  ·                   ·
+·                           vectorized     false                  ·                   ·
+render                      ·              ·                      (x)                 ·
+ │                          render 0       x                      ·                   ·
+ └── run                    ·              ·                      (x, rowid[hidden])  ·
+      └── insert-fast-path  ·              ·                      (x, rowid[hidden])  ·
+·                           into           mutation(x, rowid, y)  ·                   ·
+·                           strategy       inserter               ·                   ·
+·                           size           3 columns, 1 row       ·                   ·
+·                           row 0, expr 0  2                      ·                   ·
+·                           row 0, expr 1  unique_rowid()         ·                   ·
+·                           row 0, expr 2  10                     ·                   ·
 
 statement ok
 ROLLBACK
@@ -486,17 +485,16 @@ BEGIN; ALTER TABLE mutation ADD COLUMN z INT AS (x + y) STORED
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
-·                 distributed    false                  ·                            ·
-·                 vectorized     false                  ·                            ·
-count             ·              ·                      ()                           ·
- └── insert       ·              ·                      ()                           ·
-      │           into           mutation(x, y, rowid)  ·                            ·
-      │           strategy       inserter               ·                            ·
-      └── values  ·              ·                      (column1, column2, column7)  ·
-·                 size           3 columns, 1 row       ·                            ·
-·                 row 0, expr 0  2                      ·                            ·
-·                 row 0, expr 1  2                      ·                            ·
-·                 row 0, expr 2  unique_rowid()         ·                            ·
+·                      distributed    false                  ·   ·
+·                      vectorized     false                  ·   ·
+count                  ·              ·                      ()  ·
+ └── insert-fast-path  ·              ·                      ()  ·
+·                      into           mutation(x, y, rowid)  ·   ·
+·                      strategy       inserter               ·   ·
+·                      size           3 columns, 1 row       ·   ·
+·                      row 0, expr 0  2                      ·   ·
+·                      row 0, expr 1  2                      ·   ·
+·                      row 0, expr 2  unique_rowid()         ·   ·
 
 statement ok
 ROLLBACK

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -567,20 +567,19 @@ ordinality        ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-·                      distributed    false               ·                ·
-·                      vectorized     false               ·                ·
-render                 ·              ·                   (b)              ·
- │                     render 0       b                   ·                ·
- └── run               ·              ·                   (a, b)           ·
-      └── insert       ·              ·                   (a, b)           ·
-           │           into           t(a, b, c)          ·                ·
-           │           strategy       inserter            ·                ·
-           │           auto commit    ·                   ·                ·
-           └── values  ·              ·                   (x, y, column6)  ·
-·                      size           3 columns, 1 row    ·                ·
-·                      row 0, expr 0  1                   ·                ·
-·                      row 0, expr 1  2                   ·                ·
-·                      row 0, expr 2  CAST(NULL AS BOOL)  ·                ·
+·                           distributed    false               ·       ·
+·                           vectorized     false               ·       ·
+render                      ·              ·                   (b)     ·
+ │                          render 0       b                   ·       ·
+ └── run                    ·              ·                   (a, b)  ·
+      └── insert-fast-path  ·              ·                   (a, b)  ·
+·                           into           t(a, b, c)          ·       ·
+·                           strategy       inserter            ·       ·
+·                           auto commit    ·                   ·       ·
+·                           size           3 columns, 1 row    ·       ·
+·                           row 0, expr 0  1                   ·       ·
+·                           row 0, expr 1  2                   ·       ·
+·                           row 0, expr 2  CAST(NULL AS BOOL)  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -138,6 +138,7 @@ type Memo struct {
 	optimizerFKs      bool
 	safeUpdates       bool
 	saveTablesPrefix  string
+	insertFastPath    bool
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
@@ -170,6 +171,7 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.optimizerFKs = evalCtx.SessionData.OptimizerFKs
 	m.safeUpdates = evalCtx.SessionData.SafeUpdates
 	m.saveTablesPrefix = evalCtx.SessionData.SaveTablesPrefix
+	m.insertFastPath = evalCtx.SessionData.InsertFastPath
 
 	m.curID = 0
 	m.curWithID = 0
@@ -277,7 +279,8 @@ func (m *Memo) IsStale(
 		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled ||
 		m.optimizerFKs != evalCtx.SessionData.OptimizerFKs ||
 		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
-		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix {
+		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix ||
+		m.insertFastPath != evalCtx.SessionData.InsertFastPath {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -190,6 +190,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData.ZigzagJoinEnabled = true
 	ot.evalCtx.SessionData.OptimizerFKs = true
 	ot.evalCtx.SessionData.ReorderJoinsLimit = opt.DefaultJoinOrderLimit
+	ot.evalCtx.SessionData.InsertFastPath = true
 
 	return ot
 }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -163,6 +163,7 @@ var _ planNode = &groupNode{}
 var _ planNode = &hookFnNode{}
 var _ planNode = &indexJoinNode{}
 var _ planNode = &insertNode{}
+var _ planNode = &insertFastPathNode{}
 var _ planNode = &joinNode{}
 var _ planNode = &limitNode{}
 var _ planNode = &max1RowNode{}

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -75,6 +75,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *insertNode:
 		return n.columns
+	case *insertFastPathNode:
+		return n.columns
 	case *upsertNode:
 		return n.columns
 	case *indexJoinNode:

--- a/pkg/sql/plan_ordering.go
+++ b/pkg/sql/plan_ordering.go
@@ -60,7 +60,7 @@ func planReqOrdering(plan planNode) ReqOrdering {
 		return n.reqOrdering
 	case *unionNode:
 		// TODO(knz): this can be ordered if the source is ordered already.
-	case *insertNode:
+	case *insertNode, *insertFastPathNode:
 		// TODO(knz): RETURNING is ordered by the PK.
 	case *updateNode, *upsertNode:
 		// After an update, the original order may have been destroyed.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -96,6 +96,9 @@ type SessionData struct {
 	SaveTablesPrefix string
 	// TempTablesEnabled indicates whether temporary tables can be created or not.
 	TempTablesEnabled bool
+	// InsertFastPath is true if the fast path for insert (with VALUES input) may
+	// be used.
+	InsertFastPath bool
 }
 
 // DataConversionConfig contains the parameters that influence

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -464,6 +464,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`enable_insert_fast_path`: {
+		GetStringVal: makeBoolGetStringValFn(`enable_insert_fast_path`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetInsertFastPath(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.InsertFastPath)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(insertFastPathClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_serial_normalization`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.SerialNormalizationModeFromString(s)

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -150,29 +150,15 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	switch n := plan.(type) {
 	case *valuesNode:
 		if v.observer.attr != nil {
-			suffix := "not yet populated"
+			numRows := len(n.tuples)
 			if n.rows != nil {
-				suffix = fmt.Sprintf("%d row%s",
-					n.rows.Len(), util.Pluralize(int64(n.rows.Len())))
-			} else if n.tuples != nil {
-				suffix = fmt.Sprintf("%d row%s",
-					len(n.tuples), util.Pluralize(int64(len(n.tuples))))
+				numRows = n.rows.Len()
 			}
-			description := fmt.Sprintf("%d column%s, %s",
-				len(n.columns), util.Pluralize(int64(len(n.columns))), suffix)
-			v.observer.attr(name, "size", description)
+			v.observer.attr(name, "size", formatValuesSize(numRows, len(n.columns)))
 		}
 
 		if v.observer.expr != nil {
-			for i, tuple := range n.tuples {
-				for j, expr := range tuple {
-					var fieldName string
-					if v.observer.attr != nil {
-						fieldName = fmt.Sprintf("row %d, expr", i)
-					}
-					v.metadataExpr(name, fieldName, j, expr)
-				}
-			}
+			v.metadataTuples(name, n.tuples)
 		}
 
 	case *scanNode:
@@ -456,26 +442,54 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *relocateNode:
 		n.rows = v.visit(n.rows)
 
-	case *insertNode:
+	case *insertNode, *insertFastPathNode:
+		var run *insertRun
+		if ins, ok := n.(*insertNode); ok {
+			run = &ins.run
+		} else {
+			run = &n.(*insertFastPathNode).run.insertRun
+		}
+
 		if v.observer.attr != nil {
 			var buf bytes.Buffer
-			buf.WriteString(n.run.ti.tableDesc().Name)
+			buf.WriteString(run.ti.tableDesc().Name)
 			buf.WriteByte('(')
-			for i := range n.run.insertCols {
+			for i := range run.insertCols {
 				if i > 0 {
 					buf.WriteString(", ")
 				}
-				buf.WriteString(n.run.insertCols[i].Name)
+				buf.WriteString(run.insertCols[i].Name)
 			}
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
-			v.observer.attr(name, "strategy", n.run.ti.desc())
-			if n.run.ti.autoCommit == autoCommitEnabled {
+			v.observer.attr(name, "strategy", run.ti.desc())
+			if run.ti.autoCommit == autoCommitEnabled {
 				v.observer.attr(name, "auto commit", "")
 			}
 		}
 
-		n.source = v.visit(n.source)
+		if ins, ok := n.(*insertNode); ok {
+			ins.source = v.visit(ins.source)
+		} else {
+			ins := n.(*insertFastPathNode)
+			if v.observer.attr != nil {
+				for i := range ins.run.fkChecks {
+					c := &ins.run.fkChecks[i]
+					tabDesc := c.ReferencedTable.(*optTable).desc
+					idxDesc := c.ReferencedIndex.(*optIndex).desc
+					v.observer.attr(name, "FK check", fmt.Sprintf("%s@%s", tabDesc.Name, idxDesc.Name))
+				}
+			}
+			if len(ins.input) != 0 {
+				if v.observer.attr != nil {
+					v.observer.attr(name, "size", formatValuesSize(len(ins.input), len(ins.input[0])))
+				}
+
+				if v.observer.expr != nil {
+					v.metadataTuples(name, ins.input)
+				}
+			}
+		}
 
 	case *upsertNode:
 		if v.observer.attr != nil {
@@ -673,13 +687,26 @@ func (v *planVisitor) expr(nodeName string, fieldName string, n int, expr tree.E
 	v.observer.expr(observeAlways, nodeName, fieldName, n, expr)
 }
 
-// metadata wraps observer.expr() and provides it with the current node's
+// metadataExpr wraps observer.expr() and provides it with the current node's
 // name, with verbosity = metadata.
 func (v *planVisitor) metadataExpr(nodeName string, fieldName string, n int, expr tree.Expr) {
 	if v.err != nil {
 		return
 	}
 	v.observer.expr(observeMetadata, nodeName, fieldName, n, expr)
+}
+
+// metadataTuples calls metadataExpr for each expression in a matrix.
+func (v *planVisitor) metadataTuples(nodeName string, tuples [][]tree.TypedExpr) {
+	for i := range tuples {
+		for j, expr := range tuples[i] {
+			var fieldName string
+			if v.observer.attr != nil {
+				fieldName = fmt.Sprintf("row %d, expr", i)
+			}
+			v.metadataExpr(nodeName, fieldName, j, expr)
+		}
+	}
 }
 
 func formatOrdering(ordering sqlbase.ColumnOrdering, columns sqlbase.ResultColumns) string {
@@ -700,6 +727,15 @@ func formatOrdering(ordering sqlbase.ColumnOrdering, columns sqlbase.ResultColum
 	}
 	fmtCtx.Close()
 	return buf.String()
+}
+
+// formatValuesSize returns a string of the form "5 columns, 1 row".
+func formatValuesSize(numRows, numCols int) string {
+	return fmt.Sprintf(
+		"%d column%s, %d row%s",
+		numCols, util.Pluralize(int64(numCols)),
+		numRows, util.Pluralize(int64(numRows)),
+	)
 }
 
 // nodeName returns the name of the given planNode as string.  The
@@ -799,6 +835,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&hookFnNode{}):               "plugin",
 	reflect.TypeOf(&indexJoinNode{}):            "index-join",
 	reflect.TypeOf(&insertNode{}):               "insert",
+	reflect.TypeOf(&insertFastPathNode{}):       "insert-fast-path",
 	reflect.TypeOf(&joinNode{}):                 "join",
 	reflect.TypeOf(&limitNode{}):                "limit",
 	reflect.TypeOf(&lookupJoinNode{}):           "lookup-join",


### PR DESCRIPTION
I still have to add more tests but wanted to start getting some feedback.

----

We implement a specialized execution operator for inserting into a
table when we know it is semantically correct to run foreign key
checks before (or in parallel with) the mutation. This is the case
when there is a single mutation and there are no self-referencing FKs.

To make the implementation more streamlined and optimize a common use
case, the fast path also requires that the input is a Values operator
with the columns in the correct order.

The operator shares most of the code with the insert operator, and
reimplements a simplified FK check path that is similar to the
existing path. The main difference is that we perform all checks in a
single batch (as opposed to one batch per inserted row) and
deduplicate keys (useful when multiple rows refer to the same parent).

Like the legacy FK path, the fast path allows auto-commit (by running
the checks before the mutation), which is an important optimization.
The general opt-driven FK path does not support auto-commit because
the FK checks are run after the mutation.

Ran `tpccbench` on master vs this change (with optimizer-driven FKs
turned on); results (10 runs each):
  - master: 2390 ± 58 max warehouses
  - opt-fk: 2437 ± 34 max warehouses

The optimizer-driven FKs are not enabled by default by this change; it
will be done in a separate PR.

Relase note: None