### PR TITLE
sqlsmith: add support for multi-use CTEs.

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -35,10 +35,6 @@ type aliasedTableRef struct {
 
 type tableRefs []*tableRef
 
-func (t tableRefs) Pop() (*tableRef, tableRefs) {
-	return t[0], t[1:]
-}
-
 // ReloadSchemas loads tables from the database.
 func (s *Smither) ReloadSchemas() error {
 	if s.db == nil {


### PR DESCRIPTION
The ability to reference the same CTE multiple times in the same query was
added in #38670. This patch removes the work-around in sqlsmith that was
tracking already-used CTEs and preventing them from reuse. This change has
already surfaced issue #43148.

Release note: None