### PR TITLE
roachtest: Change backup to use nodelocal

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -76,8 +76,8 @@ func registerBackup(r *testRegistry) {
 			if local {
 				duration = 5 * time.Second
 			}
-			warehouses := 1
-			backupDir := "gs://cockroachdb-backup-testing/" + c.name
+			warehouses := 10
+			backupDir := "nodelocal://1/" + c.name
 			fullDir := backupDir + "/full"
 			incDir := backupDir + "/inc"
 


### PR DESCRIPTION
We've recently made a few changes to nodelocal.
To make sure these changes are tested in a more
realistic environment, we've changed `backupTPCC`
to use nodelocal for backup and restore. This
will test all the cross-node reads and writes
that the nodelocal local changes introduced.

Release note: None