### PR TITLE
release-19.2: sql: fix parsing of 0000-01-01 as Time/TimeTZ

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -327,3 +327,16 @@ SELECT extract(epoch from time '12:00:00')
 
 query error pgcode 22023 extract\(\): unsupported timespan: day
 SELECT extract(day from time '12:00:00')
+
+subtest regression_42749
+
+# cast to string to prove it is 24:00
+query T
+SELECT '0000-01-01 24:00:00'::time::string
+----
+24:00:00
+
+query T
+SELECT '2001-01-01 01:24:00'::time
+----
+0000-01-01 01:24:00 +0000 UTC

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -485,6 +485,7 @@ func TestParseDTime(t *testing.T) {
 		str      string
 		expected timeofday.TimeOfDay
 	}{
+		{" 04:05:06 ", timeofday.New(4, 5, 6, 0)},
 		{"04:05:06", timeofday.New(4, 5, 6, 0)},
 		{"04:05:06.000001", timeofday.New(4, 5, 6, 1)},
 		{"04:05:06-07", timeofday.New(4, 5, 6, 0)},
@@ -492,6 +493,14 @@ func TestParseDTime(t *testing.T) {
 		{"24:00:00", timeofday.Time2400},
 		{"24:00:00.000", timeofday.Time2400},
 		{"24:00:00.000000", timeofday.Time2400},
+		{"0000-01-01 04:05:06", timeofday.New(4, 5, 6, 0)},
+		{"2001-01-01 04:05:06", timeofday.New(4, 5, 6, 0)},
+		{"0000-01-01T04:05:06", timeofday.New(4, 5, 6, 0)},
+		{"0000-01-01T24:00:00", timeofday.Time2400},
+		{"0000-01-01 24:00:00", timeofday.Time2400},
+		{"0000-01-01 24:00:00.0", timeofday.Time2400},
+		{" 24:00:00.0", timeofday.Time2400},
+		{" 24:00:00.0 ", timeofday.Time2400},
 	}
 	for _, td := range testData {
 		actual, err := tree.ParseDTime(nil, td.str)

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -12,6 +12,7 @@ package timeutil
 
 import (
 	"math"
+	"strings"
 	"time"
 )
 
@@ -19,6 +20,9 @@ import (
 // runs in "clockless" mode. In that (experimental) mode, we operate without
 // assuming any bound on the clock drift.
 const ClocklessMaxOffset = math.MaxInt64
+
+// LibPQTimePrefix is the prefix lib/pq prints time-type datatypes with.
+const LibPQTimePrefix = "0000-01-01"
 
 // Since returns the time elapsed since t.
 // It is shorthand for Now().Sub(t).
@@ -71,4 +75,13 @@ func SleepUntil(untilNanos int64, currentTimeNanos func() int64) {
 		}
 		time.Sleep(d)
 	}
+}
+
+// ReplaceLibPQTimePrefix replaces unparsable lib/pq dates used for timestamps
+// (0000-01-01) with timestamps that can be parsed by date libraries.
+func ReplaceLibPQTimePrefix(s string) string {
+	if strings.HasPrefix(s, LibPQTimePrefix) {
+		return "1970-01-01" + s[len(LibPQTimePrefix):]
+	}
+	return s
 }

--- a/pkg/util/timeutil/time_test.go
+++ b/pkg/util/timeutil/time_test.go
@@ -15,6 +15,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnixMicros(t *testing.T) {
@@ -62,4 +64,9 @@ func TestUnixMicrosRounding(t *testing.T) {
 			t.Errorf("%d:ToUnixMicro: expected %v, but got %v", i, e, a)
 		}
 	}
+}
+
+func TestReplaceLibPQTimePrefix(t *testing.T) {
+	assert.Equal(t, "1970-02-02 11:00", ReplaceLibPQTimePrefix("1970-02-02 11:00"))
+	assert.Equal(t, "1970-01-01 11:00", ReplaceLibPQTimePrefix("0000-01-01 11:00"))
 }


### PR DESCRIPTION
Backport 1/1 commits from #42762.

/cc @cockroachdb/release

---

Resolves https://github.com/cockroachdb/cockroach/issues/42749

Since `lib/pq` outputs `time.Time` for time datums as 0000-01-01, we
should be able to parse this in. However, `pgdate` library cannot do
that - so we hack around it for now by replacing the year for these
kinds of dates.

Release note (bug fix): Previously, attempting to parse `0000-01-01
00:00` when involving `time` did not work as `pgdate` does not
understand `0000` as a year. This PR will fix that behaviour.
