### PR TITLE
build: use -maxtime 1h in nightly unit test stress

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -46,7 +46,7 @@ go install ./pkg/cmd/github-post
 # are test failures.
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 if ! stdbuf -oL -eL \
-  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
+  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxtime 1h -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
   exit_status=${PIPESTATUS[0]}
   go tool test2json -t < artifacts/stress.log | github-post

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -49,7 +49,7 @@ if ! stdbuf -oL -eL \
   make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxtime 1h -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
   exit_status=${PIPESTATUS[0]}
-  go tool test2json -t < artifacts/stress.log | github-post
+  go tool test2json -t -p "${PKG} < artifacts/stress.log | github-post
   exit $exit_status
 fi
 


### PR DESCRIPTION
I noticed that some nightly stress builds were taking ~10h just for a
single package. This is because of the `-race -p 2` flags under which
some packages (sql, storage) take >5 minutes to complete. Getting
through 100 iterations (while perfectly reasonable for smaller packages)
does not make sense for these behemoths, so we want them to stop after
one hour.

The caveat here is that if the package doesn't even get through a single
iteration -maxtime at the time of writing would call it a success
anyway. That is being fixed in cockroachdb/stress#12
but also we're still adding `-timeout 40m` so we're safe anyway.

Release note: None