### PR TITLE
sql/sem/tree: fix max time regex bugs for DTime

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -65,7 +65,7 @@ var (
 	DZero = NewDInt(0)
 
 	// DTimeMaxTimeRegex is a compiled regex for parsing the 24:00 time value.
-	DTimeMaxTimeRegex = regexp.MustCompile(`^([0-9-]*(\s+T)?\s+)?24:00($|(:00$)|(:00.0+$))`)
+	DTimeMaxTimeRegex = regexp.MustCompile(`^([0-9-]*(\s|T))?\s*24:00(:00(.0+)?)?\s*$`)
 )
 
 // Datum represents a SQL value.

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -489,6 +489,7 @@ func TestParseDTime(t *testing.T) {
 		precision time.Duration
 		expected  timeofday.TimeOfDay
 	}{
+		{" 04:05:06 ", time.Microsecond, timeofday.New(4, 5, 6, 0)},
 		{"04:05:06", time.Microsecond, timeofday.New(4, 5, 6, 0)},
 		{"04:05:06.000001", time.Microsecond, timeofday.New(4, 5, 6, 1)},
 		{"04:05:06.000001", time.Second, timeofday.New(4, 5, 6, 0)},
@@ -499,6 +500,12 @@ func TestParseDTime(t *testing.T) {
 		{"24:00:00", time.Microsecond, timeofday.Time2400},
 		{"24:00:00.000", time.Microsecond, timeofday.Time2400},
 		{"24:00:00.000000", time.Microsecond, timeofday.Time2400},
+		{"0000-01-01T24:00:00", time.Microsecond, timeofday.Time2400},
+		{"0000-01-01T24:00:00.0", time.Microsecond, timeofday.Time2400},
+		{"0000-01-01 24:00:00", time.Microsecond, timeofday.Time2400},
+		{"0000-01-01 24:00:00.0", time.Microsecond, timeofday.Time2400},
+		{" 24:00:00.0", time.Microsecond, timeofday.Time2400},
+		{" 24:00:00.0  ", time.Microsecond, timeofday.Time2400},
 	}
 	for _, td := range testData {
 		actual, err := tree.ParseDTime(nil, td.str, td.precision)


### PR DESCRIPTION
Oops, whilst doing a qa of time, I found I did not do dates of the form
"0001-01-01T24:00:00" correctly in `06f3076` (which we didn't do
correctly before that anyway). This rectifies that, and
is also fixed in the backport.

Release note: None