### PR TITLE
storage: create TestReplicaRangefeedPushesTransactions

### DIFF
--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -460,7 +460,16 @@ func setupTestClusterForClosedTimestampTesting(
 	repls []*storage.Replica,
 ) {
 
-	tc = serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	tc = serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &storage.StoreTestingKnobs{
+					RangeFeedPushTxnsInterval: 10 * time.Millisecond,
+					RangeFeedPushTxnsAge:      20 * time.Millisecond,
+				},
+			},
+		},
+	})
 	db0 = tc.ServerConn(0)
 
 	if _, err := db0.Exec(fmt.Sprintf(`

--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -344,6 +344,8 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		Clock:            r.Clock(),
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,
+		PushTxnsInterval: r.store.TestingKnobs().RangeFeedPushTxnsInterval,
+		PushTxnsAge:      r.store.TestingKnobs().RangeFeedPushTxnsAge,
 		EventChanCap:     defaultEventChanCap,
 		EventChanTimeout: 50 * time.Millisecond,
 		Metrics:          r.store.metrics.RangeFeedMetrics,

--- a/pkg/storage/replica_rangefeed_test.go
+++ b/pkg/storage/replica_rangefeed_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -696,6 +697,117 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		pErr := <-streamErrC
 		assertRangefeedRetryErr(t, pErr, roachpb.RangeFeedRetryError_REASON_LOGICAL_OPS_MISSING)
 	})
+}
+
+// TestReplicaRangefeedPushesTransactions tests that rangefeed detects intents
+// that are holding up its resolved timestamp and periodically pushes them to
+// ensure that its resolved timestamp continues to advance.
+func TestReplicaRangefeedPushesTransactions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc, db, _, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
+	defer tc.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	// While we're here, drop the target duration. This was set to
+	// testingTargetDuration above, but this is higher then it needs to be now
+	// that cluster and schema setup is complete.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
+
+	// Make sure all the nodes have gotten the rangefeed enabled setting from
+	// gossip, so that they will immediately be able to accept RangeFeeds. The
+	// target_duration one is just to speed up the test, we don't care if it has
+	// propagated everywhere yet.
+	testutils.SucceedsSoon(t, func() error {
+		for i := 0; i < tc.NumServers(); i++ {
+			var enabled bool
+			if err := tc.ServerConn(i).QueryRow(
+				`SHOW CLUSTER SETTING kv.rangefeed.enabled`,
+			).Scan(&enabled); err != nil {
+				return err
+			}
+			if !enabled {
+				return errors.Errorf(`waiting for rangefeed to be enabled on node %d`, i)
+			}
+		}
+		return nil
+	})
+
+	ts1 := tc.Server(0).Clock().Now()
+	rangeFeedCtx, rangeFeedCancel := context.WithCancel(ctx)
+	defer rangeFeedCancel()
+	rangeFeedChs := make([]chan *roachpb.RangeFeedEvent, len(repls))
+	rangeFeedErrC := make(chan error, len(repls))
+	for i := range repls {
+		desc := repls[i].Desc()
+		ds := tc.Server(i).DistSenderI().(*kv.DistSender)
+		rangeFeedCh := make(chan *roachpb.RangeFeedEvent)
+		rangeFeedChs[i] = rangeFeedCh
+		go func() {
+			span := roachpb.Span{
+				Key: desc.StartKey.AsRawKey(), EndKey: desc.EndKey.AsRawKey(),
+			}
+			rangeFeedErrC <- ds.RangeFeed(rangeFeedCtx, span, ts1, false /* withDiff */, rangeFeedCh)
+		}()
+	}
+
+	// Wait for a RangeFeed checkpoint on each RangeFeed after the RangeFeed
+	// initial scan time (which is the timestamp passed in the request) to make
+	// sure everything is set up. We intentionally don't care about the spans in
+	// the checkpoints, just verifying that something has made it past the
+	// initial scan and is running.
+	waitForCheckpoint := func(ts hlc.Timestamp) {
+		t.Helper()
+		for _, rangeFeedCh := range rangeFeedChs {
+			checkpointed := false
+			for !checkpointed {
+				select {
+				case event := <-rangeFeedCh:
+					if c := event.Checkpoint; c != nil && ts.Less(c.ResolvedTS) {
+						checkpointed = true
+					}
+				case err := <-rangeFeedErrC:
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+	waitForCheckpoint(ts1)
+
+	// Start a transaction and write an intent on the range. This intent would
+	// prevent from the rangefeed's resolved timestamp from advancing. To get
+	// around this, the rangefeed periodically pushes all intents on its range
+	// to higher timestamps.
+	tx1, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = tx1.ExecContext(ctx, "INSERT INTO cttest.kv VALUES (1, 'test')")
+	require.NoError(t, err)
+
+	// Read the current transaction timestamp. This prevents the txn from committing
+	// if it ever gets pushed.
+	var ts2Str string
+	require.NoError(t, tx1.QueryRowContext(ctx, "SELECT cluster_logical_timestamp()").Scan(&ts2Str))
+	ts2, err := sql.ParseHLC(ts2Str)
+	require.NoError(t, err)
+
+	// Wait for the RangeFeed checkpoint on each RangeFeed to exceed this timestamp.
+	// For this to be possible, it must push the transaction's timestamp forward.
+	waitForCheckpoint(ts2)
+
+	// The txn should not be able to commit since its commit timestamp was pushed
+	// and it has observed its timestamp.
+	require.Regexp(t, "TransactionRetryError: retry txn", tx1.Commit())
+
+	// Make sure the RangeFeed hasn't errored yet.
+	select {
+	case err := <-rangeFeedErrC:
+		t.Fatal(err)
+	default:
+	}
+	// Now cancel it and wait for it to shut down.
+	rangeFeedCancel()
 }
 
 // TestReplicaRangefeedNudgeSlowClosedTimestamp tests that rangefeed detects

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -221,11 +221,16 @@ type StoreTestingKnobs struct {
 	// BeforeRelocateOne intercepts the return values of s.relocateOne before
 	// they're being put into effect.
 	BeforeRelocateOne func(_ []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget, _ error)
-
 	// MaxApplicationBatchSize enforces a maximum size on application batches.
 	// This can be useful for testing conditions which require commands to be
 	// applied in separate batches.
 	MaxApplicationBatchSize int
+	// RangeFeedPushTxnsInterval overrides the default value for
+	// rangefeed.Config.PushTxnsInterval.
+	RangeFeedPushTxnsInterval time.Duration
+	// RangeFeedPushTxnsAge overrides the default value for
+	// rangefeed.Config.PushTxnsAge.
+	RangeFeedPushTxnsAge time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
I noticed that there weren't any storage-level integration tests that verified that an active rangefeed processor would push transactions that were holding up its resolved timestamp from progressing. This commit adds such a test.

Periodically flakes under stress with the following panic unless rebased on #42939:
```
panic: resolved timestamp 1576109922.890013000,0 equal to or above timestamp of operation {<nil> txn_id:d599eb68-cf29-4e15-90be-554b04f10a8b txn_key:"\275\211\211\210" txn_min_timestamp:<wall_time:1576109922877135000 > timestamp:<wall_time:1576109922883114000 logical:2 >  <nil> <nil> <nil> <nil>}
```

Release note: None