### PR TITLE
colrpc: downgrade Inbox init error

### DIFF
--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -280,7 +280,11 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 	// termination). DrainMeta will use the stream to read any remaining metadata
 	// after Next returns a zero-length batch during normal execution.
 	if err := i.maybeInitLocked(ctx); err != nil {
-		execerror.VectorizedInternalPanic(err)
+		// An error occurred while initializing the Inbox and is likely caused by
+		// the connection issues. We propagate the error as a "non-vectorized
+		// panic" so that the whole stack trace is not printed out (as an
+		// unexpected vectorized error) and the sentry issue is not reported.
+		execerror.NonVectorizedPanic(err)
 	}
 
 	for {


### PR DESCRIPTION
Previously, whenever an error occurred during the initialization of the
Inbox, it would be propagated as VectorizedInternalPanic. This causes
the error to be print out with AssertionFailed and a sentry issue to be
reported. However, it is likely that there are network connection
problems, and we don't want to have that reported, so we downdgrade the
propagation method to NonVectorizedPanic.

Release note: None