### PR TITLE
storage: pull Store-level concurrency retry loop under Replica, clean up req validation

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -538,9 +538,9 @@ func CountLeases(
 // a version of the table descriptor. A tableVersionState with the
 // expiration time set to expiration is returned.
 //
-// This returns an error when Replica.requestCanProceed() returns an
-// error when the expiration timestamp is less than the storage layer
-// GC threshold.
+// This returns an error when Replica.checkTSAboveGCThresholdRLocked()
+// returns an error when the expiration timestamp is less than the storage
+// layer GC threshold.
 func (s LeaseStore) getForExpiration(
 	ctx context.Context, expiration hlc.Timestamp, id sqlbase.ID,
 ) (*tableVersionState, error) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -594,11 +594,6 @@ func (r *Replica) sendWithRangeID(
 		log.Fatalf(ctx, "don't know how to handle command %s", ba)
 	}
 	if pErr != nil {
-		if _, ok := pErr.GetDetail().(*roachpb.RaftGroupDeletedError); ok {
-			// This error needs to be converted appropriately so that
-			// clients will retry.
-			pErr = roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID, r.store.StoreID()))
-		}
 		log.Eventf(ctx, "replica.Send got error: %s", pErr)
 	} else {
 		if filter := r.store.cfg.TestingKnobs.TestingResponseFilter; filter != nil {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/storage/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
@@ -528,10 +529,12 @@ func NewReplica(
 // Send executes a command on this range, dispatching it to the
 // read-only, read-write, or admin execution path as appropriate.
 // ctx should contain the log tags from the store (and up).
+// TODO(nvanbenschoten): Move Replica.Send and it's callees into
+// the new replica_send.go file once this review is complete.
 func (r *Replica) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	return r.sendWithRangeID(ctx, r.RangeID, ba)
+	return r.sendWithRangeID(ctx, r.RangeID, &ba)
 }
 
 // sendWithRangeID takes an unused rangeID argument so that the range
@@ -546,7 +549,7 @@ func (r *Replica) Send(
 //
 // github.com/cockroachdb/cockroach/pkg/storage.(*Replica).sendWithRangeID(0xc420d1a000, 0x64bfb80, 0xc421564b10, 0x15, 0x153fd4634aeb0193, 0x0, 0x100000001, 0x1, 0x15, 0x0, ...)
 func (r *Replica) sendWithRangeID(
-	ctx context.Context, rangeID roachpb.RangeID, ba roachpb.BatchRequest,
+	ctx context.Context, rangeID roachpb.RangeID, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	var br *roachpb.BatchResponse
 	if r.leaseholderStats != nil && ba.Header.GatewayNodeID != 0 {
@@ -564,27 +567,39 @@ func (r *Replica) sendWithRangeID(
 	isReadOnly := ba.IsReadOnly()
 	useRaft := !isReadOnly && ba.IsWrite()
 
-	if err := r.checkBatchRequest(&ba, isReadOnly); err != nil {
+	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {
+		return nil, roachpb.NewError(err)
+	}
+
+	if err := r.maybeBackpressureBatch(ctx, ba); err != nil {
+		return nil, roachpb.NewError(err)
+	}
+
+	// NB: must be performed before collecting request spans.
+	ba, err := maybeStripInFlightWrites(ba)
+	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
 	if filter := r.store.cfg.TestingKnobs.TestingRequestFilter; filter != nil {
-		if pErr := filter(ba); pErr != nil {
+		if pErr := filter(*ba); pErr != nil {
 			return nil, pErr
 		}
 	}
 
-	// Differentiate between admin, read-only and write.
+	// Differentiate between read-write, read-only, and admin.
 	var pErr *roachpb.Error
 	if useRaft {
 		log.Event(ctx, "read-write path")
-		br, pErr = r.executeWriteBatch(ctx, &ba)
+		fn := (*Replica).executeWriteBatch
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn)
 	} else if isReadOnly {
 		log.Event(ctx, "read-only path")
-		br, pErr = r.executeReadOnlyBatch(ctx, &ba)
+		fn := (*Replica).executeReadOnlyBatch
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn)
 	} else if ba.IsAdmin() {
 		log.Event(ctx, "admin path")
-		br, pErr = r.executeAdminBatch(ctx, &ba)
+		br, pErr = r.executeAdminBatch(ctx, ba)
 	} else if len(ba.Requests) == 0 {
 		// empty batch; shouldn't happen (we could handle it, but it hints
 		// at someone doing weird things, and once we drop the key range
@@ -597,10 +612,260 @@ func (r *Replica) sendWithRangeID(
 		log.Eventf(ctx, "replica.Send got error: %s", pErr)
 	} else {
 		if filter := r.store.cfg.TestingKnobs.TestingResponseFilter; filter != nil {
-			pErr = filter(ba, br)
+			pErr = filter(*ba, br)
 		}
 	}
 	return br, pErr
+}
+
+// batchExecutionFn is a method on Replica that is able to execute a
+// BatchRequest. It is called with the batch, along with the span bounds that
+// the batch will operate over and a guard for the latches protecting the span
+// bounds. The function must ensure that the latch guard is eventually released.
+type batchExecutionFn func(
+	*Replica, context.Context, *roachpb.BatchRequest, *spanset.SpanSet, *spanlatch.Guard,
+) (*roachpb.BatchResponse, *roachpb.Error)
+
+var _ batchExecutionFn = (*Replica).executeWriteBatch
+var _ batchExecutionFn = (*Replica).executeReadOnlyBatch
+
+// executeBatchWithConcurrencyRetries is the entry point for client (non-admin)
+// requests that execute against the range's state. The method coordinates the
+// execution of requests that may require multiple retries due to interactions
+// with concurrent transactions.
+//
+// The method acquires latches for the request, which synchronizes it with
+// conflicting requests. This permits the execution function to run without
+// concern of coordinating with logically conflicting operations, although it
+// still needs to worry about coordinating with non-conflicting operations when
+// accessing shared data structures.
+//
+// If the execution function hits a concurrency error like a WriteIntentError or
+// a TransactionPushError it will propagate the error back to this method, which
+// handles the process of retrying batch execution after addressing the error.
+func (r *Replica) executeBatchWithConcurrencyRetries(
+	ctx context.Context, ba *roachpb.BatchRequest, fn batchExecutionFn,
+) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
+	// Determine the maximal set of key spans that the batch will operate on.
+	spans, err := r.collectSpans(ba)
+	if err != nil {
+		return nil, roachpb.NewError(err)
+	}
+
+	// Handle load-based splitting.
+	r.recordBatchForLoadBasedSplitting(ctx, ba, spans)
+
+	// TODO(nvanbenschoten): Clean this up once it's pulled inside the
+	// concurrency manager.
+	var cleanup intentresolver.CleanupFunc
+	defer func() {
+		if cleanup != nil {
+			// This request wrote an intent only if there was no error, the
+			// request is transactional, the transaction is not yet finalized,
+			// and the request wasn't read-only.
+			if pErr == nil && ba.Txn != nil && !br.Txn.Status.IsFinalized() && !ba.IsReadOnly() {
+				cleanup(nil, &br.Txn.TxnMeta)
+			} else {
+				cleanup(nil, nil)
+			}
+		}
+	}()
+
+	// Try to execute command; exit retry loop on success.
+	for {
+		// Exit loop if context has been canceled or timed out.
+		if err := ctx.Err(); err != nil {
+			return nil, roachpb.NewError(errors.Wrap(err, "aborted during Replica.Send"))
+		}
+
+		// If necessary, the request may need to wait in the txn wait queue,
+		// pending updates to the target transaction for either PushTxn or
+		// QueryTxn requests.
+		// TODO(nvanbenschoten): Push this into the concurrency package.
+		br, pErr = r.maybeWaitForPushee(ctx, ba)
+		if br != nil || pErr != nil {
+			return br, pErr
+		}
+
+		// Acquire latches to prevent overlapping commands from executing until
+		// this command completes.
+		// TODO(nvanbenschoten): Replace this with a call into the upcoming
+		// concurrency package when it is introduced.
+		lg, err := r.beginCmds(ctx, ba, spans)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
+
+		br, pErr = fn(r, ctx, ba, spans, lg)
+		switch t := pErr.GetDetail().(type) {
+		case nil:
+			// Success.
+			return br, nil
+		case *roachpb.WriteIntentError:
+			if cleanup, pErr = r.handleWriteIntentError(ctx, ba, pErr, t, cleanup); pErr != nil {
+				return nil, pErr
+			}
+			// Retry...
+		case *roachpb.TransactionPushError:
+			if pErr = r.handleTransactionPushError(ctx, ba, pErr, t); pErr != nil {
+				return nil, pErr
+			}
+			// Retry...
+		case *roachpb.IndeterminateCommitError:
+			if pErr = r.handleIndeterminateCommitError(ctx, ba, pErr, t); pErr != nil {
+				return nil, pErr
+			}
+			// Retry...
+		case *roachpb.MergeInProgressError:
+			if pErr = r.handleMergeInProgressError(ctx, ba, pErr, t); pErr != nil {
+				return nil, pErr
+			}
+			// Retry...
+		default:
+			// Propagate error.
+			return nil, pErr
+		}
+	}
+}
+
+func (r *Replica) handleWriteIntentError(
+	ctx context.Context,
+	ba *roachpb.BatchRequest,
+	pErr *roachpb.Error,
+	t *roachpb.WriteIntentError,
+	cleanup intentresolver.CleanupFunc,
+) (intentresolver.CleanupFunc, *roachpb.Error) {
+	if r.store.cfg.TestingKnobs.DontPushOnWriteIntentError {
+		return cleanup, pErr
+	}
+
+	// Process and resolve write intent error.
+	var pushType roachpb.PushTxnType
+	if ba.IsWrite() {
+		pushType = roachpb.PUSH_ABORT
+	} else {
+		pushType = roachpb.PUSH_TIMESTAMP
+	}
+
+	index := pErr.Index
+	args := ba.Requests[index.Index].GetInner()
+	// Make a copy of the header for the upcoming push; we will update the
+	// timestamp.
+	h := ba.Header
+	if h.Txn != nil {
+		// We must push at least to h.Timestamp, but in fact we want to
+		// go all the way up to a timestamp which was taken off the HLC
+		// after our operation started. This allows us to not have to
+		// restart for uncertainty as we come back and read.
+		obsTS, ok := h.Txn.GetObservedTimestamp(ba.Replica.NodeID)
+		if !ok {
+			// This was set earlier in this method, so it's
+			// completely unexpected to not be found now.
+			log.Fatalf(ctx, "missing observed timestamp: %+v", h.Txn)
+		}
+		h.Timestamp.Forward(obsTS)
+		// We are going to hand the header (and thus the transaction proto)
+		// to the RPC framework, after which it must not be changed (since
+		// that could race). Since the subsequent execution of the original
+		// request might mutate the transaction, make a copy here.
+		//
+		// See #9130.
+		h.Txn = h.Txn.Clone()
+	}
+
+	// Handle the case where we get more than one write intent error;
+	// we need to cleanup the previous attempt to handle it to allow
+	// any other pusher queued up behind this RPC to proceed.
+	if cleanup != nil {
+		cleanup(t, nil)
+	}
+	cleanup, pErr = r.store.intentResolver.ProcessWriteIntentError(ctx, pErr, args, h, pushType)
+	if pErr != nil {
+		// Do not propagate ambiguous results; assume success and retry original op.
+		if _, ok := pErr.GetDetail().(*roachpb.AmbiguousResultError); ok {
+			return cleanup, nil
+		}
+		// Propagate new error. Preserve the error index.
+		pErr.Index = index
+		return cleanup, pErr
+	}
+	// We've resolved the write intent; retry command.
+	return cleanup, nil
+}
+
+func (r *Replica) handleTransactionPushError(
+	ctx context.Context,
+	ba *roachpb.BatchRequest,
+	pErr *roachpb.Error,
+	t *roachpb.TransactionPushError,
+) *roachpb.Error {
+	// On a transaction push error, retry immediately if doing so will enqueue
+	// into the txnWaitQueue in order to await further updates to the unpushed
+	// txn's status. We check ShouldPushImmediately to avoid retrying
+	// non-queueable PushTxnRequests (see #18191).
+	dontRetry := r.store.cfg.TestingKnobs.DontRetryPushTxnFailures
+	if !dontRetry && ba.IsSinglePushTxnRequest() {
+		pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
+		dontRetry = txnwait.ShouldPushImmediately(pushReq)
+	}
+	if dontRetry {
+		return pErr
+	}
+	// Enqueue unsuccessfully pushed transaction on the txnWaitQueue and retry.
+	r.txnWaitQueue.Enqueue(&t.PusheeTxn)
+	return nil
+}
+
+func (r *Replica) handleIndeterminateCommitError(
+	ctx context.Context,
+	ba *roachpb.BatchRequest,
+	pErr *roachpb.Error,
+	t *roachpb.IndeterminateCommitError,
+) *roachpb.Error {
+	if r.store.cfg.TestingKnobs.DontRecoverIndeterminateCommits {
+		return pErr
+	}
+	// On an indeterminate commit error, attempt to recover and finalize the
+	// stuck transaction. Retry immediately if successful.
+	if _, err := r.store.recoveryMgr.ResolveIndeterminateCommit(ctx, t); err != nil {
+		// Do not propagate ambiguous results; assume success and retry original op.
+		if _, ok := err.(*roachpb.AmbiguousResultError); ok {
+			return nil
+		}
+		// Propagate new error. Preserve the error index.
+		newPErr := roachpb.NewError(err)
+		newPErr.Index = pErr.Index
+		return newPErr
+	}
+	// We've recovered the transaction that blocked the push; retry command.
+	return nil
+}
+
+func (r *Replica) handleMergeInProgressError(
+	ctx context.Context,
+	ba *roachpb.BatchRequest,
+	pErr *roachpb.Error,
+	t *roachpb.MergeInProgressError,
+) *roachpb.Error {
+	// A merge was in progress. We need to retry the command after the merge
+	// completes, as signaled by the closing of the replica's mergeComplete
+	// channel. Note that the merge may have already completed, in which case
+	// its mergeComplete channel will be nil.
+	mergeCompleteCh := r.getMergeCompleteCh()
+	if mergeCompleteCh == nil {
+		// Merge no longer in progress. Retry the command.
+		return nil
+	}
+	log.Event(ctx, "waiting on in-progress merge")
+	select {
+	case <-mergeCompleteCh:
+		// Merge complete. Retry the command.
+		return nil
+	case <-ctx.Done():
+		return roachpb.NewError(errors.Wrap(ctx.Err(), "aborted during merge"))
+	case <-r.store.stopper.ShouldQuiesce():
+		return roachpb.NewError(&roachpb.NodeUnavailableError{})
+	}
 }
 
 // String returns the string representation of the replica using an
@@ -1338,60 +1603,47 @@ func (r *Replica) collectSpans(ba *roachpb.BatchRequest) (*spanset.SpanSet, erro
 // when the commands are done and can release their latches.
 func (r *Replica) beginCmds(
 	ctx context.Context, ba *roachpb.BatchRequest, spans *spanset.SpanSet,
-) (endCmds, error) {
+) (*spanlatch.Guard, error) {
 	// Only acquire latches for consistent operations.
-	var lg *spanlatch.Guard
-	if ba.ReadConsistency == roachpb.CONSISTENT {
-		// Check for context cancellation before acquiring latches.
-		if err := ctx.Err(); err != nil {
-			log.VEventf(ctx, 2, "%s before acquiring latches: %s", err, ba.Summary())
-			return endCmds{}, errors.Wrap(err, "aborted before acquiring latches")
-		}
-
-		var beforeLatch time.Time
-		if log.ExpensiveLogEnabled(ctx, 2) {
-			beforeLatch = timeutil.Now()
-		}
-
-		// Acquire latches for all the request's declared spans to ensure
-		// protected access and to avoid interacting requests from operating at
-		// the same time. The latches will be held for the duration of request.
-		var err error
-		lg, err = r.latchMgr.Acquire(ctx, spans)
-		if err != nil {
-			return endCmds{}, err
-		}
-
-		if !beforeLatch.IsZero() {
-			dur := timeutil.Since(beforeLatch)
-			log.VEventf(ctx, 2, "waited %s to acquire latches", dur)
-		}
-
-		if filter := r.store.cfg.TestingKnobs.TestingLatchFilter; filter != nil {
-			if pErr := filter(*ba); pErr != nil {
-				r.latchMgr.Release(lg)
-				return endCmds{}, pErr.GoError()
-			}
-		}
-	} else {
+	if ba.ReadConsistency != roachpb.CONSISTENT {
 		log.Event(ctx, "operation accepts inconsistent results")
+		return nil, nil
 	}
 
-	// Handle load-based splitting.
-	if r.SplitByLoadEnabled() {
-		shouldInitSplit := r.loadBasedSplitter.Record(timeutil.Now(), len(ba.Requests), func() roachpb.Span {
-			return spans.BoundarySpan(spanset.SpanGlobal)
-		})
-		if shouldInitSplit {
-			r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
+	// Don't acquire latches for lease requests. These are run on replicas that
+	// do not hold the lease, so acquiring latches wouldn't help synchronize
+	// with other requests.
+	if ba.IsLeaseRequest() {
+		return nil, nil
+	}
+
+	var beforeLatch time.Time
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		beforeLatch = timeutil.Now()
+	}
+
+	// Acquire latches for all the request's declared spans to ensure
+	// protected access and to avoid interacting requests from operating at
+	// the same time. The latches will be held for the duration of request.
+	log.Event(ctx, "acquire latches")
+	lg, err := r.latchMgr.Acquire(ctx, spans)
+	if err != nil {
+		return nil, err
+	}
+
+	if !beforeLatch.IsZero() {
+		dur := timeutil.Since(beforeLatch)
+		log.VEventf(ctx, 2, "waited %s to acquire latches", dur)
+	}
+
+	if filter := r.store.cfg.TestingKnobs.TestingLatchFilter; filter != nil {
+		if pErr := filter(*ba); pErr != nil {
+			r.latchMgr.Release(lg)
+			return nil, pErr.GoError()
 		}
 	}
 
-	ec := endCmds{
-		repl: r,
-		lg:   lg,
-	}
-	return ec, nil
+	return lg, nil
 }
 
 // executeAdminBatch executes the command directly. There is no interaction

--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -90,9 +90,9 @@ func (r *Replica) shouldBackpressureWrites() bool {
 	return r.exceedsMultipleOfSplitSizeRLocked(mult)
 }
 
-// maybeBackpressureWriteBatch blocks to apply backpressure if the replica
-// deems that backpressure is necessary.
-func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba *roachpb.BatchRequest) error {
+// maybeBackpressureBatch blocks to apply backpressure if the replica deems
+// that backpressure is necessary.
+func (r *Replica) maybeBackpressureBatch(ctx context.Context, ba *roachpb.BatchRequest) error {
 	if !canBackpressureBatch(ba) {
 		return nil
 	}

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -70,43 +70,6 @@ func (r *Replica) evalAndPropose(
 	spans *spanset.SpanSet,
 	ec endCmds,
 ) (_ chan proposalResult, _ func(), _ int64, pErr *roachpb.Error) {
-	// Guarantee we release the latches that we acquired if we never make
-	// it to passing responsibility to a proposal. This is wrapped to
-	// delay pErr evaluation to its value when returning.
-	defer func() {
-		// No-op if we move ec into proposal.ec.
-		ec.done(ba, nil /* br */, pErr)
-	}()
-
-	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?
-	r.mu.RLock()
-	if !r.mu.destroyStatus.IsAlive() {
-		err := r.mu.destroyStatus.err
-		r.mu.RUnlock()
-		return nil, nil, 0, roachpb.NewError(err)
-	}
-	r.mu.RUnlock()
-
-	rSpan, err := keys.Range(ba.Requests)
-	if err != nil {
-		return nil, nil, 0, roachpb.NewError(err)
-	}
-
-	// Checking the context just before proposing can help avoid ambiguous errors.
-	if err := ctx.Err(); err != nil {
-		errStr := fmt.Sprintf("%s before proposing: %s", err, ba.Summary())
-		log.Warning(ctx, errStr)
-		return nil, nil, 0, roachpb.NewError(errors.Wrap(err, "aborted before proposing"))
-	}
-
-	// Only need to check that the request is in bounds at proposal time, not at
-	// application time, because the spanlatch manager will synchronize all
-	// requests (notably EndTransaction with SplitTrigger) that may cause this
-	// condition to change.
-	if err := r.requestCanProceed(rSpan, ba.Timestamp); err != nil {
-		return nil, nil, 0, roachpb.NewError(err)
-	}
-
 	idKey := makeIDKey()
 	proposal, pErr := r.requestToProposal(ctx, idKey, ba, spans)
 	log.Event(proposal.ctx, "evaluated request")
@@ -195,6 +158,7 @@ func (r *Replica) evalAndPropose(
 			"command is too large: %d bytes (max: %d)", quotaSize, maxSize,
 		))
 	}
+	var err error
 	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, quotaSize)
 	if err != nil {
 		return nil, nil, 0, roachpb.NewError(err)

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -65,7 +65,7 @@ func makeIDKey() storagebase.CmdIDKey {
 //   which case the other returned values are zero.
 func (r *Replica) evalAndPropose(
 	ctx context.Context,
-	lease roachpb.Lease,
+	lease *roachpb.Lease,
 	ba *roachpb.BatchRequest,
 	spans *spanset.SpanSet,
 	ec endCmds,

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -581,18 +581,10 @@ func (r *Replica) leaseStatus(
 	return status
 }
 
-// requiresExpiringLease returns whether this range uses an expiration-based
-// lease; false if epoch-based. Ranges located before or including the node
-// liveness table must use expiration leases to avoid circular dependencies on
-// the node liveness table.
-func (r *Replica) requiresExpiringLease() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.requiresExpiringLeaseRLocked()
-}
-
-// requiresExpiringLeaseRLocked is like requiresExpiringLease, but requires that
-// the replica mutex be held.
+// requiresExpiringLeaseRLocked returns whether this range uses an
+// expiration-based lease; false if epoch-based. Ranges located before or
+// including the node liveness table must use expiration leases to avoid
+// circular dependencies on the node liveness table.
 func (r *Replica) requiresExpiringLeaseRLocked() bool {
 	return r.store.cfg.NodeLiveness == nil || !r.store.cfg.EnableEpochRangeLeases ||
 		r.mu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
@@ -22,27 +23,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// executeReadOnlyBatch updates the read timestamp cache and waits for any
-// overlapping writes currently processing through Raft ahead of us to
-// clear via the latches.
+// executeReadOnlyBatch is the execution logic for client requests which do not
+// mutate the range's replicated state. The method uses a single RocksDB
+// iterator to evaluate the batch and then updates the read timestamp cache to
+// reflect the key spans that it read.
 func (r *Replica) executeReadOnlyBatch(
-	ctx context.Context, ba *roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest, spans *spanset.SpanSet, lg *spanlatch.Guard,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
-	spans, err := r.collectSpans(ba)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// Acquire latches to prevent overlapping commands from executing
-	// until this command completes.
-	log.Event(ctx, "acquire latches")
-	ec, err := r.beginCmds(ctx, ba, spans)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// Guarantee we release the latches that we just acquired. This is wrapped
-	// to delay pErr evaluation to its value when returning.
+	// Guarantee we release the provided latches. This is wrapped to delay pErr
+	// evaluation to its value when returning.
+	ec := endCmds{repl: r, lg: lg}
 	defer func() {
 		ec.done(ba, br, pErr)
 	}()

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -13,7 +13,6 @@ package storage
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
@@ -66,14 +65,7 @@ func (r *Replica) executeReadOnlyBatch(
 	defer r.readOnlyCmdMu.RUnlock()
 
 	// Verify that the batch can be executed.
-	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?
-	if _, err := r.IsDestroyed(); err != nil {
-		return nil, roachpb.NewError(err)
-	} else if rSpan, err := keys.Range(ba.Requests); err != nil {
-		return nil, roachpb.NewError(err)
-	} else if err = r.requestCanProceed(rSpan, ba.Timestamp); err != nil {
-		return nil, roachpb.NewError(err)
-	} else if err := r.checkForPendingMerge(ctx, ba, ec.lg, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, ec.lg, &status); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1002,7 +1002,9 @@ func TestReplicaRangeBoundsChecking(t *testing.T) {
 	}
 
 	gArgs := getArgs(roachpb.Key("b"))
-	_, pErr := tc.SendWrapped(&gArgs)
+	_, pErr := client.SendWrappedWith(context.Background(), tc.store, roachpb.Header{
+		RangeID: 1,
+	}, &gArgs)
 
 	if mismatchErr, ok := pErr.GetDetail().(*roachpb.RangeKeyMismatchError); !ok {
 		t.Errorf("expected range key mismatch error: %s", pErr)

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -161,7 +161,7 @@ func (r *Replica) executeWriteBatch(
 
 	// After the command is proposed to Raft, invoking endCmds.done is the
 	// responsibility of Raft, so move the endCmds into evalAndPropose.
-	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, lease, ba, spans, ec.move())
+	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, &lease, ba, spans, ec.move())
 	if pErr != nil {
 		if maxLeaseIndex != 0 {
 			log.Fatalf(

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -242,13 +242,6 @@ func (s *Store) Send(
 				dontRetry = txnwait.ShouldPushImmediately(pushReq)
 			}
 			if dontRetry {
-				// If we're not retrying on push txn failures return a txn retry error
-				// after the first failure to guarantee a retry.
-				if ba.Txn != nil {
-					err := roachpb.NewTransactionRetryError(
-						roachpb.RETRY_REASON_UNKNOWN, "DontRetryPushTxnFailures testing knob")
-					return nil, roachpb.NewErrorWithTxn(err, ba.Txn)
-				}
 				return nil, pErr
 			}
 

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -16,12 +16,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
 )
 
 // Send fetches a range based on the header's replica, assembles method, args &
@@ -166,224 +164,86 @@ func (s *Store) Send(
 		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 
-	var cleanupAfterWriteIntentError func(newWIErr *roachpb.WriteIntentError, newIntentTxn *enginepb.TxnMeta)
-	defer func() {
-		if cleanupAfterWriteIntentError != nil {
-			// This request wrote an intent only if there was no error, the request
-			// is transactional, the transaction is not yet finalized, and the request
-			// wasn't read-only.
-			if pErr == nil && ba.Txn != nil && !br.Txn.Status.IsFinalized() && !ba.IsReadOnly() {
-				cleanupAfterWriteIntentError(nil, &br.Txn.TxnMeta)
-			} else {
-				cleanupAfterWriteIntentError(nil, nil)
-			}
-		}
-	}()
+	// Get range and add command to the range for execution.
+	repl, err := s.GetReplica(ba.RangeID)
+	if err != nil {
+		return nil, roachpb.NewError(err)
+	}
+	if !repl.IsInitialized() {
+		repl.mu.RLock()
+		replicaID := repl.mu.replicaID
+		repl.mu.RUnlock()
 
-	// Add the command to the range for execution; exit retry loop on success.
-	for {
-		// Exit loop if context has been canceled or timed out.
-		if err := ctx.Err(); err != nil {
-			return nil, roachpb.NewError(errors.Wrap(err, "aborted during Store.Send"))
-		}
+		// If we have an uninitialized copy of the range, then we are
+		// probably a valid member of the range, we're just in the
+		// process of getting our snapshot. If we returned
+		// RangeNotFoundError, the client would invalidate its cache,
+		// but we can be smarter: the replica that caused our
+		// uninitialized replica to be created is most likely the
+		// leader.
+		return nil, roachpb.NewError(&roachpb.NotLeaseHolderError{
+			RangeID:     ba.RangeID,
+			LeaseHolder: repl.creatingReplica,
+			// The replica doesn't have a range descriptor yet, so we have to build
+			// a ReplicaDescriptor manually.
+			Replica: roachpb.ReplicaDescriptor{
+				NodeID:    repl.store.nodeDesc.NodeID,
+				StoreID:   repl.store.StoreID(),
+				ReplicaID: replicaID,
+			},
+		})
+	}
 
-		// Get range and add command to the range for execution.
-		repl, err := s.GetReplica(ba.RangeID)
+	br, pErr = repl.Send(ctx, ba)
+	if pErr == nil {
+		return br, nil
+	}
+
+	// Augment error if necessary and return.
+	switch t := pErr.GetDetail().(type) {
+	case *roachpb.RangeKeyMismatchError:
+		// On a RangeKeyMismatchError where the batch didn't even overlap
+		// the start of the mismatched Range, try to suggest a more suitable
+		// Range from this Store.
+		rSpan, err := keys.Range(ba.Requests)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		if !repl.IsInitialized() {
-			repl.mu.RLock()
-			replicaID := repl.mu.replicaID
-			repl.mu.RUnlock()
-
-			// If we have an uninitialized copy of the range, then we are
-			// probably a valid member of the range, we're just in the
-			// process of getting our snapshot. If we returned
-			// RangeNotFoundError, the client would invalidate its cache,
-			// but we can be smarter: the replica that caused our
-			// uninitialized replica to be created is most likely the
-			// leader.
-			return nil, roachpb.NewError(&roachpb.NotLeaseHolderError{
-				RangeID:     ba.RangeID,
-				LeaseHolder: repl.creatingReplica,
-				// The replica doesn't have a range descriptor yet, so we have to build
-				// a ReplicaDescriptor manually.
-				Replica: roachpb.ReplicaDescriptor{
-					NodeID:    repl.store.nodeDesc.NodeID,
-					StoreID:   repl.store.StoreID(),
-					ReplicaID: replicaID,
-				},
-			})
-		}
-
-		// If necessary, the request may need to wait in the txn wait queue,
-		// pending updates to the target transaction for either PushTxn or
-		// QueryTxn requests.
-		if br, pErr = s.maybeWaitForPushee(ctx, &ba, repl); br != nil || pErr != nil {
-			return br, pErr
-		}
-		br, pErr = repl.Send(ctx, ba)
-		if pErr == nil {
-			return br, nil
-		}
-
-		// Handle push txn failures and write intent conflicts locally and
-		// retry. Other errors are returned to caller.
-		switch t := pErr.GetDetail().(type) {
-		case *roachpb.TransactionPushError:
-			// On a transaction push error, retry immediately if doing so will
-			// enqueue into the txnWaitQueue in order to await further updates to
-			// the unpushed txn's status. We check ShouldPushImmediately to avoid
-			// retrying non-queueable PushTxnRequests (see #18191).
-			dontRetry := s.cfg.TestingKnobs.DontRetryPushTxnFailures
-			if !dontRetry && ba.IsSinglePushTxnRequest() {
-				pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
-				dontRetry = txnwait.ShouldPushImmediately(pushReq)
-			}
-			if dontRetry {
-				return nil, pErr
-			}
-
-			// Enqueue unsuccessfully pushed transaction on the txnWaitQueue and
-			// retry the command.
-			repl.txnWaitQueue.Enqueue(&t.PusheeTxn)
-			pErr = nil
-
-		case *roachpb.IndeterminateCommitError:
-			if s.cfg.TestingKnobs.DontRecoverIndeterminateCommits {
-				return nil, pErr
-			}
-			// On an indeterminate commit error, attempt to recover and finalize
-			// the stuck transaction. Retry immediately if successful.
-			if _, err := s.recoveryMgr.ResolveIndeterminateCommit(ctx, t); err != nil {
-				// Do not propagate ambiguous results; assume success and retry original op.
-				if _, ok := err.(*roachpb.AmbiguousResultError); !ok {
-					// Preserve the error index.
-					index := pErr.Index
-					pErr = roachpb.NewError(err)
-					pErr.Index = index
-					return nil, pErr
+		if !t.MismatchedRange.ContainsKey(rSpan.Key) {
+			if r2 := s.LookupReplica(rSpan.Key); r2 != nil {
+				// Only return the correct range descriptor as a hint
+				// if we know the current lease holder for that range, which
+				// indicates that our knowledge is not stale.
+				if l, _ := r2.GetLease(); r2.IsLeaseValid(l, s.Clock().Now()) {
+					t.SuggestedRange = r2.Desc()
 				}
 			}
-			// We've recovered the transaction that blocked the push; retry command.
-			pErr = nil
-
-		case *roachpb.WriteIntentError:
-			// Process and resolve write intent error.
-			var pushType roachpb.PushTxnType
-			if ba.IsWrite() {
-				pushType = roachpb.PUSH_ABORT
-			} else {
-				pushType = roachpb.PUSH_TIMESTAMP
-			}
-
-			index := pErr.Index
-			args := ba.Requests[index.Index].GetInner()
-			// Make a copy of the header for the upcoming push; we will update
-			// the timestamp.
-			h := ba.Header
-			if h.Txn != nil {
-				// We must push at least to h.Timestamp, but in fact we want to
-				// go all the way up to a timestamp which was taken off the HLC
-				// after our operation started. This allows us to not have to
-				// restart for uncertainty as we come back and read.
-				obsTS, ok := h.Txn.GetObservedTimestamp(ba.Replica.NodeID)
-				if !ok {
-					// This was set earlier in this method, so it's
-					// completely unexpected to not be found now.
-					log.Fatalf(ctx, "missing observed timestamp: %+v", h.Txn)
-				}
-				h.Timestamp.Forward(obsTS)
-				// We are going to hand the header (and thus the transaction proto)
-				// to the RPC framework, after which it must not be changed (since
-				// that could race). Since the subsequent execution of the original
-				// request might mutate the transaction, make a copy here.
-				//
-				// See #9130.
-				h.Txn = h.Txn.Clone()
-			}
-			// Handle the case where we get more than one write intent error;
-			// we need to cleanup the previous attempt to handle it to allow
-			// any other pusher queued up behind this RPC to proceed.
-			if cleanupAfterWriteIntentError != nil {
-				cleanupAfterWriteIntentError(t, nil)
-			}
-			if cleanupAfterWriteIntentError, pErr =
-				s.intentResolver.ProcessWriteIntentError(ctx, pErr, args, h, pushType); pErr != nil {
-				// Do not propagate ambiguous results; assume success and retry original op.
-				if _, ok := pErr.GetDetail().(*roachpb.AmbiguousResultError); !ok {
-					// Preserve the error index.
-					pErr.Index = index
-					return nil, pErr
-				}
-				pErr = nil
-			}
-			// We've resolved the write intent; retry command.
-
-		case *roachpb.MergeInProgressError:
-			// A merge was in progress. We need to retry the command after the merge
-			// completes, as signaled by the closing of the replica's mergeComplete
-			// channel. Note that the merge may have already completed, in which case
-			// its mergeComplete channel will be nil.
-			mergeCompleteCh := repl.getMergeCompleteCh()
-			if mergeCompleteCh != nil {
-				log.Event(ctx, "waiting on in-progress merge")
-				select {
-				case <-mergeCompleteCh:
-					// Merge complete. Retry the command.
-				case <-ctx.Done():
-					return nil, roachpb.NewError(errors.Wrap(ctx.Err(), "aborted during merge"))
-				case <-s.stopper.ShouldQuiesce():
-					return nil, roachpb.NewError(&roachpb.NodeUnavailableError{})
-				}
-			}
-			pErr = nil
-
-		case *roachpb.RangeKeyMismatchError:
-			// On a RangeKeyMismatchError where the batch didn't even overlap
-			// the start of the mismatched Range, try to suggest a more suitable
-			// Range from this Store.
-			rSpan, err := keys.Range(ba.Requests)
-			if err != nil {
-				return nil, roachpb.NewError(err)
-			}
-			if !t.MismatchedRange.ContainsKey(rSpan.Key) {
-				if r2 := s.LookupReplica(rSpan.Key); r2 != nil {
-					// Only return the correct range descriptor as a hint
-					// if we know the current lease holder for that range, which
-					// indicates that our knowledge is not stale.
-					if l, _ := r2.GetLease(); r2.IsLeaseValid(l, s.Clock().Now()) {
-						t.SuggestedRange = r2.Desc()
-					}
-				}
-			}
-
-		case *roachpb.RaftGroupDeletedError:
-			// This error needs to be converted appropriately so that clients
-			// will retry.
-			err := roachpb.NewRangeNotFoundError(repl.RangeID, repl.store.StoreID())
-			pErr = roachpb.NewError(err)
 		}
-
-		if pErr != nil {
-			return nil, pErr
-		}
+	case *roachpb.RaftGroupDeletedError:
+		// This error needs to be converted appropriately so that clients
+		// will retry.
+		err := roachpb.NewRangeNotFoundError(repl.RangeID, repl.store.StoreID())
+		pErr = roachpb.NewError(err)
 	}
+	return nil, pErr
 }
 
 // maybeWaitForPushee potentially diverts the incoming request to
 // the txnwait.Queue, where it will wait for updates to the target
 // transaction.
-func (s *Store) maybeWaitForPushee(
-	ctx context.Context, ba *roachpb.BatchRequest, repl *Replica,
+// TODO(nvanbenschoten): Move this method.
+func (r *Replica) maybeWaitForPushee(
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// If this is a push txn request, check the push queue first, which
 	// may cause this request to wait and either return a successful push
 	// txn response or else allow this request to proceed.
 	if ba.IsSinglePushTxnRequest() {
+		if r.store.cfg.TestingKnobs.DontRetryPushTxnFailures {
+			return nil, nil
+		}
 		pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
-		pushResp, pErr := repl.txnWaitQueue.MaybeWaitForPush(repl.AnnotateCtx(ctx), repl, pushReq)
+		pushResp, pErr := r.txnWaitQueue.MaybeWaitForPush(ctx, r, pushReq)
 		// Copy the request in anticipation of setting the force arg and
 		// updating the Now timestamp (see below).
 		pushReqCopy := *pushReq
@@ -403,7 +263,7 @@ func (s *Store) maybeWaitForPushee(
 		// request may have been waiting to push the txn. If we don't
 		// move the timestamp forward to the current time, we may fail
 		// to push a txn which has expired.
-		now := s.Clock().Now()
+		now := r.Clock().Now()
 		ba.Timestamp.Forward(now)
 		ba.Requests = nil
 		ba.Add(&pushReqCopy)
@@ -411,7 +271,7 @@ func (s *Store) maybeWaitForPushee(
 		// For query txn requests, wait in the txn wait queue either for
 		// transaction update or for dependent transactions to change.
 		queryReq := ba.Requests[0].GetInner().(*roachpb.QueryTxnRequest)
-		pErr := repl.txnWaitQueue.MaybeWaitForQuery(repl.AnnotateCtx(ctx), repl, queryReq)
+		pErr := r.txnWaitQueue.MaybeWaitForQuery(ctx, r, queryReq)
 		if pErr != nil {
 			return nil, pErr
 		}

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -368,6 +368,12 @@ func (s *Store) Send(
 					}
 				}
 			}
+
+		case *roachpb.RaftGroupDeletedError:
+			// This error needs to be converted appropriately so that clients
+			// will retry.
+			err := roachpb.NewRangeNotFoundError(repl.RangeID, repl.store.StoreID())
+			pErr = roachpb.NewError(err)
 		}
 
 		if pErr != nil {

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -171,6 +171,10 @@ type StoreTestingKnobs struct {
 	SystemLogsGCPeriod time.Duration
 	// SystemLogsGCGCDone is used to notify when system logs GC is done.
 	SystemLogsGCGCDone chan<- struct{}
+	// DontPushOnWriteIntentError will propagate a write intent error immediately
+	// instead of utilizing the intent resolver to try to push the corresponding
+	// transaction.
+	DontPushOnWriteIntentError bool
 	// DontRetryPushTxnFailures will propagate a push txn failure immediately
 	// instead of utilizing the txn wait queue to wait for the transaction to
 	// finish or be pushed by a higher priority contender.


### PR DESCRIPTION
This PR contains a number of cleanup steps necessary to pave the way for the unified `pkg/storage/concurrency` package that we plan to introduce for #41720 (see [prototype](https://github.com/nvanbenschoten/cockroach/commits/nvanbenschoten/lockTable)). Primarily, the PR cleans up Replica-level request validation, unifies some of the request synchronization logic between the read-only and read-write execution paths, and pulls the Store-level concurrency retry loop under the Replica. Future commits will pull parts of this retry loop down into the `concurrency` package's "concurrency manager".