### PR TITLE
release-19.2: colexec: check for unsupported output type of a builtin

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 type defaultBuiltinFuncOperator struct {
@@ -180,7 +181,7 @@ func NewBuiltinFunctionOperator(
 	argumentCols []int,
 	outputIdx int,
 	input Operator,
-) Operator {
+) (Operator, error) {
 
 	switch funcExpr.ResolvedOverload().SpecializedVecBuiltin {
 	case tree.SubstringStringIntInt:
@@ -188,9 +189,16 @@ func NewBuiltinFunctionOperator(
 			OneInputNode: NewOneInputNode(input),
 			argumentCols: argumentCols,
 			outputIdx:    outputIdx,
-		}
+		}, nil
 	default:
 		outputType := funcExpr.ResolvedType()
+		outputPhysType := typeconv.FromColumnType(outputType)
+		if outputPhysType == coltypes.Unhandled {
+			return nil, errors.Errorf(
+				"unsupported output type %q of %s",
+				outputType.String(), funcExpr.String(),
+			)
+		}
 		return &defaultBuiltinFuncOperator{
 			OneInputNode:   NewOneInputNode(input),
 			evalCtx:        evalCtx,
@@ -198,10 +206,10 @@ func NewBuiltinFunctionOperator(
 			outputIdx:      outputIdx,
 			columnTypes:    columnTypes,
 			outputType:     outputType,
-			outputPhysType: typeconv.FromColumnType(outputType),
+			outputPhysType: outputPhysType,
 			converter:      typeconv.GetDatumToPhysicalFn(outputType),
 			row:            make(tree.Datums, len(argumentCols)),
 			argumentCols:   argumentCols,
-		}
+		}, nil
 	}
 }

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock typing context for the typechecker.
@@ -96,7 +97,7 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					return NewBuiltinFunctionOperator(tctx, typedExpr.(*tree.FuncExpr), tc.outputTypes, tc.inputCols, 1, input[0]), nil
+					return NewBuiltinFunctionOperator(tctx, typedExpr.(*tree.FuncExpr), tc.outputTypes, tc.inputCols, 1, input[0])
 				})
 		})
 	}
@@ -147,7 +148,8 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	if err != nil {
 		b.Fatal(err)
 	}
-	op := NewBuiltinFunctionOperator(tctx, typedExpr.(*tree.FuncExpr), []types.T{*types.Int}, []int{0}, 1, source)
+	op, err := NewBuiltinFunctionOperator(tctx, typedExpr.(*tree.FuncExpr), []types.T{*types.Int}, []int{0}, 1, source)
+	require.NoError(b, err)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1167,8 +1167,8 @@ func planProjectionOperators(
 		funcOutputType := t.ResolvedType()
 		resultIdx = len(ct)
 		ct = append(ct, *funcOutputType)
-		op = NewBuiltinFunctionOperator(ctx, t, ct, inputCols, resultIdx, op)
-		return op, resultIdx, ct, memUsed, nil
+		op, err = NewBuiltinFunctionOperator(ctx, t, ct, inputCols, resultIdx, op)
+		return op, resultIdx, ct, memUsed, err
 	case tree.Datum:
 		datumType := t.ResolvedType()
 		ct = columnTypes

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -54,3 +54,8 @@ SELECT * FROM all_types ORDER BY 1
 ----
 NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL
 false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000
+
+# This query uses a builtin that returns currently unsupported type
+# (TimestampTZ). We're only interested in not getting an error. See #42871.
+statement ok
+SELECT experimental_strptime(_string, _string) IS NULL FROM all_types


### PR DESCRIPTION
Backport 1/1 commits from #42968.

/cc @cockroachdb/release

---

Previously, we would always create a defaultBuiltinOperator with
a converted physical output type from a builtin function. This could be
coltypes.Unhandled, and only during runtime we would realize that we do
not support the output type of the builtin. Now this is fixed.

Fixes: #42871.

Release note (bug fix): Previously, in some cases, when executing a builtin
function via the vectorized engine that returns an output type unsupported
by the vectorized engine CockroachDB would return an error instead of
falling back to row-by-row execution engine. Now this is fixed.
