### PR TITLE
storage: removed redundant activeVersion argument

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -1008,10 +1008,9 @@ func splitTriggerHelper(
 		// writeInitialReplicaState which essentially writes a ReplicaState
 		// only.
 
-		v := cluster.Version.ActiveVersion(ctx, rec.ClusterSettings()).Version
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
 			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
-			*gcThreshold, v, truncStateType,
+			*gcThreshold, truncStateType,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -272,7 +272,6 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 				*testDesc,
 				roachpb.BootstrapLease(),
 				hlc.Timestamp{},
-				bootstrapVersion,
 				stateloader.TruncatedStateUnreplicated,
 			); err != nil {
 				t.Fatal(err)

--- a/pkg/storage/stateloader/initial.go
+++ b/pkg/storage/stateloader/initial.go
@@ -38,9 +38,6 @@ const (
 // entries already having applied. The supplied MVCCStats are used for the Stats
 // field after adjusting for persisting the state itself, and the updated stats
 // are returned.
-//
-// Args:
-// activeVersion: The cluster's version.
 func WriteInitialReplicaState(
 	ctx context.Context,
 	eng engine.ReadWriter,
@@ -48,16 +45,9 @@ func WriteInitialReplicaState(
 	desc roachpb.RangeDescriptor,
 	lease roachpb.Lease,
 	gcThreshold hlc.Timestamp,
-	activeVersion roachpb.Version,
 	truncStateType TruncatedStateType,
 ) (enginepb.MVCCStats, error) {
 	rsl := Make(desc.RangeID)
-	// NB: be careful using activeVersion here. One caller of this code is the
-	// split trigger, and the version with which the split trigger is called can
-	// vary across followers. Thus, actions which require coordination cannot
-	// use the version as a trigger (this is why this method takes a
-	// truncStateType argument).
-
 	var s storagepb.ReplicaState
 	s.TruncatedState = &roachpb.RaftTruncatedState{
 		Term:  raftInitialLogTerm,
@@ -96,9 +86,6 @@ func WriteInitialReplicaState(
 // SynthesizeRaftState. It is typically called during bootstrap. The supplied
 // MVCCStats are used for the Stats field after adjusting for persisting the
 // state itself, and the updated stats are returned.
-//
-// Args:
-// bootstrapVersion: The version at which the cluster is bootstrapped.
 func WriteInitialState(
 	ctx context.Context,
 	eng engine.ReadWriter,
@@ -106,11 +93,10 @@ func WriteInitialState(
 	desc roachpb.RangeDescriptor,
 	lease roachpb.Lease,
 	gcThreshold hlc.Timestamp,
-	bootstrapVersion roachpb.Version,
 	truncStateType TruncatedStateType,
 ) (enginepb.MVCCStats, error) {
 	newMS, err := WriteInitialReplicaState(
-		ctx, eng, ms, desc, lease, gcThreshold, bootstrapVersion, truncStateType)
+		ctx, eng, ms, desc, lease, gcThreshold, truncStateType)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/pkg/storage/store_bootstrap.go
+++ b/pkg/storage/store_bootstrap.go
@@ -232,7 +232,6 @@ func WriteInitialClusterData(
 			*desc,
 			lease,
 			hlc.Timestamp{}, /* gcThreshold */
-			bootstrapVersion,
 			truncStateType,
 		)
 		if err != nil {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1351,10 +1351,9 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 		rangeID, splitKey, repl.Desc().EndKey, repl.Desc().Replicas())
 	// Minimal amount of work to keep this deprecated machinery working: Write
 	// some required Raft keys.
-	cv := cluster.Version.ActiveVersion(ctx, store.ClusterSettings()).Version
 	_, err = stateloader.WriteInitialState(
 		ctx, store.engine, enginepb.MVCCStats{}, *rhsDesc, roachpb.Lease{},
-		hlc.Timestamp{}, cv, stateloader.TruncatedStateUnreplicated,
+		hlc.Timestamp{}, stateloader.TruncatedStateUnreplicated,
 	)
 	require.NoError(t, err)
 	newRng, err := NewReplica(rhsDesc, store, 0)
@@ -2886,10 +2885,9 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	}
 
 	uninitDesc := roachpb.RangeDescriptor{RangeID: repl1.Desc().RangeID}
-	cv := cluster.Version.ActiveVersion(ctx, s.ClusterSettings()).Version
 	if _, err := stateloader.WriteInitialState(
 		ctx, s.Engine(), enginepb.MVCCStats{}, uninitDesc, roachpb.Lease{},
-		hlc.Timestamp{}, cv, stateloader.TruncatedStateUnreplicated,
+		hlc.Timestamp{}, stateloader.TruncatedStateUnreplicated,
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Clean up all comments/plumbed instances of the activeVersion passed
through.

Release note: None