### PR TITLE
release-19.2: opt: fix selectivity calculation for multiple predicates

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1554,3 +1554,72 @@ select
  │    └── fd: (1)-->(2-4)
  └── filters
       └── (n_name, neighbor) IN (('FRANCE', 'GERMANY'), ('GERMANY', 'FRANCE')) [type=bool, outer=(2,4), constraints=(/2/4: [/'FRANCE'/'GERMANY' - /'FRANCE'/'GERMANY'] [/'GERMANY'/'FRANCE' - /'GERMANY'/'FRANCE']; /4: [/'FRANCE' - /'FRANCE'] [/'GERMANY' - /'GERMANY']; tight)]
+
+# Make sure the that histogram and distinct counts don't interfere with each
+# other during selectivity calculation.
+exec-ddl
+CREATE TABLE hist_and_distinct (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  INDEX idx_a (a)
+)
+----
+
+exec-ddl
+ALTER TABLE hist_and_distinct INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "distinct_range": 9, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "distinct_range": 9, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "distinct_range": 9, "upper_bound": "40"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 5
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 5
+  },
+  {
+    "columns": ["d"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 120
+  }
+]'
+----
+
+norm
+SELECT * FROM hist_and_distinct WHERE a = 10 AND b = 10 AND c = 10 AND d >= 10 AND d < 100
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
+ ├── stats: [rows=0.3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0]
+ │   histogram(1)=  0 0.3
+ │                <--- 10
+ ├── fd: ()-->(1-3)
+ ├── scan hist_and_distinct
+ │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
+ │    └── stats: [rows=1000, distinct(1)=40, null(1)=0, distinct(2)=5, null(2)=0, distinct(3)=5, null(3)=0, distinct(4)=120, null(4)=0]
+ │        histogram(1)=  0  0  90  10  180  20  270  30  360  40
+ │                     <--- 0 ---- 10 ----- 20 ----- 30 ----- 40
+ └── filters
+      ├── (d >= 10) AND (d < 100) [type=bool, outer=(4), constraints=(/4: [/10 - /99]; tight)]
+      ├── a = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+      ├── b = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+      └── c = 10 [type=bool, outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -80,33 +80,12 @@ func (s *Statistics) Init(relProps *Relational) (zeroCardinality bool) {
 
 // ApplySelectivity applies a given selectivity to the statistics. RowCount and
 // Selectivity are updated. Note that DistinctCounts and NullCounts are not
-// updated, other than limiting them to the new RowCount.
+// updated.
 // See ColumnStatistic.ApplySelectivity for updating distinct counts and null
 // counts.
 func (s *Statistics) ApplySelectivity(selectivity float64) {
-	if selectivity == 0 {
-		s.RowCount = 0
-		for i, n := 0, s.ColStats.Count(); i < n; i++ {
-			colStat := s.ColStats.Get(i)
-			colStat.DistinctCount = 0
-			colStat.NullCount = 0
-		}
-		return
-	}
-
 	s.RowCount *= selectivity
 	s.Selectivity *= selectivity
-
-	// Make sure none of the distinct / null counts are larger than the row count.
-	for i, n := 0, s.ColStats.Count(); i < n; i++ {
-		colStat := s.ColStats.Get(i)
-		if colStat.DistinctCount > s.RowCount {
-			colStat.DistinctCount = s.RowCount
-		}
-		if colStat.NullCount > s.RowCount {
-			colStat.NullCount = s.RowCount
-		}
-	}
 }
 
 func (s *Statistics) String() string {


### PR DESCRIPTION
Backport 1/1 commits from #42916.

/cc @cockroachdb/release

---

Since we do not yet support multi-column statistics, the selectivity
of a SELECT operation with multiple filters is calculated as
sel1 * sel2 * sel3... where sel1 is the selectivity of the first filter,
sel2 is the selectivity of the second filter, and so on.

Prior to this commit, there was a bug in which the selectivity of the
first filter could affect the calculated selectivity of later filters,
in particluar if sel1 was calculated using a histogram and others were
calculated using distinct counts. This commit fixes the bug so that each
selectivity value is calculated and applied independently.

The issue existed because we calculate new distinct and null counts due to
filters before we calculate the selectivity of each filter. After updating
all the distinct and null counts, we calculate filter selectivity, starting
with filters on columns that have a histogram. After the selectivity is
calculated for some filters using histograms, the selectivity is "applied"
to the stats, which reduces the row count based on the selectivity, and
previously also reduced any distinct and null counts that were higher than
the updated row count. The problem with updating the distinct and null counts
is that they may be used later to calculate the selectivity of the other
filters, and this changes the calculation.

For example, consider the query:
```
  SELECT * FROM t WHERE x = 5 AND y >= 1 AND y <= 100;
```
Suppose that `t` originally has 1000 rows, we have a histogram on column `x`,
and column `y` originally has 200 distinct values. Based on the histogram on `x`,
we determine that there are 10 rows with `x = 5`. Although the predicate on `y`
indicates that there are 100 distinct values, that number would be reduced
to 10 to match the row count after the `x = 5` predicate is applied. Then
once the `(y >= 1 AND y <= 100)` predicate is applied, the selectivity is
calculated as 10/200 instead of 100/200, causing the selectivity to be
severely underestimated.

The solution is to avoid reducing any distinct counts or null counts to match
the row count until after all filters have been applied.

Release note (bug fix): Fixed the row count estimate during query planning
for some queries with multiple predicates in which the selectivity of one
predicate was calculated using a histogram.
