### PR TITLE
protectedts,RFC: update RFC and interfaces for simpler verification

### DIFF
--- a/pkg/storage/protectedts/protectedts_test.go
+++ b/pkg/storage/protectedts/protectedts_test.go
@@ -16,10 +16,10 @@ import "testing"
 func TestProtectedTimestamps(t *testing.T) {
 	var (
 		_ Provider
-		_ Tracker
+		_ Cache
 		_ Verifier
 		_ Storage
-		_ = ClockTracker(nil)
+		_ = EmptyCache(nil)
 		_ = ErrNotExists
 		_ = ErrExists
 		_ = PollInterval


### PR DESCRIPTION
This change is motivated by the discussion in #42890 and offline. Firstly
the `Tracker` is renamed to `Cache` which is more appropriate for its
actual purpose. Secondly the Verfication protocol state is reduced by
forcing the request to update the `Cache` state to determine whether the
record applies rather than maintaining extra state. Lastly the change
updates the RFC to reflect this change and moves it to "in progress".

Release note: None.