### PR TITLE
release-19.1: various changefeed correctness fixes

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -88,8 +88,7 @@ func (o *changeAggregatorLowerBoundOracle) inclusiveLowerBoundTS() hlc.Timestamp
 		// on the timestamps of the updates contained within the file.
 		// Files being created at the point this method is called are guaranteed
 		// to contain row updates with timestamps strictly greater than the local
-		// span frontier timestamp (not in all cases, there's a known bug with
-		// the poller that can violate this. See: #41415. A fix is in progress).
+		// span frontier timestamp.
 		return frontier.Next()
 	}
 	// This should only be returned in the case where the changefeed job hasn't yet

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -111,6 +111,7 @@ func makePoller(
 		p.mu.highWater = highWater
 	}
 	p.tableHist = makeTableHistory(p.validateTable, highWater)
+
 	return p
 }
 
@@ -207,12 +208,45 @@ func (p *poller) Run(ctx context.Context) error {
 // the experimental Rangefeed system to capture changes rather than the
 // poll-and-export method.  Note
 func (p *poller) RunUsingRangefeeds(ctx context.Context) error {
+	// Fetch the table descs as of the initial highWater and prime the table
+	// history with them. This addresses #41694 where we'd skip the rest of a
+	// backfill if the changefeed was paused/unpaused during it. The bug was that
+	// the changefeed wouldn't notice the table descriptor had changed (and thus
+	// we were in the backfill state) when it restarted.
+	if err := p.primeInitialTableDescs(ctx); err != nil {
+		return err
+	}
+
 	// Start polling tablehistory, which must be done concurrently with
 	// the individual rangefeed routines.
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(p.pollTableHistory)
 	g.GoCtx(p.rangefeedImpl)
 	return g.Wait()
+}
+
+func (p *poller) primeInitialTableDescs(ctx context.Context) error {
+	p.mu.Lock()
+	initialTableDescTs := p.mu.highWater
+	p.mu.Unlock()
+	var initialDescs []*sqlbase.TableDescriptor
+	initialTableDescsFn := func(ctx context.Context, txn *client.Txn) error {
+		initialDescs = initialDescs[:0]
+		txn.SetFixedTimestamp(ctx, initialTableDescTs)
+		// Note that all targets are currently guaranteed to be tables.
+		for tableID := range p.details.Targets {
+			tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, tableID)
+			if err != nil {
+				return err
+			}
+			initialDescs = append(initialDescs, tableDesc)
+		}
+		return nil
+	}
+	if err := p.db.Txn(ctx, initialTableDescsFn); err != nil {
+		return err
+	}
+	return p.tableHist.IngestDescriptors(ctx, hlc.Timestamp{}, initialTableDescTs, initialDescs)
 }
 
 var errBoundaryReached = errors.New("scan boundary reached")
@@ -371,7 +405,7 @@ func (p *poller) rangefeedImpl(ctx context.Context) error {
 						return err
 					}
 					p.mu.Lock()
-					if len(p.mu.scanBoundaries) > 0 && p.mu.scanBoundaries[0].Less(resolvedTS) {
+					if len(p.mu.scanBoundaries) > 0 && !resolvedTS.Less(p.mu.scanBoundaries[0]) {
 						boundaryBreak = true
 						resolvedTS = p.mu.scanBoundaries[0]
 					}
@@ -490,7 +524,7 @@ func (p *poller) exportSpansParallel(
 			err := p.exportSpan(ctx, span, start, end, willBeResolvedAfterScan, isFullScan)
 			finished := atomic.AddInt64(&atomicFinished, 1)
 			if log.V(2) {
-				log.Infof(ctx, `exported %d of %d`, finished, len(spans))
+				log.Infof(ctx, `exported %d of %d: %v`, finished, len(spans), err)
 			}
 			if err != nil {
 				return err

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -75,8 +75,6 @@ type cloudStorageSinkFile struct {
 // `changeAggregator`, as of the time the last `Flush()` call was made (or `StatementTime`
 // if `Flush()` hasn't been called yet). Intuitively, this can be thought of as an
 // inclusive lower bound on the timestamps of updates that can be seen in a given file.
-// NOTE: Due to a bug in the poller, this is not always true when there's a schema change
-// that causes a backfill. See issue #41415 for more details.
 //
 // `<topic>` corresponds to one SQL table.
 //

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -401,4 +401,51 @@ func TestCloudStorageSink(t *testing.T) {
 			`{"resolved":"4.0000000000"}`,
 		}, slurpDir(t, dir))
 	})
+
+	t.Run(`ordering-among-schema-versions`, func(t *testing.T) {
+		t1 := &sqlbase.TableDescriptor{Name: `t1`}
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := makeSpanFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
+		dir := `ordering-among-schema-versions`
+		var targetMaxFileSize int64 = 10
+		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, targetMaxFileSize, settings,
+			opts, timestampOracle)
+		require.NoError(t, err)
+
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
+		t1.Version = 1
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1)))
+		// Make the first file exceed its file size threshold. This should trigger a flush
+		// for the first file but not the second one.
+		t1.Version = 0
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1)))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+		}, slurpDir(t, dir))
+
+		// Now make the file with the newer schema exceed its file size threshold and ensure
+		// that the file with the older schema is flushed (and ordered) before.
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1)))
+		t1.Version = 1
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1)))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+			"v2\n",
+			"v3\ntrigger-flush-v3\n",
+		}, slurpDir(t, dir))
+
+		// Calling `Flush()` on the sink should emit files in the order of their schema IDs.
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1)))
+		t1.Version = 0
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1)))
+		require.NoError(t, s.Flush(ctx))
+		require.Equal(t, []string{
+			"v1\ntrigger-flush-v1\n",
+			"v2\n",
+			"v3\ntrigger-flush-v3\n",
+			"x1\n",
+			"w1\n",
+		}, slurpDir(t, dir))
+	})
 }

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -443,8 +443,10 @@ func TestCloudStorageSink(t *testing.T) {
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
 			"v2\n",
-			"v3\ntrigger-flush-v3\n",
+			// NOTE: x1 comes after v3 in release-19.1 because it sorts by fileID
+			// before schemaID but release 19.1 is the other way.
 			"x1\n",
+			"v3\ntrigger-flush-v3\n",
 			"w1\n",
 		}, slurpDir(t, dir))
 	})


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: fix cloud file naming to prevent ordering violation across schema changes" (#41615)
  * 1/1 commits from "changefeedccl: fix bug in poller that allows it to emit a resolved ts before emitting row updates at the ts" (#41665)
  * 1/1 commits from "changefeedccl: fix bug in table history when fetching old table descs after restart" (#41702)

Please see individual PRs for details.

/cc @cockroachdb/release
