### PR TITLE
sqlsmith: specify random index hints

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1481,7 +1481,8 @@ CREATE TABLE crdb_internal.table_indexes (
   index_id         INT NOT NULL,
   index_name       STRING NOT NULL,
   index_type       STRING NOT NULL,
-  is_unique        BOOL NOT NULL
+  is_unique        BOOL NOT NULL,
+  is_inverted      BOOL NOT NULL
 )
 `,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1498,6 +1499,7 @@ CREATE TABLE crdb_internal.table_indexes (
 					tree.NewDString(table.PrimaryIndex.Name),
 					primary,
 					tree.MakeDBool(tree.DBool(table.PrimaryIndex.Unique)),
+					tree.MakeDBool(table.PrimaryIndex.Type == sqlbase.IndexDescriptor_INVERTED),
 				); err != nil {
 					return err
 				}
@@ -1509,6 +1511,7 @@ CREATE TABLE crdb_internal.table_indexes (
 						tree.NewDString(idx.Name),
 						secondary,
 						tree.MakeDBool(tree.DBool(idx.Unique)),
+						tree.MakeDBool(idx.Type == sqlbase.IndexDescriptor_INVERTED),
 					); err != nil {
 						return err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -182,10 +182,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTB colnames
+query ITITTBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted
 
 query ITITTITT colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -32,24 +32,24 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 59             test_v1          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
 60             test_v2          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
 
-query ITITTB colnames
+query ITITTBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
 ----
-descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
-53             test_kv          1         primary          primary     true
-53             test_kv          2         test_v_idx       secondary   true
-53             test_kv          3         test_v_idx2      secondary   false
-53             test_kv          4         test_v_idx3      secondary   false
-54             test_kvr1        1         primary          primary     true
-55             test_kvr2        1         primary          primary     true
-55             test_kvr2        2         test_kvr2_v_key  secondary   true
-56             test_kvr3        1         primary          primary     true
-56             test_kvr3        2         test_kvr3_v_key  secondary   true
-57             test_kvi1        1         primary          primary     true
-58             test_kvi2        1         primary          primary     true
-58             test_kvi2        2         test_kvi2_idx    secondary   true
-59             test_v1          0         ·                primary     false
-60             test_v2          0         ·                primary     false
+descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique  is_inverted
+53             test_kv          1         primary          primary     true       false
+53             test_kv          2         test_v_idx       secondary   true       false
+53             test_kv          3         test_v_idx2      secondary   false      false
+53             test_kv          4         test_v_idx3      secondary   false      false
+54             test_kvr1        1         primary          primary     true       false
+55             test_kvr2        1         primary          primary     true       false
+55             test_kvr2        2         test_kvr2_v_key  secondary   true       false
+56             test_kvr3        1         primary          primary     true       false
+56             test_kvr3        2         test_kvr3_v_key  secondary   true       false
+57             test_kvi1        1         primary          primary     true       false
+58             test_kvi2        1         primary          primary     true       false
+58             test_kvi2        2         test_kvi2_idx    secondary   true       false
+59             test_v1          0         ·                primary     false      false
+60             test_v2          0         ·                primary     false      false
 
 query ITITTITT colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id


### PR DESCRIPTION
**sql: add is_inverted column to crdb_internal.table_indexes vtable**

Release note (sql change): A new boolean column 'is_inverted' has been
added to crdb_internal.table_indexes virtual table which indicates
whether the index is inverted or not.

**sqlsmith: specify random index hints**

Now in 50% a random index on a table will be chosen to be used as the
hint. Inverted indexes are omitted.

Release note: None