### PR TITLE
engine: clean up variable names for `{Reader,Writer,ReadWriter}` types

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -605,14 +605,14 @@ func NewDefaultEngine(cacheSize int64, storageConfig base.StorageConfig) (Engine
 //
 // Deprecated: use MVCCPutProto instead.
 func PutProto(
-	engine Writer, key MVCCKey, msg protoutil.Message,
+	writer Writer, key MVCCKey, msg protoutil.Message,
 ) (keyBytes, valBytes int64, err error) {
 	bytes, err := protoutil.Marshal(msg)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	if err := engine.Put(key, bytes); err != nil {
+	if err := writer.Put(key, bytes); err != nil {
 		return 0, 0, err
 	}
 
@@ -622,9 +622,9 @@ func PutProto(
 // Scan returns up to max key/value objects starting from
 // start (inclusive) and ending at end (non-inclusive).
 // Specify max=0 for unbounded scans.
-func Scan(engine Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
+func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
-	err := engine.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
+	err := reader.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
 		if max != 0 && int64(len(kvs)) >= max {
 			return true, nil
 		}
@@ -652,8 +652,8 @@ func WriteSyncNoop(ctx context.Context, eng Engine) error {
 // ClearRangeWithHeuristic clears the keys from start (inclusive) to end
 // (exclusive). Depending on the number of keys, it will either use ClearRange
 // or ClearIterRange.
-func ClearRangeWithHeuristic(eng Reader, writer Writer, start, end roachpb.Key) error {
-	iter := eng.NewIterator(IterOptions{UpperBound: end})
+func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Key) error {
+	iter := reader.NewIterator(IterOptions{UpperBound: end})
 	defer iter.Close()
 
 	// It is expensive for there to be many range deletion tombstones in the same

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -244,17 +244,17 @@ func TestEngineBatch(t *testing.T) {
 				{key, appender("  B"), true},
 			}
 
-			apply := func(eng ReadWriter, d data) error {
+			apply := func(rw ReadWriter, d data) error {
 				if d.value == nil {
-					return eng.Clear(d.key)
+					return rw.Clear(d.key)
 				} else if d.merge {
-					return eng.Merge(d.key, d.value)
+					return rw.Merge(d.key, d.value)
 				}
-				return eng.Put(d.key, d.value)
+				return rw.Put(d.key, d.value)
 			}
 
-			get := func(eng ReadWriter, key MVCCKey) []byte {
-				b, err := eng.Get(key)
+			get := func(rw ReadWriter, key MVCCKey) []byte {
+				b, err := rw.Get(key)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/engine/mvcc_incremental_iterator.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator.go
@@ -55,7 +55,7 @@ type MVCCIncrementalIterator struct {
 	// fields used for a workaround for a bug in the time-bound iterator
 	// (#28358)
 	upperBound roachpb.Key
-	e          Reader
+	reader     Reader
 	sanityIter Iterator
 
 	startTime hlc.Timestamp
@@ -77,9 +77,9 @@ type MVCCIncrementalIterOptions struct {
 }
 
 // NewMVCCIncrementalIterator creates an MVCCIncrementalIterator with the
-// specified engine and options.
+// specified reader and options.
 func NewMVCCIncrementalIterator(
-	e Reader, opts MVCCIncrementalIterOptions,
+	reader Reader, opts MVCCIncrementalIterOptions,
 ) *MVCCIncrementalIterator {
 	var sanityIter Iterator
 	if !opts.IterOptions.MinTimestampHint.IsEmpty() && !opts.IterOptions.MaxTimestampHint.IsEmpty() {
@@ -90,15 +90,15 @@ func NewMVCCIncrementalIterator(
 		// between the two iterators lead to intents and values falling outside of
 		// the timestamp range **from iter's perspective**. This allows us to simply
 		// ignore discrepancies that we notice in advance(). See #34819.
-		sanityIter = e.NewIterator(IterOptions{
+		sanityIter = reader.NewIterator(IterOptions{
 			UpperBound: opts.IterOptions.UpperBound,
 		})
 	}
 
 	return &MVCCIncrementalIterator{
-		e:          e,
+		reader:     reader,
 		upperBound: opts.IterOptions.UpperBound,
-		iter:       e.NewIterator(opts.IterOptions),
+		iter:       reader.NewIterator(opts.IterOptions),
 		startTime:  opts.StartTime,
 		endTime:    opts.EndTime,
 		sanityIter: sanityIter,

--- a/pkg/storage/engine/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator_test.go
@@ -308,10 +308,10 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 }
 
 func slurpKVsInTimeRange(
-	e Reader, prefix roachpb.Key, startTime, endTime hlc.Timestamp,
+	reader Reader, prefix roachpb.Key, startTime, endTime hlc.Timestamp,
 ) ([]MVCCKeyValue, error) {
 	endKey := prefix.PrefixEnd()
-	iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter := NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
 		IterOptions: IterOptions{
 			UpperBound: endKey,
 		},

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 // assertEq compares the given ms and expMS and errors when they don't match. It
-// also recomputes the stats over the whole engine with all known
+// also recomputes the stats over the whole ReadWriter with all known
 // implementations and errors on mismatch with any of them.
-func assertEq(t *testing.T, engine ReadWriter, debug string, ms, expMS *enginepb.MVCCStats) {
+func assertEq(t *testing.T, rw ReadWriter, debug string, ms, expMS *enginepb.MVCCStats) {
 	t.Helper()
 
 	msCpy := *ms // shallow copy
@@ -44,7 +44,7 @@ func assertEq(t *testing.T, engine ReadWriter, debug string, ms, expMS *enginepb
 		t.Errorf("%s: diff(ms, expMS) nontrivial", debug)
 	}
 
-	it := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+	it := rw.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 
 	for _, mvccStatsTest := range mvccStatsTests {

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -1086,7 +1086,7 @@ func (p pebbleSnapshot) NewIterator(opts IterOptions) Iterator {
 }
 
 func pebbleExportToSst(
-	e Reader,
+	reader Reader,
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -1098,7 +1098,7 @@ func pebbleExportToSst(
 
 	var rows RowCounter
 	iter := NewMVCCIncrementalIterator(
-		e,
+		reader,
 		MVCCIncrementalIterOptions{
 			IterOptions: io,
 			StartTime:   startTS,

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -164,8 +164,8 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		after.SeekGE(k)
 		t.Fatalf(`Seek on batch-backed iter after batched closed should panic.
 			iter.engine: %T, iter.engine.Closed: %v, batch.Closed %v`,
-			after.(*rocksDBIterator).engine,
-			after.(*rocksDBIterator).engine.Closed(),
+			after.(*rocksDBIterator).reader,
+			after.(*rocksDBIterator).reader.Closed(),
 			b.Closed(),
 		)
 	}()
@@ -1547,14 +1547,14 @@ func TestRocksDBWALFileEmptyBatch(t *testing.T) {
 		batch := e.NewBatch()
 		defer batch.Close()
 
-		var writer ReadWriter = batch
+		var rw ReadWriter = batch
 		if distinct {
 			// NB: we can't actually close this distinct batch because it auto-
 			// closes when the batch commits.
-			writer = batch.Distinct()
+			rw = batch.Distinct()
 		}
 
-		if err := writer.LogData([]byte("foo")); err != nil {
+		if err := rw.LogData([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 		if batch.Empty() {


### PR DESCRIPTION
We should be using {reader,writer,readWriter} for
{Reader,Writer,ReadWriter} respectively instead.

(Same thing as #43265, but for pkg/storage/engine).

Release note: None