### PR TITLE
tree: fix various interval parsing bugs with interval qualifiers

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -16,14 +16,16 @@ statement ok
 INSERT INTO interval_duration_type (id, regular, regular_precision, second, second_precision, minute, minute_to_second_precision) VALUES
   (1, '12:34:56.123456', '12:34:56.123456', '12:34:56.123456', '12:34:56.123456', '12:34:56.123456', '12:34:56.123456'),
   (2, '12:56.123456', '12:56.123456', '12:56.123456', '12:56.123456', '12:56.123456', '12:56.123456'),
-  (3, '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456')
+  (3, '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456', '366 12:34:56.123456'),
+  (4, '1-2 3.1', '1-2 3.1', '1-2 3.1', '1-2 3.1', '1-2 3.1', '1-2 3.1')
 
 query ITTTTTT
 select * from interval_duration_type order by id asc
 ----
-1  12:34:56.123456           12:34:56.123           12:34:56.123456           12:34:56.123           12:34:00           12:34:56.123
-2  00:12:56.123456           00:12:56.123           00:12:56.123456           00:12:56.123           00:12:00           00:12:56.123
-3  366 days 12:34:56.123456  366 days 12:34:56.123  366 days 12:34:56.123456  366 days 12:34:56.123  366 days 12:34:00  366 days 12:34:56.123
+1  12:34:56.123456           12:34:56.123              12:34:56.123456           12:34:56.123              12:34:00                12:34:56.123
+2  00:12:56.123456           00:12:56.123              00:12:56.123456           00:12:56.123              00:12:00                00:12:56.123
+3  366 days 12:34:56.123456  366 days 12:34:56.123     366 days 12:34:56.123456  366 days 12:34:56.123     366 days 12:34:00       366 days 12:34:56.123
+4  1 year 2 mons 00:00:03.1  1 year 2 mons 00:00:03.1  1 year 2 mons 00:00:03.1  1 year 2 mons 00:00:03.1  1 year 2 mons 00:03:00  1 year 2 mons 00:00:03.1
 
 # tests various typmods of intervals
 # matches subset of tests in src/test/regress/expected/interval.out
@@ -97,11 +99,10 @@ SELECT interval '1-2' year to month
 ----
 1 year 2 mons
 
-# TODO(#43079): fix this
-#query T
-#SELECT interval '1 2' day to hour
-#----
-#1 day 02:00:00
+query T
+SELECT interval '1 2' day to hour
+----
+1 day 02:00:00
 
 query T
 SELECT interval '1 2:03' day to hour
@@ -198,11 +199,10 @@ SELECT interval '1 -2:03:04' minute to second
 ----
 1 day -02:03:04
 
-# TODO(#43079): fix this
-#query T
-#SELECT interval '123 11' day to hour
-#----
-#123 days 11:00:00
+query T
+SELECT interval '123 11' day to hour
+----
+123 days 11:00:00
 
 query error could not parse "123 11" as type interval
 SELECT interval '123 11' day
@@ -296,3 +296,25 @@ query T
 SELECT interval '-1:02.123456'
 ----
 -00:01:02.123456
+
+subtest regression_43079
+
+query T
+SELECT interval '1-2 3' year
+----
+4 years
+
+query T
+SELECT interval '1-2 3' day
+----
+1 year 2 mons 3 days
+
+query T
+SELECT interval '2.1 00:'
+----
+2 days 02:24:00
+
+query T
+SELECT interval ' 5  ' year
+----
+5 years

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2507,30 +2507,8 @@ func parseDInterval(s string, itm types.IntervalTypeMetadata) (*DInterval, error
 			return nil, makeParseError(s, types.Interval, err)
 		}
 		return &DInterval{Duration: dur}, nil
-	} else if f, err := strconv.ParseFloat(s, 64); err == nil {
-		// An interval that's just a number uses the field as its unit.
-		// All numbers are rounded down unless the precision is SECOND.
-		ret := &DInterval{Duration: duration.Duration{}}
-		switch itm.DurationField.DurationType {
-		case types.IntervalDurationType_YEAR:
-			ret.Months = int64(f) * 12
-		case types.IntervalDurationType_MONTH:
-			ret.Months = int64(f)
-		case types.IntervalDurationType_DAY:
-			ret.Days = int64(f)
-		case types.IntervalDurationType_HOUR:
-			ret.SetNanos(time.Hour.Nanoseconds() * int64(f))
-		case types.IntervalDurationType_MINUTE:
-			ret.SetNanos(time.Minute.Nanoseconds() * int64(f))
-		case types.IntervalDurationType_SECOND, types.IntervalDurationType_UNSET:
-			ret.SetNanos(int64(float64(time.Second.Nanoseconds()) * f))
-		case types.IntervalDurationType_MILLISECOND:
-			ret.SetNanos(int64(float64(time.Millisecond.Nanoseconds()) * f))
-		default:
-			return nil, errors.AssertionFailedf("unhandled DurationField constant %#v", itm.DurationField)
-		}
-		return ret, nil
-	} else if strings.IndexFunc(s, unicode.IsLetter) == -1 {
+	}
+	if strings.IndexFunc(s, unicode.IsLetter) == -1 {
 		// If it has no letter, then we're most likely working with a SQL standard
 		// interval, as both postgres and golang have letter(s) and iso8601 has been tested.
 		dur, err := sqlStdToDuration(s, itm)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -737,6 +737,13 @@ func (m *IntervalDurationField) IsMinuteToSecond() bool {
 		m.DurationType == IntervalDurationType_SECOND
 }
 
+// IsDayToHour returns whether the IntervalDurationField represents
+// the DAY TO HOUR interval qualifier.
+func (m *IntervalDurationField) IsDayToHour() bool {
+	return m.FromDurationType == IntervalDurationType_DAY &&
+		m.DurationType == IntervalDurationType_HOUR
+}
+
 // IntervalTypeMetadata returns the IntervalTypeMetadata for interval types.
 func (t *T) IntervalTypeMetadata() (IntervalTypeMetadata, error) {
 	if t.Family() != IntervalFamily {


### PR DESCRIPTION
This PR aims to address all issues related to bugs with intervals when
we have interval qualifiers (e.g. DAY TO HOUR, etc).

The major thing of note is removing one block of parsing from
`ParseDInterval` into `sqlStdToDuration`, to simplify the logic for
these bug fixes. The other ones are (hopefully) straightforward to review.

Release note (sql change, bug fix):
* Previously, `SELECT interval '1-2 1' DAY TO HOUR` would fail, but is
permitted as per the SQL standard. This is now fixed.
* Previously, adding spaces to intervals with qualifiers, e.g. `SELECT
interval '  1  ' YEAR` would try evaluate it as seconds always. Patched
to use the qualifier as the multiplier instead.
* Previously, adding a decimal point to days, e.g. `SELECT interval '1.5
01:00:00'` would return `1 day 01:00:00`, instead of postgres which
returns `1 day 13:00:00`. This PR fixes that behaviour to match postgres.
* Previously, using the `Y-M <constant>` format for intervals, e.g.
`SELECT INTERVAL '1-2 3'` will always resolve the '<constant>' component
(3) as seconds. However, for items such as `SELECT INTERVAL '1-2 3' DAY`,
the constant (3) should represent days, as does postgres.