### PR TITLE
release-19.1: changefeedccl: fix bug which leaves a dangling table lease after job restart

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -299,7 +299,6 @@ SELECT DISTINCT node_id, store_id, replica_id
 ----
 node_id  store_id  replica_id
 1        1         6
-1        1         7
 1        1         20
 
 subtest system_table_lookup

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -295,7 +295,6 @@ SELECT DISTINCT node_id, store_id, replica_id
 ----
 node_id  store_id  replica_id
 1        1         6
-1        1         7
 1        1         20
 
 subtest system_table_lookup


### PR DESCRIPTION
Backport 1/1 commits from #41785.

/cc @cockroachdb/release

---

Fixes #41780

Currently, any call to `acquireNodeLease()` in `lease.go` goes through
a `singleflight.Group`. The group uses the `context.Context` of its first
caller. The method `AcquireFreshestFromStore()` calls `acquireNodeLease()`.

Now, in `poller.go` and `table_history.go` we repeatedly call
`leaseManager.AcquireFreshestFromStore()` in order to make sure the table
descriptor is up to date with respect to a certain timestamp.
Additionally, we also call `leaseManager.AcquireFreshestFromStore()`
periodically inside `leaseManager.RefreshLeases()`.

Now consider the case where there is a job cancellation around the same
time as a `RefreshLeases` call. Since the single flight group simply uses
the `context` of its first caller, it's possible that it's using the
changefeed job's context that's passed down into this call from the `poller`.
Due to the job cancellation and because the single flight group is using
the changefeed job's context, the `purgeOldVersions` call
(called by `RefreshLeases`) also gets cancelled; this leaves a dangling table
lease that doesn't get purged at the end of the call.

This PR fixes this problem by having `acquireNodeLease` create a new context
inside of its single flight closure to make sure that this closure doesn't
get cancelled, after copying the tags from the context it's handed.

Release note (bug fix): Other callers to `acquireNodeLease` will not get
erroneously cancelled just because the context of the first caller was
cancelled.
