### PR TITLE
roachpb: assert that leaves don't accumulate writes to refresh

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -817,7 +817,13 @@ func (meta *TxnCoordMeta) StripRootToLeaf() *TxnCoordMeta {
 
 // StripLeafToRoot strips out all information that is unnecessary to communicate
 // back to the root transaction.
-func (meta *TxnCoordMeta) StripLeafToRoot() *TxnCoordMeta {
+func (meta *TxnCoordMeta) StripLeafToRoot(ctx context.Context) *TxnCoordMeta {
+	if len(meta.RefreshWrites) != 0 {
+		// Leaves don't do writes, and StripRootToLeaf strips all the Refresh*
+		// collections before creating the Leaf, so there's no way for a Leaf to
+		// have accumulated anything in RefreshWrites.
+		log.Fatalf(ctx, "unexpected RefreshWrites on leaf: %v", meta.RefreshWrites)
+	}
 	meta.InFlightWrites = nil
 	return meta
 }

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -261,7 +261,7 @@ func SendTraceData(ctx context.Context, dst RowReceiver) {
 func GetTxnCoordMeta(ctx context.Context, txn *client.Txn) *roachpb.TxnCoordMeta {
 	if txn.Type() == client.LeafTxn {
 		txnMeta := txn.GetTxnCoordMeta(ctx)
-		txnMeta.StripLeafToRoot()
+		txnMeta.StripLeafToRoot(ctx)
 		if txnMeta.Txn.ID != uuid.Nil {
 			return &txnMeta
 		}


### PR DESCRIPTION
This is working towards removing the write timestamp cache.

Release note: None