### PR TITLE
cli: Support nodelocal file upload in CLI

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -199,6 +199,7 @@ func init() {
 		userCmd,
 		nodeCmd,
 		dumpCmd,
+		nodeLocalCmd,
 
 		// Miscellaneous commands.
 		// TODO(pmattis): stats

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -127,10 +127,11 @@ func newCLITest(params cliTestParams) cliTest {
 		}
 
 		s, err := serverutils.StartServerRaw(base.TestServerArgs{
-			Insecure:    params.insecure,
-			SSLCertsDir: c.certsDir,
-			StoreSpecs:  params.storeSpecs,
-			Locality:    params.locality,
+			Insecure:      params.insecure,
+			SSLCertsDir:   c.certsDir,
+			StoreSpecs:    params.storeSpecs,
+			Locality:      params.locality,
+			ExternalIODir: filepath.Join(certsDir, "extern"),
 		})
 		if err != nil {
 			c.fail(err)
@@ -358,7 +359,7 @@ func isSQLCommand(args []string) bool {
 		return false
 	}
 	switch args[0] {
-	case "user", "sql", "dump", "workload":
+	case "user", "sql", "dump", "workload", "nodelocal":
 		return true
 	case "node":
 		if len(args) == 0 {
@@ -1603,6 +1604,7 @@ Available Commands:
   node              list, inspect or remove nodes
   dump              dump sql tables
 
+  nodelocal         upload and delete nodelocal files
   demo              open a demo sql shell
   gen               generate auxiliary files
   version           output version information

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -466,6 +466,7 @@ func init() {
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, systemBenchCmds...)
 	clientCmds = append(clientCmds, initCmd)
+	clientCmds = append(clientCmds, nodeLocalCmds...)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		VarFlag(f, addrSetter{&cliCtx.clientConnHost, &cliCtx.clientConnPort}, cliflags.ClientHost)
@@ -548,6 +549,7 @@ func init() {
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}
 	sqlCmds = append(sqlCmds, userCmds...)
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
+	sqlCmds = append(sqlCmds, nodeLocalCmds...)
 	for _, cmd := range sqlCmds {
 		f := cmd.Flags()
 		BoolFlag(f, &sqlCtx.echo, cliflags.EchoSQL, sqlCtx.echo)

--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -1,0 +1,120 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const (
+	chunkSize = 4 * 1024
+)
+
+var nodeLocalUploadCmd = &cobra.Command{
+	Use:   "upload <source> <destination>",
+	Short: "Upload file from source to destination",
+	Long: `
+Uploads a file to a gateway node's local file system using a SQL connection.
+`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: maybeShoutError(runUpload),
+}
+
+func runUpload(cmd *cobra.Command, args []string) error {
+	conn, err := makeSQLClient("cockroach nodelocal", useSystemDb)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	source := args[0]
+	destination := args[1]
+	reader, err := openSourceFile(source)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	return uploadFile(conn, reader, destination)
+}
+
+func openSourceFile(source string) (io.ReadCloser, error) {
+	f, err := os.Open(source)
+	if err != nil {
+		return nil, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get source file stats for %s", source)
+	}
+	if stat.IsDir() {
+		return nil, fmt.Errorf("source file %s is a directory, not a file", source)
+	}
+	return f, nil
+}
+
+func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
+	err := conn.ExecTxn(func(cn *sqlConn) error {
+		stmt, err := cn.conn.Prepare(sql.CopyInFileStmt(destination, "crdb_internal", "file_upload"))
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = stmt.Close()
+		}()
+		send := make([]byte, chunkSize)
+		for {
+			n, err := reader.Read(send)
+			if n > 0 {
+				_, err = stmt.Exec([]driver.Value{string(send[:n])})
+				if err != nil {
+					return err
+				}
+			} else if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	nodeID, _, _, err := conn.getServerMetadata()
+	if err != nil {
+		return errors.Wrap(err, "unable to get node id")
+	}
+	fmt.Printf("successfully uploaded to nodelocal://%s\n", filepath.Join(nodeID.String(), destination))
+	return nil
+}
+
+var nodeLocalCmds = []*cobra.Command{
+	nodeLocalUploadCmd,
+}
+
+var nodeLocalCmd = &cobra.Command{
+	Use:   "nodelocal [command]",
+	Short: "upload and delete nodelocal files",
+	Long:  "Upload and delete files on the gateway node's local file system.",
+	RunE:  usageAndErr,
+}
+
+func init() {
+	nodeLocalCmd.AddCommand(nodeLocalCmds...)
+}

--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -1,0 +1,114 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func Example_nodelocal() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	file, cleanUp := createTestFile()
+	defer cleanUp()
+
+	c.Run(fmt.Sprintf("nodelocal upload %s /test/file1.csv", file))
+	c.Run(fmt.Sprintf("nodelocal upload %s /test/file2.csv", file))
+	c.Run(fmt.Sprintf("nodelocal upload %s /test/file1.csv", file))
+	c.Run(fmt.Sprintf("nodelocal upload %s /test/../../file1.csv", file))
+	c.Run(fmt.Sprintf("nodelocal upload notexist.csv /test/file1.csv"))
+
+	// Output:
+	// nodelocal upload test.csv /test/file1.csv
+	// successfully uploaded to nodelocal://1/test/file1.csv
+	// nodelocal upload test.csv /test/file2.csv
+	// successfully uploaded to nodelocal://1/test/file2.csv
+	// nodelocal upload test.csv /test/file1.csv
+	// ERROR: destination file already exists for /test/file1.csv
+	// nodelocal upload test.csv /test/../../file1.csv
+	// ERROR: current transaction is aborted, commands ignored until end of transaction block
+	// SQLSTATE: 25P02
+	// nodelocal upload notexist.csv /test/file1.csv
+	// ERROR: open notexist.csv: no such file or directory
+}
+
+func TestNodeLocalFileUpload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+
+	for i, tc := range []struct {
+		name        string
+		fileContent []byte
+	}{
+		{
+			"exactly-one-chunk",
+			make([]byte, chunkSize),
+		},
+		{
+			"exactly-five-chunks",
+			make([]byte, chunkSize*5),
+		},
+		{
+			"less-than-one-chunk",
+			make([]byte, chunkSize-100),
+		},
+		{
+			"more-than-one-chunk",
+			make([]byte, chunkSize+100),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath := filepath.Join(dir, fmt.Sprintf("file%d.csv", i))
+			err := ioutil.WriteFile(filePath, tc.fileContent, 0666)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destination := fmt.Sprintf("/test/file%d.csv", i)
+
+			_, err = c.RunWithCapture(fmt.Sprintf("nodelocal upload %s %s", filePath, destination))
+			if err != nil {
+				t.Fatal(err)
+			}
+			writtenContent, err := ioutil.ReadFile(filepath.Join(c.Cfg.Settings.ExternalIODir, destination))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(tc.fileContent, writtenContent) {
+				t.Fatalf("expected:\n%s\nbut got:\n%s", tc.fileContent, writtenContent)
+			}
+		})
+	}
+}
+
+func createTestFile() (string, func()) {
+	filePath := "test.csv"
+	err := ioutil.WriteFile(filePath, []byte("file content"), 0666)
+	if err != nil {
+		return "", func() {}
+	}
+	return filePath, func() {
+		_ = os.Remove(filePath)
+	}
+}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1646,7 +1646,7 @@ func (ex *connExecutor) execCopyIn(
 		ex.initPlanner(ctx, p)
 		ex.resetPlanner(ctx, p, txn, stmtTS, 0 /* numAnnotations */)
 	}
-	if cmd.Stmt.Table.TableName == fileUploadTable {
+	if table := cmd.Stmt.Table; table.Table() == fileUploadTable && table.Schema() == crdbInternalName {
 		cm, err = newFileUploadMachine(cmd.Conn, cmd.Stmt, ex.server.cfg, resetPlanner)
 	} else {
 		cm, err = newCopyMachine(

--- a/pkg/sql/copy_file_upload_test.go
+++ b/pkg/sql/copy_file_upload_test.go
@@ -49,10 +49,6 @@ func runCopyFile(t *testing.T, serverParams base.TestServerArgs, testSendFile st
 	s, db, _ := serverutils.StartServer(t, serverParams)
 	defer s.Stopper().Stop(context.TODO())
 
-	if _, err := db.Exec(`CREATE DATABASE d;`); err != nil {
-		t.Fatal(err)
-	}
-
 	txn, err := db.Begin()
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +59,7 @@ func runCopyFile(t *testing.T, serverParams base.TestServerArgs, testSendFile st
 		}
 	}()
 
-	stmt, err := txn.Prepare(CopyInFileStmt(filename, "d", fileUploadTable))
+	stmt, err := txn.Prepare(CopyInFileStmt(filename, crdbInternalName, fileUploadTable))
 	if err != nil {
 		return err
 	}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1461,6 +1461,8 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* const .* is unused`),
 				// The methods in exprgen.customFuncs are used via reflection.
 				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
+				// Using deprecated method to COPY.
+				stream.GrepNot(`pkg/cli/nodelocal.go:.* stmt.Exec is deprecated: .*`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {


### PR DESCRIPTION
This change uses the changes made in #42748, which enabled
COPY to upload files. We are now implementing the CLI to include
a new command: `nodelocal upload`. This command takes in a
source file to upload, and a destination filename. It will
then use the COPY command to upload the file and drop it
on the gateway node's local file system, at:

`externalIODir/destination/filename`

This PR also includes the CLI testing for this feature as
well as a bug fix for the previous PR #42748:
- If writing the file fails, we do not delete the file
 that was created. This PR fixes that.

Release note (cli change): Adds a nodelocal command
that can be used to upload file:
`cockroach nodelocal upload location/of/file destination/of/file`