### PR TITLE
closedts: shorten target_duration from 30s to 3s

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -32,7 +32,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-const expectedFollowerReadOffset = -1 * (30 * (1 + .2*3)) * time.Second
+const (
+	defaultInterval                          = 3
+	defaultFraction                          = .2
+	defaultMultiple                          = 3
+	expectedFollowerReadOffset time.Duration = 1e9 * /* 1 second */
+		-defaultInterval * (1 + defaultFraction*defaultMultiple)
+)
 
 func TestEvalFollowerReadOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/storage/closedts/setting.go
+++ b/pkg/storage/closedts/setting.go
@@ -21,7 +21,7 @@ import (
 var TargetDuration = settings.RegisterNonNegativeDurationSetting(
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
-	30*time.Second,
+	3*time.Second,
 )
 
 // CloseFraction is the fraction of TargetDuration determining how often closed


### PR DESCRIPTION
This PR dramatically shortens the closed timestamp target interval. With this
setting the experimental_follower_read_timestamp() will now be 4.8 seconds in
the past as opposed to the current 48 seconds in the past. This relatively
aggressive setting of 3s is intended to shake out issues.

This value has been verified to work on the `schemachange/mixed/tpcc` roachtest
introduced in #39096 and for vanilla TPC-C runs around where we have
established a baseline in the past using tpccbench. Specifically several runs
at 2300 warehouses on 3x c5d.4xlarge nodes which is right at the passing
boundary without the change were run only a very small difference in
efficiency or tail latency was observed.

It seems reasonable to attempt to live with this value on master for a while
and see what happens.

Fixes #37083.

Release note (enterprise change): Shorten the default closed timestamp target
interval from 30s to 3s leading to permit follower reads at 4.8 seconds in
the past rather than the previous 48 seconds.