### PR TITLE
release-19.2: opt: fix estimation of row count for lookup joins

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -895,8 +895,7 @@ func (sb *statisticsBuilder) buildJoin(
 
 	// Calculate distinct counts for constrained columns in the ON conditions
 	// ----------------------------------------------------------------------
-	// TODO(rytaft): use histogram for joins.
-	numUnappliedConjuncts, constrainedCols, _ := sb.applyFilter(h.filters, join, relProps)
+	numUnappliedConjuncts, constrainedCols, histCols := sb.applyFilter(h.filters, join, relProps)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -941,7 +940,8 @@ func (sb *statisticsBuilder) buildJoin(
 		s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &h.filtersFD, join, s))
 	}
 
-	s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols, join, s))
+	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, join, s))
+	s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols.Difference(histCols), join, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(join, relProps, constrainedCols))
 
@@ -1004,8 +1004,8 @@ func (sb *statisticsBuilder) buildJoin(
 		s.ColStats.Clear()
 	}
 
-	// Loop through all colSets added in this step, and adjust null counts and
-	// distinct counts.
+	// Loop through all colSets added in this step, and adjust null counts,
+	// distinct counts, and histograms.
 	for i := 0; i < s.ColStats.Count(); i++ {
 		colStat := s.ColStats.Get(i)
 		leftSideCols := leftCols.Intersection(colStat.Cols)
@@ -1049,6 +1049,10 @@ func (sb *statisticsBuilder) buildJoin(
 			// Ensure distinct count is non-zero.
 			colStat.DistinctCount = max(colStat.DistinctCount, 1)
 		}
+
+		// We don't yet calculate histograms correctly for joins, so remove any
+		// histograms that have been created above.
+		colStat.Histogram = nil
 	}
 
 	sb.finalizeFromCardinality(relProps)
@@ -2565,6 +2569,15 @@ func countJSONPaths(conjunct *FiltersItem) int {
 func (sb *statisticsBuilder) applyFilter(
 	filters FiltersExpr, e RelExpr, relProps *props.Relational,
 ) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
+	if lookupJoin, ok := e.(*LookupJoinExpr); ok {
+		// Special hack for lookup joins. Add constant filters from the equality
+		// conditions.
+		// TODO(rytaft): the correct way to do this is probably to fully implement
+		// histograms in Project and Join expressions, and use them in
+		// selectivityFromEquivalencies. See Issue #38082.
+		filters = append(filters, lookupJoin.ConstFilters...)
+	}
+
 	applyConjunct := func(conjunct *FiltersItem) {
 		if isEqualityWithTwoVars(conjunct.Condition) {
 			// We'll handle equalities later.

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -353,3 +353,109 @@ anti-join (lookup t@xy_idx)
  │    ├── columns: u.x:1(int) u.y:2(int)
  │    └── stats: [rows=10, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]
  └── filters (true)
+
+
+exec-ddl
+CREATE TABLE medium (m INT, n INT)
+----
+
+exec-ddl
+ALTER TABLE medium INJECT STATISTICS '[
+  {
+    "columns": ["m"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 40,
+    "distinct_count": 40
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE wxyz (w INT, x INT, y INT, z INT, INDEX (x,y,z))
+----
+
+exec-ddl
+ALTER TABLE wxyz INJECT STATISTICS '[
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 11,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 50, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 50, "num_range": 900, "distinct_range": 9, "upper_bound": "10"}
+    ]
+  }
+]'
+----
+
+# Choose the lookup join due to the highly selective constant column.
+opt
+SELECT * FROM medium INNER JOIN wxyz ON m=x AND y=10
+----
+inner-join (lookup wxyz)
+ ├── columns: m:1(int!null) n:2(int) w:4(int) x:5(int!null) y:6(int!null) z:7(int)
+ ├── key columns: [8] = [8]
+ ├── lookup columns are key
+ ├── stats: [rows=49.3441882, distinct(1)=39.1263061, null(1)=0, distinct(5)=39.1263061, null(5)=0]
+ ├── fd: ()-->(6), (1)==(5), (5)==(1)
+ ├── inner-join (lookup wxyz@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) x:5(int!null) y:6(int!null) z:7(int) wxyz.rowid:8(int!null)
+ │    ├── key columns: [1 9] = [5 6]
+ │    ├── stats: [rows=19.8, distinct(1)=19.8, null(1)=0, distinct(5)=19.8, null(5)=0, distinct(6)=1, null(6)=0, distinct(9)=1, null(9)=0]
+ │    ├── fd: ()-->(6), (8)-->(5,7), (1)==(5), (5)==(1)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@6":9(int!null) m:1(int) n:2(int)
+ │    │    ├── stats: [rows=40, distinct(1)=40, null(1)=0, distinct(9)=1, null(9)=0]
+ │    │    ├── fd: ()-->(9)
+ │    │    ├── scan medium
+ │    │    │    ├── columns: m:1(int) n:2(int)
+ │    │    │    └── stats: [rows=40, distinct(1)=40, null(1)=0]
+ │    │    └── projections
+ │    │         └── const: 10 [type=int]
+ │    └── filters (true)
+ └── filters (true)
+
+exec-ddl
+ALTER TABLE wxyz INJECT STATISTICS '[
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 11,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 10, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 900, "num_range": 90, "distinct_range": 9, "upper_bound": "10"}
+    ]
+  }
+]'
+----
+
+# With a less selective constant column, the hash join should be chosen instead.
+opt
+SELECT * FROM medium INNER JOIN wxyz ON m=x AND y=10
+----
+inner-join (hash)
+ ├── columns: m:1(int!null) n:2(int) w:4(int) x:5(int!null) y:6(int!null) z:7(int)
+ ├── stats: [rows=356.4, distinct(1)=40, null(1)=0, distinct(5)=40, null(5)=0]
+ ├── fd: ()-->(6), (1)==(5), (5)==(1)
+ ├── select
+ │    ├── columns: w:4(int) x:5(int) y:6(int!null) z:7(int)
+ │    ├── stats: [rows=900, distinct(5)=100, null(5)=9, distinct(6)=1, null(6)=0]
+ │    │   histogram(6)=  0 900
+ │    │                <--- 10
+ │    ├── fd: ()-->(6)
+ │    ├── scan wxyz
+ │    │    ├── columns: w:4(int) x:5(int) y:6(int) z:7(int)
+ │    │    └── stats: [rows=1000, distinct(5)=100, null(5)=10, distinct(6)=11, null(6)=0]
+ │    │        histogram(6)=  0 10  90 900
+ │    │                     <--- 0 ---- 10
+ │    └── filters
+ │         └── y = 10 [type=bool, outer=(6), constraints=(/6: [/10 - /10]; tight), fd=()-->(6)]
+ ├── scan medium
+ │    ├── columns: m:1(int) n:2(int)
+ │    └── stats: [rows=40, distinct(1)=40, null(1)=0]
+ └── filters
+      └── m = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -312,6 +312,11 @@ define LookupJoinPrivate {
     # lookup join appear more like other join operators.
     lookupProps RelProps
 
+    # ConstFilters contains the constant filters that are represented as equality
+    # conditions on the KeyCols. These filters are needed by the statistics code to
+    # correctly estimate selectivity.
+    ConstFilters FiltersExpr
+
     _ JoinPrivate
 }
 

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1213,6 +1213,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		// Remove the redundant filters and update the lookup condition.
 		lookupJoin.On = memo.ExtractRemainingJoinFilters(on, lookupJoin.KeyCols, rightSideCols)
 		lookupJoin.On.RemoveCommonFilters(constFilters)
+		lookupJoin.ConstFilters = constFilters
 
 		if iter.isCovering() {
 			// Case 1 (see function comment).

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1879,7 +1879,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~30KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~31KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (select G8 G9) (select G10 G11) (select G12 G7) (select G13 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)


### PR DESCRIPTION
Backport 1/1 commits from #43325.

/cc @cockroachdb/release

---

Previously, the optimizer estimated an incorrect row count for some
lookup joins that had a constant column as one of the equality
conditions. This was a problem when there was a histogram on the
constant column, because the histogram was used to estimate the number
of rows input to a hash or merge join, but it was not being
used for the lookup join. This caused the relative cost between the
different types of joins to be inaccurate.

This commit adds a new field to the `LookupJoinPrivate` called `ConstFilters`,
which allows the `statisticsBuilder` to easily estimate the selectivity of
those filters and use a histogram if it exists for the given column.

Release note (performance improvement): Improved the estimated row count
for some lookup joins during planning, leading to better plans in some
cases.
