### PR TITLE
sql: fix decoding error in fetcher

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -701,7 +701,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 					}
 					var err error
 					// Slice off an extra encoded column from remainingBytes.
-					remainingBytes, err = colencoding.SkipTableKey(
+					remainingBytes, err = sqlbase.SkipTableKey(
 						&rf.table.cols[colIdx].Type,
 						remainingBytes,
 						// Extra columns are always stored in ascending order.

--- a/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
+++ b/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
@@ -218,3 +218,15 @@ Del /Table/53/5/1/3/1
 InitPut /Table/53/5/2/0 -> /BYTES/0x8a
 InitPut /Table/53/5/2/2/1 -> /TUPLE/3:3:Int/2
 InitPut /Table/53/5/2/3/1 -> /TUPLE/4:4:Int/2/1:5:Int/2
+
+# Regression for #42992.
+statement ok
+CREATE TABLE t42992 (x TIMESTAMP PRIMARY KEY, y INT, z INT, UNIQUE INDEX i (y) STORING (z), FAMILY (x), FAMILY (y), FAMILY (z))
+
+statement ok
+INSERT INTO t42992 VALUES (now(), NULL, 2)
+
+query II
+SELECT y, z FROM t42992@i
+----
+NULL 2

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/colencoding"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -678,7 +677,7 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 				colIdx := rf.currentTable.colIdxMap[colID]
 				var err error
 				// Slice off an extra encoded column from rf.keyRemainingBytes.
-				rf.keyRemainingBytes, err = colencoding.SkipTableKey(
+				rf.keyRemainingBytes, err = sqlbase.SkipTableKey(
 					&rf.currentTable.cols[colIdx].Type,
 					rf.keyRemainingBytes,
 					// Extra columns are always stored in ascending order.

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -168,6 +169,78 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 		return encoding.EncodeVarintDescending(b, int64(t.DInt)), nil
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)
+}
+
+// SkipTableKey skips a value of type valType in key, returning the remainder
+// of the key.
+// TODO(jordan): each type could be optimized here.
+func SkipTableKey(valType *types.T, key []byte, dir IndexDescriptor_Direction) ([]byte, error) {
+	if (dir != IndexDescriptor_ASC) && (dir != IndexDescriptor_DESC) {
+		return nil, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
+	}
+	var isNull bool
+	if key, isNull = encoding.DecodeIfNull(key); isNull {
+		return key, nil
+	}
+	var rkey []byte
+	var err error
+	switch valType.Family() {
+	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily, types.TimeFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeVarintDescending(key)
+		}
+	case types.FloatFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeFloatAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeFloatDescending(key)
+		}
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.INetFamily, types.CollatedStringFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
+		}
+	case types.DecimalFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
+		}
+	case types.TimestampFamily, types.TimestampTZFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeTimeAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeTimeDescending(key)
+		}
+	case types.TimeTZFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeTimeTZAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeTimeTZDescending(key)
+		}
+	case types.IntervalFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeDurationAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeDurationDescending(key)
+		}
+	case types.BitFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeBitArrayAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeBitArrayDescending(key)
+		}
+	default:
+		// Tuples and arrays aren't indexable types right now, so we don't have cases for them.
+		return key, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
+	}
+	if err != nil {
+		return key, err
+	}
+	return rkey, nil
 }
 
 // DecodeTableKey decodes a value encoded by EncodeTableKey.


### PR DESCRIPTION
Fixes #42992.

PR #42073 introduced column families for secondary indexes, but also introduced
a bug where if the extra columns of a unique index were included because that
row had a null value, then those extra columns needed to be skipped when
decoding keys. If the type of that extra column was not supported by the
vectorized engine, and internal error was thrown.  This PR fixes the bug by
updating the key skipping logic to handle all valid types.

There is no release note because this was not a change visible
through major versions.

Release note: None