### PR TITLE
opt: inline Values inside Any

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -279,46 +279,6 @@ SELECT a, (SELECT a FROM y) FROM x
 ----
 1  1
 
-# Regression test for #40590: non-executable apply join inside apply join.
-
-statement ok
-CREATE TABLE IF NOT EXISTS tab_orig AS
-  SELECT
-    '2001-01-01'::TIMESTAMP + g * '1 day' AS _timestamp,
-    g AS _string
-  FROM
-    generate_series(NULL, NULL) AS g;
-
-statement error could not decorrelate subquery
-SELECT
-    NULL
-FROM
-    tab_orig AS tab_9962, tab_orig AS tab_9963 JOIN tab_orig AS tab_9964 ON true
-WHERE
-    NOT
-        (
-            tab_9964._timestamp IN (SELECT tab_9962._timestamp)
-            OR EXISTS(
-                    WITH
-                        with_2063 AS (SELECT NULL)
-                    SELECT
-                        *
-                    FROM
-                        (
-                            SELECT
-                                COALESCE(
-                                    tab_9962._string,
-                                    tab_9963._string,
-                                    (SELECT * FROM with_2063),
-                                    (SELECT * FROM with_2063)
-                                )
-                                    AS foo
-                        )
-                    WHERE
-                        foo IS NOT NULL
-                )
-        )
-
 # Regression test for #40589.
 statement ok
 CREATE TABLE IF NOT EXISTS t40589 AS

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -211,6 +211,41 @@
 =>
 (SimplifyWhens $condition $whens $orElse)
 
+# InlineAnyValuesSingleCol converts Any with Values input to AnyScalar.
+# This version handles the case where there is a single column.
+[InlineAnyValuesSingleCol, Normalize]
+(Any
+    $values:(Values)
+    $scalar:*
+    $private:*
+)
+=>
+(AnyScalar
+    $scalar
+    (InlineValues $values)
+    (SubqueryCmp $private)
+)
+
+# InlineAnyValuesMultiCol converts Any with Values input to AnyScalar.
+# This version handles the case where there are multiple columns; in this case,
+# the Values is wrapped into a Project that converts each row to a tuple.
+[InlineAnyValuesMultiCol, Normalize]
+(Any
+    (Project
+        $values:(Values)
+        [ (ProjectionsItem $tuple:(Tuple)) ] & (IsTupleOfVars $tuple (ValuesCols $values))
+        $passthrough:* & (ColsAreEmpty $passthrough)
+    )
+    $scalar:*
+    $private:*
+)
+=>
+(AnyScalar
+    $scalar
+    (InlineValues $values)
+    (SubqueryCmp $private)
+)
+
 # SimplifyEqualsAnyTuple converts a scalar ANY operation to an IN comparison.
 # It transforms
 #

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -894,6 +894,109 @@ project
       └── fd: (1)-->(5)
 
 # --------------------------------------------------
+# InlineAnyValuesSingleCol
+# --------------------------------------------------
+
+opt expect=InlineAnyValuesSingleCol
+SELECT k FROM a WHERE k IN (VALUES (1), (2), (3))
+----
+scan a
+ ├── columns: k:1(int!null)
+ ├── constraint: /1: [/1 - /3]
+ ├── cardinality: [0 - 3]
+ └── key: (1)
+
+opt expect=InlineAnyValuesSingleCol
+SELECT k FROM a WHERE k IN (VALUES ((SELECT k*i FROM a)), (2), (3))
+----
+select
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── in [type=bool, outer=(1), subquery]
+           ├── variable: k [type=int]
+           └── tuple [type=tuple{int}]
+                ├── subquery [type=int]
+                │    └── max1-row
+                │         ├── columns: "?column?":13(int)
+                │         ├── cardinality: [0 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(13)
+                │         └── project
+                │              ├── columns: "?column?":13(int)
+                │              ├── scan a
+                │              │    ├── columns: k:7(int!null) i:8(int)
+                │              │    ├── key: (7)
+                │              │    └── fd: (7)-->(8)
+                │              └── projections
+                │                   └── k * i [type=int, outer=(7,8)]
+                ├── const: 2 [type=int]
+                └── const: 3 [type=int]
+
+# --------------------------------------------------
+# InlineAnyValuesMultiCol
+# --------------------------------------------------
+
+opt expect=InlineAnyValuesMultiCol
+SELECT k FROM a WHERE (k, i) IN (VALUES (1, 1), (2, 2), (3, 3))
+----
+project
+ ├── columns: k:1(int!null)
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── cardinality: [0 - 3]
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── constraint: /1: [/1 - /3]
+      │    ├── cardinality: [0 - 3]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── (k, i) IN ((1, 1), (2, 2), (3, 3)) [type=bool, outer=(1,2), constraints=(/1/2: [/1/1 - /1/1] [/2/2 - /2/2] [/3/3 - /3/3]; /2: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+
+# The rule should not fire if the columns are not in the right order.
+opt expect-not=InlineAnyValuesMultiCol
+SELECT k FROM a WHERE (k, i) IN (SELECT b, a FROM (VALUES (1, 1), (2, 2), (3, 3)) AS v(a,b))
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── semi-join (hash)
+      ├── columns: k:1(int!null) column10:10(tuple{int, int})
+      ├── key: (1)
+      ├── fd: (1)-->(10)
+      ├── project
+      │    ├── columns: column10:10(tuple{int, int}) k:1(int!null)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(10)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections
+      │         └── (k, i) [type=tuple{int, int}, outer=(1,2)]
+      ├── project
+      │    ├── columns: column9:9(tuple{int, int})
+      │    ├── cardinality: [3 - 3]
+      │    ├── values
+      │    │    ├── columns: column1:7(int!null) column2:8(int!null)
+      │    │    ├── cardinality: [3 - 3]
+      │    │    ├── (1, 1) [type=tuple{int, int}]
+      │    │    ├── (2, 2) [type=tuple{int, int}]
+      │    │    └── (3, 3) [type=tuple{int, int}]
+      │    └── projections
+      │         └── (column2, column1) [type=tuple{int, int}, outer=(7,8)]
+      └── filters
+           └── column10 = column9 [type=bool, outer=(9,10), constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
+
+# --------------------------------------------------
 # SimplifyEqualsAnyTuple
 # --------------------------------------------------
 


### PR DESCRIPTION
In an expression like `a IN (VALUES (a11, a12), (b11, b12), ...)`, the
Values clause is a subquery, but since it has fixed results we can
just inline the values directly: `a IN ((a11, a12), (b11, b12), ...)`.
This leads to better plans, e.g we can constrain scans to these
values. The two forms are equivalent, even if the expressions have
side-effects.

Release note (performance improvement): better execution plans when a
`VALUES` clause is used as the right-hand side of `IN` or `ANY`.