### PR TITLE
roachtest: default Run{,E} to a per-invocation file

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -531,8 +531,9 @@ func Post(ctx context.Context, req PostRequest) error {
 	return defaultP.post(ctx, req)
 }
 
-// CanPost returns true if the github API token environment variable is set.
+// CanPost returns true if the github API token environment variable is set to
+// a nontrivial value.
 func CanPost() bool {
-	_, ok := os.LookupEnv(githubAPITokenEnv)
-	return ok
+	s, ok := os.LookupEnv(githubAPITokenEnv)
+	return ok && len(s) > 0
 }

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -27,7 +27,7 @@ func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase
 
 	t.Status("deploying offset injector")
 	offsetInjector := newOffsetInjector(c)
-	if err := offsetInjector.deploy(ctx, t.l); err != nil {
+	if err := offsetInjector.deploy(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -27,7 +27,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 
 	t.Status("deploying offset injector")
 	offsetInjector := newOffsetInjector(c)
-	if err := offsetInjector.deploy(ctx, t.l); err != nil {
+	if err := offsetInjector.deploy(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -39,22 +39,22 @@ type offsetInjector struct {
 }
 
 // deploy installs ntp and downloads / compiles bumptime used to create a clock offset
-func (oi *offsetInjector) deploy(ctx context.Context, l *logger) error {
+func (oi *offsetInjector) deploy(ctx context.Context) error {
 	if err := oi.c.RunE(ctx, oi.c.All(), "test -x ./bumptime"); err == nil {
 		oi.deployed = true
 		return nil
 	}
 
-	if err := oi.c.Install(ctx, l, oi.c.All(), "ntp"); err != nil {
+	if err := oi.c.Install(ctx, oi.c.l, oi.c.All(), "ntp"); err != nil {
 		return err
 	}
-	if err := oi.c.Install(ctx, l, oi.c.All(), "gcc"); err != nil {
+	if err := oi.c.Install(ctx, oi.c.l, oi.c.All(), "gcc"); err != nil {
 		return err
 	}
-	if err := oi.c.RunL(ctx, l, oi.c.All(), "sudo", "service", "ntp", "stop"); err != nil {
+	if err := oi.c.RunL(ctx, oi.c.l, oi.c.All(), "sudo", "service", "ntp", "stop"); err != nil {
 		return err
 	}
-	if err := oi.c.RunL(ctx, l,
+	if err := oi.c.RunL(ctx, oi.c.l,
 		oi.c.All(),
 		"curl",
 		"-kO",
@@ -62,7 +62,7 @@ func (oi *offsetInjector) deploy(ctx context.Context, l *logger) error {
 	); err != nil {
 		return err
 	}
-	if err := oi.c.RunL(ctx, l,
+	if err := oi.c.RunL(ctx, oi.c.l,
 		oi.c.All(), "gcc", "bumptime.c", "-o", "bumptime", "&&", "rm bumptime.c",
 	); err != nil {
 		return err

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -320,4 +321,19 @@ func TestLoadGroups(t *testing.T) {
 			makeLoadGroups(nil, numZones, numRoachNodes, numLoadNodes)
 		}, "Failed to panic when number of zones is not divisible by number of load nodes")
 	})
+}
+
+func TestCmdLogFileName(t *testing.T) {
+	ts := time.Date(2000, 1, 1, 15, 4, 12, 0, time.Local)
+
+	const exp = `run_150412.000_n1,3-4,9_cockroach_bla`
+	nodes := nodeListOption{1, 3, 4, 9}
+	assert.Equal(t,
+		exp,
+		cmdLogFileName(ts, nodes, "./cockroach", "bla", "--foo", "bar"),
+	)
+	assert.Equal(t,
+		exp,
+		cmdLogFileName(ts, nodes, "./cockroach bla --foo bar"),
+	)
 }

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -141,18 +141,12 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 
 	var m *errgroup.Group // see comment in version.go
 	m, ctx = errgroup.WithContext(ctx)
-	for i, cmd := range workloads {
+	for _, cmd := range workloads {
 		cmd := cmd // copy is important for goroutine
-		i := i     // ditto
 
 		cmd = fmt.Sprintf(cmd, nodes)
 		m.Go(func() error {
-			quietL, err := t.l.ChildLogger("kv-"+strconv.Itoa(i), quietStdout)
-			if err != nil {
-				return err
-			}
-			defer quietL.close()
-			return c.RunL(ctx, quietL, c.Node(nodes), cmd)
+			return c.RunE(ctx, c.Node(nodes), cmd)
 		})
 	}
 

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -42,16 +42,10 @@ func registerHotSpotSplits(r *testRegistry) {
 		m.Go(func() error {
 			t.l.Printf("starting load generator\n")
 
-			quietL, err := t.l.ChildLogger("kv-0", quietStdout)
-			if err != nil {
-				return err
-			}
-			defer quietL.close()
-
 			// TODO(rytaft): reset this to 1 << 19 (512 KB) once we can dynamically
 			// size kv batches.
 			const blockSize = 1 << 18 // 256 KB
-			return c.RunL(ctx, quietL, appNode, fmt.Sprintf(
+			return c.RunE(ctx, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
 					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",
 				concurrency, blockSize, blockSize, duration.String()))

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -104,20 +104,15 @@ func registerInterleaved(r *testRegistry) {
 		t.Status("running workload")
 		m := newMonitor(ctx, c, cockroachNodes)
 
-		runLocality := func(name string, node nodeListOption, cmd string) {
+		runLocality := func(node nodeListOption, cmd string) {
 			m.Go(func(ctx context.Context) error {
-				l, err := t.l.ChildLogger(name)
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer l.close()
-				return c.RunL(ctx, l, node, cmd)
+				return c.RunE(ctx, node, cmd)
 			})
 		}
 
-		runLocality("west", workloadWest, createCmd("west", cockroachWest))
-		runLocality("east", workloadEast, createCmd("east", cockroachEast))
-		runLocality("central", workloadCentral, cmdCentral)
+		runLocality(workloadWest, createCmd("west", cockroachWest))
+		runLocality(workloadEast, createCmd("east", cockroachEast))
+		runLocality(workloadCentral, cmdCentral)
 
 		m.Wait()
 	}

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -509,13 +509,7 @@ func registerKVScalability(r *testRegistry) {
 					" {pgurl:1-%d}",
 					percent, nodes)
 
-				l, err := t.l.ChildLogger(fmt.Sprint(i))
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer l.close()
-
-				return c.RunL(ctx, l, c.Node(nodes+1), cmd)
+				return c.RunE(ctx, c.Node(nodes+1), cmd)
 			})
 			m.Wait()
 		}

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -69,13 +69,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		m.Go(func() error {
 			t.l.Printf("starting load generator\n")
 
-			quietL, err := t.l.ChildLogger("kv-0", quietStdout)
-			if err != nil {
-				return err
-			}
-			defer quietL.close()
-
-			err = c.RunL(ctx, quietL, appNode, fmt.Sprintf(
+			err := c.RunE(ctx, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=95 --tolerate-errors --concurrency=%d "+
 					"--duration=%v {pgurl:1-%d}",
 				concurrency, maxDuration, len(roachNodes)))

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -39,12 +39,7 @@ func registerRoachmart(r *testRegistry) {
 				"--orders=100",
 				fmt.Sprintf("--partition=%v", partition))
 
-			l, err := t.l.ChildLogger(fmt.Sprint(nodes[i].i))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer l.close()
-			if err := c.RunL(ctx, l, c.Node(nodes[i].i), args...); err != nil {
+			if err := c.RunE(ctx, c.Node(nodes[i].i), args...); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -95,18 +95,8 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 		m.Go(ch.Runner(c, m))
 	}
 	m.Go(func(ctx context.Context) error {
-		// Sqlapp logs are very noisy - so noisy that if not directed to /dev/null
-		// they often have the effect of slowing down the test so much that it
-		// fails. To get around this we create a new logger that writes to an
-		// artifacts file but does not output to stdout or stderr.
-		sqlappL, err := t.l.ChildLogger("sqlapp", logPrefix(""), quietStdout, quietStderr)
-		if err != nil {
-			return err
-		}
-		defer sqlappL.close()
-
 		t.Status("installing schema")
-		err = c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s --install_schema "+
+		err = c.RunE(ctx, appNode, fmt.Sprintf("./%s --install_schema "+
 			"--cockroach_ip_addresses_csv='%s' %s", app, addrStr, flags))
 		if err != nil {
 			return err
@@ -114,7 +104,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 
 		t.Status("running consistency checker")
 		const workers = 16
-		return c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s  --duration_secs=%d "+
+		return c.RunE(ctx, appNode, fmt.Sprintf("./%s  --duration_secs=%d "+
 			"--num_workers=%d --cockroach_ip_addresses_csv='%s' %s",
 			app, int(dur.Seconds()), workers, addrStr, flags))
 	})

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -61,18 +60,11 @@ func registerVersion(r *testRegistry) {
 		}
 
 		m := newMonitor(ctx, c, c.Range(1, nodes))
-		for i, cmd := range workloads {
+		for _, cmd := range workloads {
 			cmd := cmd // loop-local copy
-			i := i     // ditto
 			m.Go(func(ctx context.Context) error {
 				cmd = fmt.Sprintf(cmd, nodes)
-				// Direct stderr only to disk. We expect errors from the workload as
-				// nodes are stopped and started.
-				childL, err := t.l.ChildLogger("workload"+strconv.Itoa(i), quietStderr)
-				if err != nil {
-					return err
-				}
-				return c.RunL(ctx, childL, c.Node(nodes+1), cmd)
+				return c.RunE(ctx, c.Node(nodes+1), cmd)
 			})
 		}
 


### PR DESCRIPTION
A regular complaint about roachtest is that it is difficult to reason about
the flow of the test given only the log files. This is in part because the
main log often contains lenghty workload outputs that create large files
with lots of non-timestamped sections where output is often even hard to
assign to a specific process. Questions that often come up are "did this
process already terminate at this point?", "Did it ever print output?",
"What process does this log line belong to", "What is this test even doing?
All I'm seeing are pages and pages of some bogus workload output",among
many others.

This commit changes the default behavior to creating a unique file per
invocation (sorting in timestamp order) and streaming the output there and
only there. Where streaming to stdout/stderr is desired, `RunL` can be used
instead.

Certainly a lot more can be done here, but this could already help quite a
bit in keeping the main log manageable in size while also allowing us to
better diagnose test failures.

Release note: None