### PR TITLE
sql: fix some issue links

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -183,7 +183,7 @@ SELECT bar FROM foo WHERE bar->'a' = '"b"'::JSON
 ----
 {"a": "b"}
 
-statement error pgcode 0A000 can't order by column type jsonb.*\nHINT.*\n.*32706
+statement error pgcode 0A000 can't order by column type jsonb.*\nHINT.*\n.*35706
 SELECT bar FROM foo ORDER BY bar
 
 statement error pgcode 0A000 column k is of type jsonb and thus is not indexable

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -255,9 +255,9 @@ func (b *Builder) analyzeExtraArgument(
 func ensureColumnOrderable(e tree.TypedExpr) {
 	typ := e.ResolvedType()
 	if typ.Family() == types.ArrayFamily {
-		panic(unimplementedWithIssueDetailf(32707, "", "can't order by column type %s", typ))
+		panic(unimplementedWithIssueDetailf(35707, "", "can't order by column type %s", typ))
 	}
 	if typ.Family() == types.JsonFamily {
-		panic(unimplementedWithIssueDetailf(32706, "", "can't order by column type jsonb"))
+		panic(unimplementedWithIssueDetailf(35706, "", "can't order by column type jsonb"))
 	}
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -402,7 +403,7 @@ func (b *Builder) buildScalar(
 		if b.AllowUnsupportedExpr {
 			out = b.factory.ConstructUnsupportedExpr(scalar)
 		} else {
-			panic(unimplementedWithIssueDetailf(34848, fmt.Sprintf("%T", scalar), "not yet implemented: scalar expression: %T", scalar))
+			panic(unimplemented.Newf(fmt.Sprintf("optbuilder.%T", scalar), "not yet implemented: scalar expression: %T", scalar))
 		}
 	}
 


### PR DESCRIPTION
Found by @mjibson.
 
The code was incorrectly referencing irrelevant issues 32707 and
32706, as well as closed issue 34848.

(Note that we likely need a better process to prevent this kind of mistake from now on.)

Release note (bug fix): Some incorrect issue links referenced to by
error hints have been corrected.