### PR TITLE
sql: add no-op support for fillfactor storage parameter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -39,3 +39,16 @@ CREATE TABLE v (
    INDEX "v_auto_index_fk_'_ref_t" ("'" ASC),
    FAMILY "primary" ("'", s, rowid)
 )  {"ALTER TABLE v ADD CONSTRAINT \"fk_'_ref_t\" FOREIGN KEY (\"'\") REFERENCES t(rowid)","ALTER TABLE v ADD CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES v(s)"}  {"ALTER TABLE v VALIDATE CONSTRAINT \"fk_'_ref_t\"","ALTER TABLE v VALIDATE CONSTRAINT fk_s_ref_v"}
+
+statement error invalid storage parameter "foo"
+CREATE TABLE a (b INT) WITH (foo=100);
+
+statement error argument of fillfactor must be type int, not type bool
+CREATE TABLE a (b INT) WITH (fillfactor=true);
+
+statement error unimplemented: storage parameter "toast_tuple_target"
+CREATE TABLE a (b INT) WITH (toast_tuple_target=100);
+
+statement ok
+CREATE TABLE a (b INT) WITH (fillfactor=100);
+

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1425,6 +1425,8 @@ func TestParse2(t *testing.T) {
 			`CREATE DATABASE a TEMPLATE = 'template0'`},
 		{`CREATE DATABASE a TEMPLATE = invalid`,
 			`CREATE DATABASE a TEMPLATE = 'invalid'`},
+		{`CREATE TABLE a (b INT) WITH (fillfactor=100)`,
+			`CREATE TABLE a (b INT8)`},
 		{`CREATE TABLE a (b INT, UNIQUE INDEX foo (b))`,
 			`CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b))`},
 		{`CREATE TABLE a (b INT, UNIQUE INDEX foo (b) INTERLEAVE IN PARENT c (d))`,
@@ -3103,7 +3105,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE TABLE a(LIKE b)`, 30840, ``},
 
 		{`CREATE TABLE a(b INT8) WITH OIDS`, 0, `create table with oids`},
-		{`CREATE TABLE a(b INT8) WITH foo = bar`, 0, `create table with foo`},
 
 		{`CREATE TABLE a AS SELECT b WITH NO DATA`, 0, `create table as with no data`},
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -900,13 +900,38 @@ func (node *RangePartition) Format(ctx *FmtCtx) {
 	}
 }
 
+// StorageParam is a key-value parameter for table storage.
+type StorageParam struct {
+	Key   Name
+	Value Expr
+}
+
+// StorageParams is a list of StorageParams.
+type StorageParams []StorageParam
+
+// Format implements the NodeFormatter interface.
+func (o *StorageParams) Format(ctx *FmtCtx) {
+	for i := range *o {
+		n := &(*o)[i]
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNode(&n.Key)
+		if n.Value != nil {
+			ctx.WriteString(` = `)
+			ctx.FormatNode(n.Value)
+		}
+	}
+}
+
 // CreateTable represents a CREATE TABLE statement.
 type CreateTable struct {
-	IfNotExists bool
-	Table       TableName
-	Interleave  *InterleaveDef
-	PartitionBy *PartitionBy
-	Temporary   bool
+	IfNotExists   bool
+	Table         TableName
+	Interleave    *InterleaveDef
+	PartitionBy   *PartitionBy
+	Temporary     bool
+	StorageParams StorageParams
 	// In CREATE...AS queries, Defs represents a list of ColumnTableDefs, one for
 	// each column, and a ConstraintTableDef for each constraint on a subset of
 	// these columns.
@@ -970,6 +995,8 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 		if node.PartitionBy != nil {
 			ctx.FormatNode(node.PartitionBy)
 		}
+		// No storage parameters are implemented, so we never list the storage
+		// parameters in the output format.
 	}
 }
 


### PR DESCRIPTION
closes #42467

Release note (sql change): Some tools generate SQL that includes the
fillfactor storage parameter, e.g., `CREATE TABLE ... WITH (fillfactor=100)`.
The syntax is now supported, but it has no effect, since the parameter
has no meaning in CockroachDB.