### PR TITLE
cdctest: perform txn retries in validator

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -127,7 +127,7 @@ type beforeAfterValidator struct {
 func NewBeforeAfterValidator(sqlDB *gosql.DB, table string) (Validator, error) {
 	primaryKeyCols, err := fetchPrimaryKeyCols(sqlDB, table)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetchPrimaryKeyCols failed")
 	}
 
 	return &beforeAfterValidator{
@@ -346,7 +346,11 @@ func (v *fingerprintValidator) NoteRow(
 }
 
 // applyRowUpdate applies the update represented by `row` to the scratch table.
-func (v *fingerprintValidator) applyRowUpdate(row validatorRow) error {
+func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
+	defer func() {
+		_err = errors.Wrap(_err, "fingerprintValidator failed")
+	}()
+
 	txn, err := v.sqlDB.Begin()
 	if err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -351,12 +351,7 @@ func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
 		_err = errors.Wrap(_err, "fingerprintValidator failed")
 	}()
 
-	txn, err := v.sqlDB.Begin()
-	if err != nil {
-		return err
-	}
 	var args []interface{}
-
 	var primaryKeyDatums []interface{}
 	if err := gojson.Unmarshal([]byte(row.key), &primaryKeyDatums); err != nil {
 		return err
@@ -423,13 +418,8 @@ func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
 			args = append(args, datum)
 		}
 	}
-	if _, err := txn.Exec(stmtBuf.String(), args...); err != nil {
-		return err
-	}
-	if err := txn.Commit(); err != nil {
-		return err
-	}
-	return nil
+	_, err := v.sqlDB.Exec(stmtBuf.String(), args...)
+	return err
 }
 
 // NoteResolved implements the Validator interface.

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -27,8 +27,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 	"github.com/codahale/hdrhistogram"
-	"github.com/pkg/errors"
 )
 
 type workloadType string
@@ -298,10 +298,15 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		if atomic.LoadInt64(&doneAtomic) > 0 {
 			return nil
 		}
-		return err
+		return errors.Wrap(err, "workload failed")
 	})
-	m.Go(func(ctx context.Context) error {
+	m.Go(func(ctx context.Context) (_err error) {
 		defer workloadCancel()
+
+		defer func() {
+			_err = errors.Wrap(_err, "CDC failed")
+		}()
+
 		l, err := t.l.ChildLogger(`changefeed`)
 		if err != nil {
 			return err
@@ -317,13 +322,13 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		if _, err := db.Exec(
 			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,
 		); err != nil {
-			return err
+			return errors.Wrap(err, "CREATE TABLE failed")
 		}
 
 		const requestedResolved = 100
 		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions, 0)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "error creating validator")
 		}
 		validators := cdctest.Validators{
 			cdctest.NewOrderValidator(`bank`),
@@ -366,7 +371,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 			}
 		}
 		if failures := v.Failures(); len(failures) > 0 {
-			return errors.New(strings.Join(failures, "\n"))
+			return errors.New("validator failures:\n" + strings.Join(failures, "\n"))
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -672,6 +672,7 @@ func (k kafkaManager) basePath() string {
 }
 
 func (k kafkaManager) install(ctx context.Context) {
+	k.c.status("installing kafka")
 	folder := k.basePath()
 	k.c.Run(ctx, k.nodes, `mkdir -p `+folder)
 	k.c.Run(ctx, k.nodes, `curl -s https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz | tar -xz -C `+folder)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -785,9 +785,12 @@ func (p clusterReusePolicyOption) apply(spec *clusterSpec) {
 //
 // A cluster is safe for concurrent use by multiple goroutines.
 type cluster struct {
-	name   string
-	tag    string
-	spec   clusterSpec
+	name string
+	tag  string
+	spec clusterSpec
+	// status is used to communicate the test's status. The callback is a noop
+	// until the cluster is passed to a test, at which point it's hooked up to
+	// test.Status().
 	status func(...interface{})
 	t      testI
 	// r is the registry tracking this cluster. Destroying the cluster will


### PR DESCRIPTION
Before this patch, fingerprintValidator.applyRowUpdate() was missing a
retry loop around its sql txn. But turns out that the txn was not needed
at all since we're running a single statement.

Fixes #42773