### PR TITLE
importccl: WIP: DO NOT MERGE

### DIFF
--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -15,6 +15,7 @@
 package sysutil
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -58,4 +59,15 @@ func RefreshSignaledChan() <-chan os.Signal {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, refreshSignal)
 	return ch
+}
+
+// IsErrConnectionReset returns true if an
+// error is a "connection reset by peer" error.
+func IsErrConnectionReset(err error) bool {
+	if opErr, ok := err.(*net.OpError); ok {
+		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
+			return sysErr.Err == syscall.ECONNRESET
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Make importing data into cockroach from external http servers
resilient to connection interruption.

If the download is interrupted, and if the external server
supports "Accept-Ranges: bytes" (and most servers do support that),
we attempt to request the next "Content-Range" from the server.

Release note (enterprise change): more resilient http import