### PR TITLE
colexec: fix handling of Unhandled type in cfetcher, ResetInternalBatch

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -196,7 +196,9 @@ func (m *MemBatch) Reset(types []coltypes.T, length int) {
 func (m *MemBatch) ResetInternalBatch() {
 	m.SetSelection(false)
 	for _, v := range m.b {
-		v.Nulls().UnsetNulls()
+		if v.Type() != coltypes.Unhandled {
+			v.Nulls().UnsetNulls()
+		}
 		if v.Type() == coltypes.Bytes {
 			v.Bytes().Reset()
 		}

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -57,9 +57,6 @@ type cTableInfo struct {
 	// schema changes.
 	cols []sqlbase.ColumnDescriptor
 
-	// The exec types corresponding to the table columns in cols.
-	typs []coltypes.T
-
 	// The ordered list of ColumnIDs that are required.
 	neededColsList []int
 
@@ -284,7 +281,6 @@ func (rf *cFetcher) Init(
 		index:            tableArgs.Index,
 		isSecondaryIndex: tableArgs.IsSecondaryIndex,
 		cols:             colDescriptors,
-		typs:             typs,
 
 		// These slice fields might get re-allocated below, so reslice them from
 		// the old table here in case they've got enough capacity already.
@@ -613,8 +609,10 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
 		case stateResetBatch:
-			for i := range rf.machine.colvecs {
-				rf.machine.colvecs[i].Nulls().UnsetNulls()
+			for _, colvec := range rf.machine.colvecs {
+				if colvec.Type() != coltypes.Unhandled {
+					colvec.Nulls().UnsetNulls()
+				}
 			}
 			rf.machine.batch.ResetInternalBatch()
 			rf.shiftState()

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -88,3 +88,20 @@ RESET vectorize
 # (TimestampTZ). We're only interested in not getting an error. See #42871.
 statement ok
 SELECT experimental_strptime(_string, _string) IS NULL FROM all_types
+
+statement ok
+CREATE TABLE unsupported_type (id INT PRIMARY KEY, unsupported INT ARRAY)
+
+statement ok
+INSERT INTO unsupported_type (id) SELECT * FROM generate_series(1, 2000)
+
+statement ok
+SET vectorize=experimental_always
+
+# This query makes sure that CFetcher when reading from a table with an
+# unhandled type (that isn't needed) is reset correctly between batches.
+statement ok
+SELECT id FROM unsupported_type LIMIT 1 OFFSET 1100
+
+statement ok
+RESET vectorize


### PR DESCRIPTION
We recently merged a change to allow for 'unknown' vectors to be present
among colvecs. However, we forgot to update the resetting of the batch -
unknown columns do not have nulls and don't need to be reset. Now this
is fixed.

Also this commit removes an unused field in cfetcher.

Addresses: https://github.com/cockroachdb/cockroach/issues/37815#issuecomment-561631592.

Release note: None