### PR TITLE
sql: death to DOidWrapper

### DIFF
--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -184,12 +184,6 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 		}
 	case types.StringFamily:
 		return func(datum tree.Datum) (interface{}, error) {
-			// Handle other STRING-related OID types, like oid.T_name.
-			wrapper, ok := datum.(*tree.DOidWrapper)
-			if ok {
-				datum = wrapper.Wrapped
-			}
-
 			d, ok := datum.(*tree.DString)
 			if !ok {
 				return nil, errors.Errorf("expected *tree.DString, found %s", reflect.TypeOf(datum))

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -349,6 +349,8 @@ func (h *hasher) HashDatum(val tree.Datum) {
 		h.HashFloat64(float64(*t))
 	case *tree.DString:
 		h.HashString(string(*t))
+	case *tree.DName:
+		h.HashString(string(*t))
 	case *tree.DBytes:
 		h.HashBytes([]byte(*t))
 	case *tree.DDate:
@@ -682,6 +684,10 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 		}
 	case *tree.DString:
 		if rt, ok := r.(*tree.DString); ok {
+			return h.IsStringEqual(string(*lt), string(*rt))
+		}
+	case *tree.DName:
+		if rt, ok := r.(*tree.DName); ok {
 			return h.IsStringEqual(string(*lt), string(*rt))
 		}
 	case *tree.DBytes:

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1803,9 +1803,6 @@ func (c *CustomFuncs) ConvertConstArrayToTuple(scalar opt.ScalarExpr) opt.Scalar
 // collated string constant with the given locale.
 func (c *CustomFuncs) CastToCollatedString(str opt.ScalarExpr, locale string) opt.ScalarExpr {
 	datum := str.(*memo.ConstExpr).Value
-	if wrap, ok := datum.(*tree.DOidWrapper); ok {
-		datum = wrap.Wrapped
-	}
 
 	var value string
 	switch t := datum.(type) {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -142,6 +142,9 @@ func (b *writeBuffer) writeTextDatum(
 	case *tree.DString:
 		b.writeLengthPrefixedString(string(*v))
 
+	case *tree.DName:
+		b.writeLengthPrefixedString(string(*v))
+
 	case *tree.DCollatedString:
 		b.writeLengthPrefixedString(v.Contents)
 
@@ -405,6 +408,9 @@ func (b *writeBuffer) writeBinaryDatum(
 		}
 
 	case *tree.DString:
+		b.writeLengthPrefixedString(string(*v))
+
+	case *tree.DName:
 		b.writeLengthPrefixedString(string(*v))
 
 	case *tree.DCollatedString:

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2937,6 +2937,8 @@ may increase either contention or retry errors, or both.`,
 				switch t := args[0].(type) {
 				case *tree.DString:
 					collation = "default"
+				case *tree.DName:
+					collation = "default"
 				case *tree.DCollatedString:
 					collation = t.Locale
 				default:

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -447,6 +447,7 @@ var (
 		// assertions.
 		types.String,
 		types.Bytes,
+		types.Name,
 		types.Bool,
 		types.Int,
 		types.Float,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1079,6 +1079,8 @@ func AsDString(e Expr) (DString, bool) {
 	switch t := e.(type) {
 	case *DString:
 		return *t, true
+	case *DName:
+		return DString(*t), true
 	}
 	return "", false
 }
@@ -1104,7 +1106,6 @@ func (d *DString) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	fmt.Println("Hello", d, other)
 	var v string
 	unwrapped := UnwrapDatum(ctx, other)
 	switch t := unwrapped.(type) {
@@ -1187,7 +1188,6 @@ func (d *DName) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	fmt.Println("Helloo", d, other)
 	var v string
 	unwrapped := UnwrapDatum(ctx, other)
 	switch t := unwrapped.(type) {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3153,7 +3153,7 @@ func queryOidWithJoin(
 	switch d.(type) {
 	case *DOid:
 		queryCol = "oid"
-	case *DString:
+	case *DString, *DName:
 		queryCol = info.nameCol
 	default:
 		return nil, errors.AssertionFailedf("invalid argument to OID cast: %s", d)
@@ -3443,6 +3443,8 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			s = AsStringWithFlags(d, FmtBareStrings)
 		case *DString:
 			s = string(*t)
+		case *DName:
+			s = string(*t)
 		case *DCollatedString:
 			s = t.Contents
 		case *DBytes:
@@ -3456,6 +3458,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		switch t.Family() {
 		case types.StringFamily:
 			if t.Oid() == oid.T_name {
+				fmt.Println("Converting a string to a name", s)
 				return NewDName(s), nil
 			}
 
@@ -4336,6 +4339,11 @@ func (t *DString) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
+func (t *DName) Eval(_ *EvalContext) (Datum, error) {
+	return t, nil
+}
+
+// Eval implements the TypedExpr interface.
 func (t *DCollatedString) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
@@ -4362,11 +4370,6 @@ func (t *DArray) Eval(_ *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (t *DOid) Eval(_ *EvalContext) (Datum, error) {
-	return t, nil
-}
-
-// Eval implements the TypedExpr interface.
-func (t *DOidWrapper) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1717,13 +1717,13 @@ func (node *DJSON) String() string            { return AsString(node) }
 func (node *DUuid) String() string            { return AsString(node) }
 func (node *DIPAddr) String() string          { return AsString(node) }
 func (node *DString) String() string          { return AsString(node) }
+func (node *DName) String() string            { return AsString(node) }
 func (node *DCollatedString) String() string  { return AsString(node) }
 func (node *DTimestamp) String() string       { return AsString(node) }
 func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
 func (node *DArray) String() string           { return AsString(node) }
 func (node *DOid) String() string             { return AsString(node) }
-func (node *DOidWrapper) String() string      { return AsString(node) }
 func (node *Exprs) String() string            { return AsString(node) }
 func (node *ArrayFlatten) String() string     { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -37,6 +37,8 @@ func (d *DTuple) pgwireFormat(ctx *FmtCtx) {
 		case dNull:
 		case *DString:
 			pgwireFormatStringInTuple(&ctx.Buffer, string(*dv))
+		case *DName:
+			pgwireFormatStringInTuple(&ctx.Buffer, string(*dv))
 		case *DCollatedString:
 			pgwireFormatStringInTuple(&ctx.Buffer, dv.Contents)
 			// Bytes cannot use the default case because they will be incorrectly
@@ -110,6 +112,8 @@ func (d *DArray) pgwireFormat(ctx *FmtCtx) {
 		case dNull:
 			ctx.WriteString("NULL")
 		case *DString:
+			pgwireFormatStringInArray(&ctx.Buffer, string(*dv))
+		case *DName:
 			pgwireFormatStringInArray(&ctx.Buffer, string(*dv))
 		case *DCollatedString:
 			pgwireFormatStringInArray(&ctx.Buffer, dv.Contents)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1351,6 +1351,10 @@ func (d *DString) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { ret
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
+func (d *DName) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
+
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
 func (d *DCollatedString) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
@@ -1423,10 +1427,6 @@ func (d *DArray) TypeCheck(_ *SemaContext, desired *types.T) (TypedExpr, error) 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
 func (d *DOid) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
-
-// TypeCheck implements the Expr interface. It is implemented as an idempotent
-// identity function for Datum.
-func (d *DOidWrapper) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -650,6 +650,9 @@ func (expr dNull) Walk(_ Visitor) Expr { return expr }
 func (expr *DString) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr *DName) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *DCollatedString) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
@@ -666,9 +669,6 @@ func (expr *DArray) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DOid) Walk(_ Visitor) Expr { return expr }
-
-// Walk implements the Expr interface.
-func (expr *DOidWrapper) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 //

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -1169,8 +1169,6 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		return encoding.EncodeUntaggedIntValue(b, int64(t.DInt)), nil
 	case *tree.DCollatedString:
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
-	case *tree.DOidWrapper:
-		return encodeArrayElement(b, t.Wrapped)
 	default:
 		return nil, errors.Errorf("don't know how to encode %s (%T)", d, d)
 	}

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -201,18 +201,15 @@ func truncateDatum(evalCtx *tree.EvalContext, d tree.Datum, maxBytes int) tree.D
 	case *tree.DString:
 		return tree.NewDString(truncateString(string(*t), maxBytes))
 
+	case *tree.DName:
+		return tree.NewDName(truncateString(string(*t), maxBytes))
+
 	case *tree.DCollatedString:
 		contents := truncateString(t.Contents, maxBytes)
 
 		// Note: this will end up being larger than maxBytes due to the key and
 		// locale, so this is just a best-effort attempt to limit the size.
 		return tree.NewDCollatedString(contents, t.Locale, &evalCtx.CollationEnv)
-
-	case *tree.DOidWrapper:
-		return &tree.DOidWrapper{
-			Wrapped: truncateDatum(evalCtx, t.Wrapped, maxBytes),
-			Oid:     t.Oid,
-		}
 
 	default:
 		// It's not easy to truncate other types (e.g. Decimal).
@@ -251,15 +248,12 @@ func deepCopyDatum(evalCtx *tree.EvalContext, d tree.Datum) tree.Datum {
 	case *tree.DString:
 		return tree.NewDString(deepCopyString(string(*t)))
 
+	case *tree.DName:
+		return tree.NewDName(deepCopyString(string(*t)))
+
 	case *tree.DCollatedString:
 		contents := deepCopyString(t.Contents)
 		return tree.NewDCollatedString(contents, t.Locale, &evalCtx.CollationEnv)
-
-	case *tree.DOidWrapper:
-		return &tree.DOidWrapper{
-			Wrapped: deepCopyDatum(evalCtx, t.Wrapped),
-			Oid:     t.Oid,
-		}
 
 	default:
 		// We do not collect stats on JSON, and other types do not require a deep

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -307,6 +307,8 @@ func DatumToGoSQL(d tree.Datum) (interface{}, error) {
 		return bool(*d), nil
 	case *tree.DString:
 		return string(*d), nil
+	case *tree.DName:
+		return string(*d), nil
 	case *tree.DBytes:
 		return string(*d), nil
 	case *tree.DDate, *tree.DTime:


### PR DESCRIPTION
This commit makes an explicit DName, removing the last use case for
DOidWrapper, which was a hack that made lots of things harder to deal
with.

Release note: None