### PR TITLE
*: allow periods (.) in usernames

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1339,7 +1339,7 @@ func Example_cert() {
 	// cert create-client Ομηρος
 	// cert create-client 0foo
 	// cert create-client ,foo
-	// failed to generate client certificate and key: username ",foo" invalid; usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
+	// failed to generate client certificate and key: username ",foo" invalid
 }
 
 // TestFlagUsage is a basic test to make sure the fragile

--- a/pkg/sql/create_user_test.go
+++ b/pkg/sql/create_user_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestUserName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		username   string
+		normalized string
+		err        string
+		sqlstate   string
+	}{
+		{"Abc123", "abc123", "", ""},
+		{"0123121132", "0123121132", "", ""},
+		{"HeLlO", "hello", "", ""},
+		{"Ομηρος", "ομηρος", "", ""},
+		{"_HeLlO", "_hello", "", ""},
+		{"a-BC-d", "a-bc-d", "", ""},
+		{"A.Bcd", "a.bcd", "", ""},
+		{"WWW.BIGSITE.NET", "www.bigsite.net", "", ""},
+		{"", "", `username "" invalid`, pgcode.InvalidName},
+		{"-ABC", "", `username "-abc" invalid`, pgcode.InvalidName},
+		{".ABC", "", `username ".abc" invalid`, pgcode.InvalidName},
+		{"*.wildcard", "", `username "\*.wildcard" invalid`, pgcode.InvalidName},
+		{"foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof", "", `username "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof" is too long`, pgcode.NameTooLong},
+	}
+
+	for _, tc := range testCases {
+		normalized, err := sql.NormalizeAndValidateUsername(tc.username)
+		if !testutils.IsError(err, tc.err) {
+			t.Errorf("%q: expected %q, got %v", tc.username, tc.err, err)
+			continue
+		}
+		if err != nil {
+			if pgcode := pgerror.GetPGCode(err); pgcode != tc.sqlstate {
+				t.Errorf("%q: expected SQLSTATE %s, got %s", tc.username, tc.sqlstate, pgcode)
+				continue
+			}
+		}
+		if normalized != tc.normalized {
+			t.Errorf("%q: expected %q, got %q", tc.username, tc.normalized, normalized)
+		}
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -54,7 +54,7 @@ DROP USER IF EXISTS user1
 statement error username "node" reserved
 DROP USER node
 
-statement error pq: username "foo☂" invalid; usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
+statement error pq: username "foo☂" invalid
 DROP USER foo☂
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -48,10 +48,10 @@ CREATE USER uSEr2 WITH PASSWORD 'cockroach'
 statement ok
 CREATE USER user3 WITH PASSWORD '蟑螂'
 
-statement error pq: username "foo☂" invalid; usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
+statement error pq: username "foo☂" invalid
 CREATE USER foo☂
 
-statement error pq: username "-foo" invalid; usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
+statement error pq: username "-foo" invalid
 CREATE USER "-foo"
 
 statement error at or near "-": syntax error


### PR DESCRIPTION
Fixes #43105.

Requested by a user:

> Currently, there is a restriction for the database username which
> will limit the certificate-based authentication. It's very common to
> include .local (e.g.: internal-service2.local) in the CN (Common Name)
> of a certificate.  The AWS Certificate Manager (ACM) won't even issue
> a certificate if the "dot" (.) is not present.

Release note (sql change): Usernames can now contain periods, for
compatibility with certificate managers that require domain names to
be used as usernames.

Release note (security update): The validation rule for principal
names was extended to support periods and thus allow domainname-like
principals. For reference, the validation rule is currently the regular
expression `^[\p{Ll}0-9_][---\p{Ll}0-9_.]+$` and a size limit of 63
UTF-8 bytes (larger usernames are rejected with an error); for
comparison, PostgreSQL allows many more characters and truncates at 63
chacters silently.