### PR TITLE
[dnm] storage: use engine.Batch in replica read codepath 

### DIFF
--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -63,9 +62,6 @@ func (r *Replica) executeReadOnlyBatch(
 	var result result.Result
 	rec := NewReplicaEvalContext(r, spans)
 	readOnly := r.store.Engine().NewReadOnly()
-	if util.RaceEnabled {
-		readOnly = spanset.NewReadWriterAt(readOnly, spans, ba.Timestamp)
-	}
 	defer readOnly.Close()
 	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba, true /* readOnly */)
 

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -61,7 +61,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// Evaluate read-only batch command.
 	var result result.Result
 	rec := NewReplicaEvalContext(r, spans)
-	readOnly := r.store.Engine().NewReadOnly()
+	readOnly := r.store.Engine().NewBatch()
 	defer readOnly.Close()
 	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba, true /* readOnly */)
 


### PR DESCRIPTION
By making this change, I observe `TestReplicaLookupUseReverseScan`
failing after being stuck emitting just the following:

```
W191220 03:55:37.815241 21 internal/client/range_lookup.go:259  range lookup of key "c" found only non-matching ranges []; retrying
W191220 03:55:37.816682 21 internal/client/range_lookup.go:259  range lookup of key "c" found only non-matching ranges []; retrying
W191220 03:55:37.818981 21 internal/client/range_lookup.go:259  range lookup of key "c" found only non-matching ranges []; retrying
W191220 03:55:37.824012 21 internal/client/range_lookup.go:259  range lookup of key "c" found only non-matching ranges []; retrying
```

This does not match with my expected behavior of NewBatch. Should the
behavior not be identical to when Engine().NewReadOnly() is used to
evaluate the read only command? If no, why not?

Release note: None