### PR TITLE
release-19.2: cdctest: perform txn retries in validator

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -232,7 +232,11 @@ func (v *fingerprintValidator) NoteRow(
 }
 
 // applyRowUpdate applies the update represented by `row` to the scratch table.
-func (v *fingerprintValidator) applyRowUpdate(row validatorRow) error {
+func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
+	defer func() {
+		_err = errors.Wrap(_err, "fingerprintValidator failed")
+	}()
+
 	txn, err := v.sqlDB.Begin()
 	if err != nil {
 		return err

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -636,6 +636,7 @@ func (k kafkaManager) basePath() string {
 }
 
 func (k kafkaManager) install(ctx context.Context) {
+	k.c.status("installing kafka")
 	folder := k.basePath()
 	k.c.Run(ctx, k.nodes, `mkdir -p `+folder)
 	k.c.Run(ctx, k.nodes, `curl -s https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz | tar -xz -C `+folder)

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -27,8 +27,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 	"github.com/codahale/hdrhistogram"
-	"github.com/pkg/errors"
 )
 
 type workloadType string
@@ -291,10 +291,15 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		if atomic.LoadInt64(&doneAtomic) > 0 {
 			return nil
 		}
-		return err
+		return errors.Wrap(err, "workload failed")
 	})
-	m.Go(func(ctx context.Context) error {
+	m.Go(func(ctx context.Context) (_err error) {
 		defer workloadCancel()
+
+		defer func() {
+			_err = errors.Wrap(_err, "CDC failed")
+		}()
+
 		l, err := t.l.ChildLogger(`changefeed`)
 		if err != nil {
 			return err
@@ -310,13 +315,13 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		if _, err := db.Exec(
 			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,
 		); err != nil {
-			return err
+			return errors.Wrap(err, "CREATE TABLE failed")
 		}
 
 		const requestedResolved = 100
 		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions, 0)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "error creating validator")
 		}
 		v := cdctest.MakeCountValidator(cdctest.Validators{
 			cdctest.NewOrderValidator(`bank`),
@@ -349,7 +354,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 			}
 		}
 		if failures := v.Failures(); len(failures) > 0 {
-			return errors.New(strings.Join(failures, "\n"))
+			return errors.New("validator failures:\n" + strings.Join(failures, "\n"))
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -770,9 +770,12 @@ func (p clusterReusePolicyOption) apply(spec *clusterSpec) {
 //
 // A cluster is safe for concurrent use by multiple goroutines.
 type cluster struct {
-	name   string
-	tag    string
-	spec   clusterSpec
+	name string
+	tag  string
+	spec clusterSpec
+	// status is used to communicate the test's status. The callback is a noop
+	// until the cluster is passed to a test, at which point it's hooked up to
+	// test.Status().
 	status func(...interface{})
 	t      testI
 	// r is the registry tracking this cluster. Destroying the cluster will


### PR DESCRIPTION
Backport 4/4 commits from #43215.

/cc @cockroachdb/release

---

Before this patch, fingerprintValidator.applyRowUpdate() was missing a
retry loop around its sql txn. But turns out that the txn was not needed
at all since we're running a single statement.

Fixes #42773
