### PR TITLE
release-2.1: sql: support EXPLAIN with AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -687,6 +687,8 @@ func (p *planner) isAsOf(stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp
 		asOf = s.AsOf
 	case *tree.Export:
 		return p.isAsOf(s.Query, max)
+	case *tree.Explain:
+		return p.isAsOf(s.Statement, max)
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -40,3 +40,7 @@ SELECT * FROM t AS OF SYSTEM TIME '-1h'
 
 statement error cannot specify timestamp in the future
 SELECT * FROM t AS OF SYSTEM TIME '10s'
+
+# Verify we can explain a statement that has AS OF.
+statement ok
+EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'


### PR DESCRIPTION
Backport 1/1 commits from #43296.

/cc @cockroachdb/release

---

We apparently can't stick an `EXPLAIN` in front of a query that uses
AOST. The fix is very easy, we need an extra case for the logic that
figures out the statement-wide timestamp.

Note that if we want to do `SELECT FROM [EXPLAIN ...]`, in that case
we still need to add AS OF SYSTEM TIME to the outer clause as usual.

Fixes #43294.

Release note (bug fix): EXPLAIN can now be used with statements that
use AS OF SYSTEM TIME.
