### PR TITLE
tree: allow string concat with any non-array type (init approach)

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -415,6 +415,7 @@
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
+<tr><td><a href="bool.html">bool</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
@@ -422,42 +423,73 @@
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date</a></td><td><a href="date.html">date[]</a></td></tr>
 <tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
 <tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float</a></td><td><a href="float.html">float[]</a></td></tr>
 <tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
 <tr><td><a href="inet.html">inet</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet</a></td><td><a href="inet.html">inet[]</a></td></tr>
 <tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int</a></td><td><a href="int.html">int[]</a></td></tr>
 <tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
+<tr><td>jsonb <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td>oid <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="date.html">date</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="decimal.html">decimal</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="float.html">float</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="inet.html">inet</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="int.html">int</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> jsonb</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> oid</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="time.html">time</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="timestamp.html">timestamp</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="timestamp.html">timestamptz</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> timetz</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> tuple</td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="uuid.html">uuid</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> varbit</td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="time.html">time</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="time.html">time</a> <code>||</code> <a href="time.html">time[]</a></td><td><a href="time.html">time[]</a></td></tr>
 <tr><td><a href="time.html">time[]</a> <code>||</code> <a href="time.html">time</a></td><td><a href="time.html">time[]</a></td></tr>
 <tr><td><a href="time.html">time[]</a> <code>||</code> <a href="time.html">time[]</a></td><td><a href="time.html">time[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> timestamptz</td><td>timestamptz</td></tr>
 <tr><td>timestamptz <code>||</code> <a href="timestamp.html">timestamptz</a></td><td>timestamptz</td></tr>
 <tr><td>timestamptz <code>||</code> timestamptz</td><td>timestamptz</td></tr>
+<tr><td>timetz <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>timetz <code>||</code> timetz</td><td>timetz</td></tr>
+<tr><td>tuple <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="uuid.html">uuid</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
+<tr><td>varbit <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td>varbit <code>||</code> varbit</td><td>varbit</td></tr>
 </tbody></table>
 <table><thead>

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -19,3 +19,25 @@ eval
 array['foo'] || '{a,b}'
 ----
 ARRAY['foo','a','b']
+
+# String || any; any || String
+
+eval
+'b' || (5)::char || (8)::char || 'c'
+----
+'b58c'
+
+eval
+3 || 'a' || 3
+----
+'3a3'
+
+eval
+3::oid || 'a' || 3::oid
+----
+'3a3'
+
+eval
+3.33 || 'a' || 3.33
+----
+'3.33a3.33'


### PR DESCRIPTION
Refs #41872. This solution involves no edits to the type system.

Previously, the || concat operator only worked on string pairs. Postgres
supports concatenation between strings and any other non-array type. This
patch adds support for that as well.

Release note (sql change): the concatenation operator || is now usable
between strings and any other non-array type.