### PR TITLE
storage: remove clock arg from Replica.{init,initRaftMuLockedReplicaMuLocked}

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -523,7 +523,7 @@ func NewReplica(
 	desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.ReplicaID,
 ) (*Replica, error) {
 	r := newReplica(desc.RangeID, store)
-	return r, r.init(desc, store.Clock(), replicaID)
+	return r, r.init(desc, replicaID)
 }
 
 // Send executes a command on this range, dispatching it to the

--- a/pkg/storage/store_create_replica.go
+++ b/pkg/storage/store_create_replica.go
@@ -230,7 +230,7 @@ func (s *Store) tryGetOrCreateReplica(
 			// NB: other fields are unknown; need to populate them from
 			// snapshot.
 		}
-		return repl.initRaftMuLockedReplicaMuLocked(desc, s.Clock(), replicaID)
+		return repl.initRaftMuLockedReplicaMuLocked(desc, replicaID)
 	}(); err != nil {
 		// Mark the replica as destroyed and remove it from the replicas maps to
 		// ensure nobody tries to use it

--- a/pkg/storage/store_split.go
+++ b/pkg/storage/store_split.go
@@ -130,7 +130,7 @@ func splitPostApply(
 	} else {
 		rightRng := rightRngOrNil
 		// Finish initialization of the RHS.
-		err := rightRng.initRaftMuLockedReplicaMuLocked(&split.RightDesc, r.store.Clock(), 0)
+		err := rightRng.initRaftMuLockedReplicaMuLocked(&split.RightDesc, 0)
 		rightRng.mu.Unlock()
 		if err != nil {
 			log.Fatal(ctx, err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1002,7 +1002,7 @@ func TestMaybeMarkReplicaInitialized(t *testing.T) {
 		store:     store,
 		abortSpan: abortspan.New(desc.RangeID),
 	}
-	if err := r.init(desc, store.Clock(), 0); err != nil {
+	if err := r.init(desc, 0); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The argument was unnecessary, especially because we already have access
to the Replica's Store, which itself has a clock.

Release note: None