### PR TITLE
sql: fix a few issues with reporting of errors to sentry

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1431,11 +1430,9 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		pe, ok := payload.(payloadWithError)
 		if ok {
 			ex.sessionEventf(ctx, "execution error: %s", pe.errorCause())
-		}
-		if resErr == nil && ok {
-			res.SetError(pe.errorCause())
-		} else {
-			ex.recordError(ctx, resErr)
+			if resErr == nil {
+				res.SetError(pe.errorCause())
+			}
 		}
 		res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 	} else {
@@ -2130,13 +2127,6 @@ func (ex *connExecutor) initStatementResult(
 		res.SetColumns(ctx, cols)
 	}
 	return nil
-}
-
-// recordError processes an error at the end of query execution.
-// This triggers telemetry and, if the error is an internal error,
-// triggers the emission of a sentry report.
-func (ex *connExecutor) recordError(ctx context.Context, err error) {
-	sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 }
 
 // newStatsCollector returns a sqlStatsCollector that will record stats in the

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1376,7 +1376,7 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 			if ex.idleConn() {
 				// If we're about to close the connection, close res in order to flush
 				// now, as we won't have an opportunity to do it later.
-				res.Close(stateToTxnStatusIndicator(ex.machine.CurState()))
+				res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 				return errDrainingComplete
 			}
 		}
@@ -1435,10 +1435,10 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		if resErr == nil && ok {
 			// Depending on whether the result has the error already or not, we have
 			// to call either Close or CloseWithErr.
-			res.CloseWithErr(pe.errorCause())
+			res.CloseWithErr(ctx, pe.errorCause())
 		} else {
 			ex.recordError(ctx, resErr)
-			res.Close(stateToTxnStatusIndicator(ex.machine.CurState()))
+			res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 		}
 	} else {
 		res.Discard()

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1433,13 +1433,11 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 			ex.sessionEventf(ctx, "execution error: %s", pe.errorCause())
 		}
 		if resErr == nil && ok {
-			// Depending on whether the result has the error already or not, we have
-			// to call either Close or CloseWithErr.
-			res.CloseWithErr(ctx, pe.errorCause())
+			res.SetError(pe.errorCause())
 		} else {
 			ex.recordError(ctx, resErr)
-			res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 		}
+		res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 	} else {
 		res.Discard()
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
@@ -1151,7 +1152,9 @@ func (ex *connExecutor) runShowSyntax(
 		func(ctx context.Context, field, msg string) {
 			commErr = res.AddRow(ctx, tree.Datums{tree.NewDString(field), tree.NewDString(msg)})
 		},
-		ex.recordError, /* reportErr */
+		func(ctx context.Context, err error) {
+			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
+		},
 	)
 	return commErr
 }

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -636,8 +636,8 @@ type CommandResult interface {
 // query execution error.
 type CommandResultErrBase interface {
 	// SetError accumulates an execution error that needs to be reported to the
-	// client. No further calls other than SetError(), Close()/CloseWithError()
-	// and Discard() are allowed.
+	// client. No further calls other than SetError(), Close() and Discard() are
+	// allowed.
 	//
 	// Calling SetError() a second time overwrites the previously set error.
 	SetError(error)
@@ -658,24 +658,14 @@ type ResultBase interface {
 type CommandResultClose interface {
 	// Close marks a result as complete. No further uses of the CommandResult are
 	// allowed after this call. All results must be eventually closed through
-	// Close()/CloseWithErr()/Discard(), except in case query processing has
-	// encountered an irrecoverable error and the client connection will be
-	// closed; in such cases it is not mandated that these functions are called on
-	// the result that may have been open at the time the error occurred.
+	// Close()/Discard(), except in case query processing has encountered an
+	// irrecoverable error and the client connection will be closed; in such
+	// cases it is not mandated that these functions are called on the result
+	// that may have been open at the time the error occurred.
 	// NOTE(andrei): We might want to tighten the contract if the results get any
 	// state that needs to be closed even when the whole connection is about to be
 	// terminated.
 	Close(context.Context, TransactionStatusIndicator)
-
-	// CloseWithErr is like Close, except it tells the client that an execution
-	// error has happened. All rows previously accumulated on the result might be
-	// discarded; only this error might be delivered to the client as a result of
-	// the command.
-	//
-	// After calling CloseWithErr it is illegal to create CommandResults for any
-	// command in the same batch as the one being closed. The contract is that the
-	// next result created corresponds to the first command in the next batch.
-	CloseWithErr(context.Context, error)
 
 	// Discard is called to mark the fact that the result is being disposed off.
 	// No completion message will be sent to the client. The expectation is that
@@ -858,8 +848,7 @@ type bufferedCommandResult struct {
 	// of the query is not expected to produce any results.
 	errOnly bool
 
-	// closeCallback, if set, is called when Close()/CloseWithErr()/Discard() is
-	// called.
+	// closeCallback, if set, is called when Close()/Discard() is called.
 	closeCallback func(*bufferedCommandResult, resCloseType, error)
 }
 
@@ -918,14 +907,6 @@ func (r *bufferedCommandResult) RowsAffected() int {
 func (r *bufferedCommandResult) Close(context.Context, TransactionStatusIndicator) {
 	if r.closeCallback != nil {
 		r.closeCallback(r, closed, nil /* err */)
-	}
-}
-
-// CloseWithErr is part of the CommandResultClose interface.
-func (r *bufferedCommandResult) CloseWithErr(ctx context.Context, err error) {
-	r.err = err
-	if r.closeCallback != nil {
-		r.closeCallback(r, closed, err)
 	}
 }
 

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -665,7 +665,7 @@ type CommandResultClose interface {
 	// NOTE(andrei): We might want to tighten the contract if the results get any
 	// state that needs to be closed even when the whole connection is about to be
 	// terminated.
-	Close(TransactionStatusIndicator)
+	Close(context.Context, TransactionStatusIndicator)
 
 	// CloseWithErr is like Close, except it tells the client that an execution
 	// error has happened. All rows previously accumulated on the result might be
@@ -675,7 +675,7 @@ type CommandResultClose interface {
 	// After calling CloseWithErr it is illegal to create CommandResults for any
 	// command in the same batch as the one being closed. The contract is that the
 	// next result created corresponds to the first command in the next batch.
-	CloseWithErr(err error)
+	CloseWithErr(context.Context, error)
 
 	// Discard is called to mark the fact that the result is being disposed off.
 	// No completion message will be sent to the client. The expectation is that
@@ -864,6 +864,7 @@ type bufferedCommandResult struct {
 }
 
 var _ RestrictedCommandResult = &bufferedCommandResult{}
+var _ CommandResultClose = &bufferedCommandResult{}
 
 // SetColumns is part of the RestrictedCommandResult interface.
 func (r *bufferedCommandResult) SetColumns(_ context.Context, cols sqlbase.ResultColumns) {
@@ -913,15 +914,15 @@ func (r *bufferedCommandResult) RowsAffected() int {
 	return r.rowsAffected
 }
 
-// Close is part of the CommandResult interface.
-func (r *bufferedCommandResult) Close(TransactionStatusIndicator) {
+// Close is part of the CommandResultClose interface.
+func (r *bufferedCommandResult) Close(context.Context, TransactionStatusIndicator) {
 	if r.closeCallback != nil {
 		r.closeCallback(r, closed, nil /* err */)
 	}
 }
 
-// CloseWithErr is part of the CommandResult interface.
-func (r *bufferedCommandResult) CloseWithErr(err error) {
+// CloseWithErr is part of the CommandResultClose interface.
+func (r *bufferedCommandResult) CloseWithErr(ctx context.Context, err error) {
 	r.err = err
 	if r.closeCallback != nil {
 		r.closeCallback(r, closed, err)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -200,7 +201,7 @@ func (ie *internalExecutorImpl) initConnEx(
 	wg.Add(1)
 	go func() {
 		if err := ex.run(ctx, ie.mon, mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
-			ex.recordError(ctx, err)
+			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 			errCallback(err)
 		}
 		closeMode := normalClose

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -86,8 +86,10 @@ type commandResult struct {
 	released bool
 }
 
+var _ sql.CommandResult = &commandResult{}
+
 // Close is part of the CommandResult interface.
-func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
+func (r *commandResult) Close(ctx context.Context, t sql.TransactionStatusIndicator) {
 	r.assertNotReleased()
 	defer r.release()
 	if r.errExpected && r.err == nil {
@@ -96,7 +98,7 @@ func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
 
 	r.conn.writerState.fi.registerCmd(r.pos)
 	if r.err != nil {
-		r.conn.bufferErr(r.err)
+		r.conn.bufferErr(ctx, r.err)
 		return
 	}
 
@@ -130,7 +132,7 @@ func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
 }
 
 // CloseWithErr is part of the CommandResult interface.
-func (r *commandResult) CloseWithErr(err error) {
+func (r *commandResult) CloseWithErr(ctx context.Context, err error) {
 	r.assertNotReleased()
 	defer r.release()
 	if r.err != nil {
@@ -138,7 +140,7 @@ func (r *commandResult) CloseWithErr(err error) {
 	}
 
 	r.conn.writerState.fi.registerCmd(r.pos)
-	r.conn.bufferErr(err)
+	r.conn.bufferErr(ctx, err)
 }
 
 // Discard is part of the CommandResult interface.

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -131,18 +131,6 @@ func (r *commandResult) Close(ctx context.Context, t sql.TransactionStatusIndica
 	}
 }
 
-// CloseWithErr is part of the CommandResult interface.
-func (r *commandResult) CloseWithErr(ctx context.Context, err error) {
-	r.assertNotReleased()
-	defer r.release()
-	if r.err != nil {
-		panic(fmt.Sprintf("can't overwrite err: %s with err: %s", r.err, err))
-	}
-
-	r.conn.writerState.fi.registerCmd(r.pos)
-	r.conn.bufferErr(ctx, err)
-}
-
 // Discard is part of the CommandResult interface.
 func (r *commandResult) Discard() {
 	r.assertNotReleased()

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1151,10 +1151,8 @@ func (c *conn) bufferPortalSuspended() {
 	}
 }
 
-func (c *conn) bufferErr(err error) {
-	// TODO(andrei,knz): This would benefit from a context with the
-	// current connection log tags.
-	if err := writeErr(context.Background(), c.sv,
+func (c *conn) bufferErr(ctx context.Context, err error) {
+	if err := writeErr(ctx, c.sv,
 		err, &c.msgBuilder, &c.writerState.buf); err != nil {
 		panic(fmt.Sprintf("unexpected err from buffer: %s", err))
 	}


### PR DESCRIPTION
**sql: use the correct context when recording an error for sentry**

Previously, context.Background() was used to record an internal error.
That context is missing the registered tags (e.g. 'statement' tag) which
results in an incomplete sentry report. Now this is fixed.

Release note: None

**sql: remove CloseWithErr method from CommandResultClose interface**

The behavior of CloseWithErr method can be obtained with SetError
followed by Close, so this commit does such refactoring which simplifies
the interface.

Release note: None

**sql: fix double reporting of the same error with sentry**

Previously, in a certain code path both connExecutor and pgwire would
record telemetry for the same error to be sent to sentry. This resulted
in duplicated events. Now this is fixed.

Release note: None