### PR TITLE
colexec: minor cleanup

### DIFF
--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -207,11 +207,13 @@ func TestAndOrOps(t *testing.T) {
 								RenderExprs: []execinfrapb.Expression{{Expr: fmt.Sprintf("@1 %s @2", test.operation)}},
 							},
 						}
-						result, err := NewColOperator(
-							ctx, flowCtx, spec, input, testMemAcc,
-							true, /* useStreamingMemAccountForBuffering */
-							nil,  /* processorConstructor */
-						)
+						args := NewColOperatorArgs{
+							Spec:                               spec,
+							Inputs:                             input,
+							StreamingMemAccount:                testMemAcc,
+							UseStreamingMemAccountForBuffering: true,
+						}
+						result, err := NewColOperator(ctx, flowCtx, args)
 						if err != nil {
 							return nil, err
 						}
@@ -276,11 +278,13 @@ func benchmarkLogicalProjOp(
 		},
 	}
 
-	result, err := NewColOperator(
-		ctx, flowCtx, spec, []Operator{input}, testMemAcc,
-		true, /* useStreamingMemAccountForBuffering */
-		nil,  /* processorConstructor */
-	)
+	args := NewColOperatorArgs{
+		Spec:                               spec,
+		Inputs:                             []Operator{input},
+		StreamingMemAccount:                testMemAcc,
+		UseStreamingMemAccountForBuffering: true,
+	}
+	result, err := NewColOperator(ctx, flowCtx, args)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -82,11 +82,13 @@ func TestCaseOp(t *testing.T) {
 		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(inputs []Operator) (Operator, error) {
 			spec.Input[0].ColumnTypes = tc.inputTypes
 			spec.Post.RenderExprs[0].Expr = tc.renderExpr
-			result, err := NewColOperator(
-				ctx, flowCtx, spec, inputs, testMemAcc,
-				true, /* useStreamingMemAccountForBuffering */
-				nil,  /* processorConstructor */
-			)
+			args := NewColOperatorArgs{
+				Spec:                               spec,
+				Inputs:                             inputs,
+				StreamingMemAccount:                testMemAcc,
+				UseStreamingMemAccountForBuffering: true,
+			}
+			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -151,10 +151,17 @@ func newNotVectorizedInternalError(err error) *notVectorizedInternalError {
 
 // VectorizedInternalPanic simply panics with the provided object. It will
 // always be returned as internal error to the client with the corresponding
-// stack trace. This method should be called to propagate all unexpected errors
-// that originated within the vectorized engine.
+// stack trace. This method should be called to propagate all *unexpected*
+// errors that originated within the vectorized engine.
 func VectorizedInternalPanic(err interface{}) {
 	panic(err)
+}
+
+// VectorizedExpectedInternalPanic is the same as NonVectorizedPanic. It should
+// be called to propagate all *expected* errors that originated within the
+// vectorized engine.
+func VectorizedExpectedInternalPanic(err error) {
+	NonVectorizedPanic(err)
 }
 
 // NonVectorizedPanic panics with the error that is wrapped by

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -917,11 +917,13 @@ func TestHashJoiner(t *testing.T) {
 			typs := [][]coltypes.T{tc.leftTypes, tc.rightTypes}
 			runTestsWithTyps(t, inputs, typs, tc.expectedTuples, unorderedVerifier, func(sources []Operator) (Operator, error) {
 				spec := createSpecForHashJoiner(tc)
-				result, err := NewColOperator(
-					ctx, flowCtx, spec, sources, testMemAcc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := NewColOperatorArgs{
+					Spec:                               spec,
+					Inputs:                             sources,
+					StreamingMemAccount:                testMemAcc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
 				}
@@ -1132,11 +1134,13 @@ func TestHashJoinerProjection(t *testing.T) {
 
 	leftSource := newOpTestInput(1, leftTuples, leftColTypes)
 	rightSource := newOpTestInput(1, rightTuples, rightColTypes)
-	hjOp, err := NewColOperator(
-		ctx, flowCtx, spec, []Operator{leftSource, rightSource}, testMemAcc,
-		true, /* useStreamingMemAccountForBuffering */
-		nil,  /* processorConstructor */
-	)
+	args := NewColOperatorArgs{
+		Spec:                               spec,
+		Inputs:                             []Operator{leftSource, rightSource},
+		StreamingMemAccount:                testMemAcc,
+		UseStreamingMemAccountForBuffering: true,
+	}
+	hjOp, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
 	hjOp.Op.Init()
 	for {

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -99,11 +99,13 @@ func TestIsNullProjOp(t *testing.T) {
 						},
 					},
 				}
-				result, err := NewColOperator(
-					ctx, flowCtx, spec, input, testMemAcc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := NewColOperatorArgs{
+					Spec:                               spec,
+					Inputs:                             input,
+					StreamingMemAccount:                testMemAcc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
 				}
@@ -187,11 +189,13 @@ func TestIsNullSelOp(t *testing.T) {
 						Filter: execinfrapb.Expression{Expr: fmt.Sprintf("@1 %s", selExpr)},
 					},
 				}
-				result, err := NewColOperator(
-					ctx, flowCtx, spec, input, testMemAcc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := NewColOperatorArgs{
+					Spec:                               spec,
+					Inputs:                             input,
+					StreamingMemAccount:                testMemAcc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1645,11 +1645,13 @@ func TestMergeJoiner(t *testing.T) {
 		runner(t, []tuples{tc.leftTuples, tc.rightTuples}, nil /* typs */, tc.expected, mergeJoinVerifier,
 			func(input []Operator) (Operator, error) {
 				spec := createSpecForMergeJoiner(tc)
-				result, err := NewColOperator(
-					ctx, flowCtx, spec, input, testMemAcc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := NewColOperatorArgs{
+					Spec:                               spec,
+					Inputs:                             input,
+					StreamingMemAccount:                testMemAcc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -139,11 +139,13 @@ func TestRank(t *testing.T) {
 					Windower: &tc.windowerSpec,
 				},
 			}
-			result, err := NewColOperator(
-				ctx, flowCtx, spec, inputs, testMemAcc,
-				true, /* useStreamingMemAccountForBuffering */
-				nil,  /* processorConstructor */
-			)
+			args := NewColOperatorArgs{
+				Spec:                               spec,
+				Inputs:                             inputs,
+				StreamingMemAccount:                testMemAcc,
+				UseStreamingMemAccountForBuffering: true,
+			}
+			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err
 			}
@@ -211,11 +213,13 @@ func TestRowNumber(t *testing.T) {
 					Windower: &tc.windowerSpec,
 				},
 			}
-			result, err := NewColOperator(
-				ctx, flowCtx, spec, inputs, testMemAcc,
-				true, /* useStreamingMemAccountForBuffering */
-				nil,  /* processorConstructor */
-			)
+			args := NewColOperatorArgs{
+				Spec:                               spec,
+				Inputs:                             inputs,
+				StreamingMemAccount:                testMemAcc,
+				UseStreamingMemAccountForBuffering: true,
+			}
+			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -78,11 +78,12 @@ func BenchmarkColBatchScan(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				res, err := colexec.NewColOperator(
-					ctx, &flowCtx, &spec, nil /* inputs */, testMemAcc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := colexec.NewColOperatorArgs{
+					Spec:                               &spec,
+					StreamingMemAccount:                testMemAcc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				res, err := colexec.NewColOperator(ctx, &flowCtx, args)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -281,10 +281,8 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 	// after Next returns a zero-length batch during normal execution.
 	if err := i.maybeInitLocked(ctx); err != nil {
 		// An error occurred while initializing the Inbox and is likely caused by
-		// the connection issues. We propagate the error as a "non-vectorized
-		// panic" so that the whole stack trace is not printed out (as an
-		// unexpected vectorized error) and the sentry issue is not reported.
-		execerror.NonVectorizedPanic(err)
+		// the connection issues. It is expected that such an error can occur.
+		execerror.VectorizedExpectedInternalPanic(err)
 	}
 
 	for {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -708,11 +708,13 @@ func (s *vectorizedFlowCreator) setupFlow(
 			inputs = append(inputs, input)
 		}
 
-		result, err := colexec.NewColOperator(
-			ctx, flowCtx, pspec, inputs, s.newStreamingMemAccount(flowCtx),
-			false, /* useStreamingMemAccountForBuffering */
-			rowexec.NewProcessor,
-		)
+		args := colexec.NewColOperatorArgs{
+			Spec:                 pspec,
+			Inputs:               inputs,
+			StreamingMemAccount:  s.newStreamingMemAccount(flowCtx),
+			ProcessorConstructor: rowexec.NewProcessor,
+		}
+		result, err := colexec.NewColOperator(ctx, flowCtx, args)
 		// Even when err is non-nil, it is possible that the buffering memory
 		// monitor and account have been created, so we always want to accumulate
 		// them for a proper cleanup.

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -92,11 +92,13 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()
 				defer acc.Close(ctx)
-				result, err := colexec.NewColOperator(
-					ctx, flowCtx, tc.spec, inputs, &mon.BoundAccount{},
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := colexec.NewColOperatorArgs{
+					Spec:                               tc.spec,
+					Inputs:                             inputs,
+					StreamingMemAccount:                &acc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := colexec.NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -200,11 +202,13 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()
 				defer acc.Close(ctx)
-				result, err := colexec.NewColOperator(
-					ctx, flowCtx, tc.spec, inputs, &acc,
-					true, /* useStreamingMemAccountForBuffering */
-					nil,  /* processorConstructor */
-				)
+				args := colexec.NewColOperatorArgs{
+					Spec:                               tc.spec,
+					Inputs:                             inputs,
+					StreamingMemAccount:                &acc,
+					UseStreamingMemAccountForBuffering: true,
+				}
+				result, err := colexec.NewColOperator(ctx, flowCtx, args)
 				require.NoError(t, err)
 				err = execerror.CatchVectorizedRuntimeError(func() {
 					result.Op.Init()

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -87,11 +87,13 @@ func verifyColOperator(
 		columnarizers[i] = c
 	}
 
-	result, err := colexec.NewColOperator(
-		ctx, flowCtx, pspec, columnarizers, &acc,
-		true, /* useStreamingMemAccountForBuffering */
-		nil,  /* processorConstructor */
-	)
+	args := colexec.NewColOperatorArgs{
+		Spec:                               pspec,
+		Inputs:                             columnarizers,
+		StreamingMemAccount:                &acc,
+		UseStreamingMemAccountForBuffering: true,
+	}
+	result, err := colexec.NewColOperator(ctx, flowCtx, args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**colexec: add VectorizedExpectedInternalPanic method**

This method should be used to propagate the errors that are expected to
occur. It will prevent the print out of the stack trace as well as
filing of the sentry issue. So far only errors during Inbox.Init() are
classified as "expected vectorized errors."

Release note: None

**colexec: extract args to NewColOperator into a helper struct**

The argument list of NewColOperator has gotten quite big. This commit
extracts all arguments (except for contexts) into a helper struct.

Release note: None