### PR TITLE
sql: fix bug that allowed objects to be renamed to existing objects

### DIFF
--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -33,9 +33,9 @@ func (node *RenameDatabase) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.NewName)
 }
 
-// RenameTable represents a RENAME TABLE or RENAME VIEW statement.
-// Whether the user has asked to rename a table or view is indicated
-// by the IsView field.
+// RenameTable represents a RENAME TABLE or RENAME VIEW or RENAME SEQUENCE
+// statement. Whether the user has asked to rename a view or a sequence
+// is indicated by the IsView and IsSequence fields.
 type RenameTable struct {
 	Name       *UnresolvedObjectName
 	NewName    *UnresolvedObjectName


### PR DESCRIPTION
Previously, when  renaming an object(sequence/database/view/table) we
would only check the "active" namespace table.

This could lead to the following scenario:
Any object created after the system.namespace table was migrated, but
before the cluster version bump was finalized, would be present in the
old `system.namespace`. If a user tried to rename an object to the same
name after the cluster version was bumped, it would be successful.

This PR fixes this bug by correctly using the interface defined in
`namespace.go` to do lookups, instead of looking up in the
`system.namespace` table directly. Now, the appropriate error is
returned.

Release note (bug fix): This code was not released, but the bug
described above no longer exists.