### PR TITLE
tree: allow string concat with any type (attempt #2)

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -414,6 +414,7 @@
 <table><thead>
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
+<tr><td>anyelement <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
@@ -441,6 +442,7 @@
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> anyelement</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -19,3 +19,26 @@ eval
 array['foo'] || '{a,b}'
 ----
 ARRAY['foo','a','b']
+
+
+# String || any; any || String
+
+eval
+'b' || (0x32)::char || (0x33)::char || 'c'
+----
+b56c
+
+eval
+3 || 'a' || 3
+----
+3a3
+
+eval
+3::oid || 'a' || 3::oid
+----
+3a3
+
+eval
+3.33 || 'a' || 3.33
+----
+3.33a3.33


### PR DESCRIPTION
Refs #41872.

Previously, the || concat operator only worked on string pairs. Postgres
supports concatenation between strings and any other type. This patch
adds support for that as well.

To support this, we had to add `preferred` support for binops, as Any
and String can collide. I chose this over the approach of adding another
heuristic in `typeCheckOverloadedExprs` to prefer type matches as this
should be the only case of this problem (select * from pg_operator where
oprleft = 2776 or oprright = 2776).

Release note (sql change): the concatenation operator || is now usable
between strings and any other type.