### PR TITLE
cli: remove experimental clockless mode

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -608,13 +608,6 @@ a public network without combining it with --listen-addr.`,
 		Description: `Path to the CA key.`,
 	}
 
-	// TODO(tschottdorf): once clockless mode becomes non-experimental, explain it here:
-	// <PRE>
-	//
-	// </PRE>
-	// Specifying the string value 'experimental-clockless' instead of a duration runs the cluster
-	// in clockless reads mode. In that mode, reads are routed through Raft and subsequently
-	// performance is reduced, but clock synchronization is not relied upon for correctness.
 	MaxOffset = FlagInfo{
 		Name: "max-offset",
 		Description: `

--- a/pkg/internal/client/lease.go
+++ b/pkg/internal/client/lease.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
 )
@@ -137,11 +136,6 @@ func (m *LeaseManager) TimeRemaining(l *Lease) time.Duration {
 
 func (m *LeaseManager) timeRemaining(val *LeaseVal) time.Duration {
 	maxOffset := m.clock.MaxOffset()
-	if maxOffset == timeutil.ClocklessMaxOffset {
-		// Clockless reads are active, so we don't need to stop using the lease
-		// early.
-		maxOffset = 0
-	}
 	return val.Expiration.GoTime().Sub(m.clock.Now().GoTime()) - maxOffset
 }
 

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -862,20 +861,16 @@ func (tc *TxnCoordSender) Send(
 // client.
 // Below we choose the option that involves less waiting, which is likely the
 // first one unless a transaction commits with an odd timestamp.
-//
-// Can't use linearizable mode with clockless reads since in that case we don't
-// know how long to sleep - could be forever!
 func (tc *TxnCoordSender) maybeSleepForLinearizable(
 	ctx context.Context, br *roachpb.BatchResponse, startNs int64,
 ) {
 	if tsNS := br.Txn.WriteTimestamp.WallTime; startNs > tsNS {
 		startNs = tsNS
 	}
-	maxOffset := tc.clock.MaxOffset()
-	sleepNS := maxOffset -
+	sleepNS := tc.clock.MaxOffset() -
 		time.Duration(tc.clock.PhysicalNow()-startNs)
 
-	if maxOffset != timeutil.ClocklessMaxOffset && tc.linearizable && sleepNS > 0 {
+	if tc.linearizable && sleepNS > 0 {
 		// TODO(andrei): perhaps we shouldn't sleep with the lock held.
 		log.VEventf(ctx, 2, "%v: waiting %s on EndTransaction for linearizability",
 			br.Txn.Short(), duration.Truncate(sleepNS, time.Millisecond))

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft/raftpb"
@@ -782,15 +781,7 @@ func MakeTransaction(
 	name string, baseKey Key, userPriority UserPriority, now hlc.Timestamp, maxOffsetNs int64,
 ) Transaction {
 	u := uuid.FastMakeV4()
-	var maxTS hlc.Timestamp
-	if maxOffsetNs == timeutil.ClocklessMaxOffset {
-		// For clockless reads, use the largest possible maxTS. This means we'll
-		// always restart if we see something in our future (but we do so at
-		// most once thanks to ObservedTimestamps).
-		maxTS.WallTime = math.MaxInt64
-	} else {
-		maxTS = now.Add(maxOffsetNs, 0)
-	}
+	maxTS := now.Add(maxOffsetNs, 0)
 
 	return Transaction{
 		TxnMeta: enginepb.TxnMeta{

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/montanaflynn/stats"
 )
@@ -194,7 +193,7 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 	//
 	// TODO(tschottdorf): disallow maxOffset == 0 but probably lots of tests to
 	// fix.
-	if maxOffset := r.clock.MaxOffset(); maxOffset != 0 && maxOffset != timeutil.ClocklessMaxOffset {
+	if maxOffset := r.clock.MaxOffset(); maxOffset != 0 {
 		now := r.clock.PhysicalTime()
 
 		healthyOffsetCount := 0

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1113,9 +1113,7 @@ func (ctx *Context) runHeartbeat(
 				// successful response from the server.
 				pingDuration := receiveTime.Sub(sendTime)
 				maxOffset := ctx.LocalClock.MaxOffset()
-				if maxOffset != timeutil.ClocklessMaxOffset &&
-					pingDuration > maximumPingDurationMult*maxOffset {
-
+				if pingDuration > maximumPingDurationMult*maxOffset {
 					request.Offset.Reset()
 				} else {
 					// Offset and error are measured using the remote clock reading

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -146,10 +146,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	// Note that we validated this connection already. Different clusters
 	// could very well have different max offsets.
 	mo, amo := hs.clock.MaxOffset(), time.Duration(args.MaxOffsetNanos)
-	if mo != 0 && amo != 0 &&
-		mo != timeutil.ClocklessMaxOffset && amo != timeutil.ClocklessMaxOffset &&
-		mo != amo {
-
+	if mo != 0 && amo != 0 && mo != amo {
 		panic(fmt.Sprintf("locally configured maximum clock offset (%s) "+
 			"does not match that of node %s (%s)", mo, args.Addr, amo))
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/elastic/gosigar"
 	"github.com/pkg/errors"
@@ -93,10 +92,6 @@ func (mo *MaxOffsetType) Type() string {
 
 // Set implements the pflag.Value interface.
 func (mo *MaxOffsetType) Set(v string) error {
-	if v == "experimental-clockless" {
-		*mo = MaxOffsetType(timeutil.ClocklessMaxOffset)
-		return nil
-	}
 	nanos, err := time.ParseDuration(v)
 	if err != nil {
 		return err
@@ -110,9 +105,6 @@ func (mo *MaxOffsetType) Set(v string) error {
 
 // String implements the pflag.Value interface.
 func (mo *MaxOffsetType) String() string {
-	if *mo == timeutil.ClocklessMaxOffset {
-		return "experimental-clockless"
-	}
 	return time.Duration(*mo).String()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1006,12 +1006,7 @@ func ensureClockMonotonicity(
 		// As an optimization for tests, we don't sleep if all the stores are brand
 		// new. In this case, the node will not serve anything anyway until it
 		// synchronizes with other nodes.
-
-		// Don't have to sleep for monotonicity when using clockless reads
-		// (nor can we, for we would sleep forever).
-		if maxOffset := clock.MaxOffset(); maxOffset != timeutil.ClocklessMaxOffset {
-			sleepUntil = startTime.UnixNano() + int64(maxOffset) + 1
-		}
+		sleepUntil = startTime.UnixNano() + int64(clock.MaxOffset()) + 1
 	}
 
 	currentWallTimeFn := func() int64 { /* function to report current time */

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -587,13 +587,9 @@ func (nl *NodeLiveness) heartbeatInternal(
 		}
 	}
 	// We need to add the maximum clock offset to the expiration because it's
-	// used when determining liveness for a node (unless we're configured for
-	// clockless reads).
+	// used when determining liveness for a node.
 	{
 		maxOffset := nl.clock.MaxOffset()
-		if maxOffset == timeutil.ClocklessMaxOffset {
-			maxOffset = 0
-		}
 		update.Expiration = hlc.LegacyTimestamp(
 			nl.clock.Now().Add((nl.livenessThreshold + maxOffset).Nanoseconds(), 0))
 		// This guards against the system clock moving backwards. As long

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -570,11 +570,6 @@ func (r *Replica) sendWithRangeID(
 	isReadOnly := ba.IsReadOnly()
 	useRaft := !isReadOnly && ba.IsWrite()
 
-	if isReadOnly && r.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset {
-		// Clockless reads mode: reads go through Raft.
-		useRaft = true
-	}
-
 	if err := r.checkBatchRequest(&ba, isReadOnly); err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -746,12 +746,9 @@ func (r *Replica) evaluateProposal(
 	// 2. the request had an impact on the MVCCStats. NB: this is possible
 	//    even with an empty write batch when stats are recomputed.
 	// 3. the request has replicated side-effects.
-	// 4. the cluster is in "clockless" mode, in which case consensus is
-	//    used to enforce a linearization of all reads and writes.
 	needConsensus := !batch.Empty() ||
 		ms != (enginepb.MVCCStats{}) ||
-		!res.Replicated.Equal(storagepb.ReplicatedEvalResult{}) ||
-		r.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset
+		!res.Replicated.Equal(storagepb.ReplicatedEvalResult{})
 
 	if needConsensus {
 		// Set the proposal's WriteBatch, which is the serialized representation of

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -564,10 +564,6 @@ func (r *Replica) leaseStatus(
 		expiration = hlc.Timestamp(status.Liveness.Expiration)
 	}
 	maxOffset := r.store.Clock().MaxOffset()
-	if maxOffset == timeutil.ClocklessMaxOffset {
-		// No stasis when using clockless reads.
-		maxOffset = 0
-	}
 	stasis := expiration.Add(-int64(maxOffset), 0)
 	if timestamp.Less(stasis) {
 		status.State = storagepb.LeaseState_VALID

--- a/pkg/storage/storagepb/liveness.go
+++ b/pkg/storage/storagepb/liveness.go
@@ -14,16 +14,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // IsLive returns whether the node is considered live at the given time with the
 // given clock offset.
 func (l *Liveness) IsLive(now hlc.Timestamp, maxOffset time.Duration) bool {
-	if maxOffset == timeutil.ClocklessMaxOffset {
-		// When using clockless reads, we're live without a buffer period.
-		maxOffset = 0
-	}
 	expiration := hlc.Timestamp(l.Expiration).Add(-maxOffset.Nanoseconds(), 0)
 	return now.Less(expiration)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -750,10 +750,6 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 	// the sum of the offset (=length of stasis period) and the active
 	// duration, but definitely not by 2x.
 	maxOffset := sc.Clock.MaxOffset()
-	if maxOffset == timeutil.ClocklessMaxOffset {
-		// Don't do shady math on clockless reads.
-		maxOffset = 0
-	}
 	return 2 * (sc.RangeLeaseActiveDuration() + maxOffset).Nanoseconds()
 }
 

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -328,7 +328,7 @@ func (c *Clock) updateLocked(rt Timestamp, updateIfMaxOffsetExceeded bool) (Time
 	}
 
 	offset := time.Duration(rt.WallTime - physicalClock)
-	if c.maxOffset > 0 && c.maxOffset != timeutil.ClocklessMaxOffset && offset > c.maxOffset {
+	if c.maxOffset > 0 && offset > c.maxOffset {
 		err = fmt.Errorf("remote wall time is too far ahead (%s) to be trustworthy", offset)
 		if !updateIfMaxOffsetExceeded {
 			return Timestamp{}, err

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -11,15 +11,9 @@
 package timeutil
 
 import (
-	"math"
 	"strings"
 	"time"
 )
-
-// ClocklessMaxOffset is a special-cased value that is used when the cluster
-// runs in "clockless" mode. In that (experimental) mode, we operate without
-// assuming any bound on the clock drift.
-const ClocklessMaxOffset = math.MaxInt64
 
 // LibPQTimePrefix is the prefix lib/pq prints time-type datatypes with.
 const LibPQTimePrefix = "0000-01-01"


### PR DESCRIPTION
A long time back, we experimentally introduced a mode in which reads
would go through Raft. This never received much attention and whatever
testing we did highlighted that it just wasn't working. It was never
made work but somehow never got removed. Remove it now.

No release note since this was never officially released (nor did it
ever work).

Release note: None