### PR TITLE
sql: fix current_timestamp behaviour with time zone set

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -193,7 +193,6 @@ SELECT extract(timezone FROM '2001-01-01 13:00:00+01:15'::timestamptz)
 ----
 10800
 
-
 subtest regression_41776
 
 statement ok
@@ -203,3 +202,24 @@ query T
 SELECT '2001-01-01 00:00:00'::TIMESTAMP::TIMESTAMPTZ
 ----
 2001-01-01 00:00:00 +0100 +0100
+
+# test that current_timestamp is correct in different timezones.
+subtest current_timestamp_correct_in_timezone
+
+statement ok
+set time zone +3
+
+statement ok
+create table current_timestamp_test (a timestamp, b timestamptz)
+
+statement ok
+insert into current_timestamp_test values (current_timestamp, current_timestamp)
+
+statement ok
+set time zone 0
+
+# a was written at an interval 3 hours ahead, and should persist that way.
+# b will remember the timezone, so should be "constant" for comparison's sake.
+query TT
+select * from current_timestamp_test WHERE a - interval '3h' <> b
+----

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2932,7 +2932,7 @@ func (ctx *EvalContext) GetTxnTimestamp(precision time.Duration) *DTimestampTZ {
 	if !ctx.PrepareOnly && ctx.TxnTimestamp.IsZero() {
 		panic(errors.AssertionFailedf("zero transaction timestamp in EvalContext"))
 	}
-	return MakeDTimestampTZ(ctx.TxnTimestamp, precision)
+	return MakeDTimestampTZ(ctx.GetRelativeParseTime(), precision)
 }
 
 // GetTxnTimestampNoZone retrieves the current transaction timestamp as per
@@ -2943,7 +2943,10 @@ func (ctx *EvalContext) GetTxnTimestampNoZone(precision time.Duration) *DTimesta
 	if !ctx.PrepareOnly && ctx.TxnTimestamp.IsZero() {
 		panic(errors.AssertionFailedf("zero transaction timestamp in EvalContext"))
 	}
-	return MakeDTimestamp(ctx.TxnTimestamp, precision)
+	// Move the time to UTC, but keeping the location's time.
+	t := ctx.GetRelativeParseTime()
+	_, offsetSecs := t.Zone()
+	return MakeDTimestamp(t.Add(time.Second*time.Duration(offsetSecs)).In(time.UTC), precision)
 }
 
 // SetTxnTimestamp sets the corresponding timestamp in the EvalContext.


### PR DESCRIPTION
With time zones set, current_timestamp needs to localise to the timezone
set in the context for time options, e.g. for `TIME` with `UTC+3` at
`UTC midnight`, `current_timestamp()` should return `3am`. This was
previously not handled correctly by Timestamp, and is rectified in this
PR.

Release note (bug fix): Previously, current_timestamp would not
correctly account for `SET TIME ZONE` in the background when storing
results, storing the timestamp as `UTC` instead. This is fixed in this
PR.