### PR TITLE
ccl/changefeedccl: respect filesystem walk errors in cloudFeed

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -613,10 +613,20 @@ func (c *cloudFeed) Next() (*TestFeedMessage, error) {
 	}
 }
 
-func (c *cloudFeed) walkDir(path string, info os.FileInfo, _ error) error {
+func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
 	if strings.HasSuffix(path, `.tmp`) {
 		// File in the process of being written by ExternalStorage. Ignore.
 		return nil
+	}
+
+	if err != nil {
+		// From filepath.WalkFunc:
+		//  If there was a problem walking to the file or directory named by
+		//  path, the incoming error will describe the problem and the function
+		//  can decide how to handle that error (and Walk will not descend into
+		//  that directory). In the case of an error, the info argument will be
+		//  nil. If an error is returned, processing stops.
+		return err
 	}
 
 	if info.IsDir() {


### PR DESCRIPTION
Closes #42979.

This commit properly handles errors in `cloudFeed`'s `filepath.WalkFunc`
implementation. The documentation says:
> If there was a problem walking to the file or directory named by
> path, the incoming error will describe the problem and the function
> can decide how to handle that error (and Walk will not descend into
> that directory). If an error is returned, processing stops.

I stressed the test for 10,000 iterations and never saw anything, so it's
possible that this was a fluke. It's not clear what filesystem error this was
throwing so we might still see this pop up again, but at least we'll now
correctly propagate the error and surface it instead of hitting an NPE.
Because of that, I'm closing the issue for now.

Release note: None