### PR TITLE
sql: fix the parsing of interval types and literal values

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1495,8 +1495,7 @@ d_expr ::=
 	| 'BCONST'
 	| 'BITCONST'
 	| const_typename 'SCONST'
-	| interval
-	| const_interval '(' iconst32 ')' 'SCONST'
+	| interval_value
 	| 'TRUE'
 	| 'FALSE'
 	| 'NULL'
@@ -1523,9 +1522,7 @@ simple_typename ::=
 	const_typename
 	| bit_with_length
 	| character_with_length
-	| const_interval
-	| const_interval interval_qualifier
-	| const_interval '(' iconst32 ')'
+	| interval_type
 	| postgres_oid
 
 opt_array_bounds ::=
@@ -1834,14 +1831,9 @@ const_typename ::=
 	| 'INT2VECTOR'
 	| 'identifier'
 
-interval ::=
-	const_interval 'SCONST' opt_interval
-
-const_interval ::=
-	'INTERVAL'
-
-iconst32 ::=
-	'ICONST'
+interval_value ::=
+	'INTERVAL' 'SCONST' opt_interval_qualifier
+	| 'INTERVAL' '(' iconst32 ')' 'SCONST'
 
 column_path_with_star ::=
 	column_path
@@ -1887,20 +1879,10 @@ bit_with_length ::=
 character_with_length ::=
 	character_base '(' iconst32 ')'
 
-interval_qualifier ::=
-	'YEAR'
-	| 'MONTH'
-	| 'DAY'
-	| 'HOUR'
-	| 'MINUTE'
-	| interval_second
-	| 'YEAR' 'TO' 'MONTH'
-	| 'DAY' 'TO' 'HOUR'
-	| 'DAY' 'TO' 'MINUTE'
-	| 'DAY' 'TO' interval_second
-	| 'HOUR' 'TO' 'MINUTE'
-	| 'HOUR' 'TO' interval_second
-	| 'MINUTE' 'TO' interval_second
+interval_type ::=
+	'INTERVAL'
+	| 'INTERVAL' interval_qualifier
+	| 'INTERVAL' '(' iconst32 ')'
 
 postgres_oid ::=
 	'REGPROC'
@@ -2125,9 +2107,12 @@ const_json ::=
 	'JSON'
 	| 'JSONB'
 
-opt_interval ::=
+opt_interval_qualifier ::=
 	interval_qualifier
 	| 
+
+iconst32 ::=
+	'ICONST'
 
 func_application ::=
 	func_name '(' ')'
@@ -2196,9 +2181,20 @@ character_base ::=
 	| 'VARCHAR'
 	| 'STRING'
 
-interval_second ::=
-	'SECOND'
-	| 'SECOND' '(' iconst32 ')'
+interval_qualifier ::=
+	'YEAR'
+	| 'MONTH'
+	| 'DAY'
+	| 'HOUR'
+	| 'MINUTE'
+	| interval_second
+	| 'YEAR' 'TO' 'MONTH'
+	| 'DAY' 'TO' 'HOUR'
+	| 'DAY' 'TO' 'MINUTE'
+	| 'DAY' 'TO' interval_second
+	| 'HOUR' 'TO' 'MINUTE'
+	| 'HOUR' 'TO' interval_second
+	| 'MINUTE' 'TO' interval_second
 
 window_definition_list ::=
 	( window_definition ) ( ( ',' window_definition ) )*
@@ -2340,6 +2336,10 @@ tuple1_unambiguous_values ::=
 char_aliases ::=
 	'CHAR'
 	| 'CHARACTER'
+
+interval_second ::=
+	'SECOND'
+	| 'SECOND' '(' iconst32 ')'
 
 window_definition ::=
 	window_name 'AS' window_specification

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1669,8 +1669,10 @@ func TestParse2(t *testing.T) {
 
 		// Interval constructor gets eagerly processed.
 		{`SELECT INTERVAL '0'`, `SELECT '00:00:00'`},
+		{`SELECT INTERVAL '1' SECOND`, `SELECT '00:00:01'`},
 		{`SELECT INTERVAL(3) '12.1234s'`, `SELECT '00:00:12.123'`},
-		{`SELECT INTERVAL '14.7899s' SECOND(3)`, `SELECT '00:00:14.79'`},
+		{`SELECT INTERVAL '12.1234s' SECOND(3)`, `SELECT '00:00:12.123'`},
+		{`SELECT INTERVAL '14.7899s' SECOND(3)`, `SELECT '00:00:14.79'`}, // Check rounding.
 
 		{`SELECT '11s'::INTERVAL(3)`, `SELECT '11s'::INTERVAL(3)`},
 		{`SELECT '10:00:13.123456'::INTERVAL SECOND`, `SELECT '10:00:13.123456'::INTERVAL SECOND`},
@@ -1702,6 +1704,8 @@ func TestParse2(t *testing.T) {
 		{`SET TIME ZONE "Europe/Rome"`,
 			`SET timezone = 'Europe/Rome'`},
 		{`SET TIME ZONE INTERVAL '-7h'`,
+			`SET timezone = '-07:00:00'`},
+		{`SET TIME ZONE INTERVAL(3) '-7h'`,
 			`SET timezone = '-07:00:00'`},
 		{`SET TIME ZONE INTERVAL '-7h0m5s' HOUR TO MINUTE`,
 			`SET timezone = '-06:59:00'`},


### PR DESCRIPTION
Prior to this patch, the interval-with-precision literal value syntax
was only allowed as scalar expression. However in PostgreSQL any
literal interval value is also allowed as a time zone.

This patch fixes it.

Additionally, the action rules in the grammar were unnecessarily
pushing `types.Interval` as a (parsing) stack entry, to be immediately
discarded because the surrounding non-terminal did not need it.

This patch removes this unnecessary work.

Finally, the grammar was splitting the non-terminals for intervals in
various places and did not fully clarify the difference between
interval-as-type and interval-as-value, making reading and understanding
the grammar unnecessarily difficult.

This patch fixes it by renaming the non-terminals.

(No release note is added because the user-facing change is a bug fix
for the PR immediately before this, where the resulting behavior is
still accurately described by the previous release note.)

Release note: None