### PR TITLE
ui: add changefeed retryable errors graph to web ui

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -44,5 +44,11 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.node.changefeed.flush_nanos" title="Flush Time" nonNegativeRate />
       </Axis>
     </LineGraph>,
+
+    <LineGraph title="Changefeed Restarts" sources={storeSources}>
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric name="cr.node.changefeed.error_retries" title="Retryable Errors" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
   ];
 }


### PR DESCRIPTION
We were keeping a metric for how many times changefeeds restart due to
retryable errors, but were not exposing this in the admin ui. This would
have helped a lot in debugging a recent chagnefeed issue in the reg
server.

Release note (admin ui change): A graph of changefeed restarts due to
retryable errors is now included in the web ui.