### PR TITLE
colexec: allow unneeded index columns to be skipped in cfetcher

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -69,6 +69,9 @@ type cTableInfo struct {
 	// One value per column that is part of the key; each value is a column
 	// index (into cols); -1 if we don't need the value for that column.
 	indexColOrdinals []int
+	// allIndexColOrdinals is the same as indexColOrdinals but
+	// does not contain any -1's. It is meant to be used only in logging.
+	allIndexColOrdinals []int
 
 	// The set of column ordinals which are both composite and part of the index
 	// key.
@@ -277,25 +280,14 @@ func (rf *cFetcher) Init(
 		// the old table here in case they've got enough capacity already.
 		indexColOrdinals:       oldTable.indexColOrdinals[:0],
 		extraValColOrdinals:    oldTable.extraValColOrdinals[:0],
+		allIndexColOrdinals:    oldTable.allIndexColOrdinals[:0],
 		allExtraValColOrdinals: oldTable.allExtraValColOrdinals[:0],
 	}
 
-	// All columns that are part of the index key will be decoded when reading a key. Since some types
-	// are not supported by the vectorized engine, we should error out during setup if some needed columns
-	// or columns we decode always will be attempted to be decoded.
 	typs := make([]coltypes.T, len(colDescriptors))
-	var indexedCols util.FastIntSet
-	for _, colID := range tableArgs.Index.ColumnIDs {
-		indexedCols.Add(int(colID))
-	}
-	if cHasExtraCols(&table) {
-		for _, colID := range tableArgs.Index.ExtraColumnIDs {
-			indexedCols.Add(int(colID))
-		}
-	}
 	for i := range typs {
 		typs[i] = typeconv.FromColumnType(&colDescriptors[i].Type)
-		if typs[i] == coltypes.Unhandled && (tableArgs.ValNeededForCol.Contains(i) || indexedCols.Contains(int(colDescriptors[i].ID))) {
+		if typs[i] == coltypes.Unhandled && tableArgs.ValNeededForCol.Contains(i) {
 			// Only return an error if the type is unhandled and needed. If not needed,
 			// a placeholder Vec will be created.
 			return errors.Errorf("unhandled type %+v", &colDescriptors[i].Type)
@@ -338,19 +330,23 @@ func (rf *cFetcher) Init(
 	} else {
 		table.indexColOrdinals = make([]int, nIndexCols)
 	}
+	if cap(table.allIndexColOrdinals) >= nIndexCols {
+		table.allIndexColOrdinals = table.allIndexColOrdinals[:nIndexCols]
+	} else {
+		table.allIndexColOrdinals = make([]int, nIndexCols)
+	}
 	for i, id := range indexColumnIDs {
 		colIdx, ok := tableArgs.ColIdxMap[id]
-		if ok {
+		table.allIndexColOrdinals[i] = colIdx
+		if ok && neededCols.Contains(int(id)) {
 			table.indexColOrdinals[i] = colIdx
-			if neededCols.Contains(int(id)) {
-				neededIndexCols++
-				// A composite column might also have a value encoding which must be
-				// decoded. Others can be removed from neededValueColsByIdx.
-				if compositeColumnIDs.Contains(int(id)) {
-					table.compositeIndexColOrdinals.Add(colIdx)
-				} else {
-					table.neededValueColsByIdx.Remove(colIdx)
-				}
+			neededIndexCols++
+			// A composite column might also have a value encoding which must be
+			// decoded. Others can be removed from neededValueColsByIdx.
+			if compositeColumnIDs.Contains(int(id)) {
+				table.compositeIndexColOrdinals.Add(colIdx)
+			} else {
+				table.neededValueColsByIdx.Remove(colIdx)
 			}
 		} else {
 			table.indexColOrdinals[i] = -1
@@ -644,12 +640,16 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 					matches bool
 					err     error
 				)
+				indexOrds := rf.table.indexColOrdinals
+				if rf.traceKV {
+					indexOrds = rf.table.allIndexColOrdinals
+				}
 				key, matches, foundNull, err = colencoding.DecodeIndexKeyToCols(
 					rf.machine.colvecs,
 					rf.machine.rowIdx,
 					rf.table.desc,
 					rf.table.index,
-					rf.table.indexColOrdinals,
+					indexOrds,
 					rf.table.keyValTypes,
 					rf.table.indexColumnDirs,
 					rf.machine.nextKV.Key[rf.table.knownPrefixLength:],
@@ -893,7 +893,7 @@ func (rf *cFetcher) processValue(
 		buf.WriteString(rf.table.desc.Name)
 		buf.WriteByte('/')
 		buf.WriteString(rf.table.index.Name)
-		for _, idx := range rf.table.indexColOrdinals {
+		for _, idx := range rf.table.allIndexColOrdinals {
 			buf.WriteByte('/')
 			if idx != -1 {
 				buf.WriteString(rf.getDatumAt(idx, rf.machine.rowIdx, rf.table.cols[idx].Type).String())
@@ -969,27 +969,19 @@ func (rf *cFetcher) processValue(
 				// This is a unique secondary index; decode the extra
 				// column values from the value.
 				var err error
+				extraColOrds := table.extraValColOrdinals
 				if rf.traceKV {
-					valueBytes, _, err = colencoding.DecodeKeyValsToCols(
-						rf.machine.colvecs,
-						rf.machine.rowIdx,
-						table.allExtraValColOrdinals,
-						table.extraTypes,
-						nil,
-						&rf.machine.remainingValueColsByIdx,
-						valueBytes,
-					)
-				} else {
-					valueBytes, _, err = colencoding.DecodeKeyValsToCols(
-						rf.machine.colvecs,
-						rf.machine.rowIdx,
-						table.extraValColOrdinals,
-						table.extraTypes,
-						nil,
-						&rf.machine.remainingValueColsByIdx,
-						valueBytes,
-					)
+					extraColOrds = table.allExtraValColOrdinals
 				}
+				valueBytes, _, err = colencoding.DecodeKeyValsToCols(
+					rf.machine.colvecs,
+					rf.machine.rowIdx,
+					extraColOrds,
+					table.extraTypes,
+					nil,
+					&rf.machine.remainingValueColsByIdx,
+					valueBytes,
+				)
 				if err != nil {
 					return "", "", scrub.WrapError(scrub.SecondaryIndexKeyExtraValueDecodingError, err)
 				}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1007,12 +1007,21 @@ SELECT * FROM t_42816 ORDER BY a OFFSET 1020 LIMIT 10
 1024
 1025
 
-# Regression test for #42994
+# Regression tests for #42994
 statement ok
-CREATE TABLE t42994 (a int primary key, b bit, index i (a, b));
+CREATE TABLE t42994 (a INT PRIMARY KEY, b BIT, INDEX i (a, b));
 INSERT INTO t42994 VALUES (1, 1::BIT);
 
 query I
 SELECT a FROM t42994@i
 ----
 1
+
+statement ok
+CREATE TABLE t42994_2 (a BIT PRIMARY KEY, b INT, UNIQUE INDEX i (b));
+INSERT INTO t42994_2 VALUES (1::BIT, NULL);
+
+query I
+SELECT b FROM t42994_2@i
+----
+NULL


### PR DESCRIPTION
It seems like all indexed columns were being marked as needed in
the cfetcher initialization steps, whether they were actually
in neededCols or not. This meant that unneeded columns weren't
actually getting skipped.

Release note: None