### PR TITLE
backupccl: change the error code for "file already exists" errors

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -938,7 +938,7 @@ func VerifyUsableExportTarget(
 		// TODO(dt): If we audit exactly what not-exists error each ExternalStorage
 		// returns (and then wrap/tag them), we could narrow this check.
 		r.Close()
-		return pgerror.Newf(pgcode.DuplicateFile,
+		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file",
 			readable, BackupDescriptorName)
 	}
@@ -946,13 +946,13 @@ func VerifyUsableExportTarget(
 		// TODO(dt): If we audit exactly what not-exists error each ExternalStorage
 		// returns (and then wrap/tag them), we could narrow this check.
 		r.Close()
-		return pgerror.Newf(pgcode.DuplicateFile,
+		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file",
 			readable, BackupManifestName)
 	}
 	if r, err := exportStore.ReadFile(ctx, BackupDescriptorCheckpointName); err == nil {
 		r.Close()
-		return pgerror.Newf(pgcode.DuplicateFile,
+		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file (is another operation already in progress?)",
 			readable, BackupDescriptorCheckpointName)
 	}

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -222,6 +222,7 @@ const (
 	InvalidSchemaDefinition            = "42P15"
 	InvalidTableDefinition             = "42P16"
 	InvalidObjectDefinition            = "42P17"
+	FileAlreadyExists                  = "42C01"
 	// Class 44 - WITH CHECK OPTION Violation
 	WithCheckOptionViolation = "44000"
 	// Class 53 - Insufficient Resources


### PR DESCRIPTION
The backup code used to use a class 58 error code ("system error") for
situations where a backup target already exists - DuplicateFile. Class
58 is the wrong one, particularly since we've started using 58 errors to
represent errors about the state of the cluster (range unavailable,
dropped connections). So clients should treat 58 errors as retriable
(and for example the scaledata tests do).  This patch switches to a new
code in "Class 42 - Syntax or Access Rule Violation".

It's hard to imagine that Postgres returns the 58 code for anything
related to user input.

Release note (sql change): The error code for backups which would
overwrite files changed from class 58 ("system") to class 42 ("Syntax or
Access Rule Violation").