### PR TITLE
sqlsmith: populate is_inverted differently on 19.2 version

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -277,7 +277,11 @@ func extractIndexes(
 `, t.TableName.Table(), idx))
 			var isInverted bool
 			if err = row.Scan(&isInverted); err != nil {
-				return nil, err
+				// We got an error which likely indicates that 'is_inverted' column is
+				// not present in crdb_internal.table_indexes vtable (probably because
+				// we're running 19.2 version). We will use a heuristic to determine
+				// whether the index is inverted.
+				isInverted = strings.Contains(strings.ToLower(idx.String()), "jsonb")
 			}
 			indexes[idx].Inverted = isInverted
 		}


### PR DESCRIPTION
Column 'is_inverted' is not present in crdb_internal.table_indexes
virtual table before 20.1, so we use a heuristic (string matching on the
name of the index) to determine whether the index is inverted.

Fixes: #43230.

Release note: None