### PR TITLE
build: upgrade to go1.13.5

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -76,6 +76,11 @@ back to this document:
 * [ ] Rebuild the Docker image and bump the version in builder.sh accordingly ([source](./builder.sh#L6)).
 * [ ] Bump the version in go-version-check.sh ([source](./go-version-check.sh)), unless bumping to a new patch release.
 * [ ] Bump the default installed version of Go in bootstrap-debian.sh ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
+* [ ] Update the `builder.dockerImage` parameter in the TeamCity `Cockroach` project.
+
+You can test the new builder image in TeamCity by using the custom parameters
+UI (the "..." icon next to the "Run" button) to verify the image before
+committing the change.
 
 ## Updating Dependencies
 

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -38,9 +38,9 @@ echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.12.12.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-4cf11ac6a8fa42d26ab85e27a5d916ee171900a87745d9f7d4a29a21587d78fc  /tmp/go.tgz
+512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20191029-105705
+version=20191218-092712
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,8 +196,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.12.12.src.tar.gz -o golang.tar.gz \
- && echo 'fcb33b5290fa9bcc52be3211501540df7483d7276b031fc77528672a3c705b99 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.13.5.src.tar.gz -o golang.tar.gz \
+ && echo '27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \

--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -39,12 +39,12 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, security.RootUser, true /* generate pk8 key */))
+		1024, 48*time.Hour, false, security.RootUser, true /* generate pk8 key */))
 
 	// Test user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, "testuser", true /* generate pk8 key */))
+		1024, 48*time.Hour, false, "testuser", true /* generate pk8 key */))
 
 	// Certs for starting a cockroach server. Key size is from cli/cert.go:defaultKeySize.
 	maybePanic(security.CreateNodePair(

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -163,11 +163,7 @@ func TestErrorReporting(t *testing.T) {
 				severity: log.Severity_INFO,
 				cause:    errors.New("routine"),
 			}),
-			// TODO: In Go 1.13 and later, we should unwrap successfully and get
-			// log.Severity_INFO. With all compilers, wantCLICause is false - in Go
-			// 1.12 the cause is the top-level error, and in Go 1.13+ the cause is
-			// "routine".
-			wantSeverity: log.Severity_ERROR,
+			wantSeverity: log.Severity_INFO,
 			wantCLICause: false,
 		},
 	}


### PR DESCRIPTION
* [X] Adjust version in Docker image ([source](./builder/Dockerfile#L199-L200)).
* [X] Rebuild the Docker image and bump the version in builder.sh accordingly ([source](./builder.sh#L6)).
* [X] Bump the version in go-version-check.sh ([source](./go-version-check.sh)), unless bumping to a new patch release.
* [X] Bump the default installed version of Go in bootstrap-debian.sh ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
* [X] Update the `builder.dockerImage` parameter in the TeamCity `Cockroach` project.

This change also adds some additional information to the README for validating
the image.

Fixes: #41808

Release note (build change): CockroachDB is now built against go1.13.5