### PR TITLE
AUTHORS: update a few entries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Alex Robinson <alexdwanerobinson@gmail.com> <arob@google.com> <@cockroachlabs.co
 Alfonso Subiotto Marqués <alfonso.subiotto.marques@gmail.com> Alfonso Subiotto Marques <alfonso@cockroachlabs.com>
 Amos Bird <amosbird@gmail.com>
 Amruta Ranade <amruta@cockroachlabs.com> Amruta <amruta@cockroachlabs.com> <amruta2799@gmail.com>
+Anantha Krishnan <kannan4mi3@gmail.com> Ananthakrishnan <kannan4mi3@gmail.com>
 Andrei Matei <andrei@cockroachlabs.com> <andreimatei1@gmail.com>
 Andrew Bonventre <abonventre@palantir.com> <andybons@gmail.com>
 Andrew Couch <andrew@cockroachlabs.com> <github@couchand.com> <hi@andrewcou.ch>
@@ -100,6 +101,7 @@ fangwens <pananc@126.com>
 Francis Bergin <bergin.francis@gmail.com>
 funkygao <funky.gao@gmail.com>
 Garvit Juniwal <garvitjuniwal@gmail.com>
+George Buckerfield <georgebuckerfield@gmail.com> georgebuckerfield <georgebuckerfield@gmail.com>
 George Papadrosou <gpapadrosou@gmail.com>
 George Utsin <george@cockroachlabs.com>
 Georgia Hong <georgiah@cockroachlabs.com>
@@ -217,7 +219,7 @@ Rich Loveland <loveland.richard@gmail.com> <rich@cockroachlabs.com> Richard Love
 Richard Artoul <richardartoul@gmail.com>
 Richard Wu <richardwu1997@gmail.com> <@cockroachlabs.com>
 Ridwan Sharif <ridwan@cockroachlabs.com> <ridwanmsharif@Ridwans-MacBook-Pro.local>
-Rohan Yadav <rohany@cockroachlabs.com>
+Rohan Yadav <rohany@cockroachlabs.com> <rohany@alumni.cmu.edu> rohany <rohany@alumni.cmu.edu>
 Roland Crosby <roland@cockroachlabs.com>
 Roy Hvaara <roy@lightyear.no>
 Rushi Agrawal <rushi.agr@gmail.com>
@@ -258,6 +260,7 @@ veteranlu <23907238@qq.com>
 Victor Chen <victor@cockroachlabs.com>
 Vijay Karthik <vijay.karthik@rubrik.com>
 Vivek Menezes <vivek.menezes@gmail.com> <vivek1@viveks-MacBook-Pro.local> <vivek@cockroachlabs.com> vivekmenezes <vivekmenezes@users.noreply.github.com>
+Vlad Artamonov <carrott9@gmail.com> Vlad <carrott9@gmail.com> <@cockroachlabs.com>
 wenyong-h <weyo.huang@gmail.com>
 Will Haack <will.haack@appboy.com> <will@cockroachlabs.com>
 Xiang Li <xiangli.cs@gmail.com>
@@ -275,6 +278,7 @@ Yosi Attias <yosy101@gmail.com>
 yuhit <longyuhit@163.com>
 Yulei Xiao <21739034@qq.com>
 Rafael Yim <rafelyim@qq.com> yznming <rafaelyim@qq.com>
+Ryan Kuo <8740013+taroface@users.noreply.github.com> taroface <ryankuo@gmail.com>
 Zach Brock <zbrock@gmail.com> <zbrock@squareup.com>
 Zachary Smith <Zachary.smith@yodle.com> Zachary.smith <Zachary.smith@yodle.com>
 何羿宏 <heyihong.cn@gmail.com>


### PR DESCRIPTION
Some aliases were present in the git log but not mentioned in AUTHORS,
causing duplicate entries in release note reports.
