### PR TITLE
release-19.2: sql: bugfixes in role membership caching

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -660,6 +660,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		HistogramWindowInterval: s.cfg.HistogramWindowInterval(),
 		RangeDescriptorCache:    s.distSender.RangeDescriptorCache(),
 		LeaseHolderCache:        s.distSender.LeaseHolderCache(),
+		RoleMemberCache:         &sql.MembershipCache{},
 		TestingKnobs:            sqlExecutorTestingKnobs,
 
 		DistSQLPlanner: sql.NewDistSQLPlanner(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -520,6 +520,9 @@ type ExecutorConfig struct {
 	// Caches updated by DistSQL.
 	RangeDescriptorCache *kv.RangeDescriptorCache
 	LeaseHolderCache     *kv.LeaseHolderCache
+
+	// Role membership cache.
+	RoleMemberCache *MembershipCache
 }
 
 // Organization returns the value of cluster.organization.


### PR DESCRIPTION
Backport 1/1 commits from #42998.

/cc @cockroachdb/release

---

Fixes #42098.

This PR fixes some bugs in role membership caching.

* The role membership cache was a single global, which meant
  multiple servers in the same cockroach process could pollute
  the cache for each other, causing flaky test failures.
* The cache updating mechanism seemed to use the incorrect variable
  to update the cache version when a concurrent request caused a cache
  invalidation as well. Although unlikely, this could have lead to incorrect
  results being served.

Release note (bug fix): This change fixes some existing caching issues
surrounding role memberships, where users could sometimes see out of date
role membership information.
