### PR TITLE
release-19.1: changefeedccl: fix cloud file naming to prevent ordering violation across schema changes

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -401,4 +401,53 @@ func TestCloudStorageSink(t *testing.T) {
 			`{"resolved":"4.0000000000"}`,
 		}, slurpDir(t, dir))
 	})
+
+	t.Run(`ordering-among-schema-versions`, func(t *testing.T) {
+		t1 := &sqlbase.TableDescriptor{Name: `t1`}
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
+		dir := `ordering-among-schema-versions`
+		var targetMaxFileSize int64 = 10
+		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, targetMaxFileSize, settings,
+			opts, timestampOracle)
+		require.NoError(t, err)
+
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
+		t1.Version = 1
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1)))
+		// Make the first file exceed its file size threshold. This should trigger a flush
+		// for the first file but not the second one.
+		t1.Version = 0
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1)))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+		}, slurpDir(t, dir))
+
+		// Now make the file with the newer schema exceed its file size threshold and ensure
+		// that the file with the older schema is flushed (and ordered) before.
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1)))
+		t1.Version = 1
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1)))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+			"v2\n",
+			"v3\ntrigger-flush-v3\n",
+		}, slurpDir(t, dir))
+
+		// Calling `Flush()` on the sink should emit files in the order of their schema IDs.
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1)))
+		t1.Version = 0
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1)))
+		require.NoError(t, s.Flush(ctx))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+			"v2\n",
+			// NOTE: x1 comes after v3 in release-19.1 because it sorts by fileID
+			// before schemaID but release 19.1 is the other way.
+			"x1\n",
+			"v3\ntrigger-flush-v3\n",
+			"w1\n",
+		}, slurpDir(t, dir))
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #41615.

/cc @cockroachdb/release

---

Currently, our naming convention for cloud storage sink files is
as follows:

```
<timestamp>-<uniquer>-<topic_id>-<schema_id>.<ext>
```

With `<uniquer>` being `<sessionid>-<nodeid>-<sinkid>-<fileid>`.

Now consider the following case where this convention fails to
preserve row orderings in presence of a schema change:
1. The sink starts buffering a file for schema `1`.
2. It then starts buffering a file for schema `2`.
3. The newer, schema `2` file exceeds the file size threshold
and thus gets flushed at timestamp `x`. This would lead to it being
assigned a `fileid` of `0`.
4. The older, schema `1` file is flushed at timestamp `x` and
assigned a `fileid` of `1`.

This leads to the older, schema `1` file, being lexically ordered
*after* the newer, schema `2` file.

This PR fixes this violation by making sure that when flushing a file
that corresponds to schema `x`, we flush all files in memory that
correspond to schema versions less than `x` before, in sorted order
of schema versions.

Release note: Fix bug in cloud storage sink for CDC.

Release justification: Fix bug in cloud storage sink file naming that
violates ordering in presence of a schema changes.
