### PR TITLE
colexec: cfetcher errors on setup when indexed column contains unhandled type

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -265,15 +265,6 @@ func (rf *cFetcher) Init(
 	}
 	sort.Sort(m)
 	colDescriptors := tableArgs.Cols
-	typs := make([]coltypes.T, len(colDescriptors))
-	for i := range typs {
-		typs[i] = typeconv.FromColumnType(&colDescriptors[i].Type)
-		if typs[i] == coltypes.Unhandled && tableArgs.ValNeededForCol.Contains(i) {
-			// Only return an error if the type is unhandled and needed. If not needed,
-			// a placeholder Vec will be created.
-			return errors.Errorf("unhandled type %+v", &colDescriptors[i].Type)
-		}
-	}
 	table := cTableInfo{
 		spans:            tableArgs.Spans,
 		desc:             tableArgs.Desc,
@@ -288,6 +279,29 @@ func (rf *cFetcher) Init(
 		extraValColOrdinals:    oldTable.extraValColOrdinals[:0],
 		allExtraValColOrdinals: oldTable.allExtraValColOrdinals[:0],
 	}
+
+	// All columns that are part of the index key will be decoded when reading a key. Since some types
+	// are not supported by the vectorized engine, we should error out during setup if some needed columns
+	// or columns we decode always will be attempted to be decoded.
+	typs := make([]coltypes.T, len(colDescriptors))
+	var indexedCols util.FastIntSet
+	for _, colID := range tableArgs.Index.ColumnIDs {
+		indexedCols.Add(int(colID))
+	}
+	if cHasExtraCols(&table) {
+		for _, colID := range tableArgs.Index.ExtraColumnIDs {
+			indexedCols.Add(int(colID))
+		}
+	}
+	for i := range typs {
+		typs[i] = typeconv.FromColumnType(&colDescriptors[i].Type)
+		if typs[i] == coltypes.Unhandled && (tableArgs.ValNeededForCol.Contains(i) || indexedCols.Contains(int(colDescriptors[i].ID))) {
+			// Only return an error if the type is unhandled and needed. If not needed,
+			// a placeholder Vec will be created.
+			return errors.Errorf("unhandled type %+v", &colDescriptors[i].Type)
+		}
+	}
+
 	rf.machine.batch = allocator.NewMemBatch(typs)
 	rf.machine.colvecs = rf.machine.batch.ColVecs()
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1006,3 +1006,13 @@ SELECT * FROM t_42816 ORDER BY a OFFSET 1020 LIMIT 10
 1023
 1024
 1025
+
+# Regression test for #42994
+statement ok
+CREATE TABLE t42994 (a int primary key, b bit, index i (a, b));
+INSERT INTO t42994 VALUES (1, 1::BIT);
+
+query I
+SELECT a FROM t42994@i
+----
+1


### PR DESCRIPTION
Fixes #42994.

Indexed columns are always decoded by the fetcher, even if they are unneeded.
This PR adds the check to cfetcher initialization to error out if an indexed
column is of an unneeded type.

Release note (bug fix): Fixed a bug where scanning an index of an unsupported
type with the vectorized engine would lead to an internal error.