### PR TITLE
opt: use norm in normalization rule tests

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -6,7 +6,7 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
 # EliminateAggDistinct
 # --------------------------------------------------
 
-opt expect=EliminateAggDistinct
+norm expect=EliminateAggDistinct
 SELECT min(DISTINCT i), max(DISTINCT i), bool_and(DISTINCT i>f), bool_or(DISTINCT i>f) FROM a
 ----
 scalar-group-by
@@ -31,7 +31,7 @@ scalar-group-by
            └── variable: column9 [type=bool]
 
 # The rule should not apply to these aggregations.
-opt expect-not=EliminateAggDistinct
+norm expect-not=EliminateAggDistinct
 SELECT
     count(DISTINCT i),
     sum(DISTINCT i),

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -15,7 +15,7 @@ CREATE TABLE c (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL)
 # NormalizeNestedAnds
 # --------------------------------------------------
 
-opt expect=NormalizeNestedAnds
+norm expect=NormalizeNestedAnds
 SELECT a AND (b AND (c AND (d AND e))) FROM c
 ----
 project
@@ -25,7 +25,7 @@ project
  └── projections
       └── (((a AND b) AND c) AND d) AND e [type=bool, outer=(1-5)]
 
-opt expect=NormalizeNestedAnds
+norm expect=NormalizeNestedAnds
 SELECT (a AND b) AND (c AND (d OR e)) FROM c
 ----
 project
@@ -36,7 +36,7 @@ project
       └── ((a AND b) AND c) AND (d OR e) [type=bool, outer=(1-5)]
 
 # Already normalized.
-opt expect-not=NormalizeNestedAnds
+norm expect-not=NormalizeNestedAnds
 SELECT a AND b AND c FROM c
 ----
 project
@@ -50,7 +50,7 @@ project
 # SimplifyTrueAnd + SimplifyAndTrue
 # --------------------------------------------------
 
-opt expect=SimplifyTrueAnd
+norm expect=SimplifyTrueAnd
 SELECT true AND k=1 AS r FROM a
 ----
 project
@@ -61,7 +61,7 @@ project
  └── projections
       └── k = 1 [type=bool, outer=(1)]
 
-opt expect=SimplifyAndTrue
+norm expect=SimplifyAndTrue
 SELECT k=1 AND true AS r FROM a
 ----
 project
@@ -72,7 +72,7 @@ project
  └── projections
       └── k = 1 [type=bool, outer=(1)]
 
-opt expect=(SimplifyTrueAnd,SimplifyAndTrue)
+norm expect=(SimplifyTrueAnd,SimplifyAndTrue)
 SELECT true AND k=1 AND true AND i=2 AS r FROM a
 ----
 project
@@ -85,7 +85,7 @@ project
       └── (k = 1) AND (i = 2) [type=bool, outer=(1,2)]
 
 # No conditions left after rule.
-opt expect=SimplifyTrueAnd
+norm expect=SimplifyTrueAnd
 SELECT * FROM a WHERE true AND (true AND true)
 ----
 scan a
@@ -97,7 +97,7 @@ scan a
 # SimplifyFalseAnd + SimplifyAndFalse
 # --------------------------------------------------
 
-opt expect=SimplifyFalseAnd
+norm expect=SimplifyFalseAnd
 SELECT false AND s='foo' AS r FROM a
 ----
 project
@@ -107,7 +107,7 @@ project
  └── projections
       └── false [type=bool]
 
-opt expect=SimplifyAndFalse
+norm expect=SimplifyAndFalse
 SELECT s='foo' AND false AS r FROM a
 ----
 project
@@ -117,7 +117,7 @@ project
  └── projections
       └── false [type=bool]
 
-opt expect=(SimplifyAndFalse,SimplifyFalseAnd)
+norm expect=(SimplifyAndFalse,SimplifyFalseAnd)
 SELECT k=1 AND false AND (f=3.5 AND false) AS r FROM a
 ----
 project
@@ -131,7 +131,7 @@ project
 # SimplifyTrueOr + SimplifyOrTrue
 # --------------------------------------------------
 
-opt expect=SimplifyTrueOr
+norm expect=SimplifyTrueOr
 SELECT true OR s='foo' AS r FROM a
 ----
 project
@@ -141,7 +141,7 @@ project
  └── projections
       └── true [type=bool]
 
-opt expect=SimplifyOrTrue
+norm expect=SimplifyOrTrue
 SELECT s='foo' OR true AS r FROM a
 ----
 project
@@ -151,7 +151,7 @@ project
  └── projections
       └── true [type=bool]
 
-opt expect=(SimplifyTrueOr,SimplifyOrTrue)
+norm expect=(SimplifyTrueOr,SimplifyOrTrue)
 SELECT k=1 OR true OR (true OR f=3.5) AS r FROM a
 ----
 project
@@ -165,7 +165,7 @@ project
 # SimplifyFalseOr + SimplifyOrFalse
 # --------------------------------------------------
 
-opt expect=SimplifyFalseOr
+norm expect=SimplifyFalseOr
 SELECT false OR k=1 AS r FROM a
 ----
 project
@@ -176,7 +176,7 @@ project
  └── projections
       └── k = 1 [type=bool, outer=(1)]
 
-opt expect=SimplifyOrFalse
+norm expect=SimplifyOrFalse
 SELECT k=1 OR false AS r FROM a
 ----
 project
@@ -187,7 +187,7 @@ project
  └── projections
       └── k = 1 [type=bool, outer=(1)]
 
-opt expect=(SimplifyFalseOr,SimplifyOrFalse)
+norm expect=(SimplifyFalseOr,SimplifyOrFalse)
 SELECT (false OR k=1) OR (i=2 OR false) AS r FROM a
 ----
 project
@@ -200,7 +200,7 @@ project
       └── (k = 1) OR (i = 2) [type=bool, outer=(1,2)]
 
 # No conditions left after rule.
-opt expect=SimplifyFalseOr
+norm expect=SimplifyFalseOr
 SELECT * FROM a WHERE false OR false OR false
 ----
 values
@@ -212,7 +212,7 @@ values
 # --------------------------------------------------
 # SimplifyAnd + SimplifyOr
 # --------------------------------------------------
-opt expect=(SimplifyOrFalse,SimplifyFalseOr,SimplifyAndTrue)
+norm expect=(SimplifyOrFalse,SimplifyFalseOr,SimplifyAndTrue)
 SELECT (k=1 OR false) AND (false OR k=2 OR false) AND true AS r FROM a
 ----
 project
@@ -227,20 +227,25 @@ project
 # SimplifyRange
 # --------------------------------------------------
 
-opt expect=SimplifyRange disable=InlineConstVar
+norm expect=SimplifyRange disable=InlineConstVar
 SELECT * FROM a WHERE k = 1 AND k = 2-1
 ----
-scan a
+select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── constraint: /1: [/1 - /1]
  ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(1-5)
+ ├── fd: ()-->(1-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
 
 # --------------------------------------------------
 # FoldNullAndOr
 # --------------------------------------------------
-opt expect=FoldNullAndOr
+norm expect=FoldNullAndOr
 SELECT null and null AS r FROM a
 ----
 project
@@ -250,7 +255,7 @@ project
  └── projections
       └── null [type=bool]
 
-opt expect=FoldNullAndOr
+norm expect=FoldNullAndOr
 SELECT null or null AS r FROM a
 ----
 project
@@ -260,7 +265,7 @@ project
  └── projections
       └── null [type=bool]
 
-opt expect=FoldNullAndOr
+norm expect=FoldNullAndOr
 SELECT null or (null and null and null) or null AS r FROM a
 ----
 project
@@ -271,7 +276,7 @@ project
       └── null [type=bool]
 
 # Don't fold.
-opt expect-not=FoldNullAndOr
+norm expect-not=FoldNullAndOr
 SELECT (null or k=1) AS r, (null and k=1) AS s FROM a
 ----
 project
@@ -287,7 +292,7 @@ project
 # FoldNotTrue + FoldNotFalse
 # --------------------------------------------------
 
-opt expect=(FoldNotTrue,FoldNotFalse)
+norm expect=(FoldNotTrue,FoldNotFalse)
 SELECT NOT(1=1), NOT(1=2)
 ----
 values
@@ -302,7 +307,7 @@ values
 # --------------------------------------------------
 
 # Equality and inequality comparisons.
-opt expect=NegateComparison
+norm expect=NegateComparison
 SELECT * FROM a WHERE NOT(i=1) AND NOT(f<>i) AND NOT(i>k) AND NOT(i>=f) AND NOT(f<1) AND NOT(i<=1)
 ----
 select
@@ -321,7 +326,7 @@ select
       └── f >= 1.0 [type=bool, outer=(3), constraints=(/3: [/1.0 - ]; tight)]
 
 # IN and IS comparisons.
-opt expect=NegateComparison
+norm expect=NegateComparison
 SELECT *
 FROM a
 WHERE NOT(i IN (1,2)) AND NOT(f NOT IN (3,4)) AND NOT(f IS NULL) AND NOT(s IS NOT NULL)
@@ -340,7 +345,7 @@ select
       └── s IS NULL [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL]; tight), fd=()-->(4)]
 
 # Like comparisons.
-opt expect=NegateComparison
+norm expect=NegateComparison
 SELECT *
 FROM a
 WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
@@ -360,7 +365,7 @@ select
       └── s ILIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 # SimilarTo comparisons.
-opt expect=NegateComparison
+norm expect=NegateComparison
 SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
@@ -376,7 +381,7 @@ select
       └── s SIMILAR TO 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # RegMatch comparisons.
-opt expect=NegateComparison
+norm expect=NegateComparison
 SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
 ----
 select
@@ -393,7 +398,7 @@ select
       ├── s !~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
       └── s ~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
-opt expect-not=NegateComparison
+norm expect-not=NegateComparison
 SELECT * FROM a WHERE
   NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]') AND
   NOT(j ? 'foo') AND
@@ -420,7 +425,7 @@ select
 # --------------------------------------------------
 # EliminateNot
 # --------------------------------------------------
-opt expect=EliminateNot
+norm expect=EliminateNot
 SELECT * FROM c WHERE NOT(NOT(a))
 ----
 select
@@ -434,7 +439,7 @@ select
 # --------------------------------------------------
 # NegateAnd + NegateComparison
 # --------------------------------------------------
-opt expect=(NegateAnd,NegateComparison)
+norm expect=(NegateAnd,NegateComparison)
 SELECT * FROM a WHERE NOT (k >= i AND i < f)
 ----
 select
@@ -448,7 +453,7 @@ select
  └── filters
       └── (k < i) OR (i >= f) [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
 
-opt expect=(NegateAnd,NegateComparison)
+norm expect=(NegateAnd,NegateComparison)
 SELECT * FROM a WHERE NOT (k >= i AND i < f AND (i > 5 AND i < 10 AND f > 1))
 ----
 select
@@ -466,7 +471,7 @@ select
 # --------------------------------------------------
 # NegateOr + NegateComparison
 # --------------------------------------------------
-opt expect=(NegateOr,NegateComparison)
+norm expect=(NegateOr,NegateComparison)
 SELECT * FROM a WHERE NOT (k >= i OR i < f OR k + i < f)
 ----
 select
@@ -482,7 +487,7 @@ select
       ├── i >= f [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
       └── f <= (k + i) [type=bool, outer=(1-3), constraints=(/3: (/NULL - ])]
 
-opt expect=(NegateOr,NegateComparison)
+norm expect=(NegateOr,NegateComparison)
 SELECT * FROM a WHERE NOT (k >= i OR i < f OR (i > 10 OR i < 5 OR f > 1))
 ----
 select
@@ -502,7 +507,7 @@ select
 # --------------------------------------------------
 # NegateAnd + NegateOr + NegateComparison
 # --------------------------------------------------
-opt expect=(NegateAnd,NegateOr,NegateComparison)
+norm expect=(NegateAnd,NegateOr,NegateComparison)
 SELECT * FROM a WHERE NOT ((k >= i OR i < f) AND (i > 5 OR f > 1))
 ----
 select
@@ -516,7 +521,7 @@ select
  └── filters
       └── ((k < i) AND (i >= f)) OR ((i <= 5) AND (f <= 1.0)) [type=bool, outer=(1-3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
 
-opt expect=(NegateAnd,NegateOr,NegateComparison)
+norm expect=(NegateAnd,NegateOr,NegateComparison)
 SELECT * FROM a WHERE NOT ((k >= i AND i < f) OR (i > 5 AND f > 1))
 ----
 select
@@ -534,7 +539,7 @@ select
 # --------------------------------------------------
 # ExtractRedundantConjunct
 # --------------------------------------------------
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT b OR b FROM c
 ----
 project
@@ -544,7 +549,7 @@ project
  └── projections
       └── variable: b [type=bool, outer=(2)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT a OR (a AND b) OR (a AND c) FROM c
 ----
 project
@@ -554,7 +559,7 @@ project
  └── projections
       └── variable: a [type=bool, outer=(1)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT (a AND b) OR a OR (a AND c) FROM c
 ----
 project
@@ -564,7 +569,7 @@ project
  └── projections
       └── variable: a [type=bool, outer=(1)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT (a AND b) OR (b AND a) FROM c
 ----
 project
@@ -574,7 +579,7 @@ project
  └── projections
       └── b AND a [type=bool, outer=(1,2)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT (a AND b) OR (c AND a) FROM c
 ----
 project
@@ -584,7 +589,7 @@ project
  └── projections
       └── a AND (b OR c) [type=bool, outer=(1-3)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT * FROM c WHERE (a AND b) OR (a AND b AND c) OR (b AND a)
 ----
 select
@@ -596,7 +601,7 @@ select
       ├── variable: a [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
       └── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT * FROM c WHERE (b AND (a AND c)) OR (d AND (e AND a))
 ----
 select
@@ -608,7 +613,7 @@ select
       ├── variable: a [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
       └── (b AND c) OR (d AND e) [type=bool, outer=(2-5)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT * FROM c WHERE (b AND a) OR (c AND (a AND e) OR (e AND a AND d))
 ----
 select
@@ -620,7 +625,7 @@ select
       ├── variable: a [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
       └── b OR (e AND (c OR d)) [type=bool, outer=(2-5)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT * FROM a WHERE ((k > 5) AND (i < 2) AND (i > 0)) OR ((k > 5) AND (i < 2) AND (s = 'foo'))
 ----
 select
@@ -629,24 +634,29 @@ select
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/6 - ]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
       ├── i < 2 [type=bool, outer=(2), constraints=(/2: (/NULL - /1]; tight)]
+      ├── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
       └── (i > 0) OR (s = 'foo') [type=bool, outer=(2,4)]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT * FROM a WHERE (k > 5) OR ((k > 5) AND (i < 2) AND (s = 'foo'))
 ----
-scan a
+select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── constraint: /1: [/6 - ]
  ├── key: (1)
- └── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
 
 # Works with nulls too.
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT null or (null and k=1) AS r FROM a
 ----
 project
@@ -656,7 +666,7 @@ project
  └── projections
       └── null [type=unknown]
 
-opt expect=(ExtractRedundantConjunct)
+norm expect=(ExtractRedundantConjunct)
 SELECT (null and k=2) or (null and k=1) AS r FROM a
 ----
 project
@@ -668,7 +678,7 @@ project
       └── NULL AND ((k = 2) OR (k = 1)) [type=bool, outer=(1)]
 
 # Check that we don't match non-redundant cases.
-opt expect-not=(ExtractRedundantConjunct)
+norm expect-not=(ExtractRedundantConjunct)
 SELECT a OR b OR b FROM c
 ----
 project
@@ -678,7 +688,7 @@ project
  └── projections
       └── (a OR b) OR b [type=bool, outer=(1,2)]
 
-opt expect-not=(ExtractRedundantConjunct)
+norm expect-not=(ExtractRedundantConjunct)
 SELECT (a AND b) OR (a OR c) FROM c
 ----
 project
@@ -688,7 +698,7 @@ project
  └── projections
       └── (a AND b) OR (a OR c) [type=bool, outer=(1-3)]
 
-opt expect-not=(ExtractRedundantConjunct)
+norm expect-not=(ExtractRedundantConjunct)
 SELECT (a AND b) OR (NOT a AND c) FROM c
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -8,7 +8,7 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, d DATE)
 
 # Put variables on both sides of comparison operator to avoid matching constant
 # patterns.
-opt expect=CommuteVarInequality
+norm expect=CommuteVarInequality
 SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
@@ -29,7 +29,7 @@ select
 # --------------------------------------------------
 # CommuteConstInequality
 # --------------------------------------------------
-opt expect=CommuteConstInequality
+norm expect=CommuteConstInequality
 SELECT * FROM a WHERE 5+1<i+k AND 5*5/3<=i*2 AND 5>i AND 'foo'>=s
 ----
 select
@@ -46,7 +46,7 @@ select
       ├── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       └── s <= 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo']; tight)]
 
-opt expect=CommuteConstInequality
+norm expect=CommuteConstInequality
 SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2
 ----
 select
@@ -62,7 +62,7 @@ select
       └── (i * 2) >= 3 [type=bool, outer=(2)]
 
 # Impure function should not be considered constant.
-opt expect-not=CommuteConstInequality
+norm expect-not=CommuteConstInequality
 SELECT * FROM a WHERE random()::int>a.i+a.i
 ----
 select
@@ -80,7 +80,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpPlusConst
 # --------------------------------------------------
-opt expect=NormalizeCmpPlusConst
+norm expect=NormalizeCmpPlusConst
 SELECT *
 FROM a
 WHERE
@@ -97,17 +97,16 @@ select
  ├── fd: ()-->(1-6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
- │    ├── constraint: /1: [/1 - /1]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-6)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
  └── filters
       ├── (i >= 2) AND (i > 6) [type=bool, outer=(2), constraints=(/2: [/7 - ]; tight)]
+      ├── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       ├── (f + f) < 3.0 [type=bool, outer=(3)]
       └── i::INTERVAL >= '01:00:00' [type=bool, outer=(2)]
 
 # Try case that should not match pattern because Minus overload is not defined.
-opt expect-not=NormalizeCmpPlusConst
+norm expect-not=NormalizeCmpPlusConst
 SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timestamp
 ----
 select
@@ -124,7 +123,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpMinusConst
 # --------------------------------------------------
-opt expect=NormalizeCmpMinusConst
+norm expect=NormalizeCmpMinusConst
 SELECT *
 FROM a
 WHERE
@@ -142,18 +141,17 @@ select
  ├── fd: ()-->(1-6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
- │    ├── constraint: /1: [/3 - /3]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-6)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
  └── filters
       ├── (i >= 4) AND (i < 14) [type=bool, outer=(2), constraints=(/2: [/4 - /13]; tight)]
+      ├── k = 3 [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
       ├── (f + f) < 7.0 [type=bool, outer=(3)]
       ├── (f + i::FLOAT8) >= 110.0 [type=bool, outer=(2,3)]
       └── d >= '2018-09-30' [type=bool, outer=(6), constraints=(/6: [/'2018-09-30' - ]; tight)]
 
 # Try case that should not match pattern because Plus overload is not defined.
-opt expect-not=NormalizeCmpMinusConst
+norm expect-not=NormalizeCmpMinusConst
 SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
@@ -170,7 +168,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpConstMinus
 # --------------------------------------------------
-opt expect=NormalizeCmpConstMinus
+norm expect=NormalizeCmpConstMinus
 SELECT *
 FROM a
 WHERE
@@ -187,17 +185,16 @@ select
  ├── fd: ()-->(1-6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
- │    ├── constraint: /1: [/-1 - /-1]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-6)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
  └── filters
       ├── (i >= -2) AND (i > 10) [type=bool, outer=(2), constraints=(/2: [/11 - ]; tight)]
+      ├── k = -1 [type=bool, outer=(1), constraints=(/1: [/-1 - /-1]; tight), fd=()-->(1)]
       ├── (f + f) > -3.0 [type=bool, outer=(3)]
       └── (f + i::FLOAT8) <= -90.0 [type=bool, outer=(2,3)]
 
 # Try case that should not match pattern because Minus overload is not defined.
-opt expect-not=NormalizeCmpConstMinus
+norm expect-not=NormalizeCmpConstMinus
 SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
@@ -214,7 +211,7 @@ select
 # --------------------------------------------------
 # NormalizeTupleEquality
 # --------------------------------------------------
-opt expect=NormalizeTupleEquality
+norm expect=NormalizeTupleEquality
 SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
@@ -231,7 +228,7 @@ select
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # Empty tuples.
-opt expect=NormalizeTupleEquality
+norm expect=NormalizeTupleEquality
 SELECT * FROM a WHERE () = ()
 ----
 scan a
@@ -244,7 +241,7 @@ scan a
 # --------------------------------------------------
 
 # Nested tuples.
-opt expect=(NormalizeTupleEquality,NormalizeNestedAnds)
+norm expect=(NormalizeTupleEquality,NormalizeNestedAnds)
 SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
@@ -254,11 +251,10 @@ select
  ├── fd: ()-->(1-6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
- │    ├── constraint: /1: [/1 - /1]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-6)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
  └── filters
+      ├── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       ├── i = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -267,7 +263,7 @@ select
 # --------------------------------------------------
 
 # Use null::type to circumvent type checker constant folding.
-opt expect=(FoldNullComparisonLeft,FoldNullComparisonRight)
+norm expect=(FoldNullComparisonLeft,FoldNullComparisonRight)
 SELECT *
 FROM a
 WHERE
@@ -302,7 +298,7 @@ values
 # --------------------------------------------------
 # FoldIsNull
 # --------------------------------------------------
-opt expect=FoldIsNull
+norm expect=FoldIsNull
 SELECT NULL IS NULL AS r
 ----
 values
@@ -315,7 +311,7 @@ values
 # --------------------------------------------------
 # FoldNonNullIsNull
 # --------------------------------------------------
-opt expect=FoldNonNullIsNull
+norm expect=FoldNonNullIsNull
 SELECT 1 IS NULL AS r
 ----
 values
@@ -325,7 +321,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldNonNullIsNull
+norm expect=FoldNonNullIsNull
 SELECT (1, 2, 3) IS NULL AS r
 ----
 values
@@ -338,7 +334,7 @@ values
 # --------------------------------------------------
 # FoldIsNotNull
 # --------------------------------------------------
-opt expect=FoldIsNotNull
+norm expect=FoldIsNotNull
 SELECT NULL IS NOT NULL AS r, NULL IS NOT TRUE AS s
 ----
 values
@@ -354,7 +350,7 @@ values
 
 # We could (but do not currently) infer that k IS NOT NULL is always True given
 # that k is declared NOT NULL.
-opt expect=FoldNonNullIsNotNull
+norm expect=FoldNonNullIsNotNull
 SELECT 1 IS NOT NULL AS r, k IS NOT NULL AS s, i IS NOT NULL AS t FROM a
 ----
 project
@@ -369,7 +365,7 @@ project
       ├── k IS NOT NULL [type=bool, outer=(1)]
       └── i IS NOT NULL [type=bool, outer=(2)]
 
-opt expect=FoldNonNullIsNotNull
+norm expect=FoldNonNullIsNotNull
 SELECT (1, 2, 3) IS NOT NULL AS r
 ----
 values
@@ -382,7 +378,7 @@ values
 # --------------------------------------------------
 # CommuteNullIs
 # --------------------------------------------------
-opt expect=CommuteNullIs
+norm expect=CommuteNullIs
 SELECT NULL IS NOT TRUE AS r, NULL IS TRUE AS s
 ----
 values

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -17,48 +17,42 @@ CREATE TABLE cd (c INT PRIMARY KEY, d INT NOT NULL)
 # --------------------------------------------------
 # DecorrelateJoin
 # --------------------------------------------------
-opt expect=DecorrelateJoin
+norm expect=DecorrelateJoin
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k)
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null)
- │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=DecorrelateJoin
+norm expect=DecorrelateJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k)
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null)
- │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Decorrelate UPDATE statement.
-opt expect=DecorrelateJoin
+norm expect=DecorrelateJoin
 UPDATE xy SET (x, y)=(SELECT * FROM uv WHERE u=x)
 ----
 update xy
@@ -69,26 +63,23 @@ update xy
  │    └──  v:6 => y:2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── left-join (merge)
+ └── left-join (hash)
       ├── columns: x:3(int!null) y:4(int) u:5(int) v:6(int)
-      ├── left ordering: +3
-      ├── right ordering: +5
       ├── key: (3,5)
       ├── fd: (3)-->(4), (5)-->(6)
       ├── scan xy
       │    ├── columns: x:3(int!null) y:4(int)
       │    ├── key: (3)
-      │    ├── fd: (3)-->(4)
-      │    └── ordering: +3
+      │    └── fd: (3)-->(4)
       ├── scan uv
       │    ├── columns: u:5(int!null) v:6(int)
       │    ├── key: (5)
-      │    ├── fd: (5)-->(6)
-      │    └── ordering: +5
-      └── filters (true)
+      │    └── fd: (5)-->(6)
+      └── filters
+           └── u = x [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 # Decorrelate INSERT..ON CONFLICT statement.
-opt expect=DecorrelateJoin
+norm expect=DecorrelateJoin
 INSERT INTO xy VALUES (1,2), (3,4)
 ON CONFLICT (x) DO UPDATE SET (x, y)=(SELECT * FROM uv WHERE u=excluded.x)
 RETURNING *
@@ -112,16 +103,12 @@ upsert xy
       ├── columns: upsert_x:9(int) upsert_y:10(int) column1:3(int!null) column2:4(int!null) x:5(int) y:6(int)
       ├── cardinality: [2 - ]
       ├── fd: (5)-->(6)
-      ├── left-join (lookup uv)
+      ├── left-join (hash)
       │    ├── columns: column1:3(int!null) column2:4(int!null) x:5(int) y:6(int) u:7(int) v:8(int)
-      │    ├── key columns: [3] = [7]
-      │    ├── lookup columns are key
       │    ├── cardinality: [2 - ]
       │    ├── fd: (5)-->(6), (7)-->(8)
-      │    ├── left-join (lookup xy)
+      │    ├── left-join (hash)
       │    │    ├── columns: column1:3(int!null) column2:4(int!null) x:5(int) y:6(int)
-      │    │    ├── key columns: [3] = [5]
-      │    │    ├── lookup columns are key
       │    │    ├── cardinality: [2 - ]
       │    │    ├── fd: (5)-->(6)
       │    │    ├── values
@@ -129,14 +116,24 @@ upsert xy
       │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── (1, 2) [type=tuple{int, int}]
       │    │    │    └── (3, 4) [type=tuple{int, int}]
-      │    │    └── filters (true)
-      │    └── filters (true)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:5(int!null) y:6(int)
+      │    │    │    ├── key: (5)
+      │    │    │    └── fd: (5)-->(6)
+      │    │    └── filters
+      │    │         └── column1 = x [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+      │    ├── scan uv
+      │    │    ├── columns: u:7(int!null) v:8(int)
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8)
+      │    └── filters
+      │         └── u = column1 [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
       └── projections
            ├── CASE WHEN x IS NULL THEN column1 ELSE u END [type=int, outer=(3,5,7)]
            └── CASE WHEN x IS NULL THEN column2 ELSE v END [type=int, outer=(4,5,8)]
 
 # Decorrelate DELETE statement.
-opt expect=DecorrelateJoin
+norm expect=DecorrelateJoin
 DELETE FROM xy WHERE EXISTS(SELECT * FROM uv WHERE u=x)
 ----
 delete xy
@@ -144,26 +141,23 @@ delete xy
  ├── fetch columns: x:3(int)
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── semi-join (merge)
+ └── semi-join (hash)
       ├── columns: x:3(int!null)
-      ├── left ordering: +3
-      ├── right ordering: +5
       ├── key: (3)
       ├── scan xy
       │    ├── columns: x:3(int!null)
-      │    ├── key: (3)
-      │    └── ordering: +3
+      │    └── key: (3)
       ├── scan uv
       │    ├── columns: u:5(int!null)
-      │    ├── key: (5)
-      │    └── ordering: +5
-      └── filters (true)
+      │    └── key: (5)
+      └── filters
+           └── u = x [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 # --------------------------------------------------
 # DecorrelateProjectSet
 # --------------------------------------------------
 
-opt expect=DecorrelateProjectSet
+norm expect=DecorrelateProjectSet
 SELECT generate_series(0, 5) FROM xy
 ----
 inner-join (cross)
@@ -183,7 +177,7 @@ inner-join (cross)
  │              └── const: 5 [type=int]
  └── filters (true)
 
-opt expect=DecorrelateProjectSet
+norm expect=DecorrelateProjectSet
 SELECT * FROM a WHERE i IN (SELECT generate_series(k, i) FROM xy)
 ----
 semi-join-apply
@@ -216,7 +210,7 @@ semi-join-apply
  └── filters
       └── i = generate_series [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
-opt expect=DecorrelateProjectSet
+norm expect=DecorrelateProjectSet
 SELECT generate_series(0, (SELECT generate_series(1,0) FROM xy)) FROM uv
 ----
 inner-join (cross)
@@ -645,7 +639,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateSelect
 # --------------------------------------------------
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (k), (i)) WHERE column1=k)
 ----
 semi-join-apply
@@ -665,7 +659,7 @@ semi-join-apply
  └── filters
       └── column1 = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k), (i)) WHERE column1=k)
 ----
 anti-join-apply
@@ -688,7 +682,7 @@ anti-join-apply
 # Attempt to decorrelate query by pulling up outer select. But since limit query
 # cannot be decorrelated, push the outer select back down again (and make sure
 # potential rule cycle is detected and handled).
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT * FROM xy WHERE y=k LIMIT 1) WHERE y=10)
 ----
 semi-join-apply
@@ -720,7 +714,7 @@ semi-join-apply
       └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
 
 # Same as previous, but using anti-join.
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (SELECT * FROM xy WHERE y=k LIMIT 1) WHERE y=10)
 ----
 anti-join-apply
@@ -752,7 +746,7 @@ anti-join-apply
       └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
 
 # Decorrelate Select with reference to outer column and no limit.
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE (SELECT x FROM xy WHERE x=i) > 100
 ----
 project
@@ -773,15 +767,19 @@ project
       │    │    └── fd: (1)-->(2-5)
       │    └── filters
       │         └── i > 100 [type=bool, outer=(2), constraints=(/2: [/101 - ]; tight)]
-      ├── scan xy
+      ├── select
       │    ├── columns: x:6(int!null)
-      │    ├── constraint: /6: [/101 - ]
-      │    └── key: (6)
+      │    ├── key: (6)
+      │    ├── scan xy
+      │    │    ├── columns: x:6(int!null)
+      │    │    └── key: (6)
+      │    └── filters
+      │         └── x > 100 [type=bool, outer=(6), constraints=(/6: [/101 - ]; tight)]
       └── filters
            └── x = i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 # Decorrelate Select with LeftJoinApply.
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE (SELECT x FROM (SELECT * FROM xy LIMIT 1) WHERE k=x) > 100
 ----
 project
@@ -789,30 +787,43 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup a)
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
-      ├── key columns: [6] = [1]
-      ├── lookup columns are key
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-6)
+      ├── select
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    └── filters
+      │         └── k > 100 [type=bool, outer=(1), constraints=(/1: [/101 - ]; tight)]
       ├── select
       │    ├── columns: x:6(int!null)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6)
-      │    ├── scan xy
+      │    ├── limit
       │    │    ├── columns: x:6(int!null)
-      │    │    ├── limit: 1
+      │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(6)
+      │    │    ├── fd: ()-->(6)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null)
+      │    │    │    ├── key: (6)
+      │    │    │    └── limit hint: 1.00
+      │    │    └── const: 1 [type=int]
       │    └── filters
       │         └── x > 100 [type=bool, outer=(6), constraints=(/6: [/101 - ]; tight)]
       └── filters
-           └── k > 100 [type=bool, outer=(1), constraints=(/1: [/101 - ]; tight)]
+           └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Decorrelate with non-apply operator because of multi-level nesting.
-opt expect=TryDecorrelateSelect
+norm expect=TryDecorrelateSelect
 SELECT *
 FROM a
 WHERE EXISTS(SELECT * FROM xy WHERE x=k AND EXISTS(SELECT * FROM uv WHERE u=10 AND s='foo'))
@@ -832,12 +843,16 @@ semi-join-apply
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null)
  │    │    └── key: (6)
- │    ├── scan uv
+ │    ├── select
  │    │    ├── columns: u:8(int!null)
- │    │    ├── constraint: /8: [/10 - /10]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(8)
+ │    │    ├── fd: ()-->(8)
+ │    │    ├── scan uv
+ │    │    │    ├── columns: u:8(int!null)
+ │    │    │    └── key: (8)
+ │    │    └── filters
+ │    │         └── u = 10 [type=bool, outer=(8), constraints=(/8: [/10 - /10]; tight), fd=()-->(8)]
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  └── filters
@@ -853,7 +868,7 @@ semi-join-apply
 # --------------------------------------------------
 
 # Left join caused by correlated ANY clause.
-opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -861,40 +876,33 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── key: (1)
  │    ├── fd: (1)-->(10)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) x:6(int) notnull:9(bool)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── key: (1,6)
  │    │    ├── fd: (6)-->(9)
- │    │    ├── ordering: +1
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null)
- │    │    │    ├── key: (1)
- │    │    │    └── ordering: +1
+ │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: notnull:9(bool) x:6(int!null)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(9)
- │    │    │    ├── ordering: +6
  │    │    │    ├── select
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
  │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    ├── ordering: +6
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
- │    │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    │    └── ordering: +6
+ │    │    │    │    │    └── fd: (6)-->(7)
  │    │    │    │    └── filters
  │    │    │    │         └── (y = 5) IS NOT false [type=bool, outer=(7)]
  │    │    │    └── projections
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
- │    │    └── filters (true)
+ │    │    └── filters
+ │    │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    └── aggregations
  │         └── bool-or [type=bool, outer=(9)]
  │              └── variable: notnull [type=bool]
@@ -902,7 +910,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Left join caused by zero or one cardinality subquery.
-opt expect=TryDecorrelateProjectSelect
+norm expect=TryDecorrelateProjectSelect
 SELECT * FROM a WHERE (SELECT y+1 AS r FROM (SELECT * FROM xy LIMIT 1) WHERE x=k) > 10
 ----
 project
@@ -910,29 +918,38 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup a)
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
-      ├── key columns: [6] = [1]
-      ├── lookup columns are key
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-7)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-5)
       ├── select
       │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6,7)
-      │    ├── scan xy
+      │    ├── limit
       │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    ├── limit: 1
+      │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(6,7)
+      │    │    ├── fd: ()-->(6,7)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │    ├── key: (6)
+      │    │    │    ├── fd: (6)-->(7)
+      │    │    │    └── limit hint: 1.00
+      │    │    └── const: 1 [type=int]
       │    └── filters
       │         └── y > 9 [type=bool, outer=(7), constraints=(/7: [/10 - ]; tight)]
-      └── filters (true)
+      └── filters
+           └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Any clause with constant.
-opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -940,40 +957,33 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── key: (1)
  │    ├── fd: (1)-->(10)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) x:6(int) notnull:9(bool)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── key: (1,6)
  │    │    ├── fd: (6)-->(9)
- │    │    ├── ordering: +1
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null)
- │    │    │    ├── key: (1)
- │    │    │    └── ordering: +1
+ │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: notnull:9(bool) x:6(int!null)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(9)
- │    │    │    ├── ordering: +6
  │    │    │    ├── select
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
  │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    ├── ordering: +6
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
- │    │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    │    └── ordering: +6
+ │    │    │    │    │    └── fd: (6)-->(7)
  │    │    │    │    └── filters
  │    │    │    │         └── (y = 5) IS NOT false [type=bool, outer=(7)]
  │    │    │    └── projections
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
- │    │    └── filters (true)
+ │    │    └── filters
+ │    │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    └── aggregations
  │         └── bool-or [type=bool, outer=(9)]
  │              └── variable: notnull [type=bool]
@@ -981,7 +991,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Any clause with variable.
-opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT i=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -989,34 +999,28 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) i:2(int) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,10)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) i:2(int) x:6(int) y:7(int) notnull:9(bool)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(2), (6)-->(7), (7)~~>(9), (1,6)-->(9)
- │    │    ├── ordering: +1
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null) i:2(int)
  │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2)
- │    │    │    └── ordering: +1
+ │    │    │    └── fd: (1)-->(2)
  │    │    ├── project
  │    │    │    ├── columns: notnull:9(bool) x:6(int!null) y:7(int)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(7), (7)-->(9)
- │    │    │    ├── ordering: +6
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
- │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    └── ordering: +6
+ │    │    │    │    └── fd: (6)-->(7)
  │    │    │    └── projections
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
  │    │    └── filters
+ │    │         ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── (i = y) IS NOT false [type=bool, outer=(2,7)]
  │    └── aggregations
  │         ├── bool-or [type=bool, outer=(9)]
@@ -1027,7 +1031,7 @@ project
       └── CASE WHEN bool_or AND (i IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(2,10)]
 
 # Any clause with more complex expression that must be cached.
-opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -1036,44 +1040,37 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) scalar:9(decimal) bool_or:11(bool)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(9,11)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) x:6(int) y:7(int) scalar:9(decimal) notnull:10(bool)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── side-effects
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
- │    │    ├── ordering: +1
  │    │    ├── project
  │    │    │    ├── columns: scalar:9(decimal) k:1(int!null)
  │    │    │    ├── side-effects
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(9)
- │    │    │    ├── ordering: +1
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1(int!null) i:2(int)
  │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: (1)-->(2)
- │    │    │    │    └── ordering: +1
+ │    │    │    │    └── fd: (1)-->(2)
  │    │    │    └── projections
  │    │    │         └── (i * i) / 5 [type=decimal, outer=(2), side-effects]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10(bool) x:6(int!null) y:7(int)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(7), (7)-->(10)
- │    │    │    ├── ordering: +6
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
- │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    └── ordering: +6
+ │    │    │    │    └── fd: (6)-->(7)
  │    │    │    └── projections
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
  │    │    └── filters
+ │    │         ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── (scalar = y) IS NOT false [type=bool, outer=(7,9)]
  │    └── aggregations
  │         ├── bool-or [type=bool, outer=(10)]
@@ -1086,7 +1083,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProject
 # --------------------------------------------------
-opt expect=TryDecorrelateProject
+norm expect=TryDecorrelateProject
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -1109,27 +1106,26 @@ distinct-on
       │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
       │    │    ├── key: (1,6,8)
       │    │    ├── fd: ()-->(2)
-      │    │    ├── inner-join (cross)
-      │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
-      │    │    │    ├── key: (1,8)
+      │    │    ├── select
+      │    │    │    ├── columns: k:1(int!null) i:2(int!null)
+      │    │    │    ├── key: (1)
       │    │    │    ├── fd: ()-->(2)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2)
+      │    │    │    └── filters
+      │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
+      │    │    │    ├── key: (6,8)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:6(int!null)
+      │    │    │    │    └── key: (6)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: k:1(int!null) i:2(int!null)
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: ()-->(2)
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: k:1(int!null) i:2(int)
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    │    └── filters
-      │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    │    │    └── filters (true)
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:6(int!null)
-      │    │    │    └── key: (6)
       │    │    └── filters (true)
       │    └── projections
       │         └── u / 1.1 [type=decimal, outer=(8), side-effects]
@@ -1137,7 +1133,7 @@ distinct-on
            └── x = div [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
 
 # Don't hoist Project operator in right join case.
-opt
+norm
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -1186,7 +1182,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProjectSelect
 # --------------------------------------------------
-opt
+norm
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -1229,7 +1225,7 @@ project
       └── filters (true)
 
 # Don't decorrelate FULL JOIN case.
-opt
+norm
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -1274,7 +1270,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProjectInnerJoin
 # --------------------------------------------------
-opt expect=TryDecorrelateProjectInnerJoin
+norm expect=TryDecorrelateProjectInnerJoin
 SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 ----
 project
@@ -1282,46 +1278,37 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) sum:11(decimal)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── key: (1)
  │    ├── fd: (1)-->(11)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) x:6(int) column10:10(int)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── key: (1,6)
  │    │    ├── fd: (6)-->(10)
- │    │    ├── ordering: +1
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null)
- │    │    │    ├── key: (1)
- │    │    │    └── ordering: +1
+ │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: column10:10(int) x:6(int!null)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(10)
- │    │    │    ├── ordering: +6
- │    │    │    ├── inner-join (merge)
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int!null) v:9(int)
- │    │    │    │    ├── left ordering: +6
- │    │    │    │    ├── right ordering: +8
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    │    │    │    ├── ordering: +(6|8) [actual: +6]
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
- │    │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    │    └── ordering: +6
+ │    │    │    │    │    └── fd: (6)-->(7)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
  │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    ├── fd: (8)-->(9)
- │    │    │    │    │    └── ordering: +8
- │    │    │    │    └── filters (true)
+ │    │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    │    └── filters
+ │    │    │    │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │    │    │    └── projections
  │    │    │         └── y + v [type=int, outer=(7,9)]
- │    │    └── filters (true)
+ │    │    └── filters
+ │    │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    └── aggregations
  │         └── sum [type=decimal, outer=(10)]
  │              └── variable: column10 [type=int]
@@ -1332,77 +1319,65 @@ project
 # TryDecorrelateInnerJoin
 # --------------------------------------------------
 # Semi-join as outer.
-opt expect=TryDecorrelateInnerJoin
+norm expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE EXISTS
 (
     SELECT * FROM xy INNER JOIN uv ON x=u AND x=k
 )
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── scan a
  │    ├── columns: k:1(int!null)
- │    ├── key: (1)
- │    └── ordering: +1
- ├── inner-join (merge)
+ │    └── key: (1)
+ ├── inner-join (hash)
  │    ├── columns: x:6(int!null) u:8(int!null)
- │    ├── left ordering: +6
- │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8) [actual: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
+ │    │    └── key: (6)
  │    ├── scan uv
  │    │    ├── columns: u:8(int!null)
- │    │    ├── key: (8)
- │    │    └── ordering: +8
- │    └── filters (true)
- └── filters (true)
+ │    │    └── key: (8)
+ │    └── filters
+ │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Anti-join as outer.
-opt expect=TryDecorrelateInnerJoin
+norm expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE NOT EXISTS
 (
     SELECT * FROM xy INNER JOIN uv ON x=u AND x=k
 )
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── scan a
  │    ├── columns: k:1(int!null)
- │    ├── key: (1)
- │    └── ordering: +1
- ├── inner-join (merge)
+ │    └── key: (1)
+ ├── inner-join (hash)
  │    ├── columns: x:6(int!null) u:8(int!null)
- │    ├── left ordering: +6
- │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8) [actual: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
+ │    │    └── key: (6)
  │    ├── scan uv
  │    │    ├── columns: u:8(int!null)
- │    │    ├── key: (8)
- │    │    └── ordering: +8
- │    └── filters (true)
- └── filters (true)
+ │    │    └── key: (8)
+ │    └── filters
+ │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Right-join as outer.
-opt expect=TryDecorrelateInnerJoin
+norm expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE
 (
@@ -1422,37 +1397,29 @@ project
       ├── group-by
       │    ├── columns: k:1(int!null) count_rows:10(int)
       │    ├── grouping columns: k:1(int!null)
-      │    ├── internal-ordering: +1
       │    ├── key: (1)
       │    ├── fd: (1)-->(10)
-      │    ├── left-join (merge)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) x:6(int) u:8(int)
-      │    │    ├── left ordering: +1
-      │    │    ├── right ordering: +6
       │    │    ├── key: (1,8)
       │    │    ├── fd: (6)==(8), (8)==(6)
-      │    │    ├── ordering: +1
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null)
-      │    │    │    ├── key: (1)
-      │    │    │    └── ordering: +1
-      │    │    ├── inner-join (merge)
+      │    │    │    └── key: (1)
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: x:6(int!null) u:8(int!null)
-      │    │    │    ├── left ordering: +6
-      │    │    │    ├── right ordering: +8
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: (6)==(8), (8)==(6)
-      │    │    │    ├── ordering: +(6|8) [actual: +6]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
-      │    │    │    │    ├── key: (6)
-      │    │    │    │    └── ordering: +6
+      │    │    │    │    └── key: (6)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
-      │    │    │    │    ├── key: (8)
-      │    │    │    │    └── ordering: +8
-      │    │    │    └── filters (true)
-      │    │    └── filters (true)
+      │    │    │    │    └── key: (8)
+      │    │    │    └── filters
+      │    │    │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+      │    │    └── filters
+      │    │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │    └── aggregations
       │         └── count [type=int, outer=(6)]
       │              └── variable: x [type=int]
@@ -1460,7 +1427,7 @@ project
            └── count_rows IS DISTINCT FROM 1 [type=bool, outer=(10), constraints=(/10: [ - /0] [/2 - ]; tight)]
 
 # Can't decorrelate left-join as inner.
-opt
+norm
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -1473,26 +1440,23 @@ semi-join-apply
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── key: (1)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: x:6(int!null) u:8(int)
- │    ├── left ordering: +6
- │    ├── right ordering: +8
  │    ├── outer: (1)
  │    ├── key: (6,8)
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
+ │    │    └── key: (6)
  │    ├── scan uv
  │    │    ├── columns: u:8(int!null)
- │    │    ├── key: (8)
- │    │    └── ordering: +8
+ │    │    └── key: (8)
  │    └── filters
+ │         ├── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters (true)
 
 # Can't decorrelate semi-join as inner.
-opt
+norm
 SELECT k
 FROM a
 WHERE EXISTS
@@ -1511,32 +1475,24 @@ semi-join-apply
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── key: (1)
- ├── project
+ ├── semi-join (cross)
  │    ├── outer: (1)
- │    └── inner-join (cross)
- │         ├── columns: uv2.u:10(int!null)
- │         ├── outer: (1)
- │         ├── fd: ()-->(10)
- │         ├── scan xy
- │         ├── distinct-on
- │         │    ├── columns: uv2.u:10(int!null)
- │         │    ├── grouping columns: uv2.u:10(int!null)
- │         │    ├── key: (10)
- │         │    └── inner-join (cross)
- │         │         ├── columns: uv2.u:10(int!null)
- │         │         ├── scan uv
- │         │         ├── scan uv2
- │         │         │    ├── columns: uv2.u:10(int!null)
- │         │         │    └── key: (10)
- │         │         └── filters (true)
- │         └── filters
- │              └── uv2.u = k [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    ├── scan xy
+ │    ├── inner-join (cross)
+ │    │    ├── columns: uv2.u:10(int!null)
+ │    │    ├── scan uv
+ │    │    ├── scan uv2
+ │    │    │    ├── columns: uv2.u:10(int!null)
+ │    │    │    └── key: (10)
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── uv2.u = k [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  └── filters (true)
 
 # --------------------------------------------------
 # TryDecorrelateInnerLeftJoin
 # --------------------------------------------------
-opt expect=TryDecorrelateInnerLeftJoin
+norm expect=TryDecorrelateInnerLeftJoin
 SELECT *
 FROM (VALUES (1), (2)) AS v(v1)
 WHERE EXISTS(
@@ -1582,16 +1538,19 @@ semi-join-apply
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(11)
- │    │    ├── scan uv
- │    │    │    ├── limit: 1
- │    │    │    └── key: ()
+ │    │    ├── limit
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── scan uv
+ │    │    │    │    └── limit hint: 1.00
+ │    │    │    └── const: 1 [type=int]
  │    │    └── projections
  │    │         └── variable: column1 [type=int, outer=(1)]
  │    └── filters
  │         └── x = v1 [type=bool, outer=(7,11), constraints=(/7: (/NULL - ]; /11: (/NULL - ]), fd=(7)==(11), (11)==(7)]
  └── filters (true)
 
-opt expect=TryDecorrelateInnerLeftJoin
+norm expect=TryDecorrelateInnerLeftJoin
 SELECT *
 FROM xy, uv
 WHERE (SELECT i FROM a WHERE k=x) IS DISTINCT FROM u
@@ -1632,7 +1591,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateGroupBy
 # --------------------------------------------------
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1657,25 +1616,24 @@ group-by
  │    │    ├── inner-join (cross)
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    ├── inner-join (cross)
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
  │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters
+ │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    ├── inner-join (cross)
+ │    │    │    │    ├── columns: x:6(int!null) v:9(int)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    └── columns: v:9(int)
- │    │    │    │    ├── select
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    │    ├── scan a
- │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    │    └── filters
- │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
  │    │    │    │    └── filters (true)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── count-rows [type=int]
@@ -1699,7 +1657,7 @@ group-by
       └── const-agg [type=jsonb, outer=(5)]
            └── variable: j [type=jsonb]
 
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1724,25 +1682,24 @@ group-by
  │    │    ├── inner-join (cross)
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    ├── inner-join (cross)
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
  │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters
+ │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    ├── inner-join (cross)
+ │    │    │    │    ├── columns: x:6(int!null) v:9(int)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    └── columns: v:9(int)
- │    │    │    │    ├── select
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    │    ├── scan a
- │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    │    └── filters
- │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
  │    │    │    │    └── filters (true)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── count [type=int, outer=(9)]
@@ -1769,7 +1726,7 @@ group-by
            └── variable: j [type=jsonb]
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY.
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x=v AND u=(SELECT max(i) FROM a WHERE k=x)
@@ -1791,36 +1748,32 @@ project
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int!null) i:6(int!null)
       │    │    ├── key: (3)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4,5), (4)==(1,5), (5)-->(6), (5)==(1,4)
-      │    │    ├── scan uv
-      │    │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── inner-join (hash)
+      │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
       │    │    │    ├── key: (3)
-      │    │    │    └── fd: (3)-->(4)
-      │    │    ├── inner-join (merge)
-      │    │    │    ├── columns: x:1(int!null) y:2(int) k:5(int!null) i:6(int!null)
-      │    │    │    ├── left ordering: +1
-      │    │    │    ├── right ordering: +5
-      │    │    │    ├── key: (5)
-      │    │    │    ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+      │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:1(int!null) y:2(int)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2)
-      │    │    │    │    └── ordering: +1
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: k:5(int!null) i:6(int!null)
+      │    │    │    │    └── fd: (1)-->(2)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    │    │    ├── key: (3)
+      │    │    │    │    └── fd: (3)-->(4)
+      │    │    │    └── filters
+      │    │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    │    ├── select
+      │    │    │    ├── columns: k:5(int!null) i:6(int!null)
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: (5)-->(6)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:5(int!null) i:6(int)
       │    │    │    │    ├── key: (5)
-      │    │    │    │    ├── fd: (5)-->(6)
-      │    │    │    │    ├── ordering: +5
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: k:5(int!null) i:6(int)
-      │    │    │    │    │    ├── key: (5)
-      │    │    │    │    │    ├── fd: (5)-->(6)
-      │    │    │    │    │    └── ordering: +5
-      │    │    │    │    └── filters
-      │    │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
-      │    │    │    └── filters (true)
+      │    │    │    │    └── fd: (5)-->(6)
+      │    │    │    └── filters
+      │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
       │    │    └── filters
-      │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    └── aggregations
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: i [type=int]
@@ -1835,7 +1788,7 @@ project
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY. Use
 # IS DISTINCT FROM to retain left join.
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x=v AND (SELECT max(i) FROM a WHERE k=x) IS DISTINCT FROM u
@@ -1853,14 +1806,10 @@ project
       │    ├── grouping columns: u:3(int!null)
       │    ├── key: (3)
       │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
-      │    ├── right-join (hash)
+      │    ├── left-join (hash)
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int) i:6(int)
       │    │    ├── key: (3,5)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1), (5)-->(6)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:5(int!null) i:6(int)
-      │    │    │    ├── key: (5)
-      │    │    │    └── fd: (5)-->(6)
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
       │    │    │    ├── key: (3)
@@ -1875,6 +1824,10 @@ project
       │    │    │    │    └── fd: (3)-->(4)
       │    │    │    └── filters
       │    │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    │    ├── key: (5)
+      │    │    │    └── fd: (5)-->(6)
       │    │    └── filters
       │    │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    └── aggregations
@@ -1890,7 +1843,7 @@ project
            └── u IS DISTINCT FROM max [type=bool, outer=(3,10)]
 
 # Synthesize key when one is not present.
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM
 (
@@ -1920,11 +1873,17 @@ project
  │    │    │    │    ├── fd: (10)-->(2)
  │    │    │    │    └── scan xy
  │    │    │    │         └── columns: y:2(int)
- │    │    │    ├── scan a
+ │    │    │    ├── limit
  │    │    │    │    ├── columns: k:4(int!null) s:7(string)
- │    │    │    │    ├── limit: 1
+ │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(4,7)
+ │    │    │    │    ├── fd: ()-->(4,7)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:4(int!null) s:7(string)
+ │    │    │    │    │    ├── key: (4)
+ │    │    │    │    │    ├── fd: (4)-->(7)
+ │    │    │    │    │    └── limit hint: 1.00
+ │    │    │    │    └── const: 1 [type=int]
  │    │    │    └── filters
  │    │    │         └── k = y [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
  │    │    └── aggregations
@@ -1938,7 +1897,7 @@ project
       └── const: 'foo' [type=string]
 
 # Decorrelate DistinctOn.
-opt expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1966,28 +1925,28 @@ group-by
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) u:8(int!null) v:9(int)
  │    │    │    ├── key: (1,6,8)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5), (8)-->(9)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters
+ │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
  │    │    │    ├── inner-join (cross)
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) u:8(int!null) v:9(int)
- │    │    │    │    ├── key: (1,8)
- │    │    │    │    ├── fd: ()-->(2), (8)-->(9), (1)-->(3-5)
+ │    │    │    │    ├── columns: x:6(int!null) u:8(int!null) v:9(int)
+ │    │    │    │    ├── key: (6,8)
+ │    │    │    │    ├── fd: (8)-->(9)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
  │    │    │    │    │    ├── key: (8)
  │    │    │    │    │    └── fd: (8)-->(9)
- │    │    │    │    ├── select
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    │    ├── scan a
- │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    │    └── filters
- │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
  │    │    │    │    └── filters (true)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── first-agg [type=int, outer=(8)]
@@ -2026,7 +1985,7 @@ CREATE TABLE tab_orig (
 )
 ----
 
-opt expect=TryDecorrelateGroupBy disable=InlineWith
+norm expect=TryDecorrelateGroupBy disable=InlineWith
 SELECT
   NULL
 FROM
@@ -2093,101 +2052,84 @@ with &1 (w0)
       │    │    │         ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int!null) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) t5._decimal:54(int!null)
       │    │    │         ├── outer: (6)
       │    │    │         ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31,41), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
-      │    │    │         ├── project
-      │    │    │         │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int) t4._timestamptz:45(timestamptz)
+      │    │    │         ├── inner-join (hash)
+      │    │    │         │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null)
       │    │    │         │    ├── outer: (6)
-      │    │    │         │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
-      │    │    │         │    └── select
-      │    │    │         │         ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
-      │    │    │         │         ├── outer: (6)
-      │    │    │         │         ├── key: (14,21,28,35,60)
-      │    │    │         │         ├── fd: ()-->(25), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (14,21,28,35,60)-->(19,26,29,31,41,44,45)
-      │    │    │         │         ├── group-by
-      │    │    │         │         │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool) t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
-      │    │    │         │         │    ├── grouping columns: tab_orig.rowid:14(int!null) t1.rowid:21(int!null) t2.rowid:28(int!null) t3.rowid:35(int!null) rownum:60(int!null)
-      │    │    │         │         │    ├── outer: (6)
-      │    │    │         │         │    ├── key: (14,21,28,35,60)
-      │    │    │         │         │    ├── fd: ()-->(25), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (14,21,28,35,60)-->(19,25,26,29,31,41,44,45)
-      │    │    │         │         │    ├── project
-      │    │    │         │         │    │    ├── columns: true:40(bool!null) tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) rownum:60(int!null)
-      │    │    │         │         │    │    ├── outer: (6)
-      │    │    │         │         │    │    ├── key: (14,21,28,35,60)
-      │    │    │         │         │    │    ├── fd: ()-->(25,40), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
-      │    │    │         │         │    │    ├── inner-join (hash)
-      │    │    │         │         │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) rownum:60(int!null)
-      │    │    │         │         │    │    │    ├── outer: (6)
-      │    │    │         │         │    │    │    ├── key: (14,21,28,35,60)
-      │    │    │         │         │    │    │    ├── fd: ()-->(25), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
-      │    │    │         │         │    │    │    ├── inner-join (cross)
-      │    │    │         │         │    │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
-      │    │    │         │         │    │    │    │    ├── key: (14,21,28,35)
-      │    │    │         │         │    │    │    │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31)
-      │    │    │         │         │    │    │    │    ├── inner-join (cross)
-      │    │    │         │         │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
-      │    │    │         │         │    │    │    │    │    ├── key: (21,35)
-      │    │    │         │         │    │    │    │    │    ├── fd: (35)-->(29,31), (21)-->(19)
-      │    │    │         │         │    │    │    │    │    ├── scan t3
-      │    │    │         │         │    │    │    │    │    │    ├── columns: t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
-      │    │    │         │         │    │    │    │    │    │    ├── key: (35)
-      │    │    │         │         │    │    │    │    │    │    └── fd: (35)-->(29,31)
-      │    │    │         │         │    │    │    │    │    ├── scan t1
-      │    │    │         │         │    │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null)
-      │    │    │         │         │    │    │    │    │    │    ├── key: (21)
-      │    │    │         │         │    │    │    │    │    │    └── fd: (21)-->(19)
-      │    │    │         │         │    │    │    │    │    └── filters (true)
-      │    │    │         │         │    │    │    │    ├── inner-join (cross)
-      │    │    │         │         │    │    │    │    │    ├── columns: tab_orig.rowid:14(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null)
-      │    │    │         │         │    │    │    │    │    ├── key: (14,28)
-      │    │    │         │         │    │    │    │    │    ├── fd: ()-->(25), (28)-->(26)
-      │    │    │         │         │    │    │    │    │    ├── scan tab_orig
-      │    │    │         │         │    │    │    │    │    │    ├── columns: tab_orig.rowid:14(int!null)
-      │    │    │         │         │    │    │    │    │    │    └── key: (14)
-      │    │    │         │         │    │    │    │    │    ├── select
-      │    │    │         │         │    │    │    │    │    │    ├── columns: t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null)
-      │    │    │         │         │    │    │    │    │    │    ├── key: (28)
-      │    │    │         │         │    │    │    │    │    │    ├── fd: ()-->(25), (28)-->(26)
-      │    │    │         │         │    │    │    │    │    │    ├── scan t2
-      │    │    │         │         │    │    │    │    │    │    │    ├── columns: t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null)
-      │    │    │         │         │    │    │    │    │    │    │    ├── key: (28)
-      │    │    │         │         │    │    │    │    │    │    │    └── fd: (28)-->(25,26)
-      │    │    │         │         │    │    │    │    │    │    └── filters
-      │    │    │         │         │    │    │    │    │    │         └── variable: t2._bool [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
-      │    │    │         │         │    │    │    │    │    └── filters (true)
-      │    │    │         │         │    │    │    │    └── filters (true)
-      │    │    │         │         │    │    │    ├── ordinality
-      │    │    │         │         │    │    │    │    ├── columns: t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
-      │    │    │         │         │    │    │    │    ├── key: (60)
-      │    │    │         │         │    │    │    │    ├── fd: (60)-->(44,45)
-      │    │    │         │         │    │    │    │    └── scan t4
-      │    │    │         │         │    │    │    │         └── columns: t4._int8:44(int) t4._timestamptz:45(timestamptz)
-      │    │    │         │         │    │    │    └── filters
-      │    │    │         │         │    │    │         ├── t0._string = 1 [type=bool, outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
-      │    │    │         │         │    │    │         ├── t3._timestamptz = t4._timestamptz [type=bool, outer=(31,45), constraints=(/31: (/NULL - ]; /45: (/NULL - ]), fd=(31)==(45), (45)==(31)]
-      │    │    │         │         │    │    │         └── t3._int2 = t4._int8 [type=bool, outer=(29,44), constraints=(/29: (/NULL - ]; /44: (/NULL - ]), fd=(29)==(44), (44)==(29)]
-      │    │    │         │         │    │    └── projections
-      │    │    │         │         │    │         └── true [type=bool]
-      │    │    │         │         │    └── aggregations
-      │    │    │         │         │         ├── const-not-null-agg [type=bool, outer=(40)]
-      │    │    │         │         │         │    └── variable: true [type=bool]
-      │    │    │         │         │         ├── const-agg [type=bool, outer=(25)]
-      │    │    │         │         │         │    └── variable: t2._bool [type=bool]
-      │    │    │         │         │         ├── const-agg [type=int, outer=(26)]
-      │    │    │         │         │         │    └── variable: t2._decimal [type=int]
-      │    │    │         │         │         ├── const-agg [type=int, outer=(29)]
-      │    │    │         │         │         │    └── variable: t3._int2 [type=int]
-      │    │    │         │         │         ├── const-agg [type=timestamptz, outer=(31)]
-      │    │    │         │         │         │    └── variable: t3._timestamptz [type=timestamptz]
-      │    │    │         │         │         ├── const-agg [type=int, outer=(19)]
-      │    │    │         │         │         │    └── variable: t1._decimal [type=int]
-      │    │    │         │         │         ├── const-agg [type=int, outer=(44)]
-      │    │    │         │         │         │    └── variable: t4._int8 [type=int]
-      │    │    │         │         │         └── const-agg [type=timestamptz, outer=(45)]
-      │    │    │         │         │              └── variable: t4._timestamptz [type=timestamptz]
-      │    │    │         │         └── filters
-      │    │    │         │              └── true_agg IS NOT NULL [type=bool, outer=(41), constraints=(/41: (/NULL - ]; tight)]
+      │    │    │         │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31), (14,21,28,35)-->(19,25,26,29,31,41), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
+      │    │    │         │    ├── select
+      │    │    │         │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool!null)
+      │    │    │         │    │    ├── outer: (6)
+      │    │    │         │    │    ├── key: (14,21,28,35)
+      │    │    │         │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31), (14,21,28,35)-->(19,25,26,29,31,41)
+      │    │    │         │    │    ├── group-by
+      │    │    │         │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool)
+      │    │    │         │    │    │    ├── grouping columns: tab_orig.rowid:14(int!null) t1.rowid:21(int!null) t2.rowid:28(int!null) t3.rowid:35(int!null)
+      │    │    │         │    │    │    ├── outer: (6)
+      │    │    │         │    │    │    ├── key: (14,21,28,35)
+      │    │    │         │    │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31), (14,21,28,35)-->(19,25,26,29,31,41)
+      │    │    │         │    │    │    ├── project
+      │    │    │         │    │    │    │    ├── columns: true:40(bool!null) tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+      │    │    │         │    │    │    │    ├── outer: (6)
+      │    │    │         │    │    │    │    ├── key: (14,21,28,35)
+      │    │    │         │    │    │    │    ├── fd: ()-->(40), (21)-->(19), (28)-->(25,26), (35)-->(29,31)
+      │    │    │         │    │    │    │    ├── inner-join (cross)
+      │    │    │         │    │    │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+      │    │    │         │    │    │    │    │    ├── outer: (6)
+      │    │    │         │    │    │    │    │    ├── key: (14,21,28,35)
+      │    │    │         │    │    │    │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31)
+      │    │    │         │    │    │    │    │    ├── scan tab_orig
+      │    │    │         │    │    │    │    │    │    ├── columns: tab_orig.rowid:14(int!null)
+      │    │    │         │    │    │    │    │    │    └── key: (14)
+      │    │    │         │    │    │    │    │    ├── inner-join (cross)
+      │    │    │         │    │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+      │    │    │         │    │    │    │    │    │    ├── key: (21,28,35)
+      │    │    │         │    │    │    │    │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31)
+      │    │    │         │    │    │    │    │    │    ├── scan t1
+      │    │    │         │    │    │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null)
+      │    │    │         │    │    │    │    │    │    │    ├── key: (21)
+      │    │    │         │    │    │    │    │    │    │    └── fd: (21)-->(19)
+      │    │    │         │    │    │    │    │    │    ├── inner-join (cross)
+      │    │    │         │    │    │    │    │    │    │    ├── columns: t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+      │    │    │         │    │    │    │    │    │    │    ├── key: (28,35)
+      │    │    │         │    │    │    │    │    │    │    ├── fd: (28)-->(25,26), (35)-->(29,31)
+      │    │    │         │    │    │    │    │    │    │    ├── scan t2
+      │    │    │         │    │    │    │    │    │    │    │    ├── columns: t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null)
+      │    │    │         │    │    │    │    │    │    │    │    ├── key: (28)
+      │    │    │         │    │    │    │    │    │    │    │    └── fd: (28)-->(25,26)
+      │    │    │         │    │    │    │    │    │    │    ├── scan t3
+      │    │    │         │    │    │    │    │    │    │    │    ├── columns: t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+      │    │    │         │    │    │    │    │    │    │    │    ├── key: (35)
+      │    │    │         │    │    │    │    │    │    │    │    └── fd: (35)-->(29,31)
+      │    │    │         │    │    │    │    │    │    │    └── filters (true)
+      │    │    │         │    │    │    │    │    │    └── filters (true)
+      │    │    │         │    │    │    │    │    └── filters
+      │    │    │         │    │    │    │    │         └── t0._string = 1 [type=bool, outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │    │    │         │    │    │    │    └── projections
+      │    │    │         │    │    │    │         └── true [type=bool]
+      │    │    │         │    │    │    └── aggregations
+      │    │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(40)]
+      │    │    │         │    │    │         │    └── variable: true [type=bool]
+      │    │    │         │    │    │         ├── const-agg [type=bool, outer=(25)]
+      │    │    │         │    │    │         │    └── variable: t2._bool [type=bool]
+      │    │    │         │    │    │         ├── const-agg [type=int, outer=(26)]
+      │    │    │         │    │    │         │    └── variable: t2._decimal [type=int]
+      │    │    │         │    │    │         ├── const-agg [type=int, outer=(29)]
+      │    │    │         │    │    │         │    └── variable: t3._int2 [type=int]
+      │    │    │         │    │    │         ├── const-agg [type=timestamptz, outer=(31)]
+      │    │    │         │    │    │         │    └── variable: t3._timestamptz [type=timestamptz]
+      │    │    │         │    │    │         └── const-agg [type=int, outer=(19)]
+      │    │    │         │    │    │              └── variable: t1._decimal [type=int]
+      │    │    │         │    │    └── filters
+      │    │    │         │    │         └── true_agg IS NOT NULL [type=bool, outer=(41), constraints=(/41: (/NULL - ]; tight)]
+      │    │    │         │    ├── scan t4
+      │    │    │         │    │    └── columns: t4._int8:44(int) t4._timestamptz:45(timestamptz)
+      │    │    │         │    └── filters
+      │    │    │         │         ├── t3._timestamptz = t4._timestamptz [type=bool, outer=(31,45), constraints=(/31: (/NULL - ]; /45: (/NULL - ]), fd=(31)==(45), (45)==(31)]
+      │    │    │         │         └── t3._int2 = t4._int8 [type=bool, outer=(29,44), constraints=(/29: (/NULL - ]; /44: (/NULL - ]), fd=(29)==(44), (44)==(29)]
       │    │    │         ├── scan t5
       │    │    │         │    └── columns: t5._decimal:54(int)
       │    │    │         └── filters
+      │    │    │              ├── variable: t2._bool [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
       │    │    │              └── t1._decimal = t5._decimal [type=bool, outer=(19,54), constraints=(/19: (/NULL - ]; /54: (/NULL - ]), fd=(19)==(54), (54)==(19)]
       │    │    └── const: 66 [type=int]
       │    └── filters (true)
@@ -2197,7 +2139,7 @@ with &1 (w0)
 # --------------------------------------------------
 # TryDecorrelateScalarGroupBy
 # --------------------------------------------------
-opt expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -2266,7 +2208,7 @@ group-by
            └── variable: j [type=jsonb]
 
 # Synthesize key when one is not present.
-opt expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy
 SELECT * FROM (SELECT i, 'foo' AS cst FROM a) WHERE 5=(SELECT max(y) FROM xy WHERE x=i)
 ----
 project
@@ -2315,7 +2257,7 @@ project
 
 # With an aggregate that can't ignore nulls. xy.y = a.k rejects nulls, so
 # there's no canary column to be synthesized.
-opt expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy
 SELECT k, (SELECT array_agg(xy.y) FROM xy WHERE xy.y = a.k) FROM a
 ----
 project
@@ -2453,7 +2395,7 @@ project
 
 # Nest scalar decorrelation within scalar decorrelation, using IS NULL to force
 # use of left joins.
-opt expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy
 SELECT *
 FROM a
 WHERE
@@ -2647,7 +2589,7 @@ project
 # --------------------------------------------------
 
 # Right input of SemiJoin is GroupBy.
-opt expect=TryDecorrelateSemiJoin
+norm expect=TryDecorrelateSemiJoin
 SELECT *
 FROM xy
 WHERE EXISTS
@@ -2669,35 +2611,35 @@ group-by
  │    │    ├── grouping columns: x:1(int!null) k:3(int!null)
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13)
- │    │    ├── inner-join (cross)
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) i:9(int!null) f:10(float!null) column14:14(float!null)
  │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
- │    │    │    ├── inner-join (hash)
- │    │    │    │    ├── columns: x:1(int!null) y:2(int) i:9(int!null) f:10(float!null) column14:14(float!null)
- │    │    │    │    ├── fd: (1)-->(2), (2)-->(14), (10)==(14), (14)==(10)
- │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
- │    │    │    │    │    ├── scan xy
- │    │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    └── fd: (1)-->(2)
- │    │    │    │    │    └── projections
- │    │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── projections
+ │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
+ │    │    │    ├── inner-join (cross)
+ │    │    │    │    ├── columns: k:3(int!null) i:4(int) i:9(int!null) f:10(float)
+ │    │    │    │    ├── fd: (3)-->(4)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+ │    │    │    │    │    ├── key: (3)
+ │    │    │    │    │    └── fd: (3)-->(4)
  │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: i:9(int!null) f:10(float)
  │    │    │    │    │    ├── scan a
  │    │    │    │    │    │    └── columns: i:9(int) f:10(float)
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
- │    │    │    │    └── filters
- │    │    │    │         └── column14 = f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
- │    │    │    ├── scan a
- │    │    │    │    ├── columns: k:3(int!null) i:4(int)
- │    │    │    │    ├── key: (3)
- │    │    │    │    └── fd: (3)-->(4)
- │    │    │    └── filters (true)
+ │    │    │    │    └── filters (true)
+ │    │    │    └── filters
+ │    │    │         └── column14 = f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(9)]
  │    │         │    └── variable: i [type=int]
@@ -2712,7 +2654,7 @@ group-by
            └── variable: y [type=int]
 
 # Right input of SemiJoin is DistinctOn.
-opt expect=TryDecorrelateSemiJoin
+norm expect=TryDecorrelateSemiJoin
 SELECT *
 FROM xy
 WHERE EXISTS
@@ -2757,7 +2699,7 @@ group-by
            └── variable: y [type=int]
 
 # Right input of SemiJoin is Project.
-opt expect=TryDecorrelateSemiJoin
+norm expect=TryDecorrelateSemiJoin
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -2775,34 +2717,33 @@ project
       │    ├── columns: computed:10(int) k:1(int!null) x:6(int!null)
       │    ├── key: (1,6)
       │    ├── fd: (1)-->(10)
-      │    ├── inner-join (cross)
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:6(int!null)
-      │    │    │    └── key: (6)
-      │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      │    │    │    └── fd: (1)-->(2)
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
+      │    │    │    ├── key: (6,8)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:6(int!null)
+      │    │    │    │    └── key: (6)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    └── filters
-      │    │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
-      │    │    └── filters (true)
+      │    │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
       │    └── projections
       │         └── COALESCE(u, 10) [type=int, outer=(8)]
       └── filters
            └── x = computed [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
 
 # Right input of SemiJoin is ProjectSet.
-opt expect=TryDecorrelateSemiJoin
+norm expect=TryDecorrelateSemiJoin
 SELECT * FROM xy WHERE EXISTS(SELECT generate_series(x, 10), generate_series(y, 10))
 ----
 group-by
@@ -2835,7 +2776,7 @@ group-by
 # --------------------------------------------------
 
 # With inner join.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT *
 FROM a
 WHERE EXISTS
@@ -2846,43 +2787,32 @@ WHERE EXISTS
     ON x=u
 )
 ----
-project
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── inner-join (hash)
-      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int!null)
-      ├── key: (1)
-      ├── fd: (1)-->(2-5), (2)==(9), (9)==(2)
-      ├── scan a
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2-5)
-      ├── distinct-on
-      │    ├── columns: v:9(int)
-      │    ├── grouping columns: v:9(int)
-      │    ├── key: (9)
-      │    └── inner-join (merge)
-      │         ├── columns: x:6(int!null) u:8(int!null) v:9(int)
-      │         ├── left ordering: +6
-      │         ├── right ordering: +8
-      │         ├── key: (8)
-      │         ├── fd: (8)-->(9), (6)==(8), (8)==(6)
-      │         ├── scan xy
-      │         │    ├── columns: x:6(int!null)
-      │         │    ├── key: (6)
-      │         │    └── ordering: +6
-      │         ├── scan uv
-      │         │    ├── columns: u:8(int!null) v:9(int)
-      │         │    ├── key: (8)
-      │         │    ├── fd: (8)-->(9)
-      │         │    └── ordering: +8
-      │         └── filters (true)
-      └── filters
-           └── v = i [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── inner-join (hash)
+ │    ├── columns: x:6(int!null) u:8(int!null) v:9(int)
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(9), (6)==(8), (8)==(6)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null)
+ │    │    └── key: (6)
+ │    ├── scan uv
+ │    │    ├── columns: u:8(int!null) v:9(int)
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ └── filters
+      └── v = i [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
 
 # With left join.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT (SELECT x FROM xy WHERE y=i LIMIT 1) FROM a
 ----
 project
@@ -2915,7 +2845,7 @@ project
       └── variable: xy.x [type=int, outer=(6)]
 
 # With multiple limited queries.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT * FROM a WHERE (SELECT x FROM xy WHERE y=i LIMIT 1)=k AND (SELECT u FROM uv WHERE v=i LIMIT 1)=k
 ----
 project
@@ -2931,14 +2861,10 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,8)
-      │    ├── right-join (hash)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) u:8(int) v:9(int)
       │    │    ├── key: (1,8)
       │    │    ├── fd: (1)-->(2-5), (1)==(6), (6)==(1), (8)-->(9)
-      │    │    ├── scan uv
-      │    │    │    ├── columns: u:8(int!null) v:9(int)
-      │    │    │    ├── key: (8)
-      │    │    │    └── fd: (8)-->(9)
       │    │    ├── select
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
       │    │    │    ├── key: (1)
@@ -2975,6 +2901,10 @@ project
       │    │    │    │              └── variable: x [type=int]
       │    │    │    └── filters
       │    │    │         └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │    ├── scan uv
+      │    │    │    ├── columns: u:8(int!null) v:9(int)
+      │    │    │    ├── key: (8)
+      │    │    │    └── fd: (8)-->(9)
       │    │    └── filters
       │    │         └── v = i [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    └── aggregations
@@ -2992,7 +2922,7 @@ project
            └── k = u [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # With nested limited queries.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT *
 FROM a
 WHERE
@@ -3074,7 +3004,7 @@ project
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # With inner join + ORDER BY.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT
 (
     SELECT v
@@ -3099,23 +3029,20 @@ project
  │    │    ├── scan xy
  │    │    │    ├── columns: x:1(int!null)
  │    │    │    └── key: (1)
- │    │    ├── inner-join (merge)
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: u:3(int!null) uv.v:4(int) k:5(int!null) i:6(int)
- │    │    │    ├── left ordering: +3
- │    │    │    ├── right ordering: +5
  │    │    │    ├── key: (5)
  │    │    │    ├── fd: (3)-->(4), (5)-->(6), (3)==(5), (5)==(3)
  │    │    │    ├── scan uv
  │    │    │    │    ├── columns: u:3(int!null) uv.v:4(int)
  │    │    │    │    ├── key: (3)
- │    │    │    │    ├── fd: (3)-->(4)
- │    │    │    │    └── ordering: +3
+ │    │    │    │    └── fd: (3)-->(4)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:5(int!null) i:6(int)
  │    │    │    │    ├── key: (5)
- │    │    │    │    ├── fd: (5)-->(6)
- │    │    │    │    └── ordering: +5
- │    │    │    └── filters (true)
+ │    │    │    │    └── fd: (5)-->(6)
+ │    │    │    └── filters
+ │    │    │         └── u = k [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
  │    │    └── filters
  │    │         └── i = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    └── aggregations
@@ -3125,7 +3052,7 @@ project
       └── variable: uv.v [type=int, outer=(4)]
 
 # With left join + ORDER BY.
-opt expect=TryDecorrelateLimitOne
+norm expect=TryDecorrelateLimitOne
 SELECT * FROM xy WHERE (SELECT k FROM a WHERE i=y ORDER BY f,s LIMIT 1)=x
 ----
 project
@@ -3172,34 +3099,29 @@ project
 # --------------------------------------------------
 # HoistSelectExists
 # --------------------------------------------------
-opt expect=HoistSelectExists
+norm expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k)
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null)
- │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Ensure that EXISTS is hoisted even when it is one of several conjuncts.
-opt expect=HoistSelectExists
+norm expect=HoistSelectExists
 SELECT * FROM a WHERE s='foo' AND EXISTS(SELECT * FROM xy WHERE x=k) AND i>1
 ----
-semi-join (lookup xy)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── select
@@ -3213,10 +3135,14 @@ semi-join (lookup xy)
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Multiple Exists operators in same Select list.
-opt expect=HoistSelectExists
+norm expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND EXISTS(SELECT * FROM xy WHERE x=i)
 ----
 semi-join (hash)
@@ -3243,7 +3169,7 @@ semi-join (hash)
       └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Don't hoist uncorrelated subqueries.
-opt expect-not=HoistSelectExists
+norm expect-not=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy)
 ----
 select
@@ -3256,75 +3182,70 @@ select
  │    └── fd: (1)-->(2-5)
  └── filters
       └── exists [type=bool, subquery]
-           └── scan xy
+           └── limit
                 ├── columns: x:6(int!null) y:7(int)
-                ├── limit: 1
+                ├── cardinality: [0 - 1]
                 ├── key: ()
-                └── fd: ()-->(6,7)
+                ├── fd: ()-->(6,7)
+                ├── scan xy
+                │    ├── columns: x:6(int!null) y:7(int)
+                │    ├── key: (6)
+                │    ├── fd: (6)-->(7)
+                │    └── limit hint: 1.00
+                └── const: 1 [type=int]
 
 # Hoist nested EXISTS.
-opt expect=HoistSelectExists
+norm expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE EXISTS (SELECT * FROM uv WHERE x=u) AND x=k)
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── semi-join (merge)
+ │    └── fd: (1)-->(2-5)
+ ├── semi-join (hash)
  │    ├── columns: x:6(int!null)
- │    ├── left ordering: +6
- │    ├── right ordering: +8
  │    ├── key: (6)
- │    ├── ordering: +6
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
+ │    │    └── key: (6)
  │    ├── scan uv
  │    │    ├── columns: u:8(int!null)
- │    │    ├── key: (8)
- │    │    └── ordering: +8
- │    └── filters (true)
- └── filters (true)
+ │    │    └── key: (8)
+ │    └── filters
+ │         └── x = u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # HoistSelectNotExists
 # --------------------------------------------------
-opt expect=HoistSelectNotExists
+norm expect=HoistSelectNotExists
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k)
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null)
- │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Ensure that NOT EXISTS is hoisted even when one of several conjuncts.
-opt expect=HoistSelectNotExists
+norm expect=HoistSelectNotExists
 SELECT * FROM a WHERE s='foo' AND NOT EXISTS(SELECT * FROM xy WHERE x=k) AND i>1
 ----
-anti-join (lookup xy)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── select
@@ -3338,18 +3259,20 @@ anti-join (lookup xy)
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Multiple Not Exists operators in same Select list.
-opt expect=HoistSelectNotExists
+norm expect=HoistSelectNotExists
 SELECT *
 FROM a
 WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
 ----
-anti-join (lookup xy)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── anti-join (hash)
@@ -3365,10 +3288,14 @@ anti-join (lookup xy)
  │    │    └── key: (8)
  │    └── filters
  │         └── x = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Don't hoist uncorrelated subqueries.
-opt expect-not=HoistSelectNotExists
+norm expect-not=HoistSelectNotExists
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy)
 ----
 select
@@ -3382,22 +3309,26 @@ select
  └── filters
       └── not [type=bool, subquery]
            └── exists [type=bool]
-                └── scan xy
+                └── limit
                      ├── columns: x:6(int!null) y:7(int)
-                     ├── limit: 1
+                     ├── cardinality: [0 - 1]
                      ├── key: ()
-                     └── fd: ()-->(6,7)
+                     ├── fd: ()-->(6,7)
+                     ├── scan xy
+                     │    ├── columns: x:6(int!null) y:7(int)
+                     │    ├── key: (6)
+                     │    ├── fd: (6)-->(7)
+                     │    └── limit hint: 1.00
+                     └── const: 1 [type=int]
 
 # --------------------------------------------------
 # HoistSelectExists + HoistSelectNotExists
 # --------------------------------------------------
-opt expect=(HoistSelectExists,HoistSelectNotExists)
+norm expect=(HoistSelectExists,HoistSelectNotExists)
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
 ----
-semi-join (lookup xy)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── anti-join (hash)
@@ -3413,12 +3344,16 @@ semi-join (lookup xy)
  │    │    └── key: (8)
  │    └── filters
  │         └── x = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # HoistSelectSubquery
 # --------------------------------------------------
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
 project
@@ -3460,7 +3395,7 @@ project
            └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Multiple other conjuncts, including uncorrelated subquery (don't hoist).
-opt expect=HoistSelectSubquery disable=InlineConstVar
+norm expect=HoistSelectSubquery disable=InlineConstVar
 SELECT *
 FROM a
 WHERE k=10 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i AND (SELECT x FROM xy LIMIT 1) = 100
@@ -3480,10 +3415,8 @@ project
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1-5,7)
-      │    ├── left-join (merge)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int)
-      │    │    ├── left ordering: +1
-      │    │    ├── right ordering: +7
       │    │    ├── fd: ()-->(1-5), ()~~>(7)
       │    │    ├── limit hint: 1.00
       │    │    ├── select
@@ -3493,18 +3426,22 @@ project
       │    │    │    ├── fd: ()-->(1-5)
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    │    │    │    ├── constraint: /1: [/10 - /10]
-      │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    ├── key: ()
-      │    │    │    │    └── fd: ()-->(1-5)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2-5)
       │    │    │    └── filters
+      │    │    │         ├── k = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
       │    │    │         └── eq [type=bool, subquery]
       │    │    │              ├── subquery [type=int]
-      │    │    │              │    └── scan xy
+      │    │    │              │    └── limit
       │    │    │              │         ├── columns: x:8(int!null)
-      │    │    │              │         ├── limit: 1
+      │    │    │              │         ├── cardinality: [0 - 1]
       │    │    │              │         ├── key: ()
-      │    │    │              │         └── fd: ()-->(8)
+      │    │    │              │         ├── fd: ()-->(8)
+      │    │    │              │         ├── scan xy
+      │    │    │              │         │    ├── columns: x:8(int!null)
+      │    │    │              │         │    ├── key: (8)
+      │    │    │              │         │    └── limit hint: 1.00
+      │    │    │              │         └── const: 1 [type=int]
       │    │    │              └── const: 100 [type=int]
       │    │    ├── select
       │    │    │    ├── columns: y:7(int!null)
@@ -3515,19 +3452,25 @@ project
       │    │    │         ├── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
       │    │    │         └── eq [type=bool, subquery]
       │    │    │              ├── subquery [type=int]
-      │    │    │              │    └── scan xy
+      │    │    │              │    └── limit
       │    │    │              │         ├── columns: x:8(int!null)
-      │    │    │              │         ├── limit: 1
+      │    │    │              │         ├── cardinality: [0 - 1]
       │    │    │              │         ├── key: ()
-      │    │    │              │         └── fd: ()-->(8)
+      │    │    │              │         ├── fd: ()-->(8)
+      │    │    │              │         ├── scan xy
+      │    │    │              │         │    ├── columns: x:8(int!null)
+      │    │    │              │         │    ├── key: (8)
+      │    │    │              │         │    └── limit hint: 1.00
+      │    │    │              │         └── const: 1 [type=int]
       │    │    │              └── const: 100 [type=int]
-      │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── y = k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │    └── const: 1 [type=int]
       └── filters
            └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Multiple correlated subqueries.
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a
 WHERE (SELECT count(*) FROM xy WHERE y=k) > 0 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
@@ -3544,11 +3487,9 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,10)
-      │    ├── right-join (hash)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count_rows:8(int!null) y:10(int)
       │    │    ├── fd: (1)-->(2-5,8)
-      │    │    ├── scan xy
-      │    │    │    └── columns: y:10(int)
       │    │    ├── select
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count_rows:8(int!null)
       │    │    │    ├── key: (1)
@@ -3582,6 +3523,8 @@ project
       │    │    │    │              └── variable: j [type=jsonb]
       │    │    │    └── filters
       │    │    │         └── count_rows > 0 [type=bool, outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    │    ├── scan xy
+      │    │    │    └── columns: y:10(int)
       │    │    └── filters
       │    │         └── y = k [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    └── aggregations
@@ -3600,7 +3543,7 @@ project
 
 # Subquery nested below interesting scalar operators like cast, function, tuple,
 # or, etc).
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE (0, length((SELECT count(*) FROM uv WHERE k=u)::string)) > (0, 1) OR i=1
 ----
 project
@@ -3614,26 +3557,21 @@ project
       ├── group-by
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count_rows:8(int)
       │    ├── grouping columns: k:1(int!null)
-      │    ├── internal-ordering: +1
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,8)
-      │    ├── left-join (merge)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) u:6(int)
-      │    │    ├── left ordering: +1
-      │    │    ├── right ordering: +6
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2-5)
-      │    │    ├── ordering: +1
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5)
-      │    │    │    └── ordering: +1
+      │    │    │    └── fd: (1)-->(2-5)
       │    │    ├── scan uv
       │    │    │    ├── columns: u:6(int!null)
-      │    │    │    ├── key: (6)
-      │    │    │    └── ordering: +6
-      │    │    └── filters (true)
+      │    │    │    └── key: (6)
+      │    │    └── filters
+      │    │         └── k = u [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │    └── aggregations
       │         ├── count [type=int, outer=(6)]
       │         │    └── variable: u [type=int]
@@ -3649,7 +3587,7 @@ project
            └── ((0, length(count_rows::STRING)) > (0, 1)) OR (i = 1) [type=bool, outer=(2,8)]
 
 # Exists within a disjunction.
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE i=1 OR EXISTS(SELECT * FROM xy WHERE y=i)
 ----
 project
@@ -3696,7 +3634,7 @@ project
            └── (i = 1) OR (true_agg IS NOT NULL) [type=bool, outer=(2,9)]
 
 # Any with IS NULL.
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy WHERE x=k)) IS NULL
 ----
 project
@@ -3714,34 +3652,28 @@ project
       │    ├── group-by
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) bool_or:9(bool)
       │    │    ├── grouping columns: k:1(int!null)
-      │    │    ├── internal-ordering: +1
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-5,9)
-      │    │    ├── left-join (merge)
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int) notnull:8(bool)
-      │    │    │    ├── left ordering: +1
-      │    │    │    ├── right ordering: +6
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: (1)-->(2-5), (6)-->(7), (7)~~>(8), (1,6)-->(8)
-      │    │    │    ├── ordering: +1
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-5)
-      │    │    │    │    └── ordering: +1
+      │    │    │    │    └── fd: (1)-->(2-5)
       │    │    │    ├── project
       │    │    │    │    ├── columns: notnull:8(bool) x:6(int!null) y:7(int)
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: (6)-->(7), (7)-->(8)
-      │    │    │    │    ├── ordering: +6
       │    │    │    │    ├── scan xy
       │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    │    │    │    ├── key: (6)
-      │    │    │    │    │    ├── fd: (6)-->(7)
-      │    │    │    │    │    └── ordering: +6
+      │    │    │    │    │    └── fd: (6)-->(7)
       │    │    │    │    └── projections
       │    │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
       │    │    │    └── filters
+      │    │    │         ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │    │    │         └── (i = y) IS NOT false [type=bool, outer=(2,7)]
       │    │    └── aggregations
       │    │         ├── bool-or [type=bool, outer=(8)]
@@ -3760,7 +3692,7 @@ project
            └── case IS NULL [type=bool, outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
 
 # Any with uncorrelated subquery (should not be hoisted).
-opt
+norm
 SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy)) IS NULL
 ----
 select
@@ -3780,7 +3712,7 @@ select
            └── null [type=unknown]
 
 # ALL with non-trivial expression on left.
-opt
+norm
 SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 ----
 project
@@ -3789,44 +3721,37 @@ project
  ├── group-by
  │    ├── columns: k:1(int!null) s:4(string) scalar:9(decimal) bool_or:11(bool)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +1
  │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(4,9,11)
- │    ├── left-join (merge)
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) s:4(string) x:6(int) y:7(int) scalar:9(decimal) notnull:10(bool)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +6
  │    │    ├── side-effects
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(4,9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
- │    │    ├── ordering: +1
  │    │    ├── project
  │    │    │    ├── columns: scalar:9(decimal) k:1(int!null) s:4(string)
  │    │    │    ├── side-effects
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(4,9)
- │    │    │    ├── ordering: +1
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: (1)-->(2,4)
- │    │    │    │    └── ordering: +1
+ │    │    │    │    └── fd: (1)-->(2,4)
  │    │    │    └── projections
  │    │    │         └── (i * i) / 100 [type=decimal, outer=(2), side-effects]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10(bool) x:6(int!null) y:7(int)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(7), (7)-->(10)
- │    │    │    ├── ordering: +6
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
- │    │    │    │    ├── fd: (6)-->(7)
- │    │    │    │    └── ordering: +6
+ │    │    │    │    └── fd: (6)-->(7)
  │    │    │    └── projections
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
  │    │    └── filters
+ │    │         ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── (scalar >= y) IS NOT false [type=bool, outer=(7,9)]
  │    └── aggregations
  │         ├── bool-or [type=bool, outer=(10)]
@@ -3840,7 +3765,7 @@ project
 
 # Regress issue #32270: Panic when expression contains both correlated and
 # uncorrelated subquery.
-opt expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy) OR EXISTS(SELECT * FROM xy WHERE x=k)
 ----
 project
@@ -3854,33 +3779,27 @@ project
       ├── group-by
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) true_agg:11(bool)
       │    ├── grouping columns: k:1(int!null)
-      │    ├── internal-ordering: +1
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,11)
-      │    ├── left-join (merge)
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:8(int) true:10(bool)
-      │    │    ├── left ordering: +1
-      │    │    ├── right ordering: +8
       │    │    ├── key: (1,8)
       │    │    ├── fd: (1)-->(2-5), ()~~>(10), (1,8)-->(10)
-      │    │    ├── ordering: +1
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5)
-      │    │    │    └── ordering: +1
+      │    │    │    └── fd: (1)-->(2-5)
       │    │    ├── project
       │    │    │    ├── columns: true:10(bool!null) x:8(int!null)
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: ()-->(10)
-      │    │    │    ├── ordering: +8 opt(10) [actual: +8]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:8(int!null)
-      │    │    │    │    ├── key: (8)
-      │    │    │    │    └── ordering: +8
+      │    │    │    │    └── key: (8)
       │    │    │    └── projections
       │    │    │         └── true [type=bool]
-      │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── x = k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       │    └── aggregations
       │         ├── const-not-null-agg [type=bool, outer=(10)]
       │         │    └── variable: true [type=bool]
@@ -3895,40 +3814,43 @@ project
       └── filters
            └── or [type=bool, outer=(11), subquery]
                 ├── exists [type=bool]
-                │    └── scan xy
+                │    └── limit
                 │         ├── columns: x:6(int!null) y:7(int)
-                │         ├── limit: 1
+                │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         └── fd: ()-->(6,7)
+                │         ├── fd: ()-->(6,7)
+                │         ├── scan xy
+                │         │    ├── columns: x:6(int!null) y:7(int)
+                │         │    ├── key: (6)
+                │         │    ├── fd: (6)-->(7)
+                │         │    └── limit hint: 1.00
+                │         └── const: 1 [type=int]
                 └── true_agg IS NOT NULL [type=bool]
 
 # --------------------------------------------------
 # HoistProjectSubquery
 # --------------------------------------------------
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT (SELECT x FROM xy WHERE x=k) FROM a
 ----
 project
  ├── columns: x:8(int)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: k:1(int!null) xy.x:6(int)
- │    ├── left ordering: +1
- │    ├── right ordering: +6
  │    ├── key: (1,6)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null)
- │    │    ├── key: (1)
- │    │    └── ordering: +1
+ │    │    └── key: (1)
  │    ├── scan xy
  │    │    ├── columns: xy.x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
- │    └── filters (true)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── xy.x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── projections
       └── variable: xy.x [type=int, outer=(6)]
 
 # Mixed correlated and uncorrelated subqueries.
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT
     5 AS a,
     (SELECT x FROM xy WHERE x=k),
@@ -3948,20 +3870,17 @@ project
  │    ├── fd: (1,6)-->(16)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) xy.x:6(int) xy.y:15(int)
- │    │    ├── left-join (merge)
+ │    │    ├── left-join (hash)
  │    │    │    ├── columns: k:1(int!null) xy.x:6(int)
- │    │    │    ├── left ordering: +1
- │    │    │    ├── right ordering: +6
  │    │    │    ├── key: (1,6)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1(int!null)
- │    │    │    │    ├── key: (1)
- │    │    │    │    └── ordering: +1
+ │    │    │    │    └── key: (1)
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: xy.x:6(int!null)
- │    │    │    │    ├── key: (6)
- │    │    │    │    └── ordering: +6
- │    │    │    └── filters (true)
+ │    │    │    │    └── key: (6)
+ │    │    │    └── filters
+ │    │    │         └── xy.x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │    ├── scan xy
  │    │    │    └── columns: xy.y:15(int)
  │    │    └── filters
@@ -3973,25 +3892,35 @@ project
       ├── const: 5 [type=int]
       ├── variable: xy.x [type=int, outer=(6)]
       ├── subquery [type=int, subquery]
-      │    └── scan xy
+      │    └── limit
       │         ├── columns: xy.y:9(int)
-      │         ├── limit: 1
+      │         ├── cardinality: [0 - 1]
       │         ├── key: ()
-      │         └── fd: ()-->(9)
+      │         ├── fd: ()-->(9)
+      │         ├── scan xy
+      │         │    ├── columns: xy.y:9(int)
+      │         │    └── limit hint: 1.00
+      │         └── const: 1 [type=int]
       ├── any: eq [type=bool, subquery]
       │    ├── scan xy
       │    │    └── columns: xy.y:11(int)
       │    └── const: 5 [type=int]
       ├── exists [type=bool, subquery]
-      │    └── scan xy
+      │    └── limit
       │         ├── columns: xy.x:12(int!null) xy.y:13(int)
-      │         ├── limit: 1
+      │         ├── cardinality: [0 - 1]
       │         ├── key: ()
-      │         └── fd: ()-->(12,13)
+      │         ├── fd: ()-->(12,13)
+      │         ├── scan xy
+      │         │    ├── columns: xy.x:12(int!null) xy.y:13(int)
+      │         │    ├── key: (12)
+      │         │    ├── fd: (12)-->(13)
+      │         │    └── limit hint: 1.00
+      │         └── const: 1 [type=int]
       └── variable: count_rows [type=int, outer=(16)]
 
 # Subquery in GroupBy aggregate (optbuilder creates correlated Project).
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT max((SELECT y FROM xy WHERE y=i)) FROM a
 ----
 scalar-group-by
@@ -4027,7 +3956,7 @@ scalar-group-by
            └── variable: column8 [type=int]
 
 # Exists in projection list.
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
@@ -4062,7 +3991,7 @@ project
       └── true_agg IS NOT NULL [type=bool, outer=(10)]
 
 # Any in projection list.
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT 5 < ANY(SELECT y FROM xy WHERE y=i) AS r FROM a
 ----
 project
@@ -4101,7 +4030,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Correlated subquery nested in uncorrelated subquery.
-opt expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a)
 ----
 values
@@ -4116,10 +4045,24 @@ values
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(2,7,9,12)
-                ├── right-join (hash)
+                ├── left-join (hash)
                 │    ├── columns: i:2(int) y:7(int) true:9(bool) rownum:12(int!null)
                 │    ├── fd: ()-->(2,12), ()~~>(9)
                 │    ├── limit hint: 1.00
+                │    ├── ordinality
+                │    │    ├── columns: i:2(int) rownum:12(int!null)
+                │    │    ├── cardinality: [0 - 1]
+                │    │    ├── key: ()
+                │    │    ├── fd: ()-->(2,12)
+                │    │    └── limit
+                │    │         ├── columns: i:2(int)
+                │    │         ├── cardinality: [0 - 1]
+                │    │         ├── key: ()
+                │    │         ├── fd: ()-->(2)
+                │    │         ├── scan a
+                │    │         │    ├── columns: i:2(int)
+                │    │         │    └── limit hint: 1.00
+                │    │         └── const: 1 [type=int]
                 │    ├── project
                 │    │    ├── columns: true:9(bool!null) y:7(int)
                 │    │    ├── fd: ()-->(9)
@@ -4127,22 +4070,12 @@ values
                 │    │    │    └── columns: y:7(int)
                 │    │    └── projections
                 │    │         └── true [type=bool]
-                │    ├── ordinality
-                │    │    ├── columns: i:2(int) rownum:12(int!null)
-                │    │    ├── cardinality: [0 - 1]
-                │    │    ├── key: ()
-                │    │    ├── fd: ()-->(2,12)
-                │    │    └── scan a
-                │    │         ├── columns: i:2(int)
-                │    │         ├── limit: 1
-                │    │         ├── key: ()
-                │    │         └── fd: ()-->(2)
                 │    └── filters
                 │         └── y = i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
                 └── const: 1 [type=int]
 
 # Don't hoist uncorrelated subquery.
-opt
+norm
 SELECT i < ANY(SELECT y FROM xy) AS r FROM a
 ----
 project
@@ -4158,7 +4091,7 @@ project
 # --------------------------------------------------
 # HoistJoinSubquery
 # --------------------------------------------------
-opt expect=HoistJoinSubquery
+norm expect=HoistJoinSubquery
 SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = x
 ----
 project
@@ -4192,7 +4125,7 @@ project
            └── x = ?column? [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
 
 # Hoist Exists in join filter disjunction.
-opt expect=HoistJoinSubquery
+norm expect=HoistJoinSubquery
 SELECT s, x FROM a INNER JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 ----
 project
@@ -4242,7 +4175,7 @@ project
            └── exists OR (k = x) [type=bool, outer=(1,6,12)]
 
 # Any in Join filter disjunction.
-opt expect=HoistJoinSubquery
+norm expect=HoistJoinSubquery
 SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y AND v=i) OR x IS NULL
 ----
 project
@@ -4305,7 +4238,7 @@ project
 # --------------------------------------------------
 # HoistValuesSubquery
 # --------------------------------------------------
-opt expect=HoistValuesSubquery
+norm expect=HoistValuesSubquery
 SELECT (VALUES ((SELECT i+1 AS r)), (10), ((SELECT k+1 AS s))) FROM a
 ----
 project
@@ -4367,7 +4300,7 @@ project
       └── variable: column1 [type=int, outer=(8)]
 
 # Exists in values row.
-opt expect=HoistValuesSubquery
+norm expect=HoistValuesSubquery
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
@@ -4445,7 +4378,7 @@ project
       └── variable: column1 [type=bool, outer=(8)]
 
 # Any in values row.
-opt expect=HoistValuesSubquery
+norm expect=HoistValuesSubquery
 SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
@@ -4527,7 +4460,7 @@ project
 # ---------------------------------------------------
 # HoistProjectSetSubquery + TryDecorrelateProjectSet
 # ---------------------------------------------------
-opt expect=HoistProjectSetSubquery
+norm expect=HoistProjectSetSubquery
 SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
 ----
 project
@@ -4538,29 +4471,26 @@ project
       ├── side-effects
       ├── project
       │    ├── columns: v:4(int)
-      │    └── left-join (merge)
+      │    └── left-join (hash)
       │         ├── columns: x:1(int!null) u:3(int) v:4(int)
-      │         ├── left ordering: +1
-      │         ├── right ordering: +3
       │         ├── key: (1,3)
       │         ├── fd: (3)-->(4)
       │         ├── scan xy
       │         │    ├── columns: x:1(int!null)
-      │         │    ├── key: (1)
-      │         │    └── ordering: +1
+      │         │    └── key: (1)
       │         ├── scan uv
       │         │    ├── columns: u:3(int!null) v:4(int)
       │         │    ├── key: (3)
-      │         │    ├── fd: (3)-->(4)
-      │         │    └── ordering: +3
-      │         └── filters (true)
+      │         │    └── fd: (3)-->(4)
+      │         └── filters
+      │              └── u = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── zip
            └── function: generate_series [type=int, outer=(4), side-effects]
                 ├── const: 1 [type=int]
                 └── variable: v [type=int]
 
 # Zip correlation within EXISTS.
-opt expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
+norm expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
 group-by
@@ -4576,23 +4506,20 @@ group-by
  │    ├── project
  │    │    ├── columns: x:1(int!null) y:2(int) v:4(int)
  │    │    ├── fd: (1)-->(2)
- │    │    └── left-join (merge)
+ │    │    └── left-join (hash)
  │    │         ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int)
- │    │         ├── left ordering: +1
- │    │         ├── right ordering: +3
  │    │         ├── key: (1,3)
  │    │         ├── fd: (1)-->(2), (3)-->(4)
  │    │         ├── scan xy
  │    │         │    ├── columns: x:1(int!null) y:2(int)
  │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2)
- │    │         │    └── ordering: +1
+ │    │         │    └── fd: (1)-->(2)
  │    │         ├── scan uv
  │    │         │    ├── columns: u:3(int!null) v:4(int)
  │    │         │    ├── key: (3)
- │    │         │    ├── fd: (3)-->(4)
- │    │         │    └── ordering: +3
- │    │         └── filters (true)
+ │    │         │    └── fd: (3)-->(4)
+ │    │         └── filters
+ │    │              └── u = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  │    └── zip
  │         └── function: generate_series [type=int, outer=(4), side-effects]
  │              ├── const: 1 [type=int]
@@ -4602,7 +4529,7 @@ group-by
            └── variable: y [type=int]
 
 # Function contains multiple subqueries in arguments.
-opt expect=HoistProjectSetSubquery
+norm expect=HoistProjectSetSubquery
 SELECT generate_series((select y FROM xy WHERE x=k), (SELECT v FROM uv WHERE u=k)) FROM a
 ----
 project
@@ -4613,42 +4540,36 @@ project
       ├── side-effects
       ├── project
       │    ├── columns: y:7(int) v:9(int)
-      │    └── left-join (merge)
+      │    └── left-join (hash)
       │         ├── columns: k:1(int!null) x:6(int) y:7(int) u:8(int) v:9(int)
-      │         ├── left ordering: +1
-      │         ├── right ordering: +8
       │         ├── key: (1,6,8)
       │         ├── fd: (6)-->(7), (8)-->(9)
-      │         ├── left-join (merge)
+      │         ├── left-join (hash)
       │         │    ├── columns: k:1(int!null) x:6(int) y:7(int)
-      │         │    ├── left ordering: +1
-      │         │    ├── right ordering: +6
       │         │    ├── key: (1,6)
       │         │    ├── fd: (6)-->(7)
-      │         │    ├── ordering: +1
       │         │    ├── scan a
       │         │    │    ├── columns: k:1(int!null)
-      │         │    │    ├── key: (1)
-      │         │    │    └── ordering: +1
+      │         │    │    └── key: (1)
       │         │    ├── scan xy
       │         │    │    ├── columns: x:6(int!null) y:7(int)
       │         │    │    ├── key: (6)
-      │         │    │    ├── fd: (6)-->(7)
-      │         │    │    └── ordering: +6
-      │         │    └── filters (true)
+      │         │    │    └── fd: (6)-->(7)
+      │         │    └── filters
+      │         │         └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │         ├── scan uv
       │         │    ├── columns: u:8(int!null) v:9(int)
       │         │    ├── key: (8)
-      │         │    ├── fd: (8)-->(9)
-      │         │    └── ordering: +8
-      │         └── filters (true)
+      │         │    └── fd: (8)-->(9)
+      │         └── filters
+      │              └── u = k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       └── zip
            └── function: generate_series [type=int, outer=(7,9), side-effects]
                 ├── variable: y [type=int]
                 └── variable: v [type=int]
 
 # Multiple functions.
-opt expect=HoistProjectSetSubquery
+norm expect=HoistProjectSetSubquery
 SELECT
     generate_series(1, (SELECT v FROM uv WHERE u=k)),
     information_schema._pg_expandarray(ARRAY[(SELECT x FROM xy WHERE x=k)])
@@ -4662,34 +4583,28 @@ project
  │    ├── side-effects
  │    ├── project
  │    │    ├── columns: v:7(int) xy.x:9(int)
- │    │    └── left-join (merge)
+ │    │    └── left-join (hash)
  │    │         ├── columns: k:1(int!null) u:6(int) v:7(int) xy.x:9(int)
- │    │         ├── left ordering: +1
- │    │         ├── right ordering: +9
  │    │         ├── key: (1,6,9)
  │    │         ├── fd: (6)-->(7)
- │    │         ├── left-join (merge)
+ │    │         ├── left-join (hash)
  │    │         │    ├── columns: k:1(int!null) u:6(int) v:7(int)
- │    │         │    ├── left ordering: +1
- │    │         │    ├── right ordering: +6
  │    │         │    ├── key: (1,6)
  │    │         │    ├── fd: (6)-->(7)
- │    │         │    ├── ordering: +1
  │    │         │    ├── scan a
  │    │         │    │    ├── columns: k:1(int!null)
- │    │         │    │    ├── key: (1)
- │    │         │    │    └── ordering: +1
+ │    │         │    │    └── key: (1)
  │    │         │    ├── scan uv
  │    │         │    │    ├── columns: u:6(int!null) v:7(int)
  │    │         │    │    ├── key: (6)
- │    │         │    │    ├── fd: (6)-->(7)
- │    │         │    │    └── ordering: +6
- │    │         │    └── filters (true)
+ │    │         │    │    └── fd: (6)-->(7)
+ │    │         │    └── filters
+ │    │         │         └── u = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         ├── scan xy
  │    │         │    ├── columns: xy.x:9(int!null)
- │    │         │    ├── key: (9)
- │    │         │    └── ordering: +9
- │    │         └── filters (true)
+ │    │         │    └── key: (9)
+ │    │         └── filters
+ │    │              └── xy.x = k [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── zip
  │         ├── function: generate_series [type=int, outer=(7), side-effects]
  │         │    ├── const: 1 [type=int]
@@ -4699,7 +4614,7 @@ project
  └── projections
       └── ((x, n) AS x, n) [type=tuple{int AS x, int AS n}, outer=(11,12)]
 
-opt expect=HoistProjectSetSubquery
+norm expect=HoistProjectSetSubquery
 SELECT a, generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
@@ -4734,7 +4649,7 @@ project
                 ├── const: 1 [type=int]
                 └── variable: a [type=int]
 
-opt expect=HoistProjectSetSubquery
+norm expect=HoistProjectSetSubquery
 SELECT a, generate_series(1, (SELECT a)), generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
@@ -4800,7 +4715,7 @@ CREATE TABLE articles (
 ----
 
 # Regression test for #31706.
-opt expect=(TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
+norm expect=(TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
 SELECT a0.id, a0.body, a0.description, a0.title, a0.slug, a0.tag_list, a0.user_id, a0.created_at, a0.updated_at
     FROM articles AS a0
    WHERE EXISTS(SELECT * FROM unnest(a0.tag_list) AS tag WHERE tag = 'dragons')
@@ -4866,7 +4781,7 @@ limit
  └── const: 10 [type=int]
 
 # TODO(justin): figure out how to get this to decorrelate again.
-opt
+norm
 SELECT * FROM articles, xy WHERE EXISTS(
   SELECT * FROM ROWS FROM (generate_series(x, id), length(title), upper(title), unnest(tag_list))
 )
@@ -4955,7 +4870,7 @@ project
       └── filters
            └── true_agg IS NOT NULL [type=bool, outer=(17), constraints=(/17: (/NULL - ]; tight)]
 
-opt expect=TryDecorrelateProjectSet
+norm expect=TryDecorrelateProjectSet
 SELECT id FROM articles WHERE title = ANY(
   SELECT unnest FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
 )
@@ -4992,32 +4907,24 @@ distinct-on
 # --------------------------------------------------
 # NormalizeSelectAnyFilter + NormalizeJoinAnyFilter
 # --------------------------------------------------
-opt expect=NormalizeSelectAnyFilter
+norm expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE i IN (SELECT y FROM xy)
 ----
-project
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── inner-join (hash)
-      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) y:7(int!null)
-      ├── key: (1)
-      ├── fd: (1)-->(2-5), (2)==(7), (7)==(2)
-      ├── scan a
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2-5)
-      ├── distinct-on
-      │    ├── columns: y:7(int)
-      │    ├── grouping columns: y:7(int)
-      │    ├── key: (7)
-      │    └── scan xy
-      │         └── columns: y:7(int)
-      └── filters
-           └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    └── columns: y:7(int)
+ └── filters
+      └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Any is one of several conjuncts.
-opt expect=NormalizeSelectAnyFilter
+norm expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE k=10 AND i < ANY(SELECT y FROM xy) AND s='foo'
 ----
 semi-join (cross)
@@ -5032,11 +4939,10 @@ semi-join (cross)
  │    ├── fd: ()-->(1-5)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    ├── constraint: /1: [/10 - /10]
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    └── fd: ()-->(1-5)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
  │    └── filters
+ │         ├── k = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── scan xy
  │    └── columns: y:7(int)
@@ -5044,44 +4950,36 @@ semi-join (cross)
       └── i < y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Multiple ANY conjuncts.
-opt expect=NormalizeSelectAnyFilter
+norm expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE i < ANY(SELECT y FROM xy) AND s = ANY(SELECT y::string FROM xy)
 ----
 semi-join (cross)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── project
+ ├── semi-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── inner-join (hash)
- │         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb) y:10(string!null)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-5), (4)==(10), (10)==(4)
- │         ├── scan a
- │         │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-5)
- │         ├── distinct-on
- │         │    ├── columns: y:10(string)
- │         │    ├── grouping columns: y:10(string)
- │         │    ├── key: (10)
- │         │    └── project
- │         │         ├── columns: y:10(string)
- │         │         ├── scan xy
- │         │         │    └── columns: xy.y:9(int)
- │         │         └── projections
- │         │              └── xy.y::STRING [type=string, outer=(9)]
- │         └── filters
- │              └── s = y [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    ├── project
+ │    │    ├── columns: y:10(string)
+ │    │    ├── scan xy
+ │    │    │    └── columns: xy.y:9(int)
+ │    │    └── projections
+ │    │         └── xy.y::STRING [type=string, outer=(9)]
+ │    └── filters
+ │         └── s = y [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── scan xy
  │    └── columns: xy.y:7(int)
  └── filters
       └── i < xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Don't hoist uncorrelated ANY (but rewrite it to EXISTS).
-opt expect=NormalizeSelectAnyFilter
+norm expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE 5 IN (SELECT y FROM xy)
 ----
 select
@@ -5111,33 +5009,25 @@ select
                 └── const: 1 [type=int]
 
 # ANY in Join On condition.
-opt expect=NormalizeJoinAnyFilter
+norm expect=NormalizeJoinAnyFilter
 SELECT * FROM a INNER JOIN xy ON i IN (SELECT v FROM uv) AND k=x
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── project
+ ├── semi-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── inner-join (hash)
- │         ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int!null)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-5), (2)==(9), (9)==(2)
- │         ├── scan a
- │         │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-5)
- │         ├── distinct-on
- │         │    ├── columns: v:9(int)
- │         │    ├── grouping columns: v:9(int)
- │         │    ├── key: (9)
- │         │    └── scan uv
- │         │         └── columns: v:9(int)
- │         └── filters
- │              └── i = v [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    ├── scan uv
+ │    │    └── columns: v:9(int)
+ │    └── filters
+ │         └── i = v [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  ├── scan xy
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
@@ -5148,7 +5038,7 @@ inner-join (hash)
 # --------------------------------------------------
 # NormalizeSelectNotAnyFilter + NormalizeJoinNotAnyFilter
 # --------------------------------------------------
-opt expect=NormalizeSelectNotAnyFilter
+norm expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE i NOT IN (SELECT y FROM xy)
 ----
 anti-join (cross)
@@ -5166,7 +5056,7 @@ anti-join (cross)
 
 # NOT ANY is one of several conjuncts. Note that i > ALL(...) gets mapped to
 # NOT i <= ANY(...) by optbuilder.
-opt expect=NormalizeSelectNotAnyFilter
+norm expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE k > 1 AND k < 5 AND i > ALL(SELECT y FROM xy)
 ----
 anti-join (cross)
@@ -5174,19 +5064,24 @@ anti-join (cross)
  ├── cardinality: [0 - 3]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/2 - /4]
  │    ├── cardinality: [0 - 3]
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── (k > 1) AND (k < 5) [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
  ├── scan xy
  │    └── columns: y:7(int)
  └── filters
       └── (i <= y) IS NOT false [type=bool, outer=(2,7)]
 
 # Multiple NOT ANY conjuncts.
-opt expect=NormalizeSelectNotAnyFilter
+norm expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE i < ALL(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
 anti-join (cross)
@@ -5215,7 +5110,7 @@ anti-join (cross)
       └── (i >= xy.y) IS NOT false [type=bool, outer=(2,7)]
 
 # Don't hoist uncorrelated NOT ANY (but rewrite it to NOT EXISTS).
-opt expect=NormalizeSelectNotAnyFilter
+norm expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE 5 NOT IN (SELECT y FROM xy)
 ----
 select
@@ -5245,17 +5140,13 @@ select
                      └── const: 1 [type=int]
 
 # NOT ANY in Join On condition.
-opt expect=NormalizeJoinNotAnyFilter
+norm expect=NormalizeJoinNotAnyFilter
 SELECT * FROM a INNER JOIN xy ON i NOT IN (SELECT v FROM uv) AND k=x
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── scan xy
- │    ├── columns: x:6(int!null) y:7(int)
- │    ├── key: (6)
- │    └── fd: (6)-->(7)
  ├── anti-join (cross)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
@@ -5268,44 +5159,40 @@ inner-join (hash)
  │    │    └── columns: v:9(int)
  │    └── filters
  │         └── (i = v) IS NOT false [type=bool, outer=(2,9)]
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
  └── filters
       └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # NormalizeSelectAnyFilter + NormalizeSelectNotAnyFilter
 # --------------------------------------------------
-opt expect=(NormalizeSelectAnyFilter,NormalizeSelectNotAnyFilter)
+norm expect=(NormalizeSelectAnyFilter,NormalizeSelectNotAnyFilter)
 SELECT * FROM a WHERE i = ANY(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
-project
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── inner-join (hash)
-      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) xy.y:7(int!null)
-      ├── key: (1)
-      ├── fd: (1)-->(2-5), (2)==(7), (7)==(2)
-      ├── anti-join (cross)
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5)
-      │    ├── scan a
-      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2-5)
-      │    ├── project
-      │    │    ├── columns: y:10(string)
-      │    │    ├── scan xy
-      │    │    │    └── columns: xy.y:9(int)
-      │    │    └── projections
-      │    │         └── xy.y::STRING [type=string, outer=(9)]
-      │    └── filters
-      │         └── (s = y) IS NOT false [type=bool, outer=(4,10)]
-      ├── distinct-on
-      │    ├── columns: xy.y:7(int)
-      │    ├── grouping columns: xy.y:7(int)
-      │    ├── key: (7)
-      │    └── scan xy
-      │         └── columns: xy.y:7(int)
-      └── filters
-           └── i = xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ ├── anti-join (cross)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    ├── project
+ │    │    ├── columns: y:10(string)
+ │    │    ├── scan xy
+ │    │    │    └── columns: xy.y:9(int)
+ │    │    └── projections
+ │    │         └── xy.y::STRING [type=string, outer=(9)]
+ │    └── filters
+ │         └── (s = y) IS NOT false [type=bool, outer=(4,10)]
+ ├── scan xy
+ │    └── columns: xy.y:7(int)
+ └── filters
+      └── i = xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -11,7 +11,7 @@ CREATE TABLE t (
 # --------------------------------------------------
 # FoldNullCast
 # --------------------------------------------------
-opt expect=FoldNullCast
+norm expect=FoldNullCast
 SELECT
     null::int,
     null::timestamptz,
@@ -29,7 +29,7 @@ values
 # --------------------------------------------------
 # FoldNullUnary
 # --------------------------------------------------
-opt expect=FoldNullUnary
+norm expect=FoldNullUnary
 SELECT +null::int AS r, -null::int AS s, ~null::int AS t FROM a
 ----
 project
@@ -44,7 +44,7 @@ project
 # --------------------------------------------------
 # FoldNullBinaryLeft, FoldNullBinaryRight
 # --------------------------------------------------
-opt expect=(FoldNullBinaryLeft,FoldNullBinaryRight)
+norm expect=(FoldNullBinaryLeft,FoldNullBinaryRight)
 SELECT
     null::int & 1 AS ra, 1 & null::int AS rb,
     null::decimal + 1 AS sa, 1 + null::decimal AS sb,
@@ -78,7 +78,7 @@ project
       ├── i::DECIMAL || CAST(NULL AS DECIMAL[]) [type=decimal[], outer=(2)]
       └── CAST(NULL AS FLOAT8[]) || i::FLOAT8 [type=float[], outer=(2)]
 
-opt
+norm
 SELECT
     null::json || '[1, 2]' AS ra, '[1, 2]' || null::json AS rb,
     null::json->'foo' AS sa, '{}'::jsonb->null::string AS sb,
@@ -106,7 +106,7 @@ project
 # --------------------------------------------------
 # FoldNullInNonEmpty
 # --------------------------------------------------
-opt expect=FoldNullInNonEmpty
+norm expect=FoldNullInNonEmpty
 SELECT null IN (i) AS r, null NOT IN (s) AS s FROM a
 ----
 project
@@ -120,7 +120,7 @@ project
 # --------------------------------------------------
 # FoldInNull
 # --------------------------------------------------
-opt expect=FoldInNull
+norm expect=FoldInNull
 SELECT i IN (null, null) AS r, k NOT IN (1 * null, null::int, 1 < null) AS s FROM a
 ----
 project
@@ -134,7 +134,7 @@ project
 # --------------------------------------------------
 # FoldArray
 # --------------------------------------------------
-opt expect=FoldArray
+norm expect=FoldArray
 SELECT ARRAY[1, 2, 3] FROM t
 ----
 project
@@ -145,7 +145,7 @@ project
       └── const: ARRAY[1,2,3] [type=int[]]
 
 # Do not fold if there is a non-constant element.
-opt expect-not=FoldArray
+norm expect-not=FoldArray
 SELECT ARRAY[1, 2, 3, x] FROM t
 ----
 project
@@ -156,7 +156,7 @@ project
  └── projections
       └── ARRAY[1, 2, 3, x] [type=int[], outer=(1)]
 
-opt expect=FoldArray
+norm expect=FoldArray
 SELECT ARRAY['foo', 'bar']
 ----
 values
@@ -170,7 +170,7 @@ values
 # FoldBinary
 # --------------------------------------------------
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT 1::INT + 2::DECIMAL
 ----
 values
@@ -181,7 +181,7 @@ values
  └── (3,) [type=tuple{decimal}]
 
 # Don't fold: out of range error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT 9223372036854775800::INT + 9223372036854775800::INT
 ----
 values
@@ -192,7 +192,7 @@ values
  └── (9223372036854775800 + 9223372036854775800,) [type=tuple{int}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT 1::INT - 2::INT
 ----
 values
@@ -203,7 +203,7 @@ values
  └── (-1,) [type=tuple{int}]
 
 # Don't fold: out of range error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT (-9223372036854775800)::INT - 9223372036854775800::INT
 ----
 values
@@ -214,7 +214,7 @@ values
  └── (-9223372036854775800 - 9223372036854775800,) [type=tuple{int}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT 4::INT * 2::INT
 ----
 values
@@ -225,7 +225,7 @@ values
  └── (8,) [type=tuple{int}]
 
 # Don't fold: out of range error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT 9223372036854775800::INT * 9223372036854775800::INT
 ----
 values
@@ -236,7 +236,7 @@ values
  └── (9223372036854775800 * 9223372036854775800,) [type=tuple{int}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT 1::FLOAT / 2::FLOAT
 ----
 values
@@ -247,7 +247,7 @@ values
  └── (0.5,) [type=tuple{float}]
 
 # Don't fold: divide by zero error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT 1::INT / 0::INT
 ----
 values
@@ -259,7 +259,7 @@ values
  └── (1 / 0,) [type=tuple{decimal}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT B'01' # B'11'
 ----
 values
@@ -270,7 +270,7 @@ values
  └── (B'10',) [type=tuple{varbit}]
 
 # Don't fold: cannot mix bit array sizes error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT B'01' # B'11001001010101'
 ----
 values
@@ -281,7 +281,7 @@ values
  └── (B'01' # B'11001001010101',) [type=tuple{varbit}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT B'01' | B'11'
 ----
 values
@@ -292,7 +292,7 @@ values
  └── (B'11',) [type=tuple{varbit}]
 
 # Don't fold: cannot mix bit array sizes error.
-opt expect-not=FoldBinary
+norm expect-not=FoldBinary
 SELECT B'01' | B'11001001010101'
 ----
 values
@@ -303,7 +303,7 @@ values
  └── (B'01' | B'11001001010101',) [type=tuple{varbit}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMP
 ----
 values
@@ -314,7 +314,7 @@ values
  └── ('-24:00:00',) [type=tuple{interval}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMPTZ
 ----
 values
@@ -325,7 +325,7 @@ values
  └── ('-21:00:00',) [type=tuple{interval}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT ARRAY['a','b','c'] || 'd'::string
 ----
 values
@@ -336,7 +336,7 @@ values
  └── (ARRAY['a','b','c','d'],) [type=tuple{string[]}]
 
 # Fold constant.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT ARRAY['a','b','c'] || ARRAY['d','e','f']
 ----
 values
@@ -347,7 +347,7 @@ values
  └── (ARRAY['a','b','c','d','e','f'],) [type=tuple{string[]}]
 
 # NULL should not be added to the array.
-opt expect=FoldBinary
+norm expect=FoldBinary
 SELECT ARRAY[1,2,3] || NULL
 ----
 values
@@ -358,7 +358,7 @@ values
  └── (ARRAY[1,2,3],) [type=tuple{int[]}]
 
 # Regression test for #34270.
-opt expect=FoldBinary
+norm expect=FoldBinary
 VALUES ((e'{}' ->> 0) || (e'{}' ->> 0))
 ----
 values
@@ -371,7 +371,7 @@ values
 # --------------------------------------------------
 # FoldUnary
 # --------------------------------------------------
-opt expect=FoldUnary
+norm expect=FoldUnary
 SELECT -(1:::int)
 ----
 values
@@ -381,7 +381,7 @@ values
  ├── fd: ()-->(1)
  └── (-1,) [type=tuple{int}]
 
-opt expect=FoldUnary
+norm expect=FoldUnary
 SELECT -(1:::float)
 ----
 values
@@ -393,7 +393,7 @@ values
 
 # TODO(justin): it would be better if this produced an error in the optimizer
 # rather than falling back to execution to error.
-opt expect-not=FoldUnary format=show-all
+norm expect-not=FoldUnary format=show-all
 SELECT -((-9223372036854775808)::int)
 ----
 values
@@ -408,7 +408,7 @@ values
       └── unary-minus [type=int]
            └── const: -9223372036854775808 [type=int]
 
-opt expect=FoldUnary format=show-all
+norm expect=FoldUnary format=show-all
 SELECT -(1:::decimal)
 ----
 values
@@ -422,7 +422,7 @@ values
  └── tuple [type=tuple{decimal}]
       └── const: -1 [type=decimal]
 
-opt expect=FoldUnary format=show-all
+norm expect=FoldUnary format=show-all
 SELECT -('-1d'::interval);
 ----
 values
@@ -438,7 +438,7 @@ values
 
 # TODO(justin): this seems incorrect but it's consistent with the existing
 # planner. Revisit this: #26932.
-opt expect=FoldUnary
+norm expect=FoldUnary
 SELECT -('-9223372036854775808d'::interval);
 ----
 values
@@ -449,7 +449,7 @@ values
  └── ('-9223372036854775808 days',) [type=tuple{interval}]
 
 # Fold constant.
-opt expect=FoldUnary
+norm expect=FoldUnary
 SELECT ~(500::INT)
 ----
 values
@@ -460,7 +460,7 @@ values
  └── (-501,) [type=tuple{int}]
 
 # Fold constant.
-opt expect=FoldUnary
+norm expect=FoldUnary
 SELECT ~('35.231.178.195'::INET)
 ----
 values
@@ -473,7 +473,7 @@ values
 # --------------------------------------------------
 # FoldComparison
 # --------------------------------------------------
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 1::INT < 2::INT
 ----
 values
@@ -483,7 +483,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 1::INT > 2::INT
 ----
 values
@@ -493,7 +493,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 10.0::FLOAT <= 20.0::FLOAT
 ----
 values
@@ -503,7 +503,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 10.0::FLOAT >= 20.0::FLOAT
 ----
 values
@@ -513,7 +513,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 2.0::DECIMAL = 2::INT
 ----
 values
@@ -523,7 +523,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 2.0::DECIMAL != 2::INT
 ----
 values
@@ -533,7 +533,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 100 IS NOT DISTINCT FROM 200
 ----
 values
@@ -543,7 +543,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 100 IS DISTINCT FROM 200
 ----
 values
@@ -553,7 +553,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' IN ('a', 'b', 'c')
 ----
 values
@@ -563,7 +563,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' NOT IN ('a', 'b', 'c')
 ----
 values
@@ -573,7 +573,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' LIKE 'foobar'
 ----
 values
@@ -583,7 +583,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' NOT LIKE 'foobar'
 ----
 values
@@ -593,7 +593,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' ILIKE 'FOO%'
 ----
 values
@@ -603,7 +603,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'foo' NOT ILIKE 'FOO%'
 ----
 values
@@ -613,7 +613,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'monday' SIMILAR TO '_onday'
 ----
 values
@@ -623,7 +623,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'monday' NOT SIMILAR TO '_onday'
 ----
 values
@@ -633,7 +633,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'tuEsday' ~ 't[uU][eE]sday'
 ----
 values
@@ -643,7 +643,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'tuEsday' !~ 't[uU][eE]sday'
 ----
 values
@@ -653,7 +653,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'wednesday' ~* 'W.*y'
 ----
 values
@@ -663,7 +663,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT 'wednesday' !~* 'W.*y'
 ----
 values
@@ -673,7 +673,7 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT '[1, 2]'::JSONB <@ '[1, 2, 3]'::JSONB
 ----
 values
@@ -683,7 +683,7 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-opt expect=FoldComparison
+norm expect=FoldComparison
 SELECT ('a', 'b', 'c') = ('d', 'e', 'f')
 ----
 values
@@ -696,7 +696,7 @@ values
 # --------------------------------------------------
 # FoldCast
 # --------------------------------------------------
-opt expect=FoldCast
+norm expect=FoldCast
 SELECT 1::int/1
 ----
 values
@@ -709,7 +709,7 @@ values
 # --------------------------------------------------
 # FoldFunction
 # --------------------------------------------------
-opt expect=FoldFunction
+norm expect=FoldFunction
 SELECT length('abc'), upper('xyz'), lower('DEF')
 ----
 values
@@ -719,7 +719,7 @@ values
  ├── fd: ()-->(1-3)
  └── (3, 'XYZ', 'def') [type=tuple{int, string, string}]
 
-opt expect=FoldFunction
+norm expect=FoldFunction
 SELECT encode('abc', 'hex'), decode('616263', 'hex')
 ----
 values
@@ -729,7 +729,7 @@ values
  ├── fd: ()-->(1,2)
  └── ('616263', '\x616263') [type=tuple{string, bytes}]
 
-opt expect=FoldFunction locality=(region=east,dc=east1-b)
+norm expect=FoldFunction locality=(region=east,dc=east1-b)
 SELECT crdb_internal.locality_value('dc')
 ----
 values
@@ -739,7 +739,7 @@ values
  ├── fd: ()-->(1)
  └── ('east1-b',) [type=tuple{string}]
 
-opt expect=FoldFunction
+norm expect=FoldFunction
 SELECT crdb_internal.locality_value('unk')
 ----
 values
@@ -749,7 +749,7 @@ values
  ├── fd: ()-->(1)
  └── (NULL,) [type=tuple{string}]
 
-opt expect-not=FoldFunction
+norm expect-not=FoldFunction
 SELECT now(), current_user(), current_database()
 ----
 values
@@ -764,7 +764,7 @@ values
 # FoldIndirection
 # --------------------------------------------------
 # Fold when input is a static array constructor (but elements are not constant).
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[i, i + 1][1] FROM a
 ----
 project
@@ -774,7 +774,7 @@ project
  └── projections
       └── variable: i [type=int, outer=(2)]
 
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[i, i + 1][2] FROM a
 ----
 project
@@ -785,7 +785,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Fold when input is a DArray constant.
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[4, 5, 6][2] FROM a
 ----
 project
@@ -796,7 +796,7 @@ project
       └── const: 5 [type=int]
 
 # Array bounds are out-of-range.
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[s, 'foo'][0] FROM a
 ----
 project
@@ -806,7 +806,7 @@ project
  └── projections
       └── null [type=string]
 
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[i, i + 1][3] FROM a
 ----
 project
@@ -816,7 +816,7 @@ project
  └── projections
       └── null [type=int]
 
-opt expect=FoldIndirection
+norm expect=FoldIndirection
 SELECT ARRAY[4, 5, 6][0] FROM a
 ----
 project
@@ -827,7 +827,7 @@ project
       └── null [type=int]
 
 # Array is dynamically constructed.
-opt expect-not=FoldIndirection
+norm expect-not=FoldIndirection
 SELECT arr[0] FROM a
 ----
 project
@@ -861,7 +861,7 @@ values
 # Fold when input is a static tuple constructor (but elements are not constant).
 # NOTE: Use constant array access to avoid triggering ColumnAccess::TypeCheck
 #       constant tuple folding.
-opt expect=FoldColumnAccess
+norm expect=FoldColumnAccess
 SELECT (ARRAY[(('foo', i) AS foo, bar)][1]).foo FROM a
 ----
 project
@@ -871,7 +871,7 @@ project
  └── projections
       └── const: 'foo' [type=string]
 
-opt expect=FoldColumnAccess
+norm expect=FoldColumnAccess
 SELECT (ARRAY[(('foo', i) AS foo, bar)][1]).bar FROM a
 ----
 project
@@ -882,7 +882,7 @@ project
       └── variable: i [type=int, outer=(2)]
 
 # Fold when input is a constant DTuple.
-opt expect=FoldColumnAccess
+norm expect=FoldColumnAccess
 SELECT (ARRAY[(('foo', 'bar') AS foo, bar)][1]).foo
 ----
 values

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -51,7 +51,7 @@ CREATE TABLE s (
 # --------------------------------------------------
 # ConvertGroupByToDistinct
 # --------------------------------------------------
-opt expect=ConvertGroupByToDistinct
+norm expect=ConvertGroupByToDistinct
 SELECT s, f FROM a GROUP BY s, f
 ----
 distinct-on
@@ -62,7 +62,7 @@ distinct-on
       └── columns: f:3(float) s:4(string!null)
 
 # Group by not converted to DistinctOn because it has an aggregation.
-opt expect-not=ConvertGroupByToDistinct
+norm expect-not=ConvertGroupByToDistinct
 SELECT s, f, sum(f) FROM a GROUP BY s, f
 ----
 group-by
@@ -80,30 +80,30 @@ group-by
 # --------------------------------------------------
 # EliminateDistinct
 # --------------------------------------------------
-opt expect=EliminateDistinct
+norm expect=EliminateDistinct
 SELECT DISTINCT k FROM a
 ----
-scan a@fi_idx
+scan a
  ├── columns: k:1(int!null)
  └── key: (1)
 
-opt expect=EliminateDistinct
+norm expect=EliminateDistinct
 SELECT DISTINCT s, i FROM a
 ----
-scan a@si_idx
+scan a
  ├── columns: s:4(string!null) i:2(int!null)
  └── key: (2,4)
 
-opt expect=EliminateDistinct
+norm expect=EliminateDistinct
 SELECT DISTINCT ON (s, i) k, i, f FROM a
 ----
-scan a@fi_idx
+scan a
  ├── columns: k:1(int!null) i:2(int!null) f:3(float)
  ├── key: (1)
  └── fd: (1)-->(2,3), (2,3)~~>(1)
 
 # Strict superset of key.
-opt expect=EliminateDistinct
+norm expect=EliminateDistinct
 SELECT DISTINCT s, i, f FROM a
 ----
 scan a
@@ -112,29 +112,27 @@ scan a
  └── fd: (2,4)-->(3), (2,3)~~>(4)
 
 # Distinct not eliminated because columns aren't superset of any weak key.
-opt expect-not=EliminateDistinct
+norm expect-not=EliminateDistinct
 SELECT DISTINCT i FROM a
 ----
 distinct-on
  ├── columns: i:2(int!null)
  ├── grouping columns: i:2(int!null)
  ├── key: (2)
- └── scan a@fi_idx
+ └── scan a
       └── columns: i:2(int!null)
 
 # Distinct not eliminated despite a unique index on (f, i) because f is nullable.
-opt expect-not=EliminateDistinct
+norm expect-not=EliminateDistinct
 SELECT DISTINCT f, i FROM a
 ----
 distinct-on
  ├── columns: f:3(float) i:2(int!null)
  ├── grouping columns: i:2(int!null) f:3(float)
- ├── internal-ordering: +3,+2
  ├── key: (2,3)
- └── scan a@fi_idx
+ └── scan a
       ├── columns: i:2(int!null) f:3(float)
-      ├── lax-key: (2,3)
-      └── ordering: +3,+2
+      └── lax-key: (2,3)
 
 # Regression test for #40295. Ensure that the DistinctOn is replaced with a
 # Project operator to keep the correct number of output columns.
@@ -146,7 +144,7 @@ exec-ddl
 CREATE TABLE table1 (col0 REGCLASS, col1 REGTYPE, col2 INT4);
 ----
 
-opt expect=EliminateDistinct
+norm expect=EliminateDistinct
 SELECT
   (
     SELECT
@@ -178,7 +176,7 @@ values
 # --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------
-opt expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a)) GROUP BY i
 ----
 project
@@ -206,7 +204,7 @@ project
                 └── variable: s [type=string]
 
 # ScalarGroupBy case.
-opt expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 scalar-group-by
@@ -232,7 +230,7 @@ scalar-group-by
            └── variable: s [type=string]
 
 # DistinctOn case.
-opt expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject
 SELECT DISTINCT ON (i) s FROM (SELECT i, s, f FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 distinct-on
@@ -258,7 +256,7 @@ distinct-on
            └── variable: s [type=string]
 
 # Don't eliminate project if it computes extra column(s).
-opt expect-not=EliminateGroupByProject
+norm expect-not=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i+1 AS i2, s FROM a) GROUP BY i2
 ----
 project
@@ -270,7 +268,7 @@ project
       ├── fd: (6)-->(7)
       ├── project
       │    ├── columns: i2:6(int) s:4(string!null)
-      │    ├── scan a@si_idx
+      │    ├── scan a
       │    │    ├── columns: i:2(int!null) s:4(string!null)
       │    │    └── key: (2,4)
       │    └── projections
@@ -282,20 +280,18 @@ project
 # --------------------------------------------------
 # ReduceGroupingCols
 # --------------------------------------------------
-opt expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols
 SELECT k, min(i), f, s FROM a GROUP BY s, f, k
 ----
 group-by
  ├── columns: k:1(int!null) min:6(int) f:3(float) s:4(string)
  ├── grouping columns: k:1(int!null)
- ├── internal-ordering: +1
  ├── key: (1)
  ├── fd: (1)-->(3,4,6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
  └── aggregations
       ├── min [type=int, outer=(2)]
       │    └── variable: i [type=int]
@@ -304,7 +300,7 @@ group-by
       └── const-agg [type=string, outer=(4)]
            └── variable: s [type=string]
 
-opt expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols
 SELECT k, sum(DISTINCT i), f, s FROM a, xy GROUP BY s, f, k
 ----
 group-by
@@ -331,7 +327,7 @@ group-by
            └── variable: s [type=string]
 
 # Eliminated columns are not part of projection.
-opt expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols
 SELECT min(f) FROM a GROUP BY i, s, k
 ----
 project
@@ -350,7 +346,7 @@ project
                 └── variable: f [type=float]
 
 # All grouping columns eliminated.
-opt expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols
 SELECT sum(f), i FROM a GROUP BY k, i, f HAVING k=1
 ----
 group-by
@@ -358,19 +354,24 @@ group-by
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2,6)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
- │    ├── constraint: /1: [/1 - /1]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(1-3)
+ │    ├── fd: ()-->(1-3)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+ │    └── filters
+ │         └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  └── aggregations
       ├── sum [type=float, outer=(3)]
       │    └── variable: f [type=float]
       └── const-agg [type=int, outer=(2)]
            └── variable: i [type=int]
 
-opt expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols
 SELECT DISTINCT ON (k, f, s) i, f, x FROM a JOIN xy ON i=y
 ----
 distinct-on
@@ -382,7 +383,7 @@ distinct-on
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) x:6(int!null) y:7(int!null)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2,3), (2,3)~~>(1), (6)-->(7), (2)==(7), (7)==(2)
- │    ├── scan a@fi_idx
+ │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -406,7 +407,7 @@ distinct-on
 
 # ScalarGroupBy with key argument. Only the first aggregation can be
 # simplified.
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT k), sum(DISTINCT i) FROM a
 ----
 scalar-group-by
@@ -414,7 +415,7 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(6,7)
- ├── scan a@fi_idx
+ ├── scan a
  │    ├── columns: k:1(int!null) i:2(int!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
@@ -425,7 +426,7 @@ scalar-group-by
            └── agg-distinct [type=int]
                 └── variable: i [type=int]
 
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT string_agg(DISTINCT s, ', ') FROM s
 ----
 scalar-group-by
@@ -448,7 +449,7 @@ scalar-group-by
            └── const: ', ' [type=string]
 
 # GroupBy with key argument.
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT k) FROM a GROUP BY i
 ----
 project
@@ -458,7 +459,7 @@ project
       ├── grouping columns: i:2(int!null)
       ├── key: (2)
       ├── fd: (2)-->(6)
-      ├── scan a@fi_idx
+      ├── scan a
       │    ├── columns: k:1(int!null) i:2(int!null)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
@@ -467,7 +468,7 @@ project
                 └── variable: k [type=int]
 
 # GroupBy with no key.
-opt expect-not=EliminateAggDistinctForKeys
+norm expect-not=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT a) FROM abc GROUP BY b
 ----
 project
@@ -485,7 +486,7 @@ project
                      └── variable: a [type=int]
 
 # GroupBy with composite key formed by argument plus grouping columns.
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT a) FROM abc GROUP BY b, c
 ----
 project
@@ -503,7 +504,7 @@ project
                 └── variable: a [type=int]
 
 # GroupBy with multiple aggregations simplified.
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT i), avg(DISTINCT f) FROM a GROUP BY k
 ----
 project
@@ -513,7 +514,7 @@ project
       ├── grouping columns: k:1(int!null)
       ├── key: (1)
       ├── fd: (1)-->(6,7)
-      ├── scan a@fi_idx
+      ├── scan a
       │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -525,7 +526,7 @@ project
 
 # GroupBy where only some aggregations are simplified (the table has
 # keys u,v and v,w).
-opt expect=EliminateAggDistinctForKeys
+norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT u), stddev(DISTINCT w), avg(DISTINCT z) FROM uvwz GROUP BY v
 ----
 project
@@ -552,17 +553,26 @@ project
 # EliminateDistinctOnNoColumns
 # --------------------------------------------------
 
-opt expect=EliminateDistinctOnNoColumns
+norm expect=EliminateDistinctOnNoColumns
 SELECT DISTINCT ON (a) a, b FROM abc WHERE a = 1
 ----
-scan abc
+limit
  ├── columns: a:1(int!null) b:2(int!null)
- ├── constraint: /1/2/3: [/1 - /1]
- ├── limit: 1
+ ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(1,2)
+ ├── fd: ()-->(1,2)
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null)
+ │    ├── fd: ()-->(1)
+ │    ├── limit hint: 1.00
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null)
+ │    │    └── limit hint: 1.00
+ │    └── filters
+ │         └── a = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ └── const: 1 [type=int]
 
-opt expect=EliminateDistinctOnNoColumns
+norm expect=EliminateDistinctOnNoColumns
 SELECT DISTINCT ON (b) b, c FROM abc WHERE b = 1 ORDER BY b, c
 ----
 limit

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -15,7 +15,7 @@ CREATE TABLE computed (a INT PRIMARY KEY, b INT, c INT AS (a+b+1) STORED)
 # --------------------------------------------------
 
 # Inline constants from Project expression.
-opt expect=InlineProjectConstants
+norm expect=InlineProjectConstants
 UPDATE computed SET a=1, b=2
 ----
 update computed
@@ -41,7 +41,7 @@ update computed
            └── const: 2 [type=int]
 
 # Inline constants from Values expression.
-opt expect=InlineProjectConstants
+norm expect=InlineProjectConstants
 SELECT one+two+three+four FROM (VALUES (1, $1:::int, 2, $2:::int)) AS t(one, two, three, four)
 ----
 project
@@ -62,7 +62,7 @@ project
 
 # Multiple constant columns, multiple refs to each, interspersed with other
 # columns.
-opt expect=InlineProjectConstants
+norm expect=InlineProjectConstants
 SELECT one+two, x, one*two, y FROM (SELECT x, 1 AS one, y, 2 AS two FROM xy)
 ----
 project
@@ -79,7 +79,7 @@ project
 
 # Constant column reference within correlated subquery (which becomes
 # uncorrelated as a result).
-opt expect=InlineProjectConstants
+norm expect=InlineProjectConstants
 SELECT EXISTS(SELECT * FROM a WHERE k=one AND i=two) FROM (VALUES (1, 2)) AS t(one, two)
 ----
 values
@@ -96,15 +96,14 @@ values
                 ├── fd: ()-->(3-7)
                 ├── scan a
                 │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
-                │    ├── constraint: /3: [/1 - /1]
-                │    ├── cardinality: [0 - 1]
-                │    ├── key: ()
-                │    └── fd: ()-->(3-7)
+                │    ├── key: (3)
+                │    └── fd: (3)-->(4-7)
                 └── filters
+                     ├── k = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
                      └── i = 2 [type=bool, outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
 
 # Do not inline constants from Values expression with multiple rows.
-opt expect-not=InlineProjectConstants
+norm expect-not=InlineProjectConstants
 SELECT one+two FROM (VALUES (1, 2), (3, 4)) AS t(one, two)
 ----
 project
@@ -123,7 +122,7 @@ project
 # --------------------------------------------------
 
 # Inline constants from Project expression.
-opt expect=InlineSelectConstants
+norm expect=InlineSelectConstants
 SELECT * FROM (SELECT 1 AS one from xy) WHERE one > 0
 ----
 project
@@ -134,7 +133,7 @@ project
       └── const: 1 [type=int]
 
 # Inline constants from Values expression.
-opt expect=InlineSelectConstants
+norm expect=InlineSelectConstants
 SELECT *
 FROM (VALUES ($1:::int, 1, $2:::float, 2)) AS t(one, two, three, four)
 WHERE one = two OR three = four
@@ -157,7 +156,7 @@ select
 
 # Multiple constant columns, multiple refs to each, interspersed with other
 # columns.
-opt expect=InlineSelectConstants
+norm expect=InlineSelectConstants
 SELECT * FROM (SELECT x, 1 AS one, y, 2 AS two FROM xy) WHERE x=one AND y=two
 ----
 project
@@ -172,18 +171,17 @@ project
  │    ├── fd: ()-->(1,2)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    ├── constraint: /1: [/1 - /1]
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    └── fd: ()-->(1,2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
  │    └── filters
+ │         ├── x = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  │         └── y = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
  └── projections
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
 
 # Do not inline constants from Values expression with multiple rows.
-opt expect-not=InlineSelectConstants
+norm expect-not=InlineSelectConstants
 SELECT * FROM (VALUES (1, 2), (3, 4)) AS t(one, two) WHERE one=two
 ----
 select
@@ -201,7 +199,7 @@ select
 # --------------------------------------------------
 # InlineJoinConstantsLeft + InlineJoinConstantsRight
 # --------------------------------------------------
-opt expect=InlineJoinConstantsLeft
+norm expect=InlineJoinConstantsLeft
 SELECT * FROM (SELECT 1 AS one) LEFT JOIN a ON k=one
 ----
 left-join (cross)
@@ -215,15 +213,20 @@ left-join (cross)
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1,) [type=tuple{int}]
- ├── scan a
+ ├── select
  │    ├── columns: k:2(int!null) i:3(int) f:4(float) s:5(string) j:6(jsonb)
- │    ├── constraint: /2: [/1 - /1]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(2-6)
+ │    ├── fd: ()-->(2-6)
+ │    ├── scan a
+ │    │    ├── columns: k:2(int!null) i:3(int) f:4(float) s:5(string) j:6(jsonb)
+ │    │    ├── key: (2)
+ │    │    └── fd: (2)-->(3-6)
+ │    └── filters
+ │         └── k = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
  └── filters (true)
 
-opt expect=InlineJoinConstantsRight
+norm expect=InlineJoinConstantsRight
 SELECT * FROM a FULL JOIN (SELECT 1 AS one) ON k=one
 ----
 full-join (cross)
@@ -244,7 +247,7 @@ full-join (cross)
  └── filters
       └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
 
-opt expect=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
+norm expect=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
 SELECT * FROM (SELECT 1 AS one) INNER JOIN (SELECT 2 AS two) ON one=two
 ----
 values
@@ -254,7 +257,7 @@ values
  └── fd: ()-->(1,2)
 
 # Constant column exists in input, but is not referenced.
-opt expect-not=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
+norm expect-not=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
 SELECT * FROM a INNER JOIN (SELECT 1 AS one, y FROM xy) ON k=y
 ----
 inner-join (hash)
@@ -279,7 +282,7 @@ inner-join (hash)
 # --------------------------------------------------
 
 # Inline comparison.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT k=1 AS expr FROM a) a WHERE expr IS NULL
 ----
 project
@@ -296,7 +299,7 @@ project
       └── k = 1 [type=bool, outer=(1)]
 
 # Inline arithmetic.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT k*2+1 AS expr FROM a) a WHERE expr > 10
 ----
 project
@@ -313,20 +316,24 @@ project
       └── (k * 2) + 1 [type=int, outer=(1)]
 
 # Inline boolean logic.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT NOT(k>1 AND k<=5) AS expr FROM a) a WHERE expr
 ----
 project
  ├── columns: expr:6(bool)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [ - /1] [/6 - ]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (k <= 1) OR (k > 5) [type=bool, outer=(1), constraints=(/1: (/NULL - /1] [/6 - ])]
  └── projections
       └── (k <= 1) OR (k > 5) [type=bool, outer=(1)]
 
 # Inline constants.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT (f IS NULL OR f != 10.5) AS expr FROM a) a WHERE expr
 ----
 project
@@ -341,7 +348,7 @@ project
       └── (f IS NULL) OR (f != 10.5) [type=bool, outer=(3)]
 
 # Reference the expression to inline multiple times.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT f+1 AS expr FROM a) a WHERE expr=expr
 ----
 project
@@ -356,7 +363,7 @@ project
       └── f + 1.0 [type=float, outer=(3)]
 
 # Use outer references in both inlined expression and in referencing expression.
-opt expect=PushSelectIntoInlinableProject
+norm expect=PushSelectIntoInlinableProject
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT (x-i) AS expr FROM xy) WHERE expr > i*i)
 ----
 semi-join (cross)
@@ -479,7 +486,7 @@ project
 # --------------------------------------------------
 # InlineProjectInProject
 # --------------------------------------------------
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT NOT(expr), i+1 AS r FROM (SELECT k=1 AS expr, i FROM a)
 ----
 project
@@ -494,7 +501,7 @@ project
 
 # Multiple synthesized column references to same inner passthrough column
 # (should still inline).
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT x+1, x+2, y1+2 FROM (SELECT x, y+1 AS y1 FROM xy)
 ----
 project
@@ -510,7 +517,7 @@ project
 
 # Synthesized and passthrough references to same inner passthrough column
 # (should still inline).
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT x+y1 FROM (SELECT x, y+1 AS y1 FROM xy) ORDER BY x
 ----
 project
@@ -527,7 +534,7 @@ project
       └── x + (y + 1) [type=int, outer=(1,2)]
 
 # Inline multiple expressions.
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT expr+1 AS r, i, expr2 || 'bar' AS s FROM (SELECT k+1 AS expr, s || 'foo' AS expr2, i FROM a)
 ----
 project
@@ -541,7 +548,7 @@ project
       └── (a.s || 'foo') || 'bar' [type=string, outer=(4)]
 
 # Don't inline when there are multiple references.
-opt expect-not=InlineProjectInProject
+norm expect-not=InlineProjectInProject
 SELECT expr, expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
@@ -558,7 +565,7 @@ project
       └── expr * 2 [type=int, outer=(6)]
 
 # Uncorrelated subquery should not block inlining.
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
@@ -569,16 +576,29 @@ project
  │    └── key: (1)
  └── projections
       ├── exists [type=bool, subquery]
-      │    └── scan xy
+      │    └── limit
       │         ├── columns: x:7(int!null) y:8(int)
-      │         ├── constraint: /7: [/1 - /2]
-      │         ├── limit: 1
+      │         ├── cardinality: [0 - 1]
       │         ├── key: ()
-      │         └── fd: ()-->(7,8)
+      │         ├── fd: ()-->(7,8)
+      │         ├── select
+      │         │    ├── columns: x:7(int!null) y:8(int)
+      │         │    ├── cardinality: [0 - 2]
+      │         │    ├── key: (7)
+      │         │    ├── fd: (7)-->(8)
+      │         │    ├── limit hint: 1.00
+      │         │    ├── scan xy
+      │         │    │    ├── columns: x:7(int!null) y:8(int)
+      │         │    │    ├── key: (7)
+      │         │    │    ├── fd: (7)-->(8)
+      │         │    │    └── limit hint: 1.00
+      │         │    └── filters
+      │         │         └── (x = 1) OR (x = 2) [type=bool, outer=(7), constraints=(/7: [/1 - /1] [/2 - /2])]
+      │         └── const: 1 [type=int]
       └── (k + 1) * 2 [type=int, outer=(1)]
 
 # Correlated subquery should be hoisted as usual.
-opt expect=InlineProjectInProject
+norm expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 ----
 project
@@ -617,14 +637,18 @@ project
       └── true_agg IS NOT NULL [type=bool, outer=(11)]
 
 # After c is replaced with k+2, (k+2) > 2 should be simplified to k > 0.
-opt
+norm
 SELECT c FROM (SELECT k+2 AS c FROM a) AS t WHERE c > 2;
 ----
 project
  ├── columns: c:6(int)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [/1 - ]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── k > 0 [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
  └── projections
       └── k + 2 [type=int, outer=(1)]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -22,7 +22,7 @@ exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
 
-opt
+norm
 SELECT * FROM a INNER JOIN b ON a.s='foo' OR b.y<10
 ----
 inner-join (cross)
@@ -44,32 +44,29 @@ inner-join (cross)
 # CommuteRightJoin
 # --------------------------------------------------
 
-opt
+norm
 SELECT * FROM a RIGHT JOIN b ON k=x
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +6
- ├── right ordering: +1
  ├── key: (1,6)
  ├── fd: (6)-->(7), (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- └── filters (true)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # DetectJoinContradiction
 # --------------------------------------------------
 
-opt expect=DetectJoinContradiction
+norm expect=DetectJoinContradiction
 SELECT * FROM a INNER JOIN b ON k IN ()
 ----
 values
@@ -78,7 +75,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-7)
 
-opt expect=DetectJoinContradiction
+norm expect=DetectJoinContradiction
 SELECT * FROM a LEFT JOIN b ON i=5 AND k IN () AND s='foo'
 ----
 left-join (cross)
@@ -96,7 +93,7 @@ left-join (cross)
  │    └── fd: ()-->(6,7)
  └── filters (true)
 
-opt expect=DetectJoinContradiction
+norm expect=DetectJoinContradiction
 SELECT * FROM a FULL JOIN b ON i=5 AND k IN () AND s='foo'
 ----
 full-join (cross)
@@ -117,13 +114,11 @@ full-join (cross)
 # --------------------------------------------------
 # PushFilterIntoJoinLeft
 # --------------------------------------------------
-opt expect=PushFilterIntoJoinLeft
+norm expect=PushFilterIntoJoinLeft
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.s='foo'
 ----
-inner-join (lookup b)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb) x:6(int!null) y:7(int)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (6)
  ├── fd: ()-->(4), (1)-->(2,3,5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
@@ -136,39 +131,39 @@ inner-join (lookup b)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
- └── filters (true)
+ ├── scan b
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # LEFT JOIN should not push down conditions to left side of join.
-opt expect-not=PushFilterIntoJoinLeft
+norm expect-not=PushFilterIntoJoinLeft
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.i=1
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
 
 # Semi-join case.
-opt expect=PushFilterIntoJoinLeft
+norm expect=PushFilterIntoJoinLeft
 SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE x=k AND s='foo')
 ----
-semi-join (lookup b)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── select
@@ -181,42 +176,45 @@ semi-join (lookup b)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
- └── filters (true)
+ ├── scan b
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Do not push anti-join conditions into left input.
-opt expect-not=PushFilterIntoJoinLeft
+norm expect-not=PushFilterIntoJoinLeft
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE x=k AND s='foo')
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null)
- │    ├── key: (6)
- │    └── ordering: +6
+ │    └── key: (6)
  └── filters
+      ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # --------------------------------------------------
 # PushFilterIntoJoinRight
 # --------------------------------------------------
-opt expect=PushFilterIntoJoinRight
+norm expect=PushFilterIntoJoinRight
 SELECT * FROM b INNER JOIN a ON b.x=a.k AND a.s='foo'
 ----
-inner-join (lookup b)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) f:5(float!null) s:6(string!null) j:7(jsonb)
- ├── key columns: [3] = [1]
- ├── lookup columns are key
  ├── key: (3)
  ├── fd: ()-->(6), (1)-->(2), (3)-->(4,5,7), (1)==(3), (3)==(1)
+ ├── scan b
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  ├── select
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string!null) j:7(jsonb)
  │    ├── key: (3)
@@ -227,169 +225,160 @@ inner-join (lookup b)
  │    │    └── fd: (3)-->(4-7)
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
- └── filters (true)
+ └── filters
+      └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
-opt expect=PushFilterIntoJoinRight
+norm expect=PushFilterIntoJoinRight
 SELECT * FROM b LEFT JOIN a ON (a.i<0 OR a.i>10) AND b.y=1 AND a.s='foo' AND b.x=a.k
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- ├── left ordering: +1
- ├── right ordering: +3
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4,5,7), ()~~>(6), (1,3)-->(6)
  ├── scan b
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2)
  ├── select
  │    ├── columns: k:3(int!null) i:4(int!null) f:5(float!null) s:6(string!null) j:7(jsonb)
  │    ├── key: (3)
  │    ├── fd: ()-->(6), (3)-->(4,5,7)
- │    ├── ordering: +3 opt(6) [actual: +3]
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3 opt(6) [actual: +3]
+ │    │    └── fd: (3)-->(4-7)
  │    └── filters
  │         ├── (i < 0) OR (i > 10) [type=bool, outer=(4), constraints=(/4: (/NULL - /-1] [/11 - ])]
  │         └── s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
  └── filters
-      └── y = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      ├── y = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # RIGHT JOIN should not push down conditions to right side of join.
-opt expect-not=PushFilterIntoJoinRight
+norm expect-not=PushFilterIntoJoinRight
 SELECT * FROM b RIGHT JOIN a ON b.x=a.k AND a.i=1
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: x:1(int) y:2(int) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
- ├── left ordering: +3
- ├── right ordering: +1
  ├── key: (1,3)
  ├── fd: (3)-->(4-7), (1)-->(2)
  ├── scan a
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  │    ├── key: (3)
- │    ├── fd: (3)-->(4-7)
- │    └── ordering: +3
+ │    └── fd: (3)-->(4-7)
  ├── scan b
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2)
  └── filters
+      ├── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── i = 1 [type=bool, outer=(4), constraints=(/4: [/1 - /1]; tight), fd=()-->(4)]
 
 # Semi-join case.
-opt expect=PushFilterIntoJoinRight
+norm expect=PushFilterIntoJoinRight
 SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE x=k AND y>10)
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── y > 10 [type=bool, outer=(7), constraints=(/7: [/11 - ]; tight)]
- └── filters (true)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Anti-join case.
-opt expect=PushFilterIntoJoinRight
+norm expect=PushFilterIntoJoinRight
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE x=k AND y>10)
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── y > 10 [type=bool, outer=(7), constraints=(/7: [/11 - ]; tight)]
- └── filters (true)
+ └── filters
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # -------------------------------------------------------------------------------
 # PushFilterIntoJoinLeftAndRight + MapFilterIntoJoinLeft + MapFilterIntoJoinRight
 # -------------------------------------------------------------------------------
 
 # Can push to both sides with inner join.
-opt expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    ├── ordering: +1
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── (k * i) = 3 [type=bool, outer=(1,2)]
  ├── select
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── (x + y) > 5 [type=bool, outer=(6,7)]
- └── filters (true)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Multiple equivalent columns.
-opt expect=MapFilterIntoJoinLeft
+norm expect=MapFilterIntoJoinLeft
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.i=b.x AND a.i=b.y AND a.f + b.y::FLOAT > 5 AND a.s || b.x::STRING = 'foo1'
 ----
-inner-join (lookup a)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
- ├── key columns: [6] = [1]
- ├── lookup columns are key
  ├── key: (6)
  ├── fd: (1)-->(3-5), (1)==(2,6,7), (2)==(1,6,7), (6)==(1,2,7), (7)==(1,2,6)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3-5), (1)==(2), (2)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         ├── (f + k::FLOAT8) > 5.0 [type=bool, outer=(1,3)]
+ │         ├── (s || k::STRING) = 'foo1' [type=bool, outer=(1,4)]
+ │         └── k = i [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  ├── select
  │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── key: (6)
@@ -401,251 +390,235 @@ inner-join (lookup a)
  │    └── filters
  │         └── x = y [type=bool, outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
  └── filters
-      ├── (f + k::FLOAT8) > 5.0 [type=bool, outer=(1,3)]
-      ├── (s || k::STRING) = 'foo1' [type=bool, outer=(1,4)]
-      └── k = i [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Can push to both sides with semi-join.
-opt expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a WHERE EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 )
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    ├── ordering: +1
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── (k * i) = 3 [type=bool, outer=(1,2)]
  ├── select
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── (x + y) > 5 [type=bool, outer=(6,7)]
- └── filters (true)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=PushFilterIntoJoinLeftAndRight
+norm expect=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 )
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/7 - /7] [/10 - /10]
  │    ├── cardinality: [0 - 2]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan b
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── (k > 5) AND (k IN (3, 7, 10)) [type=bool, outer=(1), constraints=(/1: [/7 - /7] [/10 - /10]; tight)]
+ ├── select
  │    ├── columns: x:6(int!null)
- │    ├── constraint: /6: [/7 - /7] [/10 - /10]
  │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan b
+ │    │    ├── columns: x:6(int!null)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── (x IN (3, 7, 10)) AND (x > 5) [type=bool, outer=(6), constraints=(/6: [/7 - /7] [/10 - /10]; tight)]
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Can only push to right side with left join.
-opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
+norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── (x + y) > 5 [type=bool, outer=(6,7)]
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
+norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan b
+ │    └── fd: (1)-->(2-5)
+ ├── select
  │    ├── columns: x:6(int!null) y:7(int)
- │    ├── constraint: /6: [/7 - /7] [/10 - /10]
  │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan b
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── (x IN (3, 7, 10)) AND (x > 5) [type=bool, outer=(6), constraints=(/6: [/7 - /7] [/10 - /10]; tight)]
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Cannot push with full join.
-opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
-full-join (merge)
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       ├── (k + y) > 5 [type=bool, outer=(1,7)]
       └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
-full-join (merge)
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       ├── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
       └── x IN (3, 7, 10) [type=bool, outer=(6), constraints=(/6: [/3 - /3] [/7 - /7] [/10 - /10]; tight)]
 
 # Can only push to right side with anti-join.
-opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
+norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 )
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan b
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── (x + y) > 5 [type=bool, outer=(6,7)]
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
+norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 )
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan b
+ │    └── fd: (1)-->(2-5)
+ ├── select
  │    ├── columns: x:6(int!null)
- │    ├── constraint: /6: [/7 - /7] [/10 - /10]
  │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan b
+ │    │    ├── columns: x:6(int!null)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── (x IN (3, 7, 10)) AND (x > 5) [type=bool, outer=(6), constraints=(/6: [/7 - /7] [/10 - /10]; tight)]
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Works with a non-correlated subquery.
-opt expect=MapFilterIntoJoinLeft
+norm expect=MapFilterIntoJoinLeft
 SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT min(b.x) FROM b)
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    ├── ordering: +1
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── eq [type=bool, outer=(1,2), subquery]
  │              ├── k * i [type=int]
@@ -657,21 +630,19 @@ inner-join (merge)
  │                        ├── fd: ()-->(10)
  │                        ├── scan b
  │                        │    ├── columns: x:8(int!null)
- │                        │    ├── limit: 1
- │                        │    ├── key: ()
- │                        │    └── fd: ()-->(8)
+ │                        │    └── key: (8)
  │                        └── aggregations
- │                             └── const-agg [type=int, outer=(8)]
+ │                             └── min [type=int, outer=(8)]
  │                                  └── variable: x [type=int]
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
- └── filters (true)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Optimization does not apply with correlated suqueries.
-opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT a.k * b.y FROM b)
 ----
 project
@@ -714,7 +685,7 @@ project
            └── ?column? = (x * i) [type=bool, outer=(2,6,10), constraints=(/10: (/NULL - ])]
 
 # Ensure that we do not map filters for types with composite key encoding.
-opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT *
 FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y)WHERE x=y AND x::text = '1.0'
 ----
@@ -722,11 +693,6 @@ inner-join (hash)
  ├── columns: x:1(decimal!null) y:2(decimal!null)
  ├── cardinality: [0 - 4]
  ├── fd: (1)==(2), (2)==(1)
- ├── values
- │    ├── columns: column1:2(decimal!null)
- │    ├── cardinality: [2 - 2]
- │    ├── (1.00,) [type=tuple{decimal}]
- │    └── (2.00,) [type=tuple{decimal}]
  ├── select
  │    ├── columns: column1:1(decimal!null)
  │    ├── cardinality: [0 - 2]
@@ -737,11 +703,16 @@ inner-join (hash)
  │    │    └── (2.0,) [type=tuple{decimal}]
  │    └── filters
  │         └── column1::STRING = '1.0' [type=bool, outer=(1)]
+ ├── values
+ │    ├── columns: column1:2(decimal!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1.00,) [type=tuple{decimal}]
+ │    └── (2.00,) [type=tuple{decimal}]
  └── filters
       └── column1 = column1 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 
 # Optimization does not apply if equality is only on one side.
-opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON b.y=b.x AND a.k=a.i AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 inner-join (cross)
@@ -773,7 +744,7 @@ inner-join (cross)
       └── (x * i) = 3 [type=bool, outer=(2,6)]
 
 # Ensure that MapFilterIntoJoinLeft doesn't cause cycle with decorrelation.
-opt
+norm
 SELECT
 (
     SELECT b.x
@@ -788,7 +759,7 @@ project
  │    ├── columns: c.x:1(int!null) b.x:4(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
- │    ├── scan c@secondary
+ │    ├── scan c
  │    │    ├── columns: c.x:1(int!null)
  │    │    └── key: (1)
  │    ├── max1-row
@@ -828,7 +799,7 @@ project
       └── variable: b.x [type=int, outer=(4)]
 
 # Ensure that MapFilterIntoJoinRight doesn't cause cycle with decorrelation.
-opt
+norm
 SELECT
 (
     SELECT b.x FROM a, (SELECT b.* FROM b FULL OUTER JOIN b AS b2 ON c.x=5) AS b
@@ -842,7 +813,7 @@ project
  │    ├── columns: c.x:1(int!null) b.x:9(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(9)
- │    ├── scan c@secondary
+ │    ├── scan c
  │    │    ├── columns: c.x:1(int!null)
  │    │    └── key: (1)
  │    ├── max1-row
@@ -858,6 +829,14 @@ project
  │    │              ├── columns: k:4(int!null) b.x:9(int!null)
  │    │              ├── outer: (1)
  │    │              ├── fd: (4)==(9), (9)==(4)
+ │    │              ├── select
+ │    │              │    ├── columns: k:4(int!null)
+ │    │              │    ├── key: (4)
+ │    │              │    ├── scan a
+ │    │              │    │    ├── columns: k:4(int!null)
+ │    │              │    │    └── key: (4)
+ │    │              │    └── filters
+ │    │              │         └── (k + k) < 5 [type=bool, outer=(4)]
  │    │              ├── full-join (cross)
  │    │              │    ├── columns: b.x:9(int)
  │    │              │    ├── outer: (1)
@@ -867,14 +846,6 @@ project
  │    │              │    ├── scan b2
  │    │              │    └── filters
  │    │              │         └── c.x = 5 [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
- │    │              ├── select
- │    │              │    ├── columns: k:4(int!null)
- │    │              │    ├── key: (4)
- │    │              │    ├── scan a
- │    │              │    │    ├── columns: k:4(int!null)
- │    │              │    │    └── key: (4)
- │    │              │    └── filters
- │    │              │         └── (k + k) < 5 [type=bool, outer=(4)]
  │    │              └── filters
  │    │                   └── k = b.x [type=bool, outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
  │    └── filters (true)
@@ -891,7 +862,7 @@ CREATE TABLE t2 (b TIMESTAMPTZ)
 
 # Make sure that we do not create invalid filters due to substituting columns
 # with different types.
-opt
+norm
 SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL '1 day'
 ----
 inner-join (cross)
@@ -912,7 +883,7 @@ inner-join (cross)
 
 # Regression for issue 28818. Try to trigger undetectable cycle between the
 # PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
-opt
+norm
 SELECT 1
 FROM a
 WHERE EXISTS (
@@ -959,8 +930,25 @@ project
  │         │    │    │    │    ├── columns: xy.x:6(int!null) u:8(int!null)
  │         │    │    │    │    ├── outer: (4)
  │         │    │    │    │    ├── inner-join (cross)
- │         │    │    │    │    │    ├── columns: u:8(int!null)
- │         │    │    │    │    │    ├── outer: (4)
+ │         │    │    │    │    │    ├── columns: xy.x:6(int!null) u:8(int!null)
+ │         │    │    │    │    │    ├── key: (6,8)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
+ │         │    │    │    │    │    │    ├── key: (6)
+ │         │    │    │    │    │    │    ├── scan xy
+ │         │    │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
+ │         │    │    │    │    │    │    │    └── key: (6)
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── eq [type=bool, subquery]
+ │         │    │    │    │    │    │              ├── subquery [type=string]
+ │         │    │    │    │    │    │              │    └── max1-row
+ │         │    │    │    │    │    │              │         ├── columns: s:19(string)
+ │         │    │    │    │    │    │              │         ├── cardinality: [0 - 1]
+ │         │    │    │    │    │    │              │         ├── key: ()
+ │         │    │    │    │    │    │              │         ├── fd: ()-->(19)
+ │         │    │    │    │    │    │              │         └── scan a
+ │         │    │    │    │    │    │              │              └── columns: s:19(string)
+ │         │    │    │    │    │    │              └── const: 'foo' [type=string]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: u:8(int!null)
  │         │    │    │    │    │    │    ├── key: (8)
@@ -978,35 +966,18 @@ project
  │         │    │    │    │    │    │              │         └── scan a
  │         │    │    │    │    │    │              │              └── columns: s:19(string)
  │         │    │    │    │    │    │              └── const: 'foo' [type=string]
- │         │    │    │    │    │    ├── limit
- │         │    │    │    │    │    │    ├── outer: (4)
- │         │    │    │    │    │    │    ├── cardinality: [0 - 10]
- │         │    │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    │    ├── outer: (4)
- │         │    │    │    │    │    │    │    ├── limit hint: 10.00
- │         │    │    │    │    │    │    │    ├── scan b
- │         │    │    │    │    │    │    │    │    └── limit hint: 10.00
- │         │    │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │    │         └── s >= 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - ]; tight)]
- │         │    │    │    │    │    │    └── const: 10 [type=int]
  │         │    │    │    │    │    └── filters (true)
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: xy.x:6(int!null)
- │         │    │    │    │    │    ├── key: (6)
- │         │    │    │    │    │    ├── scan xy
- │         │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
- │         │    │    │    │    │    │    └── key: (6)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── eq [type=bool, subquery]
- │         │    │    │    │    │              ├── subquery [type=string]
- │         │    │    │    │    │              │    └── max1-row
- │         │    │    │    │    │              │         ├── columns: s:19(string)
- │         │    │    │    │    │              │         ├── cardinality: [0 - 1]
- │         │    │    │    │    │              │         ├── key: ()
- │         │    │    │    │    │              │         ├── fd: ()-->(19)
- │         │    │    │    │    │              │         └── scan a
- │         │    │    │    │    │              │              └── columns: s:19(string)
- │         │    │    │    │    │              └── const: 'foo' [type=string]
+ │         │    │    │    │    ├── limit
+ │         │    │    │    │    │    ├── outer: (4)
+ │         │    │    │    │    │    ├── cardinality: [0 - 10]
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── outer: (4)
+ │         │    │    │    │    │    │    ├── limit hint: 10.00
+ │         │    │    │    │    │    │    ├── scan b
+ │         │    │    │    │    │    │    │    └── limit hint: 10.00
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── s >= 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - ]; tight)]
+ │         │    │    │    │    │    └── const: 10 [type=int]
  │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters (true)
  │         │    │    └── projections
@@ -1021,27 +992,24 @@ project
 
 # Regression for issue 36137. Try to trigger undetectable cycle between the
 # PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
-opt
+norm
 SELECT * FROM a JOIN b ON a.k = b.x
 WHERE (a.k = b.x) OR (a.k IN (SELECT 5 FROM b WHERE x = y));
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── or [type=bool, outer=(1,6), correlated-subquery]
            ├── k = x [type=bool]
            └── any: eq [type=bool]
@@ -1163,123 +1131,100 @@ inner-join (hash)
 # MapEqualityIntoJoinLeftAndRight
 # ---------------------------------
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * FROM (SELECT a.k AS a_k, b.x AS b_x FROM a, b) JOIN (SELECT c.x AS c_x, d.x AS d_x FROM c, d)
 ON a_k = c_x AND c_x = b_x AND b_x = d_x
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: a_k:1(int!null) b_x:6(int!null) c_x:8(int!null) d_x:11(int!null)
- ├── left ordering: +1
- ├── right ordering: +8
  ├── key: (11)
  ├── fd: (1)==(6,8,11), (6)==(1,8,11), (8)==(1,6,11), (11)==(1,6,8)
- ├── inner-join (merge)
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) b.x:6(int!null)
- │    ├── left ordering: +1
- │    ├── right ordering: +6
  │    ├── key: (6)
  │    ├── fd: (1)==(6), (6)==(1)
- │    ├── ordering: +(1|6) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null)
- │    │    ├── key: (1)
- │    │    └── ordering: +1
+ │    │    └── key: (1)
  │    ├── scan b
  │    │    ├── columns: b.x:6(int!null)
- │    │    ├── key: (6)
- │    │    └── ordering: +6
- │    └── filters (true)
- ├── inner-join (merge)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── k = b.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── inner-join (hash)
  │    ├── columns: c.x:8(int!null) d.x:11(int!null)
- │    ├── left ordering: +8
- │    ├── right ordering: +11
  │    ├── key: (11)
  │    ├── fd: (8)==(11), (11)==(8)
- │    ├── ordering: +(8|11) [actual: +8]
- │    ├── scan c@secondary
+ │    ├── scan c
  │    │    ├── columns: c.x:8(int!null)
- │    │    ├── key: (8)
- │    │    └── ordering: +8
+ │    │    └── key: (8)
  │    ├── scan d
  │    │    ├── columns: d.x:11(int!null)
- │    │    ├── key: (11)
- │    │    └── ordering: +11
- │    └── filters (true)
- └── filters (true)
+ │    │    └── key: (11)
+ │    └── filters
+ │         └── c.x = d.x [type=bool, outer=(8,11), constraints=(/8: (/NULL - ]; /11: (/NULL - ]), fd=(8)==(11), (11)==(8)]
+ └── filters
+      └── k = c.x [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * FROM (SELECT b.x AS b_x, c.x AS c_x FROM b, c), d WHERE b_x=d.x AND c_x=d.x
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: b_x:1(int!null) c_x:3(int!null) x:6(int!null) y:7(int!null) z:8(int!null)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)==(3,6), (3)==(1,6), (6)-->(7,8), (6)==(1,3)
- ├── inner-join (merge)
+ ├── inner-join (hash)
  │    ├── columns: b.x:1(int!null) c.x:3(int!null)
- │    ├── left ordering: +1
- │    ├── right ordering: +3
  │    ├── key: (3)
  │    ├── fd: (1)==(3), (3)==(1)
- │    ├── ordering: +(1|3) [actual: +1]
  │    ├── scan b
  │    │    ├── columns: b.x:1(int!null)
- │    │    ├── key: (1)
- │    │    └── ordering: +1
- │    ├── scan c@secondary
+ │    │    └── key: (1)
+ │    ├── scan c
  │    │    ├── columns: c.x:3(int!null)
- │    │    ├── key: (3)
- │    │    └── ordering: +3
- │    └── filters (true)
+ │    │    └── key: (3)
+ │    └── filters
+ │         └── b.x = c.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  ├── scan d
  │    ├── columns: d.x:6(int!null) d.y:7(int!null) d.z:8(int!null)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7,8)
- │    └── ordering: +6
- └── filters (true)
+ │    └── fd: (6)-->(7,8)
+ └── filters
+      └── b.x = d.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * FROM b, c, d WHERE b.x=c.x AND b.x=d.x
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) x:3(int!null) y:4(int!null) z:5(int!null) x:6(int!null) y:7(int!null) z:8(int!null)
- ├── left ordering: +1
- ├── right ordering: +3
  ├── key: (6)
  ├── fd: (1)-->(2), (3)-->(4,5), (6)-->(7,8), (3)==(1,6), (6)==(1,3), (1)==(3,6)
  ├── scan b
  │    ├── columns: b.x:1(int!null) b.y:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
- ├── inner-join (merge)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
  │    ├── columns: c.x:3(int!null) c.y:4(int!null) c.z:5(int!null) d.x:6(int!null) d.y:7(int!null) d.z:8(int!null)
- │    ├── left ordering: +3
- │    ├── right ordering: +6
  │    ├── key: (6)
  │    ├── fd: (3)-->(4,5), (6)-->(7,8), (3)==(6), (6)==(3)
- │    ├── ordering: +(3|6) [actual: +3]
  │    ├── scan c
  │    │    ├── columns: c.x:3(int!null) c.y:4(int!null) c.z:5(int!null)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4,5)
- │    │    └── ordering: +3
+ │    │    └── fd: (3)-->(4,5)
  │    ├── scan d
  │    │    ├── columns: d.x:6(int!null) d.y:7(int!null) d.z:8(int!null)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7,8)
- │    │    └── ordering: +6
- │    └── filters (true)
- └── filters (true)
+ │    │    └── fd: (6)-->(7,8)
+ │    └── filters
+ │         └── c.x = d.x [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ └── filters
+      └── b.x = c.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * FROM c INNER JOIN d ON c.x = d.x AND d.x = c.y AND c.y = d.y AND d.y = c.z AND c.z = d.z AND d.z = c.x
 ----
-inner-join (lookup d)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
- ├── key columns: [1] = [4]
- ├── lookup columns are key
  ├── key: (4)
  ├── fd: (1)==(2-6), (2)==(1,3-6), (3)==(1,2,4-6), (4)==(1-3,5,6), (5)==(1-4,6), (6)==(1-5)
  ├── select
@@ -1293,17 +1238,25 @@ inner-join (lookup d)
  │    └── filters
  │         ├── c.x = c.y [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  │         └── c.x = c.z [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ ├── select
+ │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)==(5,6), (5)==(4,6), (6)==(4,5)
+ │    ├── scan d
+ │    │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5,6)
+ │    └── filters
+ │         ├── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+ │         └── d.x = d.z [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
  └── filters
-      ├── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
-      └── d.x = d.z [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+      └── c.x = d.x [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * from c, d WHERE c.x = c.y AND c.x = d.x AND c.y = d.y;
 ----
-inner-join (lookup d)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
- ├── key columns: [1] = [4]
- ├── lookup columns are key
  ├── key: (4)
  ├── fd: (1)-->(3), (1)==(2,4,5), (2)==(1,4,5), (4)-->(6), (4)==(1,2,5), (5)==(1,2,4)
  ├── select
@@ -1316,16 +1269,24 @@ inner-join (lookup d)
  │    │    └── fd: (1)-->(2,3)
  │    └── filters
  │         └── c.x = c.y [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ ├── select
+ │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(6), (4)==(5), (5)==(4)
+ │    ├── scan d
+ │    │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5,6)
+ │    └── filters
+ │         └── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
  └── filters
-      └── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+      └── c.x = d.x [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 SELECT * FROM c, d WHERE c.x = d.x AND d.x = c.y AND c.y = d.y
 ----
-inner-join (lookup d)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
- ├── key columns: [1] = [4]
- ├── lookup columns are key
  ├── key: (4)
  ├── fd: (1)-->(3), (1)==(2,4,5), (2)==(1,4,5), (4)-->(6), (4)==(1,2,5), (5)==(1,2,4)
  ├── select
@@ -1338,8 +1299,18 @@ inner-join (lookup d)
  │    │    └── fd: (1)-->(2,3)
  │    └── filters
  │         └── c.x = c.y [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ ├── select
+ │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(6), (4)==(5), (5)==(4)
+ │    ├── scan d
+ │    │    ├── columns: d.x:4(int!null) d.y:5(int!null) d.z:6(int!null)
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5,6)
+ │    └── filters
+ │         └── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
  └── filters
-      └── d.x = d.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+      └── c.x = d.x [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
 exec-ddl
 create table aa (a int, a1 int, a2 int)
@@ -1353,19 +1324,12 @@ exec-ddl
 create table cc (c int, c1 int, c2 int)
 ----
 
-opt expect=MapEqualityIntoJoinLeftAndRight
+norm expect=MapEqualityIntoJoinLeftAndRight
 select * from aa, bb where a2 = b and b = a and a = b1 and b1 = a1
 ----
 inner-join (hash)
  ├── columns: a:1(int!null) a1:2(int!null) a2:3(int!null) b:5(int!null) b1:6(int!null) b2:7(int)
  ├── fd: (1)==(2,3,5,6), (2)==(1,3,5,6), (3)==(1,2,5,6), (5)==(1-3,6), (6)==(1-3,5)
- ├── select
- │    ├── columns: b:5(int!null) b1:6(int!null) b2:7(int)
- │    ├── fd: (5)==(6), (6)==(5)
- │    ├── scan bb
- │    │    └── columns: b:5(int) b1:6(int) b2:7(int)
- │    └── filters
- │         └── b = b1 [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
  ├── select
  │    ├── columns: a:1(int!null) a1:2(int!null) a2:3(int!null)
  │    ├── fd: (1)==(2,3), (2)==(1,3), (3)==(1,2)
@@ -1374,6 +1338,13 @@ inner-join (hash)
  │    └── filters
  │         ├── a = a1 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  │         └── a = a2 [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ ├── select
+ │    ├── columns: b:5(int!null) b1:6(int!null) b2:7(int)
+ │    ├── fd: (5)==(6), (6)==(5)
+ │    ├── scan bb
+ │    │    └── columns: b:5(int) b1:6(int) b2:7(int)
+ │    └── filters
+ │         └── b = b1 [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
  └── filters
       └── a = b [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
@@ -1381,15 +1352,23 @@ inner-join (hash)
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight
 # --------------------------------------------------
 
-opt expect=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
+norm expect=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.i=1 AND b.y=1
 ----
-inner-join (lookup a)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
- ├── key columns: [6] = [1]
- ├── lookup columns are key
  ├── key: (6)
  ├── fd: ()-->(2,7), (1)-->(3-5), (1)==(6), (6)==(1)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
  ├── select
  │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── key: (6)
@@ -1401,34 +1380,31 @@ inner-join (lookup a)
  │    └── filters
  │         └── y = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
  └── filters
-      └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # FULL JOIN should not push down conditions to either side of join.
-opt expect-not=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
+norm expect-not=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.i=1 AND b.y=1
 ----
-full-join (merge)
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       ├── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── y = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Nested semi/anti-join case.
-opt expect=PushFilterIntoJoinRight
+norm expect=PushFilterIntoJoinRight
 SELECT * FROM b
 WHERE EXISTS
 (
@@ -1473,7 +1449,7 @@ semi-join-apply
 # --------------------------------------------------
 # SimplifyLeftJoinWithoutFilters
 # --------------------------------------------------
-opt expect=SimplifyLeftJoinWithoutFilters
+norm expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a LEFT JOIN (SELECT count(*) FROM b) ON True
 ----
 inner-join (cross)
@@ -1495,18 +1471,14 @@ inner-join (cross)
  └── filters (true)
 
 # Full-join.
-opt expect=SimplifyLeftJoinWithoutFilters
+norm expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a FULL JOIN (SELECT count(*) FROM b) ON True
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── key: (1)
  ├── fd: ()-->(8), (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
  ├── scalar-group-by
  │    ├── columns: count_rows:8(int)
  │    ├── cardinality: [1 - 1]
@@ -1515,10 +1487,14 @@ right-join (cross)
  │    ├── scan b
  │    └── aggregations
  │         └── count-rows [type=int]
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
  └── filters (true)
 
 # Left-join-apply.
-opt expect=SimplifyLeftJoinWithoutFilters
+norm expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a WHERE (SELECT sum(column1) FROM (VALUES (k), (1))) = 1
 ----
 project
@@ -1563,18 +1539,14 @@ project
            └── sum = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Don't simplify right join
-opt expect-not=SimplifyLeftJoinWithoutFilters
+norm expect-not=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a RIGHT JOIN (SELECT count(*) FROM b) ON True
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── key: (1)
  ├── fd: ()-->(8), (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
  ├── scalar-group-by
  │    ├── columns: count_rows:8(int)
  │    ├── cardinality: [1 - 1]
@@ -1583,6 +1555,10 @@ right-join (cross)
  │    ├── scan b
  │    └── aggregations
  │         └── count-rows [type=int]
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
  └── filters (true)
 
 # --------------------------------------------------
@@ -1611,18 +1587,14 @@ left-join (cross)
  └── filters (true)
 
 # Full-join.
-opt expect=SimplifyRightJoinWithoutFilters
+norm expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) FULL JOIN a ON True
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── key: (4)
  ├── fd: ()-->(3), (4)-->(5-8)
- ├── scan a
- │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
- │    ├── key: (4)
- │    └── fd: (4)-->(5-8)
  ├── scalar-group-by
  │    ├── columns: count_rows:3(int)
  │    ├── cardinality: [1 - 1]
@@ -1631,21 +1603,21 @@ right-join (cross)
  │    ├── scan b
  │    └── aggregations
  │         └── count-rows [type=int]
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
  └── filters (true)
 
 # Full-join.
-opt expect=SimplifyRightJoinWithoutFilters
+norm expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) FULL JOIN a ON True
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── key: (4)
  ├── fd: ()-->(3), (4)-->(5-8)
- ├── scan a
- │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
- │    ├── key: (4)
- │    └── fd: (4)-->(5-8)
  ├── scalar-group-by
  │    ├── columns: count_rows:3(int)
  │    ├── cardinality: [1 - 1]
@@ -1654,21 +1626,21 @@ right-join (cross)
  │    ├── scan b
  │    └── aggregations
  │         └── count-rows [type=int]
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
  └── filters (true)
 
 # Don't simplify left join
-opt expect-not=SimplifyRightJoinWithoutFilters
+norm expect-not=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) LEFT JOIN a ON True
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── key: (4)
  ├── fd: ()-->(3), (4)-->(5-8)
- ├── scan a
- │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
- │    ├── key: (4)
- │    └── fd: (4)-->(5-8)
  ├── scalar-group-by
  │    ├── columns: count_rows:3(int)
  │    ├── cardinality: [1 - 1]
@@ -1677,57 +1649,60 @@ right-join (cross)
  │    ├── scan b
  │    └── aggregations
  │         └── count-rows [type=int]
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
  └── filters (true)
 
 # --------------------------------------------------
 # SimplifyLeftJoinWithFilters + SimplifyRightJoinWithFilters
 # --------------------------------------------------
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb)
- ├── left ordering: +6
- ├── right ordering: +1
  ├── key: (6)
  ├── fd: (6)-->(7-10), (1)-->(2-5), (1)==(6), (6)==(1)
  ├── scan a2
  │    ├── columns: a2.k:6(int!null) a2.i:7(int) a2.f:8(float!null) a2.s:9(string) a2.j:10(jsonb)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7-10)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7-10)
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float!null) a.s:4(string) a.j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- └── filters (true)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── a.k = a2.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Right side has partial rows, so only right-join can be simplified.
-opt expect=SimplifyRightJoinWithFilters
+norm expect=SimplifyRightJoinWithFilters
 SELECT * FROM a FULL JOIN (SELECT * FROM a WHERE k>0) AS a2 ON a.k=a2.k
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan a
+ │    └── fd: (1)-->(2-5)
+ ├── select
  │    ├── columns: k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb)
- │    ├── constraint: /6: [/1 - ]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7-10)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan a
+ │    │    ├── columns: k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7-10)
+ │    └── filters
+ │         └── k > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+ └── filters
+      └── k = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Multiple equality conditions, with duplicates and reversed columns.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k AND a.k=a2.k AND a2.f=a.f
 ----
 inner-join (hash)
@@ -1747,7 +1722,7 @@ inner-join (hash)
       └── a2.k = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Input contains Project operator.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT * FROM (SELECT length(s), f FROM a) AS a FULL JOIN a AS a2 ON a.f=a2.f
 ----
 inner-join (hash)
@@ -1767,30 +1742,27 @@ inner-join (hash)
       └── a.f = a2.f [type=bool, outer=(3,9), constraints=(/3: (/NULL - ]; /9: (/NULL - ]), fd=(3)==(9), (9)==(3)]
 
 # Multiple join levels.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT * FROM a FULL JOIN (SELECT * FROM a INNER JOIN a AS a2 ON a.k=a2.k) AS a2 ON a.f=a2.f
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb) k:11(int!null) i:12(int) f:13(float!null) s:14(string) j:15(jsonb)
  ├── key: (1,11)
  ├── fd: (6)-->(7-10), (11)-->(12-15), (6)==(11), (11)==(6), (1)-->(2-5), (3)==(8), (8)==(3)
- ├── inner-join (merge)
+ ├── inner-join (hash)
  │    ├── columns: a.k:6(int!null) a.i:7(int) a.f:8(float!null) a.s:9(string) a.j:10(jsonb) a2.k:11(int!null) a2.i:12(int) a2.f:13(float!null) a2.s:14(string) a2.j:15(jsonb)
- │    ├── left ordering: +6
- │    ├── right ordering: +11
  │    ├── key: (11)
  │    ├── fd: (6)-->(7-10), (11)-->(12-15), (6)==(11), (11)==(6)
  │    ├── scan a
  │    │    ├── columns: a.k:6(int!null) a.i:7(int) a.f:8(float!null) a.s:9(string) a.j:10(jsonb)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7-10)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7-10)
  │    ├── scan a2
  │    │    ├── columns: a2.k:11(int!null) a2.i:12(int) a2.f:13(float!null) a2.s:14(string) a2.j:15(jsonb)
  │    │    ├── key: (11)
- │    │    ├── fd: (11)-->(12-15)
- │    │    └── ordering: +11
- │    └── filters (true)
+ │    │    └── fd: (11)-->(12-15)
+ │    └── filters
+ │         └── a.k = a2.k [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float!null) a.s:4(string) a.j:5(jsonb)
  │    ├── key: (1)
@@ -1799,7 +1771,7 @@ inner-join (hash)
       └── a.f = a.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
 
 # Left joins on a foreign key turn into inner joins.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM c
 LEFT OUTER JOIN a
@@ -1821,33 +1793,31 @@ inner-join (hash)
       └── y = k [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 
 # Left joins on a multiple-column foreign key turn into inner joins.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM d
 LEFT OUTER JOIN c
 ON d.z = c.z
 AND d.y = c.x
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
- ├── left ordering: +2,+3
- ├── right ordering: +4,+6
  ├── key: (1)
  ├── fd: (1)-->(2,3), (4)-->(5,6), (3)==(6), (6)==(3), (2)==(4), (4)==(2)
- ├── scan d@d_auto_index_fk_y_ref_c
+ ├── scan d
  │    ├── columns: d.x:1(int!null) d.y:2(int!null) d.z:3(int!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
- │    └── ordering: +2,+3
+ │    └── fd: (1)-->(2,3)
  ├── scan c
  │    ├── columns: c.x:4(int!null) c.y:5(int!null) c.z:6(int!null)
  │    ├── key: (4)
- │    ├── fd: (4)-->(5,6)
- │    └── ordering: +4
- └── filters (true)
+ │    └── fd: (4)-->(5,6)
+ └── filters
+      ├── d.z = c.z [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+      └── d.y = c.x [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 
 # Left join on a part of a foreign key turns into an inner join.
-opt expect=SimplifyLeftJoinWithFilters
+norm expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM d
 LEFT OUTER JOIN c
@@ -1869,7 +1839,7 @@ inner-join (hash)
       └── d.z = c.z [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
 
 # Can't simplify: joins on non-foreign keys.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM c
 LEFT OUTER JOIN a
@@ -1891,32 +1861,29 @@ left-join (hash)
       └── z = k [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
 
 # Can't simplify: joins on non-foreign keys still in foreign key index.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM c
 LEFT OUTER JOIN a
 ON c.x = a.k
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
- ├── left ordering: +1
- ├── right ordering: +4
  ├── key: (1,4)
  ├── fd: (1)-->(2,3), (4)-->(5-8)
  ├── scan c
  │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2,3)
  ├── scan a
  │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
  │    ├── key: (4)
- │    ├── fd: (4)-->(5-8)
- │    └── ordering: +4
- └── filters (true)
+ │    └── fd: (4)-->(5-8)
+ └── filters
+      └── x = k [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
 # Can't simplify: non-equality condition.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k<a2.k
 ----
 full-join (cross)
@@ -1935,7 +1902,7 @@ full-join (cross)
       └── a.k < a2.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Can't simplify: non-join equality condition.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.f=1 AND a.f=a2.f
 ----
 full-join (hash)
@@ -1955,7 +1922,7 @@ full-join (hash)
       └── a.f = a2.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
 
 # Can't simplify: non-null column.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.s=a2.s
 ----
 full-join (hash)
@@ -1974,7 +1941,7 @@ full-join (hash)
       └── a.s = a2.s [type=bool, outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
 
 # Can't simplify: equality column that is synthesized.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN (SELECT k+1 AS k FROM a) AS a2 ON a.k=a2.k
 ----
 full-join (hash)
@@ -1995,7 +1962,7 @@ full-join (hash)
       └── a.k = k [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # Can't simplify: equality condition with different column ordinals.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.f
 ----
 full-join (cross)
@@ -2014,31 +1981,28 @@ full-join (cross)
       └── a.k = a2.f [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Can't simplify: one equality condition has columns from same side of join.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k AND a.f=a.f AND a2.f=a2.f
 ----
-full-join (merge)
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float!null) a.s:4(string) a.j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan a2
  │    ├── columns: a2.k:6(int!null) a2.i:7(int) a2.f:8(float!null) a2.s:9(string) a2.j:10(jsonb)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7-10)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7-10)
  └── filters
+      ├── a.k = a2.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       ├── a.f = a.f [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
       └── a2.f = a2.f [type=bool, outer=(8), constraints=(/8: (/NULL - ])]
 
 # Can't simplify: equality conditions have columns from different tables.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM (SELECT * FROM a, b) AS a FULL JOIN a AS a2 ON a.k=a2.k AND a.x=a2.k
 ----
 full-join (hash)
@@ -2067,13 +2031,17 @@ full-join (hash)
       └── x = a2.k [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
 
 # Can't simplify: The a2.x column is not part of unfilteredCols.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a LEFT JOIN (SELECT * FROM a, b) AS a2 ON a.k=a2.x
 ----
-right-join (hash)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb) x:11(int) y:12(int)
  ├── key: (1,6,11)
  ├── fd: (1)-->(2-5), (6)-->(7-10), (11)-->(12)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
  ├── inner-join (cross)
  │    ├── columns: k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb) x:11(int!null) y:12(int)
  │    ├── key: (6,11)
@@ -2087,15 +2055,11 @@ right-join (hash)
  │    │    ├── key: (11)
  │    │    └── fd: (11)-->(12)
  │    └── filters (true)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
  └── filters
       └── k = x [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # Can't simplify if IGNORE_FOREIGN_KEYS hint is passed.
-opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM c@{IGNORE_FOREIGN_KEYS}
 LEFT OUTER JOIN a
@@ -2119,7 +2083,7 @@ left-join (hash)
 # --------------------------------------------------
 # EliminateSemiJoin
 # --------------------------------------------------
-opt expect=EliminateSemiJoin
+norm expect=EliminateSemiJoin
 SELECT * FROM a WHERE EXISTS(SELECT count(*) FROM b WHERE x=k)
 ----
 scan a
@@ -2127,7 +2091,7 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(2-5)
 
-opt expect=EliminateSemiJoin
+norm expect=EliminateSemiJoin
 SELECT * FROM a WHERE EXISTS(VALUES (k))
 ----
 scan a
@@ -2139,7 +2103,7 @@ scan a
 # SimplifyZeroCardinalitySemiJoin
 # --------------------------------------------------
 # TODO(justin): figure out if there's a good way to make this still apply.
-opt disable=SimplifyZeroCardinalityGroup expect=SimplifyZeroCardinalitySemiJoin
+norm disable=SimplifyZeroCardinalityGroup expect=SimplifyZeroCardinalitySemiJoin
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
 ----
 values
@@ -2152,7 +2116,7 @@ values
 # EliminateAntiJoin
 # --------------------------------------------------
 # TODO(justin): figure out if there's a good way to make this still apply.
-opt disable=SimplifyZeroCardinalityGroup expect=EliminateAntiJoin
+norm disable=SimplifyZeroCardinalityGroup expect=EliminateAntiJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
 ----
 scan a
@@ -2163,7 +2127,7 @@ scan a
 # --------------------------------------------------
 # SimplifyZeroCardinalityAntiJoin
 # --------------------------------------------------
-opt expect=SimplifyZeroCardinalityAntiJoin
+norm expect=SimplifyZeroCardinalityAntiJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT count(*) FROM b WHERE x=k)
 ----
 values
@@ -2172,7 +2136,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifyZeroCardinalityAntiJoin
+norm expect=SimplifyZeroCardinalityAntiJoin
 SELECT * FROM a WHERE NOT EXISTS(VALUES (k))
 ----
 values
@@ -2184,7 +2148,7 @@ values
 # --------------------------------------------------
 # EliminateJoinNoColsLeft
 # --------------------------------------------------
-opt expect=EliminateJoinNoColsLeft
+norm expect=EliminateJoinNoColsLeft
 SELECT s FROM (VALUES (1, 2)) INNER JOIN a ON s='foo'
 ----
 select
@@ -2198,7 +2162,7 @@ select
 # --------------------------------------------------
 # EliminateJoinNoColsRight
 # --------------------------------------------------
-opt expect=EliminateJoinNoColsRight
+norm expect=EliminateJoinNoColsRight
 SELECT s FROM a INNER JOIN (SELECT count(*) FROM b) ON s='foo'
 ----
 select
@@ -2215,19 +2179,21 @@ select
 # --------------------------------------------------
 
 # Inner-join case.
-opt expect=HoistJoinProjectRight
+norm expect=HoistJoinProjectRight
 SELECT * FROM a INNER JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (1)==(6), (6)==(1)
- └── inner-join (lookup a)
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
-      ├── key columns: [6] = [1]
-      ├── lookup columns are key
       ├── key: (6)
       ├── fd: ()-->(7), (1)-->(2-5), (1)==(6), (6)==(1)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-5)
       ├── select
       │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── key: (6)
@@ -2238,57 +2204,52 @@ project
       │    │    └── fd: (6)-->(7)
       │    └── filters
       │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
-      └── filters (true)
+      └── filters
+           └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Left-join case.
-opt expect=HoistJoinProjectRight
+norm expect=HoistJoinProjectRight
 SELECT * FROM a LEFT JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5)
- └── left-join (merge)
+ └── left-join (hash)
       ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
-      ├── left ordering: +1
-      ├── right ordering: +6
       ├── key: (1,6)
       ├── fd: (1)-->(2-5), ()~~>(7), (1,6)-->(7)
       ├── scan a
       │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5)
-      │    └── ordering: +1
+      │    └── fd: (1)-->(2-5)
       ├── select
       │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── key: (6)
       │    ├── fd: ()-->(7)
-      │    ├── ordering: +6 opt(7) [actual: +6]
       │    ├── scan b
       │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    ├── key: (6)
-      │    │    ├── fd: (6)-->(7)
-      │    │    └── ordering: +6 opt(7) [actual: +6]
+      │    │    └── fd: (6)-->(7)
       │    └── filters
       │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
-      └── filters (true)
+      └── filters
+           └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # HoistJoinProjectLeft
 # --------------------------------------------------
 
 # Inner-join case.
-opt expect=HoistJoinProjectLeft
+norm expect=HoistJoinProjectLeft
 SELECT * FROM (SELECT x FROM b WHERE y=10) INNER JOIN a ON x=k
 ----
 project
  ├── columns: x:1(int!null) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  ├── key: (3)
  ├── fd: (3)-->(4-7), (1)==(3), (3)==(1)
- └── inner-join (lookup a)
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int!null) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
-      ├── key columns: [1] = [3]
-      ├── lookup columns are key
       ├── key: (3)
       ├── fd: ()-->(2), (3)-->(4-7), (1)==(3), (3)==(1)
       ├── select
@@ -2301,20 +2262,23 @@ project
       │    │    └── fd: (1)-->(2)
       │    └── filters
       │         └── y = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
-      └── filters (true)
+      ├── scan a
+      │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4-7)
+      └── filters
+           └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Left-join case.
-opt expect=HoistJoinProjectLeft
+norm expect=HoistJoinProjectLeft
 SELECT * FROM (SELECT x FROM b WHERE y=10) LEFT JOIN a ON x=k
 ----
 project
  ├── columns: x:1(int!null) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── key: (1,3)
  ├── fd: (3)-->(4-7)
- └── left-join (lookup a)
+ └── left-join (hash)
       ├── columns: x:1(int!null) y:2(int!null) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
-      ├── key columns: [1] = [3]
-      ├── lookup columns are key
       ├── key: (1,3)
       ├── fd: ()-->(2), (3)-->(4-7)
       ├── select
@@ -2327,7 +2291,12 @@ project
       │    │    └── fd: (1)-->(2)
       │    └── filters
       │         └── y = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
-      └── filters (true)
+      ├── scan a
+      │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4-7)
+      └── filters
+           └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # --------------------------------------------------
 # SimplifyJoinNotNullEquality
@@ -2497,7 +2466,7 @@ inner-join (cross)
 # ExtractJoinEqualities
 # --------------------------------------------------
 
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON x+y=u
 ----
 project
@@ -2525,7 +2494,7 @@ project
       └── filters
            └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON u=x+y
 ----
 project
@@ -2553,7 +2522,7 @@ project
       └── filters
            └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON x=u+v
 ----
 project
@@ -2581,7 +2550,7 @@ project
       └── filters
            └── x = column5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON u+v=x
 ----
 project
@@ -2609,7 +2578,7 @@ project
       └── filters
            └── x = column5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON x+y=u+v
 ----
 project
@@ -2644,7 +2613,7 @@ project
            └── column5 = column6 [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
 
 # Multiple extractable equalities.
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON x+y=u AND x=u+v AND x*y+1=u*v+2
 ----
 project
@@ -2683,7 +2652,7 @@ project
            └── column7 = column8 [type=bool, outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ]), fd=(7)==(8), (8)==(7)]
 
 # An extractable equality with another expression.
-opt expect=ExtractJoinEqualities
+norm expect=ExtractJoinEqualities
 SELECT * FROM xy JOIN uv ON x+y=u AND x+u=v
 ----
 project
@@ -2713,28 +2682,25 @@ project
            └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 # Cases with non-extractable equality.
-opt expect-not=ExtractJoinEqualities
+norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON x=u
 ----
-full-join (merge)
+full-join (hash)
  ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
- ├── left ordering: +1
- ├── right ordering: +3
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2)
  ├── scan uv
  │    ├── columns: u:3(int!null) v:4(int)
  │    ├── key: (3)
- │    ├── fd: (3)-->(4)
- │    └── ordering: +3
- └── filters (true)
+ │    └── fd: (3)-->(4)
+ └── filters
+      └── x = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
-opt expect-not=ExtractJoinEqualities
+norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON x+y=1
 ----
 full-join (cross)
@@ -2752,7 +2718,7 @@ full-join (cross)
  └── filters
       └── (x + y) = 1 [type=bool, outer=(1,2)]
 
-opt expect-not=ExtractJoinEqualities
+norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
 ----
 full-join (cross)
@@ -2770,7 +2736,7 @@ full-join (cross)
  └── filters
       └── (u + v) = 1 [type=bool, outer=(3,4)]
 
-opt expect-not=ExtractJoinEqualities
+norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy INNER JOIN uv ON (SELECT k FROM a WHERE i=x)=u
 ----
 project
@@ -2819,7 +2785,7 @@ project
       └── filters
            └── u = k [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
-opt expect-not=ExtractJoinEqualities
+norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy INNER JOIN uv ON x=(SELECT k FROM a WHERE i=u)
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -17,27 +17,8 @@ CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 # --------------------------------------------------
 # EliminateLimit
 # --------------------------------------------------
-opt expect=EliminateLimit
+norm expect=EliminateLimit
 SELECT * FROM (SELECT * FROM a LIMIT 99) LIMIT 100
-----
-scan a
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── limit: 99
- ├── key: (1)
- └── fd: (1)-->(2-5)
-
-opt expect=EliminateLimit
-SELECT * FROM (SELECT * FROM a LIMIT 100) LIMIT 100
-----
-scan a
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── limit: 100
- ├── key: (1)
- └── fd: (1)-->(2-5)
-
-# Don't eliminate the outer limit if it's less than the inner.
-opt
-SELECT * FROM (SELECT * FROM a LIMIT 100) LIMIT 99
 ----
 limit
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
@@ -46,30 +27,72 @@ limit
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── limit: 100
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    └── limit hint: 99.00
  └── const: 99 [type=int]
 
+norm expect=EliminateLimit
+SELECT * FROM (SELECT * FROM a LIMIT 100) LIMIT 100
+----
+limit
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 100]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── limit hint: 100.00
+ └── const: 100 [type=int]
+
+# Don't eliminate the outer limit if it's less than the inner.
+norm
+SELECT * FROM (SELECT * FROM a LIMIT 100) LIMIT 99
+----
+limit
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 99]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── limit
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 100]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── limit hint: 99.00
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5)
+ │    │    └── limit hint: 100.00
+ │    └── const: 100 [type=int]
+ └── const: 99 [type=int]
+
 # High limits (> max uint32), can't eliminate in this case.
-opt
+norm
 SELECT * FROM (SELECT * FROM a LIMIT 5000000000) LIMIT 5100000000
 ----
 limit
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── limit: 5000000000
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── limit hint: 5100000000.00
+ │    ├── limit hint: 5100000000.00
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5)
+ │    │    └── limit hint: 5000000000.00
+ │    └── const: 5000000000 [type=int]
  └── const: 5100000000 [type=int]
 
 # Don't eliminate in case of negative limit.
-opt
+norm
 SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 ----
 limit
@@ -89,7 +112,7 @@ limit
 # --------------------------------------------------
 # EliminateOffset
 # --------------------------------------------------
-opt expect=EliminateOffset
+norm expect=EliminateOffset
 SELECT * FROM a OFFSET 0
 ----
 scan a
@@ -97,16 +120,22 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(2-5)
 
-opt expect=EliminateOffset
+norm expect=EliminateOffset
 SELECT * FROM a LIMIT 5 OFFSET 0
 ----
-scan a
+limit
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── limit: 5
+ ├── cardinality: [0 - 5]
  ├── key: (1)
- └── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── limit hint: 5.00
+ └── const: 5 [type=int]
 
-opt expect-not=EliminateOffset
+norm expect-not=EliminateOffset
 SELECT * FROM a LIMIT 5 OFFSET 1
 ----
 offset
@@ -114,17 +143,23 @@ offset
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── limit: 6
+ │    ├── cardinality: [0 - 6]
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5)
+ │    │    └── limit hint: 6.00
+ │    └── const: 6 [type=int]
  └── const: 1 [type=int]
 
 # --------------------------------------------------
 # PushLimitIntoProject
 # --------------------------------------------------
-opt expect=PushLimitIntoProject
+norm expect=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a LIMIT 5
 ----
 project
@@ -132,15 +167,21 @@ project
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: (1)-->(6)
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) f:3(float)
- │    ├── limit: 5
+ │    ├── cardinality: [0 - 5]
  │    ├── key: (1)
- │    └── fd: (1)-->(3)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) f:3(float)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(3)
+ │    │    └── limit hint: 5.00
+ │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
 
-opt expect=PushLimitIntoProject
+norm expect=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k LIMIT 5
 ----
 project
@@ -149,18 +190,26 @@ project
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +1
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) f:3(float)
- │    ├── limit: 5
+ │    ├── internal-ordering: +1
+ │    ├── cardinality: [0 - 5]
  │    ├── key: (1)
  │    ├── fd: (1)-->(3)
- │    └── ordering: +1
+ │    ├── ordering: +1
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) f:3(float)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(3)
+ │    │    ├── ordering: +1
+ │    │    └── limit hint: 5.00
+ │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
 
 # Don't push the limit through project when the ordering is on a
 # synthesized column.
-opt expect-not=PushLimitIntoProject
+norm expect-not=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY r LIMIT 5
 ----
 limit
@@ -190,7 +239,7 @@ limit
 
 
 # Detect PushLimitIntoProject and FilterUnusedLimitCols dependency cycle.
-opt
+norm
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f LIMIT 5
 ----
 project
@@ -220,7 +269,7 @@ project
       └── f + 1.1 [type=float, outer=(3)]
 
 # Don't push negative limit into Scan.
-opt
+norm
 SELECT * FROM a LIMIT -1
 ----
 limit
@@ -239,7 +288,7 @@ limit
 # --------------------------------------------------
 # PushOffsetIntoProject
 # --------------------------------------------------
-opt expect=PushOffsetIntoProject
+norm expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a OFFSET 5
 ----
 project
@@ -258,7 +307,7 @@ project
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
 
-opt expect=PushOffsetIntoProject
+norm expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k OFFSET 5
 ----
 project
@@ -283,7 +332,7 @@ project
 
 # Don't push the offset through project when the ordering is on a
 # synthesized column.
-opt expect-not=PushOffsetIntoProject
+norm expect-not=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY r OFFSET 5
 ----
 offset
@@ -310,7 +359,7 @@ offset
  └── const: 5 [type=int]
 
 # Detect PushOffsetIntoProject and FilterUnusedOffsetCols dependency cycle.
-opt
+norm
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5
 ----
 project
@@ -338,7 +387,7 @@ project
 # --------------------------------------------------
 # PushLimitIntoProject + PushOffsetIntoProject
 # --------------------------------------------------
-opt expect=(PushLimitIntoProject,PushOffsetIntoProject)
+norm expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT k, f*2.0 AS r FROM a OFFSET 5 LIMIT 10
 ----
 project
@@ -351,16 +400,22 @@ project
  │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(3)
- │    ├── scan a
+ │    ├── limit
  │    │    ├── columns: k:1(int!null) f:3(float)
- │    │    ├── limit: 15
+ │    │    ├── cardinality: [0 - 15]
  │    │    ├── key: (1)
- │    │    └── fd: (1)-->(3)
+ │    │    ├── fd: (1)-->(3)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null) f:3(float)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(3)
+ │    │    │    └── limit hint: 15.00
+ │    │    └── const: 15 [type=int]
  │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
 
-opt expect=(PushLimitIntoProject,PushOffsetIntoProject)
+norm expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5 LIMIT 10
 ----
 project
@@ -400,7 +455,7 @@ project
 # PushLimitIntoOffset
 # --------------------------------------------------
 
-opt expect=PushLimitIntoOffset
+norm expect=PushLimitIntoOffset
 SELECT k, i FROM a LIMIT 10 OFFSET 10
 ----
 offset
@@ -408,14 +463,20 @@ offset
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2)
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── limit: 20
+ │    ├── cardinality: [0 - 20]
  │    ├── key: (1)
- │    └── fd: (1)-->(2)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    └── limit hint: 20.00
+ │    └── const: 20 [type=int]
  └── const: 10 [type=int]
 
-opt expect=(PushLimitIntoOffset)
+norm expect=(PushLimitIntoOffset)
 SELECT k, i FROM a OFFSET 10 LIMIT 10
 ----
 offset
@@ -423,15 +484,21 @@ offset
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2)
- ├── scan a
+ ├── limit
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── limit: 20
+ │    ├── cardinality: [0 - 20]
  │    ├── key: (1)
- │    └── fd: (1)-->(2)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    └── limit hint: 20.00
+ │    └── const: 20 [type=int]
  └── const: 10 [type=int]
 
 # Limit can be pushed into the ordering if they have the same ordering.
-opt expect=PushLimitIntoOffset
+norm expect=PushLimitIntoOffset
 SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i LIMIT 10
 ----
 offset
@@ -461,7 +528,7 @@ offset
  │    └── const: 30 [type=int]
  └── const: 20 [type=int]
 
-opt expect-not=PushLimitIntoOffset
+norm expect-not=PushLimitIntoOffset
 SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i DESC LIMIT 10
 ----
 limit
@@ -495,7 +562,7 @@ limit
  └── const: 10 [type=int]
 
 # Using MaxInt64. Do not apply rule when sum overflows.
-opt expect-not=PushLimitIntoOffset
+norm expect-not=PushLimitIntoOffset
 SELECT k, i FROM a LIMIT 9223372036854775807 OFFSET 9223372036854775807
 ----
 limit
@@ -515,7 +582,7 @@ limit
  │    └── const: 9223372036854775807 [type=int]
  └── const: 9223372036854775807 [type=int]
 
-opt expect=PushLimitIntoOrdinality
+norm expect=PushLimitIntoOrdinality
 SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY LIMIT 10
 ----
 ordinality
@@ -523,14 +590,22 @@ ordinality
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-6), (6)-->(1-5)
- └── scan a
+ └── limit
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      ├── limit: 10
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2-5)
-      └── ordering: +1
+      ├── ordering: +1
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5)
+      │    ├── ordering: +1
+      │    └── limit hint: 10.00
+      └── const: 10 [type=int]
 
-opt expect=PushLimitIntoOrdinality
+norm expect=PushLimitIntoOrdinality
 SELECT * FROM a WITH ORDINALITY ORDER BY k LIMIT 10
 ----
 sort
@@ -544,16 +619,24 @@ sort
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2-6), (6)-->(1-5)
-      └── scan a
+      └── limit
            ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-           ├── limit: 10
+           ├── internal-ordering: +1
+           ├── cardinality: [0 - 10]
            ├── key: (1)
-           └── fd: (1)-->(2-5)
+           ├── fd: (1)-->(2-5)
+           ├── scan a
+           │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-5)
+           │    ├── ordering: +1
+           │    └── limit hint: 10.00
+           └── const: 10 [type=int]
 
 
 # More complex example of an intersection:
 # +(i|f) +s and +f have the intersection +(i|f) +s
-opt expect=PushLimitIntoOrdinality
+norm expect=PushLimitIntoOrdinality
 SELECT * FROM (SELECT * FROM a WHERE i=f ORDER BY i, s) WITH ORDINALITY ORDER BY f LIMIT 10
 ----
 ordinality
@@ -587,7 +670,7 @@ ordinality
       │              └── i = f [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
       └── const: 10 [type=int]
 
-opt expect-not=PushLimitIntoOrdinality
+norm expect-not=PushLimitIntoOrdinality
 SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY ORDER BY i LIMIT 10
 ----
 limit
@@ -614,7 +697,7 @@ limit
  │              └── ordering: +1
  └── const: 10 [type=int]
 
-opt expect-not=PushLimitIntoOrdinality
+norm expect-not=PushLimitIntoOrdinality
 SELECT * FROM (SELECT * FROM a WITH ORDINALITY) ORDER BY ordinality LIMIT 10
 ----
 limit

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -9,7 +9,7 @@ CREATE TABLE t.b (x INT PRIMARY KEY, y INT)
 # --------------------------------------------------
 # EliminateMax1Row
 # --------------------------------------------------
-opt expect=EliminateMax1Row
+norm expect=EliminateMax1Row
 SELECT (SELECT i FROM a LIMIT 1) > 5 AS r
 ----
 values
@@ -20,14 +20,18 @@ values
  └── tuple [type=tuple{bool}]
       └── gt [type=bool]
            ├── subquery [type=int]
-           │    └── scan a
+           │    └── limit
            │         ├── columns: i:2(int)
-           │         ├── limit: 1
+           │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         └── fd: ()-->(2)
+           │         ├── fd: ()-->(2)
+           │         ├── scan a
+           │         │    ├── columns: i:2(int)
+           │         │    └── limit hint: 1.00
+           │         └── const: 1 [type=int]
            └── const: 5 [type=int]
 
-opt expect=EliminateMax1Row
+norm expect=EliminateMax1Row
 SELECT (SELECT count(*) FROM a) > 100 AS r
 ----
 values
@@ -48,7 +52,7 @@ values
            │              └── count-rows [type=int]
            └── const: 100 [type=int]
 
-opt expect=EliminateMax1Row
+norm expect=EliminateMax1Row
 SELECT (SELECT i FROM a LIMIT 0) > 5 AS r
 ----
 values
@@ -67,7 +71,7 @@ values
            └── const: 5 [type=int]
 
 # Don't remove the Max1Row operator.
-opt expect-not=EliminateMax1Row
+norm expect-not=EliminateMax1Row
 SELECT (SELECT i FROM a) > 5 AS r
 ----
 values

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -7,7 +7,7 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, d DECIMAL, t TIME)
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt expect=(FoldPlusZero,FoldZeroPlus)
+norm expect=(FoldPlusZero,FoldZeroPlus)
 SELECT
     (a.i + a.i) + 0 AS r, 0 + (a.i + a.i) AS s,
     (a.f + a.f) + 0 AS t, 0 + (a.f + a.f) AS u,
@@ -28,7 +28,7 @@ project
 
 
 # Regression test for #35113.
-opt expect=FoldPlusZero
+norm expect=FoldPlusZero
 SELECT i + 0::decimal FROM a
 ----
 project
@@ -38,7 +38,7 @@ project
  └── projections
       └── i::DECIMAL [type=decimal, outer=(2)]
 
-opt expect=FoldZeroPlus
+norm expect=FoldZeroPlus
 SELECT 0::decimal + i FROM a
 ----
 project
@@ -53,7 +53,7 @@ project
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt expect=FoldMinusZero
+norm expect=FoldMinusZero
 SELECT
     (a.i + a.i) - 0 AS r,
     (a.f + a.f) - 0 AS s,
@@ -70,7 +70,7 @@ project
       └── d + d [type=decimal, outer=(4)]
 
 # Regression test for #35113.
-opt expect=FoldMinusZero
+norm expect=FoldMinusZero
 SELECT i - 0::decimal FROM a
 ----
 project
@@ -81,7 +81,7 @@ project
       └── i::DECIMAL [type=decimal, outer=(2)]
 
 # Regression test for #35612.
-opt expect-not=FoldMinusZero
+norm expect-not=FoldMinusZero
 SELECT '[123]'::jsonb - 0
 ----
 values
@@ -96,7 +96,7 @@ values
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt expect=(FoldMultOne,FoldOneMult)
+norm expect=(FoldMultOne,FoldOneMult)
 SELECT
     (a.i + a.i) * 1 AS r, 1 * (a.i + a.i) AS s,
     (a.f + a.f) * 1 AS t, 1 * (a.f + a.f) AS u,
@@ -116,7 +116,7 @@ project
       └── d + d [type=decimal, outer=(4)]
 
 # Regression test for #35113.
-opt expect=FoldMultOne
+norm expect=FoldMultOne
 SELECT i * 1::decimal FROM a
 ----
 project
@@ -126,7 +126,7 @@ project
  └── projections
       └── i::DECIMAL [type=decimal, outer=(2)]
 
-opt expect=FoldOneMult
+norm expect=FoldOneMult
 SELECT 1::decimal * i FROM a
 ----
 project
@@ -140,7 +140,7 @@ project
 # FoldDivOne
 # --------------------------------------------------
 
-opt expect=FoldDivOne
+norm expect=FoldDivOne
 SELECT
     a.i / 1 AS r,
     a.f / 1 AS s,
@@ -157,7 +157,7 @@ project
       └── variable: d [type=decimal, outer=(4)]
 
 # Regression test for #35113.
-opt expect=FoldDivOne
+norm expect=FoldDivOne
 SELECT i / 1::decimal FROM a
 ----
 project
@@ -167,7 +167,7 @@ project
  └── projections
       └── i::DECIMAL [type=decimal, outer=(2)]
 
-opt expect=FoldDivOne
+norm expect=FoldDivOne
 SELECT i / 1::int8 FROM a
 ----
 project
@@ -180,7 +180,7 @@ project
 # --------------------------------------------------
 # InvertMinus
 # --------------------------------------------------
-opt expect=InvertMinus
+norm expect=InvertMinus
 SELECT
     -(a.f - a.f) AS r,
     -(a.d - a.i) AS s,
@@ -199,7 +199,7 @@ project
 # --------------------------------------------------
 # EliminateUnaryMinus
 # --------------------------------------------------
-opt expect=EliminateUnaryMinus
+norm expect=EliminateUnaryMinus
 SELECT -(-a.i::int) AS r FROM a
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -21,7 +21,7 @@ CREATE TABLE xyz (
 # SimplifyLimitOrdering
 # --------------------------------------------------
 # Remove constant column.
-opt expect=SimplifyLimitOrdering
+norm expect=SimplifyLimitOrdering
 SELECT d, e FROM (SELECT d, 1 AS one, e FROM abcde) ORDER BY d, one, e LIMIT 10
 ----
 limit
@@ -38,7 +38,7 @@ limit
  └── const: 10 [type=int]
 
 # Remove multiple constant columns.
-opt expect=SimplifyLimitOrdering
+norm expect=SimplifyLimitOrdering
 SELECT b, c FROM abcde WHERE d=1 AND e=2 ORDER BY b, c, d, e, a LIMIT 10
 ----
 limit
@@ -68,21 +68,33 @@ limit
  └── const: 10 [type=int]
 
 # Remove functionally dependent column that's only used in ordering.
-opt expect=SimplifyLimitOrdering
+norm expect=SimplifyLimitOrdering
 SELECT c FROM abcde ORDER BY b, c, a, d LIMIT 10
 ----
-scan abcde@bc
+limit
  ├── columns: c:3(int)  [hidden: a:1(int!null) b:2(int)]
- ├── limit: 10
+ ├── internal-ordering: +2,+3,+1
+ ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- └── ordering: +2,+3,+1
+ ├── ordering: +2,+3,+1
+ ├── sort
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ │    ├── ordering: +2,+3,+1
+ │    ├── limit hint: 10.00
+ │    └── scan abcde
+ │         ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2,3), (2,3)~~>(1)
+ └── const: 10 [type=int]
 
 # --------------------------------------------------
 # SimplifyOffsetOrdering
 # --------------------------------------------------
 # Remove all order by columns, because all are constant.
-opt expect=SimplifyOffsetOrdering
+norm expect=SimplifyOffsetOrdering
 SELECT d, e FROM (SELECT d, 1 AS one, e FROM abcde) ORDER BY one OFFSET 10
 ----
 offset
@@ -97,7 +109,7 @@ offset
 # Remove columns functionally dependent on key.
 # TODO(justin): figure out why this doesn't trigger SimplifyGroupByOrdering (it
 # triggers SimplifyRootOrdering).
-opt
+norm
 SELECT array_agg(b), a, c FROM abcde GROUP BY b, a, c ORDER BY a, b, c
 ----
 group-by
@@ -118,7 +130,7 @@ group-by
            └── variable: c [type=int]
 
 # ScalarGroupBy case.
-opt expect=SimplifyGroupByOrdering
+norm expect=SimplifyGroupByOrdering
 SELECT array_agg(b) FROM (SELECT * FROM abcde ORDER BY a, b, c)
 ----
 scalar-group-by
@@ -137,7 +149,7 @@ scalar-group-by
            └── variable: b [type=int]
 
 # DistinctOn case.
-opt expect=SimplifyGroupByOrdering
+norm expect=SimplifyGroupByOrdering
 SELECT DISTINCT ON (b, c) a, b, c FROM abcde ORDER BY b, c, a, d, e
 ----
 distinct-on
@@ -147,11 +159,15 @@ distinct-on
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)-->(1)
  ├── ordering: +2,+3
- ├── scan abcde@bc
+ ├── sort
  │    ├── columns: a:1(int!null) b:2(int) c:3(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (2,3)~~>(1)
- │    └── ordering: +2,+3,+1
+ │    ├── ordering: +2,+3,+1
+ │    └── scan abcde
+ │         ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2,3), (2,3)~~>(1)
  └── aggregations
       └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
@@ -160,7 +176,7 @@ distinct-on
 # SimplifyOrdinalityOrdering
 # --------------------------------------------------
 # Remove column functionally dependent on multi-column key.
-opt expect=SimplifyOrdinalityOrdering
+norm expect=SimplifyOrdinalityOrdering
 SELECT * FROM (SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL ORDER BY c, d, b, e) WITH ORDINALITY
 ----
 ordinality
@@ -188,25 +204,28 @@ ordinality
 # SimplifyExplainOrdering
 # --------------------------------------------------
 # Remove functionally dependent synthesized column.
-opt expect=SimplifyExplainOrdering
+norm expect=SimplifyExplainOrdering
 EXPLAIN SELECT b, b+1 AS plus, c FROM abcde ORDER BY b, plus, c
 ----
 explain
  ├── columns: tree:7(string) field:8(string) description:9(string)
- └── project
+ └── sort
       ├── columns: b:2(int) plus:6(int) c:3(int)
       ├── lax-key: (2,3)
       ├── fd: (2)-->(6)
       ├── ordering: +2,+3
-      ├── scan abcde@bc
-      │    ├── columns: b:2(int) c:3(int)
-      │    ├── lax-key: (2,3)
-      │    └── ordering: +2,+3
-      └── projections
-           └── b + 1 [type=int, outer=(2)]
+      └── project
+           ├── columns: plus:6(int) b:2(int) c:3(int)
+           ├── lax-key: (2,3)
+           ├── fd: (2)-->(6)
+           ├── scan abcde
+           │    ├── columns: b:2(int) c:3(int)
+           │    └── lax-key: (2,3)
+           └── projections
+                └── b + 1 [type=int, outer=(2)]
 
 # Regression: Explain a statement having constant column, but with no ordering.
-opt
+norm
 SELECT field FROM [EXPLAIN SELECT 123 AS k]
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -11,7 +11,7 @@ CREATE TABLE b (x INT PRIMARY KEY, z INT)
 # --------------------------------------------------
 
 # Same order, same names.
-opt expect=EliminateProject
+norm expect=EliminateProject
 SELECT x, y FROM a
 ----
 scan a
@@ -20,7 +20,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Different order, aliased names.
-opt expect=EliminateProject
+norm expect=EliminateProject
 SELECT a.y AS aliasy, a.x FROM a
 ----
 scan a
@@ -29,7 +29,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Reordered, duplicate, aliased columns.
-opt expect=EliminateProject
+norm expect=EliminateProject
 SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM a
 ----
 scan a
@@ -38,7 +38,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Added column (projection should not be eliminated).
-opt expect-not=EliminateProject
+norm expect-not=EliminateProject
 SELECT *, 1 r FROM a
 ----
 project
@@ -57,32 +57,29 @@ project
 # --------------------------------------------------
 
 # Inner project has no synthesized columns.
-opt expect=MergeProjects
+norm expect=MergeProjects
 SELECT y+1 AS r FROM (SELECT a.y FROM a, b WHERE a.x=b.x) a
 ----
 project
  ├── columns: r:7(int)
- ├── inner-join (merge)
+ ├── inner-join (hash)
  │    ├── columns: a.x:1(int!null) y:2(int) b.x:5(int!null)
- │    ├── left ordering: +1
- │    ├── right ordering: +5
  │    ├── key: (5)
  │    ├── fd: (1)-->(2), (1)==(5), (5)==(1)
  │    ├── scan a
  │    │    ├── columns: a.x:1(int!null) y:2(int)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2)
  │    ├── scan b
  │    │    ├── columns: b.x:5(int!null)
- │    │    ├── key: (5)
- │    │    └── ordering: +5
- │    └── filters (true)
+ │    │    └── key: (5)
+ │    └── filters
+ │         └── a.x = b.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
       └── y + 1 [type=int, outer=(2)]
 
 # Outer and inner projections have synthesized columns.
-opt expect=MergeProjects
+norm expect=MergeProjects
 SELECT y1, f+1 FROM (SELECT y+1 AS y1, f FROM a)
 ----
 project
@@ -94,7 +91,7 @@ project
       └── y + 1 [type=int, outer=(2)]
 
 # Multiple synthesized columns in both outer and inner projections.
-opt expect=MergeProjects
+norm expect=MergeProjects
 SELECT y1, f+1, x2, s||'foo' FROM (SELECT y+1 AS y1, f, s, x*2 AS x2 FROM a)
 ----
 project
@@ -110,7 +107,7 @@ project
       └── x * 2 [type=int, outer=(1)]
 
 # Outer project selects subset of inner columns.
-opt expect=MergeProjects
+norm expect=MergeProjects
 SELECT y1 FROM (SELECT y+1 AS y1, f*2 AS f2 FROM a)
 ----
 project
@@ -121,7 +118,7 @@ project
       └── y + 1 [type=int, outer=(2)]
 
 # Don't merge, since outer depends on inner.
-opt expect-not=MergeProjects
+norm expect-not=MergeProjects
 SELECT y1*2, y1/2 FROM (SELECT y+1 AS y1 FROM a)
 ----
 project
@@ -138,7 +135,7 @@ project
       └── y1 / 2 [type=decimal, outer=(5), side-effects]
 
 # Discard all inner columns.
-opt expect=MergeProjects
+norm expect=MergeProjects
 SELECT 1 r FROM (SELECT y+1, x FROM a) a
 ----
 project
@@ -152,7 +149,7 @@ project
 # MergeProjectWithValues
 # --------------------------------------------------
 
-opt expect=MergeProjectWithValues
+norm expect=MergeProjectWithValues
 SELECT column1, 3 FROM (VALUES (1, 2))
 ----
 values
@@ -163,7 +160,7 @@ values
  └── (1, 3) [type=tuple{int, int}]
 
 # Only passthrough columns.
-opt expect=MergeProjectWithValues
+norm expect=MergeProjectWithValues
 SELECT column1, column3 FROM (VALUES (1, 2, 3))
 ----
 values
@@ -174,7 +171,7 @@ values
  └── (1, 3) [type=tuple{int, int}]
 
 # Only synthesized columns.
-opt expect=MergeProjectWithValues
+norm expect=MergeProjectWithValues
 SELECT 4, 5 FROM (VALUES (1, 2, 3))
 ----
 values
@@ -185,7 +182,7 @@ values
  └── (4, 5) [type=tuple{int, int}]
 
 # Don't trigger rule when there is more than one Values row.
-opt expect-not=MergeProjectWithValues
+norm expect-not=MergeProjectWithValues
 SELECT column1, 3 FROM (VALUES (1, 2), (1, 4))
 ----
 project
@@ -201,7 +198,7 @@ project
       └── const: 3 [type=int]
 
 # Don't trigger rule when Project column depends on Values column.
-opt expect-not=MergeProjectWithValues
+norm expect-not=MergeProjectWithValues
 SELECT column1+1, 3 FROM (VALUES ($1::int, $2::int))
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -48,7 +48,7 @@ CREATE TABLE family (
 # --------------------------------------------------
 
 # Discard some of columns.
-opt expect=PruneProjectCols
+norm expect=PruneProjectCols
 SELECT k1*2 FROM (SELECT k+1 AS k1, i+1 FROM a) a
 ----
 project
@@ -60,7 +60,7 @@ project
       └── (k + 1) * 2 [type=int, outer=(1)]
 
 # Use column values within computed column.
-opt expect=PruneProjectCols
+norm expect=PruneProjectCols
 SELECT k+length(s) AS r FROM (SELECT i, k, s || 'foo' AS s FROM a) a
 ----
 project
@@ -73,7 +73,7 @@ project
       └── k + length(a.s || 'foo') [type=int, outer=(1,4)]
 
 # Discard non-computed columns and keep computed column.
-opt expect=PruneProjectCols
+norm expect=PruneProjectCols
 SELECT l, l*2, k FROM (SELECT length(s) l, * FROM a) a
 ----
 project
@@ -94,7 +94,7 @@ project
       └── l * 2 [type=int, outer=(5)]
 
 # Compute column based on another computed column.
-opt expect=PruneProjectCols
+norm expect=PruneProjectCols
 SELECT l*l AS r, k FROM (SELECT k, length(s) l, i FROM a) a
 ----
 project
@@ -119,7 +119,7 @@ project
 # --------------------------------------------------
 
 # Project subset of columns.
-opt expect=PruneScanCols
+norm expect=PruneScanCols
 SELECT k FROM a
 ----
 scan a
@@ -127,7 +127,7 @@ scan a
  └── key: (1)
 
 # Project subset of columns, some used in computed columns.
-opt expect=PruneScanCols
+norm expect=PruneScanCols
 SELECT k, k+1 AS r, i+1 AS s FROM a
 ----
 project
@@ -143,7 +143,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Use columns only in computed columns.
-opt expect=PruneScanCols
+norm expect=PruneScanCols
 SELECT k+i AS r FROM a
 ----
 project
@@ -156,7 +156,7 @@ project
       └── k + i [type=int, outer=(1,2)]
 
 # Use no scan columns.
-opt expect=PruneScanCols
+norm expect=PruneScanCols
 SELECT 1 r FROM a
 ----
 project
@@ -171,7 +171,7 @@ project
 # --------------------------------------------------
 
 # Columns used only by projection or filter, but not both.
-opt expect=PruneSelectCols
+norm expect=PruneSelectCols
 SELECT k FROM a WHERE i<5
 ----
 project
@@ -189,7 +189,7 @@ project
            └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # Columns used by both projection and filter.
-opt expect=PruneSelectCols
+norm expect=PruneSelectCols
 SELECT k, i FROM a WHERE k=1 AND i<5
 ----
 select
@@ -199,15 +199,14 @@ select
  ├── fd: ()-->(1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── constraint: /1: [/1 - /1]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1,2)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── filters
+      ├── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # No needed select columns.
-opt expect=PruneSelectCols
+norm expect=PruneSelectCols
 SELECT 1 r FROM a WHERE $1<'2000-01-01T02:00:00'::timestamp
 ----
 project
@@ -223,7 +222,7 @@ project
       └── const: 1 [type=int]
 
 # Select columns used in computed columns.
-opt expect=PruneSelectCols
+norm expect=PruneSelectCols
 SELECT i-1 AS r, k*k AS t FROM a WHERE k+1<5 AND s||'o'='foo'
 ----
 project
@@ -234,17 +233,17 @@ project
  │    ├── fd: (1)-->(2,4)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
- │    │    ├── constraint: /1: [ - /3]
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2,4)
  │    └── filters
+ │         ├── k < 4 [type=bool, outer=(1), constraints=(/1: (/NULL - /3]; tight)]
  │         └── (s || 'o') = 'foo' [type=bool, outer=(4)]
  └── projections
       ├── i - 1 [type=int, outer=(2)]
       └── k * k [type=int, outer=(1)]
 
 # Select nested in select.
-opt expect=PruneSelectCols
+norm expect=PruneSelectCols
 SELECT i FROM (SELECT k, i, s, f/2.0 f FROM a WHERE k = 5) a2 WHERE i::float = f
 ----
 project
@@ -265,19 +264,24 @@ project
       │    ├── side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(2,5)
-      │    ├── scan a
+      │    ├── select
       │    │    ├── columns: k:1(int!null) i:2(int) a.f:3(float)
-      │    │    ├── constraint: /1: [/5 - /5]
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(1-3)
+      │    │    ├── fd: ()-->(1-3)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1(int!null) i:2(int) a.f:3(float)
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2,3)
+      │    │    └── filters
+      │    │         └── k = 5 [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
       │    └── projections
       │         └── a.f / 2.0 [type=float, outer=(3), side-effects]
       └── filters
            └── f = i::FLOAT8 [type=bool, outer=(2,5), constraints=(/5: (/NULL - ])]
 
 # Detect PruneSelectCols and PushSelectIntoProject dependency cycle.
-opt
+norm
 SELECT f, f+1.1 AS r FROM (SELECT f, k FROM a GROUP BY f, k HAVING sum(k)=100) a
 ----
 project
@@ -289,14 +293,12 @@ project
  │    ├── group-by
  │    │    ├── columns: k:1(int!null) f:3(float) sum:5(decimal)
  │    │    ├── grouping columns: k:1(int!null)
- │    │    ├── internal-ordering: +1
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(3,5)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null) f:3(float)
  │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(3)
- │    │    │    └── ordering: +1
+ │    │    │    └── fd: (1)-->(3)
  │    │    └── aggregations
  │    │         ├── sum [type=decimal, outer=(1)]
  │    │         │    └── variable: k [type=int]
@@ -311,17 +313,21 @@ project
 # PruneLimitCols
 # --------------------------------------------------
 
-opt expect=PruneLimitCols
+norm expect=PruneLimitCols
 SELECT i FROM (SELECT i, s FROM a LIMIT 1)
 ----
-scan a
+limit
  ├── columns: i:2(int)
- ├── limit: 1
+ ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(2)
+ ├── fd: ()-->(2)
+ ├── scan a
+ │    ├── columns: i:2(int)
+ │    └── limit hint: 1.00
+ └── const: 1 [type=int]
 
 # The projection on top of Limit should trickle down and we shouldn't scan f.
-opt expect=PruneLimitCols
+norm expect=PruneLimitCols
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i LIMIT 10)
 ----
 project
@@ -347,7 +353,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=PruneLimitCols
+norm expect=PruneLimitCols
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10)
 ----
 project
@@ -372,7 +378,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=PruneLimitCols
+norm expect=PruneLimitCols
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10)
 ----
 project
@@ -400,7 +406,7 @@ project
 
 # Project uses subset of Limit columns, but no additional Project should be
 # introduced to tree, because it can't be pushed down to Scan.
-opt
+norm
 SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s LIMIT 5) a
 ----
 project
@@ -426,7 +432,7 @@ project
 # PruneOffsetCols
 # --------------------------------------------------
 
-opt expect=PruneOffsetCols
+norm expect=PruneOffsetCols
 SELECT f FROM (SELECT * FROM a OFFSET 1)
 ----
 offset
@@ -435,7 +441,7 @@ offset
  │    └── columns: f:3(float)
  └── const: 1 [type=int]
 
-opt expect=PruneOffsetCols
+norm expect=PruneOffsetCols
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i OFFSET 10)
 ----
 project
@@ -458,7 +464,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=PruneOffsetCols
+norm expect=PruneOffsetCols
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k OFFSET 10)
 ----
 project
@@ -480,7 +486,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=PruneOffsetCols
+norm expect=PruneOffsetCols
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k OFFSET 10)
 ----
 project
@@ -505,7 +511,7 @@ project
 
 # Project uses subset of Offset columns, but no additional Project should be
 # introduced to tree, because it can't be pushed down past Explain.
-opt
+norm
 SELECT tree, columns
 FROM
 (
@@ -539,7 +545,7 @@ offset
 # PruneLimitCols + PruneOffsetCols
 # --------------------------------------------------
 
-opt expect=(PruneLimitCols,PruneOffsetCols)
+norm expect=(PruneLimitCols,PruneOffsetCols)
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i LIMIT 10 OFFSET 10)
 ----
 project
@@ -573,7 +579,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=(PruneLimitCols,PruneOffsetCols)
+norm expect=(PruneLimitCols,PruneOffsetCols)
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10 OFFSET 10)
 ----
 project
@@ -606,7 +612,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt expect=(PruneLimitCols,PruneOffsetCols)
+norm expect=(PruneLimitCols,PruneOffsetCols)
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10 OFFSET 10)
 ----
 project
@@ -641,7 +647,7 @@ project
       └── const: 10 [type=int]
 
 # Project filter offset/limit columns, but can't push all the way down to scan.
-opt
+norm
 SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s OFFSET 5 LIMIT 5) a
 ----
 project
@@ -673,56 +679,50 @@ project
 # --------------------------------------------------
 
 # Columns used only by projection or on condition, but not both.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.i, xy.* FROM a INNER JOIN xy ON a.k=xy.x
 ----
 project
  ├── columns: i:2(int) x:5(int!null) y:6(int)
  ├── key: (5)
  ├── fd: (5)-->(2,6)
- └── inner-join (merge)
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int) x:5(int!null) y:6(int)
-      ├── left ordering: +1
-      ├── right ordering: +5
       ├── key: (5)
       ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
       ├── scan a
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2)
-      │    └── ordering: +1
+      │    └── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:5(int!null) y:6(int)
       │    ├── key: (5)
-      │    ├── fd: (5)-->(6)
-      │    └── ordering: +5
-      └── filters (true)
+      │    └── fd: (5)-->(6)
+      └── filters
+           └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # Columns used by both projection and on condition, left join.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.k, a.i, xy.* FROM a LEFT JOIN xy ON a.k=xy.x AND a.i<5
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) x:5(int) y:6(int)
- ├── left ordering: +1
- ├── right ordering: +5
  ├── key: (1,5)
  ├── fd: (1)-->(2), (5)-->(6)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2)
  ├── scan xy
  │    ├── columns: x:5(int!null) y:6(int)
  │    ├── key: (5)
- │    ├── fd: (5)-->(6)
- │    └── ordering: +5
+ │    └── fd: (5)-->(6)
  └── filters
+      ├── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # Columns needed only by projection, full join.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.k+1 AS r, xy.* FROM a FULL JOIN xy ON True
 ----
 project
@@ -744,7 +744,7 @@ project
       └── k + 1 [type=int, outer=(1)]
 
 # No columns needed from left side of join.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT xy.* FROM a, xy
 ----
 inner-join (cross)
@@ -758,7 +758,7 @@ inner-join (cross)
  └── filters (true)
 
 # Computed columns.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.k+1 AS r, a.i/2 AS s, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s||'o'='foo'
 ----
 project
@@ -769,10 +769,6 @@ project
  │    ├── columns: k:1(int!null) i:2(int) x:5(int!null) y:6(int) column7:7(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,7), (5)-->(6), (5)==(7), (7)==(5)
- │    ├── scan xy
- │    │    ├── columns: x:5(int!null) y:6(int)
- │    │    ├── key: (5)
- │    │    └── fd: (5)-->(6)
  │    ├── project
  │    │    ├── columns: column7:7(int) k:1(int!null) i:2(int)
  │    │    ├── key: (1)
@@ -789,6 +785,10 @@ project
  │    │    │         └── (a.s || 'o') = 'foo' [type=bool, outer=(4)]
  │    │    └── projections
  │    │         └── k * k [type=int, outer=(1)]
+ │    ├── scan xy
+ │    │    ├── columns: x:5(int!null) y:6(int)
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
  │    └── filters
  │         └── column7 = x [type=bool, outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
  └── projections
@@ -796,7 +796,7 @@ project
       └── i / 2 [type=decimal, outer=(2), side-effects]
 
 # Join that is nested in another join.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.k, xy.*
 FROM
 (
@@ -813,22 +813,19 @@ project
       ├── columns: k:1(int!null) i:2(int!null) x:5(int!null) x:7(int!null) y:8(int!null)
       ├── key: (5,7)
       ├── fd: (1)-->(2), (1)==(5), (5)==(1), (7)-->(8)
-      ├── inner-join (merge)
+      ├── inner-join (hash)
       │    ├── columns: k:1(int!null) i:2(int) x:5(int!null)
-      │    ├── left ordering: +1
-      │    ├── right ordering: +5
       │    ├── key: (5)
       │    ├── fd: (1)-->(2), (1)==(5), (5)==(1)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2)
-      │    │    └── ordering: +1
+      │    │    └── fd: (1)-->(2)
       │    ├── scan xy
       │    │    ├── columns: x:5(int!null)
-      │    │    ├── key: (5)
-      │    │    └── ordering: +5
-      │    └── filters (true)
+      │    │    └── key: (5)
+      │    └── filters
+      │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       ├── scan xy
       │    ├── columns: x:7(int!null) y:8(int)
       │    ├── key: (7)
@@ -837,7 +834,7 @@ project
            └── i < y [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
 
 # ApplyJoin operator.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT k, i
 FROM a
 WHERE (SELECT k+1 AS r FROM xy WHERE y=k) = 1
@@ -878,7 +875,7 @@ project
            └── r = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # SemiJoin operator.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.i
 FROM a
 WHERE
@@ -887,37 +884,31 @@ WHERE
 ----
 project
  ├── columns: i:2(int)
- └── semi-join (merge)
+ └── semi-join (hash)
       ├── columns: k:1(int!null) i:2(int)
-      ├── left ordering: +1
-      ├── right ordering: +5
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── semi-join (merge)
+      ├── semi-join (hash)
       │    ├── columns: k:1(int!null) i:2(int)
-      │    ├── left ordering: +1
-      │    ├── right ordering: +7
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
-      │    ├── ordering: +1
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2)
-      │    │    └── ordering: +1
+      │    │    └── fd: (1)-->(2)
       │    ├── scan xy
       │    │    ├── columns: x:7(int!null)
-      │    │    ├── key: (7)
-      │    │    └── ordering: +7
-      │    └── filters (true)
+      │    │    └── key: (7)
+      │    └── filters
+      │         └── k = x [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       ├── scan xy
       │    ├── columns: x:5(int!null)
-      │    ├── key: (5)
-      │    └── ordering: +5
-      └── filters (true)
+      │    └── key: (5)
+      └── filters
+           └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # AntiJoin operator.
-opt expect=PruneJoinLeftCols
+norm expect=PruneJoinLeftCols
 SELECT a.i
 FROM a
 WHERE
@@ -926,91 +917,83 @@ WHERE
 ----
 project
  ├── columns: i:2(int)
- └── anti-join (lookup xy)
+ └── anti-join (hash)
       ├── columns: k:1(int!null) i:2(int)
-      ├── key columns: [1] = [5]
-      ├── lookup columns are key
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── anti-join (merge)
+      ├── anti-join (hash)
       │    ├── columns: k:1(int!null) i:2(int)
-      │    ├── left ordering: +1
-      │    ├── right ordering: +7
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2)
-      │    │    └── ordering: +1
+      │    │    └── fd: (1)-->(2)
       │    ├── scan xy
       │    │    ├── columns: x:7(int!null)
-      │    │    ├── key: (7)
-      │    │    └── ordering: +7
-      │    └── filters (true)
-      └── filters (true)
+      │    │    └── key: (7)
+      │    └── filters
+      │         └── k = x [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+      ├── scan xy
+      │    ├── columns: x:5(int!null)
+      │    └── key: (5)
+      └── filters
+           └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # --------------------------------------------------
 # PruneJoinRightCols
 # --------------------------------------------------
 
 # Columns used only by projection or on condition, but not both.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT xy.*, a.i FROM xy INNER JOIN a ON xy.x=a.k
 ----
 project
  ├── columns: x:1(int!null) y:2(int) i:4(int)
  ├── key: (1)
  ├── fd: (1)-->(2,4)
- └── inner-join (merge)
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int)
-      ├── left ordering: +1
-      ├── right ordering: +3
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
       ├── scan xy
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2)
-      │    └── ordering: +1
+      │    └── fd: (1)-->(2)
       ├── scan a
       │    ├── columns: k:3(int!null) i:4(int)
       │    ├── key: (3)
-      │    ├── fd: (3)-->(4)
-      │    └── ordering: +3
-      └── filters (true)
+      │    └── fd: (3)-->(4)
+      └── filters
+           └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Columns used by both projection and on condition, left join.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT xy.*, a.k, a.i FROM xy LEFT JOIN a ON xy.x=a.k AND a.i<xy.x
 ----
-left-join (merge)
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int)
- ├── left ordering: +1
- ├── right ordering: +3
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2)
  ├── select
  │    ├── columns: k:3(int!null) i:4(int!null)
  │    ├── key: (3)
  │    ├── fd: (3)-->(4)
- │    ├── ordering: +3
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4)
- │    │    └── ordering: +3
+ │    │    └── fd: (3)-->(4)
  │    └── filters
  │         └── i < k [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
- └── filters (true)
+ └── filters
+      └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Columns needed only by projection, full join.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT xy.*, a.k+1 AS r FROM xy FULL JOIN a ON True
 ----
 project
@@ -1032,7 +1015,7 @@ project
       └── k + 1 [type=int, outer=(3)]
 
 # No columns needed from right side of join.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT xy.* FROM xy, a
 ----
 inner-join (cross)
@@ -1046,7 +1029,7 @@ inner-join (cross)
  └── filters (true)
 
 # Computed columns.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT xy.*, a.k+1 AS r, a.i/2 AS s FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s||'o'='foo'
 ----
 project
@@ -1084,7 +1067,7 @@ project
       └── i / 2 [type=decimal, outer=(4), side-effects]
 
 # Join that is nested in another join.
-opt expect=PruneJoinRightCols
+norm expect=PruneJoinRightCols
 SELECT a.k, xy.*
 FROM xy
 INNER JOIN
@@ -1105,22 +1088,19 @@ project
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── inner-join (merge)
+      ├── inner-join (hash)
       │    ├── columns: k:3(int!null) x:7(int!null) y:8(int)
-      │    ├── left ordering: +3
-      │    ├── right ordering: +7
       │    ├── key: (7)
       │    ├── fd: (7)-->(8), (3)==(7), (7)==(3)
       │    ├── scan a
       │    │    ├── columns: k:3(int!null)
-      │    │    ├── key: (3)
-      │    │    └── ordering: +3
+      │    │    └── key: (3)
       │    ├── scan xy
       │    │    ├── columns: x:7(int!null) y:8(int)
       │    │    ├── key: (7)
-      │    │    ├── fd: (7)-->(8)
-      │    │    └── ordering: +7
-      │    └── filters (true)
+      │    │    └── fd: (7)-->(8)
+      │    └── filters
+      │         └── k = x [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
       └── filters
            └── y < y [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
 
@@ -1129,7 +1109,7 @@ project
 # --------------------------------------------------
 
 # Columns not needed by either side of join.
-opt expect=(PruneJoinLeftCols,PruneJoinRightCols)
+norm expect=(PruneJoinLeftCols,PruneJoinRightCols)
 SELECT 1 r FROM a,xy
 ----
 project
@@ -1143,27 +1123,24 @@ project
       └── const: 1 [type=int]
 
 # Subset of columns needed by each side of join.
-opt expect=(PruneJoinLeftCols,PruneJoinRightCols)
+norm expect=(PruneJoinLeftCols,PruneJoinRightCols)
 SELECT a.k, xy.x, a.k+xy.x AS r FROM a LEFT JOIN xy ON a.k=xy.x
 ----
 project
  ├── columns: k:1(int!null) x:5(int) r:7(int)
  ├── key: (1,5)
  ├── fd: (1,5)-->(7)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: k:1(int!null) x:5(int)
- │    ├── left ordering: +1
- │    ├── right ordering: +5
  │    ├── key: (1,5)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null)
- │    │    ├── key: (1)
- │    │    └── ordering: +1
+ │    │    └── key: (1)
  │    ├── scan xy
  │    │    ├── columns: x:5(int!null)
- │    │    ├── key: (5)
- │    │    └── ordering: +5
- │    └── filters (true)
+ │    │    └── key: (5)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
       └── k + x [type=int, outer=(1,5)]
 
@@ -1172,7 +1149,7 @@ project
 # --------------------------------------------------
 
 # Discard all aggregates.
-opt expect=PruneAggCols
+norm expect=PruneAggCols
 SELECT s FROM (SELECT s, sum(i), min(s||'foo') FROM a GROUP BY s) a
 ----
 distinct-on
@@ -1183,7 +1160,7 @@ distinct-on
       └── columns: s:4(string)
 
 # Discard subset of aggregates.
-opt expect=PruneAggCols
+norm expect=PruneAggCols
 SELECT s, sumi FROM (SELECT sum(i) sumi, s, min(s||'foo') FROM a GROUP BY s) a
 ----
 group-by
@@ -1198,7 +1175,7 @@ group-by
            └── variable: i [type=int]
 
 # No aggregates to discard.
-opt expect-not=PruneAggCols
+norm expect-not=PruneAggCols
 SELECT 1 r FROM (SELECT s FROM a GROUP BY s) a
 ----
 project
@@ -1214,7 +1191,7 @@ project
       └── const: 1 [type=int]
 
 # Scalar GroupBy case.
-opt expect=PruneAggCols
+norm expect=PruneAggCols
 SELECT sumi FROM (SELECT sum(i) sumi, min(s||'foo') FROM a) a
 ----
 scalar-group-by
@@ -1232,7 +1209,7 @@ scalar-group-by
       └── sum [type=decimal, outer=(2)]
            └── variable: i [type=int]
 
-opt expect=PruneAggCols
+norm expect=PruneAggCols
 SELECT f FROM (SELECT DISTINCT ON (i) f, s FROM a)
 ----
 project
@@ -1249,7 +1226,7 @@ project
                 └── variable: f [type=float]
 
 # Columns used only by aggregation, no grouping columns.
-opt expect=PruneAggCols
+norm expect=PruneAggCols
 SELECT min(i), max(k), max(k) FROM a ORDER BY max(f)
 ----
 scalar-group-by
@@ -1272,7 +1249,7 @@ scalar-group-by
 # --------------------------------------------------
 
 # Columns used by grouping or aggregation, but not both should not be pruned.
-opt expect=PruneGroupByCols
+norm expect=PruneGroupByCols
 SELECT s, sum(i) FROM a GROUP BY s, s||'foo'
 ----
 group-by
@@ -1287,7 +1264,7 @@ group-by
            └── variable: i [type=int]
 
 # Columns used by both grouping and aggregation should not be pruned.
-opt expect=PruneGroupByCols
+norm expect=PruneGroupByCols
 SELECT avg(s::int+i), s, i FROM a GROUP BY s, i, i+1
 ----
 group-by
@@ -1307,7 +1284,7 @@ group-by
            └── variable: column5 [type=int]
 
 # Columns used only by groupings, no aggregation columns.
-opt expect=PruneGroupByCols
+norm expect=PruneGroupByCols
 SELECT s, i+1 AS r FROM a GROUP BY i, s, s||'foo'
 ----
 project
@@ -1322,7 +1299,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Groupby a groupby.
-opt expect=PruneGroupByCols
+norm expect=PruneGroupByCols
 SELECT min(sm), i FROM (SELECT s, i, sum(k) sm, avg(k) av FROM a GROUP BY i, s) a GROUP BY i, i+1
 ----
 group-by
@@ -1347,7 +1324,7 @@ group-by
            └── variable: sum [type=decimal]
 
 # Distinct (GroupBy operator with no aggregates).
-opt expect=PruneGroupByCols
+norm expect=PruneGroupByCols
 SELECT DISTINCT ON (s, s||'foo') s, f FROM a
 ----
 distinct-on
@@ -1366,7 +1343,7 @@ distinct-on
 # --------------------------------------------------
 
 # Discard all but first Values column.
-opt expect=PruneValuesCols
+norm expect=PruneValuesCols
 SELECT column1 FROM (VALUES (1, 2), (3, 4)) a
 ----
 values
@@ -1376,7 +1353,7 @@ values
  └── (3,) [type=tuple{int}]
 
 # Discard all but middle Values column.
-opt expect=PruneValuesCols
+norm expect=PruneValuesCols
 SELECT column2 FROM (VALUES (1, 2, 3), (4, 5, 6)) a
 ----
 values
@@ -1386,7 +1363,7 @@ values
  └── (5,) [type=tuple{int}]
 
 # Discard all but last Values column.
-opt expect=PruneValuesCols
+norm expect=PruneValuesCols
 SELECT column3 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 values
@@ -1396,7 +1373,7 @@ values
  └── ('cherry',) [type=tuple{string}]
 
 # Discard all Values columns.
-opt expect=PruneValuesCols
+norm expect=PruneValuesCols
 SELECT 1 r FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 project
@@ -1414,39 +1391,35 @@ project
 # Prune - multiple combined operators
 # --------------------------------------------------
 
-opt
+norm
 SELECT a.k, xy.y FROM a INNER JOIN xy ON a.k=xy.x WHERE a.i < 5
 ----
 project
  ├── columns: k:1(int!null) y:6(int)
  ├── key: (1)
  ├── fd: (1)-->(6)
- └── inner-join (merge)
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int!null) x:5(int!null) y:6(int)
-      ├── left ordering: +1
-      ├── right ordering: +5
       ├── key: (5)
       ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
       ├── select
       │    ├── columns: k:1(int!null) i:2(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
-      │    ├── ordering: +1
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2)
-      │    │    └── ordering: +1
+      │    │    └── fd: (1)-->(2)
       │    └── filters
       │         └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       ├── scan xy
       │    ├── columns: x:5(int!null) y:6(int)
       │    ├── key: (5)
-      │    ├── fd: (5)-->(6)
-      │    └── ordering: +5
-      └── filters (true)
+      │    └── fd: (5)-->(6)
+      └── filters
+           └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
-opt
+norm
 SELECT k FROM (SELECT k, min(s) FROM a GROUP BY k HAVING sum(i) > 5)
 ----
 project
@@ -1459,14 +1432,12 @@ project
       ├── group-by
       │    ├── columns: k:1(int!null) sum:6(decimal)
       │    ├── grouping columns: k:1(int!null)
-      │    ├── internal-ordering: +1
       │    ├── key: (1)
       │    ├── fd: (1)-->(6)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2)
-      │    │    └── ordering: +1
+      │    │    └── fd: (1)-->(2)
       │    └── aggregations
       │         └── sum [type=decimal, outer=(2)]
       │              └── variable: i [type=int]
@@ -1476,7 +1447,7 @@ project
 # --------------------------------------------------
 # PruneOrdinalityCols
 # --------------------------------------------------
-opt expect=PruneOrdinalityCols
+norm expect=PruneOrdinalityCols
 SELECT i, s FROM a WITH ORDINALITY
 ----
 project
@@ -1489,7 +1460,7 @@ project
            └── columns: i:2(int) s:4(string)
 
 # With order by.
-opt expect=PruneOrdinalityCols
+norm expect=PruneOrdinalityCols
 SELECT i, s FROM (SELECT * FROM a ORDER BY f) WITH ORDINALITY
 ----
 project
@@ -1507,27 +1478,36 @@ project
 # --------------------------------------------------
 # PruneExplainCols
 # --------------------------------------------------
-opt expect=PruneExplainCols
+norm expect=PruneExplainCols
 EXPLAIN SELECT a FROM abcde WHERE b=1 AND c IS NOT NULL ORDER BY c, d
 ----
 explain
  ├── columns: tree:6(string) field:7(string) description:8(string)
- └── project
+ └── sort
       ├── columns: a:1(int!null)  [hidden: c:3(int!null)]
       ├── key: (1)
       ├── fd: (1)-->(3), (3)-->(1)
       ├── ordering: +3
-      └── scan abcde@bc
-           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-           ├── constraint: /2/3: (/1/NULL - /1]
+      └── project
+           ├── columns: a:1(int!null) c:3(int!null)
            ├── key: (1)
-           ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-           └── ordering: +3 opt(2) [actual: +3]
+           ├── fd: (1)-->(3), (3)-->(1)
+           └── select
+                ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+                ├── key: (1)
+                ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
+                ├── scan abcde
+                │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+                │    ├── key: (1)
+                │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+                └── filters
+                     ├── b = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+                     └── c IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
 
 # --------------------------------------------------
 # PruneProjectSetCols
 # --------------------------------------------------
-opt expect=PruneProjectSetCols
+norm expect=PruneProjectSetCols
 SELECT a, b, generate_series(c, 10) FROM abcde
 ----
 project
@@ -1538,7 +1518,7 @@ project
       ├── columns: a:1(int!null) b:2(int) c:3(int) generate_series:6(int)
       ├── side-effects
       ├── fd: (1)-->(2,3), (2,3)~~>(1)
-      ├── scan abcde@bc
+      ├── scan abcde
       │    ├── columns: a:1(int!null) b:2(int) c:3(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -1547,7 +1527,7 @@ project
                 ├── variable: c [type=int]
                 └── const: 10 [type=int]
 
-opt expect=PruneProjectSetCols
+norm expect=PruneProjectSetCols
 SELECT k FROM a WHERE EXISTS(SELECT * FROM ROWS FROM (generate_series(i, k), length(s)))
 ----
 distinct-on
@@ -1745,7 +1725,7 @@ project
 # --------------------------------------------------
 
 # Prune all but the key column.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 DELETE FROM a
 ----
 delete a
@@ -1758,7 +1738,7 @@ delete a
       └── key: (5)
 
 # Prune when computed ordering column is present.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 DELETE FROM a WHERE i > 0 ORDER BY i*2 LIMIT 10
 ----
 delete a
@@ -1797,7 +1777,7 @@ delete a
       └── const: 10 [type=int]
 
 # Prune when a secondary index is present on the table.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 DELETE FROM abcde WHERE a > 0
 ----
 delete abcde
@@ -1805,14 +1785,19 @@ delete abcde
  ├── fetch columns: a:6(int) b:7(int) c:8(int)
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── scan abcde
+ └── select
       ├── columns: a:6(int!null) b:7(int) c:8(int)
-      ├── constraint: /6: [/1 - ]
       ├── key: (6)
-      └── fd: (6)-->(7,8), (7,8)~~>(6)
+      ├── fd: (6)-->(7,8), (7,8)~~>(6)
+      ├── scan abcde
+      │    ├── columns: a:6(int!null) b:7(int) c:8(int)
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8), (7,8)~~>(6)
+      └── filters
+           └── a > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
 
 # Prune when mutation columns/indexes exist.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 DELETE FROM mutation
 ----
 delete mutation
@@ -1825,7 +1810,7 @@ delete mutation
       ├── key: (6)
       └── fd: (6)-->(7,9,10)
 
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 DELETE FROM a RETURNING k, s
 ----
 delete a
@@ -1840,7 +1825,7 @@ delete a
       └── fd: (5)-->(8)
 
 # Prune secondary family column not needed for the update.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 UPDATE family SET b=c WHERE a > 100
 ----
 update "family"
@@ -1850,14 +1835,19 @@ update "family"
  │    └──  c:8 => b:2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── scan "family"
+ └── select
       ├── columns: a:6(int!null) b:7(int) c:8(int)
-      ├── constraint: /6: [/101 - ]
       ├── key: (6)
-      └── fd: (6)-->(7,8)
+      ├── fd: (6)-->(7,8)
+      ├── scan "family"
+      │    ├── columns: a:6(int!null) b:7(int) c:8(int)
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           └── a > 100 [type=bool, outer=(6), constraints=(/6: [/101 - ]; tight)]
 
 # Do not prune when key column is updated.
-opt expect-not=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect-not=(PruneMutationFetchCols,PruneMutationInputCols)
 UPDATE family SET a=a+1 WHERE a > 100
 ----
 update "family"
@@ -1871,16 +1861,21 @@ update "family"
       ├── columns: column11:11(int) a:6(int!null) b:7(int) c:8(int) d:9(int) e:10(int)
       ├── key: (6)
       ├── fd: (6)-->(7-11)
-      ├── scan "family"
+      ├── select
       │    ├── columns: a:6(int!null) b:7(int) c:8(int) d:9(int) e:10(int)
-      │    ├── constraint: /6: [/101 - ]
       │    ├── key: (6)
-      │    └── fd: (6)-->(7-10)
+      │    ├── fd: (6)-->(7-10)
+      │    ├── scan "family"
+      │    │    ├── columns: a:6(int!null) b:7(int) c:8(int) d:9(int) e:10(int)
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7-10)
+      │    └── filters
+      │         └── a > 100 [type=bool, outer=(6), constraints=(/6: [/101 - ]; tight)]
       └── projections
            └── a + 1 [type=int, outer=(6)]
 
 # Do not prune columns that must be returned.
-opt expect=(PruneMutationFetchCols, PruneMutationReturnCols)
+norm expect=(PruneMutationFetchCols, PruneMutationReturnCols)
 UPDATE family SET c=c+1 RETURNING b
 ----
 project
@@ -1906,7 +1901,7 @@ project
                 └── c + 1 [type=int, outer=(8)]
 
 # Prune unused upsert columns.
-opt expect=PruneMutationInputCols
+norm expect=PruneMutationInputCols
 INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1
 ----
 upsert a
@@ -1938,19 +1933,24 @@ upsert a
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5-8)
       │    │    └── (1, 'foo', NULL, NULL) [type=tuple{int, string, int, float}]
-      │    ├── scan a
+      │    ├── select
       │    │    ├── columns: k:9(int!null) i:10(int) f:11(float) s:12(string)
-      │    │    ├── constraint: /9: [/1 - /1]
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(9-12)
+      │    │    ├── fd: ()-->(9-12)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:9(int!null) i:10(int) f:11(float) s:12(string)
+      │    │    │    ├── key: (9)
+      │    │    │    └── fd: (9)-->(10-12)
+      │    │    └── filters
+      │    │         └── k = 1 [type=bool, outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
       │    └── filters (true)
       └── projections
            └── CASE WHEN k IS NULL THEN column7 ELSE i + 1 END [type=int, outer=(7,9,10)]
 
 # Prune update columns replaced by upsert columns.
 # TODO(andyk): Need to also prune output columns.
-opt expect=PruneMutationInputCols expect-not=PruneMutationFetchCols
+norm expect=PruneMutationInputCols expect-not=PruneMutationFetchCols
 INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1 RETURNING *
 ----
 upsert a
@@ -1989,12 +1989,17 @@ upsert a
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5-8)
       │    │    └── (1, 'foo', NULL, NULL) [type=tuple{int, string, int, float}]
-      │    ├── scan a
+      │    ├── select
       │    │    ├── columns: k:9(int!null) i:10(int) f:11(float) s:12(string)
-      │    │    ├── constraint: /9: [/1 - /1]
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(9-12)
+      │    │    ├── fd: ()-->(9-12)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:9(int!null) i:10(int) f:11(float) s:12(string)
+      │    │    │    ├── key: (9)
+      │    │    │    └── fd: (9)-->(10-12)
+      │    │    └── filters
+      │    │         └── k = 1 [type=bool, outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
       │    └── filters (true)
       └── projections
            ├── CASE WHEN k IS NULL THEN column1 ELSE k END [type=int, outer=(5,9)]
@@ -2003,7 +2008,7 @@ upsert a
            └── CASE WHEN k IS NULL THEN column2 ELSE s END [type=string, outer=(6,9,12)]
 
 # Prune column in column family that is not updated.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 UPSERT INTO family (a, b) VALUES (1, 2)
 ----
 upsert "family"
@@ -2031,15 +2036,20 @@ upsert "family"
       │    ├── key: ()
       │    ├── fd: ()-->(6-8)
       │    └── (1, 2, NULL) [type=tuple{int, int, int}]
-      ├── scan "family"
+      ├── select
       │    ├── columns: a:9(int!null) b:10(int)
-      │    ├── constraint: /9: [/1 - /1]
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
-      │    └── fd: ()-->(9,10)
+      │    ├── fd: ()-->(9,10)
+      │    ├── scan "family"
+      │    │    ├── columns: a:9(int!null) b:10(int)
+      │    │    ├── key: (9)
+      │    │    └── fd: (9)-->(10)
+      │    └── filters
+      │         └── a = 1 [type=bool, outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
       └── filters (true)
 
-opt
+norm
 INSERT INTO family VALUES (1, 2, 3, 4, 5) ON CONFLICT (a) DO UPDATE SET c = 10 RETURNING e
 ----
 project
@@ -2083,12 +2093,17 @@ project
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(6-10)
            │    │    └── (1, 2, 3, 4, 5) [type=tuple{int, int, int, int, int}]
-           │    ├── scan "family"
+           │    ├── select
            │    │    ├── columns: a:11(int!null) c:13(int) d:14(int) e:15(int)
-           │    │    ├── constraint: /11: [/1 - /1]
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── key: ()
-           │    │    └── fd: ()-->(11,13-15)
+           │    │    ├── fd: ()-->(11,13-15)
+           │    │    ├── scan "family"
+           │    │    │    ├── columns: a:11(int!null) c:13(int) d:14(int) e:15(int)
+           │    │    │    ├── key: (11)
+           │    │    │    └── fd: (11)-->(13-15)
+           │    │    └── filters
+           │    │         └── a = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
            │    └── filters (true)
            └── projections
                 ├── CASE WHEN a IS NULL THEN column1 ELSE a END [type=int, outer=(6,11)]
@@ -2097,7 +2112,7 @@ project
 
 # Do not prune column in same secondary family as updated column. But prune
 # non-key column in primary family.
-opt expect=(PruneMutationFetchCols,PruneMutationInputCols)
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 INSERT INTO family VALUES (1, 2, 3, 4) ON CONFLICT (a) DO UPDATE SET d=10
 ----
 upsert "family"
@@ -2130,18 +2145,23 @@ upsert "family"
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-10)
       │    │    └── (1, 2, 3, 4, NULL) [type=tuple{int, int, int, int, int}]
-      │    ├── scan "family"
+      │    ├── select
       │    │    ├── columns: a:11(int!null) c:13(int) d:14(int)
-      │    │    ├── constraint: /11: [/1 - /1]
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(11,13,14)
+      │    │    ├── fd: ()-->(11,13,14)
+      │    │    ├── scan "family"
+      │    │    │    ├── columns: a:11(int!null) c:13(int) d:14(int)
+      │    │    │    ├── key: (11)
+      │    │    │    └── fd: (11)-->(13,14)
+      │    │    └── filters
+      │    │         └── a = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
       │    └── filters (true)
       └── projections
            └── CASE WHEN a IS NULL THEN column4 ELSE 10 END [type=int, outer=(9,11)]
 
 # Prune upsert columns when mutation columns/indexes exist.
-opt expect=(PruneMutationInputCols)
+norm expect=(PruneMutationInputCols)
 INSERT INTO mutation VALUES (1, 2, 3) ON CONFLICT (a) DO UPDATE SET b=10
 ----
 upsert mutation
@@ -2173,12 +2193,17 @@ upsert mutation
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
       │    │    └── (1, 2, 3, NULL) [type=tuple{int, int, int, int}]
-      │    ├── scan mutation
+      │    ├── select
       │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int)
-      │    │    ├── constraint: /10: [/1 - /1]
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    └── fd: ()-->(10-14)
+      │    │    ├── fd: ()-->(10-14)
+      │    │    ├── scan mutation
+      │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int)
+      │    │    │    ├── key: (10)
+      │    │    │    └── fd: (10)-->(11-14)
+      │    │    └── filters
+      │    │         └── a = 1 [type=bool, outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    └── filters (true)
       └── projections
            └── CASE WHEN a IS NULL THEN column2 ELSE 10 END [type=int, outer=(7,10)]
@@ -2206,7 +2231,7 @@ CREATE TABLE returning_test (
 ----
 
 # Fetch all the columns for the RETURN expression.
-opt
+norm
 UPDATE returning_test SET a = a + 1 RETURNING *
 ----
 project
@@ -2233,7 +2258,7 @@ project
 
 
 # Fetch all the columns in the (d, e, f, g) family as d is being set.
-opt
+norm
 UPDATE returning_test SET d = a + d RETURNING a, d
 ----
 project
@@ -2261,7 +2286,7 @@ project
                 └── a + d [type=int, outer=(9,12)]
 
 # Fetch only whats being updated (not the (d, e, f, g) family).
-opt
+norm
 UPDATE returning_test SET a = a + d RETURNING a
 ----
 project
@@ -2287,7 +2312,7 @@ project
                 └── a + d [type=int, outer=(9,12)]
 
 # We only fetch the minimal set of columns which is (a, b, c, rowid).
-opt
+norm
 UPDATE returning_test SET (b, a) = (a, a + b) RETURNING a, b, c
 ----
 project
@@ -2319,7 +2344,7 @@ project
 # We apply the PruneMutationReturnCols rule multiple times, to get
 # the minimal set of columns which is (a, rowid). Notice how c and b
 # are pruned away.
-opt
+norm
 SELECT a FROM [SELECT a, b FROM [UPDATE returning_test SET a = a + 1 RETURNING a, b, c]]
 ----
 with &1
@@ -2359,7 +2384,7 @@ with &1
 # can prune away columns even when the mutation is not under a
 # projection. Another rule will fire to add the appropriate
 # projection when this happens.
-opt
+norm
 SELECT a FROM [SELECT a, b FROM [UPDATE returning_test SET a = a + 1 RETURNING a, b, c] WHERE a > 1]
 ----
 with &1
@@ -2399,7 +2424,7 @@ with &1
       └── projections
            └── variable: a [type=int, outer=(18)]
 
-opt
+norm
 SELECT
     *
 FROM
@@ -2459,7 +2484,7 @@ with &2
       └── filters (true)
 
 # Check if the rule works as desired for other mutations.
-opt
+norm
 INSERT INTO returning_test VALUES (1, 2, 'c') ON CONFLICT (a) DO UPDATE SET a = excluded.a + returning_test.a RETURNING a, b, c
 ----
 project
@@ -2511,17 +2536,17 @@ project
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(9-13)
            │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid()) [type=tuple{int, int, string, int, int}]
-           │    ├── index-join returning_test
+           │    ├── select
            │    │    ├── columns: a:14(int!null) b:15(int) c:16(string) rowid:21(int!null)
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(14-16,21)
-           │    │    └── scan returning_test@secondary
-           │    │         ├── columns: a:14(int!null) rowid:21(int!null)
-           │    │         ├── constraint: /14: [/1 - /1]
-           │    │         ├── cardinality: [0 - 1]
-           │    │         ├── key: ()
-           │    │         └── fd: ()-->(14,21)
+           │    │    ├── scan returning_test
+           │    │    │    ├── columns: a:14(int) b:15(int) c:16(string) rowid:21(int!null)
+           │    │    │    ├── key: (21)
+           │    │    │    └── fd: (21)-->(14-16), (14)~~>(15,16,21)
+           │    │    └── filters
+           │    │         └── a = 1 [type=bool, outer=(14), constraints=(/14: [/1 - /1]; tight), fd=()-->(14)]
            │    └── filters (true)
            └── projections
                 ├── CASE WHEN rowid IS NULL THEN column1 ELSE column1 + a END [type=int, outer=(9,14,21)]
@@ -2529,7 +2554,7 @@ project
                 ├── CASE WHEN rowid IS NULL THEN column3 ELSE c END [type=string, outer=(11,16,21)]
                 └── CASE WHEN rowid IS NULL THEN column13 ELSE rowid END [type=int, outer=(13,21)]
 
-opt
+norm
 DELETE FROM returning_test WHERE a < b + d RETURNING a, b, d
 ----
 project
@@ -2554,7 +2579,7 @@ project
            └── filters
                 └── a < (b + d) [type=bool, outer=(9,10,12), constraints=(/9: (/NULL - ])]
 
-opt
+norm
 UPSERT INTO returning_test (a, b, c) VALUES (1, 2, 'c') RETURNING a, b, c, d
 ----
 project
@@ -2594,10 +2619,8 @@ project
            ├── side-effects
            ├── key: (21)
            ├── fd: ()-->(9-13), (21)-->(14-17), (14)~~>(15-17,21), (17,21)-->(22), (21)-->(26)
-           ├── left-join (lookup returning_test)
+           ├── left-join (hash)
            │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(string!null) column12:12(int) column13:13(int) a:14(int) b:15(int) c:16(string) d:17(int) rowid:21(int)
-           │    ├── key columns: [13] = [21]
-           │    ├── lookup columns are key
            │    ├── cardinality: [1 - ]
            │    ├── side-effects
            │    ├── key: (21)
@@ -2609,13 +2632,18 @@ project
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(9-13)
            │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid()) [type=tuple{int, int, string, int, int}]
-           │    └── filters (true)
+           │    ├── scan returning_test
+           │    │    ├── columns: a:14(int) b:15(int) c:16(string) d:17(int) rowid:21(int!null)
+           │    │    ├── key: (21)
+           │    │    └── fd: (21)-->(14-17), (14)~~>(15-17,21)
+           │    └── filters
+           │         └── column13 = rowid [type=bool, outer=(13,21), constraints=(/13: (/NULL - ]; /21: (/NULL - ]), fd=(13)==(21), (21)==(13)]
            └── projections
                 ├── CASE WHEN rowid IS NULL THEN column12 ELSE d END [type=int, outer=(12,17,21)]
                 └── CASE WHEN rowid IS NULL THEN column13 ELSE rowid END [type=int, outer=(13,21)]
 
 # Make sure the passthrough columns of an UPDATE ... FROM query are pruned.
-opt
+norm
 UPDATE abcde
 SET
   b=family.b, c = family.c
@@ -2635,55 +2663,52 @@ update abcde
  ├── side-effects, mutations
  ├── key: (1)
  ├── fd: (1)-->(12,13)
- └── inner-join (merge)
+ └── inner-join (hash)
       ├── columns: abcde.a:6(int!null) abcde.b:7(int) abcde.c:8(int) abcde.d:9(int) abcde.e:10(int) "family".a:11(int!null) "family".b:12(int) "family".c:13(int)
-      ├── left ordering: +6
-      ├── right ordering: +11
       ├── key: (11)
       ├── fd: (6)-->(7-10), (7,8)~~>(6,9,10), (11)-->(12,13), (6)==(11), (11)==(6)
       ├── scan abcde
       │    ├── columns: abcde.a:6(int!null) abcde.b:7(int) abcde.c:8(int) abcde.d:9(int) abcde.e:10(int)
       │    ├── key: (6)
-      │    ├── fd: (6)-->(7-10), (7,8)~~>(6,9,10)
-      │    └── ordering: +6
+      │    └── fd: (6)-->(7-10), (7,8)~~>(6,9,10)
       ├── scan "family"
       │    ├── columns: "family".a:11(int!null) "family".b:12(int) "family".c:13(int)
       │    ├── key: (11)
-      │    ├── fd: (11)-->(12,13)
-      │    └── ordering: +11
-      └── filters (true)
+      │    └── fd: (11)-->(12,13)
+      └── filters
+           └── abcde.a = "family".a [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
 
 # --------------------------------------------------
 # PruneSemiAntiJoinRightCols
 # --------------------------------------------------
 
 # We should only see the `a` column scanned for family.
-opt expect=PruneSemiAntiJoinRightCols
+norm expect=PruneSemiAntiJoinRightCols
 SELECT a, b, c FROM abcde WHERE EXISTS (SELECT * FROM family WHERE abcde.a=family.a)
 ----
 semi-join (hash)
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null) abcde.b:2(int) abcde.c:3(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan "family"@secondary
+ ├── scan "family"
  │    ├── columns: "family".a:6(int!null)
  │    └── key: (6)
  └── filters
       └── abcde.a = "family".a [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # We should see the `a`, `b` and `c` columns scanned for family.
-opt expect=PruneSemiAntiJoinRightCols
+norm expect=PruneSemiAntiJoinRightCols
 SELECT a, b, c FROM abcde WHERE EXISTS (SELECT * FROM family WHERE abcde.a=family.a AND abcde.b > family.b + family.c)
 ----
 semi-join (hash)
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null) abcde.b:2(int) abcde.c:3(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -2695,25 +2720,25 @@ semi-join (hash)
       ├── abcde.a = "family".a [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── abcde.b > ("family".b + "family".c) [type=bool, outer=(2,7,8), constraints=(/2: (/NULL - ])]
 
-opt expect=PruneSemiAntiJoinRightCols
+norm expect=PruneSemiAntiJoinRightCols
 SELECT a, b, c FROM abcde WHERE NOT EXISTS (SELECT * FROM family WHERE abcde.a=family.a)
 ----
 anti-join (hash)
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null) abcde.b:2(int) abcde.c:3(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan "family"@secondary
+ ├── scan "family"
  │    ├── columns: "family".a:6(int!null)
  │    └── key: (6)
  └── filters
       └── abcde.a = "family".a [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Test using multi-level nesting so we don't decorrelate the semi-join.
-opt expect=PruneSemiAntiJoinRightCols
+norm expect=PruneSemiAntiJoinRightCols
 SELECT
     a, b, c
 FROM
@@ -2732,7 +2757,7 @@ semi-join-apply
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null) abcde.b:2(int) abcde.c:3(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -2740,7 +2765,7 @@ semi-join-apply
  │    ├── columns: "family".a:6(int!null)
  │    ├── outer: (1)
  │    ├── key: (6)
- │    ├── scan "family"@secondary
+ │    ├── scan "family"
  │    │    ├── columns: "family".a:6(int!null)
  │    │    └── key: (6)
  │    ├── scan a
@@ -2752,7 +2777,7 @@ semi-join-apply
       └── abcde.a = "family".a [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Test using multi-level nesting so we don't decorrelate the anti-join.
-opt expect=PruneSemiAntiJoinRightCols
+norm expect=PruneSemiAntiJoinRightCols
 SELECT
     a, b, c
 FROM
@@ -2771,7 +2796,7 @@ anti-join-apply
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null) abcde.b:2(int) abcde.c:3(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -2779,7 +2804,7 @@ anti-join-apply
  │    ├── columns: "family".a:6(int!null)
  │    ├── outer: (1)
  │    ├── key: (6)
- │    ├── scan "family"@secondary
+ │    ├── scan "family"
  │    │    ├── columns: "family".a:6(int!null)
  │    │    └── key: (6)
  │    ├── scan a
@@ -2790,7 +2815,7 @@ anti-join-apply
  └── filters
       └── abcde.a = "family".a [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt disable=InlineWith expect=PruneWithScanCols
+norm disable=InlineWith expect=PruneWithScanCols
 WITH foo AS (SELECT * FROM a)
   SELECT i FROM foo
 ----
@@ -2805,7 +2830,7 @@ with &1 (foo)
       └── mapping:
            └──  a.i:2(int) => i:6(int)
 
-opt disable=InlineWith format=show-all expect=PruneWithCols
+norm disable=InlineWith format=show-all expect=PruneWithCols
 WITH foo AS (SELECT * FROM a)
   SELECT i FROM (SELECT i, 1 AS y FROM foo) ORDER BY y
 ----
@@ -2835,7 +2860,7 @@ with &1 (foo)
 # PruneUnionAllCols
 # --------------------------------------------------
 
-opt expect=PruneUnionAllCols
+norm expect=PruneUnionAllCols
 SELECT a FROM (
   SELECT a, b FROM abcde
   UNION ALL
@@ -2846,14 +2871,14 @@ union-all
  ├── columns: a:8(int!null)
  ├── left columns: abcde.a:1(int)
  ├── right columns: x:6(int)
- ├── scan abcde@bc
+ ├── scan abcde
  │    ├── columns: abcde.a:1(int!null)
  │    └── key: (1)
  └── scan xy
       ├── columns: x:6(int!null)
       └── key: (6)
 
-opt expect=PruneUnionAllCols
+norm expect=PruneUnionAllCols
 SELECT count(*) FROM (
   SELECT a, b FROM abcde
   UNION ALL
@@ -2866,12 +2891,12 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(10)
  ├── union-all
- │    ├── scan abcde@bc
+ │    ├── scan abcde
  │    └── scan xy
  └── aggregations
       └── count-rows [type=int]
 
-opt expect=PruneUnionAllCols
+norm expect=PruneUnionAllCols
 SELECT 1 FROM (SELECT a FROM abcde WHERE a > 3 UNION ALL SELECT a FROM abcde)
 ----
 project
@@ -2879,15 +2904,19 @@ project
  ├── fd: ()-->(12)
  ├── union-all
  │    ├── project
- │    │    └── scan abcde
+ │    │    └── select
  │    │         ├── columns: abcde.a:1(int!null)
- │    │         ├── constraint: /1: [/4 - ]
- │    │         └── key: (1)
- │    └── scan abcde@bc
+ │    │         ├── key: (1)
+ │    │         ├── scan abcde
+ │    │         │    ├── columns: abcde.a:1(int!null)
+ │    │         │    └── key: (1)
+ │    │         └── filters
+ │    │              └── abcde.a > 3 [type=bool, outer=(1), constraints=(/1: [/4 - ]; tight)]
+ │    └── scan abcde
  └── projections
       └── const: 1 [type=int]
 
-opt expect=PruneUnionAllCols
+norm expect=PruneUnionAllCols
 SELECT 1 FROM a INNER JOIN (SELECT a, b FROM abcde UNION ALL SELECT * from xy) AS b ON a.i=b.b
 ----
 project
@@ -2896,16 +2925,16 @@ project
  ├── inner-join (hash)
  │    ├── columns: i:2(int!null) b:13(int!null)
  │    ├── fd: (2)==(13), (13)==(2)
+ │    ├── scan a
+ │    │    └── columns: i:2(int)
  │    ├── union-all
  │    │    ├── columns: b:13(int)
  │    │    ├── left columns: abcde.b:6(int)
  │    │    ├── right columns: y:11(int)
- │    │    ├── scan abcde@bc
+ │    │    ├── scan abcde
  │    │    │    └── columns: abcde.b:6(int)
  │    │    └── scan xy
  │    │         └── columns: y:11(int)
- │    ├── scan a
- │    │    └── columns: i:2(int)
  │    └── filters
  │         └── i = b [type=bool, outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
  └── projections
@@ -2917,7 +2946,7 @@ project
 # Scan has a filter and cannot prune column x), a Project is added to
 # ensure that both inputs to the UnionAll have the same number of
 # columns.
-opt expect=PruneUnionAllCols
+norm expect=PruneUnionAllCols
 SELECT 1 FROM (
   SELECT a, b FROM abcde
   UNION ALL
@@ -2928,16 +2957,20 @@ project
  ├── columns: "?column?":10(int!null)
  ├── fd: ()-->(10)
  ├── union-all
- │    ├── scan abcde@bc
+ │    ├── scan abcde
  │    └── project
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── scan xy
+ │         └── select
  │              ├── columns: x:6(int!null)
- │              ├── constraint: /6: [/1 - /1]
  │              ├── cardinality: [0 - 1]
  │              ├── key: ()
- │              └── fd: ()-->(6)
+ │              ├── fd: ()-->(6)
+ │              ├── scan xy
+ │              │    ├── columns: x:6(int!null)
+ │              │    └── key: (6)
+ │              └── filters
+ │                   └── x = 1 [type=bool, outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
  └── projections
       └── const: 1 [type=int]
 

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -14,7 +14,7 @@ CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 # RejectNullsLeftJoin + RejectNullsRightJoin
 # ----------------------------------------------------------
 
-opt expect=RejectNullsRightJoin
+norm expect=RejectNullsRightJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL
 ----
 left-join (cross)
@@ -31,26 +31,31 @@ left-join (cross)
  │    └── fd: (5)-->(6)
  └── filters (true)
 
-opt expect=RejectNullsLeftJoin
+norm expect=RejectNullsLeftJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE xy.x > 5
 ----
-right-join (cross)
+left-join (cross)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── key: (1,5)
  ├── fd: (5)-->(6), (1)-->(2-4)
+ ├── select
+ │    ├── columns: x:5(int!null) y:6(int)
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(6)
+ │    ├── scan xy
+ │    │    ├── columns: x:5(int!null) y:6(int)
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── x > 5 [type=bool, outer=(5), constraints=(/5: [/6 - ]; tight)]
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
- ├── scan xy
- │    ├── columns: x:5(int!null) y:6(int)
- │    ├── constraint: /5: [/6 - ]
- │    ├── key: (5)
- │    └── fd: (5)-->(6)
  └── filters (true)
 
 # Inner-join operator.
-opt expect=RejectNullsLeftJoin
+norm expect=RejectNullsLeftJoin
 SELECT *
 FROM (SELECT * FROM a LEFT JOIN uv ON True) AS l
 INNER JOIN (SELECT * FROM a LEFT JOIN uv ON True) AS r
@@ -61,84 +66,91 @@ inner-join (cross)
  ├── key: (1,7,11)
  ├── fd: ()-->(5,6), (1)-->(2-4), (7)-->(8-10), (11)-->(12)
  ├── inner-join (cross)
- │    ├── columns: u:5(int!null) v:6(int) k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:5(int!null) v:6(int)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(5,6), (1)-->(2-4)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── select
+ │    │    ├── columns: u:5(int!null) v:6(int)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(5,6)
+ │    │    ├── scan uv
+ │    │    │    ├── columns: u:5(int!null) v:6(int)
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    └── filters
+ │    │         └── u = 1 [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+ │    └── filters (true)
+ ├── inner-join (cross)
+ │    ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
  │    ├── key: (7,11)
- │    ├── fd: ()-->(5,6), (7)-->(8-10), (11)-->(12)
+ │    ├── fd: (7)-->(8-10), (11)-->(12)
  │    ├── scan a
  │    │    ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string)
  │    │    ├── key: (7)
  │    │    └── fd: (7)-->(8-10)
- │    ├── inner-join (cross)
- │    │    ├── columns: u:5(int!null) v:6(int) u:11(int!null) v:12(int!null)
+ │    ├── select
+ │    │    ├── columns: u:11(int!null) v:12(int!null)
  │    │    ├── key: (11)
- │    │    ├── fd: ()-->(5,6), (11)-->(12)
- │    │    ├── select
- │    │    │    ├── columns: u:11(int!null) v:12(int!null)
- │    │    │    ├── key: (11)
- │    │    │    ├── fd: (11)-->(12)
- │    │    │    ├── scan uv
- │    │    │    │    ├── columns: u:11(int!null) v:12(int)
- │    │    │    │    ├── key: (11)
- │    │    │    │    └── fd: (11)-->(12)
- │    │    │    └── filters
- │    │    │         └── v > 2 [type=bool, outer=(12), constraints=(/12: [/3 - ]; tight)]
+ │    │    ├── fd: (11)-->(12)
  │    │    ├── scan uv
- │    │    │    ├── columns: u:5(int!null) v:6(int)
- │    │    │    ├── constraint: /5: [/1 - /1]
- │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(5,6)
- │    │    └── filters (true)
+ │    │    │    ├── columns: u:11(int!null) v:12(int)
+ │    │    │    ├── key: (11)
+ │    │    │    └── fd: (11)-->(12)
+ │    │    └── filters
+ │    │         └── v > 2 [type=bool, outer=(12), constraints=(/12: [/3 - ]; tight)]
  │    └── filters (true)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
  └── filters (true)
 
 # Left-join operator.
-opt expect=RejectNullsLeftJoin
+norm expect=RejectNullsLeftJoin
 SELECT * FROM a LEFT JOIN xy ON true WHERE xy.x = a.k
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
- ├── left ordering: +1
- ├── right ordering: +5
  ├── key: (5)
  ├── fd: (1)-->(2-4), (5)-->(6), (1)==(5), (5)==(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-4)
  ├── scan xy
  │    ├── columns: x:5(int!null) y:6(int)
  │    ├── key: (5)
- │    ├── fd: (5)-->(6)
- │    └── ordering: +5
- └── filters (true)
+ │    └── fd: (5)-->(6)
+ └── filters
+      └── x = k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # Full-join operator.
-opt expect=RejectNullsLeftJoin
+norm expect=RejectNullsLeftJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL AND xy.x > 5
 ----
 inner-join (cross)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── key: (1,5)
  ├── fd: (5)-->(6), (1)-->(2-4)
+ ├── select
+ │    ├── columns: x:5(int!null) y:6(int)
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(6)
+ │    ├── scan xy
+ │    │    ├── columns: x:5(int!null) y:6(int)
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── x > 5 [type=bool, outer=(5), constraints=(/5: [/6 - ]; tight)]
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
- ├── scan xy
- │    ├── columns: x:5(int!null) y:6(int)
- │    ├── constraint: /5: [/6 - ]
- │    ├── key: (5)
- │    └── fd: (5)-->(6)
  └── filters (true)
 
 # Apply operators.
-opt expect=(RejectNullsLeftJoin,RejectNullsRightJoin)
+norm expect=(RejectNullsLeftJoin,RejectNullsRightJoin)
 SELECT *
 FROM (SELECT * FROM a FULL JOIN xy ON True)
 WHERE (SELECT u FROM uv WHERE v=k)=i
@@ -147,14 +159,10 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
- └── right-join (cross)
+ └── left-join (cross)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int) u:7(int!null)
       ├── key: (1,5)
       ├── fd: (1)-->(2-4,7), (2)==(7), (7)==(2), (5)-->(6)
-      ├── scan xy
-      │    ├── columns: x:5(int!null) y:6(int)
-      │    ├── key: (5)
-      │    └── fd: (5)-->(6)
       ├── inner-join-apply
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:7(int!null)
       │    ├── key: (1)
@@ -186,6 +194,10 @@ project
       │    │                   └── v = k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       │    └── filters
       │         └── i = u [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+      ├── scan xy
+      │    ├── columns: x:5(int!null) y:6(int)
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
       └── filters (true)
 
 # ----------------------------------------------------------
@@ -193,7 +205,7 @@ project
 # ----------------------------------------------------------
 
 # Single max aggregate function.
-opt expect=RejectNullsGroupBy
+norm expect=RejectNullsGroupBy
 SELECT max(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -230,7 +242,7 @@ project
            └── max = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Aggregate function with DISTINCT.
-opt expect=RejectNullsGroupBy
+norm expect=RejectNullsGroupBy
 SELECT sum(DISTINCT y)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT y FROM xy)
@@ -270,7 +282,7 @@ project
            └── sum = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Single max aggregate function without grouping columns.
-opt expect=RejectNullsGroupBy
+norm expect=RejectNullsGroupBy
 SELECT max(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -301,7 +313,7 @@ select
       └── max = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Multiple aggregate functions on same column.
-opt expect=RejectNullsGroupBy
+norm expect=RejectNullsGroupBy
 SELECT min(x), max(x)
 FROM a
 LEFT JOIN xy
@@ -340,7 +352,7 @@ project
            └── min = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Multiple aggregate functions on same column, some with DISTINCT.
-opt expect=RejectNullsGroupBy
+norm expect=RejectNullsGroupBy
 SELECT sum(DISTINCT y), max(y)
 FROM a
 LEFT JOIN xy
@@ -443,7 +455,7 @@ select
       └── sum = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight), fd=()-->(5)]
 
 # Don't reject nulls when multiple columns are used.
-opt expect-not=RejectNullsGroupBy
+norm expect-not=RejectNullsGroupBy
 SELECT min(x), max(y)
 FROM (select k from a)
 LEFT JOIN (select x, y from xy)
@@ -485,7 +497,7 @@ project
 
 # Don't reject column when count function is used (it doesn't return nil when
 # input is empty).
-opt expect-not=RejectNullsGroupBy
+norm expect-not=RejectNullsGroupBy
 SELECT count(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -526,7 +538,7 @@ project
 # rule no longer triggers RejectNullsGroupBy. Find another way to decorrelate
 # this query.
 # opt expect=RejectNullsGroupBy
-opt
+norm
 SELECT 1 FROM a AS ref_0 LEFT JOIN a AS ref_1 ON EXISTS(SELECT 1 FROM a WHERE a.s = ref_0.s)
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -8,7 +8,7 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
 
 # Put variables on both sides of comparison operator to avoid matching constant
 # patterns.
-opt expect=CommuteVar
+norm expect=CommuteVar
 SELECT
     (1+i) = k AS r,
     (2-k) <> i AS s,
@@ -42,7 +42,7 @@ project
 # --------------------------------------------------
 # CommuteConst
 # --------------------------------------------------
-opt expect=CommuteConst
+norm expect=CommuteConst
 SELECT
     (length('foo')+1) = (i+k) AS r,
     length('bar') <> (i*2) AS s,
@@ -76,7 +76,7 @@ project
 # --------------------------------------------------
 # EliminateCoalesce
 # --------------------------------------------------
-opt expect=EliminateCoalesce
+norm expect=EliminateCoalesce
 SELECT COALESCE(i) FROM a
 ----
 project
@@ -86,7 +86,7 @@ project
  └── projections
       └── variable: i [type=int, outer=(2)]
 
-opt expect=EliminateCoalesce
+norm expect=EliminateCoalesce
 SELECT COALESCE(NULL) FROM a
 ----
 project
@@ -100,7 +100,7 @@ project
 # SimplifyCoalesce
 # --------------------------------------------------
 
-opt expect=SimplifyCoalesce
+norm expect=SimplifyCoalesce
 SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
@@ -110,7 +110,7 @@ project
  └── projections
       └── const: 'foo' [type=string]
 
-opt expect=SimplifyCoalesce
+norm expect=SimplifyCoalesce
 SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
@@ -121,7 +121,7 @@ project
       └── COALESCE(s, s || 'foo') [type=string, outer=(4)]
 
 # Trailing null can't be removed.
-opt
+norm
 SELECT COALESCE(i, NULL, NULL) FROM a
 ----
 project
@@ -131,7 +131,7 @@ project
  └── projections
       └── COALESCE(i, NULL, NULL) [type=int, outer=(2)]
 
-opt expect=SimplifyCoalesce
+norm expect=SimplifyCoalesce
 SELECT COALESCE((1, 2, 3), (2, 3, 4)) FROM a
 ----
 project
@@ -145,7 +145,7 @@ project
 # --------------------------------------------------
 # EliminateCast
 # --------------------------------------------------
-opt expect=EliminateCast
+norm expect=EliminateCast
 SELECT
     i::int, arr::int[], '[1, 2]'::jsonb::json, null::char(2)::bit, s::string::text
 FROM a
@@ -163,7 +163,7 @@ project
       └── variable: a.s [type=string, outer=(4)]
 
 # Shouldn't eliminate these casts.
-opt
+norm
 SELECT
     i::float,
     arr::decimal[],
@@ -192,7 +192,7 @@ project
 # --------------------------------------------------
 # NormalizeInConst
 # --------------------------------------------------
-opt expect=NormalizeInConst
+norm expect=NormalizeInConst
 SELECT i IN (2, 1, 1, null, 3, 4.00, 4.0, null, 3.0) AS r FROM a
 ----
 project
@@ -203,7 +203,7 @@ project
       └── i IN (NULL, 1, 2, 3, 4) [type=bool, outer=(2)]
 
 # Single value.
-opt expect-not=NormalizeInConst
+norm expect-not=NormalizeInConst
 SELECT s NOT IN ('foo') AS r FROM a
 ----
 project
@@ -214,7 +214,7 @@ project
       └── s NOT IN ('foo',) [type=bool, outer=(4)]
 
 # Don't sort, since the list is not constant.
-opt expect-not=NormalizeInConst
+norm expect-not=NormalizeInConst
 SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) AS r FROM a
 ----
 project
@@ -225,7 +225,7 @@ project
       └── s NOT IN ('foo', s || 'foo', 'bar', length(s)::STRING, NULL) [type=bool, outer=(4)]
 
 # Regression test #36031.
-opt expect-not=NormalizeInConst
+norm expect-not=NormalizeInConst
 SELECT
     true
     IN (
@@ -248,7 +248,7 @@ values
 # --------------------------------------------------
 # EliminateExistsProject
 # --------------------------------------------------
-opt expect=EliminateExistsProject
+norm expect=EliminateExistsProject
 SELECT * FROM a WHERE EXISTS(SELECT i+1, i*k FROM a)
 ----
 select
@@ -261,18 +261,24 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters
       └── exists [type=bool, subquery]
-           └── scan a
+           └── limit
                 ├── columns: k:7(int!null) i:8(int)
-                ├── limit: 1
+                ├── cardinality: [0 - 1]
                 ├── key: ()
-                └── fd: ()-->(7,8)
+                ├── fd: ()-->(7,8)
+                ├── scan a
+                │    ├── columns: k:7(int!null) i:8(int)
+                │    ├── key: (7)
+                │    ├── fd: (7)-->(8)
+                │    └── limit hint: 1.00
+                └── const: 1 [type=int]
 
 # --------------------------------------------------
 # EliminateExistsGroupBy
 # --------------------------------------------------
 
 # Scalar group by shouldn't get eliminated.
-opt expect-not=EliminateExistsGroupBy
+norm expect-not=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
 ----
 select
@@ -299,7 +305,7 @@ select
                      └── max [type=string, outer=(10)]
                           └── variable: s [type=string]
 
-opt expect=EliminateExistsGroupBy
+norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
 ----
 select
@@ -312,13 +318,17 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters
       └── exists [type=bool, subquery]
-           └── scan a
+           └── limit
                 ├── columns: s:10(string)
-                ├── limit: 1
+                ├── cardinality: [0 - 1]
                 ├── key: ()
-                └── fd: ()-->(10)
+                ├── fd: ()-->(10)
+                ├── scan a
+                │    ├── columns: s:10(string)
+                │    └── limit hint: 1.00
+                └── const: 1 [type=int]
 
-opt expect=EliminateExistsGroupBy
+norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
 ----
 select
@@ -331,16 +341,20 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters
       └── exists [type=bool, subquery]
-           └── scan a
+           └── limit
                 ├── columns: i:8(int) s:10(string)
-                ├── limit: 1
+                ├── cardinality: [0 - 1]
                 ├── key: ()
-                └── fd: ()-->(8,10)
+                ├── fd: ()-->(8,10)
+                ├── scan a
+                │    ├── columns: i:8(int) s:10(string)
+                │    └── limit hint: 1.00
+                └── const: 1 [type=int]
 
 # --------------------------------------------------
 # EliminateExistsGroupBy + EliminateExistsProject
 # --------------------------------------------------
-opt expect=(EliminateExistsGroupBy,EliminateExistsProject)
+norm expect=(EliminateExistsGroupBy,EliminateExistsProject)
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a GROUP BY i)
 ----
 select
@@ -353,16 +367,20 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters
       └── exists [type=bool, subquery]
-           └── scan a
+           └── limit
                 ├── columns: i:8(int) s:10(string)
-                ├── limit: 1
+                ├── cardinality: [0 - 1]
                 ├── key: ()
-                └── fd: ()-->(8,10)
+                ├── fd: ()-->(8,10)
+                ├── scan a
+                │    ├── columns: i:8(int) s:10(string)
+                │    └── limit hint: 1.00
+                └── const: 1 [type=int]
 
 # --------------------------------------------------
 # NormalizeJSONFieldAccess
 # --------------------------------------------------
-opt expect=NormalizeJSONFieldAccess
+norm expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a' = '"b"'::JSON
 ----
 select
@@ -376,7 +394,7 @@ select
  └── filters
       └── j @> '{"a": "b"}' [type=bool, outer=(5)]
 
-opt expect=NormalizeJSONFieldAccess
+norm expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
 ----
 select
@@ -391,7 +409,7 @@ select
       └── j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]
 
 # The transformation is not valid in this case.
-opt expect-not=NormalizeJSONFieldAccess
+norm expect-not=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->2 = '"b"'::JSON
 ----
 select
@@ -406,7 +424,7 @@ select
       └── (j->2) = '"b"' [type=bool, outer=(5)]
 
 # The transformation is not valid in this case, since j->'a' could be an array.
-opt expect-not=NormalizeJSONFieldAccess
+norm expect-not=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a' @> '"b"'::JSON
 ----
 select
@@ -422,7 +440,7 @@ select
 
 # The transformation is not valid in this case, since containment doesn't imply
 # equality for non-scalars.
-opt
+norm
 SELECT j->'a' = '["b"]'::JSON, j->'a' = '{"b": "c"}'::JSON FROM a
 ----
 project
@@ -437,7 +455,7 @@ project
 # NormalizeJSONContains
 # --------------------------------------------------
 
-opt expect=NormalizeJSONContains
+norm expect=NormalizeJSONContains
 SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
 ----
 select
@@ -455,7 +473,7 @@ select
 # SimplifyCaseWhenConstValue
 # --------------------------------------------------
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 1 THEN 'one' END
 ----
 values
@@ -465,7 +483,7 @@ values
  ├── fd: ()-->(1)
  └── ('one',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE WHEN 1 = 1 THEN 'one' END
 ----
 values
@@ -475,7 +493,7 @@ values
  ├── fd: ()-->(1)
  └── ('one',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE false WHEN 0 = 1 THEN 'one' END
 ----
 values
@@ -485,7 +503,7 @@ values
  ├── fd: ()-->(1)
  └── ('one',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 2 THEN 'one' END
 ----
 values
@@ -495,7 +513,7 @@ values
  ├── fd: ()-->(1)
  └── (NULL,) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 2 THEN 'one' ELSE NULL END
 ----
 values
@@ -536,7 +554,7 @@ values
 
 # Verify that a true condition does not remove non-constant expressions
 # proceeding it.
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE 1
     WHEN k THEN 'one'
@@ -555,7 +573,7 @@ project
  └── projections
       └── CASE 1 WHEN k THEN 'one' ELSE 'two' END [type=string, outer=(1)]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE WHEN k = 1 THEN 'one' WHEN true THEN 'two' END
 FROM
@@ -569,7 +587,7 @@ project
  └── projections
       └── CASE WHEN k = 1 THEN 'one' ELSE 'two' END [type=string, outer=(1)]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 2 THEN 'one' ELSE 'three' END
 ----
 values
@@ -579,7 +597,7 @@ values
  ├── fd: ()-->(1)
  └── ('three',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE 1
     WHEN 2 THEN 'one'
@@ -598,7 +616,7 @@ project
  └── projections
       └── CASE 1 WHEN k THEN 'two' ELSE 'three' END [type=string, outer=(1)]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE 1
     WHEN 2 THEN 'one'
@@ -614,7 +632,7 @@ values
  ├── fd: ()-->(1)
  └── ('three',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE NULL
     WHEN true THEN 'one'
@@ -630,7 +648,7 @@ values
  ├── fd: ()-->(1)
  └── ('four',) [type=tuple{string}]
 
-opt expect=SimplifyCaseWhenConstValue
+norm expect=SimplifyCaseWhenConstValue
 SELECT CASE WHEN false THEN 'one' WHEN true THEN 'two' END
 ----
 values
@@ -664,16 +682,21 @@ CREATE TABLE e
 ## --------------------------------------------------
 
 # Compare how we can generate spans with and without the rule enabled.
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT * FROM e WHERE k > '1.0'::FLOAT
 ----
-scan e
+select
  ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
- ├── constraint: /1: [/2 - ]
  ├── key: (1)
- └── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k > 1 [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
 
-opt disable=UnifyComparisonTypes
+norm disable=UnifyComparisonTypes
 SELECT * FROM e WHERE k > '1.0'::FLOAT
 ----
 select
@@ -688,28 +711,38 @@ select
       └── k > 1.0 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Ensure the rest of normalization does its work and we move things around appropriately.
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT * FROM e WHERE '1.0'::FLOAT > k
 ----
-scan e
+select
  ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
- ├── constraint: /1: [ - /0]
  ├── key: (1)
- └── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k < 1 [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
 
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT * FROM e WHERE k - 1 = 2::DECIMAL
 ----
-scan e
+select
  ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
- ├── constraint: /1: [/3 - /3]
  ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(1-5)
+ ├── fd: ()-->(1-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k = 3 [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
 
 # TODO(justin): we should theoretically be able to generate constraints in this
 # case.
-opt expect-not=UnifyComparisonTypes
+norm expect-not=UnifyComparisonTypes
 SELECT * FROM e WHERE k > '1.1'::FLOAT
 ----
 select
@@ -724,17 +757,22 @@ select
       └── k > 1.1 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # -0 can generate spans
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT * FROM e WHERE k > '-0'::FLOAT
 ----
-scan e
+select
  ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
- ├── constraint: /1: [/1 - ]
  ├── key: (1)
- └── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k > 0 [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
 
 # NaN cannot generate spans.
-opt expect-not=UnifyComparisonTypes
+norm expect-not=UnifyComparisonTypes
 SELECT * FROM e WHERE k > 'NaN'::FLOAT
 ----
 select
@@ -752,61 +790,88 @@ select
 # We do not do the unification here (the rule matches on Const and NULL is its
 # own operator), but this is fine because when an explicit NULL is involved we
 # can generate spans anyway.
-opt expect-not=UnifyComparisonTypes format=show-all
+norm expect-not=UnifyComparisonTypes format=show-all
 SELECT k FROM e WHERE i IS NOT DISTINCT FROM NULL::FLOAT
 ----
 project
  ├── columns: k:1(int!null)
  ├── stats: [rows=10]
- ├── cost: 10.52
+ ├── cost: 1080.14
  ├── key: (1)
  ├── prune: (1)
  ├── interesting orderings: (+1)
- └── scan t.public.e@secondary
+ └── select
       ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int)
-      ├── constraint: /2/1: [/NULL - /NULL]
       ├── stats: [rows=10, distinct(2)=1, null(2)=10]
-      ├── cost: 10.41
+      ├── cost: 1080.03
       ├── key: (1)
       ├── fd: ()-->(2)
-      ├── prune: (1,2)
-      └── interesting orderings: (+1) (+2,+1)
+      ├── prune: (1)
+      ├── interesting orderings: (+1) (+2,+1)
+      ├── scan t.public.e
+      │    ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int)
+      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+      │    ├── cost: 1070.02
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── prune: (1,2)
+      │    └── interesting orderings: (+1) (+2,+1)
+      └── filters
+           └── is [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
+                ├── variable: t.public.e.i [type=int]
+                └── null [type=float]
 
-opt expect-not=UnifyComparisonTypes format=show-all
+norm expect-not=UnifyComparisonTypes format=show-all
 SELECT k FROM e WHERE i IS DISTINCT FROM NULL::FLOAT
 ----
 project
  ├── columns: k:1(int!null)
  ├── stats: [rows=990]
- ├── cost: 1039.52
+ ├── cost: 1089.94
  ├── key: (1)
  ├── prune: (1)
  ├── interesting orderings: (+1)
- └── scan t.public.e@secondary
+ └── select
       ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int!null)
-      ├── constraint: /2/1: (/NULL - ]
       ├── stats: [rows=990, distinct(2)=100, null(2)=0]
-      ├── cost: 1029.61
+      ├── cost: 1080.03
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── prune: (1,2)
-      └── interesting orderings: (+1) (+2,+1)
+      ├── prune: (1)
+      ├── interesting orderings: (+1) (+2,+1)
+      ├── scan t.public.e
+      │    ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int)
+      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+      │    ├── cost: 1070.02
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── prune: (1,2)
+      │    └── interesting orderings: (+1) (+2,+1)
+      └── filters
+           └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+                ├── variable: t.public.e.i [type=int]
+                └── null [type=float]
 
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT * FROM e WHERE k IS NOT DISTINCT FROM '1.0'::FLOAT
 ----
-scan e
+select
  ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
- ├── constraint: /1: [/1 - /1]
  ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(1-5)
+ ├── fd: ()-->(1-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k IS NOT DISTINCT FROM 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
 
 ## --------------------------------------------------
 ## TIMESTAMP / TIMESTAMPTZ / DATE
 ## --------------------------------------------------
 
-opt disable=UnifyComparisonTypes
+norm disable=UnifyComparisonTypes
 SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
 ----
 project
@@ -816,43 +881,52 @@ project
       ├── columns: k:1(int!null) tz:4(timestamptz!null)
       ├── key: (1)
       ├── fd: (1)-->(4)
-      ├── scan e@secondary
-      │    ├── columns: k:1(int!null) tz:4(timestamptz!null)
-      │    ├── constraint: /4/1: (/NULL - ]
+      ├── scan e
+      │    ├── columns: k:1(int!null) tz:4(timestamptz)
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       └── filters
            └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
-opt expect=UnifyComparisonTypes
+norm expect=UnifyComparisonTypes
 SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
 ----
 project
  ├── columns: k:1(int!null)
  ├── key: (1)
- └── scan e@secondary
+ └── select
       ├── columns: k:1(int!null) tz:4(timestamptz!null)
-      ├── constraint: /4/1: [/'2017-11-12 07:35:01.000001+00:00' - ]
       ├── key: (1)
-      └── fd: (1)-->(4)
+      ├── fd: (1)-->(4)
+      ├── scan e
+      │    ├── columns: k:1(int!null) tz:4(timestamptz)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4), constraints=(/4: [/'2017-11-12 07:35:01.000001+00:00' - ]; tight)]
 
 # Common case arising from constant folding: the folding here results in a
 # TIMESTAMP, but we would still like to be able to generate DATE spans.
-opt
+norm
 SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w'::INTERVAL
 ----
 project
  ├── columns: k:1(int!null)
  ├── key: (1)
- └── scan e@secondary
+ └── select
       ├── columns: k:1(int!null) d:5(date!null)
-      ├── constraint: /5/1: [/'2018-07-02' - /'2018-07-07']
       ├── key: (1)
-      └── fd: (1)-->(5)
+      ├── fd: (1)-->(5)
+      ├── scan e
+      │    ├── columns: k:1(int!null) d:5(date)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(5)
+      └── filters
+           └── (d > '2018-07-01') AND (d < '2018-07-08') [type=bool, outer=(5), constraints=(/5: [/'2018-07-02' - /'2018-07-07']; tight)]
 
 # A case where we can theoretically generate spans, but do not.
 # TODO(justin): modify the logic to allow us to create spans in this case.
-opt
+norm
 SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTERVAL
 ----
 project
@@ -862,16 +936,16 @@ project
       ├── columns: k:1(int!null) d:5(date!null)
       ├── key: (1)
       ├── fd: (1)-->(5)
-      ├── scan e@secondary
-      │    ├── columns: k:1(int!null) d:5(date!null)
-      │    ├── constraint: /5/1: [/'2018-07-02' - ]
+      ├── scan e
+      │    ├── columns: k:1(int!null) d:5(date)
       │    ├── key: (1)
       │    └── fd: (1)-->(5)
       └── filters
+           ├── d > '2018-07-01' [type=bool, outer=(5), constraints=(/5: [/'2018-07-02' - ]; tight)]
            └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
 
 # NULL value.
-opt
+norm
 SELECT k FROM e WHERE tz > NULL::TIMESTAMP
 ----
 values
@@ -881,32 +955,41 @@ values
  └── fd: ()-->(1)
 
 # Working in concert with other norm rules
-opt
+norm
 SELECT k FROM e WHERE d - '1w'::INTERVAL > '2018-07-01'::DATE
 ----
 project
  ├── columns: k:1(int!null)
  ├── key: (1)
- └── scan e@secondary
+ └── select
       ├── columns: k:1(int!null) d:5(date!null)
-      ├── constraint: /5/1: [/'2018-07-09' - ]
       ├── key: (1)
-      └── fd: (1)-->(5)
+      ├── fd: (1)-->(5)
+      ├── scan e
+      │    ├── columns: k:1(int!null) d:5(date)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(5)
+      └── filters
+           └── d > '2018-07-08' [type=bool, outer=(5), constraints=(/5: [/'2018-07-09' - ]; tight)]
 
 # --------------------------------------------------
 # InlineAnyValuesSingleCol
 # --------------------------------------------------
 
-opt expect=InlineAnyValuesSingleCol
+norm expect=InlineAnyValuesSingleCol
 SELECT k FROM a WHERE k IN (VALUES (1), (2), (3))
 ----
-scan a
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: [/1 - /3]
  ├── cardinality: [0 - 3]
- └── key: (1)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k IN (1, 2, 3) [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
 
-opt expect=InlineAnyValuesSingleCol
+norm expect=InlineAnyValuesSingleCol
 SELECT k FROM a WHERE k IN (VALUES ((SELECT k*i FROM a)), (2), (3))
 ----
 select
@@ -940,7 +1023,7 @@ select
 # InlineAnyValuesMultiCol
 # --------------------------------------------------
 
-opt expect=InlineAnyValuesMultiCol
+norm expect=InlineAnyValuesMultiCol
 SELECT k FROM a WHERE (k, i) IN (VALUES (1, 1), (2, 2), (3, 3))
 ----
 project
@@ -954,15 +1037,13 @@ project
       ├── fd: (1)-->(2)
       ├── scan a
       │    ├── columns: k:1(int!null) i:2(int)
-      │    ├── constraint: /1: [/1 - /3]
-      │    ├── cardinality: [0 - 3]
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
            └── (k, i) IN ((1, 1), (2, 2), (3, 3)) [type=bool, outer=(1,2), constraints=(/1/2: [/1/1 - /1/1] [/2/2 - /2/2] [/3/3 - /3/3]; /2: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
 
 # The rule should not fire if the columns are not in the right order.
-opt expect-not=InlineAnyValuesMultiCol
+norm expect-not=InlineAnyValuesMultiCol
 SELECT k FROM a WHERE (k, i) IN (SELECT b, a FROM (VALUES (1, 1), (2, 2), (3, 3)) AS v(a,b))
 ----
 project
@@ -1000,16 +1081,20 @@ project
 # SimplifyEqualsAnyTuple
 # --------------------------------------------------
 
-opt expect=SimplifyEqualsAnyTuple
+norm expect=SimplifyEqualsAnyTuple
 SELECT k FROM a WHERE k = ANY (1, 2, 3)
 ----
-scan a
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: [/1 - /3]
  ├── cardinality: [0 - 3]
- └── key: (1)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k IN (1, 2, 3) [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
 
-opt expect=SimplifyEqualsAnyTuple
+norm expect=SimplifyEqualsAnyTuple
 SELECT k FROM a WHERE k = ANY ()
 ----
 values
@@ -1022,7 +1107,7 @@ values
 # SimplifyAnyScalarArray
 # --------------------------------------------------
 
-opt expect=SimplifyAnyScalarArray
+norm expect=SimplifyAnyScalarArray
 SELECT k FROM a WHERE k > ANY ARRAY[1, 2, 3]
 ----
 select
@@ -1034,7 +1119,7 @@ select
  └── filters
       └── k > ANY (1, 2, 3) [type=bool, outer=(1)]
 
-opt expect-not=SimplifyAnyScalarArray
+norm expect-not=SimplifyAnyScalarArray
 SELECT k FROM a WHERE k > ANY ARRAY[1, 2, 3, i]
 ----
 project
@@ -1051,7 +1136,7 @@ project
       └── filters
            └── k > ANY ARRAY[1, 2, 3, i] [type=bool, outer=(1,2)]
 
-opt expect=SimplifyAnyScalarArray
+norm expect=SimplifyAnyScalarArray
 SELECT k FROM a WHERE k > ANY ARRAY[]:::INT[]
 ----
 select
@@ -1067,16 +1152,20 @@ select
 # SimplifyEqualsAnyTuple + SimplifyAnyScalarArray
 # --------------------------------------------------
 
-opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
+norm expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
 SELECT k FROM a WHERE k = ANY ARRAY[1, 2, 3]
 ----
-scan a
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: [/1 - /3]
  ├── cardinality: [0 - 3]
- └── key: (1)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k IN (1, 2, 3) [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
 
-opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
+norm expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
 SELECT k FROM a WHERE k = ANY ARRAY[]:::INT[]
 ----
 values
@@ -1086,14 +1175,18 @@ values
  └── fd: ()-->(1)
 
 # TODO(justin): fold casts.
-opt
+norm
 SELECT k FROM a WHERE k = ANY '{1,2,3}'::INT[]
 ----
-scan a
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: [/1 - /3]
  ├── cardinality: [0 - 3]
- └── key: (1)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k IN (1, 2, 3) [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
 
 # --------------------------------------------------
 # FoldCollate

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -28,7 +28,7 @@ CREATE TABLE e
 # --------------------------------------------------
 # SimplifyFilters
 # --------------------------------------------------
-opt expect=SimplifySelectFilters
+norm expect=SimplifySelectFilters
 SELECT * FROM a WHERE Null
 ----
 values
@@ -37,7 +37,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifyJoinFilters
+norm expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON NULL
 ----
 values
@@ -46,7 +46,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-7)
 
-opt expect=SimplifySelectFilters
+norm expect=SimplifySelectFilters
 SELECT * FROM a WHERE i=1 AND Null
 ----
 values
@@ -55,7 +55,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifySelectFilters
+norm expect=SimplifySelectFilters
 SELECT * FROM a WHERE k=1 AND (i=2 AND (f=3.5 AND s='foo')) AND true
 ----
 select
@@ -65,22 +65,19 @@ select
  ├── fd: ()-->(1-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/1 - /1]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
  └── filters
+      ├── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       ├── i = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
       ├── f = 3.5 [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight), fd=()-->(3)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
-opt expect=SimplifyJoinFilters
+norm expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON (k=x AND i=y) AND true AND (f=3.5 AND s='foo')
 ----
-inner-join (lookup xy)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb) x:6(int!null) y:7(int!null)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (6)
  ├── fd: ()-->(3,4), (1)-->(2,5), (6)-->(7), (1)==(6), (6)==(1), (2)==(7), (7)==(2)
  ├── select
@@ -94,14 +91,19 @@ inner-join (lookup xy)
  │    └── filters
  │         ├── f = 3.5 [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight), fd=()-->(3)]
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # --------------------------------------------------
 # ConsolidateSelectFilters
 # --------------------------------------------------
 
-opt expect=ConsolidateSelectFilters
+norm expect=ConsolidateSelectFilters
 SELECT * FROM a WHERE i >= 5 AND i < 10 AND i IN (0, 2, 4, 6, 8, 10, 12)
 ----
 select
@@ -115,7 +117,7 @@ select
  └── filters
       └── ((i >= 5) AND (i < 10)) AND (i IN (0, 2, 4, 6, 8, 10, 12)) [type=bool, outer=(2), constraints=(/2: [/6 - /6] [/8 - /8]; tight)]
 
-opt expect-not=ConsolidateSelectFilters
+norm expect-not=ConsolidateSelectFilters
 SELECT * FROM a WHERE k >= 5 AND i < 10
 ----
 select
@@ -124,13 +126,13 @@ select
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/5 - ]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
+      ├── k >= 5 [type=bool, outer=(1), constraints=(/1: [/5 - ]; tight)]
       └── i < 10 [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
 
-opt expect=ConsolidateSelectFilters
+norm expect=ConsolidateSelectFilters
 SELECT * FROM c WHERE a AND a=true AND b AND b=c
 ----
 select
@@ -143,7 +145,7 @@ select
       ├── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
       └── b = c [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
 
-opt expect=ConsolidateSelectFilters disable=InlineConstVar
+norm expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM a WHERE i IS NOT NULL AND i = 3
 AND f > 5 AND f < 15 AND s >= 'bar' AND s <= 'foo'
 ----
@@ -160,7 +162,7 @@ select
       ├── (f > 5.0) AND (f < 15.0) [type=bool, outer=(3), constraints=(/3: [/5.000000000000001 - /14.999999999999998]; tight)]
       └── (s >= 'bar') AND (s <= 'foo') [type=bool, outer=(4), constraints=(/4: [/'bar' - /'foo']; tight)]
 
-opt expect=ConsolidateSelectFilters
+norm expect=ConsolidateSelectFilters
 SELECT * FROM a WHERE i IS NULL AND i IS DISTINCT FROM 5
 ----
 select
@@ -174,7 +176,7 @@ select
  └── filters
       └── (i IS NULL) AND (i IS DISTINCT FROM 5) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
 
-opt expect=ConsolidateSelectFilters disable=InlineConstVar
+norm expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM a WHERE s LIKE 'a%' AND s SIMILAR TO 'a_' AND s = 'aa'
 ----
 select
@@ -190,7 +192,7 @@ select
       └── s SIMILAR TO 'a_' [type=bool, outer=(4), constraints=(/4: [/'a' - /'b'))]
 
 # One of the constraints is not tight, so it should not be consolidated.
-opt expect-not=ConsolidateSelectFilters
+norm expect-not=ConsolidateSelectFilters
 SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTERVAL
 ----
 project
@@ -313,7 +315,8 @@ inner-join (cross)
  │    └── fd: (6)-->(7)
  └── filters (true)
 
-# Regression test for #42035.
+# Regression test for #42035. This test uses the opt directive because the rule
+# is triggered during exploration.
 opt expect=ConsolidateSelectFilters disable=InlineConstVar
 SELECT * FROM
       (VALUES ('x', 'x'), ('y', 'y')) AS vab (a, b)
@@ -381,7 +384,7 @@ inner-join (hash)
 # --------------------------------------------------
 # EliminateSelect
 # --------------------------------------------------
-opt expect=EliminateSelect
+norm expect=EliminateSelect
 SELECT * FROM a WHERE True
 ----
 scan a
@@ -392,7 +395,7 @@ scan a
 # --------------------------------------------------
 # MergeSelects
 # --------------------------------------------------
-opt expect=MergeSelects
+norm expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE k=3) WHERE s='foo'
 ----
 select
@@ -402,14 +405,13 @@ select
  ├── fd: ()-->(1-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/3 - /3]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
  └── filters
+      ├── k = 3 [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
-opt expect=MergeSelects
+norm expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
 ----
 values
@@ -418,7 +420,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=MergeSelects
+norm expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
 ----
 select
@@ -433,7 +435,7 @@ select
       ├── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
-opt expect=MergeSelects
+norm expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i>1 AND i<10) WHERE s='foo' OR k=5
 ----
 select
@@ -451,7 +453,7 @@ select
 # --------------------------------------------------
 # PushSelectIntoProject
 # --------------------------------------------------
-opt expect=PushSelectIntoProject
+norm expect=PushSelectIntoProject
 SELECT * FROM (SELECT i, i+1 AS r, f FROM a) a WHERE f=10.0
 ----
 project
@@ -468,7 +470,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Don't push down select if it depends on computed column that can't be inlined.
-opt expect-not=PushSelectIntoProject
+norm expect-not=PushSelectIntoProject
 SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE div=2
 ----
 select
@@ -486,7 +488,7 @@ select
       └── div = 2 [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
 # Push down some conjuncts, but not others.
-opt expect=PushSelectIntoProject
+norm expect=PushSelectIntoProject
 SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE 10.0=f AND 2=div AND i=1
 ----
 select
@@ -511,7 +513,7 @@ select
       └── div = 2 [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
 # Detect PushSelectIntoProject and FilterUnusedSelectCols dependency cycle.
-opt
+norm
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i HAVING sum(f)=10.0) a
 ----
 project
@@ -540,89 +542,106 @@ project
 # --------------------------------------
 
 # Only the filters bound by the left side are mapped and pushed down.
-opt expect=PushSelectCondLeftIntoJoinLeftAndRight
+norm expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.k > 5 AND (xy.x = 6 OR xy.x IS NULL)
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- │    ├── left ordering: +1
- │    ├── right ordering: +6
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
- │    ├── scan a
+ │    ├── select
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    ├── constraint: /1: [/6 - ]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
- │    ├── scan xy
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-5)
+ │    │    └── filters
+ │    │         └── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+ │    ├── select
  │    │    ├── columns: x:6(int!null) y:7(int)
- │    │    ├── constraint: /6: [/6 - ]
  │    │    ├── key: (6)
  │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
- │    └── filters (true)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── x > 5 [type=bool, outer=(6), constraints=(/6: [/6 - ]; tight)]
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
       └── (x = 6) OR (x IS NULL) [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL] [/6 - /6])]
 
-opt expect=PushSelectCondLeftIntoJoinLeftAndRight
+norm expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
 ----
-semi-join (merge)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/6 - ]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan xy
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+ ├── select
  │    ├── columns: x:6(int!null)
- │    ├── constraint: /6: [/6 - ]
  │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── x > 5 [type=bool, outer=(6), constraints=(/6: [/6 - ]; tight)]
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=PushSelectCondLeftIntoJoinLeftAndRight
+norm expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
 ----
-anti-join (merge)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
+ ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── constraint: /1: [/6 - ]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan xy
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── k > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+ ├── select
  │    ├── columns: x:6(int!null)
- │    ├── constraint: /6: [/6 - ]
  │    ├── key: (6)
- │    └── ordering: +6
- └── filters (true)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null)
+ │    │    └── key: (6)
+ │    └── filters
+ │         └── x > 5 [type=bool, outer=(6), constraints=(/6: [/6 - ]; tight)]
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # PushSelectIntoJoinLeft
 # --------------------------------------------------
-opt expect=PushSelectIntoJoinLeft
+norm expect=PushSelectIntoJoinLeft
 SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.f=1.1
 ----
-left-join (lookup xy)
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1,6)
  ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
  ├── select
@@ -635,9 +654,14 @@ left-join (lookup xy)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── f = 1.1 [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-opt expect=PushSelectIntoJoinLeft
+norm expect=PushSelectIntoJoinLeft
 SELECT * FROM a LEFT JOIN xy ON a.k=xy.x
 WHERE a.f=1.1 AND (a.i<xy.y OR xy.y IS NULL) AND (a.s='foo' OR a.s='bar')
 ----
@@ -645,10 +669,8 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
- ├── left-join (lookup xy)
+ ├── left-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb) x:6(int) y:7(int)
- │    ├── key columns: [1] = [6]
- │    ├── lookup columns are key
  │    ├── key: (1,6)
  │    ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
  │    ├── select
@@ -662,7 +684,12 @@ select
  │    │    └── filters
  │    │         ├── f = 1.1 [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
  │    │         └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar'] [/'foo' - /'foo'])]
- │    └── filters (true)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
       └── (i < y) OR (y IS NULL) [type=bool, outer=(2,7)]
 
@@ -701,69 +728,61 @@ left-join (cross)
  └── filters (true)
 
 # Don't push down conditions in case of RIGHT JOIN.
-opt
+norm
 SELECT * FROM a RIGHT JOIN xy ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (6)-->(7), (1)-->(2-5)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- │    ├── left ordering: +6
- │    ├── right ordering: +1
  │    ├── key: (1,6)
  │    ├── fd: (6)-->(7), (1)-->(2-5)
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
- │    └── filters (true)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
       └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
 
 # Don't push down conditions in case of FULL JOIN.
-opt
+norm
 SELECT * FROM a FULL JOIN xy ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
- ├── full-join (merge)
+ ├── full-join (hash)
  │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- │    ├── left ordering: +1
- │    ├── right ordering: +6
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2-5)
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
- │    └── filters (true)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
       └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
 
 # Push into semi-join.
-opt expect=PushSelectIntoJoinLeft
+norm expect=PushSelectIntoJoinLeft
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE k=x) AND a.i=0
 ----
-semi-join (lookup xy)
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3-5)
  ├── select
@@ -776,16 +795,18 @@ semi-join (lookup xy)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Push into anti-join.
-opt expect=PushSelectIntoJoinLeft
+norm expect=PushSelectIntoJoinLeft
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE k=x) AND a.i=0
 ----
-anti-join (lookup xy)
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3-5)
  ├── select
@@ -798,112 +819,104 @@ anti-join (lookup xy)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
- └── filters (true)
+ ├── scan xy
+ │    ├── columns: x:6(int!null)
+ │    └── key: (6)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Don't push down conditions in case of LEFT JOIN.
-opt
+norm
 SELECT * FROM xy LEFT JOIN a ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4-7)
- ├── left-join (merge)
+ ├── left-join (hash)
  │    ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- │    ├── left ordering: +1
- │    ├── right ordering: +3
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2), (3)-->(4-7)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2)
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3
- │    └── filters (true)
+ │    │    └── fd: (3)-->(4-7)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── filters
       └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
 
 # Don't push down conditions in case of FULL JOIN.
-opt
+norm
 SELECT * FROM xy FULL JOIN a ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: x:1(int) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4-7)
- ├── full-join (merge)
+ ├── full-join (hash)
  │    ├── columns: x:1(int) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- │    ├── left ordering: +1
- │    ├── right ordering: +3
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2), (3)-->(4-7)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2)
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3
- │    └── filters (true)
+ │    │    └── fd: (3)-->(4-7)
+ │    └── filters
+ │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── filters
       └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
 
 # --------------------------------------------------
 # MergeSelectInnerJoin
 # --------------------------------------------------
-opt expect=MergeSelectInnerJoin
+norm expect=MergeSelectInnerJoin
 SELECT * FROM a, xy WHERE a.k=xy.x AND (a.s='foo' OR xy.y<100)
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── (s = 'foo') OR (y < 100) [type=bool, outer=(4,7)]
 
-opt expect=MergeSelectInnerJoin
+norm expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE (a.s='foo' OR xy.y<100)
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-5)
  ├── scan xy
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
+ │    └── fd: (6)-->(7)
  └── filters
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── (s = 'foo') OR (y < 100) [type=bool, outer=(4,7)]
 
-opt expect=MergeSelectInnerJoin
+norm expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE False
 ----
 values
@@ -913,7 +926,7 @@ values
  └── fd: ()-->(1-7)
 
 # Don't merge with LEFT JOIN.
-opt expect-not=MergeSelectInnerJoin
+norm expect-not=MergeSelectInnerJoin
 SELECT * FROM a LEFT JOIN xy ON True WHERE a.k=xy.x OR xy.x IS NULL
 ----
 select
@@ -937,7 +950,7 @@ select
       └── (k = x) OR (x IS NULL) [type=bool, outer=(1,6)]
 
 # Don't merge with RIGHT JOIN.
-opt expect-not=MergeSelectInnerJoin
+norm expect-not=MergeSelectInnerJoin
 SELECT * FROM a RIGHT JOIN xy ON True WHERE a.k=xy.x OR a.k IS NULL
 ----
 select
@@ -961,7 +974,7 @@ select
       └── (k = x) OR (k IS NULL) [type=bool, outer=(1,6)]
 
 # Don't merge with FULL JOIN.
-opt expect-not=MergeSelectInnerJoin
+norm expect-not=MergeSelectInnerJoin
 SELECT * FROM a FULL JOIN xy ON True WHERE a.k=xy.x OR a.k IS NULL OR xy.x IS NULL
 ----
 select
@@ -987,15 +1000,24 @@ select
 # --------------------------------------------------
 # PushSelectIntoJoinLeft + MergeSelectInnerJoin
 # --------------------------------------------------
-opt
+norm
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE a.f=1.1 AND s='foo' AND xy.y=10 AND a.i<xy.y
 ----
-inner-join (lookup a)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb) x:6(int!null) y:7(int!null)
- ├── key columns: [6] = [1]
- ├── lookup columns are key
  ├── key: (6)
  ├── fd: ()-->(3,4,7), (1)-->(2,5), (1)==(6), (6)==(1)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3,4), (1)-->(2,5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         ├── f = 1.1 [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
+ │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── select
  │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── key: (6)
@@ -1007,17 +1029,14 @@ inner-join (lookup a)
  │    └── filters
  │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
  └── filters
-      ├── i < y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
-      ├── f = 1.1 [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
-      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── i < y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
-opt
+norm
 SELECT * FROM a, xy WHERE a.i=100 AND $1>'2000-01-01T1:00:00' AND xy.x=a.k
 ----
-inner-join (lookup xy)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── key columns: [1] = [6]
- ├── lookup columns are key
  ├── has-placeholder
  ├── key: (6)
  ├── fd: ()-->(2), (1)-->(3-5), (6)-->(7), (1)==(6), (6)==(1)
@@ -1033,15 +1052,26 @@ inner-join (lookup xy)
  │    └── filters
  │         ├── $1 > '2000-01-01T1:00:00' [type=bool]
  │         └── i = 100 [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+ ├── select
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── has-placeholder
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── $1 > '2000-01-01T1:00:00' [type=bool]
  └── filters
-      └── $1 > '2000-01-01T1:00:00' [type=bool]
+      └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # --------------------------------------------------
 # PushSelectIntoGroupBy
 # --------------------------------------------------
 
 # Push down into GroupBy with aggregations.
-opt expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT i, count(*) FROM a GROUP BY i) a WHERE i=1
 ----
 group-by
@@ -1062,7 +1092,7 @@ group-by
            └── variable: i [type=int]
 
 # Push down into GroupBy with no aggregations.
-opt expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT i FROM a GROUP BY i) a WHERE i=1
 ----
 limit
@@ -1082,7 +1112,7 @@ limit
  └── const: 1 [type=int]
 
 # Push down only conditions that do not depend on aggregations.
-opt expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT k, i, max(s) m FROM a GROUP BY k, i) a WHERE i=k AND m='foo'
 ----
 select
@@ -1092,19 +1122,16 @@ select
  ├── group-by
  │    ├── columns: k:1(int!null) i:2(int) max:6(string)
  │    ├── grouping columns: k:1(int!null)
- │    ├── internal-ordering: +(1|2)
  │    ├── key: (1)
  │    ├── fd: (1)==(2), (2)==(1), (1)-->(2,6)
  │    ├── select
  │    │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(4), (1)==(2), (2)==(1)
- │    │    ├── ordering: +(1|2) [actual: +1]
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2,4)
- │    │    │    └── ordering: +1
+ │    │    │    └── fd: (1)-->(2,4)
  │    │    └── filters
  │    │         └── i = k [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  │    └── aggregations
@@ -1116,7 +1143,7 @@ select
       └── max = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
 
 # DistinctOn case.
-opt expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT DISTINCT ON (i, f) i, s, f FROM a) WHERE i>f
 ----
 distinct-on
@@ -1135,7 +1162,7 @@ distinct-on
            └── variable: s [type=string]
 
 # DistinctOn case with a ConstAgg.
-opt expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT DISTINCT ON (k, f, s) k, i, f, x FROM a JOIN xy ON i=y) WHERE k > f
 ----
 distinct-on
@@ -1147,10 +1174,6 @@ distinct-on
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) x:6(int!null) y:7(int!null)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2,3), (6)-->(7), (2)==(7), (7)==(2)
- │    ├── scan xy
- │    │    ├── columns: x:6(int!null) y:7(int)
- │    │    ├── key: (6)
- │    │    └── fd: (6)-->(7)
  │    ├── select
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null)
  │    │    ├── key: (1)
@@ -1161,6 +1184,10 @@ distinct-on
  │    │    │    └── fd: (1)-->(2,3)
  │    │    └── filters
  │    │         └── k > f [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
  └── aggregations
@@ -1172,7 +1199,7 @@ distinct-on
            └── variable: f [type=float]
 
 # Do *not* push down into scalar GroupBy.
-opt expect-not=PushSelectIntoGroupBy
+norm expect-not=PushSelectIntoGroupBy
 SELECT * FROM (SELECT count(*) c FROM a) a WHERE $1<'2000-01-01T10:00:00' AND c=0
 ----
 select
@@ -1200,25 +1227,33 @@ exec-ddl
 CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 ----
 
-opt expect=RemoveNotNullCondition
+norm expect=RemoveNotNullCondition
 SELECT k FROM b WHERE k IS NOT NULL AND k > 4
 ----
-scan b
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: [/5 - ]
- └── key: (1)
+ ├── key: (1)
+ ├── scan b
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k > 4 [type=bool, outer=(1), constraints=(/1: [/5 - ]; tight)]
 
-opt
+norm
 SELECT k FROM b WHERE k IS NULL
 ----
-scan b
+select
  ├── columns: k:1(int!null)
- ├── constraint: /1: contradiction
  ├── cardinality: [0 - 1]
  ├── key: ()
- └── fd: ()-->(1)
+ ├── fd: ()-->(1)
+ ├── scan b
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters
+      └── k IS NULL [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
 
-opt expect=RemoveNotNullCondition
+norm expect=RemoveNotNullCondition
 SELECT k,i FROM b WHERE k IS NOT NULL AND k > 4 AND i < 100 AND i IS NOT NULL
 ----
 select
@@ -1227,13 +1262,13 @@ select
  ├── fd: (1)-->(2)
  ├── scan b
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── constraint: /1: [/5 - ]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
-      └── (i < 100) AND (i IS NOT NULL) [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
+      ├── (i < 100) AND (i IS NOT NULL) [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
+      └── k > 4 [type=bool, outer=(1), constraints=(/1: [/5 - ]; tight)]
 
-opt expect=RemoveNotNullCondition
+norm expect=RemoveNotNullCondition
 SELECT k,s FROM b WHERE k IS NOT NULL AND s IS NOT NULL
 ----
 scan b
@@ -1242,7 +1277,7 @@ scan b
  └── fd: (1)-->(4)
 
 # RemoveNotNullCondition partially applied
-opt expect=RemoveNotNullCondition
+norm expect=RemoveNotNullCondition
 SELECT k,s,i FROM b WHERE k IS NOT NULL AND s IS NOT NULL AND i IS NOT NULL
 ----
 select
@@ -1257,7 +1292,7 @@ select
       └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
 
 # RemoveNotNullCondition rule is not applied
-opt expect-not=RemoveNotNullCondition
+norm expect-not=RemoveNotNullCondition
 SELECT i FROM b WHERE i IS NOT NULL
 ----
 select
@@ -1268,7 +1303,7 @@ select
       └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
 
 # RemoveNotNullCondition rule is not applied
-opt expect-not=RemoveNotNullCondition
+norm expect-not=RemoveNotNullCondition
 SELECT k FROM b WHERE i+k IS NOT NULL
 ----
 project
@@ -1289,7 +1324,7 @@ project
 # DetectSelectContradiction
 # --------------------------------------------------
 
-opt expect=DetectSelectContradiction
+norm expect=DetectSelectContradiction
 SELECT k FROM b WHERE k IN ()
 ----
 values
@@ -1298,7 +1333,7 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-opt expect=DetectSelectContradiction
+norm expect=DetectSelectContradiction
 SELECT k FROM b WHERE i=5 AND k IN () AND s='foo'
 ----
 values
@@ -1311,7 +1346,7 @@ values
 # InlineConstVar
 # --------------------------------------------------
 
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT k FROM b WHERE i=5 AND i IN (1, 2, 3, 4, 5)
 ----
 project
@@ -1328,7 +1363,7 @@ project
       └── filters
            └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
 
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT k FROM b WHERE i=8 AND 3 = mod(i, 5)
 ----
 project
@@ -1345,7 +1380,7 @@ project
       └── filters
            └── i = 8 [type=bool, outer=(2), constraints=(/2: [/8 - /8]; tight), fd=()-->(2)]
 
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT k FROM b WHERE i=5 AND i IN (1, 2, 3, 4)
 ----
 values
@@ -1355,7 +1390,7 @@ values
  └── fd: ()-->(1)
 
 # Case that requires multiple iterations to fully inline.
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT * FROM xy WHERE x=y AND y=4 AND x IN (1, 2, 3, 4)
 ----
 select
@@ -1365,14 +1400,13 @@ select
  ├── fd: ()-->(1,2)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── constraint: /1: [/4 - /4]
- │    ├── cardinality: [0 - 1]
- │    ├── key: ()
- │    └── fd: ()-->(1,2)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── filters
+      ├── x = 4 [type=bool, outer=(1), constraints=(/1: [/4 - /4]; tight), fd=()-->(1)]
       └── y = 4 [type=bool, outer=(2), constraints=(/2: [/4 - /4]; tight), fd=()-->(2)]
 
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT * FROM xy WHERE x=y AND y=4 AND x=3
 ----
 values
@@ -1382,7 +1416,7 @@ values
  └── fd: ()-->(1,2)
 
 # Can't inline composite types.
-opt expect-not=InlineConstVar
+norm expect-not=InlineConstVar
 SELECT * FROM (VALUES (0.0), (0.00), (0.000)) AS v (x) WHERE x = 0 AND x::STRING = '0.00';
 ----
 select
@@ -1400,7 +1434,7 @@ select
       └── column1::STRING = '0.00' [type=bool, outer=(1)]
 
 # The rule should trigger, but not inline the composite type.
-opt expect=InlineConstVar
+norm expect=InlineConstVar
 SELECT * FROM (VALUES (0.0, 'a'), (0.00, 'b'), (0.000, 'b')) AS v (x, y) WHERE x = 0 AND x::STRING = '0.00' AND y = 'b' AND y IN ('a', 'b');
 ----
 select

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -10,7 +10,7 @@ CREATE TABLE a (v INT PRIMARY KEY, w INT, x FLOAT, y STRING NOT NULL, z JSON)
 # EliminateUnionAllLeft
 # --------------------------------------------------
 
-opt expect=EliminateUnionAllLeft
+norm expect=EliminateUnionAllLeft
 SELECT k FROM
   (SELECT k FROM b)
   UNION ALL
@@ -28,7 +28,7 @@ project
 # EliminateUnionAllRight
 # --------------------------------------------------
 
-opt expect=EliminateUnionAllRight
+norm expect=EliminateUnionAllRight
 SELECT k FROM
   (SELECT k FROM b WHERE Null)
   UNION ALL
@@ -42,7 +42,7 @@ project
  └── projections
       └── variable: b.k [type=int, outer=(6)]
 
-opt
+norm
 SELECT k FROM
   (SELECT k FROM b WHERE False)
   UNION ALL
@@ -58,7 +58,7 @@ values
 # PushFilterIntoSetOp
 # --------------------------------------------------
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
   ((SELECT k FROM b)
   UNION ALL
@@ -69,16 +69,24 @@ union-all
  ├── columns: k:11(int!null)
  ├── left columns: b.k:1(int)
  ├── right columns: b.k:6(int)
- ├── scan b
+ ├── select
  │    ├── columns: b.k:1(int!null)
- │    ├── constraint: /1: [ - /9]
- │    └── key: (1)
- └── scan b
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: b.k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── b.k < 10 [type=bool, outer=(1), constraints=(/1: (/NULL - /9]; tight)]
+ └── select
       ├── columns: b.k:6(int!null)
-      ├── constraint: /6: [ - /9]
-      └── key: (6)
+      ├── key: (6)
+      ├── scan b
+      │    ├── columns: b.k:6(int!null)
+      │    └── key: (6)
+      └── filters
+           └── b.k < 10 [type=bool, outer=(6), constraints=(/6: (/NULL - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   UNION
@@ -90,11 +98,15 @@ union
  ├── left columns: b.k:1(int)
  ├── right columns: w:7(int)
  ├── key: (11)
- ├── scan b
+ ├── select
  │    ├── columns: b.k:1(int!null)
- │    ├── constraint: /1: [/2 - /9]
  │    ├── cardinality: [0 - 8]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: b.k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (b.k < 10) AND (b.k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  └── select
       ├── columns: w:7(int!null)
       ├── scan a
@@ -102,7 +114,7 @@ union
       └── filters
            └── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT
 (SELECT k FROM
 ((SELECT k FROM b)
@@ -150,7 +162,7 @@ project
  └── projections
       └── variable: k [type=int, outer=(16)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   EXCEPT
@@ -163,11 +175,15 @@ except
  ├── right columns: w:7(int)
  ├── cardinality: [0 - 8]
  ├── key: (1)
- ├── scan b
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [/2 - /9]
  │    ├── cardinality: [0 - 8]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (k < 10) AND (k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  └── select
       ├── columns: w:7(int!null)
       ├── scan a
@@ -175,7 +191,7 @@ except
       └── filters
            └── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   EXCEPT ALL
@@ -187,11 +203,15 @@ except-all
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
  ├── cardinality: [0 - 8]
- ├── scan b
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [/2 - /9]
  │    ├── cardinality: [0 - 8]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (k < 10) AND (k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  └── select
       ├── columns: w:7(int!null)
       ├── scan a
@@ -199,7 +219,7 @@ except-all
       └── filters
            └── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   INTERSECT
@@ -212,11 +232,15 @@ intersect
  ├── right columns: w:7(int)
  ├── cardinality: [0 - 8]
  ├── key: (1)
- ├── scan b
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [/2 - /9]
  │    ├── cardinality: [0 - 8]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (k < 10) AND (k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  └── select
       ├── columns: w:7(int!null)
       ├── scan a
@@ -224,7 +248,7 @@ intersect
       └── filters
            └── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   INTERSECT ALL
@@ -236,11 +260,15 @@ intersect-all
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
  ├── cardinality: [0 - 8]
- ├── scan b
+ ├── select
  │    ├── columns: k:1(int!null)
- │    ├── constraint: /1: [/2 - /9]
  │    ├── cardinality: [0 - 8]
- │    └── key: (1)
+ │    ├── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (k < 10) AND (k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  └── select
       ├── columns: w:7(int!null)
       ├── scan a
@@ -248,7 +276,7 @@ intersect-all
       └── filters
            └── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   UNION
@@ -268,10 +296,9 @@ union
  │    ├── key: (1)
  │    ├── scan b
  │    │    ├── columns: b.k:1(int!null)
- │    │    ├── constraint: /1: [/2 - /9]
- │    │    ├── cardinality: [0 - 8]
  │    │    └── key: (1)
  │    └── filters
+ │         ├── (b.k < 10) AND (b.k > 1) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
  │         └── random() < 0.5 [type=bool, side-effects]
  └── select
       ├── columns: w:7(int!null)
@@ -282,7 +309,7 @@ union
            ├── (w < 10) AND (w > 1) [type=bool, outer=(7), constraints=(/7: [/2 - /9]; tight)]
            └── random() < 0.5 [type=bool, side-effects]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT * FROM
   (SELECT k FROM b
     UNION ALL
@@ -302,12 +329,17 @@ union-all
  │    │    └── key: (1)
  │    └── filters
  │         └── exists [type=bool, subquery]
- │              └── scan a
+ │              └── select
  │                   ├── columns: v:12(int!null) w:13(int) x:14(float) y:15(string!null) z:16(jsonb)
- │                   ├── constraint: /12: [/1 - /1]
  │                   ├── cardinality: [0 - 1]
  │                   ├── key: ()
- │                   └── fd: ()-->(12-16)
+ │                   ├── fd: ()-->(12-16)
+ │                   ├── scan a
+ │                   │    ├── columns: v:12(int!null) w:13(int) x:14(float) y:15(string!null) z:16(jsonb)
+ │                   │    ├── key: (12)
+ │                   │    └── fd: (12)-->(13-16)
+ │                   └── filters
+ │                        └── v = 1 [type=bool, outer=(12), constraints=(/12: [/1 - /1]; tight), fd=()-->(12)]
  └── select
       ├── columns: b.k:6(int!null)
       ├── key: (6)
@@ -316,14 +348,19 @@ union-all
       │    └── key: (6)
       └── filters
            └── exists [type=bool, subquery]
-                └── scan a
+                └── select
                      ├── columns: v:12(int!null) w:13(int) x:14(float) y:15(string!null) z:16(jsonb)
-                     ├── constraint: /12: [/1 - /1]
                      ├── cardinality: [0 - 1]
                      ├── key: ()
-                     └── fd: ()-->(12-16)
+                     ├── fd: ()-->(12-16)
+                     ├── scan a
+                     │    ├── columns: v:12(int!null) w:13(int) x:14(float) y:15(string!null) z:16(jsonb)
+                     │    ├── key: (12)
+                     │    └── fd: (12)-->(13-16)
+                     └── filters
+                          └── v = 1 [type=bool, outer=(12), constraints=(/12: [/1 - /1]; tight), fd=()-->(12)]
 
-opt expect=PushFilterIntoSetOp
+norm expect=PushFilterIntoSetOp
 SELECT * FROM
 (SELECT k FROM (SELECT k FROM b UNION ALL SELECT k FROM b)
   UNION ALL
@@ -350,12 +387,17 @@ union-all
  │    │    │    └── key: (1)
  │    │    └── filters
  │    │         ├── exists [type=bool, subquery]
- │    │         │    └── scan a
+ │    │         │    └── select
  │    │         │         ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
- │    │         │         ├── constraint: /24: [/1 - /1]
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         └── fd: ()-->(24-28)
+ │    │         │         ├── fd: ()-->(24-28)
+ │    │         │         ├── scan a
+ │    │         │         │    ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
+ │    │         │         │    ├── key: (24)
+ │    │         │         │    └── fd: (24)-->(25-28)
+ │    │         │         └── filters
+ │    │         │              └── v = 1 [type=bool, outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
  │    │         └── random() < 0.5 [type=bool, side-effects]
  │    └── select
  │         ├── columns: b.k:6(int!null)
@@ -366,12 +408,17 @@ union-all
  │         │    └── key: (6)
  │         └── filters
  │              ├── exists [type=bool, subquery]
- │              │    └── scan a
+ │              │    └── select
  │              │         ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
- │              │         ├── constraint: /24: [/1 - /1]
  │              │         ├── cardinality: [0 - 1]
  │              │         ├── key: ()
- │              │         └── fd: ()-->(24-28)
+ │              │         ├── fd: ()-->(24-28)
+ │              │         ├── scan a
+ │              │         │    ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
+ │              │         │    ├── key: (24)
+ │              │         │    └── fd: (24)-->(25-28)
+ │              │         └── filters
+ │              │              └── v = 1 [type=bool, outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
  │              └── random() < 0.5 [type=bool, side-effects]
  └── union-all
       ├── columns: k:22(int!null)
@@ -387,12 +434,17 @@ union-all
       │    │    └── key: (12)
       │    └── filters
       │         ├── exists [type=bool, subquery]
-      │         │    └── scan a
+      │         │    └── select
       │         │         ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
-      │         │         ├── constraint: /24: [/1 - /1]
       │         │         ├── cardinality: [0 - 1]
       │         │         ├── key: ()
-      │         │         └── fd: ()-->(24-28)
+      │         │         ├── fd: ()-->(24-28)
+      │         │         ├── scan a
+      │         │         │    ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
+      │         │         │    ├── key: (24)
+      │         │         │    └── fd: (24)-->(25-28)
+      │         │         └── filters
+      │         │              └── v = 1 [type=bool, outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
       │         └── random() < 0.5 [type=bool, side-effects]
       └── select
            ├── columns: b.k:17(int!null)
@@ -403,15 +455,20 @@ union-all
            │    └── key: (17)
            └── filters
                 ├── exists [type=bool, subquery]
-                │    └── scan a
+                │    └── select
                 │         ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
-                │         ├── constraint: /24: [/1 - /1]
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         └── fd: ()-->(24-28)
+                │         ├── fd: ()-->(24-28)
+                │         ├── scan a
+                │         │    ├── columns: v:24(int!null) w:25(int) x:26(float) y:27(string!null) z:28(jsonb)
+                │         │    ├── key: (24)
+                │         │    └── fd: (24)-->(25-28)
+                │         └── filters
+                │              └── v = 1 [type=bool, outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
                 └── random() < 0.5 [type=bool, side-effects]
 
-opt
+norm
 SELECT * FROM ((values (1,2))
   EXCEPT (values (0,1)))
 WHERE 1 / column1 > 0
@@ -444,7 +501,7 @@ except
       └── filters
            └── (1 / 0) > 0 [type=bool, side-effects]
 
-opt
+norm
 SELECT * FROM ((values (1.0::decimal)) EXCEPT (values (1.00::decimal))) WHERE column1::string != '1.00';
 ----
 select

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -13,7 +13,7 @@ CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
 
 # Don't allow ORDER BY column to be eliminated if it has a side effect.
-opt
+norm
 SELECT * FROM a ORDER BY length('foo'), random()+1.0
 ----
 sort
@@ -35,7 +35,7 @@ sort
            └── random() + 1.0 [type=float, side-effects]
 
 # Don't allow GROUP BY column to be eliminated if it has a side effect.
-opt
+norm
 SELECT avg(f) FROM a WHERE i=5 GROUP BY i+(random()*10)::int, i+1
 ----
 project
@@ -64,20 +64,18 @@ project
                 └── variable: f [type=float]
 
 # Allow elimination of side effecting expressions during column pruning.
-opt
+norm
 SELECT i FROM (SELECT i, nextval('foo') FROM a)
 ----
 scan a
  └── columns: i:2(int)
 
 # Allow duplication of side effecting expressions during predicate pushdown.
-opt
+norm
 SELECT * FROM a INNER JOIN xy ON k=x WHERE k=random()
 ----
-inner-join (merge)
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── left ordering: +1
- ├── right ordering: +6
  ├── side-effects
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
@@ -86,12 +84,10 @@ inner-join (merge)
  │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
- │    ├── ordering: +1
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2-5)
  │    └── filters
  │         └── k = random() [type=bool, outer=(1), side-effects, constraints=(/1: (/NULL - ])]
  ├── select
@@ -99,18 +95,17 @@ inner-join (merge)
  │    ├── side-effects
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── ordering: +6
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    └── ordering: +6
+ │    │    └── fd: (6)-->(7)
  │    └── filters
  │         └── x = random() [type=bool, outer=(6), side-effects, constraints=(/6: (/NULL - ])]
- └── filters (true)
+ └── filters
+      └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # Decorrelate CASE WHEN branch if there are no side effects.
-opt
+norm
 SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT 1) ELSE 5 END FROM a
 ----
 project
@@ -130,7 +125,7 @@ project
       └── CASE WHEN i < 0 THEN y ELSE 5 END [type=int, outer=(2,7)]
 
 # Decorrelate CASE ELSE branch if there are no side effects.
-opt
+norm
 SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i LIMIT 1) END)=k
 ----
 project
@@ -158,7 +153,7 @@ project
            └── k = CASE WHEN i < 0 THEN 5 ELSE y END [type=bool, outer=(1,2,7), constraints=(/1: (/NULL - ])]
 
 # Don't decorrelate CASE WHEN branch if there are side effects.
-opt
+norm
 SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) ELSE 5 END FROM a
 ----
 project
@@ -202,7 +197,7 @@ project
            └── const: 5 [type=int]
 
 # Don't decorrelate CASE ELSE branch if there are side effects.
-opt
+norm
 SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i AND 5/y>1) END)=k
 ----
 select

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -6,7 +6,7 @@ CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 # SimplifyZeroCardinalityGroup
 # --------------------------------------------------
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT k FROM b WHERE false
 ----
 values
@@ -15,7 +15,7 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (VALUES (1) OFFSET 1)
 ----
 values
@@ -24,7 +24,7 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM b INNER JOIN b b2 ON False
 ----
 values
@@ -33,7 +33,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-10)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM b LIMIT 0
 ----
 values
@@ -42,7 +42,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE i=1) WHERE False
 ----
 values
@@ -51,7 +51,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
 ----
 values
@@ -60,7 +60,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
 ----
 values
@@ -69,7 +69,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt
+norm
 SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
 ----
 project


### PR DESCRIPTION
Most of the norm rule tests use the `opt` directive, even though
they're only testing normalization rules. This is unnecessary, and
makes the outputs of these tests more prone to changes. This change
switches these tests to the `norm` directive.

Fixes #43248.

Release note: None