### PR TITLE
storage: fix asserts around log truncations

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -395,18 +395,16 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 
 	// Invariants: NewFirstIndex >= FirstIndex
 	//             NewFirstIndex <= LastIndex (if != 10)
-	//             NewFirstIndex <= QuorumIndex (if != 0)
 	//
-	// For uninit'ed replicas we can have input.FirstIndex > input.LastIndex, more
-	// specifically input.FirstIndex = input.LastIndex + 1. FirstIndex is set to
+	// For uninit'ed replicas we can have NewFirstIndex > input.LastIndex, more
+	// specifically NewFirstIndex = input.LastIndex + 1. NewFirstIndex is set to
 	// TruncatedState.Index + 1, and for an unit'ed replica, LastIndex is simply
 	// 10. This is what informs the `input.LastIndex == 10` conditional below.
 	valid := (decision.NewFirstIndex >= input.FirstIndex) &&
-		(decision.NewFirstIndex <= input.LastIndex || input.LastIndex == 10) &&
-		(decision.NewFirstIndex <= decision.QuorumIndex || decision.QuorumIndex == 0)
+		(decision.NewFirstIndex <= input.LastIndex || input.LastIndex == 10)
 	if !valid {
-		err := fmt.Sprintf("invalid truncation decision; output = %d, input: [%d, %d], quorum idx = %d",
-			decision.NewFirstIndex, input.FirstIndex, input.LastIndex, decision.QuorumIndex)
+		err := fmt.Sprintf("invalid truncation decision; output = %d, input: [%d, %d]",
+			decision.NewFirstIndex, input.FirstIndex, input.LastIndex)
 		panic(err)
 	}
 


### PR DESCRIPTION
Stop relying on `getQuorumIndex`, as it has subtle behaviour around the addition/removal of replicas to the raft group. Assert instead that we never truncate the log past the committed index. 

This change was prompted by a faulty assertion using `QuorumIndex`, where we previously asserted that `NewFirstIndex <= QuorumIndex`. But this was incorrect, to see why consider a Raft group with first-last indexes `[(100-112), (116-124), (116-124)]`. When a new replica is added, it starts off with a match index of 0, i.e. `[(0,0), (100-112), (116-124), (116-124)]`. Naively, we'd expect the quorum index to be 116, but it's 100. The `FirstIndex` at the leaseholder will be 116, and thus we have `QuorumIndex < FirstIndex <= NewFirstIndex`. How should we think about the invariants in this situation? We don't want to truncate past the "quorum index", but new replicas muddle our computation of this "quorum index".  

~What about `raftstatus.Commit`? It's more appropriate here: `raftstatus.Commit` tells us the index that a quorum of replicas have safely committed, thus making it safe to truncate. We now assert that we're not truncating past this index.~

Release note (bug fix): Faulty assertion could cause panics when a log truncation took place concurrently with a replica being added to a raft group.

