### PR TITLE
storage: clean up usage of `{eng,batch} engine.{Reader,Writer,ReadWriter}`

### DIFF
--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -196,13 +196,13 @@ func TestExportGCThreshold(t *testing.T) {
 }
 
 // exportUsingGoIterator uses the legacy implementation of export, and is used
-// as ana oracle to check the correctness of the new C++ implementation.
+// as an oracle to check the correctness of the new C++ implementation.
 func exportUsingGoIterator(
 	filter roachpb.MVCCFilter,
 	startTime, endTime hlc.Timestamp,
 	startKey, endKey roachpb.Key,
 	enableTimeBoundIteratorOptimization bool,
-	batch engine.Reader,
+	reader engine.Reader,
 ) ([]byte, error) {
 	sst, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
@@ -230,7 +230,7 @@ func exportUsingGoIterator(
 		io.MaxTimestampHint = endTime
 		io.MinTimestampHint = startTime.Next()
 	}
-	iter := engine.NewMVCCIncrementalIterator(batch, engine.MVCCIncrementalIterOptions{
+	iter := engine.NewMVCCIncrementalIterator(reader, engine.MVCCIncrementalIterOptions{
 		IterOptions: io,
 		StartTime:   startTime,
 		EndTime:     endTime,

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func hashRange(t *testing.T, eng engine.Reader, start, end roachpb.Key) []byte {
+func hashRange(t *testing.T, reader engine.Reader, start, end roachpb.Key) []byte {
 	t.Helper()
 	h := sha256.New()
-	if err := eng.Iterate(start, end,
+	if err := reader.Iterate(start, end,
 		func(kv engine.MVCCKeyValue) (bool, error) {
 			h.Write(kv.Key.Key)
 			h.Write(kv.Value)
@@ -41,9 +41,9 @@ func hashRange(t *testing.T, eng engine.Reader, start, end roachpb.Key) []byte {
 	return h.Sum(nil)
 }
 
-func getStats(t *testing.T, batch engine.Reader) enginepb.MVCCStats {
+func getStats(t *testing.T, reader engine.Reader) enginepb.MVCCStats {
 	t.Helper()
-	iter := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
+	iter := reader.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 	s, err := engine.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
 	if err != nil {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -421,7 +421,7 @@ func SetMockAddSSTable() (undo func()) {
 	// TODO(tschottdorf): this already does nontrivial work. Worth open-sourcing the relevant
 	// subparts of the real evalAddSSTable to make this test less likely to rot.
 	evalAddSSTable := func(
-		ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
+		ctx context.Context, _ engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
 	) (result.Result, error) {
 		log.Event(ctx, "evaluated testing-only AddSSTable mock")
 		args := cArgs.Args.(*roachpb.AddSSTableRequest)

--- a/pkg/storage/rditer/replica_data_iter_test.go
+++ b/pkg/storage/rditer/replica_data_iter_test.go
@@ -120,7 +120,7 @@ func createRangeData(
 func verifyRDIter(
 	t *testing.T,
 	desc *roachpb.RangeDescriptor,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	replicatedOnly bool,
 	expectedKeys []engine.MVCCKey,
 ) {
@@ -140,9 +140,9 @@ func verifyRDIter(
 				Key:    desc.StartKey.AsRawKey(),
 				EndKey: desc.EndKey.AsRawKey(),
 			}, hlc.Timestamp{WallTime: 42})
-			eng = spanset.NewReadWriterAt(eng, &spans, hlc.Timestamp{WallTime: 42})
+			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaDataIterator(desc, eng, replicatedOnly)
+		iter := NewReplicaDataIterator(desc, readWriter, replicatedOnly)
 		defer iter.Close()
 		i := 0
 		for ; ; iter.Next() {

--- a/pkg/storage/replica_destroy.go
+++ b/pkg/storage/replica_destroy.go
@@ -199,7 +199,7 @@ func (r *Replica) cancelPendingCommandsLocked() {
 // ID that it hasn't yet received a RangeDescriptor for if it receives raft
 // requests for that replica ID (as seen in #14231).
 func (r *Replica) setTombstoneKey(
-	ctx context.Context, eng engine.Writer, externalNextReplicaID roachpb.ReplicaID,
+	ctx context.Context, writer engine.Writer, externalNextReplicaID roachpb.ReplicaID,
 ) error {
 	r.mu.Lock()
 	nextReplicaID := r.mu.state.Desc.NextReplicaID
@@ -216,6 +216,6 @@ func (r *Replica) setTombstoneKey(
 		NextReplicaID: nextReplicaID,
 	}
 	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
-	return engine.MVCCBlindPutProto(ctx, eng, nil, tombstoneKey,
+	return engine.MVCCBlindPutProto(ctx, writer, nil, tombstoneKey,
 		hlc.Timestamp{}, tombstone, nil)
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -12225,13 +12225,13 @@ func setMockPutWithEstimates(containsEstimatesDelta int64) (undo func()) {
 	prev, _ := batcheval.LookupCommand(roachpb.Put)
 
 	mockPut := func(
-		ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
+		ctx context.Context, readWriter engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
 	) (result.Result, error) {
 		args := cArgs.Args.(*roachpb.PutRequest)
 		ms := cArgs.Stats
 		ms.ContainsEstimates += containsEstimatesDelta
 		ts := cArgs.Header.Timestamp
-		return result.Result{}, engine.MVCCBlindPut(ctx, batch, ms, args.Key, ts, args.Value, cArgs.Header.Txn)
+		return result.Result{}, engine.MVCCBlindPut(ctx, readWriter, ms, args.Key, ts, args.Value, cArgs.Header.Txn)
 	}
 
 	batcheval.UnregisterCommand(roachpb.Put)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6024,8 +6024,10 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 	}
 }
 
-func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
-	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), eng)
+func verifyRangeStats(
+	reader engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats,
+) error {
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -541,7 +541,7 @@ func (rsl StateLoader) LoadRaftTruncatedState(
 
 // SetRaftTruncatedState overwrites the truncated state.
 func (rsl StateLoader) SetRaftTruncatedState(
-	ctx context.Context, eng engine.Writer, truncState *roachpb.RaftTruncatedState,
+	ctx context.Context, writer engine.Writer, truncState *roachpb.RaftTruncatedState,
 ) error {
 	if (*truncState == roachpb.RaftTruncatedState{}) {
 		return errors.New("cannot persist empty RaftTruncatedState")
@@ -549,7 +549,7 @@ func (rsl StateLoader) SetRaftTruncatedState(
 	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
 	return engine.MVCCBlindPutProto(
 		ctx,
-		eng,
+		writer,
 		nil, /* ms */
 		rsl.RaftTruncatedStateKey(),
 		hlc.Timestamp{}, /* timestamp */
@@ -574,12 +574,12 @@ func (rsl StateLoader) LoadHardState(
 
 // SetHardState overwrites the HardState.
 func (rsl StateLoader) SetHardState(
-	ctx context.Context, batch engine.Writer, hs raftpb.HardState,
+	ctx context.Context, writer engine.Writer, hs raftpb.HardState,
 ) error {
 	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
 	return engine.MVCCBlindPutProto(
 		ctx,
-		batch,
+		writer,
 		nil, /* ms */
 		rsl.RaftHardStateKey(),
 		hlc.Timestamp{}, /* timestamp */

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -130,38 +130,38 @@ const (
 // strictly for use in Result. Do before merge.
 func (rsl StateLoader) Save(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	state storagepb.ReplicaState,
 	truncStateType TruncatedStateType,
 ) (enginepb.MVCCStats, error) {
 	ms := state.Stats
-	if err := rsl.SetLease(ctx, eng, ms, *state.Lease); err != nil {
+	if err := rsl.SetLease(ctx, readWriter, ms, *state.Lease); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if err := rsl.SetGCThreshold(ctx, eng, ms, state.GCThreshold); err != nil {
+	if err := rsl.SetGCThreshold(ctx, readWriter, ms, state.GCThreshold); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	if truncStateType == TruncatedStateLegacyReplicated {
-		if err := rsl.SetLegacyRaftTruncatedState(ctx, eng, ms, state.TruncatedState); err != nil {
+		if err := rsl.SetLegacyRaftTruncatedState(ctx, readWriter, ms, state.TruncatedState); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
 	} else {
-		if err := rsl.SetRaftTruncatedState(ctx, eng, state.TruncatedState); err != nil {
+		if err := rsl.SetRaftTruncatedState(ctx, readWriter, state.TruncatedState); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
 	}
 	if state.UsingAppliedStateKey {
 		rai, lai := state.RaftAppliedIndex, state.LeaseAppliedIndex
-		if err := rsl.SetRangeAppliedState(ctx, eng, rai, lai, ms); err != nil {
+		if err := rsl.SetRangeAppliedState(ctx, readWriter, rai, lai, ms); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
 	} else {
 		if err := rsl.SetLegacyAppliedIndex(
-			ctx, eng, ms, state.RaftAppliedIndex, state.LeaseAppliedIndex,
+			ctx, readWriter, ms, state.RaftAppliedIndex, state.LeaseAppliedIndex,
 		); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
-		if err := rsl.SetLegacyMVCCStats(ctx, eng, ms); err != nil {
+		if err := rsl.SetLegacyMVCCStats(ctx, readWriter, ms); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
 	}
@@ -178,9 +178,9 @@ func (rsl StateLoader) LoadLease(ctx context.Context, reader engine.Reader) (roa
 
 // SetLease persists a lease.
 func (rsl StateLoader) SetLease(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
+	ctx context.Context, readWriter engine.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
 ) error {
-	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeLeaseKey(),
+	return engine.MVCCPutProto(ctx, readWriter, ms, rsl.RangeLeaseKey(),
 		hlc.Timestamp{}, nil, &lease)
 }
 
@@ -278,7 +278,7 @@ func (rsl StateLoader) LoadMVCCStats(
 // by the range applied state key.
 func (rsl StateLoader) SetRangeAppliedState(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	appliedIndex, leaseAppliedIndex uint64,
 	newMS *enginepb.MVCCStats,
 ) error {
@@ -290,22 +290,22 @@ func (rsl StateLoader) SetRangeAppliedState(
 	// The RangeAppliedStateKey is not included in stats. This is also reflected
 	// in C.MVCCComputeStats and ComputeStatsGo.
 	ms := (*enginepb.MVCCStats)(nil)
-	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeAppliedStateKey(), hlc.Timestamp{}, nil, &as)
+	return engine.MVCCPutProto(ctx, readWriter, ms, rsl.RangeAppliedStateKey(), hlc.Timestamp{}, nil, &as)
 }
 
 // MigrateToRangeAppliedStateKey deletes the keys that were replaced by the
 // RangeAppliedState key.
 func (rsl StateLoader) MigrateToRangeAppliedStateKey(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats,
+	ctx context.Context, readWriter engine.ReadWriter, ms *enginepb.MVCCStats,
 ) error {
 	noTS := hlc.Timestamp{}
-	if err := engine.MVCCDelete(ctx, eng, ms, rsl.RaftAppliedIndexLegacyKey(), noTS, nil); err != nil {
+	if err := engine.MVCCDelete(ctx, readWriter, ms, rsl.RaftAppliedIndexLegacyKey(), noTS, nil); err != nil {
 		return err
 	}
-	if err := engine.MVCCDelete(ctx, eng, ms, rsl.LeaseAppliedIndexLegacyKey(), noTS, nil); err != nil {
+	if err := engine.MVCCDelete(ctx, readWriter, ms, rsl.LeaseAppliedIndexLegacyKey(), noTS, nil); err != nil {
 		return err
 	}
-	return engine.MVCCDelete(ctx, eng, ms, rsl.RangeStatsLegacyKey(), noTS, nil)
+	return engine.MVCCDelete(ctx, readWriter, ms, rsl.RangeStatsLegacyKey(), noTS, nil)
 }
 
 // SetLegacyAppliedIndex sets the legacy {raft,lease} applied index values,
@@ -315,17 +315,17 @@ func (rsl StateLoader) MigrateToRangeAppliedStateKey(
 // triggered. See comment on SetRangeAppliedState for why this is "legacy".
 func (rsl StateLoader) SetLegacyAppliedIndex(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	appliedIndex, leaseAppliedIndex uint64,
 ) error {
-	if err := rsl.AssertNoRangeAppliedState(ctx, eng); err != nil {
+	if err := rsl.AssertNoRangeAppliedState(ctx, readWriter); err != nil {
 		return err
 	}
 
 	var value roachpb.Value
 	value.SetInt(int64(appliedIndex))
-	if err := engine.MVCCPut(ctx, eng, ms,
+	if err := engine.MVCCPut(ctx, readWriter, ms,
 		rsl.RaftAppliedIndexLegacyKey(),
 		hlc.Timestamp{},
 		value,
@@ -333,7 +333,7 @@ func (rsl StateLoader) SetLegacyAppliedIndex(
 		return err
 	}
 	value.SetInt(int64(leaseAppliedIndex))
-	return engine.MVCCPut(ctx, eng, ms,
+	return engine.MVCCPut(ctx, readWriter, ms,
 		rsl.LeaseAppliedIndexLegacyKey(),
 		hlc.Timestamp{},
 		value,
@@ -350,17 +350,17 @@ func (rsl StateLoader) SetLegacyAppliedIndex(
 // triggered. See comment on SetRangeAppliedState for why this is "legacy".
 func (rsl StateLoader) SetLegacyAppliedIndexBlind(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	appliedIndex, leaseAppliedIndex uint64,
 ) error {
-	if err := rsl.AssertNoRangeAppliedState(ctx, eng); err != nil {
+	if err := rsl.AssertNoRangeAppliedState(ctx, readWriter); err != nil {
 		return err
 	}
 
 	var value roachpb.Value
 	value.SetInt(int64(appliedIndex))
-	if err := engine.MVCCBlindPut(ctx, eng, ms,
+	if err := engine.MVCCBlindPut(ctx, readWriter, ms,
 		rsl.RaftAppliedIndexLegacyKey(),
 		hlc.Timestamp{},
 		value,
@@ -368,7 +368,7 @@ func (rsl StateLoader) SetLegacyAppliedIndexBlind(
 		return err
 	}
 	value.SetInt(int64(leaseAppliedIndex))
-	return engine.MVCCBlindPut(ctx, eng, ms,
+	return engine.MVCCBlindPut(ctx, readWriter, ms,
 		rsl.LeaseAppliedIndexLegacyKey(),
 		hlc.Timestamp{},
 		value,
@@ -392,13 +392,13 @@ func (rsl StateLoader) CalcAppliedIndexSysBytes(appliedIndex, leaseAppliedIndex 
 }
 
 func (rsl StateLoader) writeLegacyMVCCStatsInternal(
-	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
+	ctx context.Context, readWriter engine.ReadWriter, newMS *enginepb.MVCCStats,
 ) error {
 	// NB: newMS is copied to prevent conditional calls to this method from
 	// causing the stats argument to escape. This is legacy code which does
 	// not need to be optimized for performance.
 	newMSCopy := *newMS
-	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsLegacyKey(), hlc.Timestamp{}, nil, &newMSCopy)
+	return engine.MVCCPutProto(ctx, readWriter, nil, rsl.RangeStatsLegacyKey(), hlc.Timestamp{}, nil, &newMSCopy)
 }
 
 // SetLegacyMVCCStats overwrites the legacy MVCC stats key.
@@ -406,41 +406,41 @@ func (rsl StateLoader) writeLegacyMVCCStatsInternal(
 // The range applied state key cannot already exist or an assetion will be
 // triggered. See comment on SetRangeAppliedState for why this is "legacy".
 func (rsl StateLoader) SetLegacyMVCCStats(
-	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
+	ctx context.Context, readWriter engine.ReadWriter, newMS *enginepb.MVCCStats,
 ) error {
-	if err := rsl.AssertNoRangeAppliedState(ctx, eng); err != nil {
+	if err := rsl.AssertNoRangeAppliedState(ctx, readWriter); err != nil {
 		return err
 	}
 
-	return rsl.writeLegacyMVCCStatsInternal(ctx, eng, newMS)
+	return rsl.writeLegacyMVCCStatsInternal(ctx, readWriter, newMS)
 }
 
 // SetMVCCStats overwrites the MVCC stats. This needs to perform a read on the
 // RangeAppliedState key before overwriting the stats. Use SetRangeAppliedState
 // when performance is important.
 func (rsl StateLoader) SetMVCCStats(
-	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
+	ctx context.Context, readWriter engine.ReadWriter, newMS *enginepb.MVCCStats,
 ) error {
-	if as, err := rsl.LoadRangeAppliedState(ctx, eng); err != nil {
+	if as, err := rsl.LoadRangeAppliedState(ctx, readWriter); err != nil {
 		return err
 	} else if as != nil {
-		return rsl.SetRangeAppliedState(ctx, eng, as.RaftAppliedIndex, as.LeaseAppliedIndex, newMS)
+		return rsl.SetRangeAppliedState(ctx, readWriter, as.RaftAppliedIndex, as.LeaseAppliedIndex, newMS)
 	}
 
-	return rsl.writeLegacyMVCCStatsInternal(ctx, eng, newMS)
+	return rsl.writeLegacyMVCCStatsInternal(ctx, readWriter, newMS)
 }
 
 // SetLegacyRaftTruncatedState overwrites the truncated state.
 func (rsl StateLoader) SetLegacyRaftTruncatedState(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	truncState *roachpb.RaftTruncatedState,
 ) error {
 	if (*truncState == roachpb.RaftTruncatedState{}) {
 		return errors.New("cannot persist empty RaftTruncatedState")
 	}
-	return engine.MVCCPutProto(ctx, eng, ms,
+	return engine.MVCCPutProto(ctx, readWriter, ms,
 		rsl.RaftTruncatedStateLegacyKey(), hlc.Timestamp{}, nil, truncState)
 }
 
@@ -456,12 +456,15 @@ func (rsl StateLoader) LoadGCThreshold(
 
 // SetGCThreshold sets the GC threshold.
 func (rsl StateLoader) SetGCThreshold(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
+	ctx context.Context,
+	readWriter engine.ReadWriter,
+	ms *enginepb.MVCCStats,
+	threshold *hlc.Timestamp,
 ) error {
 	if threshold == nil {
 		return errors.New("cannot persist nil GCThreshold")
 	}
-	return engine.MVCCPutProto(ctx, eng, ms,
+	return engine.MVCCPutProto(ctx, readWriter, ms,
 		rsl.RangeLastGCKey(), hlc.Timestamp{}, nil, threshold)
 }
 
@@ -592,27 +595,29 @@ func (rsl StateLoader) SetHardState(
 // and a lastIndex from pre-seeded data in the engine (typically created via
 // writeInitialReplicaState and, on a split, perhaps the activity of an
 // uninitialized Raft group)
-func (rsl StateLoader) SynthesizeRaftState(ctx context.Context, eng engine.ReadWriter) error {
-	hs, err := rsl.LoadHardState(ctx, eng)
+func (rsl StateLoader) SynthesizeRaftState(
+	ctx context.Context, readWriter engine.ReadWriter,
+) error {
+	hs, err := rsl.LoadHardState(ctx, readWriter)
 	if err != nil {
 		return err
 	}
-	truncState, _, err := rsl.LoadRaftTruncatedState(ctx, eng)
+	truncState, _, err := rsl.LoadRaftTruncatedState(ctx, readWriter)
 	if err != nil {
 		return err
 	}
-	raftAppliedIndex, _, err := rsl.LoadAppliedIndex(ctx, eng)
+	raftAppliedIndex, _, err := rsl.LoadAppliedIndex(ctx, readWriter)
 	if err != nil {
 		return err
 	}
-	return rsl.SynthesizeHardState(ctx, eng, hs, truncState, raftAppliedIndex)
+	return rsl.SynthesizeHardState(ctx, readWriter, hs, truncState, raftAppliedIndex)
 }
 
 // SynthesizeHardState synthesizes an on-disk HardState from the given input,
 // taking care that a HardState compatible with the existing data is written.
 func (rsl StateLoader) SynthesizeHardState(
 	ctx context.Context,
-	eng engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	oldHS raftpb.HardState,
 	truncState roachpb.RaftTruncatedState,
 	raftAppliedIndex uint64,
@@ -639,6 +644,6 @@ func (rsl StateLoader) SynthesizeHardState(
 	if oldHS.Term == newHS.Term {
 		newHS.Vote = oldHS.Vote
 	}
-	err := rsl.SetHardState(ctx, eng, newHS)
+	err := rsl.SetHardState(ctx, readWriter, newHS)
 	return errors.Wrapf(err, "writing HardState %+v", &newHS)
 }


### PR DESCRIPTION
We should be using `{reader,writer,readWriter} engine.{Reader,Writer,ReadWriter}` instead. See individual commits for review.