### PR TITLE
Add transactions to sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1316,7 +1316,7 @@ func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
 			ctx, "find live node", 5*time.Second,
 			func(ctx context.Context) error {
 				db = c.Conn(ctx, i)
-				_, err := db.ExecContext(ctx, `SELECT 1`)
+				_, err := db.ExecContext(ctx, `;`)
 				return err
 			},
 		); err != nil {

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -97,6 +97,9 @@ var (
 		{10, makeDelete},
 		{10, makeUpdate},
 		{1, makeAlter},
+		{1, makeBegin},
+		{2, makeRollback},
+		{6, makeCommit},
 	}
 	nonMutatingStatements = statementWeights{
 		{10, makeSelect},
@@ -921,6 +924,18 @@ func (s *Smither) makeUpdateReturning(refs colRefs) (tree.TableExpr, colRefs, bo
 func makeInsert(s *Smither) (tree.Statement, bool) {
 	stmt, _, ok := s.makeInsert(nil)
 	return stmt, ok
+}
+
+func makeBegin(s *Smither) (tree.Statement, bool) {
+	return &tree.BeginTransaction{}, true
+}
+
+func makeCommit(s *Smither) (tree.Statement, bool) {
+	return &tree.CommitTransaction{}, true
+}
+
+func makeRollback(s *Smither) (tree.Statement, bool) {
+	return &tree.RollbackTransaction{}, true
 }
 
 // makeInsert has only one valid reference: its table source, which can be


### PR DESCRIPTION
Sqlsmith will sometimes emit `begin`, `commit`, and `rollback`.

Release note: None