### PR TITLE
release-2.1: storage: clear *cmd references in cmdQ buffers before re-use

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -629,7 +629,13 @@ func (cq *CommandQueue) getOverlaps(
 	// Both reads and writes must wait on other writes, depending on timestamps.
 	cq.writes.DoMatching(cq.collectOverlappingWritesRef, rng)
 	overlaps := cq.overlaps
-	cq.overlaps = cq.overlaps[:0]
+	if cap(cq.overlaps) > 1024 {
+		// Limit the maximum size that the overlaps buffer can grow to. We don't
+		// want to hold on to a potentially unbounded size slice.
+		cq.overlaps = nil
+	} else {
+		cq.overlaps = cq.overlaps[:0]
+	}
 	return overlaps
 }
 


### PR DESCRIPTION
This PR contains two commits that attempt to avoid indefinitely retaining references to large graphs of `*cmd` objects in the `CommandQueue` and preventing them from being GCed.

#### storage: don't let cmdQ buffers grow without bound

This commit places a limit on the size of the overlaps buffer than the CommandQueue uses to avoid repeat allocations in getOverlaps. It's risky to allow this buffer to grow without bounds and never be reclaimed.

#### storage: clear *cmd references in cmdQ buffers before re-use

This commit ensures that the *cmd references in the overlaps buffer that the CommandQueue uses to avoid repeat allocations are cleared after use. This prevents the buffer from accidentally holding references to *cmd objects and preventing them from being GCed.