### PR TITLE
smithcmp: add support for smithcmp to use different mutations

### DIFF
--- a/pkg/cmd/smithcmp/postgres.toml
+++ b/pkg/cmd/smithcmp/postgres.toml
@@ -19,6 +19,9 @@ CREATE TABLE tab_orig AS
     FROM
         generate_series(1, 5) AS g;
 
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x INT, y INT, z INT);
+
 SET statement_timeout = '9s';
 """
 smither = "cockroach"
@@ -27,6 +30,7 @@ postgres = true
 
 [databases.cockroach]
 addr = "postgresql://root@localhost:26257/postgres?sslmode=disable"
+allowmutations = true
 initsql = """
 DROP DATABASE IF EXISTS postgres;
 CREATE DATABASE postgres;

--- a/pkg/cmd/smithcmp/tpch.toml
+++ b/pkg/cmd/smithcmp/tpch.toml
@@ -508,18 +508,21 @@ ORDER BY
 
 [databases.vec-off]
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
+allowmutations = true
 initsql = """
 set vectorize=off;
 """
 
 [databases.vec-auto]
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
+allowmutations = true
 initsql = """
 set vectorize=auto;
 """
 
 [databases.vec-on]
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
+allowmutations = true
 initsql = """
 set vectorize=experimental_on;
 """

--- a/pkg/cmd/smithcmp/vec.toml
+++ b/pkg/cmd/smithcmp/vec.toml
@@ -23,12 +23,14 @@ seed = 0
 
 [databases.cockroach]
 addr = "postgresql://root@localhost:26257?sslmode=disable"
+allowmutations = true
 initsql = """
 set vectorize=off;
 """
 
 [databases.vec]
 addr = "postgresql://root@localhost:26257?sslmode=disable"
+allowmutations = true
 initsql = """
 set vectorize=experimental_on;
 """


### PR DESCRIPTION
This PR allows smithcmp to apply a different set of mutations
on the initialiation SQL and SQL generated by sqlsmith.

Release note: None