### PR TITLE
ui: [depends on #42820] Collapsible panel for Decommissioned nodes list

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeList.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeList.tsx
@@ -57,6 +57,7 @@ export default class NodeList extends React.Component<RouterState & { router: In
           width: "100%",
           height: "100%",
           overflow: "auto",
+          background: "#f6f6f6",
         }}>
           <NodesOverview />
         </div>

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -39,7 +39,7 @@ import RaftMessages from "src/views/devtools/containers/raftMessages";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
-import NodeHistory from "src/views/reports/containers/nodes/nodeHistory";
+import DecommissionedNodeHistory from "src/views/reports/containers/nodesHistory/decommissionedNodeHistory";
 import JobsPage from "src/views/jobs";
 import Certificates from "src/views/reports/containers/certificates";
 import CustomChart from "src/views/reports/containers/customChart";
@@ -166,7 +166,7 @@ ReactDOM.render(
           <Route path="network" component={ Network } />
           <Route path="nodes">
             <IndexRoute component={ Nodes } />
-            <Route path="history" component={ NodeHistory } />
+            <Route path="history" component={ DecommissionedNodeHistory } />
           </Route>
           <Route path="settings" component={ Settings } />
           <Route path={`certificates/:${nodeIDAttr}`} component={ Certificates } />

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -39,6 +39,7 @@ import RaftMessages from "src/views/devtools/containers/raftMessages";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
+import NodeHistory from "src/views/reports/containers/nodes/nodeHistory";
 import JobsPage from "src/views/jobs";
 import Certificates from "src/views/reports/containers/certificates";
 import CustomChart from "src/views/reports/containers/customChart";
@@ -163,7 +164,10 @@ ReactDOM.render(
           </Route>
           <Route path="localities" component={ Localities } />
           <Route path="network" component={ Network } />
-          <Route path="nodes" component={ Nodes } />
+          <Route path="nodes">
+            <IndexRoute component={ Nodes } />
+            <Route path="history" component={ NodeHistory } />
+          </Route>
           <Route path="settings" component={ Settings } />
           <Route path={`certificates/:${nodeIDAttr}`} component={ Certificates } />
           <Route path={`range/:${rangeIDAttr}`} component={ Range } />

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -297,3 +297,28 @@ export type NodesSummary = typeof nodesSummaryType;
 export function selectNodesSummaryValid(state: AdminUIState) {
   return state.cachedData.nodes.valid && state.cachedData.liveness.valid;
 }
+
+/**
+ * partitionedStatuses divides the list of node statuses into "live" and "dead".
+ */
+export const partitionedStatuses = createSelector(
+  nodesSummarySelector,
+  (summary) => {
+    return _.groupBy(
+      summary.nodeStatuses,
+      (ns) => {
+        switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
+          case LivenessStatus.LIVE:
+          case LivenessStatus.UNAVAILABLE:
+          case LivenessStatus.DECOMMISSIONING:
+            return "live";
+          case LivenessStatus.DECOMMISSIONED:
+            return "decommissioned";
+          case LivenessStatus.DEAD:
+          default:
+            return "dead";
+        }
+      },
+    );
+  },
+);

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 import moment from "moment";
-import { createSelector } from "reselect";
 import _ from "lodash";
 
 import {
@@ -20,6 +19,7 @@ import {
   nodeCapacityStats,
   NodesSummary,
   nodesSummarySelector,
+  partitionedStatuses,
   selectNodesSummaryValid,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
@@ -284,31 +284,6 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     );
   }
 }
-
-/**
- * partitionedStatuses divides the list of node statuses into "live" and "dead".
- */
-const partitionedStatuses = createSelector(
-  nodesSummarySelector,
-  (summary) => {
-    return _.groupBy(
-      summary.nodeStatuses,
-      (ns) => {
-        switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
-          case LivenessStatus.LIVE:
-          case LivenessStatus.UNAVAILABLE:
-          case LivenessStatus.DECOMMISSIONING:
-            return "live";
-          case LivenessStatus.DECOMMISSIONED:
-            return "decommissioned";
-          case LivenessStatus.DEAD:
-          default:
-            return "dead";
-        }
-      },
-    );
-  },
-);
 
 /**
  * LiveNodesConnected is a redux-connected HOC of LiveNodeList.

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -203,7 +203,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
  * NotLiveNodeListProps are the properties of NotLiveNodeList.
  */
 interface NotLiveNodeListProps extends NodeCategoryListProps {
-  status: LivenessStatus.DECOMMISSIONING | LivenessStatus.DEAD;
+  status: LivenessStatus.DECOMMISSIONED | LivenessStatus.DEAD;
 }
 
 /**
@@ -211,6 +211,16 @@ interface NotLiveNodeListProps extends NodeCategoryListProps {
  * nodes on the cluster.
  */
 class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
+  getHeaderInfo() {
+    const { status } = this.props;
+    if (status === LivenessStatus.DECOMMISSIONED) {
+      return (
+        <Link to={`reports/nodes/history`}>Decommissioned node history</Link>
+      );
+    }
+    return null;
+  }
+
   render() {
     const { status, statuses, nodesSummary, sortSetting } = this.props;
     if (!statuses || statuses.length === 0) {
@@ -218,11 +228,13 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     }
 
     const statusName = _.capitalize(LivenessStatus[status]);
+    const headerInfo = this.getHeaderInfo();
 
     return (
       <div className="embedded-table">
-        <section className="section section--heading">
+        <section className="section section--heading section--heading__justify-end">
           <h2>{`${statusName} Nodes`}</h2>
+          { headerInfo }
         </section>
         <NodeSortedTable
           data={statuses}

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -37,6 +37,7 @@ import deadIcon from "!!raw-loader!assets/livenessIcons/dead.svg";
 import { cockroach } from "src/js/protos";
 
 import { BytesBarChart } from "./barChart";
+import TableSection from "./tableSection";
 import "./nodes.styl";
 
 import NodeLivenessStatus = cockroach.storage.NodeLivenessStatus;
@@ -90,10 +91,10 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
     }
 
     return (
-      <div className="embedded-table">
-        <section className="section section--heading">
-          <h2>Live Nodes</h2>
-        </section>
+      <TableSection
+        id={`nodes-overview__live-nodes`}
+        title={`Live Nodes`}
+        className="embedded-table">
         <NodeSortedTable
           data={statuses}
           sortSetting={sortSetting}
@@ -194,7 +195,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               className: "expand-link",
             },
           ]} />
-      </div>
+      </TableSection>
     );
   }
 }
@@ -204,20 +205,19 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
  */
 interface NotLiveNodeListProps extends NodeCategoryListProps {
   status: LivenessStatus.DECOMMISSIONED | LivenessStatus.DEAD;
+  isCollapsible: boolean;
 }
 
 /**
  * NotLiveNodeList renders a sortable table of all "dead" or "decommissioned"
  * nodes on the cluster.
  */
-class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
+class NotLiveNodeList extends React.Component<NotLiveNodeListProps> {
   getFooter() {
     const { status } = this.props;
     if (status === LivenessStatus.DECOMMISSIONED) {
       return (
-        <div className="embedded-table__footer">
-          <Link to={`reports/nodes/history`}>View all decommissioned nodes </Link>
-        </div>
+        <Link to={`reports/nodes/history`}>View all decommissioned nodes </Link>
       );
     }
     return null;
@@ -261,7 +261,7 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
   }
 
   render() {
-    const { status, statuses, sortSetting } = this.props;
+    const { status, statuses, sortSetting, isCollapsible } = this.props;
     if (!statuses || statuses.length === 0) {
       return null;
     }
@@ -270,10 +270,12 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     const downTimeColumnConfig = this.getDownTimeColumnConfig();
 
     return (
-      <div className="embedded-table">
-        <section className="section section--heading">
-          <h2>{`${statusName} Nodes`}</h2>
-        </section>
+      <TableSection
+        id={`nodes-overview__${statusName}-nodes`}
+        title={`${statusName} Nodes`}
+        footer={footer}
+        isCollapsible={isCollapsible}
+        className="embedded-table">
         <NodeSortedTable
           data={statuses}
           sortSetting={sortSetting}
@@ -314,8 +316,7 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
             // considered dead.
             downTimeColumnConfig,
           ]} />
-        {footer}
-      </div>
+      </TableSection>
     );
   }
 }
@@ -350,6 +351,7 @@ const DeadNodesConnected = connect(
       status: LivenessStatus.DEAD,
       statuses: statuses.dead,
       nodesSummary: nodesSummarySelector(state),
+      isCollapsible: false,
     };
   },
   {
@@ -378,6 +380,7 @@ const DecommissionedNodesConnected = connect(
       status: LivenessStatus.DECOMMISSIONED,
       statuses: recentDecommissionedNodes,
       nodesSummary,
+      isCollapsible: true,
     };
   },
   {
@@ -419,7 +422,7 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
 
   render() {
     return (
-      <div>
+      <div className="nodes-list-container">
         <DeadNodesConnected />
         <LiveNodesConnected />
         <DecommissionedNodesConnected />

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -223,7 +223,7 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     return null;
   }
 
-  // Get column configuratin for the time node has been dead or decommissioned.
+  // Get column configuration for the time node has been dead or decommissioned.
   // Depending on the node status it returns relative or absolute date representation.
   getDownTimeColumnConfig(): ColumnDescriptor<INodeStatus> {
     const { status, nodesSummary } = this.props;

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -45,3 +45,10 @@
 .node-status-icon > svg
   width 16px
   height 16px
+
+.section--heading__justify-end
+  display flex
+  flex-direction row
+  justify-content space-between
+  align-items center
+

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -46,9 +46,5 @@
   width 16px
   height 16px
 
-.section--heading__justify-end
-  display flex
-  flex-direction row
-  justify-content space-between
-  align-items center
-
+.embedded-table__footer
+  margin 16px 20px

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -46,5 +46,13 @@
   width 16px
   height 16px
 
-.embedded-table__footer
-  margin 16px 20px
+.nodes-list-container
+  background $background-color
+  display flex
+  flex-direction column
+
+.nodes-list-container > *
+  margin-bottom 12px
+
+.nodes-list-container > *:last-child
+  margin-bottom 0

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.styl
@@ -1,0 +1,41 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+
+.table-section
+  box-shadow 0 0 1px 0 rgba(67, 90, 111, 0.41)
+  border solid 0 $background-color
+  background white
+
+.table-section--last
+  margin-bottom 0
+
+.table-section__heading--justify-end
+  display flex
+  flex-direction row
+  justify-content space-between
+  align-items center
+
+.table-section__content
+  border-top 1px solid $background-color
+
+.table-section__content--collapsed
+  display none
+
+.collapse-toggle__icon
+  font-size 12px
+  margin-left 12px
+
+.collapse-toggle
+  cursor pointer
+
+.table-section__footer
+  margin 16px 20px

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.tsx
@@ -54,10 +54,6 @@ class TableSection extends React.Component<TableSectionProps & MapStateToProps &
     isCollapsed: false,
   };
 
-  componentWillUnmount() {
-    this.props.saveExpandedState(this.state.isCollapsed);
-  }
-
   onExpandSectionToggle = () => {
     this.setState({
       isCollapsed: !this.state.isCollapsed,

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/tableSection.tsx
@@ -1,0 +1,140 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { connect, Dispatch } from "react-redux";
+import cn from "classnames";
+import { Icon } from "antd";
+
+import { LocalSetting, setLocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+
+import "./tableSection.styl";
+
+interface MapStateToProps {
+  isCollapsed: boolean;
+}
+
+interface MapDispatchToProps {
+  saveExpandedState: (isCollapsed: boolean) => void;
+}
+
+interface TableSectionProps {
+  // Uniq ID which is used to create LocalSettings key for storing user state in session.
+  id: string;
+  // Title of the section
+  title: string;
+  // Bottom part of the section, can be string or RectNode.
+  footer?: React.ReactNode;
+  // If true, allows collapse content of the section and only title remains visible.
+  isCollapsible?: boolean;
+  // Class which is applied on root element of the section.
+  className?: string;
+}
+
+interface TableSectionState {
+  isCollapsed: boolean;
+}
+
+class TableSection extends React.Component<TableSectionProps & MapStateToProps & MapDispatchToProps, TableSectionState> {
+  static defaultProps: Partial<TableSectionProps> = {
+    isCollapsible: false,
+    footer: null,
+    className: "",
+  };
+
+  state = {
+    isCollapsed: false,
+  };
+
+  componentWillUnmount() {
+    this.props.saveExpandedState(this.state.isCollapsed);
+  }
+
+  onExpandSectionToggle = () => {
+    this.setState({
+      isCollapsed: !this.state.isCollapsed,
+    });
+    this.props.saveExpandedState(!this.state.isCollapsed);
+  }
+
+  getCollapseSectionToggle = () => {
+    const { isCollapsible } = this.props;
+    if (!isCollapsible) {
+      return null;
+    }
+
+    const { isCollapsed } = this.state;
+
+    return (
+      <div className="collapse-toggle" onClick={this.onExpandSectionToggle}>
+        <span>{isCollapsed ? "Show" : "Hide"}</span>
+        <Icon
+          className="collapse-toggle__icon"
+          type={isCollapsed ? "caret-left" : "caret-down"} />
+      </div>
+    );
+  }
+
+  render() {
+    const { children, title, footer, className } = this.props;
+    const { isCollapsed } = this.state;
+    const rootClass = cn("table-section", className);
+    const contentClass = cn(
+      "table-section__content",
+      {
+        "table-section__content--collapsed": isCollapsed,
+      },
+    );
+    const collapseToggleButton = this.getCollapseSectionToggle();
+
+    return (
+      <div className={rootClass}>
+        <section
+          className="section section--heading table-section__heading--justify-end"
+          style={{maxWidth: "unset"}}>
+          <h2>{title}</h2>
+          {collapseToggleButton}
+        </section>
+        <div className={contentClass}>
+          {children}
+          {
+            footer && (
+              <div className="table-section__footer">
+                {footer}
+              </div>
+            )
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
+const getTableSectionKey = (id: string) => `cluster_overview/table_section/${id}/is_expanded`;
+
+const mapStateToProps = (state: AdminUIState, props: TableSectionProps) => {
+  const tableSectionState = new LocalSetting<AdminUIState, boolean>(
+    getTableSectionKey(props.id), (s) => s.localSettings,
+  );
+
+  return {
+    isCollapsed: tableSectionState.selector(state),
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch<AdminUIState>, props: TableSectionProps) => ({
+  saveExpandedState: (isCollapsed: boolean) => {
+    const tableSectionKey = getTableSectionKey(props.id);
+    dispatch(setLocalSetting(tableSectionKey, isCollapsed));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableSection);

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -148,6 +148,11 @@ export default function Debug() {
             url="#/reports/nodes?locality=region=us-east"
             note="#/reports/nodes?locality=[regex]"
           />
+          <DebugTableLink
+            name="Decommissioned node history"
+            url="#/reports/nodes/history"
+            note="#/reports/nodes/history"
+          />
         </DebugTableRow>
         <DebugTableRow title="Stores">
           <DebugTableLink name="Stores on this node" url="#/reports/stores/local" />

--- a/pkg/ui/src/views/reports/containers/nodes/nodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/nodeHistory.tsx
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { Helmet } from "react-helmet";
+
+export interface NodeHistoryProps {
+
+}
+
+export default function NodeHistory(_props: NodeHistoryProps) {
+  return (
+    <section className="section">
+      <Helmet>
+        <title>Decommissioned Node History | Debug</title>
+      </Helmet>
+      <h1>Decommissioned Node History</h1>
+    </section>
+  );
+}

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.styl
@@ -8,20 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as React from "react";
-import { Helmet } from "react-helmet";
-
-export interface NodeHistoryProps {
-
-}
-
-export default function NodeHistory(_props: NodeHistoryProps) {
-  return (
-    <section className="section">
-      <Helmet>
-        <title>Decommissioned Node History | Debug</title>
-      </Helmet>
-      <h1>Decommissioned Node History</h1>
-    </section>
-  );
-}
+.title
+  margin 8px 0 26px

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -15,20 +15,20 @@ import { Link } from "react-router";
 import moment from "moment";
 import _ from "lodash";
 
-import { AdminUIState } from "oss/src/redux/state";
+import { AdminUIState } from "src/redux/state";
 import {
   LivenessStatus,
   NodesSummary,
   nodesSummarySelector,
   partitionedStatuses,
   selectNodesSummaryValid,
-} from "oss/src/redux/nodes";
-import { refreshLiveness, refreshNodes } from "oss/src/redux/apiReducers";
-import { SortedTable } from "oss/src/views/shared/components/sortedtable";
-import { INodeStatus } from "oss/src/util/proto";
-import { LongToMoment } from "oss/src/util/convert";
-import { SortSetting } from "oss/src/views/shared/components/sortabletable";
-import { LocalSetting } from "oss/src/redux/localsettings";
+} from "src/redux/nodes";
+import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
+import { SortedTable } from "src/views/shared/components/sortedtable";
+import { INodeStatus } from "src/util/proto";
+import { LongToMoment } from "src/util/convert";
+import { SortSetting } from "src/views/shared/components/sortabletable";
+import { LocalSetting } from "src/redux/localsettings";
 
 import "./decommissionedNodeHistory.styl";
 

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -1,0 +1,138 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { Helmet } from "react-helmet";
+import { connect } from "react-redux";
+import { Link } from "react-router";
+import moment from "moment";
+import _ from "lodash";
+
+import { AdminUIState } from "oss/src/redux/state";
+import {
+  LivenessStatus,
+  NodesSummary,
+  nodesSummarySelector,
+  partitionedStatuses,
+  selectNodesSummaryValid,
+} from "oss/src/redux/nodes";
+import { refreshLiveness, refreshNodes } from "oss/src/redux/apiReducers";
+import { SortedTable } from "oss/src/views/shared/components/sortedtable";
+import { INodeStatus } from "oss/src/util/proto";
+import { LongToMoment } from "oss/src/util/convert";
+import { SortSetting } from "oss/src/views/shared/components/sortabletable";
+import { LocalSetting } from "oss/src/redux/localsettings";
+
+import "./decommissionedNodeHistory.styl";
+
+const decommissionedNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "nodes/decommissioned_sort_setting", (s) => s.localSettings,
+);
+
+class NodeSortedTable extends SortedTable<INodeStatus> {}
+
+export interface DecommissionedNodeHistoryProps {
+  refreshNodes: typeof refreshNodes;
+  refreshLiveness: typeof refreshLiveness;
+  nodesSummaryValid: boolean;
+  status: LivenessStatus.DECOMMISSIONED;
+  sortSetting: SortSetting;
+  setSort: typeof decommissionedNodesSortSetting.set;
+  statuses: INodeStatus[];
+  nodesSummary: NodesSummary;
+}
+
+class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps> {
+  componentWillMount() {
+    this.props.refreshNodes();
+    this.props.refreshLiveness();
+  }
+
+  componentWillReceiveProps(props: DecommissionedNodeHistoryProps) {
+    props.refreshNodes();
+    props.refreshLiveness();
+  }
+
+  render() {
+    const { status, statuses, nodesSummary, sortSetting, setSort } = this.props;
+    if (!statuses || statuses.length === 0) {
+      return null;
+    }
+
+    const statusName = _.capitalize(LivenessStatus[status]);
+
+    return (
+      <section className="section">
+        <Helmet>
+          <title>Decommissioned Node History | Debug</title>
+        </Helmet>
+        <h1 className="title">Decommissioned Node History</h1>
+        <div>
+          <NodeSortedTable
+            data={statuses}
+            sortSetting={sortSetting}
+            onChangeSortSetting={(setting) => setSort(setting)}
+            columns={[
+              {
+                title: "ID",
+                cell: (ns) => `n${ns.desc.node_id}`,
+                sort: (ns) => ns.desc.node_id,
+              },
+              {
+                title: "Address",
+                cell: (ns) => {
+                  return (
+                    <div>
+                      <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                    </div>
+                  );
+                },
+                sort: (ns) => ns.desc.node_id,
+                className: "sort-table__cell--link",
+              },
+              {
+                title: `${statusName} Since`,
+                cell: (ns) => {
+                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                  if (!liveness) {
+                    return "no information";
+                  }
+
+                  const deadTime = liveness.expiration.wall_time;
+                  const deadMoment = LongToMoment(deadTime);
+                  return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;
+                },
+                sort: (ns) => {
+                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                  return liveness.expiration.wall_time;
+                },
+              },
+            ]} />
+        </div>
+      </section>
+    );
+  }
+}
+
+const mapStateToProps = (state: AdminUIState) => ({
+  nodesSummaryValid: selectNodesSummaryValid(state),
+  sortSetting: decommissionedNodesSortSetting.selector(state),
+  status: LivenessStatus.DECOMMISSIONED,
+  statuses: partitionedStatuses(state).decommissioned,
+  nodesSummary: nodesSummarySelector(state),
+});
+
+const mapDispatchToProps = {
+  refreshNodes,
+  refreshLiveness,
+  setSort: decommissionedNodesSortSetting.set,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DecommissionedNodeHistory);

--- a/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/decommissionedNodeHistory.tsx
@@ -12,7 +12,6 @@ import * as React from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { Link } from "react-router";
-import moment from "moment";
 import _ from "lodash";
 
 import { AdminUIState } from "src/redux/state";
@@ -98,7 +97,7 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
                 className: "sort-table__cell--link",
               },
               {
-                title: `${statusName} Since`,
+                title: `${statusName} On`,
                 cell: (ns) => {
                   const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
                   if (!liveness) {
@@ -107,7 +106,7 @@ class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistor
 
                   const deadTime = liveness.expiration.wall_time;
                   const deadMoment = LongToMoment(deadTime);
-                  return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;
+                  return deadMoment.format("LL[ at ]h:mm a");
                 },
                 sort: (ns) => {
                   const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];

--- a/pkg/ui/src/views/reports/containers/nodesHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodesHistory/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./decommissionedNodeHistory";


### PR DESCRIPTION
It should be possible to hide the Decommissioned nodes list because for some users it is not important information at all. To accomplish this, the `TableSection` component has been implemented where main purpose is to display the title of the section, content, and a footer and provide the ability to hide content from the user.
The `TableSection` component requires `id` property which is used to construct a unique key for LocalSettings storage.

In addition to the main changes, some styles for the `NodesList` component have been adjusted to reflect the latest designs. Particularly spacing was added between sections in the `NodesList` component.