### PR TITLE
issues: add missing quote to repro steps

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -90,7 +90,7 @@ Parameters:
 {{if .ArtifactsURL }}Artifacts: [{{.Artifacts}}]({{ .ArtifactsURL }})
 {{end -}}
 {{threeticks}}
-make stressrace TESTS={{.TestName}} PKG=./pkg/{{shortpkg .PackageName}} TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS={{.TestName}} PKG=./pkg/{{shortpkg .PackageName}} TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 {{threeticks}}
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/failure-existing-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/failure-existing-issue.txt
@@ -15,7 +15,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestReplicateQueueRebalance PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestReplicateQueueRebalance PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/failure.txt
+++ b/pkg/cmd/internal/issues/testdata/failure.txt
@@ -15,7 +15,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestReplicateQueueRebalance PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestReplicateQueueRebalance PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/fatal-existing-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/fatal-existing-issue.txt
@@ -34,7 +34,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/fatal.txt
+++ b/pkg/cmd/internal/issues/testdata/fatal.txt
@@ -34,7 +34,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/panic-existing-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/panic-existing-issue.txt
@@ -35,7 +35,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/panic.txt
+++ b/pkg/cmd/internal/issues/testdata/panic.txt
@@ -35,7 +35,7 @@ Parameters:
 - GOFLAGS=race
 
 ```
-make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=TestGossipHandlesReplacedNode PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/with-artifacts-existing-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/with-artifacts-existing-issue.txt
@@ -16,7 +16,7 @@ Parameters:
 
 Artifacts: [/kv/splits/nodes=3/quiesce=true](https://teamcity.example.com/viewLog.html?buildId=8008135&tab=artifacts#/kv/splits/nodes=3/quiesce=true)
 ```
-make stressrace TESTS=kv/splits/nodes=3/quiesce=true PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=kv/splits/nodes=3/quiesce=true PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>

--- a/pkg/cmd/internal/issues/testdata/with-artifacts.txt
+++ b/pkg/cmd/internal/issues/testdata/with-artifacts.txt
@@ -16,7 +16,7 @@ Parameters:
 
 Artifacts: [/kv/splits/nodes=3/quiesce=true](https://teamcity.example.com/viewLog.html?buildId=8008135&tab=artifacts#/kv/splits/nodes=3/quiesce=true)
 ```
-make stressrace TESTS=kv/splits/nodes=3/quiesce=true PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS=-timeout 5m' 2>&1
+make stressrace TESTS=kv/splits/nodes=3/quiesce=true PKG=./pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1
 ```
 
 <sub>powered by [pkg/cmd/internal/issues](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)</sub></p></details>


### PR DESCRIPTION
When a unit test failed, the template which provided the command to
reproduce the failure was missing a closing single quote.

Release note: None