### PR TITLE
roachtest: update Hibernate and psycopg blacklists

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -22,15 +22,9 @@ var hibernateBlacklists = blacklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blacklist should be available
 // in the test log.
-var hibernateBlackList20_1 = blacklist{
-	"org.hibernate.query.GroupByAliasTest.testCompoundIdAlias": "failing on Postgres",
-	"org.hibernate.query.GroupByAliasTest.testMultiIdAlias":    "failing on Postgres",
-}
+var hibernateBlackList20_1 = blacklist{}
 
-var hibernateBlackList19_2 = blacklist{
-	"org.hibernate.query.GroupByAliasTest.testCompoundIdAlias": "failing on Postgres",
-	"org.hibernate.query.GroupByAliasTest.testMultiIdAlias":    "failing on Postgres",
-}
+var hibernateBlackList19_2 = blacklist{}
 
 var hibernateBlackList19_1 = blacklist{
 	"org.hibernate.jpa.test.indetifier.AssignedInitialValueTableGeneratorConfiguredTest.testTheFirstGeneratedIdIsEqualToTableGeneratorInitialValuePlusOne": "6583",

--- a/pkg/cmd/roachtest/psycopg_blacklist.go
+++ b/pkg/cmd/roachtest/psycopg_blacklist.go
@@ -275,7 +275,6 @@ var psycopgBlackList20_1 = blacklist{
 	"tests.test_transaction.TransactionTests.test_rollback":                                                  "5807",
 	"tests.test_types_basic.TypesBasicTests.testArray":                                                       "32552",
 	"tests.test_types_basic.TypesBasicTests.testArrayOfNulls":                                                "32552",
-	"tests.test_types_basic.TypesBasicTests.testEmptyArray":                                                  "23299",
 	"tests.test_types_basic.TypesBasicTests.testEmptyArrayRegression":                                        "36179",
 	"tests.test_types_basic.TypesBasicTests.testNestedArrays":                                                "32552",
 	"tests.test_types_basic.TypesBasicTests.testNestedEmptyArray":                                            "32552",


### PR DESCRIPTION
Hibernate now has no expected failures with our dialect, and psycopg has
one fewer expected failure.

closes #42819
closes #42434 

Release note: None