### PR TITLE
sql: support EXPLAIN with AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -875,6 +875,8 @@ func (p *planner) isAsOf(stmt tree.Statement) (*hlc.Timestamp, error) {
 			return nil, nil
 		}
 		asOf = s.Options.AsOf
+	case *tree.Explain:
+		return p.isAsOf(s.Statement)
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -66,3 +66,7 @@ SELECT * FROM t AS OF SYSTEM TIME '-0.1us'
 
 statement error pq: AS OF SYSTEM TIME: zero timestamp is invalid
 SELECT * FROM t AS OF SYSTEM TIME '0'
+
+# Verify we can explain a statement that has AS OF.
+statement ok
+EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'


### PR DESCRIPTION
We apparently can't stick an `EXPLAIN` in front of a query that uses
AOST. The fix is very easy, we need an extra case for the logic that
figures out the statement-wide timestamp.

Note that if we want to do `SELECT FROM [EXPLAIN ...]`, in that case
we still need to add AS OF SYSTEM TIME to the outer clause as usual.

Fixes #43294.

Release note (bug fix): EXPLAIN can now be used with statements that
use AS OF SYSTEM TIME.