### PR TITLE
coldata: fix printing window into Bytes

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -162,8 +162,10 @@ func (b *Bytes) Window(start, end int) *Bytes {
 		data: data,
 		// We use 'end+1' because of the extra offset to know the length of the
 		// last element of the newly created window.
-		offsets:  b.offsets[start : end+1],
-		isWindow: true,
+		offsets: b.offsets[start : end+1],
+		// maxSetIndex is set only for pretty printing the Bytes.
+		maxSetIndex: (end - start) - 1,
+		isWindow:    true,
 	}
 }
 

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -368,6 +368,37 @@ func TestBytes(t *testing.T) {
 		require.Panics(t, func() { b2.AppendVal([]byte("four")) }, "appending to the window into b1 should have panicked")
 	})
 
+	t.Run("String", func(t *testing.T) {
+		b1 := NewBytes(0)
+		vals := [][]byte{
+			[]byte("one"),
+			[]byte("two"),
+			[]byte("three"),
+		}
+		for i := range vals {
+			b1.AppendVal(vals[i])
+		}
+
+		// The values should be printed using the String function.
+		b1String := b1.String()
+		require.True(
+			t,
+			strings.Contains(b1String, fmt.Sprint(vals[0])) &&
+				strings.Contains(b1String, fmt.Sprint(vals[1])) &&
+				strings.Contains(b1String, fmt.Sprint(vals[2])),
+		)
+
+		// A window on the bytes should only print the values included in the
+		// window.
+		b2String := b1.Window(1, 3).String()
+		require.True(
+			t,
+			!strings.Contains(b2String, fmt.Sprint(vals[0])) &&
+				strings.Contains(b2String, fmt.Sprint(vals[1])) &&
+				strings.Contains(b2String, fmt.Sprint(vals[2])),
+		)
+	})
+
 	t.Run("InvariantSimple", func(t *testing.T) {
 		b1 := NewBytes(8)
 		b1.Set(0, []byte("zero"))


### PR DESCRIPTION
Bytes.String would look at the maxSetIndex to determine the last element to
print. In the case of a window into a Bytes struct, the window would always
have a maxSetIndex of 0 since it is unused (write operations are disallowed so
a maxSetIndex is not needed to enforce invariants). This would result in only
printing one element.