### PR TITLE
sqlbase: avoid the term "backfill" in err about incompatible exprs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -574,10 +574,10 @@ ALTER TABLE add_default ADD g INT UNIQUE DEFAULT 1
 statement ok
 CREATE SEQUENCE initial_seq
 
-statement error cannot backfill such sequence operation
+statement error pgcode 0A000 cannot evaluate scalar expressions containing sequence operations in this context
 ALTER TABLE add_default ADD g INT DEFAULT nextval('initial_seq')
 
-statement error cannot backfill such evaluated expression
+statement error pgcode 22C01 cannot evaluate scalar expressions using table lookups in this context
 ALTER TABLE add_default ADD g OID DEFAULT 'foo'::regclass::oid
 
 statement error cannot access virtual schema in anonymous database

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1754,7 +1754,7 @@ CREATE TABLE t42508(x INT); INSERT INTO t42508(x) VALUES (1);
 statement ok
 CREATE SEQUENCE s42508
 
-statement error pgcode 0A000 unimplemented: cannot backfill such sequence operation.*\nHINT.*\n.*42508
+statement error pgcode 0A000 unimplemented: cannot evaluate scalar expressions containing sequence operations.*\nHINT.*\n.*42508
 ALTER TABLE t42508 ADD COLUMN y INT DEFAULT nextval('s42508')
 
 statement ok
@@ -1763,5 +1763,5 @@ BEGIN
 statement ok
 ALTER TABLE t42508 ADD COLUMN y INT DEFAULT nextval('s42508')
 
-statement error pgcode XXA00 unimplemented: cannot backfill such sequence operation.*\nHINT.*\n.*42508
+statement error pgcode XXA00 unimplemented: cannot evaluate scalar expressions containing sequence operations.*\nHINT.*\n.*42508
 COMMIT

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -328,6 +328,14 @@ const (
 	//       must use 'error pgcode XXA00 ...'
 	TransactionCommittedWithSchemaChangeFailure = "XXA00"
 
+	// Class 22C - Semantic errors in the structure of a SQL statement.
+
+	// ScalarOperationCannotRunWithoutFullSessionContext signals that an
+	// operator or built-in function was used that requires a full
+	// session contextand thus cannot be run in a background job or away
+	// from the SQL gateway.
+	ScalarOperationCannotRunWithoutFullSessionContext = "22C01"
+
 	// Class 58C - System errors related to CockroachDB node problems.
 
 	// RangeUnavailable signals that some data from the cluster cannot be

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -13,6 +13,8 @@ package sqlbase
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -25,34 +27,35 @@ type DummySequenceOperators struct{}
 
 var _ tree.EvalDatabase = &DummySequenceOperators{}
 
-var errSequenceOperators = unimplemented.NewWithIssue(42508, "cannot backfill such sequence operation")
+var errSequenceOperators = unimplemented.NewWithIssue(42508,
+	"cannot evaluate scalar expressions containing sequence operations in this context")
 
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return nil, errSequenceOperators
+	return nil, errors.WithStack(errSequenceOperators)
 }
 
 // ResolveTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ResolveTableName(
 	ctx context.Context, tn *tree.TableName,
 ) (tree.ID, error) {
-	return 0, errSequenceOperators
+	return 0, errors.WithStack(errSequenceOperators)
 }
 
 // LookupSchema is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
-	return false, nil, errSequenceOperators
+	return false, nil, errors.WithStack(errSequenceOperators)
 }
 
 // IncrementSequence is part of the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
-	return 0, errSequenceOperators
+	return 0, errors.WithStack(errSequenceOperators)
 }
 
 // GetLatestValueInSessionForSequence implements the tree.SequenceOperators
@@ -60,14 +63,14 @@ func (so *DummySequenceOperators) IncrementSequence(
 func (so *DummySequenceOperators) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
-	return 0, errSequenceOperators
+	return 0, errors.WithStack(errSequenceOperators)
 }
 
 // SetSequenceValue implements the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) SetSequenceValue(
 	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
 ) error {
-	return errSequenceOperators
+	return errors.WithStack(errSequenceOperators)
 }
 
 // DummyEvalPlanner implements the tree.EvalPlanner interface by returning
@@ -76,37 +79,38 @@ type DummyEvalPlanner struct{}
 
 var _ tree.EvalPlanner = &DummyEvalPlanner{}
 
-var errEvalPlanner = errors.New("cannot backfill such evaluated expression")
+var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,
+	"cannot evaluate scalar expressions using table lookups in this context")
 
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return nil, errEvalPlanner
+	return nil, errors.WithStack(errEvalPlanner)
 }
 
 // LookupSchema is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
-	return false, nil, errEvalPlanner
+	return false, nil, errors.WithStack(errEvalPlanner)
 }
 
 // ResolveTableName is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) ResolveTableName(
 	ctx context.Context, tn *tree.TableName,
 ) (tree.ID, error) {
-	return 0, errEvalPlanner
+	return 0, errors.WithStack(errEvalPlanner)
 }
 
 // ParseType is part of the tree.EvalPlanner interface.
 func (ep *DummyEvalPlanner) ParseType(sql string) (*types.T, error) {
-	return nil, errEvalPlanner
+	return nil, errors.WithStack(errEvalPlanner)
 }
 
 // EvalSubquery is part of the tree.EvalPlanner interface.
 func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
-	return nil, errEvalPlanner
+	return nil, errors.WithStack(errEvalPlanner)
 }
 
 // DummySessionAccessor implements the tree.EvalSessionAccessor interface by returning errors.
@@ -114,21 +118,22 @@ type DummySessionAccessor struct{}
 
 var _ tree.EvalSessionAccessor = &DummySessionAccessor{}
 
-var errEvalSessionVar = errors.New("cannot backfill expressions that access session variables")
+var errEvalSessionVar = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,
+	"cannot evaluate scalar expressions that access session variables in this context")
 
 // GetSessionVar is part of the tree.EvalSessionAccessor interface.
 func (ep *DummySessionAccessor) GetSessionVar(
 	_ context.Context, _ string, _ bool,
 ) (bool, string, error) {
-	return false, "", errEvalSessionVar
+	return false, "", errors.WithStack(errEvalSessionVar)
 }
 
 // SetSessionVar is part of the tree.EvalSessionAccessor interface.
 func (ep *DummySessionAccessor) SetSessionVar(_ context.Context, _, _ string) error {
-	return errEvalSessionVar
+	return errors.WithStack(errEvalSessionVar)
 }
 
 // HasAdminRole is part of the tree.EvalSessionAccessor interface.
 func (ep *DummySessionAccessor) HasAdminRole(_ context.Context) (bool, error) {
-	return false, errEvalSessionVar
+	return false, errors.WithStack(errEvalSessionVar)
 }


### PR DESCRIPTION
Suggested by @bdarnell  in https://github.com/cockroachdb/cockroach/pull/42910#pullrequestreview-326433509

Previously, the error message reported when an attempt was made to use
an incompatible scalar expression in a bulk i/o operation was
referring to as "backfills".

For example:
```
pq: cannot backfill such sequence operation
```

The term "backfill" is both inaccurate (other operations than
backfills can come to evaluate these scalar expressions) and also
jargon (our docs do not explain "backfills" to users).

This patch fixes this by referring to "this context" instead.

For example:
```
pq: cannot evaluate scalar expressions containing sequence operation in this context
```

Additionally, the patch introduces a new SQLSTATE code for this
particular conditions, which is aimed to aid search for this class of
conditions in docs.

Release note (sql change): The error message reported when a client
specifies a bulk I/O operation that uses an incompatible SQL function
or operator now avoids the confusing and inaccurate term
"backfill". This error is also now reported with code 22C01.