### PR TITLE
sql: update keys per row estimation for secondary indexes

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -417,7 +417,11 @@ func (rf *cFetcher) Init(
 
 	// Keep track of the maximum keys per row to accommodate a
 	// limitHint when StartScan is invoked.
-	if keysPerRow := table.desc.KeysPerRow(table.index.ID); keysPerRow > rf.maxKeysPerRow {
+	keysPerRow, err := table.desc.KeysPerRow(table.index.ID)
+	if err != nil {
+		return err
+	}
+	if keysPerRow > rf.maxKeysPerRow {
 		rf.maxKeysPerRow = keysPerRow
 	}
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -427,7 +427,11 @@ func (rf *Fetcher) Init(
 
 		// Keep track of the maximum keys per row to accommodate a
 		// limitHint when StartScan is invoked.
-		if keysPerRow := table.desc.KeysPerRow(table.index.ID); keysPerRow > rf.maxKeysPerRow {
+		keysPerRow, err := table.desc.KeysPerRow(table.index.ID)
+		if err != nil {
+			return err
+		}
+		if keysPerRow > rf.maxKeysPerRow {
 			rf.maxKeysPerRow = keysPerRow
 		}
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -633,13 +633,21 @@ func (desc *TableDescriptor) IsPhysicalTable() bool {
 }
 
 // KeysPerRow returns the maximum number of keys used to encode a row for the
-// given index. For secondary indexes, we always only use one, but for primary
-// indexes, we can encode up to one kv per column family.
-func (desc *TableDescriptor) KeysPerRow(indexID IndexID) int {
+// given index. If a secondary index doesn't store any columns, then it only
+// has one k/v pair, but if it stores some columns, it can return up to one
+// k/v pair per family in the table, just like a primary index.
+func (desc *TableDescriptor) KeysPerRow(indexID IndexID) (int, error) {
 	if desc.PrimaryIndex.ID == indexID {
-		return len(desc.Families)
+		return len(desc.Families), nil
 	}
-	return 1
+	idx, err := desc.FindIndexByID(indexID)
+	if err != nil {
+		return 0, err
+	}
+	if len(idx.StoreColumnIDs) == 0 {
+		return 1, nil
+	}
+	return len(desc.Families), nil
 }
 
 // AllNonDropColumns returns all the columns, including those being added

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1266,10 +1266,11 @@ func TestKeysPerRow(t *testing.T) {
 		indexID     IndexID
 		expected    int
 	}{
-		{"(a INT PRIMARY KEY, b INT, INDEX (b))", 1, 1},                         // Primary index
-		{"(a INT PRIMARY KEY, b INT, INDEX (b))", 2, 1},                         // 'b' index
-		{"(a INT PRIMARY KEY, b INT, FAMILY (a), FAMILY (b), INDEX (b))", 1, 2}, // Primary index
-		{"(a INT PRIMARY KEY, b INT, FAMILY (a), FAMILY (b), INDEX (b))", 2, 1}, // 'b' index
+		{"(a INT PRIMARY KEY, b INT, INDEX (b))", 1, 1},                                     // Primary index
+		{"(a INT PRIMARY KEY, b INT, INDEX (b))", 2, 1},                                     // 'b' index
+		{"(a INT PRIMARY KEY, b INT, FAMILY (a), FAMILY (b), INDEX (b))", 1, 2},             // Primary index
+		{"(a INT PRIMARY KEY, b INT, FAMILY (a), FAMILY (b), INDEX (b))", 2, 1},             // 'b' index
+		{"(a INT PRIMARY KEY, b INT, FAMILY (a), FAMILY (b), INDEX (a) STORING (b))", 2, 2}, // 'a' index
 	}
 
 	for i, test := range tests {
@@ -1288,7 +1289,10 @@ func TestKeysPerRow(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
-			keys := desc.GetTable().KeysPerRow(test.indexID)
+			keys, err := desc.GetTable().KeysPerRow(test.indexID)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if test.expected != keys {
 				t.Errorf("expected %d keys got %d", test.expected, keys)
 			}


### PR DESCRIPTION
Now that secondary indexes respect column families, there can
be more than one k/v pair per index. This PR updates an existing
estimation of k/v pairs per index.

Release note: None