### PR TITLE
roachprod: don't try to make long dns names

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -159,7 +159,9 @@ func SyncDNS(vms vm.List) error {
 		}
 	}()
 	for _, vm := range vms {
-		fmt.Fprintf(f, "%s 60 IN A %s\n", vm.Name, vm.PublicIP)
+		if len(vm.Name) < 60 {
+			fmt.Fprintf(f, "%s 60 IN A %s\n", vm.Name, vm.PublicIP)
+		}
 	}
 	f.Close()
 


### PR DESCRIPTION
long cluster names break DNS. Rather than break DNS for everyone, just skip the clusters that have these long names.
DNS is a nice-to-have in any case, so it is OK to skip it -- roachprod will fallback to IPs.

Release note: none.