### PR TITLE
tree: allow string concat with any non-array type (anynonarray approach)

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -414,11 +414,13 @@
 <table><thead>
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
+<tr><td>anynonarray <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="string.html">string</a></td><td><a href="bytes.html">bytes</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
@@ -441,6 +443,8 @@
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> anynonarray</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -59,6 +59,7 @@ func makeNotUsableFalseBuiltin() builtinDefinition {
 // the existence of this map.
 var typeBuiltinsHaveUnderscore = map[oid.Oid]struct{}{
 	types.Any.Oid():         {},
+	types.AnyNonArray.Oid(): {},
 	types.AnyArray.Oid():    {},
 	types.Date.Oid():        {},
 	types.Time.Oid():        {},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -202,7 +202,7 @@ func (op *BinOp) returnType() ReturnTyper {
 	return op.retType
 }
 
-func (*BinOp) preferred() bool {
+func (op *BinOp) preferred() bool {
 	return false
 }
 
@@ -1409,6 +1409,22 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.String,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDString(string(MustBeDString(left) + MustBeDString(right))), nil
+			},
+		},
+		&BinOp{
+			LeftType:   types.String,
+			RightType:  types.AnyNonArray,
+			ReturnType: types.String,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return NewDString(string(MustBeDString(left)) + right.String()), nil
+			},
+		},
+		&BinOp{
+			LeftType:   types.AnyNonArray,
+			RightType:  types.String,
+			ReturnType: types.String,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return NewDString(left.String() + string(MustBeDString(right))), nil
 			},
 		},
 		&BinOp{

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -11,6 +11,11 @@ eval
 'a3'
 
 eval
+b'hello' || b'world'
+----
+'\x68656c6c6f776f726c64'
+
+eval
 b'hello' || 'world'
 ----
 '\x68656c6c6f776f726c64'
@@ -19,3 +24,25 @@ eval
 array['foo'] || '{a,b}'
 ----
 ARRAY['foo','a','b']
+
+# String || any; any || String
+
+eval
+'b' || (5)::char || (8)::char || 'c'
+----
+'b58c'
+
+eval
+3 || 'a' || 3
+----
+3a3
+
+eval
+3::oid || 'a' || 3::oid
+----
+3a3
+
+eval
+3.33 || 'a' || 3.33
+----
+3.33a3.33

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -480,7 +480,7 @@ var (
 func init() {
 	for _, typ := range types.OidToType {
 		switch typ.Oid() {
-		case oid.T_unknown, oid.T_anyelement:
+		case oid.T_unknown, oid.T_anyelement, oid.T_anynonarray:
 			// Don't include these.
 		case oid.T_anyarray, oid.T_oidvector, oid.T_int2vector:
 			// Include these.

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -383,6 +383,7 @@ func TestEquivalent(t *testing.T) {
 	}{
 		// ARRAY
 		{Int2Vector, IntArray, true},
+		{Int2Vector, AnyNonArray, false},
 		{OidVector, MakeArray(Oid), true},
 		{MakeArray(Int), MakeArray(Int4), true},
 		{MakeArray(String), MakeArray(MakeChar(10)), true},
@@ -394,6 +395,7 @@ func TestEquivalent(t *testing.T) {
 		{MakeBit(1), MakeBit(2), true},
 		{MakeBit(1), MakeVarBit(2), true},
 		{MakeVarBit(10), Any, true},
+		{MakeVarBit(10), AnyNonArray, true},
 		{VarBit, Bytes, false},
 
 		// COLLATEDSTRING
@@ -413,6 +415,7 @@ func TestEquivalent(t *testing.T) {
 		{Int2, Int4, true},
 		{Int4, Int, true},
 		{Int, Any, true},
+		{Int, AnyNonArray, true},
 		{Int, IntArray, false},
 
 		// TUPLE
@@ -420,6 +423,7 @@ func TestEquivalent(t *testing.T) {
 		{MakeTuple([]T{*Int, *String}), MakeTuple([]T{*Int4, *VarChar}), true},
 		{MakeTuple([]T{*Int, *String}), AnyTuple, true},
 		{AnyTuple, MakeTuple([]T{*Int, *String}), true},
+		{AnyNonArray, MakeTuple([]T{*Int, *String}), true},
 		{MakeTuple([]T{*Int, *String}),
 			MakeLabeledTuple([]T{*Int4, *VarChar}, []string{"label2", "label1"}), true},
 		{MakeLabeledTuple([]T{*Int, *String}, []string{"label1", "label2"}),
@@ -430,6 +434,7 @@ func TestEquivalent(t *testing.T) {
 		{Unknown, &T{InternalType: InternalType{
 			Family: UnknownFamily, Oid: oid.T_unknown, Locale: &emptyLocale}}, true},
 		{Any, Unknown, true},
+		{AnyNonArray, Unknown, true},
 		{Unknown, Int, false},
 	}
 


### PR DESCRIPTION
Refs #41872. This method solves the problem with heavy edits to the
type system.

Previously, the || concat operator only worked on string pairs. Postgres
supports concatenation between strings and any other non-array type. This
patch adds support for that as well.

To support this, we add another heuristic to the overload detection to
prefer omitting "Any" if possible. Furthermore, we add a new
`AnyNonArray` type constant to types.go to encode not being able to
append to arrays.

Release note (sql change): the concatenation operator || is now usable
between strings and any other non-array type.