### PR TITLE
ui: Navigation panel redesign

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
@@ -38,7 +38,7 @@ export default class NeedEnterpriseLicense extends React.Component<NodeCanvasCon
       <section className="need-license">
         <div className="need-license-blurb">
           <div>
-            <h1 className="need-license-blurb__header">View the Node Map</h1>
+            <h1 className="base-heading need-license-blurb__header">View the Node Map</h1>
             <p className="need-license-blurb__text">
               The Node Map shows the geographical layout of your cluster, along
               with metrics and health indicators. To enable the Node Map,

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -130,5 +130,8 @@
   "engines": {
     "node": ">=6",
     "yarn": ">=1.7.0"
-  }
+  },
+  "browserslist": [
+    "defaults"
+  ]
 }

--- a/pkg/ui/src/components/badge/badge.styl
+++ b/pkg/ui/src/components/badge/badge.styl
@@ -56,3 +56,8 @@
 .badge__text
   order 1
   margin auto
+
+.badge__text--no-wrap
+  text-overflow ellipsis
+  white-space nowrap
+  overflow hidden

--- a/pkg/ui/src/components/badge/badge.tsx
+++ b/pkg/ui/src/components/badge/badge.tsx
@@ -35,7 +35,7 @@ export function Badge(props: BadgeProps) {
   return (
     <div className={classes}>
       { icon && <div className={iconClasses}>{icon}</div> }
-      <div className="badge__text">
+      <div className="badge__text badge__text--no-wrap">
         { text }
       </div>
     </div>

--- a/pkg/ui/src/components/index.ts
+++ b/pkg/ui/src/components/index.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+export * from "./badge";
 export * from "./icon";
 export * from "./globalNavigation";
 export * from "./sideNavigation";

--- a/pkg/ui/src/components/index.ts
+++ b/pkg/ui/src/components/index.ts
@@ -12,7 +12,7 @@ export * from "./badge";
 export * from "./icon";
 export * from "./globalNavigation";
 export * from "./sideNavigation";
-export * from "./tabNavigation";
+export * from "./pageHeader";
 export * from "./text";
 export * from "./table";
 export * from "./tooltip";

--- a/pkg/ui/src/components/pageHeader/index.ts
+++ b/pkg/ui/src/components/pageHeader/index.ts
@@ -8,4 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./tabNavigation";
+export * from "./pageHeader";

--- a/pkg/ui/src/components/pageHeader/pageHeader.styl
+++ b/pkg/ui/src/components/pageHeader/pageHeader.styl
@@ -8,18 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as React from "react";
+@require '~src/components/core/index.styl'
 
-import "./tabNavigation.styl";
+.page-header
+  height 100%
+  display flex
+  flex-direction row
+  align-items center
 
-export interface TabNavigationProps {
-  children?: React.ReactNode;
-}
-
-export function TabNavigation(props: TabNavigationProps) {
-  return (
-    <div className="tab-navigation">
-      {props.children}
-    </div>
-  );
-}
+.page-header > *
+  margin-right $spacing-small

--- a/pkg/ui/src/components/pageHeader/pageHeader.styl
+++ b/pkg/ui/src/components/pageHeader/pageHeader.styl
@@ -14,7 +14,9 @@
   height 100%
   display flex
   flex-direction row
+  flex-flow wrap
   align-items center
+  padding $spacing-x-small 0
 
 .page-header > *
   margin-right $spacing-small

--- a/pkg/ui/src/components/pageHeader/pageHeader.styl
+++ b/pkg/ui/src/components/pageHeader/pageHeader.styl
@@ -18,3 +18,4 @@
 
 .page-header > *
   margin-right $spacing-small
+  margin-bottom 0

--- a/pkg/ui/src/components/pageHeader/pageHeader.tsx
+++ b/pkg/ui/src/components/pageHeader/pageHeader.tsx
@@ -8,13 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require '~src/components/core/index.styl'
+import * as React from "react";
 
-.tab-navigation
-  height 100%
-  display flex
-  flex-direction row
-  align-items center
+import "./pageHeader.styl";
 
-.tab-navigation > *
-  margin-right $spacing-small
+export interface PageHeaderProps {
+  children?: React.ReactNode;
+}
+
+export function PageHeader(props: PageHeaderProps) {
+  return (
+    <div className="page-header">
+      {props.children}
+    </div>
+  );
+}

--- a/pkg/ui/src/components/tabNavigation/tabNavigation.styl
+++ b/pkg/ui/src/components/tabNavigation/tabNavigation.styl
@@ -14,5 +14,7 @@
   height 100%
   display flex
   flex-direction row
-  justify-content space-between
   align-items center
+
+.tab-navigation > *
+  margin-right $spacing-small

--- a/pkg/ui/src/components/text/text.styl
+++ b/pkg/ui/src/components/text/text.styl
@@ -36,3 +36,8 @@
 
 .text--disabled
   color $colors--disabled
+
+.text--no-wrap
+  text-overflow ellipsis
+  white-space nowrap
+  overflow hidden

--- a/pkg/ui/src/components/text/text.tsx
+++ b/pkg/ui/src/components/text/text.tsx
@@ -18,6 +18,7 @@ export interface TextProps {
   disabled?: boolean;
   children: React.ReactNode;
   className?: string;
+  noWrap?: boolean;
 }
 
 export enum TextTypes {
@@ -87,15 +88,17 @@ Text.defaultProps = {
   textType: TextTypes.Body,
   disabled: false,
   className: "",
+  noWrap: false,
 };
 
 export function Text(props: TextProps) {
-  const { textType, disabled, className } = props;
+  const { textType, disabled, noWrap, className } = props;
   const textTypeClass = cn(
     "text",
     getClassByTextType(textType),
     {
       "text--disabled": disabled,
+      "text--no-wrap": noWrap,
     },
     className,
   );

--- a/pkg/ui/src/components/text/text.tsx
+++ b/pkg/ui/src/components/text/text.tsx
@@ -60,6 +60,29 @@ const getClassByTextType = (textType: TextTypes) => {
   }
 };
 
+const getElementByTextType = (textType: TextTypes) => {
+  switch (textType) {
+    case TextTypes.Heading1:
+      return "h1";
+    case TextTypes.Heading2:
+      return "h2";
+    case TextTypes.Heading3:
+      return "h3";
+    case TextTypes.Heading4:
+      return "h4";
+    case TextTypes.Heading5:
+      return "h5";
+    case TextTypes.Heading6:
+      return "h6";
+    case TextTypes.Body:
+    case TextTypes.BodyStrong:
+    case TextTypes.Caption:
+    case TextTypes.CaptionStrong:
+    default:
+      return "span";
+  }
+};
+
 Text.defaultProps = {
   textType: TextTypes.Body,
   disabled: false,
@@ -76,9 +99,11 @@ export function Text(props: TextProps) {
     },
     className,
   );
-  return (
-    <span className={textTypeClass}>
-      {props.children}
-    </span>
-  );
+  const elementName = getElementByTextType(textType);
+
+  const componentProps = {
+    className: textTypeClass,
+  };
+
+  return React.createElement(elementName, componentProps, props.children);
 }

--- a/pkg/ui/src/redux/alerts.spec.ts
+++ b/pkg/ui/src/redux/alerts.spec.ts
@@ -21,11 +21,11 @@ import { AdminUIState, createAdminUIStore } from "./state";
 import {
   AlertLevel,
   alertDataSync,
-  versionsSelector,
   staggeredVersionWarningSelector, staggeredVersionDismissedSetting,
   newVersionNotificationSelector, newVersionDismissedLocalSetting,
   disconnectedAlertSelector, disconnectedDismissedLocalSetting,
 } from "./alerts";
+import { versionsSelector } from "src/redux/nodes";
 import {
   VERSION_DISMISSED_KEY, INSTRUCTIONS_BOX_COLLAPSED_KEY,
   setUIDataKey, isInFlight,

--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -25,7 +25,7 @@ import {
   saveUIData, loadUIData, isInFlight, UIDataState, UIDataStatus,
 } from "./uiData";
 import { refreshCluster, refreshNodes, refreshVersion, refreshHealth } from "./apiReducers";
-import { nodeStatusesSelector, livenessByNodeIDSelector } from "./nodes";
+import { singleVersionSelector, versionsSelector } from "src/redux/nodes";
 import { AdminUIState } from "./state";
 import * as docsURL from "src/util/docs";
 
@@ -106,23 +106,6 @@ export function setInstructionsBoxCollapsed(collapsed: boolean) {
 ////////////////////////////////////////
 export const staggeredVersionDismissedSetting = new LocalSetting(
   "staggered_version_dismissed", localSettingsSelector, false,
-);
-
-export const versionsSelector = createSelector(
-  nodeStatusesSelector,
-  livenessByNodeIDSelector,
-  (nodeStatuses, livenessStatusByNodeID) =>
-    _.chain(nodeStatuses)
-      // Ignore nodes for which we don't have any build info.
-      .filter((status) => !!status.build_info )
-      // Exclude this node if it's known to be decommissioning.
-      .filter((status) => !status.desc ||
-                          !livenessStatusByNodeID[status.desc.node_id] ||
-                          !livenessStatusByNodeID[status.desc.node_id].decommissioning)
-      // Collect the surviving nodes' build tags.
-      .map((status) => status.build_info.tag)
-      .uniq()
-      .value(),
 );
 
 /**
@@ -280,18 +263,6 @@ export const bannerAlertsSelector = createSelector(
   disconnectedAlertSelector,
   (...alerts: Alert[]): Alert[] => {
     return _.without(alerts, null, undefined);
-  },
-);
-
-// Select the current build version of the cluster, returning undefined if the
-// cluster's version is currently staggered.
-const singleVersionSelector = createSelector(
-  versionsSelector,
-  (builds) => {
-    if (!builds || builds.length !== 1) {
-      return undefined;
-    }
-    return builds[0];
   },
 );
 

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -14,7 +14,7 @@ import _ from "lodash";
 import { Store } from "redux";
 
 import * as protos from "src/js/protos";
-import { versionsSelector } from "src/redux/alerts";
+import { versionsSelector } from "src/redux/nodes";
 import { store, history, AdminUIState } from "src/redux/state";
 import { COCKROACHLABS_ADDR } from "src/util/cockroachlabsAPI";
 

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -55,6 +55,18 @@ type NodeStatusState = Pick<AdminUIState, "cachedData", "nodes">;
 export const nodeStatusesSelector = (state: NodeStatusState) => state.cachedData.nodes.data;
 
 /*
+ * clusterSelector returns information about cluster.
+ */
+export const clusterSelector = (state: AdminUIState) => state.cachedData.cluster.data;
+
+/*
+ * clusterIdSelector returns Cluster Id (as UUID string).
+ */
+export const clusterIdSelector = createSelector(
+  clusterSelector,
+  (clusterInfo) => clusterInfo && clusterInfo.cluster_id,
+);
+/*
  * selectNodeRequestStatus returns the current status of the node status request.
  */
 export function selectNodeRequestStatus(state: AdminUIState) {
@@ -297,6 +309,41 @@ export type NodesSummary = typeof nodesSummaryType;
 export function selectNodesSummaryValid(state: AdminUIState) {
   return state.cachedData.nodes.valid && state.cachedData.liveness.valid;
 }
+
+interface ClusterDetails {
+  clusterName: string;
+  clusterVersion: string;
+}
+
+/*
+ * clusterInfoSelector returns the information about cluster which is a part
+ * of metadata on nodes of current cluster.
+ */
+export const clusterInfoSelector = createSelector(
+  nodeStatusesSelector,
+  livenessStatusByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID): ClusterDetails => {
+    if (_.isUndefined(nodeStatuses) || _.isEmpty(livenessStatusByNodeID)) {
+      return {
+        clusterVersion: undefined,
+        clusterName: undefined,
+      };
+    }
+    const liveNodesOnCluster = nodeStatuses.filter(
+      nodeStatus => livenessStatusByNodeID[nodeStatus.desc.node_id] === LivenessStatus.LIVE);
+
+    const nodesWithUniqClusterNames = _.chain(liveNodesOnCluster)
+      .filter(node => !_.isEmpty(node.desc.cluster_name))
+      .uniqBy(node => node.desc.cluster_name)
+      .value();
+
+    const nodesWithUniqClusterVersions = _.uniqBy(liveNodesOnCluster, node => node.desc.ServerVersion);
+    const { major_val, minor_val, patch, unstable } = nodesWithUniqClusterVersions[0].desc.ServerVersion;
+    return {
+      clusterName: nodesWithUniqClusterNames.length > 0 ? nodesWithUniqClusterNames[0].desc.cluster_name : undefined,
+      clusterVersion: [major_val, minor_val, patch, unstable].join("."),
+    };
+  });
 
 /**
  * partitionedStatuses divides the list of node statuses into "live" and "dead".

--- a/pkg/ui/src/views/app/components/NotFound/index.tsx
+++ b/pkg/ui/src/views/app/components/NotFound/index.tsx
@@ -13,7 +13,7 @@ import React from "react";
 function NotFound() {
   return (
     <div className="section">
-      <h1>Page Not Found</h1>
+      <h1 className="base-heading">Page Not Found</h1>
     </div>
   );
 }

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -8,171 +8,47 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import classNames from "classnames";
-import _ from "lodash";
 import React from "react";
 import { connect } from "react-redux";
-import PropTypes from "prop-types";
-import { Link } from "react-router";
+import { Link, withRouter, WithRouterProps } from "react-router";
 
-import { AdminUIState } from "src/redux/state";
-import { selectLoginState, LoginState, doLogout } from "src/redux/login";
-import { cockroachIcon } from "src/views/shared/components/icons";
-import { trustIcon } from "src/util/trust";
-import UserAvatar from "src/views/shared/components/userAvatar";
-import UserMenu from "src/views/app/components/userMenu";
-import Popover from "src/views/shared/components/popover";
-
-import homeIcon from "!!raw-loader!assets/sidebarIcons/home.svg";
-import metricsIcon from "!!raw-loader!assets/sidebarIcons/metrics.svg";
-import databasesIcon from "!!raw-loader!assets/sidebarIcons/databases.svg";
-import jobsIcon from "!!raw-loader!assets/sidebarIcons/jobs.svg";
-import statementsIcon from "!!raw-loader!assets/sidebarIcons/statements.svg";
-import unlockedIcon from "!!raw-loader!assets/unlocked.svg";
-import gearIcon from "!!raw-loader!assets/sidebarIcons/gear.svg";
+import { SideNavigation } from "src/toolbox";
 
 import "./navigation-bar.styl";
-
-interface IconLinkProps {
-  icon: string;
-  title?: string;
-  to: string;
-  activeFor?: string | string[];
-  className?: string;
-}
-
-/**
- * IconLink creats a react router Link which contains both a graphical icon and
- * a string title.
- */
-class IconLink extends React.Component<IconLinkProps, {}> {
-  static defaultProps: Partial<IconLinkProps> = {
-    className: "normal",
-    activeFor: [],
-  };
-
-  static contextTypes = {
-    router: PropTypes.object,
-  };
-
-  render() {
-    const { icon, title, to, activeFor, className } = this.props;
-
-    const router = this.context.router;
-    const linkRoutes = [to].concat(activeFor);
-    const isActive = _.some(linkRoutes, (route) => router.isActive(route, false));
-    const linkClassName = classNames("icon-link", { active: isActive });
-    return (
-      <li className={className} >
-        <Link to={to} className={linkClassName}>
-          <div className="image-container"
-               dangerouslySetInnerHTML={trustIcon(icon)}/>
-          <div>{title}</div>
-        </Link>
-      </li>
-    );
-  }
-}
-
-interface LoginIndicatorProps {
-  loginState: LoginState;
-  handleLogout: () => null;
-}
-
-interface LoginIndicatorState {
-  isOpenMenu: boolean;
-}
-
-class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicatorState> {
-  constructor(props: LoginIndicatorProps) {
-    super(props);
-    this.state = {
-      isOpenMenu: false,
-    };
-  }
-
-  onUserMenuToggle = (nextState: boolean) => {
-    this.setState({
-      isOpenMenu: nextState,
-    });
-  }
-
-  render() {
-    const { loginState, handleLogout } = this.props;
-    const { isOpenMenu } = this.state;
-    if (!loginState.useLogin()) {
-      return null;
-    }
-
-    if (!loginState.loginEnabled()) {
-      return (
-        <li className="login-indicator login-indicator--insecure">
-          <div className="image-container"
-               dangerouslySetInnerHTML={trustIcon(unlockedIcon)}/>
-          <div>Insecure mode</div>
-        </li>
-      );
-    }
-
-    const user = loginState.loggedInUser();
-    if (user == null) {
-      return null;
-    }
-
-    return (
-      <li className="login-indicator">
-        <Popover
-          content={<UserAvatar userName={user} />}
-          visible={isOpenMenu}
-          onVisibleChange={this.onUserMenuToggle}
-        >
-          <UserMenu
-            userName={user}
-            onLogoutClick={handleLogout}/>
-        </Popover>
-      </li>
-    );
-  }
-}
-
-// tslint:disable-next-line:variable-name
-const LoginIndicatorConnected = connect(
-  (state: AdminUIState) => ({
-    loginState: selectLoginState(state),
-  }),
-  (dispatch) => ({
-    handleLogout: () => {
-      dispatch(doLogout());
-    },
-  }),
-)(LoginIndicator);
 
 /**
  * Sidebar represents the static navigation sidebar available on all pages. It
  * displays a number of graphic icons representing available pages; the icon of
  * the page which is currently active will be highlighted.
  */
-export default class Sidebar extends React.Component {
-  static contextTypes = {
-    router: PropTypes.object,
-  };
+class Sidebar extends React.Component<{} & WithRouterProps> {
+  readonly routes = [
+    { path: "/overview", text: "Overview", activeFor: ["/node"] },
+    { path: "/metrics", text: "Metrics", activeFor: [] },
+    { path: "/databases", text: "Databases", activeFor: ["/database"] },
+    { path: "/statements", text: "Statements", activeFor: ["/statement"] },
+    { path: "/jobs", text: "Jobs", activeFor: [] },
+    { path: "/debug", text: "Advanced Debug", activeFor: ["/reports", "/data-distribution", "/raft"] },
+  ];
+
+  isActiveNavigationItem = (path: string): boolean => {
+    const { activeFor } = this.routes.find(route => route.path === path);
+    return [...activeFor, path].some(p => this.props.router.isActive(p));
+  }
 
   render() {
+    const navigationItems = this.routes.map(({ path, text }) => (
+      <SideNavigation.Item
+        isActive={this.isActiveNavigationItem(path)}>
+        <Link to={path}>{text}</Link>
+      </SideNavigation.Item>
+    ));
     return (
-      <nav className="navigation-bar">
-        <ul className="navigation-bar__list">
-          <IconLink to="/overview" icon={homeIcon} title="Overview" activeFor="/node" />
-          <IconLink to="/metrics" icon={metricsIcon} title="Metrics" />
-          <IconLink to="/databases" icon={databasesIcon} title="Databases" activeFor="/database" />
-          <IconLink to="/statements" icon={statementsIcon} title="Statements" activeFor="/statement" />
-          <IconLink to="/jobs" icon={jobsIcon} title="Jobs" />
-        </ul>
-        <ul className="navigation-bar__list navigation-bar__list--bottom">
-          <IconLink to="/debug" icon={gearIcon} className="normal debug-pages-link" activeFor={["/reports", "/data-distribution", "/raft"]} />
-          <LoginIndicatorConnected />
-          <IconLink to="/debug" icon={cockroachIcon} className="cockroach" />
-        </ul>
-      </nav>
+      <SideNavigation>
+        {navigationItems}
+      </SideNavigation>
     );
   }
 }
+
+export default connect(null, null)(withRouter(Sidebar));

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { Link, withRouter, WithRouterProps } from "react-router";
 
-import { SideNavigation } from "src/toolbox";
+import { SideNavigation } from "src/components";
 
 import "./navigation-bar.styl";
 

--- a/pkg/ui/src/views/app/components/loginIndicator/index.ts
+++ b/pkg/ui/src/views/app/components/loginIndicator/index.ts
@@ -8,22 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require "~styl/base/palette.styl"
-@require "~styl/base/layout-vars.styl"
+import LoginIndicator from "./loginIndicator";
 
-.popover
-  position absolute
-  z-index $z-index-tooltip
-  box-shadow: 0 0 4px 0 $popover-shadow-color
-  border-radius 4px
-  border: solid 0.5px $popover-border-color
-  display none
-  background-color white
-  right -20px
-  top 20px
-
-.popover--visible
-  display block
-
-.popover__content
-  cursor pointer
+export default LoginIndicator;

--- a/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.styl
+++ b/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.styl
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~src/toolbox/tokens/index.styl'
+
+.login-indicator
+
+.login-indicator--insecure
+  display flex
+  flex-direction row
+  color $colors--functional-yellow-4
+  text-transform uppercase
+  align-items center
+  cursor default
+
+  path
+    fill $colors--functional-yellow-4
+
+.login-indicator--insecure > div
+  margin-left $spacing-small

--- a/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.styl
+++ b/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.styl
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require '~src/toolbox/tokens/index.styl'
+@require '~src/components/core/index.styl'
 
 .login-indicator
 

--- a/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
+++ b/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
@@ -1,0 +1,96 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { connect } from "react-redux";
+
+import { AdminUIState } from "src/redux/state";
+import { trustIcon } from "src/util/trust";
+import Popover from "src/views/shared/components/popover";
+import UserAvatar from "src/views/shared/components/userAvatar";
+import UserMenu from "src/views/app/components/userMenu";
+import { doLogout, LoginState, selectLoginState } from "src/redux/login";
+
+import unlockedIcon from "!!raw-loader!assets/unlocked.svg";
+import "./loginIndicator.styl";
+
+interface LoginIndicatorProps {
+  loginState: LoginState;
+  handleLogout: () => null;
+}
+
+interface LoginIndicatorState {
+  isOpenMenu: boolean;
+}
+
+class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicatorState> {
+  constructor(props: LoginIndicatorProps) {
+    super(props);
+    this.state = {
+      isOpenMenu: false,
+    };
+  }
+
+  onUserMenuToggle = (nextState: boolean) => {
+    this.setState({
+      isOpenMenu: nextState,
+    });
+  }
+
+  render() {
+    const { loginState, handleLogout } = this.props;
+    const { isOpenMenu } = this.state;
+    if (!loginState.useLogin()) {
+      return null;
+    }
+
+    if (!loginState.loginEnabled()) {
+      return (
+        <div className="login-indicator login-indicator--insecure">
+          <div>Insecure mode</div>
+          <div className="image-container"
+               title="Insecure mode"
+               dangerouslySetInnerHTML={trustIcon(unlockedIcon)}/>
+        </div>
+      );
+    }
+
+    const user = loginState.loggedInUser();
+
+    if (user == null) {
+      return null;
+    }
+
+    return (
+      <div className="login-indicator">
+        <Popover
+          content={<UserAvatar userName={user} />}
+          visible={isOpenMenu}
+          onVisibleChange={this.onUserMenuToggle}
+        >
+          <UserMenu
+            userName={user}
+            onLogoutClick={handleLogout}/>
+        </Popover>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  (state: AdminUIState) => ({
+    loginState: selectLoginState(state),
+  }),
+  (dispatch) => ({
+    handleLogout: () => {
+      dispatch(doLogout());
+    },
+  }),
+)(LoginIndicator);

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -17,7 +17,7 @@ import NavigationBar from "src/views/app/components/layoutSidebar";
 import TimeWindowManager from "src/views/app/containers/timewindow";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import RequireLogin from "src/views/login/requireLogin";
-import { clusterIdSelector, clusterInfoSelector } from "src/redux/nodes";
+import { clusterIdSelector, clusterNameSelector, singleVersionSelector } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import LoginIndicator from "src/views/app/components/loginIndicator";
 import {
@@ -89,10 +89,9 @@ class Layout extends React.Component<LayoutProps & RouterState, {}> {
 }
 
 const mapStateToProps = (state: AdminUIState) => {
-  const { clusterName, clusterVersion } = clusterInfoSelector(state);
   return {
-    clusterName,
-    clusterVersion,
+    clusterName: clusterNameSelector(state),
+    clusterVersion: singleVersionSelector(state),
     clusterId: clusterIdSelector(state),
   };
 };

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -70,7 +70,9 @@ class Layout extends React.Component<LayoutProps & RouterState, {}> {
           </div>
           <div className="layout-panel__navigation-bar">
             <PageHeader>
-              <Text textType={TextTypes.Heading2}>{clusterName || `Cluster id: ${clusterId || ""}`}</Text>
+              <Text textType={TextTypes.Heading2} noWrap>
+                {clusterName || `Cluster id: ${clusterId || ""}`}
+              </Text>
               <Badge text={clusterVersion} />
             </PageHeader>
           </div>

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -70,7 +70,7 @@ class Layout extends React.Component<LayoutProps & RouterState, {}> {
           </div>
           <div className="layout-panel__navigation-bar">
             <TabNavigation>
-              <Text textType={TextTypes.Heading2}>{clusterName || clusterId}</Text>
+              <Text textType={TextTypes.Heading2}>{clusterName || `Cluster id: ${clusterId || ""}`}</Text>
               <Badge text={clusterVersion} />
             </TabNavigation>
           </div>

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -16,7 +16,7 @@ import NavigationBar from "src/views/app/components/layoutSidebar";
 import TimeWindowManager from "src/views/app/containers/timewindow";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import RequireLogin from "src/views/login/requireLogin";
-import { GlobalNavigation, CockroachLabsLockupIcon, Left, Right, TabNavigation, Text, TextTypes } from "src/toolbox";
+import { GlobalNavigation, CockroachLabsLockupIcon, Left, Right, TabNavigation, Text, TextTypes } from "src/components";
 import LoginIndicator from "src/views/app/components/loginIndicator";
 
 import "./layout.styl";

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -16,8 +16,11 @@ import NavigationBar from "src/views/app/components/layoutSidebar";
 import TimeWindowManager from "src/views/app/containers/timewindow";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import RequireLogin from "src/views/login/requireLogin";
+import { GlobalNavigation, CockroachLabsLockupIcon, Left, Right, TabNavigation, Text, TextTypes } from "src/toolbox";
+import LoginIndicator from "src/views/app/components/loginIndicator";
 
 import "./layout.styl";
+import "./layoutPanel.styl";
 
 /**
  * Defines the main layout of all admin ui pages. This includes static
@@ -29,12 +32,42 @@ export default class extends React.Component<RouterState, {}> {
   render() {
     return (
       <RequireLogin>
-        <Helmet titleTemplate="%s | Cockroach Console" defaultTitle="Cockroach Console" />
+        <Helmet
+          titleTemplate="%s | Cockroach Console"
+          defaultTitle="Cockroach Console"
+        />
         <TimeWindowManager/>
         <AlertBanner/>
-        <NavigationBar/>
-        <div className="page">
-          { this.props.children }
+        <div className="layout-panel">
+          <div className="layout-panel__header">
+            <GlobalNavigation>
+              <Left>
+                <CockroachLabsLockupIcon height={26} />
+              </Left>
+              <Right>
+                <LoginIndicator />
+              </Right>
+            </GlobalNavigation>
+          </div>
+          <div className="layout-panel__navigation-bar">
+            <TabNavigation>
+              <Text textType={TextTypes.Heading2}>Cluster - 01</Text>
+              <Text
+                textType={TextTypes.Body}
+                disabled
+              >
+                Cockroach version 19.2 / 12 regions / 54 machines
+              </Text>
+            </TabNavigation>
+          </div>
+          <div className="layout-panel__body">
+            <div className="layout-panel__sidebar">
+              <NavigationBar/>
+            </div>
+            <div className="layout-panel__content">
+              { this.props.children }
+            </div>
+          </div>
         </div>
       </RequireLogin>
     );

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -25,7 +25,7 @@ import {
   CockroachLabsLockupIcon,
   Left,
   Right,
-  TabNavigation,
+  PageHeader,
   Text,
   TextTypes,
   Badge,
@@ -69,10 +69,10 @@ class Layout extends React.Component<LayoutProps & RouterState, {}> {
             </GlobalNavigation>
           </div>
           <div className="layout-panel__navigation-bar">
-            <TabNavigation>
+            <PageHeader>
               <Text textType={TextTypes.Heading2}>{clusterName || `Cluster id: ${clusterId || ""}`}</Text>
               <Badge text={clusterVersion} />
-            </TabNavigation>
+            </PageHeader>
           </div>
           <div className="layout-panel__body">
             <div className="layout-panel__sidebar">

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -11,16 +11,34 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 import { RouterState } from "react-router";
+import { connect } from "react-redux";
 
 import NavigationBar from "src/views/app/components/layoutSidebar";
 import TimeWindowManager from "src/views/app/containers/timewindow";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import RequireLogin from "src/views/login/requireLogin";
-import { GlobalNavigation, CockroachLabsLockupIcon, Left, Right, TabNavigation, Text, TextTypes } from "src/components";
+import { clusterIdSelector, clusterInfoSelector } from "src/redux/nodes";
+import { AdminUIState } from "src/redux/state";
 import LoginIndicator from "src/views/app/components/loginIndicator";
+import {
+  GlobalNavigation,
+  CockroachLabsLockupIcon,
+  Left,
+  Right,
+  TabNavigation,
+  Text,
+  TextTypes,
+  Badge,
+} from "src/components";
 
 import "./layout.styl";
 import "./layoutPanel.styl";
+
+export interface LayoutProps {
+  clusterName: string;
+  clusterVersion: string;
+  clusterId: string;
+}
 
 /**
  * Defines the main layout of all admin ui pages. This includes static
@@ -28,8 +46,9 @@ import "./layoutPanel.styl";
  *
  * Individual pages provide their content via react-router.
  */
-export default class extends React.Component<RouterState, {}> {
+class Layout extends React.Component<LayoutProps & RouterState, {}> {
   render() {
+    const { clusterName, clusterVersion, clusterId } = this.props;
     return (
       <RequireLogin>
         <Helmet
@@ -51,13 +70,8 @@ export default class extends React.Component<RouterState, {}> {
           </div>
           <div className="layout-panel__navigation-bar">
             <TabNavigation>
-              <Text textType={TextTypes.Heading2}>Cluster - 01</Text>
-              <Text
-                textType={TextTypes.Body}
-                disabled
-              >
-                Cockroach version 19.2 / 12 regions / 54 machines
-              </Text>
+              <Text textType={TextTypes.Heading2}>{clusterName || clusterId}</Text>
+              <Badge text={clusterVersion} />
             </TabNavigation>
           </div>
           <div className="layout-panel__body">
@@ -73,3 +87,14 @@ export default class extends React.Component<RouterState, {}> {
     );
   }
 }
+
+const mapStateToProps = (state: AdminUIState) => {
+  const { clusterName, clusterVersion } = clusterInfoSelector(state);
+  return {
+    clusterName,
+    clusterVersion,
+    clusterId: clusterIdSelector(state),
+  };
+};
+
+export default connect(mapStateToProps)(Layout);

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -12,7 +12,6 @@
 
 $side-panel-width = 140px
 $top-bar-height = 50px
-$navigation-bar-height = 74px
 
 .layout-panel
   display flex
@@ -34,7 +33,6 @@ $navigation-bar-height = 74px
   margin 0 $spacing-small
 
 .layout-panel__navigation-bar
-  height $navigation-bar-height
   background-color $colors--white
   color $colors--title
 
@@ -44,7 +42,6 @@ $navigation-bar-height = 74px
 .layout-panel__body
   display flex
   flex-direction row
-  height "calc(100% - %s - %s)" % ($top-bar-height $navigation-bar-height)
   flex 1
 
 .layout-panel__content

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -1,0 +1,57 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~src/toolbox/tokens/index.styl'
+
+$side-panel-width = 140px
+$top-bar-height = 50px
+$navigation-bar-height = 74px
+
+.layout-panel
+  display flex
+  flex-direction column
+  width 100vw
+  height 100vh
+  min-width 100vw
+  max-width 100vw
+  min-height 100vh
+  max-height 100vh
+
+.layout-panel__header
+  height $top-bar-height
+  background-color $colors--white
+  box-shadow 0 0 4px 0 #9aa1ab54
+  z-index 0
+
+.layout-panel__header > *
+  margin 0 $spacing-small
+
+.layout-panel__navigation-bar
+  height $navigation-bar-height
+  background-color $colors--white
+  color $colors--title
+
+.layout-panel__navigation-bar > *
+  margin 0 $spacing-xx-large
+
+.layout-panel__body
+  display flex
+  flex-direction row
+  height "calc(100% - %s - %s)" % ($top-bar-height $navigation-bar-height)
+  flex 1
+
+.layout-panel__content
+  width "calc(100% - %s)" % $side-panel-width
+  overflow auto
+  margin $spacing-large 0 0
+
+.layout-panel__sidebar
+  min-width $side-panel-width
+  margin $spacing-large $spacing-medium $spacing-large $spacing-xx-large

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require '~src/toolbox/tokens/index.styl'
+@require '~src/components/core/index.styl'
 
 $side-panel-width = 140px
 $top-bar-height = 50px

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -25,6 +25,7 @@ $top-bar-height = 50px
 
 .layout-panel__header
   height $top-bar-height
+  min-height $top-bar-height
   background-color $colors--white
   box-shadow 0 0 4px 0 #9aa1ab54
   z-index 0

--- a/pkg/ui/src/views/app/containers/timewindow/index.tsx
+++ b/pkg/ui/src/views/app/containers/timewindow/index.tsx
@@ -75,7 +75,7 @@ class TimeWindowManager extends React.Component<TimeWindowManagerProps, TimeWind
       this.setWindow(props);
     } else {
       // Set a timeout to reset the window when the current window expires.
-      const newTimeout = setTimeout(() => this.setWindow(props), expires.diff(now).valueOf());
+      const newTimeout = window.setTimeout(() => this.setWindow(props), expires.diff(now).valueOf());
       this.setState({
         timeout: newTimeout,
       });

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -220,6 +220,7 @@ class ClusterOverview extends React.Component<RouterState, {}> {
         <Helmet>
           <title>Cluster Overview</title>
         </Helmet>
+        <section className="section"><h1 className="base-heading">Cluster Overview</h1></section>
         <section className="cluster-overview">
           <ClusterSummaryConnected />
         </section>

--- a/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
@@ -109,7 +109,7 @@ class DataDistribution extends React.Component<DataDistributionProps> {
     return (
       <div className="data-distribution">
         <div className="data-distribution__zone-config-sidebar">
-          <h2>
+          <h2 className="base-heading">
             Zone Configs{" "}
             <div className="section-heading__tooltip">
               <ToolTipWrapper text={ZONE_CONFIG_TEXT}>
@@ -169,7 +169,7 @@ class DataDistributionPage extends React.Component<DataDistributionPageProps> {
           <title>Data Distribution</title>
         </Helmet>
         <section className="section">
-          <h1>Data Distribution</h1>
+          <h1 className="base-heading">Data Distribution</h1>
         </section>
         <section className="section">
           <Loading

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -144,7 +144,7 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
         <title>Events</title>
       </Helmet>
       <section className="section section--heading">
-        <h1>Events</h1>
+        <h1 className="base-heading">Events</h1>
       </section>
       <section className="section l-columns">
         <div className="l-columns__left events-table">

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -218,7 +218,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
         <Helmet>
           <title>{ title }</title>
         </Helmet>
-        <section className="section"><h1>{ title }</h1></section>
+        <section className="section"><h1 className="base-heading">{ title }</h1></section>
         <PageConfig>
           <PageConfigItem>
             <Dropdown

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -96,7 +96,7 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
             <title>{ title }</title>
           </Helmet>
           <div className="section section--heading">
-            <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
+            <h2 className="base-heading">Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
           </div>
           <section className="section">
             { REMOTE_DEBUGGING_ERROR_TEXT }
@@ -111,7 +111,7 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
           <title>{ title }</title>
         </Helmet>
         <div className="section section--heading">
-          <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
+          <h2 className="base-heading">Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
         </div>
         <section className="section">
           <Loading

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -81,7 +81,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
     if (!node) {
       return (
         <div className="section">
-          <h1>Loading cluster status...</h1>
+          <h1 className="base-heading">Loading cluster status...</h1>
         </div>
       );
     }
@@ -95,7 +95,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
           <title>{`${nodesSummary.nodeDisplayNameByID[node.desc.node_id]} | Nodes`}</title>
         </Helmet>
         <div className="section section--heading">
-          <h2>{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
+          <h2 className="base-heading">{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
         </div>
         <section className="section l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
@@ -43,7 +43,7 @@ class DatabaseSummaryGrants extends DatabaseSummaryBase {
     return (
       <div className="database-summary">
         <div className="database-summary-title">
-          <h2>{dbID}</h2>
+          <h2 className="base-heading">{dbID}</h2>
         </div>
         <div className="l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -94,7 +94,7 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
     return (
       <div className="database-summary">
         <div className="database-summary-title">
-          <h2>{dbID}</h2>
+          <h2 className="base-heading">{dbID}</h2>
         </div>
         <div className="l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -96,7 +96,7 @@ class DatabaseTablesList extends React.Component<DatabaseListProps, {}> {
       <Helmet>
         <title>Tables | Databases</title>
       </Helmet>
-      <section className="section"><h1>Databases</h1></section>
+      <section className="section"><h1 className="base-heading">Databases</h1></section>
       <DatabaseListNav selected="tables"/>
       <div className="section databases">
         {
@@ -125,7 +125,7 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps, {}> {
       <Helmet>
         <title>Grants | Databases</title>
       </Helmet>
-      <section className="section"><h1>Databases</h1></section>
+      <section className="section"><h1 className="base-heading">Databases</h1></section>
       <DatabaseListNav selected="grants"/>
       <div className="section databases">
         {

--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
@@ -90,7 +90,7 @@ class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
     return (
       <div className="database-summary">
         <div className="database-summary-title">
-          <h2>Non-Table Cluster Data</h2>
+          <h2 className="base-heading">Non-Table Cluster Data</h2>
         </div>
         <div className="l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -88,7 +88,7 @@ class TableMain extends React.Component<TableMainProps, {}> {
             <Link to="/databases/tables">&lt; Back to Databases</Link>
           </section>
           <div className="database-summary-title">
-            <h2>{ title }</h2>
+            <h2 className="base-heading">{ title }</h2>
           </div>
           <div className="content l-columns">
             <div className="l-columns__left">

--- a/pkg/ui/src/views/devtools/containers/raft/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raft/index.tsx
@@ -23,7 +23,7 @@ export default class Layout extends React.Component<{}, {}> {
       <Helmet>
         <title>Raft | Debug</title>
       </Helmet>
-      <section className="section"><h1>Raft</h1></section>
+      <section className="section"><h1 className="base-heading">Raft</h1></section>
       <div className="nav-container">
         <ul className="nav">
           <li className="normal">

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -294,7 +294,7 @@ class JobsTable extends React.Component<JobsTableProps> {
   renderTable = () => {
     const jobs = this.props.jobs.data.jobs;
     if (_.isEmpty(jobs)) {
-      return <div className="no-results"><h2>No Results</h2></div>;
+      return <div className="no-results"><h2 className="base-heading">No Results</h2></div>;
     }
     return (
       <JobsSortedTable
@@ -319,7 +319,7 @@ class JobsTable extends React.Component<JobsTableProps> {
           <title>Jobs</title>
         </Helmet>
         <section className="section">
-          <h1>
+          <h1 className="base-heading">
             Jobs
             <div className="section-heading__tooltip">
               <ToolTipWrapper text={titleTooltip}>

--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -126,7 +126,7 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
           </section>
           <section className="section login-page__form">
             <div className="form-container">
-              <h1 className="heading">Log in to the Web UI</h1>
+              <h1 className="base-heading heading">Log in to the Web UI</h1>
               {this.renderError()}
               <form onSubmit={this.handleSubmit} className="form-internal" method="post">
                 <input

--- a/pkg/ui/src/views/reports/components/nodeFilterList/index.tsx
+++ b/pkg/ui/src/views/reports/components/nodeFilterList/index.tsx
@@ -69,7 +69,7 @@ export function NodeFilterList(props: NodeFilterListProps) {
 
   return (
     <div>
-      <h2>Filters</h2>
+      <h2 className="base-heading">Filters</h2>
       <ul className="node-filter-list">
         {
           _.map(filters, (filter, i) => (

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -166,7 +166,7 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     const nodeID = this.props.params[nodeIDAttr];
 
     if (_.isEmpty(certificates.certificates)) {
-      return <h2>No certificates were found on node {this.props.params[nodeIDAttr]}.</h2>;
+      return <h2 className="base-heading">No certificates were found on node {this.props.params[nodeIDAttr]}.</h2>;
     }
 
     let header: string = null;
@@ -178,7 +178,7 @@ class Certificates extends React.Component<CertificatesProps, {}> {
 
     return (
       <Fragment>
-        <h2>{header} certificates</h2>
+        <h2 className="base-heading">{header} certificates</h2>
         {
           _.map(certificates.certificates, (cert, key) => (
             this.renderCert(cert, key)
@@ -194,7 +194,7 @@ class Certificates extends React.Component<CertificatesProps, {}> {
         <Helmet>
           <title>Certificates | Debug</title>
         </Helmet>
-        <h1>Certificates</h1>
+        <h1 className="base-heading">Certificates</h1>
 
         <section className="section">
           <Loading

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -249,7 +249,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
         <Helmet>
           <title>Custom Chart | Debug</title>
         </Helmet>
-        <section className="section"><h1>Custom Chart</h1></section>
+        <section className="section"><h1 className="base-heading">Custom Chart</h1></section>
         <PageConfig>
           <PageConfigItem>
             <TimeScaleDropdown />

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -55,7 +55,7 @@ function DebugTableRow(props: { title: string, children?: React.ReactNode }) {
 function DebugTable(props: { heading: string, children?: React.ReactNode }) {
   return (
     <div>
-      <h2>{props.heading}</h2>
+      <h2 className="base-heading">{props.heading}</h2>
       <table className="debug-table">
         <tbody>
           {props.children}
@@ -85,7 +85,7 @@ export default function Debug() {
       <Helmet>
         <title>Debug</title>
       </Helmet>
-      <h1>Advanced Debugging</h1>
+      <h1 className="base-heading">Advanced Debugging</h1>
       <div className="debug-header">
         <InfoBox>
           <p>

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -136,7 +136,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
 
     return (
       <Fragment>
-        <h2>Enqueue Range Output</h2>
+        <h2 className="base-heading">Enqueue Range Output</h2>
         {response.details.map((details) => (
           <div>
             <h3>Node n{details.node_id}</h3>
@@ -169,7 +169,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
         <div className="content">
           <section className="section">
             <div className="form-container">
-              <h1 className="heading">Manually enqueue range in a replica queue</h1>
+              <h1 className="base-heading heading">Manually enqueue range in a replica queue</h1>
               <br />
               <form onSubmit={this.handleSubmit} className="form-internal" method="post">
                 <label>

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -103,7 +103,7 @@ class Localities extends React.Component<LocalitiesProps, {}> {
         <Helmet>
           <title>Localities | Debug</title>
         </Helmet>
-        <section className="section"><h1>Localities</h1></section>
+        <section className="section"><h1 className="base-heading">Localities</h1></section>
         <Loading
           loading={ !this.props.localityStatus.data || !this.props.locationStatus.data }
           error={ [this.props.localityStatus.lastError, this.props.locationStatus.lastError] }

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -55,7 +55,7 @@ function staleTable(staleIdentities: Identity[]) {
 
   return (
     <div>
-      <h2>Stale Nodes</h2>
+      <h2 className="base-heading">Stale Nodes</h2>
       <table className="failure-table">
         <tbody>
           <tr className="failure-table__row failure-table__row--header">
@@ -104,7 +104,7 @@ function noConnectionTable(noConnections: NoConnection[]) {
 
   return (
     <div>
-      <h2>No Connections</h2>
+      <h2 className="base-heading">No Connections</h2>
       <table className="failure-table">
         <tbody>
           <tr className="failure-table__row failure-table__row--header">
@@ -260,7 +260,7 @@ class Network extends React.Component<NetworkProps, {}> {
     // latencyTable is the table and heat-map that's displayed for all nodes.
     const latencyTable = (
       <div key="latency-table">
-        <h2>Latencies</h2>
+        <h2 className="base-heading">Latencies</h2>
         <table className="network-table">
           <tbody>
             <tr className="network-table__row">
@@ -300,7 +300,7 @@ class Network extends React.Component<NetworkProps, {}> {
     // legend is just a quick table showing the standard deviation values.
     const legend = (
       <div key="legend">
-        <h2>Legend</h2>
+        <h2 className="base-heading">Legend</h2>
         <table className="network-table">
           <tbody>
             <tr className="network-table__row">
@@ -425,9 +425,9 @@ class Network extends React.Component<NetworkProps, {}> {
 
     let content: JSX.Element | JSX.Element[];
     if (_.isEmpty(healthyIDs)) {
-      content = <h2>No healthy nodes match the filters</h2>;
+      content = <h2 className="base-heading">No healthy nodes match the filters</h2>;
     } else if (latencies.length < 1) {
-      content = <h2>Cannot show latency chart without two healthy nodes.</h2>;
+      content = <h2 className="base-heading">Cannot show latency chart without two healthy nodes.</h2>;
     } else {
       content = this.renderLatencyTable(latencies, staleIDs, nodesSummary, displayIdentities);
     }
@@ -446,7 +446,7 @@ class Network extends React.Component<NetworkProps, {}> {
         <Helmet>
           <title>Network Diagnostics | Debug</title>
         </Helmet>
-        <h1>Network Diagnostics</h1>
+        <h1 className="base-heading">Network Diagnostics</h1>
         <Loading
           loading={!contentAvailable(nodesSummary)}
           error={this.props.nodeSummaryErrors}

--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -45,8 +45,8 @@ const detailTimeFormat = "Y/MM/DD HH:mm:ss";
 
 const loading = (
   <div className="section">
-    <h1>Node Diagnostics</h1>
-    <h2>Loading cluster status...</h2>
+    <h1 className="base-heading">Node Diagnostics</h1>
+    <h2 className="base-heading">Loading cluster status...</h2>
   </div>
 );
 
@@ -334,9 +334,9 @@ class Nodes extends React.Component<NodesProps, {}> {
     if (_.isEmpty(orderedNodeIDs)) {
       return (
         <section className="section">
-          <h1>Node Diagnostics</h1>
+          <h1 className="base-heading">Node Diagnostics</h1>
           <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
-          <h2>No nodes match the filters</h2>
+          <h2 className="base-heading">No nodes match the filters</h2>
         </section>
       );
     }
@@ -346,9 +346,9 @@ class Nodes extends React.Component<NodesProps, {}> {
         <Helmet>
           <title>Node Diagnostics | Debug</title>
         </Helmet>
-        <h1>Node Diagnostics</h1>
+        <h1 className="base-heading">Node Diagnostics</h1>
         <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
-        <h2>Nodes</h2>
+        <h2 className="base-heading">Nodes</h2>
         <table className="nodes-table">
           <tbody>
             {

--- a/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
@@ -91,7 +91,7 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
     .value();
   return (
     <div>
-      <h2>Connections (via Node {data.node_id})</h2>
+      <h2 className="base-heading">Connections (via Node {data.node_id})</h2>
       <table className="connections-table">
         <tbody>
           <tr className="connections-table__row connections-table__row--header">

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -55,7 +55,7 @@ function ProblemRangeList(props: {
   }
   return (
     <div>
-      <h2>{props.name}</h2>
+      <h2 className="base-heading">{props.name}</h2>
       <div className="problems-list">
         {
           _.map(ids, id => {
@@ -110,14 +110,14 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
       if (_.isEmpty(this.props.params[nodeIDAttr])) {
         return (
           <div>
-            <h2>Error loading Problem Ranges for the Cluster</h2>
+            <h2 className="base-heading">Error loading Problem Ranges for the Cluster</h2>
             {problemRanges.lastError.toString()}
           </div>
         );
       } else {
         return (
           <div>
-            <h2>Error loading Problem Ranges for node n{this.props.params[nodeIDAttr]}</h2>
+            <h2 className="base-heading">Error loading Problem Ranges for node n{this.props.params[nodeIDAttr]}</h2>
             {problemRanges.lastError.toString()}
           </div>
         );
@@ -131,9 +131,9 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     }));
     if (validIDs.length === 0) {
       if (_.isEmpty(this.props.params[nodeIDAttr])) {
-        return <h2>No nodes returned any results</h2>;
+        return <h2 className="base-heading">No nodes returned any results</h2>;
       } else {
-        return <h2>No results reported for node n{this.props.params[nodeIDAttr]}</h2>;
+        return <h2 className="base-heading">No results reported for node n{this.props.params[nodeIDAttr]}</h2>;
       }
     }
 
@@ -148,7 +148,7 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     const problems = _.values(data.problems_by_node_id);
     return (
       <div>
-        <h2>
+        <h2 className="base-heading">
           {titleText}
         </h2>
         <ProblemRangeList
@@ -196,7 +196,7 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
         <Helmet>
           <title>Problem Ranges | Debug</title>
         </Helmet>
-        <h1>Problem Ranges Report</h1>
+        <h1 className="base-heading">Problem Ranges Report</h1>
         <Loading
           loading={isLoading(this.props.problemRanges)}
           error={this.props.problemRanges && this.props.problemRanges.lastError}

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -62,7 +62,7 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
     if (allocator && allocator.lastError && allocator.lastError.message === "Forbidden") {
       return (
         <div>
-          <h2>Simulated Allocator Output</h2>
+          <h2 className="base-heading">Simulated Allocator Output</h2>
           { REMOTE_DEBUGGING_ERROR_TEXT }
         </div>
       );
@@ -75,7 +75,7 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
 
     return (
       <div>
-        <h2>Simulated Allocator Output{fromNodeID}</h2>
+        <h2 className="base-heading">Simulated Allocator Output{fromNodeID}</h2>
         <Loading
           loading={!allocator || allocator.inFlight}
           error={allocator && allocator.lastError}

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -34,7 +34,7 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
 
   return (
     <div>
-      <h2>Connections {viaNodeID}</h2>
+      <h2 className="base-heading">Connections {viaNodeID}</h2>
       <Loading
         loading={!range || range.inFlight}
         error={range && range.lastError}

--- a/pkg/ui/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/src/views/reports/containers/range/index.tsx
@@ -54,8 +54,8 @@ function ErrorPage(props: {
 }) {
   return (
     <div className="section">
-      <h1>Range Report for r{props.rangeID}</h1>
-      <h2>{props.errorText}</h2>
+      <h1 className="base-heading">Range Report for r{props.rangeID}</h1>
+      <h2 className="base-heading">{props.errorText}</h2>
       <ConnectionsTable range={props.range} />
     </div>
   );
@@ -179,7 +179,7 @@ class Range extends React.Component<RangeProps, {}> {
         <Helmet>
           <title>{ `r${responseRangeID.toString()} Range | Debug` }</title>
         </Helmet>
-        <h1>Range Report for r{responseRangeID.toString()}</h1>
+        <h1 className="base-heading">Range Report for r{responseRangeID.toString()}</h1>
         <RangeTable infos={infos} replicas={replicas} />
         <LeaseTable info={_.head(infos)} />
         <ConnectionsTable range={range} />

--- a/pkg/ui/src/views/reports/containers/range/leaseTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/leaseTable.tsx
@@ -43,7 +43,7 @@ export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
     // leader?
     const rangeID = info.state.state.desc.range_id;
     const header = (
-      <h2>
+      <h2 className="base-heading">
         Lease History (from {Print.ReplicaID(rangeID, RangeInfo.GetLocalReplica(info))})
       </h2>
     );

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -129,7 +129,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
 
     return (
       <div>
-        <h2>Range Log</h2>
+        <h2 className="base-heading">Range Log</h2>
         <Loading
           loading={!log || log.inFlight}
           error={log && log.lastError}

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -554,7 +554,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
 
     return (
       <div>
-        <h2>Range r{rangeID.toString()} at {Print.Time(moment().utc())} UTC</h2>
+        <h2 className="base-heading">Range r{rangeID.toString()} at {Print.Time(moment().utc())} UTC</h2>
         <table className="range-table">
           <tbody>
             {

--- a/pkg/ui/src/views/reports/containers/redux/index.tsx
+++ b/pkg/ui/src/views/reports/containers/redux/index.tsx
@@ -44,7 +44,7 @@ class ReduxDebug extends React.Component<ReduxDebugProps, ReduxDebugState> {
         <Helmet>
           <title>Redux State | Debug</title>
         </Helmet>
-        <section className="section"><h1>Redux State</h1></section>
+        <section className="section"><h1 className="base-heading">Redux State</h1></section>
         <section className="section">
           <CopyToClipboard text={ text } onCopy={() => this.setState({ copied: true})}>
             <span className={spanClass}>

--- a/pkg/ui/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/src/views/reports/containers/settings/index.tsx
@@ -82,7 +82,7 @@ class Settings extends React.Component<SettingsProps, {}> {
         <Helmet>
           <title>Cluster Settings | Debug</title>
         </Helmet>
-        <h1>Cluster Settings</h1>
+        <h1 className="base-heading">Cluster Settings</h1>
         <Loading
           loading={!this.props.settings.data}
           error={this.props.settings.lastError}

--- a/pkg/ui/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/src/views/reports/containers/stores/index.tsx
@@ -87,7 +87,7 @@ class Stores extends React.Component<StoresProps, {}> {
     const { stores } = this.props;
     if (_.isEmpty(stores)) {
       return (
-        <h2>No stores were found on node {nodeID}.</h2>
+        <h2 className="base-heading">No stores were found on node {nodeID}.</h2>
       );
     }
 
@@ -108,8 +108,8 @@ class Stores extends React.Component<StoresProps, {}> {
         <Helmet>
           <title>Stores | Debug</title>
         </Helmet>
-        <h1>Stores</h1>
-        <h2>{header} stores</h2>
+        <h1 className="base-heading">Stores</h1>
+        <h2 className="base-heading">{header} stores</h2>
         <Loading
           loading={this.props.loading}
           error={this.props.lastError}

--- a/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
+++ b/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
@@ -8,21 +8,24 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require '~src/toolbox/tokens/index.styl'
+
 .user-avatar
-  height 40px
-  width 40px
+  height $line-height--large
+  width $line-height--large
   border-radius 50%
   background-color #e0eefb
   color: #0788ff
   font-size 14px
   font-weight bold
-  line-height 40px
+  line-height $line-height--large
   letter-spacing 0.1px
   margin auto
+  text-align center
 
 .user-avatar:hover
   border solid 2px #0788ff
-  line-height 36px
+  line-height "calc( %s - 4px )" % $line-height--large
 
 .user-avatar--disabled
   background-color #e7ecf3
@@ -30,4 +33,4 @@
 
 .user-avatar--disabled:hover
   border none
-  line-height 40px
+  line-height $line-height--large

--- a/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
+++ b/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require '~src/toolbox/tokens/index.styl'
+@require '~src/components/core/index.styl'
 
 .user-avatar
   height $line-height--large

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -175,7 +175,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             { "Details | " + (this.props.params[appAttr] ? this.props.params[appAttr] + " App | " : "") + "Statements" }
           </title>
         </Helmet>
-        <section className="section"><h1>Statement Details</h1></section>
+        <section className="section"><h1 className="base-heading">Statement Details</h1></section>
         <section className="section section--container">
           <Loading
             loading={_.isNil(this.props.statement)}

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -226,7 +226,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
         </Helmet>
 
         <section className="section">
-          <h1>Statements</h1>
+          <h1 className="base-heading">Statements</h1>
         </section>
 
         <Loading

--- a/pkg/ui/styl/base/reset.styl
+++ b/pkg/ui/styl/base/reset.styl
@@ -15,6 +15,5 @@
 
 html
 body
-  height 100%
   background-color $background-color
   min-width 700px

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -22,13 +22,13 @@ body
   font-family Lato-Regular
   font-weight 400
 
-h1
+h1.base-heading
   font-size 24px
   font-weight bold
   letter-spacing 5px
   text-transform uppercase
 
-h2
+h2.base-heading
   padding 12px 0
   font-size 20px
   font-weight bold


### PR DESCRIPTION
Related task: #42920
Depends on PR: #43181

`SideNavigation` panel on the left side displays the full text of links so it is easier to suggest what it means.
With this change, following is affected:
- Layout of the main panel is changed to adjust to the new width
- `GlobalNavigation` and `TabNavigatin` panels are added on top of the screen as fixed panels that aren't scrolled out. A scroll bar appears for the main panel only when it's content doesn't fit on a screen.

`TabNavigation` panel displays:
- cluster name (in case it is defined) otherwise cluster id;
- Cluster version in a badge;

Screens:
<img width="723" alt="Screenshot 2019-12-17 at 13 53 55" src="https://user-images.githubusercontent.com/3106437/70994432-e7aa2880-20d6-11ea-911a-0cf2a88c41bf.png">

<img width="723" alt="Screenshot 2019-12-17 at 13 54 28" src="https://user-images.githubusercontent.com/3106437/70994433-e842bf00-20d6-11ea-8a31-f24d752fc862.png">

<img width="723" alt="Screenshot 2019-12-17 at 13 54 04" src="https://user-images.githubusercontent.com/3106437/70994435-e842bf00-20d6-11ea-88fc-f7f4a822105a.png">


