### PR TITLE
opt: don't attempt to negate Overlaps operator

### DIFF
--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -132,7 +132,7 @@ $input
 # by the Not operator. For example, Eq maps to Ne, and Gt maps to Le. All
 # comparisons can be negated except for the JSON comparisons.
 [NegateComparison, Normalize]
-(Not $input:(Comparison $left:* $right:*) & ^(Contains|JsonExists|JsonSomeExists|JsonAllExists))
+(Not $input:(Comparison $left:* $right:*) & ^(Contains|JsonExists|JsonSomeExists|JsonAllExists|Overlaps))
 =>
 (NegateComparison (OpName $input) $left $right)
 

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -398,7 +398,8 @@ SELECT * FROM a WHERE
   NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]') AND
   NOT(j ? 'foo') AND
   NOT(j ?| ARRAY['foo']) AND
-  NOT(j ?& ARRAY['foo'])
+  NOT(j ?& ARRAY['foo']) AND
+  NOT(ARRAY[i] && ARRAY[1])
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
@@ -413,7 +414,8 @@ select
       ├── NOT ('[3, 4]' @> j) [type=bool, outer=(5)]
       ├── NOT (j ? 'foo') [type=bool, outer=(5)]
       ├── NOT (j ?| ARRAY['foo']) [type=bool, outer=(5)]
-      └── NOT (j ?& ARRAY['foo']) [type=bool, outer=(5)]
+      ├── NOT (j ?& ARRAY['foo']) [type=bool, outer=(5)]
+      └── NOT (ARRAY[i] && ARRAY[1]) [type=bool, outer=(2)]
 
 # --------------------------------------------------
 # EliminateNot


### PR DESCRIPTION
Fixes #43228.

Previously, we would attempt to fold expressions of the form
```
NOT(a && b)
```
which did not work, because the && operator has no negated form.
This commit adds Overlaps to the blacklist to not negate.

I thought about doing something more general (blacklist of non-negatable
ops?) to avoid this happening in the future but I think new operators
are uncommon enough that it's not worth the overhead.

Release note (bug fix): No longer fail on an expression of the form
NOT(a && b).