### PR TITLE
storage: rename `{e,b} engine.{Reader,Writer,ReadWriter}`

### DIFF
--- a/pkg/storage/rditer/replica_data_iter.go
+++ b/pkg/storage/rditer/replica_data_iter.go
@@ -112,9 +112,9 @@ func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 
 // NewReplicaDataIterator creates a ReplicaDataIterator for the given replica.
 func NewReplicaDataIterator(
-	d *roachpb.RangeDescriptor, e engine.Reader, replicatedOnly bool,
+	d *roachpb.RangeDescriptor, reader engine.Reader, replicatedOnly bool,
 ) *ReplicaDataIterator {
-	it := e.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
+	it := reader.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 
 	rangeFunc := MakeAllKeyRanges
 	if replicatedOnly {

--- a/pkg/storage/rditer/stats.go
+++ b/pkg/storage/rditer/stats.go
@@ -20,9 +20,9 @@ import (
 // iterating over all key ranges for the given range that should
 // be accounted for in its stats.
 func ComputeStatsForRange(
-	d *roachpb.RangeDescriptor, e engine.Reader, nowNanos int64,
+	d *roachpb.RangeDescriptor, reader engine.Reader, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	iter := e.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
+	iter := reader.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 	defer iter.Close()
 
 	ms := enginepb.MVCCStats{}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1449,10 +1449,10 @@ func (r *Replica) getReplicaDescriptorByIDRLocked(
 // transaction. In case the transaction has been aborted, return a
 // transaction abort error.
 func checkIfTxnAborted(
-	ctx context.Context, rec batcheval.EvalContext, b engine.Reader, txn roachpb.Transaction,
+	ctx context.Context, rec batcheval.EvalContext, reader engine.Reader, txn roachpb.Transaction,
 ) *roachpb.Error {
 	var entry roachpb.AbortSpanEntry
-	aborted, err := rec.AbortSpan().Get(ctx, b, txn.ID, &entry)
+	aborted, err := rec.AbortSpan().Get(ctx, reader, txn.ID, &entry)
 	if err != nil {
 		return roachpb.NewError(roachpb.NewReplicaCorruptionError(
 			errors.Wrap(err, "could not read from AbortSpan")))

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -344,14 +344,14 @@ func (s spanSetReader) NewIterator(opts engine.IterOptions) engine.Iterator {
 }
 
 // GetDBEngine recursively searches for the underlying rocksDB engine.
-func GetDBEngine(e engine.Reader, span roachpb.Span) engine.Reader {
-	switch v := e.(type) {
+func GetDBEngine(reader engine.Reader, span roachpb.Span) engine.Reader {
+	switch v := reader.(type) {
 	case ReadWriter:
 		return GetDBEngine(getSpanReader(v, span), span)
 	case *spanSetBatch:
 		return GetDBEngine(getSpanReader(v.ReadWriter, span), span)
 	default:
-		return e
+		return reader
 	}
 }
 


### PR DESCRIPTION
Leftover work from #43265.

Release note: None