### PR TITLE
cmd/skiperrs: add small cmd to skip erroring SQL

### DIFF
--- a/pkg/cmd/cr2pg/main.go
+++ b/pkg/cmd/cr2pg/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/cmd/cr2pg/sqlstream"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -35,10 +35,9 @@ func main() {
 	// Divide up work between parsing, filtering, and writing.
 	g.Go(func() error {
 		defer close(readStmts)
-		const maxStatementSize = 1024 * 1024 * 32
-		stream := newSQLStream(os.Stdin, maxStatementSize)
+		stream := sqlstream.NewStream(os.Stdin)
 		for {
-			stmt, err := stream.next()
+			stmt, err := stream.Next()
 			if err == io.EOF {
 				break
 			}
@@ -136,62 +135,4 @@ func main() {
 	if err := g.Wait(); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// sqlStream converts an io.Reader into a stream of tree.Statement. Modified
-// from importccl/read_import_pgdump.go.
-type sqlStream struct {
-	s *bufio.Scanner
-}
-
-// newSQLStream returns a struct that can stream statements from an
-// io.Reader.
-func newSQLStream(r io.Reader, max int) *sqlStream {
-	s := bufio.NewScanner(r)
-	s.Buffer(make([]byte, 0, max), max)
-	p := &sqlStream{s: s}
-	s.Split(splitSQLSemicolon)
-	return p
-}
-
-// splitSQLSemicolon is a bufio.SplitFunc that splits on SQL semicolon tokens.
-func splitSQLSemicolon(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF && len(data) == 0 {
-		return 0, nil, nil
-	}
-
-	if pos, ok := parser.SplitFirstStatement(string(data)); ok {
-		return pos, data[:pos], nil
-	}
-	// If we're at EOF, we have a final, non-terminated line. Return it.
-	if atEOF {
-		return len(data), data, nil
-	}
-	// Request more data.
-	return 0, nil, nil
-}
-
-func (p *sqlStream) next() (tree.Statement, error) {
-	for p.s.Scan() {
-		t := p.s.Text()
-		stmts, err := parser.Parse(t)
-		if err != nil {
-			return nil, err
-		}
-		switch len(stmts) {
-		case 0:
-			// Got whitespace or comments; try again.
-		case 1:
-			return stmts[0].AST, nil
-		default:
-			return nil, errors.Errorf("unexpected: got %d statements", len(stmts))
-		}
-	}
-	if err := p.s.Err(); err != nil {
-		if err == bufio.ErrTooLong {
-			err = errors.New("line too long")
-		}
-		return nil, err
-	}
-	return nil, io.EOF
 }

--- a/pkg/cmd/cr2pg/sqlstream/stream.go
+++ b/pkg/cmd/cr2pg/sqlstream/stream.go
@@ -1,0 +1,83 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package sqlstream streams an io.Reader into SQL statements.
+package sqlstream
+
+import (
+	"bufio"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	// Include this because the parser assumes builtin functions exist.
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
+)
+
+// Modified from importccl/read_import_pgdump.go.
+
+// Stream streams an io.Reader into tree.Statements.
+type Stream struct {
+	scan *bufio.Scanner
+}
+
+// NewStream returns a new Stream to read from r.
+func NewStream(r io.Reader) *Stream {
+	const defaultMax = 1024 * 1024 * 32
+	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 0, defaultMax), defaultMax)
+	p := &Stream{scan: s}
+	s.Split(splitSQLSemicolon)
+	return p
+}
+
+// splitSQLSemicolon is a bufio.SplitFunc that splits on SQL semicolon tokens.
+func splitSQLSemicolon(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if pos, ok := parser.SplitFirstStatement(string(data)); ok {
+		return pos, data[:pos], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+// Next returns the next statement, or io.EOF if complete.
+func (s *Stream) Next() (tree.Statement, error) {
+	for s.scan.Scan() {
+		t := s.scan.Text()
+		stmts, err := parser.Parse(t)
+		if err != nil {
+			return nil, err
+		}
+		switch len(stmts) {
+		case 0:
+			// Got whitespace or comments; try again.
+		case 1:
+			return stmts[0].AST, nil
+		default:
+			return nil, errors.Errorf("unexpected: got %d statements", len(stmts))
+		}
+	}
+	if err := s.scan.Err(); err != nil {
+		if err == bufio.ErrTooLong {
+			err = errors.New("line too long")
+		}
+		return nil, err
+	}
+	return nil, io.EOF
+}

--- a/pkg/cmd/skiperrs/main.go
+++ b/pkg/cmd/skiperrs/main.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// skiperrs connects to a postgres-compatible server with its URL specified as
+// the first argument. It then splits stdin into SQL statements and executes
+// them on the connection. Errors are printed but do not stop execution.
+package main
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/cr2pg/sqlstream"
+	"github.com/lib/pq"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("usage: %s <url>\n", os.Args[0])
+		os.Exit(1)
+	}
+	url := os.Args[1]
+
+	connector, err := pq.NewConnector(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := gosql.OpenDB(connector)
+	defer db.Close()
+
+	stream := sqlstream.NewStream(os.Stdin)
+	for {
+		stmt, err := stream.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatal(err)
+		}
+		if _, err := db.Exec(stmt.String()); err != nil {
+			fmt.Println(err)
+		}
+	}
+}


### PR DESCRIPTION
I have wanted this program many times. We can reuse the sql stream code
and most of the hard work is already done.

Release note: None