### PR TITLE
builtins: add extract functionality for intervals

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -368,6 +368,10 @@ return without an error.</p>
 quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
+<tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
+<p>Compatible elements: millennium, century, decade, year,
+month, day, hour, minute, second, millisecond, microsecond, epoch</p>
+</span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
 <p>Compatible elements: hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
@@ -387,7 +391,8 @@ timezone, timezone_hour, timezone_minute</p>
 timezone, timezone_hour, timezone_minute</p>
 </span></td></tr>
 <tr><td><a name="extract_duration"></a><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.
-Compatible elements: hour, minute, second, millisecond, microsecond.</p>
+Compatible elements: hour, minute, second, millisecond, microsecond.
+This is deprecated in favor of <code>extract</code> which supports duration.</p>
 </span></td></tr>
 <tr><td><a name="now"></a><code>now() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -25,6 +25,18 @@ select * from interval_duration_type order by id asc
 2  12:56:07.40736            12:56:07.407           12:56:07.40736            12:56:07.407           12:56:00           12:56:07.407
 3  366 days 12:34:56.123456  366 days 12:34:56.123  366 days 12:34:56.123456  366 days 12:34:56.123  366 days 12:34:00  366 days 12:34:56.123
 
+subtest interval_extract_tests
+
+query R
+SELECT extract('second', interval '10:55:01.456')
+----
+1.456
+
+query R
+SELECT extract(minute from interval '10:55:01.456')
+----
+55
+
 # tests various typmods of intervals
 # matches subset of tests in src/test/regress/expected/interval.out
 subtest interval_postgres_duration_type_tests


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/43209

This adds the postgres-esque implementation of extract for intervals.
Tested a variety of edge cases and compared against what postgres
returns.

Currently leaving the `extract_duration` function alone - we could
thereoetically get rid of it after this PR. It does behave slightly
differently as well.


Release note (sql change): Added new ability to call extract on an
interval, e.g. `extract(day from interval '254 days')`. This follows
the postgres implementation. Furthermore, this deprecates
`extract_duration`, which will be removed at a later date.