### PR TITLE
sql/mutations: add PARTITION BY mutator

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -67,10 +67,11 @@ func randTables(r *rand.Rand) string {
 	stmts := sqlbase.RandCreateTables(r, "table", r.Intn(5)+1,
 		mutations.ForeignKeyMutator,
 		mutations.StatisticsMutator,
+		mutations.PartitionMutator,
 	)
 
 	for _, stmt := range stmts {
-		sb.WriteString(stmt.String())
+		sb.WriteString(prettyCfg.Pretty(stmt))
 		sb.WriteString(";\n")
 	}
 


### PR DESCRIPTION
For now, this only supports top-level partitions with a single column.

Add this to the sqlsmith rand table creation. Also teach that how to
print better, such that values like NaN and Inf are printed as quoted
strings instead of bare values, which broke if used in partitions.

The improved print caused the strings that were used in alter stats to
error since they were asserted as strings. Correctly convert them to json.

Release note: None