### PR TITLE
opt: do some cleanup and re-packaging

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1588,7 +1588,7 @@ func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, er
 
 	for i := range zip {
 		item := &zip[i]
-		exprs[i], err = b.buildScalar(&scalarCtx, item.Func)
+		exprs[i], err = b.buildScalar(&scalarCtx, item.Fn)
 		if err != nil {
 			return execPlan{}, err
 		}

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1149,7 +1149,7 @@ func (ic *Instance) RemainingFilters() memo.FiltersExpr {
 			if newFilters == nil {
 				newFilters = make(memo.FiltersExpr, 0, len(ic.filters))
 			}
-			newFilters = append(newFilters, memo.FiltersItem{Condition: condition})
+			newFilters = append(newFilters, ic.factory.ConstructFiltersItem(condition))
 		}
 	}
 	return newFilters

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -147,7 +147,7 @@ func TestIndexConstraints(t *testing.T) {
 					return fmt.Sprintf("error: %v\n", err)
 				}
 				root := f.Memo().RootExpr().(opt.ScalarExpr)
-				filters := memo.FiltersExpr{{Condition: root}}
+				filters := memo.FiltersExpr{f.ConstructFiltersItem(root)}
 				if _, ok := root.(*memo.TrueExpr); ok {
 					filters = memo.TrueFilter
 				}
@@ -263,7 +263,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				b.Fatal(err)
 			}
 			nd := f.Memo().RootExpr()
-			filters := memo.FiltersExpr{{Condition: nd.(opt.ScalarExpr)}}
+			filters := memo.FiltersExpr{f.ConstructFiltersItem(nd.(opt.ScalarExpr))}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/pkg/sql/opt/memo/check_expr_skip.go
+++ b/pkg/sql/opt/memo/check_expr_skip.go
@@ -1,0 +1,19 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !race
+
+package memo
+
+import "github.com/cockroachdb/cockroach/pkg/sql/opt"
+
+// CheckExpr is a no-op in non-race builds.
+func (m *Memo) CheckExpr(e opt.Expr) {
+}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -711,8 +711,8 @@ func (f *ExprFmtCtx) FormatScalarProps(scalar opt.ScalarExpr) {
 			writeProp("type=%s", typ)
 		}
 
-		if propsExpr, ok := scalar.(ScalarPropsExpr); ok && f.Memo != nil {
-			scalarProps := propsExpr.ScalarProps(f.Memo)
+		if propsExpr, ok := scalar.(ScalarPropsExpr); ok {
+			scalarProps := propsExpr.ScalarProps()
 			if !f.HasFlags(ExprFmtHideMiscProps) {
 				if !scalarProps.OuterCols.Empty() {
 					writeProp("outer=%s", scalarProps.OuterCols)

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -276,7 +276,7 @@ func ExtractConstColumns(
 ) (fixedCols opt.ColSet) {
 	for i := range on {
 		scalar := on[i]
-		scalarProps := scalar.ScalarProps(mem)
+		scalarProps := scalar.ScalarProps()
 		if scalarProps.Constraints != nil && !scalarProps.Constraints.IsUnconstrained() {
 			fixedCols.UnionWith(scalarProps.Constraints.ExtractConstCols(evalCtx))
 		}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -588,7 +588,7 @@ func (h *hasher) HashZipExpr(val ZipExpr) {
 	for i := range val {
 		item := &val[i]
 		h.HashColList(item.Cols)
-		h.HashScalarExpr(item.Func)
+		h.HashScalarExpr(item.Fn)
 	}
 }
 
@@ -931,7 +931,7 @@ func (h *hasher) IsZipExprEqual(l, r ZipExpr) bool {
 		return false
 	}
 	for i := range l {
-		if !l[i].Cols.Equals(r[i].Cols) || l[i].Func != r[i].Func {
+		if !l[i].Cols.Equals(r[i].Cols) || l[i].Fn != r[i].Fn {
 			return false
 		}
 	}

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -87,23 +87,23 @@ func TestInterner(t *testing.T) {
 	scanNode := &ScanExpr{}
 	andExpr := &AndExpr{}
 
-	projections1 := ProjectionsExpr{{Element: andExpr, ColPrivate: ColPrivate{Col: 0}}}
-	projections2 := ProjectionsExpr{{Element: andExpr, ColPrivate: ColPrivate{Col: 0}}}
-	projections3 := ProjectionsExpr{{Element: andExpr, ColPrivate: ColPrivate{Col: 1}}}
+	projections1 := ProjectionsExpr{{Element: andExpr, Col: 0}}
+	projections2 := ProjectionsExpr{{Element: andExpr, Col: 0}}
+	projections3 := ProjectionsExpr{{Element: andExpr, Col: 1}}
 	projections4 := ProjectionsExpr{
-		{Element: andExpr, ColPrivate: ColPrivate{Col: 1}},
-		{Element: andExpr, ColPrivate: ColPrivate{Col: 2}},
+		{Element: andExpr, Col: 1},
+		{Element: andExpr, Col: 2},
 	}
-	projections5 := ProjectionsExpr{{Element: &AndExpr{}, ColPrivate: ColPrivate{Col: 1}}}
+	projections5 := ProjectionsExpr{{Element: &AndExpr{}, Col: 1}}
 
-	aggs1 := AggregationsExpr{{Agg: CountRowsSingleton, ColPrivate: ColPrivate{Col: 0}}}
-	aggs2 := AggregationsExpr{{Agg: CountRowsSingleton, ColPrivate: ColPrivate{Col: 0}}}
-	aggs3 := AggregationsExpr{{Agg: CountRowsSingleton, ColPrivate: ColPrivate{Col: 1}}}
+	aggs1 := AggregationsExpr{{Agg: CountRowsSingleton, Col: 0}}
+	aggs2 := AggregationsExpr{{Agg: CountRowsSingleton, Col: 0}}
+	aggs3 := AggregationsExpr{{Agg: CountRowsSingleton, Col: 1}}
 	aggs4 := AggregationsExpr{
-		{Agg: CountRowsSingleton, ColPrivate: ColPrivate{Col: 1}},
-		{Agg: CountRowsSingleton, ColPrivate: ColPrivate{Col: 2}},
+		{Agg: CountRowsSingleton, Col: 1},
+		{Agg: CountRowsSingleton, Col: 2},
 	}
-	aggs5 := AggregationsExpr{{Agg: &CountRowsExpr{}, ColPrivate: ColPrivate{Col: 1}}}
+	aggs5 := AggregationsExpr{{Agg: &CountRowsExpr{}, Col: 1}}
 
 	int1 := &ConstExpr{Value: tree.NewDInt(10)}
 	int2 := &ConstExpr{Value: tree.NewDInt(20)}
@@ -121,39 +121,24 @@ func TestInterner(t *testing.T) {
 	}
 
 	wins1 := WindowsExpr{{
-		Function: RankSingleton,
-		WindowsItemPrivate: WindowsItemPrivate{
-			ColPrivate: ColPrivate{Col: 0},
-			Frame:      frame1,
-		},
+		Function:           RankSingleton,
+		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame1},
 	}}
 	wins2 := WindowsExpr{{
-		Function: RankSingleton,
-		WindowsItemPrivate: WindowsItemPrivate{
-			ColPrivate: ColPrivate{Col: 0},
-			Frame:      frame1,
-		},
+		Function:           RankSingleton,
+		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame1},
 	}}
 	wins3 := WindowsExpr{{
-		Function: &WindowFromOffsetExpr{Input: RankSingleton, Offset: int1},
-		WindowsItemPrivate: WindowsItemPrivate{
-			ColPrivate: ColPrivate{Col: 0},
-			Frame:      frame1,
-		},
+		Function:           &WindowFromOffsetExpr{Input: RankSingleton, Offset: int1},
+		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame1},
 	}}
 	wins4 := WindowsExpr{{
-		Function: &WindowFromOffsetExpr{Input: RankSingleton, Offset: int2},
-		WindowsItemPrivate: WindowsItemPrivate{
-			ColPrivate: ColPrivate{Col: 0},
-			Frame:      frame1,
-		},
+		Function:           &WindowFromOffsetExpr{Input: RankSingleton, Offset: int2},
+		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame1},
 	}}
 	wins5 := WindowsExpr{{
-		Function: RankSingleton,
-		WindowsItemPrivate: WindowsItemPrivate{
-			ColPrivate: ColPrivate{Col: 0},
-			Frame:      frame2,
-		},
+		Function:           RankSingleton,
+		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame2},
 	}}
 
 	type testVariation struct {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -184,7 +184,7 @@ func (b *logicalPropsBuilder) buildSequenceSelectProps(
 }
 
 func (b *logicalPropsBuilder) buildSelectProps(sel *SelectExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, sel, &rel.Shared)
+	BuildSharedProps(sel, &rel.Shared)
 
 	inputProps := sel.Input.Relational()
 
@@ -206,7 +206,7 @@ func (b *logicalPropsBuilder) buildSelectProps(sel *SelectExpr, rel *props.Relat
 
 	// Outer Columns
 	// -------------
-	// Outer columns were derived by buildSharedProps; remove any that are bound
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
 	// by input columns.
 	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
 
@@ -241,7 +241,7 @@ func (b *logicalPropsBuilder) buildSelectProps(sel *SelectExpr, rel *props.Relat
 }
 
 func (b *logicalPropsBuilder) buildProjectProps(prj *ProjectExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, prj, &rel.Shared)
+	BuildSharedProps(prj, &rel.Shared)
 
 	inputProps := prj.Input.Relational()
 
@@ -273,7 +273,7 @@ func (b *logicalPropsBuilder) buildProjectProps(prj *ProjectExpr, rel *props.Rel
 
 	// Outer Columns
 	// -------------
-	// Outer columns were derived by buildSharedProps; remove any that are bound
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
 	// by input columns.
 	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
 
@@ -373,7 +373,7 @@ func (b *logicalPropsBuilder) buildAntiJoinApplyProps(
 }
 
 func (b *logicalPropsBuilder) buildJoinProps(join RelExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, join, &rel.Shared)
+	BuildSharedProps(join, &rel.Shared)
 
 	var h joinPropsHelper
 	h.init(b, join)
@@ -389,7 +389,7 @@ func (b *logicalPropsBuilder) buildJoinProps(join RelExpr, rel *props.Relational
 
 	// Outer Columns
 	// -------------
-	// Outer columns were initially set by buildSharedProps. Remove any that are
+	// Outer columns were initially set by BuildSharedProps. Remove any that are
 	// bound by the input columns.
 	inputCols := h.leftProps.OutputCols.Union(h.rightProps.OutputCols)
 	rel.OuterCols.DifferenceWith(inputCols)
@@ -414,7 +414,7 @@ func (b *logicalPropsBuilder) buildJoinProps(join RelExpr, rel *props.Relational
 }
 
 func (b *logicalPropsBuilder) buildIndexJoinProps(indexJoin *IndexJoinExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, indexJoin, &rel.Shared)
+	BuildSharedProps(indexJoin, &rel.Shared)
 
 	inputProps := indexJoin.Input.Relational()
 	md := b.mem.Metadata()
@@ -432,7 +432,7 @@ func (b *logicalPropsBuilder) buildIndexJoinProps(indexJoin *IndexJoinExpr, rel 
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -483,7 +483,7 @@ func (b *logicalPropsBuilder) buildDistinctOnProps(
 }
 
 func (b *logicalPropsBuilder) buildGroupingExprProps(groupExpr RelExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, groupExpr, &rel.Shared)
+	BuildSharedProps(groupExpr, &rel.Shared)
 
 	inputProps := groupExpr.Child(0).(RelExpr).Relational()
 	aggs := *groupExpr.Child(1).(*AggregationsExpr)
@@ -505,7 +505,7 @@ func (b *logicalPropsBuilder) buildGroupingExprProps(groupExpr RelExpr, rel *pro
 
 	// Outer Columns
 	// -------------
-	// Outer columns were derived by buildSharedProps; remove any that are bound
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
 	// by input columns.
 	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
 
@@ -571,7 +571,7 @@ func (b *logicalPropsBuilder) buildExceptAllProps(except *ExceptAllExpr, rel *pr
 }
 
 func (b *logicalPropsBuilder) buildSetProps(setNode RelExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, setNode, &rel.Shared)
+	BuildSharedProps(setNode, &rel.Shared)
 
 	leftProps := setNode.Child(0).(RelExpr).Relational()
 	rightProps := setNode.Child(1).(RelExpr).Relational()
@@ -604,7 +604,7 @@ func (b *logicalPropsBuilder) buildSetProps(setNode RelExpr, rel *props.Relation
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -628,7 +628,7 @@ func (b *logicalPropsBuilder) buildSetProps(setNode RelExpr, rel *props.Relation
 }
 
 func (b *logicalPropsBuilder) buildValuesProps(values *ValuesExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, values, &rel.Shared)
+	BuildSharedProps(values, &rel.Shared)
 
 	card := uint32(len(values.Rows))
 
@@ -659,7 +659,7 @@ func (b *logicalPropsBuilder) buildValuesProps(values *ValuesExpr, rel *props.Re
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -680,7 +680,7 @@ func (b *logicalPropsBuilder) buildValuesProps(values *ValuesExpr, rel *props.Re
 }
 
 func (b *logicalPropsBuilder) buildBasicProps(e opt.Expr, cols opt.ColList, rel *props.Relational) {
-	BuildSharedProps(b.mem, e, &rel.Shared)
+	BuildSharedProps(e, &rel.Shared)
 
 	// Output Columns
 	// --------------
@@ -714,7 +714,7 @@ func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relation
 	// Copy over the props from the input.
 	inputProps := with.Main.Relational()
 
-	BuildSharedProps(b.mem, with, &rel.Shared)
+	BuildSharedProps(with, &rel.Shared)
 
 	// Side Effects
 	// ------------
@@ -751,7 +751,7 @@ func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relation
 }
 
 func (b *logicalPropsBuilder) buildWithScanProps(withScan *WithScanExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, withScan, &rel.Shared)
+	BuildSharedProps(withScan, &rel.Shared)
 	bindingProps := withScan.BindingProps
 
 	// Side Effects
@@ -793,7 +793,7 @@ func (b *logicalPropsBuilder) buildWithScanProps(withScan *WithScanExpr, rel *pr
 }
 
 func (b *logicalPropsBuilder) buildRecursiveCTEProps(rec *RecursiveCTEExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, rec, &rel.Shared)
+	BuildSharedProps(rec, &rel.Shared)
 
 	// Output Columns
 	// --------------
@@ -892,7 +892,7 @@ func (b *logicalPropsBuilder) buildExportProps(export *ExportExpr, rel *props.Re
 }
 
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, limit, &rel.Shared)
+	BuildSharedProps(limit, &rel.Shared)
 
 	inputProps := limit.Input.Relational()
 
@@ -922,7 +922,7 @@ func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relat
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -952,7 +952,7 @@ func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relat
 }
 
 func (b *logicalPropsBuilder) buildOffsetProps(offset *OffsetExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, offset, &rel.Shared)
+	BuildSharedProps(offset, &rel.Shared)
 
 	inputProps := offset.Input.Relational()
 
@@ -968,7 +968,7 @@ func (b *logicalPropsBuilder) buildOffsetProps(offset *OffsetExpr, rel *props.Re
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -997,7 +997,7 @@ func (b *logicalPropsBuilder) buildOffsetProps(offset *OffsetExpr, rel *props.Re
 }
 
 func (b *logicalPropsBuilder) buildMax1RowProps(max1Row *Max1RowExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, max1Row, &rel.Shared)
+	BuildSharedProps(max1Row, &rel.Shared)
 
 	inputProps := max1Row.Input.Relational()
 
@@ -1013,7 +1013,7 @@ func (b *logicalPropsBuilder) buildMax1RowProps(max1Row *Max1RowExpr, rel *props
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -1033,7 +1033,7 @@ func (b *logicalPropsBuilder) buildMax1RowProps(max1Row *Max1RowExpr, rel *props
 }
 
 func (b *logicalPropsBuilder) buildOrdinalityProps(ord *OrdinalityExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, ord, &rel.Shared)
+	BuildSharedProps(ord, &rel.Shared)
 
 	inputProps := ord.Input.Relational()
 
@@ -1052,7 +1052,7 @@ func (b *logicalPropsBuilder) buildOrdinalityProps(ord *OrdinalityExpr, rel *pro
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -1078,7 +1078,7 @@ func (b *logicalPropsBuilder) buildOrdinalityProps(ord *OrdinalityExpr, rel *pro
 }
 
 func (b *logicalPropsBuilder) buildWindowProps(window *WindowExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, window, &rel.Shared)
+	BuildSharedProps(window, &rel.Shared)
 
 	inputProps := window.Input.Relational()
 
@@ -1128,7 +1128,7 @@ func (b *logicalPropsBuilder) buildWindowProps(window *WindowExpr, rel *props.Re
 func (b *logicalPropsBuilder) buildProjectSetProps(
 	projectSet *ProjectSetExpr, rel *props.Relational,
 ) {
-	BuildSharedProps(b.mem, projectSet, &rel.Shared)
+	BuildSharedProps(projectSet, &rel.Shared)
 
 	inputProps := projectSet.Input.Relational()
 
@@ -1198,7 +1198,7 @@ func (b *logicalPropsBuilder) buildDeleteProps(del *DeleteExpr, rel *props.Relat
 }
 
 func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, mutation, &rel.Shared)
+	BuildSharedProps(mutation, &rel.Shared)
 
 	private := mutation.Private().(*MutationPrivate)
 
@@ -1256,7 +1256,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were already derived by BuildSharedProps.
 
 	// Functional Dependencies
 	// -----------------------
@@ -1280,15 +1280,15 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 }
 
 func (b *logicalPropsBuilder) buildCreateTableProps(ct *CreateTableExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, ct, &rel.Shared)
+	BuildSharedProps(ct, &rel.Shared)
 }
 
 func (b *logicalPropsBuilder) buildCreateViewProps(cv *CreateViewExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, cv, &rel.Shared)
+	BuildSharedProps(cv, &rel.Shared)
 }
 
 func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *props.Scalar) {
-	BuildSharedProps(b.mem, item.Condition, &scalar.Shared)
+	BuildSharedProps(item.Condition, &scalar.Shared)
 
 	// Constraints
 	// -----------
@@ -1319,37 +1319,36 @@ func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *p
 			}
 		}
 	}
-
-	scalar.Populated = true
 }
 
 func (b *logicalPropsBuilder) buildProjectionsItemProps(
 	item *ProjectionsItem, scalar *props.Scalar,
 ) {
 	item.Typ = item.Element.DataType()
-	BuildSharedProps(b.mem, item.Element, &scalar.Shared)
+	BuildSharedProps(item.Element, &scalar.Shared)
 }
 
 func (b *logicalPropsBuilder) buildAggregationsItemProps(
 	item *AggregationsItem, scalar *props.Scalar,
 ) {
 	item.Typ = item.Agg.DataType()
-	BuildSharedProps(b.mem, item.Agg, &scalar.Shared)
+	BuildSharedProps(item.Agg, &scalar.Shared)
 }
 
 func (b *logicalPropsBuilder) buildWindowsItemProps(item *WindowsItem, scalar *props.Scalar) {
 	item.Typ = item.Function.DataType()
-	BuildSharedProps(b.mem, item.Function, &scalar.Shared)
+	BuildSharedProps(item.Function, &scalar.Shared)
 }
 
 func (b *logicalPropsBuilder) buildZipItemProps(item *ZipItem, scalar *props.Scalar) {
-	item.Typ = item.Func.DataType()
-	BuildSharedProps(b.mem, item.Func, &scalar.Shared)
+	item.Typ = item.Fn.DataType()
+	BuildSharedProps(item.Fn, &scalar.Shared)
 }
 
 // BuildSharedProps fills in the shared properties derived from the given
-// expression's subtree.
-func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
+// expression's subtree. It will only recurse into a child when it is not
+// already caching properties.
+func BuildSharedProps(e opt.Expr, shared *props.Shared) {
 	switch t := e.(type) {
 	case *VariableExpr:
 		// Variable introduces outer column.
@@ -1368,7 +1367,7 @@ func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
 		shared.HasSubquery = true
 		shared.HasCorrelatedSubquery = !e.Child(0).(RelExpr).Relational().OuterCols.Empty()
 		if t.Op() == opt.AnyOp && !shared.HasCorrelatedSubquery {
-			shared.HasCorrelatedSubquery = hasOuterCols(mem, e.Child(1))
+			shared.HasCorrelatedSubquery = hasOuterCols(e.Child(1))
 		}
 
 	case *FunctionExpr:
@@ -1394,7 +1393,7 @@ func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
 		case RelExpr:
 			cached = &t.Relational().Shared
 		case ScalarPropsExpr:
-			cached = &t.ScalarProps(mem).Shared
+			cached = &t.ScalarProps().Shared
 		}
 
 		// Don't need to recurse if properties are cached.
@@ -1416,25 +1415,25 @@ func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
 				shared.HasCorrelatedSubquery = true
 			}
 		} else {
-			BuildSharedProps(mem, e.Child(i), shared)
+			BuildSharedProps(e.Child(i), shared)
 		}
 	}
 }
 
 // hasOuterCols returns true if the given expression has outer columns (i.e.
 // columns that are referenced by the expression but not bound by it).
-func hasOuterCols(mem *Memo, e opt.Expr) bool {
+func hasOuterCols(e opt.Expr) bool {
 	switch t := e.(type) {
 	case *VariableExpr:
 		return true
 	case RelExpr:
 		return !t.Relational().OuterCols.Empty()
 	case ScalarPropsExpr:
-		return !t.ScalarProps(mem).Shared.OuterCols.Empty()
+		return !t.ScalarProps().Shared.OuterCols.Empty()
 	}
 
 	for i, n := 0, e.ChildCount(); i < n; i++ {
-		if hasOuterCols(mem, e.Child(i)) {
+		if hasOuterCols(e.Child(i)) {
 			return true
 		}
 	}
@@ -1522,7 +1521,7 @@ func (b *logicalPropsBuilder) makeSetCardinality(
 func (b *logicalPropsBuilder) rejectNullCols(filters FiltersExpr) opt.ColSet {
 	var notNullCols opt.ColSet
 	for i := range filters {
-		filterProps := filters[i].ScalarProps(b.mem)
+		filterProps := filters[i].ScalarProps()
 		if filterProps.Constraints != nil {
 			notNullCols.UnionWith(filterProps.Constraints.ExtractNotNullCols(b.evalCtx))
 		}
@@ -1534,7 +1533,7 @@ func (b *logicalPropsBuilder) rejectNullCols(filters FiltersExpr) opt.ColSet {
 // each condition in the filters.
 func (b *logicalPropsBuilder) addFiltersToFuncDep(filters FiltersExpr, fdset *props.FuncDepSet) {
 	for i := range filters {
-		filterProps := filters[i].ScalarProps(b.mem)
+		filterProps := filters[i].ScalarProps()
 		fdset.AddFrom(&filterProps.FuncDeps)
 	}
 
@@ -1550,7 +1549,7 @@ func (b *logicalPropsBuilder) addFiltersToFuncDep(filters FiltersExpr, fdset *pr
 	var cols opt.ColSet
 	possibleIntersection := false
 	for i := range filters {
-		if c := filters[i].ScalarProps(b.mem).Constraints; c != nil {
+		if c := filters[i].ScalarProps().Constraints; c != nil {
 			s := c.ExtractCols()
 			if cols.Intersects(s) {
 				possibleIntersection = true
@@ -1563,7 +1562,7 @@ func (b *logicalPropsBuilder) addFiltersToFuncDep(filters FiltersExpr, fdset *pr
 	if possibleIntersection {
 		intersection := constraint.Unconstrained
 		for i := range filters {
-			if c := filters[i].ScalarProps(b.mem).Constraints; c != nil {
+			if c := filters[i].ScalarProps().Constraints; c != nil {
 				intersection = intersection.Intersect(b.evalCtx, c)
 			}
 		}
@@ -1580,7 +1579,7 @@ func (b *logicalPropsBuilder) updateCardinalityFromFilters(
 	filters FiltersExpr, rel *props.Relational,
 ) {
 	for i := range filters {
-		filterProps := filters[i].ScalarProps(b.mem)
+		filterProps := filters[i].ScalarProps()
 		if filterProps.Constraints == nil {
 			continue
 		}

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -345,7 +345,7 @@ memo (optimized, ~2KB, required=[presentation: array_agg:3])
 memo
 SELECT DISTINCT field FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized, ~8KB, required=[presentation: field:6])
+memo (optimized, ~9KB, required=[presentation: field:6])
  ├── G1: (distinct-on G2 G3 cols=(6))
  │    └── [presentation: field:6]
  │         ├── best: (distinct-on G2 G3 cols=(6))

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -51,14 +51,18 @@ func TestSimplifyFilters(t *testing.T) {
 		Cols: opt.ColList{},
 		ID:   f.Metadata().NextUniqueID(),
 	})
-	filters := memo.FiltersExpr{{Condition: eq}, {Condition: memo.FalseSingleton}, {Condition: eq}}
+	filters := memo.FiltersExpr{
+		f.ConstructFiltersItem(eq),
+		f.ConstructFiltersItem(memo.FalseSingleton),
+		f.ConstructFiltersItem(eq),
+	}
 	sel := f.ConstructSelect(vals, filters)
 	if sel.Relational().Cardinality.Max != 0 {
 		t.Fatalf("result should have been collapsed to zero cardinality rowset")
 	}
 
 	// Filters operator skips True operands.
-	filters = memo.FiltersExpr{{Condition: eq}, {Condition: memo.TrueSingleton}}
+	filters = memo.FiltersExpr{f.ConstructFiltersItem(eq), f.ConstructFiltersItem(memo.TrueSingleton)}
 	sel = f.ConstructSelect(vals, filters)
 	if len(sel.(*memo.SelectExpr).Filters) != 1 {
 		t.Fatalf("filters result should have filtered True operator")

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -126,8 +126,7 @@ func (c *CustomFuncs) makeAggCols(
 			panic(errors.AssertionFailedf("unrecognized aggregate operator type: %v", log.Safe(aggOp)))
 		}
 
-		outAggs[i].Agg = outAgg
-		outAggs[i].Col = id
+		outAggs[i] = c.f.ConstructAggregationsItem(outAgg, id)
 		i++
 	}
 }
@@ -168,8 +167,10 @@ func (c *CustomFuncs) RemoveAggDistinctForKeys(
 			// Remove AggDistinct. We rely on the fact that AggDistinct must be
 			// directly "under" the Aggregate.
 			// TODO(radu): this will need to be revisited when we add more modifiers.
-			newAggs[i].Agg = c.replaceAggInputVar(item.Agg, v)
-			newAggs[i].Col = aggs[i].Col
+			newAggs[i] = c.f.ConstructAggregationsItem(
+				c.replaceAggInputVar(item.Agg, v),
+				aggs[i].Col,
+			)
 		} else {
 			newAggs[i] = *item
 		}
@@ -248,11 +249,7 @@ func (c *CustomFuncs) ConstructProjectionFromDistinctOn(
 		if inputCol == outputCol {
 			passthrough.Add(inputCol)
 		} else {
-			projections = append(projections, memo.ProjectionsItem{
-				Element:    varExpr,
-				ColPrivate: aggs[i].ColPrivate,
-				Typ:        aggs[i].Typ,
-			})
+			projections = append(projections, c.f.ConstructProjectionsItem(varExpr, aggs[i].Col))
 		}
 	}
 	return c.f.ConstructProject(input, projections, passthrough)

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -92,7 +92,7 @@ func (c *CustomFuncs) CanMapJoinOpEqualities(
 ) bool {
 	var equivFD props.FuncDepSet
 	for i := range filters {
-		equivFD.AddEquivFrom(&filters[i].ScalarProps(c.mem).FuncDeps)
+		equivFD.AddEquivFrom(&filters[i].ScalarProps().FuncDeps)
 	}
 	equivReps := equivFD.EquivReps()
 
@@ -136,7 +136,7 @@ func (c *CustomFuncs) canMapJoinOpEquivalenceGroup(
 	// group spans both sides of the join, these conditions can be remapped.
 	found := 0
 	for i := range filters {
-		fd := &filters[i].ScalarProps(c.mem).FuncDeps
+		fd := &filters[i].ScalarProps().FuncDeps
 		filterEqCols := fd.ComputeEquivClosure(fd.EquivReps())
 		if filterEqCols.Intersects(leftCols) && filterEqCols.Intersects(rightCols) &&
 			filterEqCols.SubsetOf(eqCols) {
@@ -158,7 +158,7 @@ func (c *CustomFuncs) MapJoinOpEqualities(
 ) memo.FiltersExpr {
 	var equivFD props.FuncDepSet
 	for i := range filters {
-		equivFD.AddEquivFrom(&filters[i].ScalarProps(c.mem).FuncDeps)
+		equivFD.AddEquivFrom(&filters[i].ScalarProps().FuncDeps)
 	}
 	equivReps := equivFD.EquivReps()
 
@@ -206,7 +206,7 @@ func (c *CustomFuncs) mapJoinOpEquivalenceGroup(
 	// First remove all the equality conditions for this equivalence group.
 	newFilters := make(memo.FiltersExpr, 0, len(filters))
 	for i := range filters {
-		fd := &filters[i].ScalarProps(c.mem).FuncDeps
+		fd := &filters[i].ScalarProps().FuncDeps
 		filterEqCols := fd.ComputeEquivClosure(fd.EquivReps())
 		if !filterEqCols.Empty() && filterEqCols.SubsetOf(eqCols) {
 			continue
@@ -233,24 +233,24 @@ func (c *CustomFuncs) mapJoinOpEquivalenceGroup(
 
 	// Connect all the columns on the left.
 	for col, ok := leftEqCols.Next(firstLeftCol + 1); ok; col, ok = leftEqCols.Next(col + 1) {
-		newFilters = append(newFilters, memo.FiltersItem{
-			Condition: c.f.ConstructEq(c.f.ConstructVariable(firstLeftCol), c.f.ConstructVariable(col)),
-		})
+		newFilters = append(newFilters, c.f.ConstructFiltersItem(
+			c.f.ConstructEq(c.f.ConstructVariable(firstLeftCol), c.f.ConstructVariable(col)),
+		))
 	}
 
 	// Connect all the columns on the right.
 	for col, ok := rightEqCols.Next(firstRightCol + 1); ok; col, ok = rightEqCols.Next(col + 1) {
-		newFilters = append(newFilters, memo.FiltersItem{
-			Condition: c.f.ConstructEq(c.f.ConstructVariable(firstRightCol), c.f.ConstructVariable(col)),
-		})
+		newFilters = append(newFilters, c.f.ConstructFiltersItem(
+			c.f.ConstructEq(c.f.ConstructVariable(firstRightCol), c.f.ConstructVariable(col)),
+		))
 	}
 
 	// Connect the two sides.
-	newFilters = append(newFilters, memo.FiltersItem{
-		Condition: c.f.ConstructEq(
+	newFilters = append(newFilters, c.f.ConstructFiltersItem(
+		c.f.ConstructEq(
 			c.f.ConstructVariable(firstLeftCol), c.f.ConstructVariable(firstRightCol),
 		),
-	})
+	))
 
 	return newFilters
 }
@@ -284,7 +284,7 @@ func (c *CustomFuncs) CanMapJoinOpFilter(
 		return true
 	}
 
-	scalarProps := src.ScalarProps(c.mem)
+	scalarProps := src.ScalarProps()
 	if scalarProps.HasCorrelatedSubquery {
 		return false
 	}
@@ -334,7 +334,7 @@ func (c *CustomFuncs) MapJoinOpFilter(
 	// Map each column in src to one column in dst. We choose an arbitrary column
 	// (the one with the smallest ColumnID) if there are multiple choices.
 	var colMap util.FastIntMap
-	outerCols := src.ScalarProps(c.mem).OuterCols
+	outerCols := src.ScalarProps().OuterCols
 	for srcCol, ok := outerCols.Next(0); ok; srcCol, ok = outerCols.Next(srcCol + 1) {
 		eqCols := c.GetEquivColsWithEquivType(srcCol, equivFD)
 		eqCols.IntersectionWith(dstCols)
@@ -436,7 +436,7 @@ func (c *CustomFuncs) GetEquivFD(
 	filters memo.FiltersExpr, left, right memo.RelExpr,
 ) (equivFD props.FuncDepSet) {
 	for i := range filters {
-		equivFD.AddEquivFrom(&filters[i].ScalarProps(c.mem).FuncDeps)
+		equivFD.AddEquivFrom(&filters[i].ScalarProps().FuncDeps)
 	}
 	equivFD.AddEquivFrom(&left.Relational().FuncDeps)
 	equivFD.AddEquivFrom(&right.Relational().FuncDeps)
@@ -721,8 +721,8 @@ func (c *CustomFuncs) CanExtractJoinEquality(
 
 	// Recursively compute properties for left and right sides.
 	var leftProps, rightProps props.Shared
-	memo.BuildSharedProps(c.mem, a, &leftProps)
-	memo.BuildSharedProps(c.mem, b, &rightProps)
+	memo.BuildSharedProps(a, &leftProps)
+	memo.BuildSharedProps(b, &rightProps)
 
 	// Disallow cases when one side has a correlated subquery.
 	// TODO(radu): investigate relaxing this.
@@ -757,7 +757,7 @@ func (c *CustomFuncs) ExtractJoinEquality(
 	a, b := eq.Left, eq.Right
 
 	var eqLeftProps props.Shared
-	memo.BuildSharedProps(c.mem, eq.Left, &eqLeftProps)
+	memo.BuildSharedProps(eq.Left, &eqLeftProps)
 	if eqLeftProps.OuterCols.SubsetOf(rightCols) {
 		a, b = b, a
 	}
@@ -773,9 +773,9 @@ func (c *CustomFuncs) ExtractJoinEquality(
 			continue
 		}
 
-		newFilters[i] = memo.FiltersItem{
-			Condition: c.f.ConstructEq(leftProj.add(a), rightProj.add(b)),
-		}
+		newFilters[i] = c.f.ConstructFiltersItem(
+			c.f.ConstructEq(leftProj.add(a), rightProj.add(b)),
+		)
 	}
 	if leftProj.empty() && rightProj.empty() {
 		panic(errors.AssertionFailedf("no equalities to extract"))

--- a/pkg/sql/opt/norm/project_builder.go
+++ b/pkg/sql/opt/norm/project_builder.go
@@ -51,10 +51,7 @@ func (pb *projectBuilder) add(e opt.ScalarExpr) opt.ScalarExpr {
 	}
 
 	newCol := pb.f.Metadata().AddColumn("", e.DataType())
-	pb.projections = append(pb.projections, memo.ProjectionsItem{
-		Element:    e,
-		ColPrivate: memo.ColPrivate{Col: newCol},
-	})
+	pb.projections = append(pb.projections, pb.f.ConstructProjectionsItem(e, newCol))
 	return pb.f.ConstructVariable(newCol)
 }
 

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -399,7 +399,7 @@ func (c *CustomFuncs) NeededWindowCols(windows memo.WindowsExpr, p *memo.WindowP
 	needed.UnionWith(p.Partition)
 	needed.UnionWith(p.Ordering.ColSet())
 	for i := range windows {
-		needed.UnionWith(windows[i].ScalarProps(c.mem).OuterCols)
+		needed.UnionWith(windows[i].ScalarProps().OuterCols)
 	}
 	return needed
 }
@@ -521,7 +521,7 @@ func DerivePruneCols(e memo.RelExpr) opt.ColSet {
 		// make sure that we still get the correct number of rows in the output.
 		projectSet := e.(*memo.ProjectSetExpr)
 		relProps.Rule.PruneCols = DerivePruneCols(projectSet.Input).Copy()
-		usedCols := projectSet.Zip.OuterCols(e.Memo())
+		usedCols := projectSet.Zip.OuterCols()
 		relProps.Rule.PruneCols.DifferenceWith(usedCols)
 
 	case opt.UnionAllOp:
@@ -539,7 +539,7 @@ func DerivePruneCols(e memo.RelExpr) opt.ColSet {
 		relProps.Rule.PruneCols.DifferenceWith(win.Ordering.ColSet())
 		for _, w := range win.Windows {
 			relProps.Rule.PruneCols.Add(w.Col)
-			relProps.Rule.PruneCols.DifferenceWith(w.ScalarProps(e.Memo()).OuterCols)
+			relProps.Rule.PruneCols.DifferenceWith(w.ScalarProps().OuterCols)
 		}
 
 	case opt.UpdateOp, opt.UpsertOp, opt.DeleteOp:

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -31,7 +31,7 @@ func (c *CustomFuncs) HasNullRejectingFilter(
 	filters memo.FiltersExpr, nullRejectCols opt.ColSet,
 ) bool {
 	for i := range filters {
-		constraints := filters[i].ScalarProps(c.mem).Constraints
+		constraints := filters[i].ScalarProps().Constraints
 		if constraints == nil {
 			continue
 		}

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -172,23 +172,10 @@ define Projections {
 # Project operator instead. However, the Element field can contain a VariableOp
 # when a new ColumnID is being assigned, such as in the case of an outer column
 # reference.
-[Scalar, ListItem]
+[Scalar, ListItem, ScalarProps]
 define ProjectionsItem {
     Element ScalarExpr
-
-    _ ColPrivate
-}
-
-# ColPrivate contains the ColumnID of a synthesized projection or aggregation
-# column, as well as a set of lazily-populated scalar properties that apply to
-# the column. ColPrivate is shared by ProjectionsItem and AggregationsItem so
-# that they can be treated polymorphically.
-[Private]
-define ColPrivate {
-    Col ColumnID
-
-    # Lazily populated.
-    scalar ScalarProps
+    Col     ColumnID
 }
 
 # Aggregations is a set of AggregationsItem expressions that specify the
@@ -215,11 +202,10 @@ define Aggregations {
 #
 # More complex arguments must be formulated using a Project operator as input to
 # the grouping operator.
-[Scalar, ListItem]
+[Scalar, ListItem, ScalarProps]
 define AggregationsItem {
     Agg ScalarExpr
-
-    _ ColPrivate
+    Col ColumnID
 }
 
 # Filters is a set of FiltersItem expressions that specify a set of conjuncts
@@ -236,11 +222,9 @@ define Filters {
 # set of scalar properties that are lazily calculated by traversing the
 # Condition scalar expression. This allows the properties for the entire
 # expression subtree to be calculated once and then repeatedly reused.
-[Scalar, Bool, ListItem]
+[Scalar, Bool, ListItem, ScalarProps]
 define FiltersItem {
     Condition ScalarExpr
-
-    scalar ScalarProps
 }
 
 # Zip represents a functional zip over generators a,b,c, which returns tuples of
@@ -271,25 +255,15 @@ define Zip {
 }
 
 # ZipItem contains a generator function or scalar expression that is contained
-# in a Zip. See the Zip header for more details.
-[Scalar, ListItem]
+# in a Zip. It also contains the list of output columns for the generator or
+# scalar expression in the ZipItem. Cols is a list since a single function may
+# output multiple columns (e.g. pg_get_keywords() outputs three columns).
+#
+# See the Zip header for more details.
+[Scalar, ListItem, ScalarProps]
 define ZipItem {
-    Func ScalarExpr
-
-    _ ZipItemPrivate
-}
-
-# ZipItemPrivate contains the list of output columns for the generator function
-# or scalar expression in a ZipItem, as well as a set of lazily-populated
-# scalar properties that apply to the ZipItem. Cols is a list since a single
-# function may output multiple columns (e.g., pg_get_keywords() outputs three
-# columns).
-[Private]
-define ZipItemPrivate {
+    Fn   ScalarExpr
     Cols ColList
-
-    # Lazily populated.
-    scalar ScalarProps
 }
 
 # And is the boolean conjunction operator that evalutes to true only if both of
@@ -942,7 +916,7 @@ define Windows {
 
 # WindowsItem is a single window function to be computed in the context of a
 # Window expression.
-[Scalar, ListItem]
+[Scalar, ListItem, ScalarProps]
 define WindowsItem {
     # Function is the window function being computed. If the frame has offset
     # expressions, the window function will be hanging off of additional
@@ -966,8 +940,7 @@ define WindowsItemPrivate {
     # TODO(justin): at this point we should probably just have a separate opt
     # version of this structure.
     Frame WindowFrame
-
-    _ ColPrivate
+    Col   ColumnID
 }
 
 # Rank computes the position of a row relative to an ordering, with same-valued
@@ -1058,8 +1031,7 @@ define KVOptions {
 [Scalar, ListItem]
 define KVOptionsItem {
     Value ScalarExpr
-
-    Key string
+    Key   string
 }
 
 # ScalarList is a list expression that has scalar expression items of type

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -140,10 +140,10 @@ func (b *Builder) buildDistinctOn(distinctOnCols opt.ColSet, inScope *scope) (ou
 	for i := range outScope.cols {
 		if id := outScope.cols[i].id; !excluded.Contains(id) {
 			excluded.Add(id)
-			aggs = append(aggs, memo.AggregationsItem{
-				Agg:        b.factory.ConstructFirstAgg(b.factory.ConstructVariable(id)),
-				ColPrivate: memo.ColPrivate{Col: id},
-			})
+			aggs = append(aggs, b.factory.ConstructAggregationsItem(
+				b.factory.ConstructFirstAgg(b.factory.ConstructVariable(id)),
+				id,
+			))
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -280,10 +280,7 @@ func (b *Builder) constructGroupBy(
 				// aggregation.
 				panic(errors.AssertionFailedf("variable as aggregation"))
 			}
-			aggs = append(aggs, memo.AggregationsItem{
-				Agg:        scalar,
-				ColPrivate: memo.ColPrivate{Col: id},
-			})
+			aggs = append(aggs, b.factory.ConstructAggregationsItem(scalar, id))
 			colSet.Add(id)
 		}
 	}
@@ -410,7 +407,7 @@ func (b *Builder) buildAggregation(having opt.ScalarExpr, fromScope *scope) (out
 	// Wrap with having filter if it exists.
 	if having != nil {
 		input := g.aggOutScope.expr.(memo.RelExpr)
-		filters := memo.FiltersExpr{{Condition: having}}
+		filters := memo.FiltersExpr{b.factory.ConstructFiltersItem(having)}
 		g.aggOutScope.expr = b.factory.ConstructSelect(input, filters)
 	}
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -688,7 +688,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 				mb.b.factory.ConstructVariable(mb.insertColID(indexCol.Ordinal)),
 				mb.b.factory.ConstructVariable(scanColID),
 			)
-			on = append(on, memo.FiltersItem{Condition: condition})
+			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
 		}
 
 		// Construct the left join + filter.
@@ -702,12 +702,12 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 					on,
 					memo.EmptyJoinPrivate,
 				),
-				memo.FiltersExpr{memo.FiltersItem{
-					Condition: mb.b.factory.ConstructIs(
+				memo.FiltersExpr{mb.b.factory.ConstructFiltersItem(
+					mb.b.factory.ConstructIs(
 						mb.b.factory.ConstructVariable(notNullColID),
 						memo.NullSingleton,
 					),
-				}},
+				)},
 			),
 			memo.EmptyProjectionsExpr,
 			insertColSet,
@@ -781,7 +781,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 					mb.b.factory.ConstructVariable(mb.insertColID(i)),
 					mb.b.factory.ConstructVariable(fetchCol.id),
 				)
-				on = append(on, memo.FiltersItem{Condition: condition})
+				on = append(on, mb.b.factory.ConstructFiltersItem(condition))
 				break
 			}
 		}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -104,7 +104,7 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 			filter := b.buildScalar(
 				outScope.resolveAndRequireType(on.Expr, types.Bool), outScope, nil, nil, nil,
 			)
-			filters = memo.FiltersExpr{{Condition: filter}}
+			filters = memo.FiltersExpr{b.factory.ConstructFiltersItem(filter)}
 		} else {
 			filters = memo.TrueFilter
 		}
@@ -451,7 +451,7 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 	leftVar := jb.b.factory.ConstructVariable(leftCol.id)
 	rightVar := jb.b.factory.ConstructVariable(rightCol.id)
 	eq := jb.b.factory.ConstructEq(leftVar, rightVar)
-	jb.filters = append(jb.filters, memo.FiltersItem{Condition: eq})
+	jb.filters = append(jb.filters, jb.b.factory.ConstructFiltersItem(eq))
 
 	// Add the merged column to the scope, constructing a new column if needed.
 	if jb.joinType == sqlbase.InnerJoin || jb.joinType == sqlbase.LeftOuterJoin {

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -46,10 +46,7 @@ func (b *Builder) constructProject(input memo.RelExpr, cols []scopeColumn) memo.
 			if scalar == nil {
 				passthrough.Add(id)
 			} else {
-				projections = append(projections, memo.ProjectionsItem{
-					Element:    scalar,
-					ColPrivate: memo.ColPrivate{Col: id},
-				})
+				projections = append(projections, b.factory.ConstructProjectionsItem(scalar, id))
 			}
 			colSet.Add(id)
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -947,7 +947,7 @@ func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
 	// Wrap the filter in a FiltersOp.
 	inScope.expr = b.factory.ConstructSelect(
 		inScope.expr.(memo.RelExpr),
-		memo.FiltersExpr{{Condition: filter}},
+		memo.FiltersExpr{b.factory.ConstructFiltersItem(filter)},
 	)
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -961,15 +961,15 @@ func (g *newRuleGen) genConstructList(list *lang.ListExpr) {
 		if listItemTyp.isGenerated {
 			listItemDef := g.compiled.LookupDefine(listItemTyp.friendlyName)
 
-			g.w.nestIndent("{\n")
+			g.w.nestIndent("%s.Construct%s(\n", g.factoryVar, listItemDef.Name)
 			for i, subItem := range item.(*lang.FuncExpr).Args {
 				field := listItemDef.Fields[i]
 
-				g.w.writeIndent("%s: %s", g.md.fieldName(field), g.md.fieldStorePrefix(field))
+				g.w.writeIndent("%s", g.md.fieldStorePrefix(field))
 				g.genNestedExpr(subItem)
 				g.w.write(",\n")
 			}
-			g.w.unnest("},\n")
+			g.w.unnest("),\n")
 		} else {
 			g.genNestedExpr(item)
 			g.w.write(",\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -233,13 +233,12 @@ type ProjectionsItem struct {
 	ColPrivate
 
 	Typ *types.T
-	id  opt.ScalarID
 }
 
 var _ opt.ScalarExpr = &ProjectionsItem{}
 
 func (e *ProjectionsItem) ID() opt.ScalarID {
-	return e.id
+	return 0
 }
 
 func (e *ProjectionsItem) Op() opt.Operator {
@@ -279,13 +278,6 @@ func (e *ProjectionsItem) SetChild(nth int, child opt.Expr) {
 
 func (e *ProjectionsItem) DataType() *types.T {
 	return e.Typ
-}
-
-func (e *ProjectionsItem) ScalarProps(mem *Memo) *props.Scalar {
-	if !e.scalar.Populated {
-		mem.logPropsBuilder.buildProjectionsItemProps(e, &e.scalar)
-	}
-	return &e.scalar
 }
 
 type ColPrivate struct {
@@ -397,8 +389,9 @@ func (m *Memo) MemoizeProject(
 			m.newGroupFn(e)
 		}
 		m.logPropsBuilder.buildProjectProps(e, &grp.rel)
+		grp.rel.Populated = true
 		m.memEstimate += size
-		m.checkExpr(e)
+		m.CheckExpr(e)
 	}
 	return interned.FirstExpr()
 }
@@ -409,7 +402,7 @@ func (m *Memo) AddProjectToGroup(e *ProjectExpr, grp RelExpr) *ProjectExpr {
 	if interned == e {
 		e.setGroup(grp)
 		m.memEstimate += size
-		m.checkExpr(e)
+		m.CheckExpr(e)
 	} else if interned.group() != grp.group() {
 		// This is a group collision, do nothing.
 		return nil

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -22,15 +22,19 @@ define InnerJoinApply {
     On    FiltersExpr
 }
 
-[Scalar, Boolean, List]
+[Scalar, Bool, List]
 define Filters {
 }
 
-[Scalar, Boolean, ListItem]
+[Scalar, Bool, ListItem, ScalarProps]
 define FiltersItem {
     Condition ScalarExpr
+}
 
-    scalar ScalarProps
+[Scalar, ListItem]
+define KVOptionsItem {
+    Value ScalarExpr
+    Key   string
 }
 
 [PushSelectIntoJoinLeft, Normalize]
@@ -136,6 +140,24 @@ func (_f *Factory) ConstructInnerJoinApply(
 	return _f.onConstructRelational(e)
 }
 
+// ConstructFiltersItem constructs an expression for the FiltersItem operator.
+func (_f *Factory) ConstructFiltersItem(
+	condition opt.ScalarExpr,
+) memo.FiltersItem {
+	item := memo.FiltersItem{Condition: condition}
+	item.PopulateProps(_f.mem)
+	return item
+}
+
+// ConstructKVOptionsItem constructs an expression for the KVOptionsItem operator.
+func (_f *Factory) ConstructKVOptionsItem(
+	value opt.ScalarExpr,
+	key string,
+) memo.KVOptionsItem {
+	item := memo.KVOptionsItem{Value: value, Key: key}
+	return item
+}
+
 // Replace enables an expression subtree to be rewritten under the control of
 // the caller. It passes each child of the given expression to the replace
 // callback. The caller can continue traversing the expression tree within the
@@ -205,7 +227,7 @@ func (f *Factory) replaceFiltersExpr(list memo.FiltersExpr, replace ReplaceFunc)
 				newList = make([]memo.FiltersItem, len(list))
 				copy(newList, list[:i])
 			}
-			newList[i].Condition = after
+			newList[i] = f.ConstructFiltersItem(after)
 		} else if newList != nil {
 			newList[i] = list[i]
 		}
@@ -250,6 +272,8 @@ func (f *Factory) copyAndReplaceDefaultFiltersExpr(src memo.FiltersExpr, replace
 	dst = make(memo.FiltersExpr, len(src))
 	for i := range src {
 		dst[i].Condition = f.invokeReplace(src[i].Condition, replace).(opt.ScalarExpr)
+		dst[i].PopulateProps(f.mem)
+		f.mem.CheckExpr(&dst[i])
 	}
 	return dst
 }

--- a/pkg/sql/opt/optgen/exprgen/custom_funcs.go
+++ b/pkg/sql/opt/optgen/exprgen/custom_funcs.go
@@ -130,28 +130,6 @@ func (c *customFuncs) FindTable(name string) opt.TableID {
 	return res
 }
 
-// ProjectionItem creates a ProjectionItem. A list of such items can be used as
-// a ProjectionsExpr.
-func (c *customFuncs) ProjectionItem(
-	element opt.ScalarExpr, col opt.ColumnID,
-) memo.ProjectionsItem {
-	return memo.ProjectionsItem{
-		Element:    element,
-		ColPrivate: memo.ColPrivate{Col: col},
-		Typ:        c.mem.Metadata().ColumnMeta(col).Type,
-	}
-}
-
-// AggregationsItem creates an AggregationsItem. A list of such items can be used as
-// an AggregationsExpr.
-func (c *customFuncs) AggregationsItem(agg opt.ScalarExpr, col opt.ColumnID) memo.AggregationsItem {
-	return memo.AggregationsItem{
-		Agg:        agg,
-		ColPrivate: memo.ColPrivate{Col: col},
-		Typ:        c.mem.Metadata().ColumnMeta(col).Type,
-	}
-}
-
 // Ordering parses a string like "+a,-b" into an Ordering.
 func (c *customFuncs) Ordering(str string) opt.Ordering {
 	defer func() {

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -262,7 +262,7 @@ func (eg *exprGen) castToDesiredType(arg interface{}, desiredType reflect.Type) 
 				if !ok {
 					return nil
 				}
-				return memo.FiltersItem{Condition: expr}
+				return eg.f.ConstructFiltersItem(expr)
 			})
 			if converted != nil {
 				return converted

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -26,7 +26,7 @@ expr
     [ (Tuple [ (Const 1) ] "tuple{int}" ) ]
     [ (Cols [ (NewColumn "x" "int") ]) ]
   )
-  [ (ProjectionItem (Plus (Var "x") (Const 10)) (NewColumn "y" "int")) ]
+  [ (ProjectionsItem (Plus (Var "x") (Const 10)) (NewColumn "y" "int")) ]
   "x"
 )
 ----

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -13,8 +13,6 @@ package props
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
 )
 
 // AvailableRuleProps is a bit set that indicates when lazily-populated Rule
@@ -51,6 +49,10 @@ const (
 // Shared are properties that are shared by both relational and scalar
 // expressions.
 type Shared struct {
+	// Populated is set to true once the properties have been built for the
+	// operator.
+	Populated bool
+
 	// OuterCols is the set of columns that are referenced by variables within
 	// this sub-expression, but are not bound within the scope of the expression.
 	// For example:
@@ -339,10 +341,6 @@ type Relational struct {
 type Scalar struct {
 	Shared
 
-	// Populated is set to true once the scalar properties have been set, usually
-	// triggered by a call to the ScalarPropsExpr.ScalarProps interface.
-	Populated bool
-
 	// Constraints is the set of constraints deduced from a boolean expression.
 	// For the expression to be true, all constraints in the set must be
 	// satisfied.
@@ -424,81 +422,4 @@ func (s *Scalar) IsAvailable(p AvailableRuleProps) bool {
 // mark them as populated on this scalar properties instance.
 func (s *Scalar) SetAvailable(p AvailableRuleProps) {
 	s.Rule.Available |= p
-}
-
-// Verify runs consistency checks against the shared properties, in order to
-// ensure that they conform to several invariants:
-//
-//   1. If HasCorrelatedSubquery is true, then HasSubquery must be true as well.
-//
-func (s *Shared) Verify() {
-	if s.HasCorrelatedSubquery && !s.HasSubquery {
-		panic(errors.AssertionFailedf("HasSubquery cannot be false if HasCorrelatedSubquery is true"))
-	}
-	if s.CanMutate && !s.CanHaveSideEffects {
-		panic(errors.AssertionFailedf("CanHaveSideEffects cannot be false if CanMutate is true"))
-	}
-}
-
-// Verify runs consistency checks against the relational properties, in order to
-// ensure that they conform to several invariants:
-//
-//   1. Functional dependencies are internally consistent.
-//   2. Not null columns are a subset of output columns.
-//   3. Outer columns do not intersect output columns.
-//   4. If functional dependencies indicate that the relation can have at most
-//      one row, then the cardinality reflects that as well.
-//
-func (r *Relational) Verify() {
-	r.Shared.Verify()
-	r.FuncDeps.Verify()
-
-	if !r.NotNullCols.SubsetOf(r.OutputCols) {
-		panic(errors.AssertionFailedf("not null cols %s not a subset of output cols %s",
-			log.Safe(r.NotNullCols), log.Safe(r.OutputCols)))
-	}
-	if r.OuterCols.Intersects(r.OutputCols) {
-		panic(errors.AssertionFailedf("outer cols %s intersect output cols %s",
-			log.Safe(r.OuterCols), log.Safe(r.OutputCols)))
-	}
-	if r.FuncDeps.HasMax1Row() {
-		if r.Cardinality.Max > 1 {
-			panic(errors.AssertionFailedf(
-				"max cardinality must be <= 1 if FDs have max 1 row: %s", r.Cardinality))
-		}
-	}
-	if r.IsAvailable(PruneCols) {
-		if !r.Rule.PruneCols.SubsetOf(r.OutputCols) {
-			panic(errors.AssertionFailedf("prune cols %s must be a subset of output cols %s",
-				log.Safe(r.Rule.PruneCols), log.Safe(r.OutputCols)))
-		}
-	}
-}
-
-// VerifyAgainst checks that the two properties don't contradict each other.
-// Used for testing (e.g. to cross-check derived properties from expressions in
-// the same group).
-func (r *Relational) VerifyAgainst(other *Relational) {
-	if !r.OutputCols.Equals(other.OutputCols) {
-		panic(errors.AssertionFailedf("output cols mismatch: %s vs %s", log.Safe(r.OutputCols), log.Safe(other.OutputCols)))
-	}
-
-	if r.Cardinality.Max < other.Cardinality.Min ||
-		r.Cardinality.Min > other.Cardinality.Max {
-		panic(errors.AssertionFailedf("cardinality mismatch: %s vs %s", log.Safe(r.Cardinality), log.Safe(other.Cardinality)))
-	}
-
-	// NotNullCols, FuncDeps are best effort, so they might differ.
-	// OuterCols, CanHaveSideEffects, and HasPlaceholder might differ if a
-	// subexpression containing them was elided.
-}
-
-// Verify runs consistency checks against the relational properties, in order to
-// ensure that they conform to several invariants:
-//
-//   1. Functional dependencies are internally consistent.
-//
-func (s *Scalar) Verify() {
-	s.Shared.Verify()
-	s.FuncDeps.Verify()
 }

--- a/pkg/sql/opt/props/verify.go
+++ b/pkg/sql/opt/props/verify.go
@@ -1,0 +1,100 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build race
+
+package props
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// Verify runs consistency checks against the shared properties, in order to
+// ensure that they conform to several invariants:
+//
+//   1. The properties must have been built.
+//   2. If HasCorrelatedSubquery is true, then HasSubquery must be true as well.
+//   3. If Mutate is true, then CanHaveSideEffects must also be true.
+//
+func (s *Shared) Verify() {
+	if !s.Populated {
+		panic(errors.AssertionFailedf("properties are not populated"))
+	}
+	if s.HasCorrelatedSubquery && !s.HasSubquery {
+		panic(errors.AssertionFailedf("HasSubquery cannot be false if HasCorrelatedSubquery is true"))
+	}
+	if s.CanMutate && !s.CanHaveSideEffects {
+		panic(errors.AssertionFailedf("CanHaveSideEffects cannot be false if CanMutate is true"))
+	}
+}
+
+// Verify runs consistency checks against the relational properties, in order to
+// ensure that they conform to several invariants:
+//
+//   1. Functional dependencies are internally consistent.
+//   2. Not null columns are a subset of output columns.
+//   3. Outer columns do not intersect output columns.
+//   4. If functional dependencies indicate that the relation can have at most
+//      one row, then the cardinality reflects that as well.
+//
+func (r *Relational) Verify() {
+	r.Shared.Verify()
+	r.FuncDeps.Verify()
+
+	if !r.NotNullCols.SubsetOf(r.OutputCols) {
+		panic(errors.AssertionFailedf("not null cols %s not a subset of output cols %s",
+			log.Safe(r.NotNullCols), log.Safe(r.OutputCols)))
+	}
+	if r.OuterCols.Intersects(r.OutputCols) {
+		panic(errors.AssertionFailedf("outer cols %s intersect output cols %s",
+			log.Safe(r.OuterCols), log.Safe(r.OutputCols)))
+	}
+	if r.FuncDeps.HasMax1Row() {
+		if r.Cardinality.Max > 1 {
+			panic(errors.AssertionFailedf(
+				"max cardinality must be <= 1 if FDs have max 1 row: %s", r.Cardinality))
+		}
+	}
+	if r.IsAvailable(PruneCols) {
+		if !r.Rule.PruneCols.SubsetOf(r.OutputCols) {
+			panic(errors.AssertionFailedf("prune cols %s must be a subset of output cols %s",
+				log.Safe(r.Rule.PruneCols), log.Safe(r.OutputCols)))
+		}
+	}
+}
+
+// VerifyAgainst checks that the two properties don't contradict each other.
+// Used for testing (e.g. to cross-check derived properties from expressions in
+// the same group).
+func (r *Relational) VerifyAgainst(other *Relational) {
+	if !r.OutputCols.Equals(other.OutputCols) {
+		panic(errors.AssertionFailedf("output cols mismatch: %s vs %s", log.Safe(r.OutputCols), log.Safe(other.OutputCols)))
+	}
+
+	if r.Cardinality.Max < other.Cardinality.Min ||
+		r.Cardinality.Min > other.Cardinality.Max {
+		panic(errors.AssertionFailedf("cardinality mismatch: %s vs %s", log.Safe(r.Cardinality), log.Safe(other.Cardinality)))
+	}
+
+	// NotNullCols, FuncDeps are best effort, so they might differ.
+	// OuterCols, CanHaveSideEffects, and HasPlaceholder might differ if a
+	// subexpression containing them was elided.
+}
+
+// Verify runs consistency checks against the relational properties, in order to
+// ensure that they conform to several invariants:
+//
+//   1. Functional dependencies are internally consistent.
+//
+func (s *Scalar) Verify() {
+	s.Shared.Verify()
+	s.FuncDeps.Verify()
+}

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -242,7 +242,7 @@ func (o *Optimizer) optimizeExpr(
 	case memo.ScalarPropsExpr:
 		// Short-circuit traversal of scalar expressions with no nested subquery,
 		// since there's only one possible tree.
-		if !t.ScalarProps(o.mem).HasSubquery {
+		if !t.ScalarProps().HasSubquery {
 			return 0, true
 		}
 		return o.optimizeScalarExpr(t)
@@ -686,7 +686,7 @@ func (o *Optimizer) setLowestCostTree(parent opt.Expr, parentProps *physical.Req
 	case memo.ScalarPropsExpr:
 		// Short-circuit traversal of scalar expressions with no nested subquery,
 		// since there's only one possible tree.
-		if !t.ScalarProps(o.mem).HasSubquery {
+		if !t.ScalarProps().HasSubquery {
 			return parent
 		}
 	}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -106,12 +106,12 @@ func TestDetachMemoRace(t *testing.T) {
 				if sel, ok := e.(*memo.SelectExpr); ok {
 					return f.ConstructSelect(
 						f.CopyAndReplaceDefault(sel.Input, replaceFn).(memo.RelExpr),
-						memo.FiltersExpr{{
-							Condition: f.ConstructEq(
+						memo.FiltersExpr{f.ConstructFiltersItem(
+							f.ConstructEq(
 								f.ConstructVariable(col),
 								f.ConstructConst(tree.NewDInt(10)),
 							),
-						}},
+						)},
 					)
 				}
 				return f.CopyAndReplaceDefault(e, replaceFn)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -489,7 +489,7 @@ memo (optimized, ~5KB, required=[presentation: min:5])
 memo
 SELECT min(b) FROM abc
 ----
-memo (optimized, ~5KB, required=[presentation: min:5])
+memo (optimized, ~6KB, required=[presentation: min:5])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: min:5]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -551,7 +551,7 @@ memo (optimized, ~5KB, required=[presentation: max:5])
 memo
 SELECT max(b) FROM abc
 ----
-memo (optimized, ~5KB, required=[presentation: max:5])
+memo (optimized, ~6KB, required=[presentation: max:5])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:5]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -640,7 +640,7 @@ scalar-group-by
 memo
 SELECT max(b) FROM abc
 ----
-memo (optimized, ~5KB, required=[presentation: max:5])
+memo (optimized, ~6KB, required=[presentation: max:5])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:5]
  │         ├── best: (scalar-group-by G2 G3 cols=())

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -430,7 +430,7 @@ inner-join (hash)
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~10KB, required=[presentation: s:1,t:2,u:3,s:4,t:5,u:6])
+memo (optimized, ~11KB, required=[presentation: s:1,t:2,u:3,s:4,t:5,u:6])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+4,+5,+6) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+6,+5,+4) (lookup-join G2 G5 stu,keyCols=[1 2 3],outCols=(1-6)) (lookup-join G2 G5 stu@uts,keyCols=[3 2 1],outCols=(1-6)) (merge-join G3 G2 G5 inner-join,+4,+5,+6,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+6,+5,+4,+3,+2,+1) (lookup-join G3 G5 stu,keyCols=[4 5 6],outCols=(1-6)) (lookup-join G3 G5 stu@uts,keyCols=[6 5 4],outCols=(1-6))
  │    └── [presentation: s:1,t:2,u:3,s:4,t:5,u:6]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +4,+5,+6]" G5 inner-join,+1,+2,+3,+4,+5,+6)
@@ -2042,7 +2042,7 @@ inner-join (lookup t5)
 memo
 SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
 ----
-memo (optimized, ~13KB, required=[presentation: a:1])
+memo (optimized, ~14KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -135,7 +135,7 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~31KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+memo (optimized, ~32KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8)) (lookup-join G12 G11 abc,keyCols=[11],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))
@@ -354,7 +354,7 @@ memo (optimized, ~12KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
 memo join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+memo (optimized, ~28KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G6 G5 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G16 G15 G4)
  │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -39,7 +39,7 @@ scan a
 memo
 SELECT k FROM a WHERE k = 1
 ----
-memo (optimized, ~4KB, required=[presentation: k:1])
+memo (optimized, ~5KB, required=[presentation: k:1])
  ├── G1: (select G2 G3) (scan a,cols=(1),constrained)
  │    └── [presentation: k:1]
  │         ├── best: (scan a,cols=(1),constrained)


### PR DESCRIPTION
This PR contains two commits that cleanup the usage and packaging
of the optimizer.

NOTE: From now on, list item expressions need to be constructed using
Factory rather than via direct construction of the struct.