### PR TITLE
storage/engine: add encryption stats for Pebble. The stats are

### DIFF
--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -293,6 +293,17 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	return nil
 }
 
+func (m *DataKeyManager) getScrubbedRegistry() *enginepbccl.DataKeysRegistry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := makeRegistryProto()
+	proto.Merge(r, m.mu.keyRegistry)
+	for _, v := range r.DataKeys {
+		v.Key = nil
+	}
+	return r
+}
+
 func validateRegistry(keyRegistry *enginepbccl.DataKeysRegistry) error {
 	if keyRegistry.ActiveStoreKeyId != "" && keyRegistry.StoreKeys[keyRegistry.ActiveStoreKeyId] == nil {
 		return fmt.Errorf("active store key %s not found", keyRegistry.ActiveStoreKeyId)

--- a/pkg/storage/engine/pebble_file_registry.go
+++ b/pkg/storage/engine/pebble_file_registry.go
@@ -216,3 +216,11 @@ func (r *PebbleFileRegistry) writeRegistry(newProto *enginepb.FileRegistry) erro
 	r.mu.currProto = newProto
 	return nil
 }
+
+func (r *PebbleFileRegistry) getRegistryCopy() *enginepb.FileRegistry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rv := &enginepb.FileRegistry{}
+	proto.Merge(rv, r.mu.currProto)
+	return rv
+}


### PR DESCRIPTION
currently incomplete (there are TODOs).
Also added a minimal test that exercises encrypted Pebble.

Release note: None