### PR TITLE
roachlint: add a pass to check for return of nil errors after checks

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1039,7 +1039,7 @@ func backupPlanHook(
 
 		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to)
 		if err != nil {
-			return nil
+			return err
 		}
 		defaultStore, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, defaultURI)
 		if err != nil {

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -206,7 +206,7 @@ func exportUsingGoIterator(
 ) ([]byte, error) {
 	sst, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
-		return nil, nil
+		return nil, nil //nolint:returnerrcheck
 	}
 	defer sst.Close()
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -323,7 +323,7 @@ func loadRangeDescriptor(
 		if err := storage.IsRangeDescriptorKey(kv.Key); err != nil {
 			// Range descriptor keys are interleaved with others, so if it
 			// doesn't parse as a range descriptor just skip it.
-			return false, nil
+			return false, nil //nolint:returnerrcheck
 		}
 		if len(kv.Value) == 0 {
 			// RangeDescriptor was deleted (range merged away).
@@ -863,11 +863,11 @@ func runTimeSeriesDump(cmd *cobra.Command, args []string) error {
 	var name, source string
 	for {
 		data, err := stream.Recv()
-		if err != nil {
-			if err != io.EOF {
-				return err
-			}
+		if err == io.EOF {
 			return nil
+		}
+		if err != nil {
+			return err
 		}
 		if name != data.Name || source != data.Source {
 			name, source = data.Name, data.Source

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -118,7 +118,7 @@ func runGenAutocompleteCmd(cmd *cobra.Command, args []string) error {
 		err = cmd.Root().GenZshCompletionFile(autoCompletePath)
 	}
 	if err != nil {
-		return nil
+		return err
 	}
 
 	fmt.Printf("Generated %s completion file: %s\n", shell, autoCompletePath)

--- a/pkg/cmd/roachlint/main.go
+++ b/pkg/cmd/roachlint/main.go
@@ -13,6 +13,7 @@ package main
 import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
 	"golang.org/x/tools/go/analysis/multichecker"
@@ -24,5 +25,6 @@ func main() {
 		timer.Analyzer,
 		unconvert.Analyzer,
 		descriptormarshal.Analyzer,
+		returnerrcheck.Analyzer,
 	)
 }

--- a/pkg/cmd/roachprod/install/cassandra.go
+++ b/pkg/cmd/roachprod/install/cassandra.go
@@ -67,7 +67,10 @@ func (Cassandra) Start(c *SyncedCluster, extraArgs []string) {
 
 				cmd := `nc -z $(hostname) 9042`
 				if _, err := session.CombinedOutput(cmd); err != nil {
-					return false, nil
+					// The common case here is going to be "exit status 1" until the
+					// cassandra process starts listening on the port. Logging would
+					// just generate noise.
+					return false, nil //nolint:returnerrcheck
 				}
 				return true, nil
 			}()

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -162,7 +162,7 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 			defer dbNode.Close()
 			var nodeID string
 			if err := dbNode.QueryRow(`SELECT node_id FROM crdb_internal.node_runtime_info LIMIT 1`).Scan(&nodeID); err != nil {
-				return "", nil
+				return "", err
 			}
 			return nodeID, nil
 		}
@@ -182,7 +182,6 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 		for tBegin, whileDown, node := timeutil.Now(), true, 1; timeutil.Since(tBegin) <= duration; whileDown, node = !whileDown, (node%numDecom)+1 {
 			t.Status(fmt.Sprintf("decommissioning %d (down=%t)", node, whileDown))
 			id, err := nodeID(node)
-
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -505,17 +505,29 @@ func getPerfArtifacts(ctx context.Context, l *logger, c *cluster, t *test) {
 	g := ctxgroup.WithContext(ctx)
 	fetchNode := func(node int) func(context.Context) error {
 		return func(ctx context.Context) error {
-			doesNotExistStr := perfArtifactsDir + " does not exist"
-			testCmd := "test -d '" + perfArtifactsDir + "' || echo '" + doesNotExistStr + "'"
-			if out, err := c.RunWithBuffer(ctx, l, c.Node(node), "bash", "-c", testCmd); err != nil {
-				// perfArtifactsDir doesn't exist, nothing to fetch.
-				if strings.Contains(string(out), doesNotExistStr) {
-					return nil
-				}
-				return err
+			testCmd := `'PERF_ARTIFACTS="` + perfArtifactsDir + `"
+if [[ -d "${PERF_ARTIFACTS}" ]]; then
+    echo true
+elif [[ -e "${PERF_ARTIFACTS}" ]]; then
+    ls -la "${PERF_ARTIFACTS}"
+    exit 1
+else
+    echo false
+fi'`
+			out, err := c.RunWithBuffer(ctx, l, c.Node(node), "bash", "-c", testCmd)
+			if err != nil {
+				return errors.Wrapf(err, "failed to check for perf artifacts: %v", string(out))
 			}
-			dst := fmt.Sprintf("%s/%d.%s", t.artifactsDir, node, perfArtifactsDir)
-			return c.Get(ctx, l, perfArtifactsDir, dst, c.Node(node))
+			switch out := strings.TrimSpace(string(out)); out {
+			case "true":
+				dst := fmt.Sprintf("%s/%d.%s", t.artifactsDir, node, perfArtifactsDir)
+				return c.Get(ctx, l, perfArtifactsDir, dst, c.Node(node))
+			case "false":
+				l.PrintfCtx(ctx, "no perf artifacts exist on node %v", c.Node(node))
+				return nil
+			default:
+				return errors.Errorf("unexpected output when checking for perf artifacts: %s", out)
+			}
 		}
 	}
 	for _, i := range c.All() {

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -2236,7 +2236,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				if _, err := txn.Get(ctx, "b"); err != nil {
-					return nil
+					return err
 				}
 				return txn.Put(ctx, "a", "put")
 			},
@@ -2249,7 +2249,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				if _, err := txn.Get(ctx, "a"); err != nil {
-					return nil
+					return err
 				}
 				return txn.Put(ctx, "a", "put")
 			},
@@ -2263,7 +2263,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				// Get so we must refresh when txn timestamp moves forward.
 				if _, err := txn.Get(ctx, "a"); err != nil {
-					return nil
+					return err
 				}
 				// Now, Put a new value to "a" out of band from the txn.
 				if err := txn.DB().Put(ctx, "a", "value2"); err != nil {

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 )
 
 // ClientVisibleRetryError is to be implemented by errors visible by
@@ -842,3 +843,13 @@ func (e *IndeterminateCommitError) message(pErr *Error) string {
 }
 
 var _ ErrorDetailInterface = &IndeterminateCommitError{}
+
+// IsRangeNotFoundError returns true if err contains a *RangeNotFoundError.
+func IsRangeNotFoundError(err error) bool {
+	// TODO(ajwerner): adopt errors.IsType once the pull request to add it merges.
+	_, isRangeNotFound := errors.If(err, func(err error) (interface{}, bool) {
+		_, isRangeNotFound := err.(*RangeNotFoundError)
+		return err, isRangeNotFound
+	})
+	return isRangeNotFound
+}

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -121,7 +121,7 @@ func TestLoadEmbeddedCerts(t *testing.T) {
 func countLoadedCertificates(certsDir string) (int, error) {
 	cl := security.NewCertificateLoader(certsDir)
 	if err := cl.Load(); err != nil {
-		return 0, nil
+		return 0, err
 	}
 	return len(cl.Certificates()), nil
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1848,8 +1848,11 @@ func (s *adminServer) enqueueRangeLocal(
 	var repl *storage.Replica
 	if err := s.server.node.stores.VisitStores(func(s *storage.Store) error {
 		r, err := s.GetReplica(req.RangeID)
-		if err != nil {
+		if roachpb.IsRangeNotFoundError(err) {
 			return nil
+		}
+		if err != nil {
+			return err
 		}
 		repl = r
 		store = s

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -69,8 +69,11 @@ func (s *Server) gcSystemLog(
 ) (time.Time, int64, error) {
 	var totalRowsAffected int64
 	repl, err := s.node.stores.GetReplicaForRangeID(roachpb.RangeID(1))
-	if err != nil {
+	if roachpb.IsRangeNotFoundError(err) {
 		return timestampLowerBound, 0, nil
+	}
+	if err != nil {
+		return timestampLowerBound, 0, err
 	}
 
 	if !repl.IsFirstRange() || !repl.OwnsValidLease(s.clock.Now()) {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2346,7 +2346,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 		g := p.ExecCfg().Gossip
 		descriptors, err := getAllNodeDescriptors(p)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		alive := make(map[roachpb.NodeID]tree.DBool)

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -187,7 +187,7 @@ func getDescriptorByID(
 				"%q is not a table", desc.String())
 		}
 		if err := table.MaybeFillInDescriptor(ctx, txn); err != nil {
-			return nil
+			return err
 		}
 
 		if err := table.Validate(ctx, txn); err != nil {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -674,7 +674,8 @@ func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) er
 		// written on startup, the most likely scenario is
 		// that the node is ready. We therefore return no
 		// error.
-		return nil
+		// TODO(ajwerner): Determine the expected error types and only filter those.
+		return nil //nolint:returnerrcheck
 	}
 
 	if drainingInfo.Draining {

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -723,7 +723,7 @@ func GeneratePlanDiagramURL(
 ) (string, url.URL, error) {
 	d, err := GeneratePlanDiagram(sql, flows, showInputTypes)
 	if err != nil {
-		return "", url.URL{}, nil
+		return "", url.URL{}, err
 	}
 	return d.ToURL()
 }

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -282,7 +282,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 				if m.statsCollectionEnabled {
 					err := m.flush(ctx)
 					if err != nil {
-						return nil
+						return err
 					}
 					if m.flowCtx.Cfg.TestingKnobs.DeterministicStats {
 						m.stats.BytesSent = 0

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1955,6 +1955,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 	if err != nil {
 		// An error occurred, but it was expected.
 		t.finishOne("XFAIL")
+		//nolint:returnerrcheck
 		return nil
 	}
 	defer rows.Close()

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -107,12 +107,7 @@ func (b *Builder) buildScalar(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.
 			if value == tree.DNull {
 				// We don't want to return an expression that has a different type; cast
 				// the NULL if necessary.
-				var newExpr tree.TypedExpr
-				newExpr, err = tree.ReType(tree.DNull, texpr.ResolvedType())
-				if err != nil {
-					return texpr, nil //nolint:returnerrcheck
-				}
-				return newExpr, nil
+				return tree.ReType(tree.DNull, texpr.ResolvedType()), nil
 			}
 			return value, nil
 		}
@@ -128,7 +123,7 @@ func (b *Builder) buildTypedExpr(
 }
 
 func (b *Builder) buildNull(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {
-	return tree.ReType(tree.DNull, scalar.DataType())
+	return tree.ReType(tree.DNull, scalar.DataType()), nil
 }
 
 func (b *Builder) buildVariable(
@@ -143,11 +138,7 @@ func (b *Builder) indexedVar(
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
 		if b.nullifyMissingVarExprs > 0 {
-			expr, err := tree.ReType(tree.DNull, md.ColumnMeta(colID).Type)
-			if err != nil {
-				panic(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected failure during ReType"))
-			}
-			return expr
+			return tree.ReType(tree.DNull, md.ColumnMeta(colID).Type)
 		}
 		panic(errors.AssertionFailedf("cannot map variable %d to an indexed var", log.Safe(colID)))
 	}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -95,6 +95,9 @@ func (b *Builder) buildScalar(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.
 		if b.evalCtx != nil && b.isConst(texpr) {
 			value, err := texpr.Eval(b.evalCtx)
 			if err != nil {
+				if errors.IsAssertionFailure(err) {
+					return nil, err
+				}
 				// Ignore any errors here (e.g. division by zero), so they can happen
 				// during execution where they are correctly handled. Note that in some
 				// cases we might not even get an error (if this particular expression
@@ -107,7 +110,7 @@ func (b *Builder) buildScalar(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.
 				var newExpr tree.TypedExpr
 				newExpr, err = tree.ReType(tree.DNull, texpr.ResolvedType())
 				if err != nil {
-					return texpr, nil
+					return texpr, nil //nolint:returnerrcheck
 				}
 				return newExpr, nil
 			}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -212,8 +212,8 @@ func (b *Builder) buildScalar(
 		// select the right overload. The solution is to wrap any mismatched
 		// arguments with a CastExpr that preserves the static type.
 
-		left, _ := tree.ReType(t.TypedLeft(), t.ResolvedBinOp().LeftType)
-		right, _ := tree.ReType(t.TypedRight(), t.ResolvedBinOp().RightType)
+		left := tree.ReType(t.TypedLeft(), t.ResolvedBinOp().LeftType)
+		right := tree.ReType(t.TypedRight(), t.ResolvedBinOp().RightType)
 		out = b.constructBinary(t.Operator,
 			b.buildScalar(left, inScope, nil, nil, colRefs),
 			b.buildScalar(right, inScope, nil, nil, colRefs),

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -330,10 +330,7 @@ func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
 			argExprs = append(argExprs, tree.NewDInt(1))
 		}
 		if len(argExprs) < 3 {
-			null, err := tree.ReType(tree.DNull, argExprs[0].ResolvedType())
-			if err != nil {
-				panic(errors.NewAssertionErrorWithWrappedErrf(err, "error calling tree.ReType"))
-			}
+			null := tree.ReType(tree.DNull, argExprs[0].ResolvedType())
 			argExprs = append(argExprs, null)
 		}
 	}

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -193,7 +193,10 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	}
 
 	ok, schemaID, err := a.IsValidSchema(ctx, txn, dbID, name.Schema())
-	if !ok || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		if flags.Required {
 			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(name))
 		}

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -297,7 +297,7 @@ func (s *sortAllProcessor) fill() (ok bool, _ error) {
 		if meta != nil {
 			s.AppendTrailingMeta(*meta)
 			if meta.Err != nil {
-				return false, nil
+				return false, nil //nolint:returnerrcheck
 			}
 			continue
 		}
@@ -525,7 +525,7 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 		if meta != nil {
 			s.AppendTrailingMeta(*meta)
 			if meta.Err != nil {
-				return false, nil
+				return false, nil //nolint:returnerrcheck
 			}
 			continue
 		} else if nextChunkRow == nil {
@@ -548,7 +548,7 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 		if meta != nil {
 			s.AppendTrailingMeta(*meta)
 			if meta.Err != nil {
-				return false, nil
+				return false, nil //nolint:returnerrcheck
 			}
 			continue
 		}

--- a/pkg/sql/sem/tree/constant_eval.go
+++ b/pkg/sql/sem/tree/constant_eval.go
@@ -58,12 +58,7 @@ func (v *ConstantEvalVisitor) VisitPost(expr Expr) Expr {
 	if value == DNull {
 		// We don't want to return an expression that has a different type; cast
 		// the NULL if necessary.
-		var newExpr TypedExpr
-		newExpr, v.err = ReType(DNull, typedExpr.ResolvedType())
-		if v.err != nil {
-			return expr
-		}
-		return newExpr
+		return ReType(DNull, typedExpr.ResolvedType())
 	}
 	return value
 }

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -127,25 +127,25 @@ func (expr *BinaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 	switch expr.Operator {
 	case Plus:
 		if v.isNumericZero(right) {
-			final, v.err = ReType(left, expectedType)
+			final = ReType(left, expectedType)
 			break
 		}
 		if v.isNumericZero(left) {
-			final, v.err = ReType(right, expectedType)
+			final = ReType(right, expectedType)
 			break
 		}
 	case Minus:
 		if types.IsAdditiveType(left.ResolvedType()) && v.isNumericZero(right) {
-			final, v.err = ReType(left, expectedType)
+			final = ReType(left, expectedType)
 			break
 		}
 	case Mult:
 		if v.isNumericOne(right) {
-			final, v.err = ReType(left, expectedType)
+			final = ReType(left, expectedType)
 			break
 		}
 		if v.isNumericOne(left) {
-			final, v.err = ReType(right, expectedType)
+			final = ReType(right, expectedType)
 			break
 		}
 		// We can't simplify multiplication by zero to zero,
@@ -153,7 +153,7 @@ func (expr *BinaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 		// the result must be NULL.
 	case Div, FloorDiv:
 		if v.isNumericOne(right) {
-			final, v.err = ReType(left, expectedType)
+			final = ReType(left, expectedType)
 			break
 		}
 	}
@@ -740,12 +740,7 @@ func (v *NormalizeVisitor) VisitPost(expr Expr) Expr {
 		if value == DNull {
 			// We don't want to return an expression that has a different type; cast
 			// the NULL if necessary.
-			var newExpr TypedExpr
-			newExpr, v.err = ReType(DNull, expr.(TypedExpr).ResolvedType())
-			if v.err != nil {
-				return expr
-			}
-			return newExpr
+			return ReType(DNull, expr.(TypedExpr).ResolvedType())
 		}
 		return value
 	}
@@ -972,11 +967,11 @@ func init() {
 
 // ReType ensures that the given numeric expression evaluates
 // to the requested type, inserting a cast if necessary.
-func ReType(expr TypedExpr, wantedType *types.T) (TypedExpr, error) {
+func ReType(expr TypedExpr, wantedType *types.T) TypedExpr {
 	if expr.ResolvedType().Equivalent(wantedType) {
-		return expr, nil
+		return expr
 	}
 	res := &CastExpr{Expr: expr, Type: wantedType}
 	res.typ = wantedType
-	return res, nil
+	return res
 }

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -56,7 +56,7 @@ func verifyFormat(sql string) error {
 	stmts, err := parser.Parse(sql)
 	if err != nil {
 		// Cannot serialize a statement list without parsing it.
-		return nil
+		return nil //nolint:returnerrcheck
 	}
 	formattedSQL := stmts.StringWithFlags(tree.FmtShowPasswords)
 	formattedStmts, err := parser.Parse(formattedSQL)
@@ -596,29 +596,29 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		// looking for datums that don't match.
 		parsed1, err := parser.ParseExpr(serializedGen)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		typed1, err := parsed1.TypeCheck(&sema, typ)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		datum1, err := typed1.Eval(&eval)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		serialized1 := tree.Serialize(datum1)
 
 		parsed2, err := parser.ParseExpr(serialized1)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		typed2, err := parsed2.TypeCheck(&sema, typ)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		datum2, err := typed2.Eval(&eval)
 		if err != nil {
-			return nil
+			return nil //nolint:returnerrcheck
 		}
 		serialized2 := tree.Serialize(datum2)
 

--- a/pkg/storage/engine/merge.go
+++ b/pkg/storage/engine/merge.go
@@ -66,7 +66,7 @@ func MergeInternalTimeSeriesData(
 	var mergedBytes []byte
 	srcBytes, err := serializeMergeInputs(sources...)
 	if err != nil {
-		return roachpb.InternalTimeSeriesData{}, nil
+		return roachpb.InternalTimeSeriesData{}, err
 	}
 	if !mergeIntoNil {
 		mergedBytes = srcBytes[0]

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -172,9 +172,10 @@ func (t *pebbleTimeBoundPropCollector) Finish(userProps map[string]string) error
 		meta := &enginepb.MVCCMetadata{}
 		if err := protoutil.Unmarshal(t.lastValue, meta); err != nil {
 			// We're unable to parse the MVCCMetadata. Fail open by not setting the
-			// min/max timestamp properties. THis mimics the behavior of
+			// min/max timestamp properties. This mimics the behavior of
 			// TimeBoundTblPropCollector.
-			return nil
+			// TODO(petermattis): Return the error here and in C++, see #43422.
+			return nil //nolint:returnerrcheck
 		}
 		if meta.Txn != nil {
 			ts := encodeTimestamp(hlc.Timestamp(meta.Timestamp))

--- a/pkg/storage/engine/row_counter.go
+++ b/pkg/storage/engine/row_counter.go
@@ -34,9 +34,15 @@ func (r *RowCounter) Count(key roachpb.Key) error {
 	// We reuse it here to count "rows" by counting when it changes.
 	// Non-SQL keys are returned unchanged or may error -- we ignore them, since
 	// non-SQL keys are obviously thus not SQL rows.
+	//
+	// TODO(ajwerner): provide a separate mechanism to determine whether the key
+	// is a valid SQL key which explicitly indicates whether the key is valid as
+	// a split key independent of an error. See #43423.
 	row, err := keys.EnsureSafeSplitKey(key)
 	if err != nil || len(key) == len(row) {
-		return nil
+		// TODO(ajwerner): Determine which errors should be ignored and only
+		// ignore those.
+		return nil //nolint:returnerrcheck
 	}
 
 	// no change key prefix => no new row.

--- a/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck.go
@@ -1,0 +1,234 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package returnerrcheck defines an suite of Analyzers that
+// detects conditionals which check for a non-nil error and then
+// proceed to return a nil error.
+package returnerrcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Doc documents this pass.
+const Doc = `check for return of nil in a conditional which check for non-nil errors`
+
+var errorType = types.Universe.Lookup("error").Type()
+
+// Analyzer is a linter that ensures that returns from functions which
+// return an error as their last return value which have returns inside
+// the body of if conditionals which check for an error to be non-nil do
+// not return a nil error without a `//nolint:returnerrcheck` comment.
+var Analyzer = &analysis.Analyzer{
+	Name:     "returnerrcheck",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run: func(pass *analysis.Pass) (interface{}, error) {
+
+		inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		inspect.Preorder([]ast.Node{
+			(*ast.IfStmt)(nil),
+		}, func(n ast.Node) {
+			ifStmt := n.(*ast.IfStmt)
+
+			// Are we inside of a function which returns an error?
+			containing := findContainingFunc(pass, n)
+			if !funcReturnsErrorLast(containing) {
+				return
+			}
+
+			// Now we want to know if the condition in this statement checks if
+			// an error is non-nil.
+			errObj, ok := isNonNilErrCheck(pass, ifStmt.Cond)
+			if !ok {
+				return
+			}
+			for i, n := range ifStmt.Body.List {
+				returnStmt, ok := n.(*ast.ReturnStmt)
+				if !ok {
+					continue
+				}
+				if len(returnStmt.Results) == 0 {
+					continue
+				}
+				lastRes := returnStmt.Results[len(returnStmt.Results)-1]
+				if !pass.TypesInfo.Types[lastRes].IsNil() {
+					continue
+				}
+				if hasAcceptableAction(pass, errObj, ifStmt.Body.List[:i+1]) {
+					continue
+				}
+				if hasNoLintComment(pass, ifStmt, returnStmt) {
+					continue
+				}
+				pass.Report(analysis.Diagnostic{
+					Pos: n.Pos(),
+					Message: fmt.Sprintf("unexpected nil error return after checking for a non-nil error" +
+						"; if this is not a mistake, add a \"//nolint:returnerrcheck\" comment"),
+				})
+			}
+		})
+		return nil, nil
+	},
+}
+
+// hasAcceptableAction determines if there is some action in statements which
+// uses errObj in a way which excuses a nil error return value. Such actions
+// include assigning the error to a value, calling Error() on it, type asserting
+// it, calling a function with the error as an argument, or returning the error
+// in a different return statement.
+func hasAcceptableAction(pass *analysis.Pass, errObj types.Object, statements []ast.Stmt) bool {
+	var seen bool
+	isObj := func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok {
+			if seen = pass.TypesInfo.Uses[id] == errObj; seen {
+				return true
+			}
+		}
+		return false
+	}
+	inspect := func(n ast.Node) (wantMore bool) {
+		switch n := n.(type) {
+		case *ast.CallExpr:
+			// If we call a function with the non-nil error object, we probably know
+			// what we're doing.
+			for _, arg := range n.Args {
+				if isObj(arg) {
+					return false
+				}
+			}
+		case *ast.AssignStmt:
+			// If we assign the error to some value, we probably know what we're
+			// doing.
+			for _, rhs := range n.Rhs {
+				if isObj(rhs) {
+					return false
+				}
+			}
+		case *ast.KeyValueExpr:
+			// If we assign the error to a field or map in a literal, we probably
+			// know what we're doing.
+			if isObj(n.Value) {
+				return false
+			}
+
+		case *ast.SelectorExpr:
+			// If we're selecting something off of the error (i.e. err.Error()) then
+			// we probably know what we're doing.
+			if isObj(n.X) {
+				return false
+			}
+		case *ast.ReturnStmt:
+			// If we return the error, perhaps in a different if statement, we
+			// might know what we're doing. This is good for cases like:
+			//
+			//  if cond || err != nil {
+			//     if err != nil {
+			//         return err
+			//     }
+			//     ...
+			//     return nil
+			//  }
+			//
+			// TODO(ajwerner): ensure that this is returning from the right
+			// function or whether this is a good idea.
+			if numRes := len(n.Results); numRes > 0 && isObj(n.Results[numRes-1]) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, stmt := range statements {
+		if ast.Inspect(stmt, inspect); seen {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNoLintComment(pass *analysis.Pass, ifStmt, returnStmt ast.Node) bool {
+	f := findContainingFile(pass, ifStmt)
+	cm := ast.NewCommentMap(pass.Fset, ifStmt, f.Comments)
+	cm = cm.Filter(returnStmt)
+	for _, cg := range cm[returnStmt] {
+		if strings.Contains(cg.Text(), "nolint:returnerrcheck") {
+			return true
+		}
+	}
+	return false
+}
+
+func isNonNilErrCheck(pass *analysis.Pass, expr ast.Expr) (errObj types.Object, ok bool) {
+	// TODO(ajwerner): Maybe make this understand !(err == nil) and its variants.
+	binaryExpr, ok := expr.(*ast.BinaryExpr)
+	if !ok {
+		return nil, false
+	}
+	// We care about cases when errors are idents not when they're fields
+	switch binaryExpr.Op {
+	case token.NEQ:
+		var id *ast.Ident
+		if pass.TypesInfo.Types[binaryExpr.X].Type == errorType &&
+			pass.TypesInfo.Types[binaryExpr.Y].IsNil() {
+			id, ok = binaryExpr.X.(*ast.Ident)
+		} else if pass.TypesInfo.Types[binaryExpr.Y].Type == errorType &&
+			pass.TypesInfo.Types[binaryExpr.X].IsNil() {
+			id, ok = binaryExpr.Y.(*ast.Ident)
+		}
+		if ok {
+			errObj, ok := pass.TypesInfo.Uses[id]
+			return errObj, ok
+		}
+	case token.LAND, token.LOR:
+		if errObj, ok := isNonNilErrCheck(pass, binaryExpr.X); ok {
+			return errObj, ok
+		}
+		return isNonNilErrCheck(pass, binaryExpr.Y)
+	}
+	return nil, false
+}
+
+func funcReturnsErrorLast(f *types.Signature) bool {
+	results := f.Results()
+	return results.Len() > 0 &&
+		results.At(results.Len()-1).Type() == errorType
+}
+
+func findContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
+	fPos := pass.Fset.File(n.Pos())
+	for _, f := range pass.Files {
+		if pass.Fset.File(f.Pos()) == fPos {
+			return f
+		}
+	}
+	panic(fmt.Errorf("cannot file file for %v", n))
+}
+
+func findContainingFunc(pass *analysis.Pass, n ast.Node) *types.Signature {
+	stack, _ := astutil.PathEnclosingInterval(findContainingFile(pass, n), n.Pos(), n.End())
+	for _, n := range stack {
+		if funcDecl, ok := n.(*ast.FuncDecl); ok {
+			return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func).Type().(*types.Signature)
+		}
+		if funcLit, ok := n.(*ast.FuncLit); ok {
+			return pass.TypesInfo.Types[funcLit].Type.(*types.Signature)
+		}
+	}
+	return nil
+}

--- a/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck_test.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package returnerrcheck_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, returnerrcheck.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/testdata/src/a/a.go
@@ -1,0 +1,130 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+import (
+	"errors"
+	"log"
+)
+
+func noReturn() {
+	err := errors.New("foo")
+	if err != nil {
+		return
+	}
+	_ = func() error {
+		if err != nil {
+			return nil // want `unexpected nil error return after checking for a non-nil error`
+		}
+		return nil
+	}()
+	return
+}
+
+func SingleReturn() error {
+	err := errors.New("foo")
+	if err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil || false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false || err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil && false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false && err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if false || err != nil && false {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if true && false && err != nil {
+		return nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil {
+		//nolint:returnerrcheck
+		return nil
+	}
+	if err != nil {
+		return nil //nolint:returnerrcheck
+	}
+	return nil
+}
+
+func MultipleReturns() (int, error) {
+	err := errors.New("foo")
+	if err != nil {
+		if true {
+			return 0, nil
+		}
+		return 0, nil // want `unexpected nil error return after checking for a non-nil error`
+	}
+	if err != nil {
+		//nolint:returnerrcheck
+		return 0, nil
+	}
+	return -1, nil
+}
+
+func AcceptableBehavior() {
+	type structThing struct {
+		err error
+	}
+	_ = func() error {
+		var t structThing
+		// Intentionally don't error if the check is not for an ident directly but
+		// rather is for a field.
+		if t.err != nil {
+			return nil
+		}
+		return nil
+	}
+	_ = func() error {
+		if err := errors.New("foo"); err != nil {
+			log.Printf("%v", err)
+			return nil
+		}
+		return nil
+	}
+	var t structThing
+	_ = func() error {
+		if err := errors.New("foo"); err != nil {
+			t.err = err
+			return nil
+		}
+		return nil
+	}
+	func() error {
+		if err := errors.New("foo"); err != nil {
+			t = structThing{err: err}
+			return nil
+		}
+		return nil
+	}()
+	func() error {
+		if err := errors.New("foo"); err != nil || true {
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		return nil
+	}()
+	func() (string, error) {
+		if err := errors.New("foo"); err != nil {
+			return err.Error(), nil
+		}
+		return "", nil
+	}()
+}

--- a/pkg/testutils/reduce/reduce.go
+++ b/pkg/testutils/reduce/reduce.go
@@ -221,6 +221,7 @@ func Reduce(
 		for {
 			next, err := findNextInteresting(vs)
 			if err != nil {
+				//nolint:returnerrcheck
 				return "", nil
 			}
 			if next == nil {

--- a/pkg/util/json/contains.go
+++ b/pkg/util/json/contains.go
@@ -202,7 +202,7 @@ func (j containsableArray) contains(other containsable) (bool, error) {
 		// objects and arrays, but for now just do the quadratic check.
 		objectsMatch, err := quadraticJSONArrayContains(j.objects, contained.objects)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if !objectsMatch {
 			return false, nil
@@ -210,7 +210,7 @@ func (j containsableArray) contains(other containsable) (bool, error) {
 
 		arraysMatch, err := quadraticJSONArrayContains(j.arrays, contained.arrays)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if !arraysMatch {
 			return false, nil

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -622,7 +622,7 @@ func (j *jsonEncoded) FetchValKeyOrIdx(key string) (JSON, error) {
 			// We shouldn't return this error because it means we couldn't parse the
 			// number, meaning it was a string and that just means we can't find the
 			// value in an array.
-			return nil, nil
+			return nil, nil //nolint:returnerrcheck
 		}
 		return j.FetchValIdx(idx)
 	}

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -1272,7 +1272,7 @@ func (j jsonArray) FetchValKeyOrIdx(key string) (JSON, error) {
 		// We shouldn't return this error because it means we couldn't parse the
 		// number, meaning it was a string and that just means we can't find the
 		// value in an array.
-		return nil, nil
+		return nil, nil //nolint:returnerrcheck
 	}
 	return j.FetchValIdx(idx)
 }

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -447,9 +447,9 @@ func TestGetLogReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir, err := mainLog.logDir.get()
-	if err != nil {
-		t.Fatal(err)
+	dir, isSet := mainLog.logDir.get()
+	if !isSet {
+		t.Fatal(errDirectoryNotSet)
 	}
 	otherFile, err := os.Create(filepath.Join(dir, "other.txt"))
 	if err != nil {

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -282,7 +282,7 @@ func (l *loggerT) listLogFiles() ([]FileInfo, error) {
 	if err != nil {
 		// No log directory configured: simply indicate that there are no
 		// log files.
-		return nil, nil
+		return nil, nil //nolint:returnerrcheck
 	}
 	infos, err := ioutil.ReadDir(dir)
 	if err != nil {

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -85,13 +85,10 @@ func (l *DirName) String() string {
 	return l.name
 }
 
-func (l *DirName) get() (string, error) {
+func (l *DirName) get() (dirName string, isSet bool) {
 	l.Lock()
 	defer l.Unlock()
-	if len(l.name) == 0 {
-		return "", errDirectoryNotSet
-	}
-	return l.name, nil
+	return l.name, l.name != ""
 }
 
 // IsSet returns true iff the directory name is set.
@@ -230,9 +227,9 @@ var errDirectoryNotSet = errors.New("log: log directory not set")
 func create(
 	logDir *DirName, prefix string, t time.Time, lastRotation int64,
 ) (f *os.File, updatedRotation int64, filename string, err error) {
-	dir, err := logDir.get()
-	if err != nil {
-		return nil, lastRotation, "", err
+	dir, isSet := logDir.get()
+	if !isSet {
+		return nil, lastRotation, "", errDirectoryNotSet
 	}
 
 	// Ensure that the timestamp of the new file name is greater than
@@ -278,11 +275,11 @@ func ListLogFiles() ([]FileInfo, error) {
 
 func (l *loggerT) listLogFiles() ([]FileInfo, error) {
 	var results []FileInfo
-	dir, err := l.logDir.get()
-	if err != nil {
+	dir, isSet := l.logDir.get()
+	if !isSet {
 		// No log directory configured: simply indicate that there are no
 		// log files.
-		return nil, nil //nolint:returnerrcheck
+		return nil, nil
 	}
 	infos, err := ioutil.ReadDir(dir)
 	if err != nil {
@@ -315,9 +312,9 @@ func (l *loggerT) listLogFiles() ([]FileInfo, error) {
 //
 // TODO(knz): make this work for secondary loggers too.
 func GetLogReader(filename string, restricted bool) (io.ReadCloser, error) {
-	dir, err := mainLog.logDir.get()
-	if err != nil {
-		return nil, err
+	dir, isSet := mainLog.logDir.get()
+	if !isSet {
+		return nil, errDirectoryNotSet
 	}
 
 	switch restricted {

--- a/pkg/util/log/log_gc.go
+++ b/pkg/util/log/log_gc.go
@@ -60,8 +60,8 @@ func (l *loggerT) gcDaemon(ctx context.Context) {
 // gcOldFiles removes the "old" files that do not match
 // the configured size and number threshold.
 func (l *loggerT) gcOldFiles() {
-	dir, err := l.logDir.get()
-	if err != nil {
+	dir, isSet := l.logDir.get()
+	if !isSet {
 		// No log directory configured. Nothing to do.
 		return
 	}

--- a/pkg/util/log/log_gc_test.go
+++ b/pkg/util/log/log_gc_test.go
@@ -101,9 +101,9 @@ func testLogGC(
 	// Check that the file exists, and also measure its size.
 	// We'll use this as base value for the maximum combined size
 	// below, to force GC.
-	dir, err := logger.logDir.get()
-	if err != nil {
-		t.Fatal(err)
+	dir, isSet := logger.logDir.get()
+	if !isSet {
+		t.Fatal(errDirectoryNotSet)
 	}
 	stat, err := os.Stat(filepath.Join(dir, allFilesOriginal[0].Name))
 	if err != nil {


### PR DESCRIPTION
This commit adds a lint pass which checks for if statments in functions
which return an error last which in their condition check if an error is
non-nil and then proceed to return a nil error.

Fixes #19316

Release note: None.