### PR TITLE
sql: fix timestamp/date vs timestamptz comparisons in alternate timezones

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -155,6 +155,26 @@ id   INT8
 t    TIMESTAMP
 ttz  TIMESTAMPTZ(5)
 
+subtest regression_timestamp_comparison
+
+statement ok
+SET TIME ZONE -5
+
+query B
+SELECT '2001-01-01'::date = '2001-01-01 00:00:00'::timestamp
+----
+true
+
+query B
+SELECT '2001-01-01'::date = '2001-01-01 00:00:00-5'::timestamptz
+----
+true
+
+query B
+SELECT '2001-01-01 00:00:00'::timestamp = '2001-01-01 01:00:00-4'::timestamptz
+----
+true
+
 subtest regression_django-cockroachdb_47
 
 statement ok

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1939,15 +1939,7 @@ may increase either contention or retry errors, or both.`,
 				if err != nil {
 					return nil, err
 				}
-				// From the given time in the context location, we also have to subtract
-				// the offset.
-				// This is because we expect to truncate in the given timezone,
-				// but the date argument assumed no timezone, meaning converting it into
-				// the location's timestamp with the date library converts it into the
-				// wrong time locally.
-				_, offset := fromTSTZ.Time.Zone()
-				fromTSTZTime := fromTSTZ.Time.Add(time.Duration(-offset) * time.Second)
-				return truncateTimestamp(ctx, fromTSTZTime, timeSpan)
+				return truncateTimestamp(ctx, fromTSTZ.Time, timeSpan)
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +


### PR DESCRIPTION
Found this one whilst adventuring.

Release note (bug fix, sql change): Previously, when the timezone is set
in the background, comparisons between `date` and `timestamp` vs
`timestamptz` were broken as it tried to normalize the timestamptz to
UTC, as opposed to converting the `date` and `timestamp` to the
`context` timezone and comparing the `timestamptz` without altering it's
timezone.