### PR TITLE
storage, ccl: Gate AddSSTable()ing RocksDBv2 format SSTs on cluster version

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -191,7 +191,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		iters = append(iters, iter)
 	}
 
-	batcher, err := bulk.MakeSSTBatcher(ctx, db, func() int64 { return MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()) })
+	batcher, err := bulk.MakeSSTBatcher(ctx, db, cArgs.EvalCtx.ClusterSettings(), func() int64 { return MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()) })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -207,7 +207,7 @@ func (b *BufferingAdder) Flush(ctx context.Context) error {
 		}
 		return nil
 	}
-	if err := b.sink.Reset(); err != nil {
+	if err := b.sink.Reset(ctx); err != nil {
 		return err
 	}
 	b.flushCounts.total++

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -331,7 +332,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if _, err := bulk.AddSSTable(
-		context.TODO(), mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, nil,
+		context.TODO(), mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(),
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Change #42763 caused all SSTs written for ingestion to
be written in the RocksDBv2 format as opposed to the leveldb format.
This turned out to be an issue in mixed-version clusters where not
all nodes can iterate over and ingest RocksDBv2 SSTs; nodes without
commit 2beab58  (so 19.2.* and below) cannot iterate over
these SSTs.

This change reverts back to creating LevelDB SSTs for ingestion
in the SSTBatcher only, unless the minimum cluster version is a 20.1 commit.
Other cases where we make RocksDBv2 SSTs (eg. in replica_raftstorage)
are okay and do not require this check, since those SSTs are ingested
by the same node where they're written.

Fixes #42081 .

Release note: None.