### PR TITLE
[DNM] changefeedccl: implement gocloud.dev/pubsub sink

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1589,13 +1589,14 @@
   revision = "4a2b4c8f7e0a3754fdd5a3341a27c2431c2a5385"
 
 [[projects]]
-  digest = "1:3b5a3bc35810830ded5e26ef9516e933083a2380d8e57371fdfde3c70d7c6952"
+  digest = "1:381ccafa5e013a0e3f9b54604ae522a73b9533a375a6a714b483c634d5e927ab"
   name = "go.opencensus.io"
   packages = [
     ".",
     "exemplar",
     "internal",
     "internal/tagencoding",
+    "plugin/ocgrpc",
     "plugin/ochttp",
     "plugin/ochttp/propagation/b3",
     "stats",
@@ -1609,6 +1610,24 @@
   ]
   pruneopts = "UT"
   revision = "b7bf3cdb64150a8c8c53b769fdeb2ba581bd4d4b"
+  version = "v0.18.0"
+
+[[projects]]
+  digest = "1:460e91b9e7607f2200a66a6a4db465d40b4d1631591ea05271f32377ada171d2"
+  name = "gocloud.dev"
+  packages = [
+    "gcerrors",
+    "internal/batcher",
+    "internal/gcerr",
+    "internal/oc",
+    "internal/openurl",
+    "internal/retry",
+    "pubsub",
+    "pubsub/driver",
+    "pubsub/mempubsub",
+  ]
+  pruneopts = "UT"
+  revision = "70c91b947b5f3e1d993e5a0137761d335e82d05c"
   version = "v0.18.0"
 
 [[projects]]
@@ -1820,6 +1839,17 @@
   ]
   pruneopts = "UT"
   revision = "63859f3815cb436d25749575cb14aef1153e5634"
+
+[[projects]]
+  branch = "master"
+  digest = "1:918a46e4a2fb83df33f668f5a6bd51b2996775d073fce1800d3ec01b0a5ddd2b"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "9bdfabe68543c54f90421aeb9a60ef8061b5b544"
 
 [[projects]]
   digest = "1:768c35ec83dd17029060ea581d6ca9fdcaef473ec87e93e4bb750949035f6070"
@@ -2131,6 +2161,8 @@
     "go.etcd.io/etcd/raft/quorum",
     "go.etcd.io/etcd/raft/raftpb",
     "go.etcd.io/etcd/raft/tracker",
+    "gocloud.dev/pubsub",
+    "gocloud.dev/pubsub/mempubsub",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/crypto/ssh",
     "golang.org/x/crypto/ssh/agent",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -263,7 +263,7 @@ func changefeedPlanHook(
 		if _, err := getEncoder(details.Opts); err != nil {
 			return err
 		}
-		if isCloudStorageSink(parsedSink) {
+		if isCloudStorageSink(parsedSink) || isPubsubSink(parsedSink) {
 			details.Opts[optKeyInValue] = ``
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -91,6 +91,7 @@ func TestChangefeedBasics(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+	t.Run(`pubsub`, pubsubTest(testFn))
 
 	// NB running TestChangefeedBasics, which includes a DELETE, with
 	// cloudStorageTest is a regression test for #36994.

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -44,6 +44,7 @@ func TestChangefeedNemeses(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+	t.Run(`pubsub`, pubsubTest(testFn))
 	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"))
 	if err != nil {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -172,6 +172,10 @@ func getSink(
 		makeSink = func() (Sink, error) {
 			return makeKafkaSink(cfg, u.Host, targets)
 		}
+	case isPubsubSink(u):
+		makeSink = func() (Sink, error) {
+			return makePubsubSink(u.String(), opts)
+		}
 	case isCloudStorageSink(u):
 		fileSizeParam := q.Get(sinkParamFileSize)
 		q.Del(sinkParamFileSize)

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -1,0 +1,88 @@
+package changefeedccl
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+	"gocloud.dev/pubsub"
+	_ "gocloud.dev/pubsub/mempubsub"
+)
+
+func isPubsubSink(u *url.URL) bool {
+	return u.Scheme == "gcppubsub" || u.Scheme == "mem"
+}
+
+type pubsubSink struct {
+	topic *pubsub.Topic
+}
+
+func makePubsubSink(baseURI string, opts map[string]string) (Sink, error) {
+
+	switch formatType(opts[optFormat]) {
+	case optFormatJSON:
+	default:
+		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
+			optFormat, opts[optFormat])
+	}
+
+	switch envelopeType(opts[optEnvelope]) {
+	case optEnvelopeWrapped:
+	default:
+		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
+			optEnvelope, opts[optEnvelope])
+	}
+
+	if _, ok := opts[optKeyInValue]; !ok {
+		return nil, errors.Errorf(`this sink requires the WITH %s option`, optKeyInValue)
+	}
+
+	ctx := context.TODO()
+	var err error
+	topic, err := pubsub.OpenTopic(ctx, baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return &pubsubSink{
+		topic: topic,
+	}, nil
+}
+
+func (p *pubsubSink) EmitRow(
+	ctx context.Context, table *sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
+) error {
+	msg := pubsub.Message{
+		Metadata: map[string]string{
+			"topic": table.Name,
+		},
+		Body: value,
+	}
+	return errors.Wrap(p.topic.Send(ctx, &msg), "failed to send")
+}
+
+func (p *pubsubSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	var noTopic string
+	payload, err := encoder.EncodeResolvedTimestamp(ctx, noTopic, resolved)
+	if err != nil {
+		return err
+	}
+	msg := pubsub.Message{
+		Body: payload,
+	}
+	return errors.Wrap(p.topic.Send(ctx, &msg), "failed to emit resolved timestamp")
+}
+
+func (p *pubsubSink) Flush(ctx context.Context) error {
+	return nil
+}
+
+func (p *pubsubSink) Close() error {
+	//	return p.topic.Shutdown(context.TODO())
+	return nil
+}
+
+var _ Sink = (*pubsubSink)(nil)


### PR DESCRIPTION
This is a very WIP PR to implement a changefeed sink for the generic pubsub API
exposed by gocloud.dev/pubsub. It does not currently deal with lack of ordering
for the nemesis test.

Fixes #36982.

Release note (enterprise change): Add support for gcp pubsub as a CHANGEFEED
sink.