### PR TITLE
storagebase: take RangeDesc by reference in ContainsKey(Range)

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -486,7 +486,7 @@ func resolveLocalIntents(
 			if len(span.EndKey) == 0 {
 				// For single-key intents, do a KeyAddress-aware check of
 				// whether it's contained in our Range.
-				if !storagebase.ContainsKey(*desc, span.Key) {
+				if !storagebase.ContainsKey(desc, span.Key) {
 					externalIntents = append(externalIntents, span)
 					return nil
 				}
@@ -497,7 +497,7 @@ func resolveLocalIntents(
 			// For intent ranges, cut into parts inside and outside our key
 			// range. Resolve locally inside, delegate the rest. In particular,
 			// an intent range for range-local data is correctly considered local.
-			inSpan, outSpans := storagebase.IntersectSpan(span, *desc)
+			inSpan, outSpans := storagebase.IntersectSpan(span, desc)
 			externalIntents = append(externalIntents, outSpans...)
 			if inSpan != nil {
 				intent.Span = *inSpan

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1128,13 +1128,13 @@ func (r *Replica) GetSplitQPS() float64 {
 //
 // TODO(bdarnell): This is not the same as RangeDescriptor.ContainsKey.
 func (r *Replica) ContainsKey(key roachpb.Key) bool {
-	return storagebase.ContainsKey(*r.Desc(), key)
+	return storagebase.ContainsKey(r.Desc(), key)
 }
 
 // ContainsKeyRange returns whether this range contains the specified
 // key range from start to end.
 func (r *Replica) ContainsKeyRange(start, end roachpb.Key) bool {
-	return storagebase.ContainsKeyRange(*r.Desc(), start, end)
+	return storagebase.ContainsKeyRange(r.Desc(), start, end)
 }
 
 // GetLastReplicaGCTimestamp reads the timestamp at which the replica was

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -340,13 +340,13 @@ func (r *Replica) adminSplitWithDescriptor(
 			// If the key that routed this request to this range is now out of this
 			// range's bounds, return an error for the client to try again on the
 			// correct range.
-			if !storagebase.ContainsKey(*desc, args.Key) {
+			if !storagebase.ContainsKey(desc, args.Key) {
 				return reply, roachpb.NewRangeKeyMismatchError(args.Key, args.Key, desc)
 			}
 			foundSplitKey = args.SplitKey
 		}
 
-		if !storagebase.ContainsKey(*desc, foundSplitKey) {
+		if !storagebase.ContainsKey(desc, foundSplitKey) {
 			return reply, errors.Errorf("requested split key %s out of bounds of %s", args.SplitKey, r)
 		}
 

--- a/pkg/storage/replica_eval_context_span.go
+++ b/pkg/storage/replica_eval_context_span.go
@@ -129,7 +129,7 @@ func (rec SpanSetReplicaEvalContext) Desc() *roachpb.RangeDescriptor {
 // on Replica.ContainsKey.
 func (rec SpanSetReplicaEvalContext) ContainsKey(key roachpb.Key) bool {
 	desc := rec.Desc() // already asserts
-	return storagebase.ContainsKey(*desc, key)
+	return storagebase.ContainsKey(desc, key)
 }
 
 // GetMVCCStats returns the Replica's MVCCStats.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6693,7 +6693,7 @@ func TestIntentIntersect(t *testing.T) {
 		{intent: iLc, from: "a", to: "z", exp: []string{kl1, kl2}},
 	} {
 		var all []string
-		in, out := storagebase.IntersectSpan(tc.intent, roachpb.RangeDescriptor{
+		in, out := storagebase.IntersectSpan(tc.intent, &roachpb.RangeDescriptor{
 			StartKey: roachpb.RKey(tc.from),
 			EndKey:   roachpb.RKey(tc.to),
 		})

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -102,7 +102,7 @@ type ReplicaApplyFilter func(args ApplyFilterArgs) (int, *roachpb.Error)
 type ReplicaResponseFilter func(roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
 
 // ContainsKey returns whether this range contains the specified key.
-func ContainsKey(desc roachpb.RangeDescriptor, key roachpb.Key) bool {
+func ContainsKey(desc *roachpb.RangeDescriptor, key roachpb.Key) bool {
 	if bytes.HasPrefix(key, keys.LocalRangeIDPrefix) {
 		return bytes.HasPrefix(key, keys.MakeRangeIDPrefix(desc.RangeID))
 	}
@@ -115,7 +115,7 @@ func ContainsKey(desc roachpb.RangeDescriptor, key roachpb.Key) bool {
 
 // ContainsKeyRange returns whether this range contains the specified key range
 // from start to end.
-func ContainsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool {
+func ContainsKeyRange(desc *roachpb.RangeDescriptor, start, end roachpb.Key) bool {
 	startKeyAddr, err := keys.Addr(start)
 	if err != nil {
 		return false
@@ -138,7 +138,7 @@ func ContainsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 // TODO(tschottdorf): move to proto, make more gen-purpose - kv.truncate does
 // some similar things.
 func IntersectSpan(
-	span roachpb.Span, desc roachpb.RangeDescriptor,
+	span roachpb.Span, desc *roachpb.RangeDescriptor,
 ) (middle *roachpb.Span, outside []roachpb.Span) {
 	start, end := desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey()
 	if len(span.EndKey) == 0 {


### PR DESCRIPTION
All callers of this had a *RangeDescriptor, so there's no reason to pass in a large RangeDescriptor struct.

Release note: None