### PR TITLE
execinfra: adjust logging of pushed rows

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -233,7 +233,7 @@ func (h *ProcOutputHelper) EmitRow(
 	}
 
 	if log.V(3) {
-		log.InfofDepth(ctx, 1, "pushing row %s", outRow)
+		log.InfofDepth(ctx, 1, "pushing row %s", outRow.String(h.OutputTypes))
 	}
 	if r := h.output.Push(outRow, nil); r != NeedMoreRows {
 		log.VEventf(ctx, 1, "no more rows required. drain requested: %t",
@@ -275,7 +275,7 @@ func (h *ProcOutputHelper) ProcessRow(
 			return nil, false, err
 		}
 		if !passes {
-			if log.V(3) {
+			if log.V(4) {
 				log.Infof(ctx, "filtered out row %s", row.String(h.filter.Types))
 			}
 			return nil, true, nil
@@ -708,6 +708,9 @@ func (pb *ProcessorBase) ProcessRowHelper(row sqlbase.EncDatumRow) sqlbase.EncDa
 		pb.MoveToDraining(nil /* err */)
 	}
 	// Note that outRow might be nil here.
+	if outRow != nil && log.V(3) {
+		log.InfofDepth(pb.Ctx, 1, "pushing row %s", outRow.String(pb.Out.OutputTypes))
+	}
 	return outRow
 }
 


### PR DESCRIPTION
This commit adds the logging of non-nil rows during the call to
ProcessRowHelper (which most processors are using to emit the row). This
will occur with verbose level 3. The commit also adjusts the logging of
filtering out a row from level 3 to level 4.

Release note: None