### PR TITLE
server/status: read current process's cgroup to determine available memory

### DIFF
--- a/pkg/util/cgroups/cgroups.go
+++ b/pkg/util/cgroups/cgroups.go
@@ -1,0 +1,186 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cgroups
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	defaultCGroupRootPath    = "/sys/fs/cgroup/"
+	cgroupV1FilesystemSpec   = "cgroup"
+	cgroupV2FilesystemSpec   = "cgroup2"
+	cgroupMemorySubsystem    = "memory"
+	cgroupV1MemLimitFilename = "memory.limit_in_bytes"
+	cgroupV2MemLimitFilename = "memory.max"
+)
+
+// GetCgroupMemoryLimit attempts to retrieve the memory limit for the current
+// process.
+func GetCgroupMemoryLimit() (limit int64, warnings string, err error) {
+	return getCgroupMem("/")
+}
+
+// treeRoot is set to "/" in production code and exists only for testing.
+func getCgroupMem(treeRoot string) (limit int64, warnings string, err error) {
+	// Let's assume that the memory cgroup is rooted at defaultMemoryCgroupRoot.
+	procCgroupFile := filepath.Join(treeRoot, "proc", strconv.Itoa(os.Getpid()), "cgroup")
+	cgroupPath, isV2, err := parseMemoryPathFromProcCgroupFile(procCgroupFile)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to read memory cgroup from cgroups file")
+	}
+	var cgroupRoot, memoryLimitFile string
+	if !isV2 {
+		memoryLimitFile = cgroupV1MemLimitFilename
+		if cgroupRoot, err = getMemoryCgroupRoot(treeRoot); err != nil {
+			return 0, "", err
+		}
+	} else {
+		memoryLimitFile = cgroupV2MemLimitFilename
+		if cgroupRoot, err = getUnifiedCgroupRoot(treeRoot); err != nil {
+			return 0, "", err
+		}
+	}
+	limit = int64(math.MinInt64)
+	var parseErrors []error
+	for p := cgroupPath; true; p = filepath.Dir(p) {
+		limitFilePath := filepath.Join(treeRoot, cgroupRoot, p, memoryLimitFile)
+		if read, err := parseCgroupLimitFile(limitFilePath); err != nil {
+			if pe := new(os.PathError); !errors.As(err, &pe) {
+				parseErrors = append(parseErrors, err)
+			}
+		} else if limit == math.MinInt64 || read < limit {
+			limit = read
+		}
+		if p == "/" {
+			break
+		}
+	}
+	if limit == math.MinInt64 {
+		if len(parseErrors) == 0 {
+			return 0, "", fmt.Errorf("failed to find cgroup memory limit")
+		}
+		return 0, "", parseErrors[0]
+	}
+	return limit, joinErrorsForWarning(parseErrors), nil
+}
+
+// parseMemoryPathFromProcCgroupFile determines the path for the cgroup which
+// contains the memory subsystem from the provided path to a cgroup file.
+//
+// From man 7 cgroups:
+//
+//  /proc/[pid]/cgroup (since Linux 2.6.24)
+//
+//  This file describes control groups to which the process with the
+//  corresponding PID belongs.  The displayed information differs for cgroups
+//  version 1 and version 2 hierarchies.
+//
+//  For each cgroup hierarchy of which the process is a member, there is one
+//  entry containing three colon-separated fields:
+//
+//    hierarchy-ID:controller-list:cgroup-path
+//
+//  For example:
+//
+//    5:cpuacct,cpu,cpuset:/daemons
+//
+//  The colon-separated fields are, from left to right:
+//
+//    1. For cgroups version 1 hierarchies, this field contains a unique
+//       hierarchy ID number that can be matched to a hierarchy ID in
+//       /proc/cgroups. For the cgroups version 2 hierarchy, this field contains
+//       the value 0.
+//
+//    2. For cgroups version 1 hierarchies, this field contains a comma-
+//       separated list of the controllers bound to the hierarchy. For the
+//       cgroups version 2 hierarchy, this field is empty.
+//
+//    3. This field contains the pathname of the control group in the hierarchy
+//       to which the process belongs.  This pathname is relative to the mount
+//       point of the hierarchy.
+//
+func parseMemoryPathFromProcCgroupFile(
+	procCgroupFilePath string,
+) (memoryCgroupPath string, isUnified bool, err error) {
+	f, err := os.Open(procCgroupFilePath)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f) // scan lines
+	var unifiedPath string
+	for scanner.Scan() {
+		row := scanner.Bytes()
+		matches := rowRegexp.FindSubmatchIndex(row)
+		if matches == nil {
+			// TODO(ajwerner): consider propagating a warning or something.
+			continue
+		}
+		if string(row[matches[2]:matches[3]]) == "0" {
+			unifiedPath = string(row[matches[6]:matches[7]])
+			continue
+		}
+		if string(row[matches[4]:matches[5]]) != "memory" {
+			continue
+		}
+		return string(row[matches[6]:matches[7]]), false, nil
+	}
+	if unifiedPath != "" {
+		return unifiedPath, true, nil
+	}
+	return "", false, errors.New("failed to find memory cgroup, must not be in one")
+}
+
+// see parseMemoryPathFromProcCgroupFile.
+var rowRegexp = regexp.MustCompile(`(\d+):(.*):(.*)`)
+
+func joinErrorsForWarning(errs []error) string {
+	var buf strings.Builder
+	for _, err := range errs {
+		if buf.Len() == 0 {
+			buf.WriteString("failed to read some cgroup files: ")
+		} else {
+			buf.WriteString("; ")
+		}
+		buf.WriteString(err.Error())
+	}
+	return buf.String()
+}
+
+// parseCgroupLimitFile reads and parses a decimal integer from the provided
+// file path.
+func parseCgroupLimitFile(limitFilePath string) (limit int64, err error) {
+	var buf []byte
+	if buf, err = ioutil.ReadFile(limitFilePath); err != nil {
+		return 0, errors.Wrapf(err, "can't read available memory from cgroup at %s", limitFilePath)
+	}
+	trimmed := string(bytes.TrimSpace(buf))
+	if trimmed == "max" {
+		return math.MaxInt64, nil
+	}
+	limit, err = strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "can't read available memory from cgroup at %s", limitFilePath)
+	}
+	return limit, nil
+}

--- a/pkg/util/cgroups/cgroups_test.go
+++ b/pkg/util/cgroups/cgroups_test.go
@@ -1,0 +1,264 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cgroups
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCgroupsGetMemory(t *testing.T) {
+	pid := os.Getpid()
+	mapping := func(s string) string {
+		if s == "pid" {
+			return strconv.Itoa(pid)
+		}
+		return ""
+	}
+	createFiles := func(t *testing.T, paths map[string]string) (dir string) {
+		dir, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+
+		for path, data := range paths {
+			path = filepath.Join(dir, os.Expand(path, mapping))
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+			require.NoError(t, ioutil.WriteFile(path, []byte(data), 0755))
+		}
+		return dir
+	}
+	const v1Mounts = `sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+udev /dev devtmpfs rw,nosuid,relatime,size=7685540k,nr_inodes=1921385,mode=755 0 0
+devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=1539340k,mode=755 0 0
+/dev/sda1 / ext4 rw,relatime,data=ordered 0 0
+securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
+tmpfs /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k 0 0
+tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
+cgroup /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd 0 0
+pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
+cgroup /sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0
+cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
+cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
+cgroup /sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0
+cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
+cgroup /sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0
+cgroup /sys/fs/cgroup/rdma cgroup rw,nosuid,nodev,noexec,relatime,rdma 0 0
+cgroup /sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0
+cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
+cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
+cgroup /sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0
+systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=27,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14670 0 0
+debugfs /sys/kernel/debug debugfs rw,relatime 0 0
+mqueue /dev/mqueue mqueue rw,relatime 0 0
+hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=2M 0 0
+fusectl /sys/fs/fuse/connections fusectl rw,relatime 0 0
+configfs /sys/kernel/config configfs rw,relatime 0 0
+lxcfs /var/lib/lxcfs fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
+/dev/nvme0n1 /mnt/data1 ext4 rw,relatime,discard,nobarrier,data=ordered 0 0
+tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=1539340k,mode=700,uid=1000,gid=1000 0 0`
+	const v2Mounts = `/dev/root / ext4 rw,relatime 0 0
+devtmpfs /dev devtmpfs rw,relatime,size=7691232k,nr_inodes=1922808,mode=755 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
+devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /run tmpfs rw,nosuid,nodev,size=1539080k,mode=755 0 0
+tmpfs /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k 0 0
+cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0
+pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
+bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
+debugfs /sys/kernel/debug debugfs rw,relatime 0 0
+hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=2M 0 0
+mqueue /dev/mqueue mqueue rw,relatime 0 0
+fusectl /sys/fs/fuse/connections fusectl rw,relatime 0 0
+configfs /sys/kernel/config configfs rw,relatime 0 0
+/dev/loop0 /snap/google-cloud-sdk/101 squashfs ro,nodev,relatime 0 0
+/dev/sda15 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0                                                                                
+/dev/loop1 /snap/core/7713 squashfs ro,nodev,relatime 0 0
+/dev/loop2 /snap/lxd/12100 squashfs ro,nodev,relatime 0 0
+/dev/nvme0n1 /mnt/data1 ext4 rw,relatime,discard,nobarrier 0 0
+tmpfs /run/snapd/ns tmpfs rw,nosuid,nodev,size=1539080k,mode=755 0 0
+nsfs /run/snapd/ns/lxd.mnt nsfs rw 0 0
+tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=1539076k,mode=700,uid=1000,gid=1001 0 0`
+	for _, tc := range []struct {
+		name       string
+		paths      map[string]string
+		limit      int64
+		errPat     string
+		warningPat string
+	}{
+		{
+			name: "simple,root",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+11:pids:/
+10:perf_event:/
+9:hugetlb:/
+8:blkio:/
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/
+4:rdma:/
+3:cpuset:/
+2:devices:/
+1:name=systemd:/
+0::/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes": "12345",
+			},
+			limit: 12345,
+		},
+		{
+			name: "intermediate cgroup contains limit",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+11:pids:/
+10:perf_event:/
+9:hugetlb:/
+8:blkio:/
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/system.slice/sshd.service
+4:rdma:/
+3:cpuset:/
+2:devices:/
+1:name=systemd:/
+0::/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes":                           "123456",
+				"/sys/fs/cgroup/memory/system.slice/sshd.service/memory.limit_in_bytes": "1234567",
+				"/sys/fs/cgroup/memory/system.slice/memory.limit_in_bytes":              "12345",
+				"/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes":                      "1234",
+			},
+			limit: 12345,
+		},
+		{
+			name: "malformed proc cgroup file with value in child",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/asdf
+4:rdma:/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes":      "123456",
+				"/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes": "12345",
+			},
+			limit: 12345,
+		},
+		{
+			name: "malformed limit file gets ignored",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/asdf
+4:rdma:/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes":      "12345a sdasdfasd12341",
+				"/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes": "123456",
+			},
+			limit: 123456,
+		},
+		{
+			name: "all malformed files leads to an error",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/asdf
+4:rdma:/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes":      "12345a sdasdfasd12341",
+				"/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes": "qwer",
+			},
+			errPat: "can't read available memory from cgroup at .*/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes: strconv.ParseInt: parsing \"qwer\"",
+		},
+		{
+			name: "one malformed files leads to a warning",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v1Mounts,
+				"/proc/${pid}/cgroup": `12:freezer:/
+
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+5:memory:/asdf
+4:rdma:/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes":      "12345",
+				"/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes": "qwer",
+			},
+			limit:      12345,
+			warningPat: "can't read available memory from cgroup at .*/sys/fs/cgroup/memory/asdf/memory.limit_in_bytes: strconv.ParseInt: parsing \"qwer\"",
+		},
+		{
+			name: "no memory subsystem in /proc/.../cgroup",
+			paths: map[string]string{
+				"/proc/${pid}/cgroup": `12:freezer:/
+7:cpu,cpuacct:/
+6:net_cls,net_prio:/
+4:rdma:/
+`,
+				"/sys/fs/cgroup/memory/memory.limit_in_bytes": "12345",
+			},
+			errPat: "failed to find memory cgroup",
+		},
+		{
+			name: "v2",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v2Mounts,
+				"/proc/${pid}/cgroup": `0::/user.slice/user-1000.slice/session-4.scope
+`,
+				"/sys/fs/cgroup/user.slice/user-1000.slice/session-4.scope/memory.max": `max`,
+				"/sys/fs/cgroup/user.slice/user-1000.slice/memory.max":                 `99999744`,
+				"/sys/fs/cgroup/user.slice/memory.max":                                 `max`,
+			},
+			limit: 99999744,
+		},
+		{
+			name: "v2 no memory controllers",
+			paths: map[string]string{
+				"/proc/${pid}/mounts": v2Mounts,
+				"/proc/${pid}/cgroup": `0::/user.slice/user-1000.slice/session-4.scope
+`,
+				"/sys/fs/cgroup/user.slice/user-1000.slice/session-4.scope/cgroup.controllers": `cpu`,
+			},
+			errPat: "failed to find cgroup memory limit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := createFiles(t, tc.paths)
+			defer func() { _ = os.RemoveAll(dir) }()
+			limit, warning, err := getCgroupMem(dir)
+			require.True(t, testutils.IsError(err, tc.errPat),
+				"%v %v", err, tc.errPat)
+			require.Regexp(t, tc.warningPat, warning)
+			require.Equal(t, tc.limit, limit)
+		})
+	}
+}

--- a/pkg/util/cgroups/mounts.go
+++ b/pkg/util/cgroups/mounts.go
@@ -1,0 +1,197 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cgroups
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+/*
+From man 5 fstab:
+
+The following is a typical example of an fstab entry:
+
+              LABEL=t-home2   /home      ext4    defaults,auto_da_alloc
+              0  2
+
+       The first field (fs_spec).
+              This field describes the block special device or remote
+              filesystem to be mounted.
+
+              For ordinary mounts, it will hold (a link to) a block special
+              device node (as created by mknod(2)) for the device to be
+              mounted, like `/dev/cdrom' or `/dev/sdb7'.  For NFS mounts,
+              this field is <host>:<dir>, e.g., `knuth.aeb.nl:/'.  For
+              filesystems with no storage, any string can be used, and will
+              show up in df(1) output, for example.  Typical usage is `proc'
+              for procfs; `mem', `none', or `tmpfs' for tmpfs.  Other
+              special filesystems, like udev and sysfs, are typically not
+              listed in fstab.
+
+              LABEL=<label> or UUID=<uuid> may be given instead of a device
+              name.  This is the recommended method, as device names are
+              often a coincidence of hardware detection order, and can
+              change when other disks are added or removed.  For example,
+              `LABEL=Boot' or `UUID=3e6be9de-8139-11d1-9106-a43f08d823a6'.
+              (Use a filesystem-specific tool like e2label(8), xfs_admin(8),
+              or fatlabel(8) to set LABELs on filesystems).
+
+              It's also possible to use PARTUUID= and PARTLABEL=. These
+              partitions identifiers are supported for example for GUID
+              Partition Table (GPT).
+
+              See mount(8), blkid(8) or lsblk(8) for more details about
+              device identifiers.
+
+              Note that mount(8) uses UUIDs as strings. The string
+              representation of the UUID should be based on lower case
+              characters.
+
+       The second field (fs_file).
+              This field describes the mount point (target) for the
+              filesystem.  For swap partitions, this field should be
+              specified as `none'. If the name of the mount point contains
+              spaces or tabs these can be escaped as `\040' and '\011'
+              respectively.
+
+       The third field (fs_vfstype).
+              This field describes the type of the filesystem.  Linux
+              supports many filesystem types: ext4, xfs, btrfs, f2fs, vfat,
+              ntfs, hfsplus, tmpfs, sysfs, proc, iso9660, udf, squashfs,
+              nfs, cifs, and many more.  For more details, see mount(8).
+
+              An entry swap denotes a file or partition to be used for
+              swapping, cf. swapon(8).  An entry none is useful for bind or
+              move mounts.
+
+              More than one type may be specified in a comma-separated list.
+
+              mount(8) and umount(8) support filesystem subtypes.  The
+              subtype is defined by '.subtype' suffix.  For example
+              'fuse.sshfs'. It's recommended to use subtype notation rather
+              than add any prefix to the first fstab field (for example
+              'sshfs#example.com' is deprecated).
+
+       The fourth field (fs_mntops).
+              This field describes the mount options associated with the
+              filesystem.
+
+              It is formatted as a comma-separated list of options.  It
+              contains at least the type of mount (ro or rw), plus any
+              additional options appropriate to the filesystem type
+              (including performance-tuning options).  For details, see
+              mount(8) or swapon(8).
+
+              Basic filesystem-independent options are:
+
+              defaults
+                     use default options: rw, suid, dev, exec, auto, nouser,
+                     and async.
+
+              noauto do not mount when "mount -a" is given (e.g., at boot
+                     time)
+
+              user   allow a user to mount
+
+              owner  allow device owner to mount
+
+              comment
+                     or x-<name> for use by fstab-maintaining programs
+
+              nofail do not report errors for this device if it does not
+                     exist.
+
+       The fifth field (fs_freq).
+              This field is used by dump(8) to determine which filesystems
+              need to be dumped.  Defaults to zero (don't dump) if not
+              present.
+
+       The sixth field (fs_passno).
+              This field is used by fsck(8) to determine the order in which
+              filesystem checks are done at boot time.  The root filesystem
+              should be specified with a fs_passno of 1.  Other filesystems
+              should have a fs_passno of 2.  Filesystems within a drive will
+              be checked sequentially, but filesystems on different drives
+              will be checked at the same time to utilize parallelism
+              available in the hardware.  Defaults to zero (don't fsck) if
+              not present.
+*/
+type fstabEntry struct {
+	fsSpec    string
+	fsFile    string
+	fsVfsOpts string
+	fsMntOpts string
+}
+
+func parseProcMounts(treeRoot string, f func(entry fstabEntry)) error {
+	procMountsFilePath := filepath.Join(treeRoot, "proc", strconv.Itoa(os.Getpid()), "mounts")
+	procMountsFile, err := os.Open(procMountsFilePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = procMountsFile.Close() }()
+	scanner := bufio.NewScanner(procMountsFile) // scan lines
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		var e fstabEntry
+		for i, field := range fields {
+			switch i {
+			case 0:
+				e.fsSpec = field
+			case 1:
+				e.fsFile = field
+			case 2:
+				e.fsVfsOpts = field
+			case 3:
+				e.fsMntOpts = field
+			}
+		}
+		f(e)
+	}
+	return nil
+}
+
+// getMemoryCgroupRoot reads /proc/${pid}/mounts to find the mountpoint for the
+// cgroup v1 memory subsystem if it exists.
+func getMemoryCgroupRoot(treeRoot string) (cgroupRoot string, err error) {
+	var memorySubsystemPath string
+	if err := parseProcMounts(treeRoot, func(entry fstabEntry) {
+		if entry.fsSpec != cgroupV1FilesystemSpec {
+			return
+		}
+		if !strings.Contains(entry.fsMntOpts, cgroupMemorySubsystem) {
+			return
+		}
+		memorySubsystemPath = entry.fsFile
+	}); err != nil {
+		return "", err
+	}
+	return memorySubsystemPath, nil
+}
+
+// getUnifiedCgroupRoot reads /proc/${pid}/mounts to find the mountpoint for the
+// cgroup v2 unified hierarchy if it exists.
+func getUnifiedCgroupRoot(treeRoot string) (cgroupRoot string, err error) {
+	var unifiedHierarchyPath string
+	if err := parseProcMounts(treeRoot, func(entry fstabEntry) {
+		if entry.fsSpec != cgroupV2FilesystemSpec {
+			return
+		}
+		unifiedHierarchyPath = entry.fsFile
+	}); err != nil {
+		return "", err
+	}
+	return unifiedHierarchyPath, nil
+}


### PR DESCRIPTION
Prior to this commit we would consult the system memory and the root cgroup
to determine the available memory. This is problematic because almost always
when systems use cgroups they use a hierarchy to create limits for specific
sets of processes. After this change we'll now determine the deepest child
hierarchy which contains this process and examine all of the relevant
limits to determine the memory limit.

Release note (bug fix): On linux machines we now respect the available memory
limit as dictated by the cgroup limits which apply to the cockroach process.