### PR TITLE
roachtest: do not use TIMETZ type for sqlsmith test on 19.2

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -55,6 +55,9 @@ func registerSQLSmith(r *testRegistry) {
 		"no-mutations": sqlsmith.Settings["no-mutations"],
 		"no-ddl":       sqlsmith.Settings["no-ddl"],
 	}
+	unsupportedTypesByVersion := map[string][]string{
+		"v19.2": {"TIMETZ"},
+	}
 
 	runSQLSmith := func(ctx context.Context, t *test, c *cluster, setupName, settingName string) {
 		// Set up a statement logger for easy reproduction. We only
@@ -92,7 +95,30 @@ func registerSQLSmith(r *testRegistry) {
 			t.Fatalf("unknown setting %s", settingName)
 		}
 
+		version, err := fetchCockroachVersion(ctx, c, c.Node(0)[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var unsupportedTypes []string
+		for prefix, types := range unsupportedTypesByVersion {
+			if strings.HasPrefix(version, prefix) {
+				unsupportedTypes = types
+				break
+			}
+		}
+
 		setup := setupFunc(rng)
+		foundUnsupportedType := false
+		for _, unsupportedType := range unsupportedTypes {
+			if strings.Contains(setup, unsupportedType) {
+				foundUnsupportedType = true
+				break
+			}
+		}
+		if foundUnsupportedType {
+			t.Skip("generated setup contains an unsupported type", setup)
+		}
+
 		setting := settingFunc(rng)
 
 		conn := c.Conn(ctx, 1)


### PR DESCRIPTION
We do not support TIMETZ type on 19.2 branch, so we want to skip the
setup if it happened to contain this type. This will stop "syntax
error" messages to be filed as errors.

Release note: None