### PR TITLE
opt: use transitive equalities to infer filters

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -65,8 +65,12 @@
         ...
         $item:* &
             ^(FiltersItem (Eq (Variable) (Variable))) &
-            (CanMapJoinOpFilter $on $item $left) &
-            (CanMapJoinOpFilter $on $item $right)
+            (CanMapJoinOpFilter
+                $item
+                $leftCols:(OutputCols $left)
+                $equivFD:(GetEquivFD $on $left $right)
+            ) &
+            (CanMapJoinOpFilter $item $rightCols:(OutputCols $right) $equivFD)
         ...
     ]
     $private:*
@@ -75,11 +79,11 @@
 ((OpName)
     (Select
         $left
-        [ (FiltersItem (MapJoinOpFilter $on $item $left)) ]
+        [ (FiltersItem (MapJoinOpFilter $item $leftCols $equivFD)) ]
     )
     (Select
         $right
-        [ (FiltersItem (MapJoinOpFilter $on $item $right)) ]
+        [ (FiltersItem (MapJoinOpFilter $item $rightCols $equivFD)) ]
     )
     (RemoveFiltersItem $on $item)
     $private
@@ -108,8 +112,8 @@
         ...
         $item:* &
             ^(FiltersItem (Eq (Variable) (Variable))) &
-            ^(IsBoundBy $item (OutputCols $left)) &
-            (CanMapJoinOpFilter $on $item $left)
+            ^(IsBoundBy $item $leftCols:(OutputCols $left)) &
+            (CanMapJoinOpFilter $item $leftCols $equivFD:(GetEquivFD $on $left $right))
         ...
     ]
     $private:*
@@ -118,7 +122,7 @@
 ((OpName)
     $left
     $right
-    (ReplaceFiltersItem $on $item (MapJoinOpFilter $on $item $left))
+    (ReplaceFiltersItem $on $item (MapJoinOpFilter $item $leftCols $equivFD))
     $private
 )
 
@@ -134,8 +138,8 @@
         ...
         $item:* &
             ^(FiltersItem (Eq (Variable) (Variable))) &
-            ^(IsBoundBy $item (OutputCols $right)) &
-            (CanMapJoinOpFilter $on $item $right)
+            ^(IsBoundBy $item $rightCols:(OutputCols $right)) &
+            (CanMapJoinOpFilter $item $rightCols $equivFD:(GetEquivFD $on $left $right))
         ...
     ]
     $private:*
@@ -144,7 +148,7 @@
 ((OpName)
     $left
     $right
-    (ReplaceFiltersItem $on $item (MapJoinOpFilter $on $item $right))
+    (ReplaceFiltersItem $on $item (MapJoinOpFilter $item $rightCols $equivFD))
     $private
 )
 

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -170,7 +170,11 @@
         ...
         $item:(FiltersItem $condition:*) &
             (IsBoundBy $item (OutputCols $left)) &
-            (CanMapJoinOpFilter $on $item $right)
+            (CanMapJoinOpFilter
+                $item
+                $rightCols:(OutputCols $right)
+                $equivFD:(GetEquivFD $on $left $right)
+            )
         ...
     ]
 )
@@ -183,7 +187,7 @@
         )
         (Select
             $right
-            [ (FiltersItem (MapJoinOpFilter $on $item $right)) ]
+            [ (FiltersItem (MapJoinOpFilter $item $rightCols $equivFD)) ]
         )
         $on
         $private
@@ -210,7 +214,11 @@
         ...
         $item:(FiltersItem $condition:*) &
             (IsBoundBy $item (OutputCols $right)) &
-            (CanMapJoinOpFilter $on $item $left)
+            (CanMapJoinOpFilter
+                $item
+                $leftCols:(OutputCols $left)
+                $equivFD:(GetEquivFD $on $left $right)
+            )
         ...
     ]
 )
@@ -219,7 +227,7 @@
     ((OpName $input)
         (Select
             $left
-            [ (FiltersItem (MapJoinOpFilter $on $item $left)) ]
+            [ (FiltersItem (MapJoinOpFilter $item $leftCols $equivFD)) ]
         )
         (Select
             $right

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1120,6 +1120,103 @@ inner-join (merge)
                 │         └── const: 5 [type=int]
                 └── variable: k [type=int]
 
+# Regression test for #43039. Use transitive equalities for filter inference.
+norm expect=PushFilterIntoJoinLeftAndRight
+SELECT
+    *
+FROM
+    a
+    JOIN b ON a.k = b.x
+    JOIN c ON b.x = c.x
+    JOIN d ON c.x = d.x
+    JOIN xy ON d.x = xy.x
+WHERE
+    a.k = 3;
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int) x:8(int!null) y:9(int!null) z:10(int!null) x:11(int!null) y:12(int!null) z:13(int!null) x:14(int!null) y:15(int)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-15)
+ ├── inner-join (hash)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int) c.x:8(int!null) c.y:9(int!null) c.z:10(int!null) d.x:11(int!null) d.y:12(int!null) d.z:13(int!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-13)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int) c.x:8(int!null) c.y:9(int!null) c.z:10(int!null)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1-10)
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1-7)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters
+ │    │    │    │         └── k = 3 [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: b.x:6(int!null) b.y:7(int)
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(6,7)
+ │    │    │    │    ├── scan b
+ │    │    │    │    │    ├── columns: b.x:6(int!null) b.y:7(int)
+ │    │    │    │    │    ├── key: (6)
+ │    │    │    │    │    └── fd: (6)-->(7)
+ │    │    │    │    └── filters
+ │    │    │    │         └── b.x = 3 [type=bool, outer=(6), constraints=(/6: [/3 - /3]; tight), fd=()-->(6)]
+ │    │    │    └── filters
+ │    │    │         └── k = b.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │    ├── select
+ │    │    │    ├── columns: c.x:8(int!null) c.y:9(int!null) c.z:10(int!null)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(8-10)
+ │    │    │    ├── scan c
+ │    │    │    │    ├── columns: c.x:8(int!null) c.y:9(int!null) c.z:10(int!null)
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    └── fd: (8)-->(9,10)
+ │    │    │    └── filters
+ │    │    │         └── c.x = 3 [type=bool, outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
+ │    │    └── filters
+ │    │         └── b.x = c.x [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │    ├── select
+ │    │    ├── columns: d.x:11(int!null) d.y:12(int!null) d.z:13(int!null)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(11-13)
+ │    │    ├── scan d
+ │    │    │    ├── columns: d.x:11(int!null) d.y:12(int!null) d.z:13(int!null)
+ │    │    │    ├── key: (11)
+ │    │    │    └── fd: (11)-->(12,13)
+ │    │    └── filters
+ │    │         └── d.x = 3 [type=bool, outer=(11), constraints=(/11: [/3 - /3]; tight), fd=()-->(11)]
+ │    └── filters
+ │         └── c.x = d.x [type=bool, outer=(8,11), constraints=(/8: (/NULL - ]; /11: (/NULL - ]), fd=(8)==(11), (11)==(8)]
+ ├── select
+ │    ├── columns: xy.x:14(int!null) xy.y:15(int)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(14,15)
+ │    ├── scan xy
+ │    │    ├── columns: xy.x:14(int!null) xy.y:15(int)
+ │    │    ├── key: (14)
+ │    │    └── fd: (14)-->(15)
+ │    └── filters
+ │         └── xy.x = 3 [type=bool, outer=(14), constraints=(/14: [/3 - /3]; tight), fd=()-->(14)]
+ └── filters
+      └── d.x = xy.x [type=bool, outer=(11,14), constraints=(/11: (/NULL - ]; /14: (/NULL - ]), fd=(11)==(14), (14)==(11)]
+
 # ---------------------------------
 # MapEqualityIntoJoinLeftAndRight
 # ---------------------------------


### PR DESCRIPTION
Previously, the optimizer was not inferring all possible filters
based on equality conditions. For example, consider a query such
as:
```
SELECT * FROM t
JOIN u ON t.a = u.a
JOIN v ON u.a = v.a
JOIN w ON v.a = w.a
WHERE t.a = 5;
```
Ideally, the optimizer should infer additional filter conditions
`u.a = 5 AND v.a = 5 AND w.a = 5` based on the equality conditions.
However, this was not occurring because the optimizer only considered
equality conditions that were at the same level in the query tree as the
filter to be mapped. Now the optimizer also considers equality conditions
that are further down in the tree, so that additional filters can
be inferred based on transitive equalities.

Informs #43039

Release note (performance improvement): The optimizer can now infer
additional filter conditions in some cases based on transitive equalities
between columns.