### PR TITLE
roachtest: send SIGABRT on timeout before cancelling context

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -691,7 +691,6 @@ func (r *testRunner) runTest(
 	// We run the actual test in a different goroutine because it might call
 	// t.Fatal() which kills the goroutine, and also because we want to enforce a
 	// timeout.
-	success := false
 	done := make(chan struct{})
 	go func() {
 		defer close(done) // closed only after we've grabbed the debug info below
@@ -715,9 +714,6 @@ func (r *testRunner) runTest(
 		t.printfAndFail(0 /* skip */, "test timed out (%s)", timeout)
 		select {
 		case <-done:
-			if success {
-				panic("expected success=false after a timeout")
-			}
 		case <-time.After(5 * time.Minute):
 			msg := "test timed out and afterwards failed to respond to cancelation"
 			t.l.PrintfCtx(ctx, msg)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -693,8 +693,7 @@ func (r *testRunner) runTest(
 	// timeout.
 	done := make(chan struct{})
 	go func() {
-		defer close(done) // closed only after we've grabbed the debug info below
-
+		defer close(done)
 		// This is the call to actually run the test.
 		t.spec.Run(runCtx, t, c)
 	}()


### PR DESCRIPTION
If a roachtest times out, it's often due to a remote process not
terminating reasonably fast, see for example:

https://github.com/cockroachdb/cockroach/issues/41876#issuecomment-565055897.

On a timeout, we used to cancel the main context which would cancel all
`roachprod` invocations without giving the remote processes a chance to
dump their stacks.

This commit introduces a (time-boxed) `roachprod stop --signal=6`
invocation before cancelling the context which at least gives us a decent
enough chance that the remote processes dump their stack and manage to send
it back to the test runner. Unfortunately, since we're also terminating the
CockroachDB processes at the same time, we probably won't be able to
observe stuck queries in this way, but this is better than nothing.

Release note: None