### PR TITLE
storage: stop modifying requests and returning responses from TxnWaitQueue

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -476,7 +476,7 @@ func mergeCheckingTimestampCaches(t *testing.T, disjointLeaseholders bool) {
 	pushee := roachpb.MakeTransaction("pushee", rhsKey, roachpb.MinUserPriority, readTS, 0)
 	pusher := roachpb.MakeTransaction("pusher", rhsKey, roachpb.MaxUserPriority, readTS, 0)
 	ba = roachpb.BatchRequest{}
-	ba.Timestamp = readTS
+	ba.Timestamp = mtc.clock.Now()
 	ba.RangeID = rhsDesc.RangeID
 	ba.Add(pushTxnArgs(&pusher, &pushee, roachpb.PUSH_ABORT))
 	if br, pErr := rhsStore.Send(ctx, ba); pErr != nil {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5549,11 +5549,18 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 			t.Fatalf("unexpected status: %v", test.status)
 		}
 
-		// Now, attempt to push the transaction with Now set to the txn start time + offset.
+		// Now, attempt to push the transaction.
 		args := pushTxnArgs(pusher, pushee, test.pushType)
-		args.PushTo = pushee.ReadTimestamp.Add(test.timeOffset, 0)
+		args.PushTo = pushee.ReadTimestamp.Add(0, 1)
+		h := roachpb.Header{Timestamp: args.PushTo}
 
-		reply, pErr := tc.SendWrappedWith(roachpb.Header{Timestamp: args.PushTo}, &args)
+		// Set the manual clock to the txn start time + offset. This is the time
+		// source used to detect transaction expiration. We make sure to set it
+		// above h.Timestamp to avoid it being updated by the request.
+		now := pushee.ReadTimestamp.Add(test.timeOffset, 0)
+		tc.manualClock.Set(now.WallTime)
+
+		reply, pErr := tc.SendWrappedWith(h, &args)
 		if !testutils.IsPError(pErr, test.expErr) {
 			t.Fatalf("%d: expected error %q; got %v, args=%+v, reply=%+v", i, test.expErr, pErr, args, reply)
 		}

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -259,12 +259,6 @@ func (r *Replica) maybeWaitForPushee(
 			br.Add(pushResp)
 			return br, nil
 		}
-		// Move the push timestamp forward to the current time, as this
-		// request may have been waiting to push the txn. If we don't
-		// move the timestamp forward to the current time, we may fail
-		// to push a txn which has expired.
-		now := r.Clock().Now()
-		ba.Timestamp.Forward(now)
 		ba.Requests = nil
 		ba.Add(&pushReqCopy)
 	} else if ba.IsSingleQueryTxnRequest() {


### PR DESCRIPTION
This PR contains three pieces of cleanup that pave the way for pulling the TxnWaitQueue underneath the upcoming `pkg/storage/concurrency` package. It removes all cases where the queue mandates an update to the PushTxnRequest that entered it. It also removes all cases where the queue could field requests directly and return results for them. This restricts the TxnWaitQueue's interface and allows it to be pushed into the concurrency manager abstraction without bloating this new abstraction.