### PR TITLE
storage/engine: clarify the MVCC history tests

### DIFF
--- a/pkg/storage/engine/testdata/mvcc_histories/put_with_txn
+++ b/pkg/storage/engine/testdata/mvcc_histories/put_with_txn
@@ -2,7 +2,7 @@ run ok
 with t=A k=k
   txn_begin ts=0,1
   put  v=v
-  get
+  get  ts=0,1
   get  ts=0,2
   get  ts=1
 ----


### PR DESCRIPTION
Suggested by @petermattis in https://github.com/cockroachdb/cockroach/pull/42250#pullrequestreview-332593782.
This clarifies the `get` timestamps in `put_with_txn`.

Release note: None