### PR TITLE
release-19.2: sql/sem/builtins: support more time spans for EXTRACT and DATE_TRUNC

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -300,8 +300,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero.</p>
@@ -309,13 +309,13 @@ significant than <code>element</code> to zero.</p>
 </span></td></tr>
 <tr><td><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns a timestamp which is very likely to be safe to perform
 against a follower replica.</p>
@@ -335,18 +335,21 @@ return without an error.</p>
 <tr><td><code>experimental_strptime(input: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns <code>input</code> as a timestamptz using <code>format</code> (which uses standard <code>strptime</code> formatting).</p>
 </span></td></tr>
 <tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
 <p>Compatible elements: hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -482,7 +482,19 @@ INSERT INTO ex VALUES
   (37, 'milliseconds', '2016-02-10 19:46:33.306157519',    306,       '2016-02-10 19:46:33.306'),
   (38, 'microsecond',  '2001-04-10 12:04:59.34565423',     345654,    '2001-04-10 12:04:59.345654'),
   (39, 'microsecond',  '2016-02-10 19:46:33.306157519',    306158,    '2016-02-10 19:46:33.306158'),
-  (40, 'microseconds', '2016-02-10 19:46:33.306157519',    306158,    '2016-02-10 19:46:33.306158')
+  (40, 'microseconds', '2016-02-10 19:46:33.306157519',    306158,    '2016-02-10 19:46:33.306158'),
+  (41, 'isodow',       '2001-04-10 12:04:59',              2,         null),
+  (42, 'isodow',       '2001-04-08 12:04:59',              7,         null),
+  (43, 'isoyear',      '2007-12-31 12:04:59',              2008,      null),
+  (44, 'isoyear',      '2008-01-01 12:04:59',              2008,      null),
+  (45, 'decade',       '2001-04-10 12:04:59',              200,       '2000-01-01 00:00:00'),
+  (46, 'decade',       '2016-02-10 19:46:33.306157519 BC', -202,      '2021-01-01 00:00:00 BC'),
+  (47, 'century',      '2016-02-10 19:46:33.306157519',    21,        '2001-01-01 00:00:00'),
+  (48, 'century',      '0004-02-10 19:46:33.306157519 BC', -1,        '0100-01-01 00:00:00 BC'),
+  (49, 'millennium',   '2016-02-10 19:46:33.306157519',    3,         '2001-01-01 00:00:00'),
+  (50, 'millennium',   '1004-02-10 19:46:33.306157519 BC', -2,        '2000-01-01 00:00:00 BC'),
+  (51, 'julian',       '4714-11-24 BC',                     0,        null),
+  (52, 'julian',       '2016-02-10 19:46:33.306157519',    2457429,   null)
 
 query IBI
 SELECT k, extract(element, input::timestamp) = extract_result, extract(element, input::timestamp) FROM ex ORDER BY k
@@ -527,6 +539,18 @@ SELECT k, extract(element, input::timestamp) = extract_result, extract(element, 
 38 true 345654
 39 true 306158
 40 true 306158
+41 true 2
+42 true 7
+43 true 2008
+44 true 2008
+45 true 200
+46 true -202
+47 true 21
+48 true -1
+49 true 3
+50 true -2
+51 true 0
+52 true 2457429
 
 query error extract\(\): unsupported timespan: nansecond
 SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamp)
@@ -540,46 +564,58 @@ SELECT INTERVAL '1 ns';
 query IBI
 SELECT k, extract(element, input::timestamptz) = extract_result, extract(element, input::timestamptz) FROM ex ORDER BY k
 ----
-1  true 2001
-2  true 2016
-3  true 2016
-4  true 2
-5  true 1
-6  true 2
-7  true 3
-8  true 4
-9  true 4
-10 true 2
-11 true 2
-12 true 15
-13 true 1
-14 true 10
-15 true 10
-16 true 10
-17 true 2
-18 true 4
-19 true 100
-20 true 102
-21 true 86401
-22 true 100801
-23 true 986904299
-24 true 12
-25 true 19
-26 true 23
-27 true 19
-28 true 23
-29 true 4
-30 true 46
-31 true 46
-32 true 59
-33 true 33
-34 true 33
-35 true 234
-36 true 306
-37 true 306
-38 true 345654
-39 true 306158
-40 true 306158
+1   true  2001
+2   true  2016
+3   true  2016
+4   true  2
+5   true  1
+6   true  2
+7   true  3
+8   true  4
+9   true  4
+10  true  2
+11  true  2
+12  true  15
+13  true  1
+14  true  10
+15  true  10
+16  true  10
+17  true  2
+18  true  4
+19  true  100
+20  true  102
+21  true  86401
+22  true  100801
+23  true  986904299
+24  true  12
+25  true  19
+26  true  23
+27  true  19
+28  true  23
+29  true  4
+30  true  46
+31  true  46
+32  true  59
+33  true  33
+34  true  33
+35  true  234
+36  true  306
+37  true  306
+38  true  345654
+39  true  306158
+40  true  306158
+41  true  2
+42  true  7
+43  true  2008
+44  true  2008
+45  true  200
+46  true  -202
+47  true  21
+48  true  -1
+49  true  3
+50  true  -2
+51  true  0
+52  true  2457429
 
 query error extract\(\): unsupported timespan: nansecond
 SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamptz)
@@ -631,6 +667,12 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38 true 2001-04-10 12:04:59.345654+00:00
 39 true 2016-02-10 19:46:33.306158+00:00
 40 true 2016-02-10 19:46:33.306158+00:00
+45 true 2000-01-01 00:00:00+00:00
+46 true -2020-01-01 00:00:00+00:00
+47 true 2001-01-01 00:00:00+00:00
+48 true -0099-01-01 00:00:00+00:00
+49 true 2001-01-01 00:00:00+00:00
+50 true -1999-01-01 00:00:00+00:00
 
 query IBT
 SELECT k, date_trunc(element, input::timestamptz) = date_trunc_result, date_trunc(element, input::timestamptz)::string
@@ -669,6 +711,27 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38 true 2001-04-10 12:04:59.345654+00:00
 39 true 2016-02-10 19:46:33.306158+00:00
 40 true 2016-02-10 19:46:33.306158+00:00
+45 true 2000-01-01 00:00:00+00:00
+46 true -2020-01-01 00:00:00+00:00
+47 true 2001-01-01 00:00:00+00:00
+48 true -0099-01-01 00:00:00+00:00
+49 true 2001-01-01 00:00:00+00:00
+50 true -1999-01-01 00:00:00+00:00
+
+query T
+SELECT date_trunc('millennia', '2000-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+1001-01-01 00:00:00-04:00
+
+query T
+SELECT date_trunc('centuries', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+2001-01-01 00:00:00-04:00
+
+query T
+SELECT date_trunc('decades', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+2010-01-01 00:00:00-04:00
 
 query T
 SELECT date_trunc('hour', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
@@ -717,6 +780,12 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38  true  2001-04-10 00:00:00+00:00
 39  true  2016-02-10 00:00:00+00:00
 40  true  2016-02-10 00:00:00+00:00
+45  true  2000-01-01 00:00:00+00:00
+46  true  -2020-01-01 00:00:00+00:00
+47  true  2001-01-01 00:00:00+00:00
+48  true  -0099-01-01 00:00:00+00:00
+49  true  2001-01-01 00:00:00+00:00
+50  true  -1999-01-01 00:00:00+00:00
 
 query T
 SELECT (timestamp '2016-02-10 19:46:33.306157519')::string

--- a/pkg/sql/sem/tree/testdata/eval/extract
+++ b/pkg/sql/sem/tree/testdata/eval/extract
@@ -36,9 +36,69 @@ extract(dayofweek from '2010-09-28'::date)
 2
 
 eval
+extract(isodow from '2010-09-28'::date)
+----
+2
+
+eval
+extract(isodow from '2010-09-26'::date)
+----
+7
+
+eval
 extract(quarter from '2010-09-28'::date)
 ----
 3
+
+eval
+extract(century from '2010-09-28'::date)
+----
+21
+
+eval
+extract(century from '2010-09-28 BC'::date)
+----
+-21
+
+eval
+extract(decade from '2010-09-28'::date)
+----
+201
+
+eval
+extract(decade from '2010-09-28 BC'::date)
+----
+-201
+
+eval
+extract(isoyear from '2006-01-01'::date)
+----
+2005
+
+eval
+extract(isoyear from '2006-01-02'::date)
+----
+2006
+
+eval
+extract(millennium from '2010-09-28'::date)
+----
+3
+
+eval
+extract(millennium from '2010-09-28 BC'::date)
+----
+-3
+
+eval
+extract(julian from '2010-09-28'::date)
+----
+2455468
+
+eval
+extract(julian from '4714-11-24 BC'::date)
+----
+0
 
 # Extract from times.
 
@@ -138,6 +198,56 @@ eval
 extract(epoch from '2010-01-10 12:13:14.1+00:00'::timestamp)
 ----
 1263125594
+
+eval
+extract(century from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+21
+
+eval
+extract(century from '0001-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-1
+
+eval
+extract(decade from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+201
+
+eval
+extract(decade from '2010-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-201
+
+eval
+extract(isoyear from '2006-01-01 12:13:14.1+00:00'::timestamp)
+----
+2005
+
+eval
+extract(isoyear from '2006-01-02 12:13:14.1+00:00'::timestamp)
+----
+2006
+
+eval
+extract(millennium from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+3
+
+eval
+extract(millennium from '0010-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-1
+
+eval
+extract(julian from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+2455207
+
+eval
+extract(julian from '4714-11-24 12:13:14.1+00:00 BC'::timestamp)
+----
+0
 
 # Extract from intervals.
 


### PR DESCRIPTION
Backport 1/1 commits from #41784.

/cc @cockroachdb/release

backport reasoning: #42936

---

PostgreSQL supports millennium, century, decade, isoyear, isodow, and
julian as field name in EXTRACT function. PostgreSQL supports
millennium, century, and decade as field name in DATE_TRUNC function.
This patch adds supports of those elements to EXTRACT and DATE_TRUNC.

Issue: #41548

Release note (sql change): EXTRACT now supports millennium, century,
decade, isoyear, isodow, and julian for date, timestamp, and timestamptz.
DATE_TRUNC now supports millennium, century, and decade for date,
timestamp, and timestamptz.
