### PR TITLE
mutations: add random storing column mutations for indexes

### DIFF
--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -508,7 +508,7 @@ type NotNullConstraint struct{}
 // NullConstraint represents NULL on a column.
 type NullConstraint struct{}
 
-// PrimaryKeyConstraint represents NULL on a column.
+// PrimaryKeyConstraint represents PRIMARY KEY on a column.
 type PrimaryKeyConstraint struct{}
 
 // UniqueConstraint represents UNIQUE on a column.

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -838,8 +838,7 @@ func RandCreateTables(
 	}
 
 	for _, m := range mutators {
-		muts := m(rng, tables)
-		tables = append(tables, muts...)
+		tables, _ = m(rng, tables)
 	}
 
 	return tables
@@ -913,7 +912,9 @@ func RandCreateTable(rng *rand.Rand, prefix string, tableIdx int) *tree.CreateTa
 		mutations.ColumnFamilyMutator(rng, ret)
 	}
 
-	return ret
+	// Maybe add some storing columns.
+	res, _ := mutations.IndexStoringMutator(rng, []tree.Statement{ret})
+	return res[0].(*tree.CreateTable)
 }
 
 // randColumnTableDef produces a random ColumnTableDef, with a random type and


### PR DESCRIPTION
This PR adds a mutation which randomly generates storing columns
for secondary indexes.

This PR also fixes an interface issue with the mutations package,
where the `MultiStatementMutation` interface was behind its
intended usage.

Release note: None