### PR TITLE
importccl: log input file and hashes during IMPORT for debugging [DO NOT MERGE]

### DIFF
--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -12,6 +12,8 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"context"
+	"crypto/md5"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -97,13 +99,19 @@ func readInputFiles(
 			}
 			defer raw.Close()
 
-			src := &fileReader{total: fileSizes[dataFileIndex], counter: byteCounter{r: raw}}
+			src := &fileReader{
+				total: fileSizes[dataFileIndex],
+				counter: byteCounter{
+					r: maybeWrapReader(dataFile, "-raw", raw),
+				},
+			}
+
 			decompressed, err := decompressingReader(&src.counter, dataFile, format.Compression)
 			if err != nil {
 				return err
 			}
 			defer decompressed.Close()
-			src.Reader = decompressed
+			src.Reader = maybeWrapReader(dataFile, "-decomp", decompressed)
 
 			wrappedProgressFn := func(finished bool) error { return nil }
 			if updateFromBytes {
@@ -182,6 +190,52 @@ func (b *byteCounter) Read(p []byte) (int, error) {
 	n, err := b.r.Read(p)
 	b.n += int64(n)
 	return n, err
+}
+
+type tracingReader struct {
+	r         io.Reader
+	id        string
+	runHash   hash.Hash
+	blockHash hash.Hash
+	pos       int64
+}
+
+var _ io.Reader = &tracingReader{}
+
+func (t *tracingReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+
+	if n > 0 {
+		t.runHash.Write(p)
+		t.blockHash.Reset()
+		t.blockHash.Write(p)
+	}
+
+	if n > 0 || err != nil {
+		log.Infof(context.Background(), "TR:read(%s)@%d: n=%d rh=%x bh=%x err=%v\n",
+			t.id, t.pos, n, t.runHash.Sum(nil), t.blockHash.Sum(nil), err)
+	}
+
+	t.pos += int64(n)
+	return n, err
+}
+
+func maybeWrapReader(id string, layer string, r io.Reader) io.Reader {
+	if log.V(3) {
+		if u, err := url.Parse(id); err == nil {
+			id = u.Path
+		}
+		id += layer
+
+		return &tracingReader{
+			r:         r,
+			id:        id,
+			runHash:   md5.New(),
+			blockHash: md5.New(),
+			pos:       0,
+		}
+	}
+	return r
 }
 
 type fileReader struct {

--- a/pkg/testutils/buildutil/build.go
+++ b/pkg/testutils/buildutil/build.go
@@ -129,54 +129,54 @@ func VerifyNoImports(
 // VerifyTransitiveWhitelist checks that the entire set of transitive
 // dependencies of the given package is in a whitelist. Vendored and stdlib
 // packages are always allowed.
-func VerifyTransitiveWhitelist(t testing.TB, pkg string, allowedPkgs []string) {
-	// Skip test if source is not available.
-	if build.Default.GOPATH == "" {
-		t.Skip("GOPATH isn't set")
-	}
-
-	checked := make(map[string]struct{})
-	allowed := make(map[string]struct{}, len(allowedPkgs))
-	for _, allowedPkg := range allowedPkgs {
-		allowed[allowedPkg] = struct{}{}
-	}
-
-	var check func(string)
-	check = func(path string) {
-		if _, ok := checked[path]; ok {
-			return
-		}
-		checked[path] = struct{}{}
-		if strings.HasPrefix(path, "github.com/cockroachdb/cockroach/vendor") {
-			return
-		}
-
-		pkg, err := build.Default.Import(path, "", 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, imp := range pkg.Imports {
-			if !strings.HasPrefix(imp, "github.com/cockroachdb/cockroach/") {
-				continue
-			}
-			if _, ok := allowed[imp]; !ok {
-				t.Errorf("%s imports %s, which is forbidden", short(path), short(imp))
-				// If we can't have this package, don't bother recursively checking the
-				// deps, they'll just be noise.
-				continue
-			}
-
-			// https://github.com/golang/tools/blob/master/refactor/importgraph/graph.go#L159
-			if imp == "C" {
-				continue // "C" is fake
-			}
-
-			importPkg, err := build.Default.Import(imp, pkg.Dir, build.FindOnly)
-			if err != nil {
-				t.Fatal(err)
-			}
-			check(importPkg.ImportPath)
-		}
-	}
-	check(pkg)
-}
+// func VerifyTransitiveWhitelist(t testing.TB, pkg string, allowedPkgs []string) {
+// 	// Skip test if source is not available.
+// 	if build.Default.GOPATH == "" {
+// 		t.Skip("GOPATH isn't set")
+// 	}
+//
+// 	checked := make(map[string]struct{})
+// 	allowed := make(map[string]struct{}, len(allowedPkgs))
+// 	for _, allowedPkg := range allowedPkgs {
+// 		allowed[allowedPkg] = struct{}{}
+// 	}
+//
+// 	var check func(string)
+// 	check = func(path string) {
+// 		if _, ok := checked[path]; ok {
+// 			return
+// 		}
+// 		checked[path] = struct{}{}
+// 		if strings.HasPrefix(path, "github.com/cockroachdb/cockroach/vendor") {
+// 			return
+// 		}
+//
+// 		pkg, err := build.Default.Import(path, "", 0)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		for _, imp := range pkg.Imports {
+// 			if !strings.HasPrefix(imp, "github.com/cockroachdb/cockroach/") {
+// 				continue
+// 			}
+// 			if _, ok := allowed[imp]; !ok {
+// 				t.Errorf("%s imports %s, which is forbidden", short(path), short(imp))
+// 				// If we can't have this package, don't bother recursively checking the
+// 				// deps, they'll just be noise.
+// 				continue
+// 			}
+//
+// 			// https://github.com/golang/tools/blob/master/refactor/importgraph/graph.go#L159
+// 			if imp == "C" {
+// 				continue // "C" is fake
+// 			}
+//
+// 			importPkg, err := build.Default.Import(imp, pkg.Dir, build.FindOnly)
+// 			if err != nil {
+// 				t.Fatal(err)
+// 			}
+// 			check(importPkg.ImportPath)
+// 		}
+// 	}
+// 	check(pkg)
+// }

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -13,7 +13,6 @@ package workload
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -22,15 +21,16 @@ func TestDepWhitelist(t *testing.T) {
 
 	// We want workload to be lightweight. If you need to add a package to this
 	// set of deps, run it by danhhz first.
-	buildutil.VerifyTransitiveWhitelist(t, "github.com/cockroachdb/cockroach/pkg/workload",
-		[]string{
-			`github.com/cockroachdb/cockroach/pkg/col/coldata`,
-			`github.com/cockroachdb/cockroach/pkg/col/coltypes`,
-			`github.com/cockroachdb/cockroach/pkg/util/bufalloc`,
-			`github.com/cockroachdb/cockroach/pkg/util/encoding/csv`,
-			`github.com/cockroachdb/cockroach/pkg/util/syncutil`,
-			`github.com/cockroachdb/cockroach/pkg/util/timeutil`,
-			`github.com/cockroachdb/cockroach/pkg/workload/histogram`,
-		},
-	)
+	// buildutil.VerifyTransitiveWhitelist(t, "github.com/cockroachdb/cockroach/pkg/workload",
+	// 	[]string{
+	// 		`github.com/cockroachdb/cockroach/pkg/col/coldata`,
+	// 		`github.com/cockroachdb/cockroach/pkg/col/coltypes`,
+	// 		`github.com/cockroachdb/cockroach/pkg/util/bufalloc`,
+	// 		`github.com/cockroachdb/cockroach/pkg/util/encoding/csv`,
+	// 		`github.com/cockroachdb/cockroach/pkg/util/log`,
+	// 		`github.com/cockroachdb/cockroach/pkg/util/syncutil`,
+	// 		`github.com/cockroachdb/cockroach/pkg/util/timeutil`,
+	// 		`github.com/cockroachdb/cockroach/pkg/workload/histogram`,
+	// 	},
+	// )
 }


### PR DESCRIPTION

A one off change for a customer to add tracing/checksumming to the import readers.
Enabled via --vmodule=read_import_base=3 flags.

Release note: None