### PR TITLE
sqlsmith: add bulk IO statements

### DIFF
--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -15,8 +15,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks to enable Bulk IO
@@ -35,11 +35,9 @@ func (s *Smither) bulkIOEnabled() bool {
 // in a test). It works by starting an in-memory fileserver to hold the
 // data for backups and exports.
 func (s *Smither) enableBulkIO() {
-	var lock sync.Mutex
-	files := map[string][]byte{}
 	s.bulkSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lock.Lock()
-		defer lock.Unlock()
+		s.lock.Lock()
+		defer s.lock.Unlock()
 		localfile := r.URL.Path
 		switch r.Method {
 		case "PUT":
@@ -48,22 +46,23 @@ func (s *Smither) enableBulkIO() {
 				http.Error(w, err.Error(), 500)
 				return
 			}
-			files[localfile] = b
+			s.bulkFiles[localfile] = b
 			w.WriteHeader(201)
 		case "GET", "HEAD":
-			b, ok := files[localfile]
+			b, ok := s.bulkFiles[localfile]
 			if !ok {
 				http.Error(w, fmt.Sprintf("not found: %s", localfile), 404)
 				return
 			}
 			_, _ = w.Write(b)
 		case "DELETE":
-			delete(files, localfile)
+			delete(s.bulkFiles, localfile)
 			w.WriteHeader(204)
 		default:
 			http.Error(w, "unsupported method", 400)
 		}
 	}))
+	s.bulkFiles = map[string][]byte{}
 	s.bulkBackups = map[string]tree.TargetList{}
 }
 
@@ -158,6 +157,105 @@ func makeRestore(s *Smither) (tree.Statement, bool) {
 			tree.KVOption{
 				Key:   "into_db",
 				Value: tree.NewStrVal(string(db)),
+			},
+		},
+	}, true
+}
+
+const exportSchema = "/create.sql"
+
+func makeExport(s *Smither) (tree.Statement, bool) {
+	// TODO(mjibson): Although this code works, in practice these
+	// exports will almost always be empty because the tables it
+	// chooses are also usually empty. Figure out a way to either
+	// encourage more INSERTS or force them before an EXPORT is executed.
+
+	if !s.bulkIOEnabled() {
+		return nil, false
+	}
+	table, ok := s.getRandTable()
+	if !ok {
+		return nil, false
+	}
+	// Get the schema so we can save it for IMPORT. Since the EXPORT
+	// is executed at some later time, there's no guarantee that this
+	// schema will be the same one as in the export. A column could
+	// be added or dropped by another parallel go routine.
+	var schema string
+	if err := s.db.QueryRow(fmt.Sprintf(
+		`select create_statement from [show create table %s]`,
+		table.TableName.String(),
+	)).Scan(&schema); err != nil {
+		return nil, false
+	}
+	stmt := &tree.Select{
+		Select: &tree.SelectClause{
+			Exprs:       tree.SelectExprs{tree.StarSelectExpr()},
+			From:        tree.From{Tables: tree.TableExprs{table.TableName}},
+			TableSelect: true,
+		},
+	}
+	exp := s.name("exp")
+	name := fmt.Sprintf("%s/%s", s.bulkSrv.URL, exp)
+	s.lock.Lock()
+	s.bulkFiles[fmt.Sprintf("/%s%s", exp, exportSchema)] = []byte(schema)
+	s.bulkExports = append(s.bulkExports, string(exp))
+	s.lock.Unlock()
+
+	return &tree.Export{
+		Query:      stmt,
+		FileFormat: "CSV",
+		File:       tree.NewStrVal(name),
+	}, true
+}
+
+var importCreateTableRE = regexp.MustCompile(`CREATE TABLE (.*) \(`)
+
+func makeImport(s *Smither) (tree.Statement, bool) {
+	if !s.bulkIOEnabled() {
+		return nil, false
+	}
+
+	s.lock.Lock()
+	if len(s.bulkExports) == 0 {
+		s.lock.Unlock()
+		return nil, false
+	}
+	exp := s.bulkExports[0]
+	s.bulkExports = s.bulkExports[1:]
+
+	// Find all CSV files created by the EXPORT.
+	var files tree.Exprs
+	for name := range s.bulkFiles {
+		if strings.Contains(name, exp+"/") && !strings.HasSuffix(name, exportSchema) {
+			files = append(files, tree.NewStrVal(s.bulkSrv.URL+name))
+		}
+	}
+	s.lock.Unlock()
+	// An empty table will produce an EXPORT with zero files.
+	if len(files) == 0 {
+		return nil, false
+	}
+
+	// Fix the table name in the existing schema file.
+	tab := s.name("tab")
+	s.lock.Lock()
+	schema := fmt.Sprintf("/%s%s", exp, exportSchema)
+	s.bulkFiles[schema] = importCreateTableRE.ReplaceAll(
+		s.bulkFiles[schema],
+		[]byte(fmt.Sprintf("CREATE TABLE %s (", tab)),
+	)
+	s.lock.Unlock()
+
+	return &tree.Import{
+		Table:      tree.NewUnqualifiedTableName(tab),
+		CreateFile: tree.NewStrVal(s.bulkSrv.URL + schema),
+		FileFormat: "CSV",
+		Files:      files,
+		Options: tree.KVOptions{
+			tree.KVOption{
+				Key:   "nullif",
+				Value: tree.NewStrVal(""),
 			},
 		},
 	}, true

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -1,0 +1,164 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlsmith
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks to enable Bulk IO
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func (s *Smither) bulkIOEnabled() bool {
+	return s.bulkSrv != nil
+}
+
+// enableBulkIO enables bulk IO statements. The smither database must pass
+// the CCL check (either it must have a license or the check is disabled
+// in a test). It works by starting an in-memory fileserver to hold the
+// data for backups and exports.
+func (s *Smither) enableBulkIO() {
+	var lock sync.Mutex
+	files := map[string][]byte{}
+	s.bulkSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		defer lock.Unlock()
+		localfile := r.URL.Path
+		switch r.Method {
+		case "PUT":
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			files[localfile] = b
+			w.WriteHeader(201)
+		case "GET", "HEAD":
+			b, ok := files[localfile]
+			if !ok {
+				http.Error(w, fmt.Sprintf("not found: %s", localfile), 404)
+				return
+			}
+			_, _ = w.Write(b)
+		case "DELETE":
+			delete(files, localfile)
+			w.WriteHeader(204)
+		default:
+			http.Error(w, "unsupported method", 400)
+		}
+	}))
+	s.bulkBackups = map[string]tree.TargetList{}
+}
+
+func makeAsOf(s *Smither) tree.AsOfClause {
+	var expr tree.Expr
+	switch s.rnd.Intn(10) {
+	case 1:
+		expr = tree.NewStrVal("-2s")
+	case 2:
+		expr = tree.NewStrVal(timeutil.Now().Add(-2 * time.Second).Format(tree.TimestampOutputFormat))
+	case 3:
+		expr = sqlbase.RandDatum(s.rnd, types.Interval, false /* nullOk */)
+	case 4:
+		datum := sqlbase.RandDatum(s.rnd, types.Timestamp, false /* nullOk */)
+		str := strings.TrimSuffix(datum.String(), `+00:00'`)
+		str = strings.TrimPrefix(str, `'`)
+		expr = tree.NewStrVal(str)
+	default:
+		// Most of the time leave this empty.
+	}
+	return tree.AsOfClause{
+		Expr: expr,
+	}
+}
+
+func makeBackup(s *Smither) (tree.Statement, bool) {
+	name := fmt.Sprintf("%s/%s", s.bulkSrv.URL, s.name("backup"))
+	var targets tree.TargetList
+	seen := map[tree.TableName]bool{}
+	for len(targets.Tables) < 1 || s.coin() {
+		table, ok := s.getRandTable()
+		if !ok {
+			return nil, false
+		}
+		if seen[*table.TableName] {
+			continue
+		}
+		seen[*table.TableName] = true
+		targets.Tables = append(targets.Tables, table.TableName)
+	}
+	s.lock.Lock()
+	s.bulkBackups[name] = targets
+	s.lock.Unlock()
+
+	var opts tree.KVOptions
+	if s.coin() {
+		opts = tree.KVOptions{
+			tree.KVOption{
+				Key: "revision_history",
+			},
+		}
+	}
+
+	return &tree.Backup{
+		Targets: targets,
+		To:      tree.PartitionedBackup{tree.NewStrVal(name)},
+		AsOf:    makeAsOf(s),
+		Options: opts,
+	}, true
+}
+
+func makeRestore(s *Smither) (tree.Statement, bool) {
+	var name string
+	var targets tree.TargetList
+	s.lock.Lock()
+	for name, targets = range s.bulkBackups {
+		break
+	}
+	// Only restore each backup once.
+	delete(s.bulkBackups, name)
+	s.lock.Unlock()
+
+	if name == "" {
+		return nil, false
+	}
+	// Choose some random subset of tables.
+	s.rnd.Shuffle(len(targets.Tables), func(i, j int) {
+		targets.Tables[i], targets.Tables[j] = targets.Tables[j], targets.Tables[i]
+	})
+	targets.Tables = targets.Tables[:1+s.rnd.Intn(len(targets.Tables))]
+
+	db := s.name("db")
+	if _, err := s.db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, db)); err != nil {
+		return nil, false
+	}
+
+	return &tree.Restore{
+		Targets: targets,
+		From:    []tree.PartitionedBackup{{tree.NewStrVal(name)}},
+		AsOf:    makeAsOf(s),
+		Options: tree.KVOptions{
+			tree.KVOption{
+				Key:   "into_db",
+				Value: tree.NewStrVal(string(db)),
+			},
+		},
+	}, true
+}

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -100,6 +100,8 @@ var (
 		{6, makeCommit},
 		{1, makeBackup},
 		{1, makeRestore},
+		{1, makeExport},
+		{1, makeImport},
 	}
 	nonMutatingStatements = []statementWeight{
 		{10, makeSelect},

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -98,6 +98,8 @@ var (
 		{1, makeBegin},
 		{2, makeRollback},
 		{6, makeCommit},
+		{1, makeBackup},
+		{1, makeRestore},
 	}
 	nonMutatingStatements = []statementWeight{
 		{10, makeSelect},

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -87,7 +87,9 @@ type Smither struct {
 	complexity         float64
 
 	bulkSrv     *httptest.Server
+	bulkFiles   map[string][]byte
 	bulkBackups map[string]tree.TargetList
+	bulkExports []string
 }
 
 type (

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -14,6 +14,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 
@@ -84,6 +85,9 @@ type Smither struct {
 	postgres           bool
 	ignoreFNs          []*regexp.Regexp
 	complexity         float64
+
+	bulkSrv     *httptest.Server
+	bulkBackups map[string]tree.TargetList
 }
 
 type (
@@ -119,7 +123,15 @@ func NewSmither(db *gosql.DB, rnd *rand.Rand, opts ...SmitherOption) (*Smither, 
 	s.selectStmtSampler = newWeightedSelectStatementSampler(s.selectStmtWeights, rnd.Int63())
 	s.scalarExprSampler = newWeightedScalarExprSampler(s.scalarExprWeights, rnd.Int63())
 	s.boolExprSampler = newWeightedScalarExprSampler(s.boolExprWeights, rnd.Int63())
+	s.enableBulkIO()
 	return s, s.ReloadSchemas()
+}
+
+// Close closes resources used by the Smither.
+func (s *Smither) Close() {
+	if s.bulkSrv != nil {
+		s.bulkSrv.Close()
+	}
 }
 
 var prettyCfg = func() tree.PrettyCfg {

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -59,6 +60,7 @@ func TestSetups(t *testing.T) {
 // sometimes put them into bad states that the parser would never do.
 func TestGenerateParse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer utilccl.TestingEnableEnterprise()()
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -96,6 +98,7 @@ func TestGenerateParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer smither.Close()
 
 	seen := map[string]bool{}
 	for i := 0; i < *flagNum; i++ {

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -396,6 +396,8 @@ var ignoredErrorPatterns = []string{
 	"column reference .* not allowed in this context",
 	"cannot write directly to computed column",
 	"index .* in the middle of being added",
+	"could not mark job .* as succeeded",
+	"failed to read backup descriptor",
 
 	// Numeric conditions
 	"exponent out of range",
@@ -495,6 +497,7 @@ var ignoredRegex = regexp.MustCompile(strings.Join(ignoredErrorPatterns, "|"))
 
 func TestRandomSyntaxSQLSmith(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer utilccl.TestingEnableEnterprise()()
 
 	var smither *sqlsmith.Smither
 

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -398,6 +398,10 @@ var ignoredErrorPatterns = []string{
 	"index .* in the middle of being added",
 	"could not mark job .* as succeeded",
 	"failed to read backup descriptor",
+	"AS OF SYSTEM TIME: cannot specify timestamp in the future",
+	"AS OF SYSTEM TIME: timestamp before 1970-01-01T00:00:00Z is invalid",
+	"BACKUP for requested time  needs option 'revision_history'",
+	"RESTORE timestamp: supplied backups do not cover requested time",
 
 	// Numeric conditions
 	"exponent out of range",
@@ -481,6 +485,8 @@ var ignoredErrorPatterns = []string{
 	"invalid IP format",
 	"invalid format code",
 	`.*val\(\): syntax error`,
+	`.*val\(\): syntax error at or near`,
+	`.*val\(\): help token in input`,
 	"invalid source encoding name",
 	"strconv.Atoi: parsing .*: invalid syntax",
 	"field position .* must be greater than zero",


### PR DESCRIPTION
This PR is basically the same as #36306, but rebased.

----

3b104d4 sqlsmith: add BACKUP, RESTORE

Add BACKUP and RESTORE statements to sqlsmith. The backups are written to and
read from an in-memory HTTP file server.

Release note: None

----

c87b28f sqlsmith: add IMPORT, EXPORT

Add IMPORT and EXPORT statements to sqlsmith.

Release note: None