### PR TITLE
sqlsmith: respect type specification in makeCompareOp

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -302,11 +302,14 @@ var compareOps = [...]tree.ComparisonOperator{
 }
 
 func makeCompareOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	typ, ok := s.pickAnyType(typ)
-	if !ok {
+	if f := typ.Family(); f != types.BoolFamily && f != types.AnyFamily {
 		return nil, false
 	}
+	typ = s.randScalarType()
 	op := compareOps[s.rnd.Intn(len(compareOps))]
+	if _, ok := tree.CmpOps[op].LookupImpl(typ, typ); !ok {
+		return nil, false
+	}
 	if s.vectorizable && (op == tree.IsDistinctFrom || op == tree.IsNotDistinctFrom) {
 		return nil, false
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1781,7 +1781,7 @@ func cmpOpFixups(cmpOps map[ComparisonOperator]cmpOpOverload) map[ComparisonOper
 // cmpOpOverload is an overloaded set of comparison operator implementations.
 type cmpOpOverload []overloadImpl
 
-func (o cmpOpOverload) lookupImpl(left, right *types.T) (*CmpOp, bool) {
+func (o cmpOpOverload) LookupImpl(left, right *types.T) (*CmpOp, bool) {
 	for _, fn := range o {
 		casted := fn.(*CmpOp)
 		if casted.matchParams(left, right) {
@@ -4407,7 +4407,7 @@ func evalComparison(ctx *EvalContext, op ComparisonOperator, left, right Datum) 
 	}
 	ltype := left.ResolvedType()
 	rtype := right.ResolvedType()
-	if fn, ok := CmpOps[op].lookupImpl(ltype, rtype); ok {
+	if fn, ok := CmpOps[op].LookupImpl(ltype, rtype); ok {
 		return fn.Fn(ctx, left, right)
 	}
 	return nil, pgerror.Newf(
@@ -5220,7 +5220,7 @@ func anchorPattern(pattern string, caseInsensitive bool) string {
 func FindEqualComparisonFunction(
 	leftType, rightType *types.T,
 ) (func(*EvalContext, Datum, Datum) (Datum, error), bool) {
-	fn, found := CmpOps[EQ].lookupImpl(leftType, rightType)
+	fn, found := CmpOps[EQ].LookupImpl(leftType, rightType)
 	if found {
 		return fn.Fn, true
 	}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -521,7 +521,7 @@ func (node *ComparisonExpr) memoizeFn() {
 		}
 	}
 
-	fn, ok := CmpOps[fOp].lookupImpl(leftRet, rightRet)
+	fn, ok := CmpOps[fOp].LookupImpl(leftRet, rightRet)
 	if !ok {
 		panic(errors.AssertionFailedf("lookup for ComparisonExpr %s's CmpOp failed",
 			AsStringWithFlags(node, FmtShowTypes)))

--- a/pkg/sql/sem/tree/like_test.go
+++ b/pkg/sql/sem/tree/like_test.go
@@ -144,7 +144,7 @@ func benchmarkLike(b *testing.B, ctx *EvalContext, caseInsensitive bool) {
 	if caseInsensitive {
 		op = ILike
 	}
-	likeFn, _ := CmpOps[op].lookupImpl(types.String, types.String)
+	likeFn, _ := CmpOps[op].LookupImpl(types.String, types.String)
 	iter := func() {
 		for _, p := range benchmarkLikePatterns {
 			if _, err := likeFn.Fn(ctx, NewDString("test"), NewDString(p)); err != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1583,7 +1583,7 @@ func typeCheckComparisonOpWithSubOperator(
 			return nil, nil, nil, false, pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sigWithErr)
 		}
 	}
-	fn, ok := ops.lookupImpl(cmpTypeLeft, cmpTypeRight)
+	fn, ok := ops.LookupImpl(cmpTypeLeft, cmpTypeRight)
 	if !ok {
 		return nil, nil, nil, false, subOpCompError(cmpTypeLeft, rightTyped.ResolvedType(), subOp, op)
 	}
@@ -1636,7 +1636,7 @@ func typeCheckComparisonOp(
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sigWithErr)
 		}
 
-		fn, ok := ops.lookupImpl(retType, types.AnyTuple)
+		fn, ok := ops.LookupImpl(retType, types.AnyTuple)
 		if !ok {
 			sig := fmt.Sprintf(compSignatureFmt, retType, op, types.AnyTuple)
 			return nil, nil, nil, false,
@@ -1665,7 +1665,7 @@ func typeCheckComparisonOp(
 		}
 
 		typ := typedLeft.ResolvedType()
-		fn, ok := ops.lookupImpl(typ, types.AnyTuple)
+		fn, ok := ops.LookupImpl(typ, types.AnyTuple)
 		if !ok {
 			sig := fmt.Sprintf(compSignatureFmt, typ, op, types.AnyTuple)
 			return nil, nil, nil, false,
@@ -1688,7 +1688,7 @@ func typeCheckComparisonOp(
 		return typedLeft, typedRight, fn, false, nil
 
 	case leftIsTuple && rightIsTuple:
-		fn, ok := ops.lookupImpl(types.AnyTuple, types.AnyTuple)
+		fn, ok := ops.LookupImpl(types.AnyTuple, types.AnyTuple)
 		if !ok {
 			sig := fmt.Sprintf(compSignatureFmt, types.AnyTuple, op, types.AnyTuple)
 			return nil, nil, nil, false,


### PR DESCRIPTION
Previously it was always using bool.

In order to not create comparisons that don't exist (like JSON < JSON),
add a check that verifies the chosen operation exists.

Closes #43089

Release note: None