### PR TITLE
backupccl: stop swallowing error in restoreResumer.OnFailOrCancel()

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1790,7 +1790,7 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) er
 		tableDesc.State = sqlbase.TableDescriptor_DROP
 		err := sqlbase.RemovePublicTableNamespaceEntry(ctx, txn, tbl.ParentID, tbl.Name)
 		if err != nil {
-			return nil
+			return errors.Wrap(err, "dropping tables")
 		}
 		existingDescVal, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, tbl)
 		if err != nil {


### PR DESCRIPTION
In `restoreResumer.OnFailOrCancel()` we'd return nil when encountering a
non-nil error in a call to `sqlbase.RemovePublicTableNamespaceEntry()`.
Error handling in `jobs.Resumer.OnFailOrCancel()` is a tricky proposition but
this behavior is certainly wrong.

Release note: None