### PR TITLE
sql:fix bug that would allow duplicate object creation during upgrades

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -50,10 +50,10 @@ func (n *createViewNode) startExec(params runParams) error {
 	tKey := sqlbase.MakePublicTableNameKey(params.ctx,
 		params.ExecCfg().Settings, n.dbDesc.ID, viewName)
 
-	key := tKey.Key()
-	if exists, err := descExists(params.ctx, params.p.txn, key); err == nil && exists {
+	exists, _, err := sqlbase.LookupPublicTableID(params.ctx, params.p.txn, n.dbDesc.ID, viewName)
+	if err == nil && exists {
 		// TODO(a-robinson): Support CREATE OR REPLACE commands.
-		return sqlbase.NewRelationAlreadyExistsError(tKey.Name())
+		return sqlbase.NewRelationAlreadyExistsError(viewName)
 	} else if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	}
 
 	if err = params.p.createDescriptorWithID(
-		params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
+		params.ctx, tKey.Key(), id, &desc, params.EvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -1,0 +1,139 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// This test creates table/database descriptors that have entries in the
+// deprecated namespace table. This simulates objects created in the window
+// where the migration from the old -> new system.namespace has run, but the
+// cluster version has not been finalized yet.
+func TestNamespaceTableSemantics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+	ctx := context.TODO()
+
+	// IDs to map (parentID, name) to. Actual ID value is irrelevant to the test.
+	idCounter := keys.MinNonPredefinedUserDescID
+
+	// Database name.
+	dKey := sqlbase.NewDeprecatedDatabaseKey("test").Key()
+	if gr, err := kvDB.Get(ctx, dKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatal("expected non-existing key")
+	}
+
+	// Add an entry for the database in the deprecated namespace table directly.
+	if err := kvDB.CPut(ctx, dKey, idCounter, nil); err != nil {
+		t.Fatal(err)
+	}
+	idCounter++
+
+	// Creating the database should fail, because an entry was explicitly added to
+	// the system.namespace_deprecated table.
+	_, err := sqlDB.Exec(`CREATE DATABASE test`)
+	if !testutils.IsError(err, sqlbase.NewDatabaseAlreadyExistsError("test").Error()) {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Remove the entry.
+	if err := kvDB.Del(ctx, dKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// Creating the database should work now, because we removed the mapping in
+	// the old system.namespace table.
+	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure the new entry is added to the new namespace table.
+	if gr, err := kvDB.Get(ctx, dKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatal("database key unexpectedly found in the deprecated system.namespace")
+	}
+	newDKey := sqlbase.NewDatabaseKey("test").Key()
+	if gr, err := kvDB.Get(ctx, newDKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("database key not found in the new system.namespace")
+	}
+
+	txn := kvDB.NewTxn(ctx, "lookup-test-db-id")
+	found, dbID, err := sqlbase.LookupDatabaseID(ctx, txn, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("Error looking up the dbID")
+	}
+
+	// Simulate the same test for a table and sequence.
+	tKey := sqlbase.NewDeprecatedTableKey(dbID, "rel").Key()
+	if err := kvDB.CPut(ctx, tKey, idCounter, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Creating a table should fail now, because an entry was explicitly added to
+	// the old system.namespace_deprecated table.
+	_, err = sqlDB.Exec(`CREATE TABLE test.public.rel(a int)`)
+	if !testutils.IsError(err, sqlbase.NewRelationAlreadyExistsError("rel").Error()) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	// Same applies to a table which doesn't explicitly specify the public schema,
+	// as that is the default.
+	_, err = sqlDB.Exec(`CREATE TABLE test.rel(a int)`)
+	if !testutils.IsError(err, sqlbase.NewRelationAlreadyExistsError("rel").Error()) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	// Can not create a sequence with the same name either.
+	_, err = sqlDB.Exec(`CREATE SEQUENCE test.rel`)
+	if !testutils.IsError(err, sqlbase.NewRelationAlreadyExistsError("rel").Error()) {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Remove the entry.
+	if err := kvDB.Del(ctx, tKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// Creating a new table should succeed now.
+	if _, err = sqlDB.Exec(`CREATE TABLE test.public.rel(a int)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure the new entry is added to the new namespace table.
+	if gr, err := kvDB.Get(ctx, tKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatal("table key unexpectedly found in the deprecated system.namespace")
+	}
+	newTKey := sqlbase.NewPublicTableKey(dbID, "rel").Key()
+	if gr, err := kvDB.Get(ctx, newTKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("table key not found in the new system.namespace")
+	}
+}


### PR DESCRIPTION
Previously, when creating a new object(sequence/database/view/table),
we would only check the "active" namespace table. This could lead to
the following scenario:

Any object created after the system.namespace table was migrated, but
before the cluster version bump was finalized, would be present in the
old `system.namespace`. If a user tried to create an object of the same
name after the cluster version was bumped, this would be succesful.

This PR fixes this issue, by checking both the old and new
`system,namespace` table when creating new objects, instead of just
the active one. Now, the appropriate error is returned.

Release note (bug fix): If an object is created before the cluster
version is upgraded, but after the namespace table is migrated,
trying to create the same object after the cluster version upgrade
results in a relation already exists error. This code was not
released.