### PR TITLE
sql: stop swallowing errors from UncachedPhysicalAccessor.IsValidSchema

### DIFF
--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -102,7 +102,10 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	flags tree.DatabaseListFlags,
 ) (TableNames, error) {
 	ok, schemaID, err := a.IsValidSchema(ctx, txn, dbDesc.ID, scName)
-	if !ok || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		if flags.Required {
 			tn := tree.MakeTableNameWithSchema(tree.Name(dbDesc.Name), tree.Name(scName), "")
 			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(&tn.TableNamePrefix))


### PR DESCRIPTION
Before this commit we'd swallow retriable errors during execution. This can
be very problematic as it can lead to lost writes and other general funkiness.
We're opting to not write a test for this specific case as there is ongoing
work to change interfaces to preclude this sort of bug.

Fixes #43067
Fixes https://github.com/cockroachdb/cockroach/issues/37883#issuecomment-566279109

Release note: None