### PR TITLE
opt: rework join hints

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -725,9 +725,11 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 }
 
 func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
-	if f := join.Private().(*memo.JoinPrivate).Flags; f.DisallowHashJoin {
+	if f := join.Private().(*memo.JoinPrivate).Flags; !f.Has(memo.AllowHashJoinStoreRight) {
+		// We need to do a bit of reverse engineering here to determine what the
+		// hint was.
 		hint := tree.AstLookup
-		if !f.DisallowMergeJoin {
+		if f.Has(memo.AllowMergeJoin) {
 			hint = tree.AstMerge
 		}
 

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -482,9 +482,7 @@ func (h *hasher) HashScanFlags(val ScanFlags) {
 }
 
 func (h *hasher) HashJoinFlags(val JoinFlags) {
-	h.HashBool(val.DisallowHashJoin)
-	h.HashBool(val.DisallowMergeJoin)
-	h.HashBool(val.DisallowLookupJoin)
+	h.HashUint64(uint64(val))
 }
 
 func (h *hasher) HashExplainOptions(val tree.ExplainOptions) {

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -54,13 +54,11 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 	case "":
 	case tree.AstHash:
 		telemetry.Inc(sqltelemetry.HashJoinHintUseCounter)
-		flags.DisallowMergeJoin = true
-		flags.DisallowLookupJoin = true
+		flags = memo.AllowHashJoinStoreRight
 
 	case tree.AstLookup:
 		telemetry.Inc(sqltelemetry.LookupJoinHintUseCounter)
-		flags.DisallowHashJoin = true
-		flags.DisallowMergeJoin = true
+		flags = memo.AllowLookupJoinIntoRight
 		if joinType != sqlbase.InnerJoin && joinType != sqlbase.LeftOuterJoin {
 			panic(pgerror.Newf(pgcode.Syntax,
 				"%s can only be used with INNER or LEFT joins", tree.AstLookup,
@@ -69,8 +67,7 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 
 	case tree.AstMerge:
 		telemetry.Inc(sqltelemetry.MergeJoinHintUseCounter)
-		flags.DisallowLookupJoin = true
-		flags.DisallowHashJoin = true
+		flags = memo.AllowMergeJoin
 
 	default:
 		panic(pgerror.Newf(

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3034,7 +3034,7 @@ project
  ├── columns: x:1(int!null) y:3(int!null)
  └── inner-join (hash)
       ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
-      ├── flags: no-lookup-join;no-hash-join
+      ├── flags: force merge join
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
       ├── scan b
@@ -3056,7 +3056,7 @@ project
  ├── columns: x:1(int) y:3(int)
  └── full-join (hash)
       ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int)
-      ├── flags: no-lookup-join;no-merge-join
+      ├── flags: force hash join (store right side)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
       ├── scan b

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -328,7 +328,7 @@ func (c *coster) computeValuesCost(values *memo.ValuesExpr) memo.Cost {
 }
 
 func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
-	if join.Private().(*memo.JoinPrivate).Flags.DisallowHashJoin {
+	if !join.Private().(*memo.JoinPrivate).Flags.Has(memo.AllowHashJoinStoreRight) {
 		return hugeCost
 	}
 	leftRowCount := join.Child(0).(memo.RelExpr).Relational().Stats.RowCount

--- a/pkg/sql/opt/xform/custom_funcs_test.go
+++ b/pkg/sql/opt/xform/custom_funcs_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package xform
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCommuteJoinFlags(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cases := [][2]memo.JoinFlags{
+		{0, 0},
+
+		{memo.AllowLookupJoinIntoLeft, memo.AllowLookupJoinIntoRight},
+
+		{
+			memo.AllowLookupJoinIntoLeft | memo.AllowLookupJoinIntoRight,
+			memo.AllowLookupJoinIntoLeft | memo.AllowLookupJoinIntoRight,
+		},
+
+		{memo.AllowHashJoinStoreLeft, memo.AllowHashJoinStoreRight},
+
+		{
+			memo.AllowHashJoinStoreLeft | memo.AllowHashJoinStoreRight,
+			memo.AllowHashJoinStoreLeft | memo.AllowHashJoinStoreRight,
+		},
+
+		{
+			memo.AllowMergeJoin | memo.AllowHashJoinStoreLeft | memo.AllowLookupJoinIntoRight,
+			memo.AllowMergeJoin | memo.AllowHashJoinStoreRight | memo.AllowLookupJoinIntoLeft,
+		},
+	}
+
+	var funcs CustomFuncs
+	for _, tc := range cases {
+		// The result of commuting flags should be symmetrical, so test each case in
+		// both directions.
+		for dir := 0; dir <= 1; dir++ {
+			in, out := tc[dir], tc[dir^1]
+			res := funcs.CommuteJoinFlags(&memo.JoinPrivate{Flags: in})
+			if res.Flags != out {
+				t.Errorf("input: '%s'  expected: '%s'  got: '%s'", in, out, res.Flags)
+			}
+		}
+	}
+}

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -11,10 +11,10 @@
     $left:*
     $right:*
     $on:*
-    $private:* & (NoJoinHints $private)
+    $private:*
 )
 =>
-((OpName) $right $left $on $private)
+((OpName) $right $left $on (CommuteJoinFlags $private))
 
 # CommuteLeftJoin creates a Join with the left and right inputs swapped.
 [CommuteLeftJoin, Explore]
@@ -22,10 +22,10 @@
     $left:*
     $right:*
     $on:*
-    $private:* & (NoJoinHints $private)
+    $private:*
 )
 =>
-(RightJoin $right $left $on $private)
+(RightJoin $right $left $on (CommuteJoinFlags $private))
 
 # CommuteRightJoin creates a Join with the left and right inputs swapped.
 [CommuteRightJoin, Explore]
@@ -33,10 +33,10 @@
     $left:*
     $right:*
     $on:*
-    $private:* & (NoJoinHints $private)
+    $private:*
 )
 =>
-(LeftJoin $right $left $on $private)
+(LeftJoin $right $left $on (CommuteJoinFlags $private))
 
 # CommuteSemiJoin generates an InnerJoin that is equivalent to the SemiJoin.
 # SemiJoins impose a partial order on the joining tables. We can convert a

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -46,7 +46,7 @@ SELECT k, x FROM a INNER MERGE JOIN b ON k=x
 ----
 inner-join (merge)
  ├── columns: k:1(int!null) x:5(int!null)
- ├── flags: no-lookup-join;no-hash-join
+ ├── flags: force merge join
  ├── left ordering: +1
  ├── right ordering: +5
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(5)=99, null(5)=0]
@@ -76,7 +76,7 @@ SELECT k, x FROM b INNER LOOKUP JOIN a ON k=x
 ----
 inner-join (lookup a)
  ├── columns: k:4(int!null) x:1(int!null)
- ├── flags: no-merge-join;no-hash-join
+ ├── flags: force lookup join (into right side)
  ├── key columns: [1] = [4]
  ├── lookup columns are key
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(4)=99, null(4)=0]
@@ -96,7 +96,7 @@ SELECT k, x FROM a INNER LOOKUP JOIN b ON k=x
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) x:5(int!null)
- ├── flags: no-merge-join;no-hash-join
+ ├── flags: force lookup join (into right side)
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(5)=99, null(5)=0]
  ├── cost: 1e+100
  ├── fd: (1)==(5), (5)==(1)

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -364,7 +364,7 @@ SELECT * FROM abc INNER LOOKUP JOIN xy ON b=y WHERE b=1
 ----
 inner-join (lookup xy@y2)
  ├── columns: a:1(int!null) b:2(int!null) c:3(string) x:4(int!null) y:5(int!null)
- ├── flags: no-merge-join;no-hash-join
+ ├── flags: force lookup join (into right side)
  ├── key columns: [2] = [5]
  ├── stats: [rows=100, distinct(2)=1, null(2)=0, distinct(5)=1, null(5)=0]
  ├── cost: 412.59
@@ -402,7 +402,7 @@ SELECT * FROM abc INNER LOOKUP JOIN xy ON b=y WHERE b=1
 ----
 inner-join (lookup xy@y1)
  ├── columns: a:1(int!null) b:2(int!null) c:3(string) x:4(int!null) y:5(int!null)
- ├── flags: no-merge-join;no-hash-join
+ ├── flags: force lookup join (into right side)
  ├── key columns: [2] = [5]
  ├── stats: [rows=100, distinct(2)=1, null(2)=0, distinct(5)=1, null(5)=0]
  ├── cost: 412.59

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -149,6 +149,27 @@ inner-join (hash)
  │         └── a = c [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── filters (true)
 
+# Verify that the hash join hint prevents swapping the sides.
+opt
+SELECT * FROM abc INNER HASH JOIN xyz ON a=c WHERE b=1
+----
+inner-join (hash)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:5(int) y:6(int) z:7(int)
+ ├── flags: force hash join (store right side)
+ ├── fd: ()-->(2), (1)==(3), (3)==(1)
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── fd: ()-->(2), (1)==(3), (3)==(1)
+ │    ├── scan abc@bc
+ │    │    ├── columns: a:1(int) b:2(int!null) c:3(int!null)
+ │    │    ├── constraint: /2/3/4: (/1/NULL - /1]
+ │    │    └── fd: ()-->(2)
+ │    └── filters
+ │         └── a = c [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ ├── scan xyz
+ │    └── columns: x:5(int) y:6(int) z:7(int)
+ └── filters (true)
+
 opt
 SELECT * FROM (SELECT * FROM abc WHERE b=1) FULL OUTER JOIN xyz ON a=z
 ----
@@ -164,15 +185,17 @@ full-join (hash)
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
-# Verify that we don't commute joins if there's a hint.
+# Verify that commuting works correctly when there is a lookup join hint
+# (specifically that it returns the original expression and flags when applied
+# twice; if it didn't, we'd see more inner-join expressions).
 memo
-SELECT * FROM abc INNER HASH JOIN xyz ON a=z
+SELECT * FROM abc INNER LOOKUP JOIN xyz ON a=x
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
- ├── G1: (inner-join G2 G3 G4)
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
- │         ├── best: (inner-join G2 G3 G4)
- │         └── cost: 2268.06
+ │         ├── best: (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,5-7))
+ │         └── cost: 41358.10
  ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    └── []
  │         ├── best: (scan abc,cols=(1-3))
@@ -181,10 +204,11 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  │    └── []
  │         ├── best: (scan xyz,cols=(5-7))
  │         └── cost: 1070.02
- ├── G4: (filters G5)
- ├── G5: (eq G6 G7)
- ├── G6: (variable a)
- └── G7: (variable z)
+ ├── G4: (filters G6)
+ ├── G5: (filters)
+ ├── G6: (eq G7 G8)
+ ├── G7: (variable a)
+ └── G8: (variable x)
 
 # --------------------------------------------------
 # CommuteLeftJoin
@@ -233,35 +257,6 @@ right-join (hash)
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
-# Verify that we don't commute joins if there's a hint.
-memo
-SELECT * FROM abc LEFT OUTER MERGE JOIN xyz ON a=z
-----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
- ├── G1: (left-join G2 G3 G4) (merge-join G2 G3 G5 left-join,+1,+7)
- │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
- │         ├── best: (merge-join G2="[ordering: +1]" G3="[ordering: +7]" G5 left-join,+1,+7)
- │         └── cost: 2479.38
- ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
- │    ├── [ordering: +1]
- │    │    ├── best: (scan abc@ab,cols=(1-3))
- │    │    └── cost: 1070.02
- │    └── []
- │         ├── best: (scan abc,cols=(1-3))
- │         └── cost: 1070.02
- ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
- │    ├── [ordering: +7]
- │    │    ├── best: (sort G3)
- │    │    └── cost: 1289.35
- │    └── []
- │         ├── best: (scan xyz,cols=(5-7))
- │         └── cost: 1070.02
- ├── G4: (filters G6)
- ├── G5: (filters)
- ├── G6: (eq G7 G8)
- ├── G7: (variable a)
- └── G8: (variable z)
-
 # --------------------------------------------------
 # CommuteRightJoin
 # --------------------------------------------------
@@ -308,29 +303,6 @@ left-join (hash)
  │    └── fd: ()-->(2)
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
-
-# Verify that we don't commute joins if there's a hint.
-memo
-SELECT * FROM abc RIGHT HASH JOIN xyz ON a=z
-----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
- ├── G1: (right-join G2 G3 G4)
- │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
- │         ├── best: (right-join G2 G3 G4)
- │         └── cost: 2270.05
- ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
- │    └── []
- │         ├── best: (scan abc,cols=(1-3))
- │         └── cost: 1070.02
- ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
- │    └── []
- │         ├── best: (scan xyz,cols=(5-7))
- │         └── cost: 1070.02
- ├── G4: (filters G5)
- ├── G5: (eq G6 G7)
- ├── G6: (variable a)
- └── G7: (variable z)
-
 
 # --------------------------------------------------
 # GenerateMergeJoins
@@ -385,7 +357,7 @@ memo
 SELECT * FROM abc INNER HASH JOIN xyz ON a=x
 ----
 memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
- ├── G1: (inner-join G2 G3 G4)
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G2 G3 G4)
  │         └── cost: 2268.06
@@ -1164,8 +1136,8 @@ No new expressions.
 memo
 SELECT a,b,n,m FROM small INNER HASH JOIN abcd ON a=m
 ----
-memo (optimized, ~7KB, required=[presentation: a:4,b:5,n:2,m:1])
- ├── G1: (inner-join G2 G3 G4)
+memo (optimized, ~8KB, required=[presentation: a:4,b:5,n:2,m:1])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:4,b:5,n:2,m:1]
  │         ├── best: (inner-join G2 G3 G4)
  │         └── cost: 1079.16
@@ -1451,7 +1423,7 @@ project
  ├── fd: ()-->(4,6)
  └── inner-join (lookup abcde@secondary)
       ├── columns: m:1(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
-      ├── flags: no-merge-join;no-hash-join
+      ├── flags: force lookup join (into right side)
       ├── key columns: [10 1 11] = [4 5 6]
       ├── fd: ()-->(4,6), (1)==(5), (5)==(1)
       ├── project


### PR DESCRIPTION
I made some separate attempts to normalize `RightJoin` to `LeftJoin`,
or remove `RightJoin` altogether or to remove the join commuting
altogether. One annoying issue that I hit was the way join hints
currently prevent join commuting (relying on this to function
correctly).

This change enables commuting with join hints, by using more specific
flags for the cases where we treat one side specially. Instead of
boolean "disallow" flags, we now use a bitfield where the bits are set
if a certain join type is allowed (with the exception that value 0
means anything is allowed). The more specific flags can also give us
additional flexibility for join hints.

Release note: None.