### PR TITLE
opt: fix optsteps crash caused by constraint expressions

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -270,7 +270,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 				// Enhance the error with the EXPLAIN (OPT, VERBOSE) of the inner
 				// expression.
 				fmtFlags := memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes
-				explainOpt := memo.FormatExpr(newRightSide, fmtFlags, nil /* catalog */)
+				explainOpt := a.optimizer.FormatExpr(newRightSide, fmtFlags)
 				err = errors.WithDetailf(err, "newRightSide:\n%s", explainOpt)
 			}
 			return false, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -52,6 +52,13 @@ TABLE abcdef
  └── INDEX primary
       └── rowid int not null default (unique_rowid()) [hidden]
 scan abcdef
+ ├── check constraint expressions
+ │    └── f > 2
+ └── computed column expressions
+      ├── d:4
+      │    └── (b + c) + 1
+      └── e:5
+           └── variable: a
 
 statement ok
 CREATE TABLE uvwxy (

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -440,6 +441,14 @@ type WindowFrame struct {
 	StartBoundType tree.WindowFrameBoundType
 	EndBoundType   tree.WindowFrameBoundType
 	FrameExclusion tree.WindowFrameExclusion
+}
+
+// IsCanonical returns true if the ScanPrivate indicates an original unaltered
+// primary index Scan operator (i.e. unconstrained and not limited).
+func (s *ScanPrivate) IsCanonical() bool {
+	return s.Index == cat.PrimaryIndex &&
+		s.Constraint == nil &&
+		s.HardLimit == 0
 }
 
 // NeedResults returns true if the mutation operator can return the rows that

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -90,10 +90,10 @@ func (f ExprFmtFlags) HasFlags(subset ExprFmtFlags) bool {
 
 // FormatExpr returns a string representation of the given expression, formatted
 // according to the specified flags.
-func FormatExpr(e opt.Expr, flags ExprFmtFlags, catalog cat.Catalog) string {
-	var mem *Memo
-	if nd, ok := e.(RelExpr); ok {
-		mem = nd.Memo()
+func FormatExpr(e opt.Expr, flags ExprFmtFlags, mem *Memo, catalog cat.Catalog) string {
+	if catalog == nil {
+		// Automatically hide qualifications if we have no catalog.
+		flags |= ExprFmtHideQualifications
 	}
 	f := MakeExprFmtCtx(flags, mem, catalog)
 	f.FormatExpr(e)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -14,6 +14,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -310,6 +312,32 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *ScanExpr:
+		if t.IsCanonical() {
+			// For the canonical scan, show the expressions attached to the TableMeta.
+			tab := md.TableMeta(t.Table)
+			if len(tab.Constraints) > 0 {
+				c := tp.Childf("check constraint expressions")
+				for i := 0; i < len(tab.Constraints); i++ {
+					f.formatExpr(tab.Constraints[i], c)
+				}
+			}
+			if len(tab.ComputedCols) > 0 {
+				c := tp.Childf("computed column expressions")
+				cols := make(opt.ColList, 0, len(tab.ComputedCols))
+				for col := range tab.ComputedCols {
+					cols = append(cols, col)
+				}
+				sort.Slice(cols, func(i, j int) bool {
+					return cols[i] < cols[j]
+				})
+				for _, col := range cols {
+					f.Buffer.Reset()
+					formatCol(f, "" /* label */, col, opt.ColSet{} /* notNullCols */, false /* omitType */)
+					colInfo := strings.TrimPrefix(f.Buffer.String(), " ")
+					f.formatExpr(tab.ComputedCols[col], c.Child(colInfo))
+				}
+			}
+		}
 		if t.Constraint != nil {
 			tp.Childf("constraint: %s", t.Constraint)
 		}

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -33,6 +33,13 @@ delete abcde
       ├── interesting orderings: (+11)
       ├── scan abcde
       │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    ├── computed column expressions
+      │    │    └── d:10(int)
+      │    │         └── plus [type=int]
+      │    │              ├── plus [type=int]
+      │    │              │    ├── variable: b [type=int]
+      │    │              │    └── variable: c [type=int]
+      │    │              └── const: 1 [type=int]
       │    ├── key: (11)
       │    ├── fd: (11)-->(7-10,12)
       │    ├── prune: (7-12)
@@ -66,6 +73,13 @@ project
            ├── interesting orderings: (+11)
            ├── scan abcde
            │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── computed column expressions
+           │    │    └── d:10(int)
+           │    │         └── plus [type=int]
+           │    │              ├── plus [type=int]
+           │    │              │    ├── variable: b [type=int]
+           │    │              │    └── variable: c [type=int]
+           │    │              └── const: 1 [type=int]
            │    ├── key: (11)
            │    ├── fd: (11)-->(7-10,12)
            │    ├── prune: (7-12)
@@ -103,6 +117,13 @@ project
            ├── interesting orderings: (+11)
            ├── scan abcde
            │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── computed column expressions
+           │    │    └── d:10(int)
+           │    │         └── plus [type=int]
+           │    │              ├── plus [type=int]
+           │    │              │    ├── variable: b [type=int]
+           │    │              │    └── variable: c [type=int]
+           │    │              └── const: 1 [type=int]
            │    ├── key: (11)
            │    ├── fd: (11)-->(7-10,12)
            │    ├── prune: (7-12)
@@ -136,6 +157,13 @@ project
            ├── interesting orderings: (+11)
            ├── scan abcde
            │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── computed column expressions
+           │    │    └── d:10(int)
+           │    │         └── plus [type=int]
+           │    │              ├── plus [type=int]
+           │    │              │    ├── variable: b [type=int]
+           │    │              │    └── variable: c [type=int]
+           │    │              └── const: 1 [type=int]
            │    ├── key: (11)
            │    ├── fd: (11)-->(7-10,12)
            │    ├── prune: (7-12)

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -48,6 +48,13 @@ update abcde
       │    │    ├── interesting orderings: (+11)
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:10(int)
+      │    │    │    │         └── plus [type=int]
+      │    │    │    │              ├── plus [type=int]
+      │    │    │    │              │    ├── variable: b [type=int]
+      │    │    │    │              │    └── variable: c [type=int]
+      │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── key: (11)
       │    │    │    ├── fd: (11)-->(7-10,12)
       │    │    │    ├── prune: (7-12)
@@ -103,6 +110,13 @@ project
            │    │    ├── interesting orderings: (+11)
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── d:10(int)
+           │    │    │    │         └── plus [type=int]
+           │    │    │    │              ├── plus [type=int]
+           │    │    │    │              │    ├── variable: b [type=int]
+           │    │    │    │              │    └── variable: c [type=int]
+           │    │    │    │              └── const: 1 [type=int]
            │    │    │    ├── key: (11)
            │    │    │    ├── fd: (11)-->(7-10,12)
            │    │    │    ├── prune: (7-12)
@@ -164,6 +178,13 @@ project
            │    │    ├── interesting orderings: (+11)
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── d:10(int)
+           │    │    │    │         └── plus [type=int]
+           │    │    │    │              ├── plus [type=int]
+           │    │    │    │              │    ├── variable: b [type=int]
+           │    │    │    │              │    └── variable: c [type=int]
+           │    │    │    │              └── const: 1 [type=int]
            │    │    │    ├── key: (11)
            │    │    │    ├── fd: (11)-->(7-10,12)
            │    │    │    ├── prune: (7-12)
@@ -219,6 +240,13 @@ project
            │    │    ├── interesting orderings: (+11)
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── d:10(int)
+           │    │    │    │         └── plus [type=int]
+           │    │    │    │              ├── plus [type=int]
+           │    │    │    │              │    ├── variable: b [type=int]
+           │    │    │    │              │    └── variable: c [type=int]
+           │    │    │    │              └── const: 1 [type=int]
            │    │    │    ├── key: (11)
            │    │    │    ├── fd: (11)-->(7-10,12)
            │    │    │    ├── prune: (7-12)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -122,6 +122,11 @@ project
            │    │    │    │              └── const: 1 [type=int]
            │    │    │    ├── scan abc
            │    │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── c:12(int)
+           │    │    │    │    │         └── plus [type=int]
+           │    │    │    │    │              ├── variable: b [type=int]
+           │    │    │    │    │              └── const: 1 [type=int]
            │    │    │    │    ├── key: (13)
            │    │    │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
            │    │    │    │    ├── prune: (10-13)
@@ -299,6 +304,11 @@ project
                 │    │         │    │         │    │              └── const: 1 [type=int]
                 │    │         │    │         │    ├── scan abc
                 │    │         │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+                │    │         │    │         │    │    ├── computed column expressions
+                │    │         │    │         │    │    │    └── c:12(int)
+                │    │         │    │         │    │    │         └── plus [type=int]
+                │    │         │    │         │    │    │              ├── variable: b [type=int]
+                │    │         │    │         │    │    │              └── const: 1 [type=int]
                 │    │         │    │         │    │    ├── key: (13)
                 │    │         │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
                 │    │         │    │         │    │    ├── prune: (10-13)
@@ -313,6 +323,11 @@ project
                 │    │         │    │                   └── null [type=unknown]
                 │    │         │    ├── scan abc
                 │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
+                │    │         │    │    ├── computed column expressions
+                │    │         │    │    │    └── c:16(int)
+                │    │         │    │    │         └── plus [type=int]
+                │    │         │    │    │              ├── variable: b [type=int]
+                │    │         │    │    │              └── const: 1 [type=int]
                 │    │         │    │    ├── key: (17)
                 │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
                 │    │         │    │    ├── prune: (14-17)
@@ -327,6 +342,11 @@ project
                 │    │                   └── null [type=unknown]
                 │    ├── scan abc
                 │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
+                │    │    ├── computed column expressions
+                │    │    │    └── c:20(int)
+                │    │    │         └── plus [type=int]
+                │    │    │              ├── variable: b [type=int]
+                │    │    │              └── const: 1 [type=int]
                 │    │    ├── key: (21)
                 │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
                 │    │    ├── prune: (18-21)
@@ -422,6 +442,11 @@ project
  │         │    │    │              └── const: 1 [type=int]
  │         │    │    ├── scan abc
  │         │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+ │         │    │    │    ├── computed column expressions
+ │         │    │    │    │    └── c:11(int)
+ │         │    │    │    │         └── plus [type=int]
+ │         │    │    │    │              ├── variable: b [type=int]
+ │         │    │    │    │              └── const: 1 [type=int]
  │         │    │    │    ├── key: (12)
  │         │    │    │    ├── fd: (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
  │         │    │    │    ├── prune: (9-12)

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -63,6 +63,9 @@ with &1
  │              ├── fd: ()-->(5), (7)-->(4,6)
  │              ├── scan abc
  │              │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+ │              │    ├── computed column expressions
+ │              │    │    └── c:6(float)
+ │              │    │         └── a::FLOAT8 [type=float]
  │              │    ├── stats: [rows=2000, distinct(4)=2000, null(4)=0, distinct(5)=10, null(5)=0, distinct(7)=2000, null(7)=0]
  │              │    ├── key: (7)
  │              │    └── fd: (7)-->(4-6)
@@ -108,6 +111,9 @@ insert xyz
            ├── fd: (7)-->(4-6)
            ├── scan abc
            │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+           │    ├── computed column expressions
+           │    │    └── c:6(float)
+           │    │         └── a::FLOAT8 [type=float]
            │    ├── stats: [rows=2000]
            │    ├── key: (7)
            │    └── fd: (7)-->(4-6)

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -92,6 +92,9 @@ with &1
  │         │    │    │    │         ├── fd: ()-->(5), (7)-->(4,6)
  │         │    │    │    │         ├── scan abc
  │         │    │    │    │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+ │         │    │    │    │         │    ├── computed column expressions
+ │         │    │    │    │         │    │    └── c:6(float)
+ │         │    │    │    │         │    │         └── a::FLOAT8 [type=float]
  │         │    │    │    │         │    ├── stats: [rows=2000, distinct(4)=2000, null(4)=0, distinct(5)=10, null(5)=0, distinct(7)=2000, null(7)=0]
  │         │    │    │    │         │    ├── key: (7)
  │         │    │    │    │         │    └── fd: (7)-->(4-6)
@@ -157,6 +160,9 @@ upsert xyz
       │         ├── fd: (7)-->(4-6)
       │         ├── scan abc
       │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+      │         │    ├── computed column expressions
+      │         │    │    └── c:6(float)
+      │         │    │         └── a::FLOAT8 [type=float]
       │         │    ├── stats: [rows=2000]
       │         │    ├── key: (7)
       │         │    └── fd: (7)-->(4-6)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -33,6 +33,9 @@ update computed
       ├── fd: ()-->(7-9), (4)-->(5,6)
       ├── scan computed
       │    ├── columns: a:4(int!null) b:5(int) c:6(int)
+      │    ├── computed column expressions
+      │    │    └── c:6(int)
+      │    │         └── (a + b) + 1 [type=int]
       │    ├── key: (4)
       │    └── fd: (4)-->(5,6)
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -44,7 +44,16 @@ delete abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  └── scan abcde
-      └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      └── computed column expressions
+           ├── d:10(int)
+           │    └── plus [type=int]
+           │         ├── plus [type=int]
+           │         │    ├── variable: b [type=int]
+           │         │    └── variable: c [type=int]
+           │         └── const: 1 [type=int]
+           └── e:11(int)
+                └── variable: a [type=int]
 
 # Use WHERE, ORDER BY, LIMIT.
 build
@@ -63,7 +72,16 @@ delete abcde
       │    └── select
       │         ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │         ├── scan abcde
-      │         │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │         │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │         │    └── computed column expressions
+      │         │         ├── d:10(int)
+      │         │         │    └── plus [type=int]
+      │         │         │         ├── plus [type=int]
+      │         │         │         │    ├── variable: b [type=int]
+      │         │         │         │    └── variable: c [type=int]
+      │         │         │         └── const: 1 [type=int]
+      │         │         └── e:11(int)
+      │         │              └── variable: a [type=int]
       │         └── filters
       │              └── gt [type=bool]
       │                   ├── variable: a [type=int]
@@ -87,7 +105,16 @@ delete foo
       │    └── select
       │         ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │         ├── scan foo
-      │         │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │         │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │         │    └── computed column expressions
+      │         │         ├── d:10(int)
+      │         │         │    └── plus [type=int]
+      │         │         │         ├── plus [type=int]
+      │         │         │         │    ├── variable: b [type=int]
+      │         │         │         │    └── variable: c [type=int]
+      │         │         │         └── const: 1 [type=int]
+      │         │         └── e:11(int)
+      │         │              └── variable: a [type=int]
       │         └── filters
       │              └── gt [type=bool]
       │                   ├── variable: a [type=int]
@@ -206,7 +233,16 @@ with &1 (cte)
       └── select
            ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
            ├── scan abcde
-           │    └── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
+           │    ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
+           │    └── computed column expressions
+           │         ├── d:13(int)
+           │         │    └── plus [type=int]
+           │         │         ├── plus [type=int]
+           │         │         │    ├── variable: b [type=int]
+           │         │         │    └── variable: c [type=int]
+           │         │         └── const: 1 [type=int]
+           │         └── e:14(int)
+           │              └── variable: a [type=int]
            └── filters
                 └── exists [type=bool]
                      └── with-scan &1 (cte)
@@ -239,7 +275,16 @@ with &1
  │         └── select
  │              ├── columns: abcde.a:7(int!null) abcde.b:8(int!null) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
  │              ├── scan abcde
- │              │    └── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    └── computed column expressions
+ │              │         ├── abcde.d:10(int)
+ │              │         │    └── plus [type=int]
+ │              │         │         ├── plus [type=int]
+ │              │         │         │    ├── variable: abcde.b [type=int]
+ │              │         │         │    └── variable: abcde.c [type=int]
+ │              │         │         └── const: 1 [type=int]
+ │              │         └── abcde.e:11(int)
+ │              │              └── variable: abcde.a [type=int]
  │              └── filters
  │                   └── eq [type=bool]
  │                        ├── variable: abcde.a [type=int]
@@ -261,7 +306,16 @@ with &1
            └── select
                 ├── columns: abcde.a:24(int!null) abcde.b:25(int!null) abcde.c:26(int) abcde.d:27(int) abcde.e:28(int) rowid:29(int!null)
                 ├── scan abcde
-                │    └── columns: abcde.a:24(int!null) abcde.b:25(int) abcde.c:26(int) abcde.d:27(int) abcde.e:28(int) rowid:29(int!null)
+                │    ├── columns: abcde.a:24(int!null) abcde.b:25(int) abcde.c:26(int) abcde.d:27(int) abcde.e:28(int) rowid:29(int!null)
+                │    └── computed column expressions
+                │         ├── abcde.d:27(int)
+                │         │    └── plus [type=int]
+                │         │         ├── plus [type=int]
+                │         │         │    ├── variable: abcde.b [type=int]
+                │         │         │    └── variable: abcde.c [type=int]
+                │         │         └── const: 1 [type=int]
+                │         └── abcde.e:28(int)
+                │              └── variable: abcde.a [type=int]
                 └── filters
                      └── eq [type=bool]
                           ├── variable: abcde.a [type=int]
@@ -295,7 +349,16 @@ project
       └── select
            ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
            ├── scan abcde
-           │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    └── computed column expressions
+           │         ├── d:10(int)
+           │         │    └── plus [type=int]
+           │         │         ├── plus [type=int]
+           │         │         │    ├── variable: b [type=int]
+           │         │         │    └── variable: c [type=int]
+           │         │         └── const: 1 [type=int]
+           │         └── e:11(int)
+           │              └── variable: a [type=int]
            └── filters
                 └── eq [type=bool]
                      ├── variable: a [type=int]
@@ -313,7 +376,16 @@ project
  │    └── select
  │         ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
  │         ├── scan foo
- │         │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │         │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │         │    └── computed column expressions
+ │         │         ├── d:10(int)
+ │         │         │    └── plus [type=int]
+ │         │         │         ├── plus [type=int]
+ │         │         │         │    ├── variable: b [type=int]
+ │         │         │         │    └── variable: c [type=int]
+ │         │         │         └── const: 1 [type=int]
+ │         │         └── e:11(int)
+ │         │              └── variable: a [type=int]
  │         └── filters
  │              └── eq [type=bool]
  │                   ├── variable: a [type=int]
@@ -347,7 +419,16 @@ with &1
  │              │    └── select
  │              │         ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
  │              │         ├── scan abcde
- │              │         │    └── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │         │    ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │         │    └── computed column expressions
+ │              │         │         ├── abcde.d:10(int)
+ │              │         │         │    └── plus [type=int]
+ │              │         │         │         ├── plus [type=int]
+ │              │         │         │         │    ├── variable: abcde.b [type=int]
+ │              │         │         │         │    └── variable: abcde.c [type=int]
+ │              │         │         │         └── const: 1 [type=int]
+ │              │         │         └── abcde.e:11(int)
+ │              │         │              └── variable: abcde.a [type=int]
  │              │         └── filters
  │              │              └── gt [type=bool]
  │              │                   ├── variable: abcde.a [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1356,7 +1356,16 @@ insert checks
       │    ├── project
       │    │    ├── columns: abcde.a:5(int!null) abcde.b:6(int) abcde.c:7(int)
       │    │    └── scan abcde
-      │    │         └── columns: abcde.a:5(int!null) abcde.b:6(int) abcde.c:7(int) abcde.d:8(int) e:9(int) rowid:10(int!null)
+      │    │         ├── columns: abcde.a:5(int!null) abcde.b:6(int) abcde.c:7(int) abcde.d:8(int) e:9(int) rowid:10(int!null)
+      │    │         └── computed column expressions
+      │    │              ├── abcde.d:8(int)
+      │    │              │    └── plus [type=int]
+      │    │              │         ├── plus [type=int]
+      │    │              │         │    ├── variable: abcde.b [type=int]
+      │    │              │         │    └── variable: abcde.c [type=int]
+      │    │              │         └── const: 1 [type=int]
+      │    │              └── e:9(int)
+      │    │                   └── variable: abcde.a [type=int]
       │    └── projections
       │         └── plus [type=int]
       │              ├── variable: abcde.c [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1227,7 +1227,13 @@ build
 SELECT * FROM [55(1) as t(a)]
 ----
 scan t
- └── columns: a:1(int!null)
+ ├── columns: a:1(int!null)
+ └── check constraint expressions
+      └── lt [type=bool]
+           ├── plus [type=int]
+           │    ├── variable: a [type=int]
+           │    └── variable: b [type=int]
+           └── const: 10 [type=int]
 
 # Regression test for #28388. Ensure that selecting from a table with no
 # columns does not cause a panic.

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -75,7 +75,16 @@ update abcde
       │    ├── select
       │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    └── filters
       │    │         └── eq [type=bool]
       │    │              ├── variable: a [type=int]
@@ -108,7 +117,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) column16:16(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── const: 1 [type=int]
       │         ├── const: 2 [type=int]
@@ -140,7 +158,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) column16:16(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── const: 1 [type=int]
       │         ├── const: 2 [type=int]
@@ -172,7 +199,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         └── cast: INT8 [type=int]
       │              └── null [type=unknown]
@@ -202,7 +238,16 @@ update abcde
       │    ├── select
       │    │    ├── columns: a:7(int!null) b:8(int!null) c:9(int) d:10(int) e:11(int!null) rowid:12(int!null)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    └── filters
       │    │         └── gt [type=bool]
       │    │              ├── variable: b [type=int]
@@ -236,7 +281,16 @@ update foo
  └── project
       ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan foo
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── computed column expressions
+      │         ├── d:10(int)
+      │         │    └── plus [type=int]
+      │         │         ├── plus [type=int]
+      │         │         │    ├── variable: b [type=int]
+      │         │         │    └── variable: c [type=int]
+      │         │         └── const: 1 [type=int]
+      │         └── e:11(int)
+      │              └── variable: a [type=int]
       └── projections
            └── plus [type=int]
                 ├── plus [type=int]
@@ -269,7 +323,16 @@ update abcde
       │    │    │    └── select
       │    │    │         ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    │    │         ├── scan abcde
-      │    │    │         │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │         │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │         │    └── computed column expressions
+      │    │    │         │         ├── d:10(int)
+      │    │    │         │         │    └── plus [type=int]
+      │    │    │         │         │         ├── plus [type=int]
+      │    │    │         │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │         │    └── variable: c [type=int]
+      │    │    │         │         │         └── const: 1 [type=int]
+      │    │    │         │         └── e:11(int)
+      │    │    │         │              └── variable: a [type=int]
       │    │    │         └── filters
       │    │    │              └── gt [type=bool]
       │    │    │                   ├── variable: a [type=int]
@@ -468,7 +531,16 @@ update abcde
       │    ├── select
       │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) e:11(int) rowid:12(int!null)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    └── filters
       │    │         └── eq [type=bool]
       │    │              ├── variable: c [type=int]
@@ -526,7 +598,16 @@ with &1
  │         └── project
  │              ├── columns: column13:13(int) abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
  │              ├── scan abcde
- │              │    └── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    └── computed column expressions
+ │              │         ├── abcde.d:10(int)
+ │              │         │    └── plus [type=int]
+ │              │         │         ├── plus [type=int]
+ │              │         │         │    ├── variable: abcde.b [type=int]
+ │              │         │         │    └── variable: abcde.c [type=int]
+ │              │         │         └── const: 1 [type=int]
+ │              │         └── abcde.e:11(int)
+ │              │              └── variable: abcde.a [type=int]
  │              └── projections
  │                   └── plus [type=int]
  │                        ├── plus [type=int]
@@ -554,7 +635,16 @@ with &1
            └── project
                 ├── columns: column31:31(int) abcde.a:25(int!null) abcde.b:26(int) abcde.c:27(int) abcde.d:28(int) abcde.e:29(int) rowid:30(int!null)
                 ├── scan abcde
-                │    └── columns: abcde.a:25(int!null) abcde.b:26(int) abcde.c:27(int) abcde.d:28(int) abcde.e:29(int) rowid:30(int!null)
+                │    ├── columns: abcde.a:25(int!null) abcde.b:26(int) abcde.c:27(int) abcde.d:28(int) abcde.e:29(int) rowid:30(int!null)
+                │    └── computed column expressions
+                │         ├── abcde.d:28(int)
+                │         │    └── plus [type=int]
+                │         │         ├── plus [type=int]
+                │         │         │    ├── variable: abcde.b [type=int]
+                │         │         │    └── variable: abcde.c [type=int]
+                │         │         └── const: 1 [type=int]
+                │         └── abcde.e:29(int)
+                │              └── variable: abcde.a [type=int]
                 └── projections
                      └── plus [type=int]
                           ├── plus [type=int]
@@ -598,7 +688,16 @@ project
            │    ├── select
            │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
            │    │    ├── scan abcde
-           │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    │    │    └── computed column expressions
+           │    │    │         ├── d:10(int)
+           │    │    │         │    └── plus [type=int]
+           │    │    │         │         ├── plus [type=int]
+           │    │    │         │         │    ├── variable: b [type=int]
+           │    │    │         │         │    └── variable: c [type=int]
+           │    │    │         │         └── const: 1 [type=int]
+           │    │    │         └── e:11(int)
+           │    │    │              └── variable: a [type=int]
            │    │    └── filters
            │    │         └── eq [type=bool]
            │    │              ├── variable: a [type=int]
@@ -632,7 +731,16 @@ project
  │         │    ├── select
  │         │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
  │         │    │    ├── scan foo
- │         │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │         │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │         │    │    │    └── computed column expressions
+ │         │    │    │         ├── d:10(int)
+ │         │    │    │         │    └── plus [type=int]
+ │         │    │    │         │         ├── plus [type=int]
+ │         │    │    │         │         │    ├── variable: b [type=int]
+ │         │    │    │         │         │    └── variable: c [type=int]
+ │         │    │    │         │         └── const: 1 [type=int]
+ │         │    │    │         └── e:11(int)
+ │         │    │    │              └── variable: a [type=int]
  │         │    │    └── filters
  │         │    │         └── eq [type=bool]
  │         │    │              ├── variable: a [type=int]
@@ -682,7 +790,16 @@ with &1
  │              │    │    │    └── select
  │              │    │    │         ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
  │              │    │    │         ├── scan abcde
- │              │    │    │         │    └── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    │    │         │    ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) abcde.d:10(int) abcde.e:11(int) rowid:12(int!null)
+ │              │    │    │         │    └── computed column expressions
+ │              │    │    │         │         ├── abcde.d:10(int)
+ │              │    │    │         │         │    └── plus [type=int]
+ │              │    │    │         │         │         ├── plus [type=int]
+ │              │    │    │         │         │         │    ├── variable: abcde.b [type=int]
+ │              │    │    │         │         │         │    └── variable: abcde.c [type=int]
+ │              │    │    │         │         │         └── const: 1 [type=int]
+ │              │    │    │         │         └── abcde.e:11(int)
+ │              │    │    │         │              └── variable: abcde.a [type=int]
  │              │    │    │         └── filters
  │              │    │    │              └── gt [type=bool]
  │              │    │    │                   ├── variable: abcde.a [type=int]
@@ -725,7 +842,16 @@ project
            ├── project
            │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
            │    ├── scan abcde
-           │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+           │    │    └── computed column expressions
+           │    │         ├── d:10(int)
+           │    │         │    └── plus [type=int]
+           │    │         │         ├── plus [type=int]
+           │    │         │         │    ├── variable: b [type=int]
+           │    │         │         │    └── variable: c [type=int]
+           │    │         │         └── const: 1 [type=int]
+           │    │         └── e:11(int)
+           │    │              └── variable: a [type=int]
            │    └── projections
            │         └── plus [type=int]
            │              ├── variable: rowid [type=int]
@@ -770,7 +896,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── cast: INT8 [type=int]
       │         │    └── null [type=unknown]
@@ -799,7 +934,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         └── cast: INT8 [type=int]
       │              └── null [type=unknown]
@@ -836,7 +980,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── const: 1 [type=int]
       │         ├── const: 2 [type=int]
@@ -865,7 +1018,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) column14:14(int!null) column15:15(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── cast: INT8 [type=int]
       │         │    └── null [type=unknown]
@@ -895,7 +1057,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         ├── cast: INT8 [type=int]
       │         │    └── null [type=unknown]
@@ -924,7 +1095,16 @@ update abcde
       ├── project
       │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    └── projections
       │         └── cast: INT8 [type=int]
       │              └── null [type=unknown]
@@ -975,7 +1155,16 @@ update abcde
       ├── left-join-apply
       │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) one:13(int)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    ├── max1-row
       │    │    ├── columns: one:13(int!null)
       │    │    └── project
@@ -1011,7 +1200,16 @@ update abcde
       ├── left-join-apply
       │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) x:16(int) z:17(int) y1:18(int)
       │    ├── scan abcde
-      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    └── computed column expressions
+      │    │         ├── d:10(int)
+      │    │         │    └── plus [type=int]
+      │    │         │         ├── plus [type=int]
+      │    │         │         │    ├── variable: b [type=int]
+      │    │         │         │    └── variable: c [type=int]
+      │    │         │         └── const: 1 [type=int]
+      │    │         └── e:11(int)
+      │    │              └── variable: a [type=int]
       │    ├── max1-row
       │    │    ├── columns: y:14(int) x:16(int) z:17(int) y1:18(int)
       │    │    └── project
@@ -1055,7 +1253,16 @@ update abcde
       │    ├── left-join-apply
       │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    ├── max1-row
       │    │    │    ├── columns: y:14(int) y1:16(int)
       │    │    │    └── project
@@ -1098,7 +1305,16 @@ update abcde
       │    ├── left-join-apply
       │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    ├── max1-row
       │    │    │    ├── columns: y:14(int) y1:16(int)
       │    │    │    └── project
@@ -1141,7 +1357,16 @@ update abcde
       │    ├── left-join-apply
       │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int)
       │    │    ├── scan abcde
-      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── d:10(int)
+      │    │    │         │    └── plus [type=int]
+      │    │    │         │         ├── plus [type=int]
+      │    │    │         │         │    ├── variable: b [type=int]
+      │    │    │         │         │    └── variable: c [type=int]
+      │    │    │         │         └── const: 1 [type=int]
+      │    │    │         └── e:11(int)
+      │    │    │              └── variable: a [type=int]
       │    │    ├── max1-row
       │    │    │    ├── columns: y:14(int) y1:16(int)
       │    │    │    └── project
@@ -1218,7 +1443,16 @@ project
            ├── project
            │    ├── columns: column19:19(int) abcde1.a:7(int!null) abcde1.b:8(int) abcde1.c:9(int) abcde1.d:10(int) abcde1.e:11(int) abcde1.rowid:12(int!null)
            │    ├── scan abcde1
-           │    │    └── columns: abcde1.a:7(int!null) abcde1.b:8(int) abcde1.c:9(int) abcde1.d:10(int) abcde1.e:11(int) abcde1.rowid:12(int!null)
+           │    │    ├── columns: abcde1.a:7(int!null) abcde1.b:8(int) abcde1.c:9(int) abcde1.d:10(int) abcde1.e:11(int) abcde1.rowid:12(int!null)
+           │    │    └── computed column expressions
+           │    │         ├── abcde1.d:10(int)
+           │    │         │    └── plus [type=int]
+           │    │         │         ├── plus [type=int]
+           │    │         │         │    ├── variable: abcde1.b [type=int]
+           │    │         │         │    └── variable: abcde1.c [type=int]
+           │    │         │         └── const: 1 [type=int]
+           │    │         └── abcde1.e:11(int)
+           │    │              └── variable: abcde1.a [type=int]
            │    └── projections
            │         └── subquery [type=int]
            │              └── max1-row
@@ -1228,7 +1462,16 @@ project
            │                        └── select
            │                             ├── columns: abcde2.a:13(int!null) abcde2.b:14(int) abcde2.c:15(int) abcde2.d:16(int) abcde2.e:17(int) abcde2.rowid:18(int!null)
            │                             ├── scan abcde2
-           │                             │    └── columns: abcde2.a:13(int!null) abcde2.b:14(int) abcde2.c:15(int) abcde2.d:16(int) abcde2.e:17(int) abcde2.rowid:18(int!null)
+           │                             │    ├── columns: abcde2.a:13(int!null) abcde2.b:14(int) abcde2.c:15(int) abcde2.d:16(int) abcde2.e:17(int) abcde2.rowid:18(int!null)
+           │                             │    └── computed column expressions
+           │                             │         ├── abcde2.d:16(int)
+           │                             │         │    └── plus [type=int]
+           │                             │         │         ├── plus [type=int]
+           │                             │         │         │    ├── variable: abcde2.b [type=int]
+           │                             │         │         │    └── variable: abcde2.c [type=int]
+           │                             │         │         └── const: 1 [type=int]
+           │                             │         └── abcde2.e:17(int)
+           │                             │              └── variable: abcde2.a [type=int]
            │                             └── filters
            │                                  └── eq [type=bool]
            │                                       ├── variable: abcde2.rowid [type=int]
@@ -1289,7 +1532,16 @@ with &1 (cte)
            ├── select
            │    ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
            │    ├── scan abcde
-           │    │    └── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
+           │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
+           │    │    └── computed column expressions
+           │    │         ├── d:13(int)
+           │    │         │    └── plus [type=int]
+           │    │         │         ├── plus [type=int]
+           │    │         │         │    ├── variable: b [type=int]
+           │    │         │         │    └── variable: c [type=int]
+           │    │         │         └── const: 1 [type=int]
+           │    │         └── e:14(int)
+           │    │              └── variable: a [type=int]
            │    └── filters
            │         └── exists [type=bool]
            │              └── with-scan &1 (cte)
@@ -1329,7 +1581,16 @@ with &1 (a)
            ├── left-join-apply
            │    ├── columns: a:11(int!null) b:12(int) c:13(int) d:14(int) e:15(int) rowid:16(int!null) y:17(int) y1:18(int)
            │    ├── scan abcde
-           │    │    └── columns: a:11(int!null) b:12(int) c:13(int) d:14(int) e:15(int) rowid:16(int!null)
+           │    │    ├── columns: a:11(int!null) b:12(int) c:13(int) d:14(int) e:15(int) rowid:16(int!null)
+           │    │    └── computed column expressions
+           │    │         ├── d:14(int)
+           │    │         │    └── plus [type=int]
+           │    │         │         ├── plus [type=int]
+           │    │         │         │    ├── variable: b [type=int]
+           │    │         │         │    └── variable: c [type=int]
+           │    │         │         └── const: 1 [type=int]
+           │    │         └── e:15(int)
+           │    │              └── variable: a [type=int]
            │    ├── max1-row
            │    │    ├── columns: y:17(int) y1:18(int)
            │    │    └── with-scan &1 (a)
@@ -1367,7 +1628,11 @@ update mutation
       │    ├── project
       │    │    ├── columns: column11:11(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
       │    │    ├── scan mutation
-      │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    └── check constraint expressions
+      │    │    │         └── gt [type=bool]
+      │    │    │              ├── variable: m [type=int]
+      │    │    │              └── const: 0 [type=int]
       │    │    └── projections
       │    │         └── const: 1 [type=int]
       │    └── projections
@@ -1398,7 +1663,11 @@ update mutation
       │    ├── project
       │    │    ├── columns: column11:11(int!null) column12:12(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
       │    │    ├── scan mutation
-      │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    └── check constraint expressions
+      │    │    │         └── gt [type=bool]
+      │    │    │              ├── variable: m [type=int]
+      │    │    │              └── const: 0 [type=int]
       │    │    └── projections
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
@@ -1437,6 +1706,10 @@ update mutation
       │    │    │    │    ├── limit hint: 10.00
       │    │    │    │    └── scan mutation
       │    │    │    │         ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    │         ├── check constraint expressions
+      │    │    │    │         │    └── gt [type=bool]
+      │    │    │    │         │         ├── variable: m [type=int]
+      │    │    │    │         │         └── const: 0 [type=int]
       │    │    │    │         └── ordering: +6
       │    │    │    └── const: 10 [type=int]
       │    │    └── projections
@@ -1504,7 +1777,19 @@ update checks
       │    ├── project
       │    │    ├── columns: column9:9(int!null) column10:10(int!null) column11:11(int!null) a:5(int!null) b:6(int) c:7(int) d:8(int)
       │    │    ├── scan checks
-      │    │    │    └── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    └── gt [type=bool]
+      │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │         └── const: 0 [type=int]
+      │    │    │    └── computed column expressions
+      │    │    │         └── d:8(int)
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: c [type=int]
+      │    │    │                   └── const: 1 [type=int]
       │    │    └── projections
       │    │         ├── const: 1 [type=int]
       │    │         ├── const: 2 [type=int]
@@ -1539,7 +1824,19 @@ update checks
       │    ├── project
       │    │    ├── columns: column9:9(int!null) a:5(int!null) b:6(int) c:7(int) d:8(int)
       │    │    ├── scan checks
-      │    │    │    └── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    └── gt [type=bool]
+      │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │         └── const: 0 [type=int]
+      │    │    │    └── computed column expressions
+      │    │    │         └── d:8(int)
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: c [type=int]
+      │    │    │                   └── const: 1 [type=int]
       │    │    └── projections
       │    │         └── const: 1 [type=int]
       │    └── projections
@@ -1572,7 +1869,19 @@ update checks
       │    ├── project
       │    │    ├── columns: column9:9(int!null) a:5(int!null) b:6(int) c:7(int) d:8(int)
       │    │    ├── scan checks
-      │    │    │    └── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── columns: a:5(int!null) b:6(int) c:7(int) d:8(int)
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    └── gt [type=bool]
+      │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │         └── const: 0 [type=int]
+      │    │    │    └── computed column expressions
+      │    │    │         └── d:8(int)
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: c [type=int]
+      │    │    │                   └── const: 1 [type=int]
       │    │    └── projections
       │    │         └── const: 2 [type=int]
       │    └── projections
@@ -1606,7 +1915,19 @@ update checks
       │    ├── left-join-apply
       │    │    ├── columns: checks.a:5(int!null) checks.b:6(int) checks.c:7(int) checks.d:8(int) abcde.a:9(int) abcde.b:10(int)
       │    │    ├── scan checks
-      │    │    │    └── columns: checks.a:5(int!null) checks.b:6(int) checks.c:7(int) checks.d:8(int)
+      │    │    │    ├── columns: checks.a:5(int!null) checks.b:6(int) checks.c:7(int) checks.d:8(int)
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    ├── variable: checks.b [type=int]
+      │    │    │    │    │    └── variable: checks.d [type=int]
+      │    │    │    │    └── gt [type=bool]
+      │    │    │    │         ├── variable: checks.a [type=int]
+      │    │    │    │         └── const: 0 [type=int]
+      │    │    │    └── computed column expressions
+      │    │    │         └── checks.d:8(int)
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: checks.c [type=int]
+      │    │    │                   └── const: 1 [type=int]
       │    │    ├── max1-row
       │    │    │    ├── columns: abcde.a:9(int!null) abcde.b:10(int)
       │    │    │    └── project
@@ -1614,7 +1935,16 @@ update checks
       │    │    │         └── select
       │    │    │              ├── columns: abcde.a:9(int!null) abcde.b:10(int) abcde.c:11(int) abcde.d:12(int) e:13(int) rowid:14(int!null)
       │    │    │              ├── scan abcde
-      │    │    │              │    └── columns: abcde.a:9(int!null) abcde.b:10(int) abcde.c:11(int) abcde.d:12(int) e:13(int) rowid:14(int!null)
+      │    │    │              │    ├── columns: abcde.a:9(int!null) abcde.b:10(int) abcde.c:11(int) abcde.d:12(int) e:13(int) rowid:14(int!null)
+      │    │    │              │    └── computed column expressions
+      │    │    │              │         ├── abcde.d:12(int)
+      │    │    │              │         │    └── plus [type=int]
+      │    │    │              │         │         ├── plus [type=int]
+      │    │    │              │         │         │    ├── variable: abcde.b [type=int]
+      │    │    │              │         │         │    └── variable: abcde.c [type=int]
+      │    │    │              │         │         └── const: 1 [type=int]
+      │    │    │              │         └── e:13(int)
+      │    │    │              │              └── variable: abcde.a [type=int]
       │    │    │              └── filters
       │    │    │                   └── eq [type=bool]
       │    │    │                        ├── variable: abcde.a [type=int]
@@ -1652,7 +1982,22 @@ update decimals
       ├── project
       │    ├── columns: a:11(decimal) b:12(decimal[]) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
       │    ├── scan decimals
-      │    │    └── columns: decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
+      │    │    ├── columns: decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
+      │    │    ├── check constraint expressions
+      │    │    │    ├── eq [type=bool]
+      │    │    │    │    ├── variable: decimals.a [type=decimal]
+      │    │    │    │    └── function: round [type=decimal]
+      │    │    │    │         └── variable: decimals.a [type=decimal]
+      │    │    │    └── gt [type=bool]
+      │    │    │         ├── indirection [type=decimal]
+      │    │    │         │    ├── variable: decimals.b [type=decimal[]]
+      │    │    │         │    └── const: 0 [type=int]
+      │    │    │         └── const: 1 [type=decimal]
+      │    │    └── computed column expressions
+      │    │         └── decimals.d:8(decimal)
+      │    │              └── plus [type=decimal]
+      │    │                   ├── variable: decimals.a [type=decimal]
+      │    │                   └── variable: c [type=decimal]
       │    └── projections
       │         ├── function: crdb_internal.round_decimal_values [type=decimal]
       │         │    ├── const: 1.1 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -111,7 +111,12 @@ upsert abc
       │    │    │    │              ├── variable: y [type=int]
       │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── scan abc
-      │    │    │    │    └── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+      │    │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c:12(int)
+      │    │    │    │              └── plus [type=int]
+      │    │    │    │                   ├── variable: b [type=int]
+      │    │    │    │                   └── const: 1 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: x [type=int]
@@ -202,7 +207,12 @@ project
            │    │    │    │              ├── variable: y [type=int]
            │    │    │    │              └── const: 1 [type=int]
            │    │    │    ├── scan abc
-           │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+           │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+           │    │    │    │    └── computed column expressions
+           │    │    │    │         └── c:11(int)
+           │    │    │    │              └── plus [type=int]
+           │    │    │    │                   ├── variable: b [type=int]
+           │    │    │    │                   └── const: 1 [type=int]
            │    │    │    └── filters
            │    │    │         ├── eq [type=bool]
            │    │    │         │    ├── variable: y [type=int]
@@ -297,7 +307,12 @@ upsert abc
       │    │    │    │    │              ├── variable: y [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
       │    │    │    │    ├── scan abc
-      │    │    │    │    │    └── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+      │    │    │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+      │    │    │    │    │    └── computed column expressions
+      │    │    │    │    │         └── c:12(int)
+      │    │    │    │    │              └── plus [type=int]
+      │    │    │    │    │                   ├── variable: b [type=int]
+      │    │    │    │    │                   └── const: 1 [type=int]
       │    │    │    │    └── filters
       │    │    │    │         └── eq [type=bool]
       │    │    │    │              ├── variable: x [type=int]
@@ -407,7 +422,12 @@ sort
       │              │    │    │    │              ├── variable: column2 [type=int]
       │              │    │    │    │              └── const: 1 [type=int]
       │              │    │    │    ├── scan abc
-      │              │    │    │    │    └── columns: abc.a:9(int!null) abc.b:10(int) abc.c:11(int) rowid:12(int!null)
+      │              │    │    │    │    ├── columns: abc.a:9(int!null) abc.b:10(int) abc.c:11(int) rowid:12(int!null)
+      │              │    │    │    │    └── computed column expressions
+      │              │    │    │    │         └── abc.c:11(int)
+      │              │    │    │    │              └── plus [type=int]
+      │              │    │    │    │                   ├── variable: abc.b [type=int]
+      │              │    │    │    │                   └── const: 1 [type=int]
       │              │    │    │    └── filters
       │              │    │    │         └── eq [type=bool]
       │              │    │    │              ├── variable: column1 [type=int]
@@ -501,7 +521,12 @@ upsert tab
       │    │    │    │              ├── variable: column2 [type=int]
       │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── scan tab
-      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c:11(int)
+      │    │    │    │              └── plus [type=int]
+      │    │    │    │                   ├── variable: b [type=int]
+      │    │    │    │                   └── const: 1 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -873,7 +898,12 @@ upsert abc
       │    │    │    │              ├── variable: column2 [type=int]
       │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── scan abc
-      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c:11(int)
+      │    │    │    │              └── plus [type=int]
+      │    │    │    │                   ├── variable: b [type=int]
+      │    │    │    │                   └── const: 1 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -977,7 +1007,12 @@ upsert abc
       │    │    │    │              ├── variable: column2 [type=int]
       │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── scan abc
-      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c:11(int)
+      │    │    │    │              └── plus [type=int]
+      │    │    │    │                   ├── variable: b [type=int]
+      │    │    │    │                   └── const: 1 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -1073,7 +1108,11 @@ upsert mutation
       │    │    │    │    │              ├── variable: column8 [type=int]
       │    │    │    │    │              └── variable: column2 [type=int]
       │    │    │    │    ├── scan mutation
-      │    │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    │    ├── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    │    └── check constraint expressions
+      │    │    │    │    │         └── gt [type=bool]
+      │    │    │    │    │              ├── variable: m [type=int]
+      │    │    │    │    │              └── const: 0 [type=int]
       │    │    │    │    └── filters
       │    │    │    │         └── eq [type=bool]
       │    │    │    │              ├── variable: column1 [type=int]
@@ -1233,7 +1272,12 @@ with &1
  │              │    │              ├── variable: column2 [type=int]
  │              │    │              └── const: 1 [type=int]
  │              │    ├── scan abc
- │              │    │    └── columns: abc.a:9(int!null) abc.b:10(int) abc.c:11(int) rowid:12(int!null)
+ │              │    │    ├── columns: abc.a:9(int!null) abc.b:10(int) abc.c:11(int) rowid:12(int!null)
+ │              │    │    └── computed column expressions
+ │              │    │         └── abc.c:11(int)
+ │              │    │              └── plus [type=int]
+ │              │    │                   ├── variable: abc.b [type=int]
+ │              │    │                   └── const: 1 [type=int]
  │              │    └── filters
  │              │         └── eq [type=bool]
  │              │              ├── variable: column7 [type=int]
@@ -1353,7 +1397,19 @@ upsert checks
       │    │    │              ├── variable: column3 [type=int]
       │    │    │              └── const: 1 [type=int]
       │    │    ├── scan checks
-      │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    └── gt [type=bool]
+      │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │         └── const: 0 [type=int]
+      │    │    │    └── computed column expressions
+      │    │    │         └── d:12(int)
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: c [type=int]
+      │    │    │                   └── const: 1 [type=int]
       │    │    └── filters
       │    │         └── eq [type=bool]
       │    │              ├── variable: column1 [type=int]
@@ -1417,7 +1473,11 @@ upsert mutation
       │    │    │    │              ├── variable: column8 [type=int]
       │    │    │    │              └── variable: column2 [type=int]
       │    │    │    ├── scan mutation
-      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    ├── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    └── check constraint expressions
+      │    │    │    │         └── gt [type=bool]
+      │    │    │    │              ├── variable: m [type=int]
+      │    │    │    │              └── const: 0 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -1498,7 +1558,11 @@ upsert mutation
       │    │    │    │              ├── variable: column8 [type=int]
       │    │    │    │              └── variable: column2 [type=int]
       │    │    │    ├── scan mutation
-      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    ├── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    └── check constraint expressions
+      │    │    │    │         └── gt [type=bool]
+      │    │    │    │              ├── variable: m [type=int]
+      │    │    │    │              └── const: 0 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -1592,7 +1656,19 @@ upsert checks
       │    │    │    │    │              ├── variable: column7 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
       │    │    │    │    ├── scan checks
-      │    │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    │    │    └── gt [type=bool]
+      │    │    │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │    │    │         └── const: 0 [type=int]
+      │    │    │    │    │    └── computed column expressions
+      │    │    │    │    │         └── d:12(int)
+      │    │    │    │    │              └── plus [type=int]
+      │    │    │    │    │                   ├── variable: c [type=int]
+      │    │    │    │    │                   └── const: 1 [type=int]
       │    │    │    │    └── filters
       │    │    │    │         └── eq [type=bool]
       │    │    │    │              ├── variable: column1 [type=int]
@@ -1682,7 +1758,19 @@ insert checks
       │         │    │              ├── variable: column7 [type=int]
       │         │    │              └── const: 1 [type=int]
       │         │    ├── scan checks
-      │         │    │    └── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │         │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │         │    │    ├── check constraint expressions
+      │         │    │    │    ├── lt [type=bool]
+      │         │    │    │    │    ├── variable: b [type=int]
+      │         │    │    │    │    └── variable: d [type=int]
+      │         │    │    │    └── gt [type=bool]
+      │         │    │    │         ├── variable: a [type=int]
+      │         │    │    │         └── const: 0 [type=int]
+      │         │    │    └── computed column expressions
+      │         │    │         └── d:12(int)
+      │         │    │              └── plus [type=int]
+      │         │    │                   ├── variable: c [type=int]
+      │         │    │                   └── const: 1 [type=int]
       │         │    └── filters
       │         │         └── eq [type=bool]
       │         │              ├── variable: column1 [type=int]
@@ -1741,7 +1829,19 @@ upsert checks
       │    │    │    │              ├── variable: column7 [type=int]
       │    │    │    │              └── const: 1 [type=int]
       │    │    │    ├── scan checks
-      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
+      │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    │    ├── variable: b [type=int]
+      │    │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    │    └── gt [type=bool]
+      │    │    │    │    │         ├── variable: a [type=int]
+      │    │    │    │    │         └── const: 0 [type=int]
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── d:12(int)
+      │    │    │    │              └── plus [type=int]
+      │    │    │    │                   ├── variable: c [type=int]
+      │    │    │    │                   └── const: 1 [type=int]
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -1820,7 +1920,12 @@ upsert checks
       │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int)
       │    │    │    │    │    │    │    └── scan abc
-      │    │    │    │    │    │    │         └── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) rowid:8(int!null)
+      │    │    │    │    │    │    │         ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) rowid:8(int!null)
+      │    │    │    │    │    │    │         └── computed column expressions
+      │    │    │    │    │    │    │              └── abc.c:7(int)
+      │    │    │    │    │    │    │                   └── plus [type=int]
+      │    │    │    │    │    │    │                        ├── variable: abc.b [type=int]
+      │    │    │    │    │    │    │                        └── const: 1 [type=int]
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── cast: INT8 [type=int]
       │    │    │    │    │    │              └── null [type=unknown]
@@ -1829,7 +1934,19 @@ upsert checks
       │    │    │    │    │              ├── variable: column9 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
       │    │    │    │    ├── scan checks
-      │    │    │    │    │    └── columns: checks.a:11(int!null) checks.b:12(int) checks.c:13(int) d:14(int)
+      │    │    │    │    │    ├── columns: checks.a:11(int!null) checks.b:12(int) checks.c:13(int) d:14(int)
+      │    │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    │    ├── lt [type=bool]
+      │    │    │    │    │    │    │    ├── variable: checks.b [type=int]
+      │    │    │    │    │    │    │    └── variable: d [type=int]
+      │    │    │    │    │    │    └── gt [type=bool]
+      │    │    │    │    │    │         ├── variable: checks.a [type=int]
+      │    │    │    │    │    │         └── const: 0 [type=int]
+      │    │    │    │    │    └── computed column expressions
+      │    │    │    │    │         └── d:14(int)
+      │    │    │    │    │              └── plus [type=int]
+      │    │    │    │    │                   ├── variable: checks.c [type=int]
+      │    │    │    │    │                   └── const: 1 [type=int]
       │    │    │    │    └── filters
       │    │    │    │         └── eq [type=bool]
       │    │    │    │              ├── variable: abc.a [type=int]

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -368,7 +368,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "norm":
 		e, err := ot.OptNorm()
@@ -385,7 +385,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "opt":
 		e, err := ot.Optimize()
@@ -393,7 +393,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "optsteps":
 		result, err := ot.OptSteps()
@@ -429,7 +429,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "exprnorm":
 		e, err := ot.ExprNorm()
@@ -437,7 +437,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "save-tables":
 		e, err := ot.SaveTables()
@@ -445,7 +445,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
+		return ot.FormatExpr(e)
 
 	case "stats":
 		result, err := ot.Stats(d)
@@ -462,6 +462,15 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		d.Fatalf(tb, "unsupported command: %s", d.Cmd)
 		return ""
 	}
+}
+
+// FormatExpr is a convenience wrapper for memo.FormatExpr.
+func (ot *OptTester) FormatExpr(e opt.Expr) string {
+	var mem *memo.Memo
+	if rel, ok := e.(memo.RelExpr); ok {
+		mem = rel.Memo()
+	}
+	return memo.FormatExpr(e, ot.Flags.ExprFormat, mem, ot.catalog)
 }
 
 func formatRuleSet(r RuleSet) string {
@@ -892,7 +901,7 @@ func (ot *OptTester) OptSteps() (string, error) {
 			return "", err
 		}
 
-		next = memo.FormatExpr(os.Root(), ot.Flags.ExprFormat, ot.catalog)
+		next = os.fo.o.FormatExpr(os.Root(), ot.Flags.ExprFormat)
 
 		// This call comes after setting "next", because we want to output the
 		// final expression, even though there were no diffs from the previous
@@ -1033,13 +1042,13 @@ func (ot *OptTester) ExploreTrace() (string, error) {
 		ot.output("%s\n", et.LastRuleName())
 		ot.separator("=")
 		ot.output("Source expression:\n")
-		ot.indent(memo.FormatExpr(et.SrcExpr(), ot.Flags.ExprFormat, ot.catalog))
+		ot.indent(et.fo.o.FormatExpr(et.SrcExpr(), ot.Flags.ExprFormat))
 		if len(newNodes) == 0 {
 			ot.output("\nNo new expressions.\n")
 		}
 		for i := range newNodes {
 			ot.output("\nNew expression %d of %d:\n", i+1, len(newNodes))
-			ot.indent(memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat, ot.catalog))
+			ot.indent(memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat, et.fo.o.Memo(), ot.catalog))
 		}
 	}
 	return ot.builder.String(), nil

--- a/pkg/sql/opt/testutils/opttester/testdata/opt_steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt_steps
@@ -115,3 +115,286 @@ Final best expression
    ├── constraint: /2/1: [/1 - /1]
    ├── key: (1)
    └── fd: ()-->(2)
+
+exec-ddl
+CREATE TABLE customers (
+    id INT8 NOT NULL,
+    name STRING NOT NULL,
+    address STRING NULL,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    FAMILY "primary" (id, name, address)
+)
+----
+
+exec-ddl
+CREATE TABLE orders (
+    id INT8 NOT NULL,
+    customer_id INT8 NULL,
+    status STRING NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    CONSTRAINT fk_customer_id_ref_customers FOREIGN KEY (customer_id) REFERENCES customers(id),
+    INDEX orders_auto_index_fk_customer_id_ref_customers (customer_id ASC),
+    FAMILY "primary" (id, customer_id, status),
+    CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))
+)
+----
+
+# Verify that we don't crash when a normalization rule runs on a constraint
+# expression that is attached to the TableMeta but otherwise not used.
+# In this example, the rule is NormalizeInConst.
+optsteps
+SELECT * FROM orders LEFT JOIN customers ON customer_id = customers.id
+----
+================================================================================
+Initial expression
+  Cost: 2160.05
+================================================================================
+  left-join (hash)
+   ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+   ├── key: (1,4)
+   ├── fd: (1)-->(2,3), (4)-->(5,6)
+   ├── scan orders
+   │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+   │    ├── key: (1)
+   │    └── fd: (1)-->(2,3)
+   ├── scan customers
+   │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+   │    ├── key: (4)
+   │    └── fd: (4)-->(5,6)
+   └── filters
+        └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+             ├── variable: customer_id [type=int]
+             └── variable: customers.id [type=int]
+--------------------------------------------------------------------------------
+NormalizeInConst (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+  -left-join (hash)
+  +right-join (hash)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+    ├── key: (1,4)
+    ├── fd: (1)-->(2,3), (4)-->(5,6)
+  + ├── scan customers
+  + │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+  + │    ├── key: (4)
+  + │    └── fd: (4)-->(5,6)
+    ├── scan orders
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── key: (1)
+    │    └── fd: (1)-->(2,3)
+  - ├── scan customers
+  - │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+  - │    ├── key: (4)
+  - │    └── fd: (4)-->(5,6)
+    └── filters
+         └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+              ├── variable: customer_id [type=int]
+              └── variable: customers.id [type=int]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateLookupJoins (higher cost)
+--------------------------------------------------------------------------------
+  -left-join (hash)
+  +left-join (lookup customers)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+  + ├── key columns: [2] = [4]
+  + ├── lookup columns are key
+    ├── key: (1,4)
+    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── scan orders
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── key: (1)
+    │    └── fd: (1)-->(2,3)
+  - ├── scan customers
+  - │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+  - │    ├── key: (4)
+  - │    └── fd: (4)-->(5,6)
+  - └── filters
+  -      └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+  -           ├── variable: customer_id [type=int]
+  -           └── variable: customers.id [type=int]
+  + └── filters (true)
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+  -left-join (lookup customers)
+  +right-join (merge)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+  - ├── key columns: [2] = [4]
+  - ├── lookup columns are key
+  + ├── left ordering: +4
+  + ├── right ordering: +2
+    ├── key: (1,4)
+    ├── fd: (1)-->(2,3), (4)-->(5,6)
+  - ├── scan orders
+  + ├── scan customers
+  + │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+  + │    ├── key: (4)
+  + │    ├── fd: (4)-->(5,6)
+  + │    └── ordering: +4
+  + ├── sort
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── key: (1)
+  - │    └── fd: (1)-->(2,3)
+  + │    ├── fd: (1)-->(2,3)
+  + │    ├── ordering: +2
+  + │    └── scan orders
+  + │         ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  + │         ├── key: (1)
+  + │         └── fd: (1)-->(2,3)
+    └── filters (true)
+================================================================================
+Final best expression
+  Cost: 2160.05
+================================================================================
+  left-join (hash)
+   ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+   ├── key: (1,4)
+   ├── fd: (1)-->(2,3), (4)-->(5,6)
+   ├── scan orders
+   │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+   │    ├── key: (1)
+   │    └── fd: (1)-->(2,3)
+   ├── scan customers
+   │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+   │    ├── key: (4)
+   │    └── fd: (4)-->(5,6)
+   └── filters
+        └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+             ├── variable: customer_id [type=int]
+             └── variable: customers.id [type=int]
+
+exec-ddl
+CREATE TABLE comp (
+  k INT,
+  c BOOL AS (k IN (1,3,2)) STORED,
+  INDEX (c, k)
+)
+----
+
+# Verify that we don't crash when a normalization rule runs on a computed
+# column expression that is attached to the TableMeta but otherwise not used.
+# In this example, the rule is NormalizeInConst.
+optsteps
+SELECT * FROM comp WHERE k=1
+----
+================================================================================
+Initial expression
+  Cost: 1070.14
+================================================================================
+  project
+   ├── columns: k:1(int!null) c:2(bool)
+   ├── fd: ()-->(1)
+   └── select
+        ├── columns: k:1(int!null) c:2(bool) rowid:3(int!null)
+        ├── key: (3)
+        ├── fd: ()-->(1), (3)-->(2)
+        ├── scan comp
+        │    ├── columns: k:1(int) c:2(bool) rowid:3(int!null)
+        │    ├── key: (3)
+        │    └── fd: (3)-->(1,2)
+        └── filters
+             └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+                  ├── variable: k [type=int]
+                  └── const: 1 [type=int]
+--------------------------------------------------------------------------------
+NormalizeInConst (no changes)
+--------------------------------------------------------------------------------
+================================================================================
+PruneSelectCols
+  Cost: 1060.14
+================================================================================
+   project
+    ├── columns: k:1(int!null) c:2(bool)
+    ├── fd: ()-->(1)
+    └── select
+  -      ├── columns: k:1(int!null) c:2(bool) rowid:3(int!null)
+  -      ├── key: (3)
+  -      ├── fd: ()-->(1), (3)-->(2)
+  +      ├── columns: k:1(int!null) c:2(bool)
+  +      ├── fd: ()-->(1)
+         ├── scan comp
+  -      │    ├── columns: k:1(int) c:2(bool) rowid:3(int!null)
+  -      │    ├── key: (3)
+  -      │    └── fd: (3)-->(1,2)
+  +      │    └── columns: k:1(int) c:2(bool)
+         └── filters
+              └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+                   ├── variable: k [type=int]
+                   └── const: 1 [type=int]
+================================================================================
+EliminateProject
+  Cost: 1060.03
+================================================================================
+  -project
+  +select
+    ├── columns: k:1(int!null) c:2(bool)
+    ├── fd: ()-->(1)
+  - └── select
+  -      ├── columns: k:1(int!null) c:2(bool)
+  -      ├── fd: ()-->(1)
+  -      ├── scan comp
+  -      │    └── columns: k:1(int) c:2(bool)
+  -      └── filters
+  -           └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+  -                ├── variable: k [type=int]
+  -                └── const: 1 [type=int]
+  + ├── scan comp
+  + │    └── columns: k:1(int) c:2(bool)
+  + └── filters
+  +      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+  +           ├── variable: k [type=int]
+  +           └── const: 1 [type=int]
+--------------------------------------------------------------------------------
+GenerateIndexScans (higher cost)
+--------------------------------------------------------------------------------
+   select
+    ├── columns: k:1(int!null) c:2(bool)
+    ├── fd: ()-->(1)
+  - ├── scan comp
+  + ├── scan comp@secondary
+    │    └── columns: k:1(int) c:2(bool)
+    └── filters
+         └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+              ├── variable: k [type=int]
+              └── const: 1 [type=int]
+--------------------------------------------------------------------------------
+GenerateZigzagJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateConstrainedScans (no changes)
+--------------------------------------------------------------------------------
+================================================================================
+FoldComparison
+  Cost: 10.51
+================================================================================
+  -select
+  +scan comp@secondary
+    ├── columns: k:1(int!null) c:2(bool)
+  - ├── fd: ()-->(1)
+  - ├── scan comp
+  - │    └── columns: k:1(int) c:2(bool)
+  - └── filters
+  -      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+  -           ├── variable: k [type=int]
+  -           └── const: 1 [type=int]
+  + ├── constraint: /2/1/3: [/true/1 - /true/1]
+  + └── fd: ()-->(1)
+================================================================================
+Final best expression
+  Cost: 10.51
+================================================================================
+  scan comp@secondary
+   ├── columns: k:1(int!null) c:2(bool)
+   ├── constraint: /2/1/3: [/true/1 - /true/1]
+   └── fd: ()-->(1)

--- a/pkg/sql/opt/testutils/opttester/testdata/opt_steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt_steps
@@ -155,6 +155,13 @@ Initial expression
    ├── fd: (1)-->(2,3), (4)-->(5,6)
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+   │    ├── check constraint expressions
+   │    │    └── in [type=bool]
+   │    │         ├── variable: status [type=string]
+   │    │         └── tuple [type=tuple{string, string, string}]
+   │    │              ├── const: 'open' [type=string]
+   │    │              ├── const: 'complete' [type=string]
+   │    │              └── const: 'cancelled' [type=string]
    │    ├── key: (1)
    │    └── fd: (1)-->(2,3)
    ├── scan customers
@@ -165,9 +172,35 @@ Initial expression
         └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
              ├── variable: customer_id [type=int]
              └── variable: customers.id [type=int]
---------------------------------------------------------------------------------
-NormalizeInConst (no changes)
---------------------------------------------------------------------------------
+================================================================================
+NormalizeInConst
+  Cost: 2160.05
+================================================================================
+   left-join (hash)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
+    ├── key: (1,4)
+    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── scan orders
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── check constraint expressions
+    │    │    └── in [type=bool]
+    │    │         ├── variable: status [type=string]
+    │    │         └── tuple [type=tuple{string, string, string}]
+  - │    │              ├── const: 'open' [type=string]
+  + │    │              ├── const: 'cancelled' [type=string]
+    │    │              ├── const: 'complete' [type=string]
+  - │    │              └── const: 'cancelled' [type=string]
+  + │    │              └── const: 'open' [type=string]
+    │    ├── key: (1)
+    │    └── fd: (1)-->(2,3)
+    ├── scan customers
+    │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
+    │    ├── key: (4)
+    │    └── fd: (4)-->(5,6)
+    └── filters
+         └── eq [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+              ├── variable: customer_id [type=int]
+              └── variable: customers.id [type=int]
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
@@ -188,6 +221,13 @@ CommuteLeftJoin (higher cost)
   + │    └── fd: (4)-->(5,6)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── check constraint expressions
+    │    │    └── in [type=bool]
+    │    │         ├── variable: status [type=string]
+    │    │         └── tuple [type=tuple{string, string, string}]
+    │    │              ├── const: 'cancelled' [type=string]
+    │    │              ├── const: 'complete' [type=string]
+    │    │              └── const: 'open' [type=string]
     │    ├── key: (1)
     │    └── fd: (1)-->(2,3)
   - ├── scan customers
@@ -213,6 +253,13 @@ GenerateLookupJoins (higher cost)
     ├── fd: (1)-->(2,3), (4)-->(5,6)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── check constraint expressions
+    │    │    └── in [type=bool]
+    │    │         ├── variable: status [type=string]
+    │    │         └── tuple [type=tuple{string, string, string}]
+    │    │              ├── const: 'cancelled' [type=string]
+    │    │              ├── const: 'complete' [type=string]
+    │    │              └── const: 'open' [type=string]
     │    ├── key: (1)
     │    └── fd: (1)-->(2,3)
   - ├── scan customers
@@ -244,12 +291,26 @@ GenerateMergeJoins (higher cost)
   + │    └── ordering: +4
   + ├── sort
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  - │    ├── check constraint expressions
+  - │    │    └── in [type=bool]
+  - │    │         ├── variable: status [type=string]
+  - │    │         └── tuple [type=tuple{string, string, string}]
+  - │    │              ├── const: 'cancelled' [type=string]
+  - │    │              ├── const: 'complete' [type=string]
+  - │    │              └── const: 'open' [type=string]
     │    ├── key: (1)
   - │    └── fd: (1)-->(2,3)
   + │    ├── fd: (1)-->(2,3)
   + │    ├── ordering: +2
   + │    └── scan orders
   + │         ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  + │         ├── check constraint expressions
+  + │         │    └── in [type=bool]
+  + │         │         ├── variable: status [type=string]
+  + │         │         └── tuple [type=tuple{string, string, string}]
+  + │         │              ├── const: 'cancelled' [type=string]
+  + │         │              ├── const: 'complete' [type=string]
+  + │         │              └── const: 'open' [type=string]
   + │         ├── key: (1)
   + │         └── fd: (1)-->(2,3)
     └── filters (true)
@@ -263,6 +324,13 @@ Final best expression
    ├── fd: (1)-->(2,3), (4)-->(5,6)
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+   │    ├── check constraint expressions
+   │    │    └── in [type=bool]
+   │    │         ├── variable: status [type=string]
+   │    │         └── tuple [type=tuple{string, string, string}]
+   │    │              ├── const: 'cancelled' [type=string]
+   │    │              ├── const: 'complete' [type=string]
+   │    │              └── const: 'open' [type=string]
    │    ├── key: (1)
    │    └── fd: (1)-->(2,3)
    ├── scan customers
@@ -301,15 +369,49 @@ Initial expression
         ├── fd: ()-->(1), (3)-->(2)
         ├── scan comp
         │    ├── columns: k:1(int) c:2(bool) rowid:3(int!null)
+        │    ├── computed column expressions
+        │    │    └── c:2(bool)
+        │    │         └── in [type=bool]
+        │    │              ├── variable: k [type=int]
+        │    │              └── tuple [type=tuple{int, int, int}]
+        │    │                   ├── const: 1 [type=int]
+        │    │                   ├── const: 3 [type=int]
+        │    │                   └── const: 2 [type=int]
         │    ├── key: (3)
         │    └── fd: (3)-->(1,2)
         └── filters
              └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
                   ├── variable: k [type=int]
                   └── const: 1 [type=int]
---------------------------------------------------------------------------------
-NormalizeInConst (no changes)
---------------------------------------------------------------------------------
+================================================================================
+NormalizeInConst
+  Cost: 1070.14
+================================================================================
+   project
+    ├── columns: k:1(int!null) c:2(bool)
+    ├── fd: ()-->(1)
+    └── select
+         ├── columns: k:1(int!null) c:2(bool) rowid:3(int!null)
+         ├── key: (3)
+         ├── fd: ()-->(1), (3)-->(2)
+         ├── scan comp
+         │    ├── columns: k:1(int) c:2(bool) rowid:3(int!null)
+         │    ├── computed column expressions
+         │    │    └── c:2(bool)
+         │    │         └── in [type=bool]
+         │    │              ├── variable: k [type=int]
+         │    │              └── tuple [type=tuple{int, int, int}]
+         │    │                   ├── const: 1 [type=int]
+  -      │    │                   ├── const: 3 [type=int]
+  -      │    │                   └── const: 2 [type=int]
+  +      │    │                   ├── const: 2 [type=int]
+  +      │    │                   └── const: 3 [type=int]
+         │    ├── key: (3)
+         │    └── fd: (3)-->(1,2)
+         └── filters
+              └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+                   ├── variable: k [type=int]
+                   └── const: 1 [type=int]
 ================================================================================
 PruneSelectCols
   Cost: 1060.14
@@ -325,9 +427,25 @@ PruneSelectCols
   +      ├── fd: ()-->(1)
          ├── scan comp
   -      │    ├── columns: k:1(int) c:2(bool) rowid:3(int!null)
+  -      │    ├── computed column expressions
+  -      │    │    └── c:2(bool)
+  -      │    │         └── in [type=bool]
+  -      │    │              ├── variable: k [type=int]
+  -      │    │              └── tuple [type=tuple{int, int, int}]
+  -      │    │                   ├── const: 1 [type=int]
+  -      │    │                   ├── const: 2 [type=int]
+  -      │    │                   └── const: 3 [type=int]
   -      │    ├── key: (3)
   -      │    └── fd: (3)-->(1,2)
-  +      │    └── columns: k:1(int) c:2(bool)
+  +      │    ├── columns: k:1(int) c:2(bool)
+  +      │    └── computed column expressions
+  +      │         └── c:2(bool)
+  +      │              └── in [type=bool]
+  +      │                   ├── variable: k [type=int]
+  +      │                   └── tuple [type=tuple{int, int, int}]
+  +      │                        ├── const: 1 [type=int]
+  +      │                        ├── const: 2 [type=int]
+  +      │                        └── const: 3 [type=int]
          └── filters
               └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
                    ├── variable: k [type=int]
@@ -344,13 +462,29 @@ EliminateProject
   -      ├── columns: k:1(int!null) c:2(bool)
   -      ├── fd: ()-->(1)
   -      ├── scan comp
-  -      │    └── columns: k:1(int) c:2(bool)
+  -      │    ├── columns: k:1(int) c:2(bool)
+  -      │    └── computed column expressions
+  -      │         └── c:2(bool)
+  -      │              └── in [type=bool]
+  -      │                   ├── variable: k [type=int]
+  -      │                   └── tuple [type=tuple{int, int, int}]
+  -      │                        ├── const: 1 [type=int]
+  -      │                        ├── const: 2 [type=int]
+  -      │                        └── const: 3 [type=int]
   -      └── filters
   -           └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
   -                ├── variable: k [type=int]
   -                └── const: 1 [type=int]
   + ├── scan comp
-  + │    └── columns: k:1(int) c:2(bool)
+  + │    ├── columns: k:1(int) c:2(bool)
+  + │    └── computed column expressions
+  + │         └── c:2(bool)
+  + │              └── in [type=bool]
+  + │                   ├── variable: k [type=int]
+  + │                   └── tuple [type=tuple{int, int, int}]
+  + │                        ├── const: 1 [type=int]
+  + │                        ├── const: 2 [type=int]
+  + │                        └── const: 3 [type=int]
   + └── filters
   +      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
   +           ├── variable: k [type=int]
@@ -362,8 +496,17 @@ GenerateIndexScans (higher cost)
     ├── columns: k:1(int!null) c:2(bool)
     ├── fd: ()-->(1)
   - ├── scan comp
+  - │    ├── columns: k:1(int) c:2(bool)
+  - │    └── computed column expressions
+  - │         └── c:2(bool)
+  - │              └── in [type=bool]
+  - │                   ├── variable: k [type=int]
+  - │                   └── tuple [type=tuple{int, int, int}]
+  - │                        ├── const: 1 [type=int]
+  - │                        ├── const: 2 [type=int]
+  - │                        └── const: 3 [type=int]
   + ├── scan comp@secondary
-    │    └── columns: k:1(int) c:2(bool)
+  + │    └── columns: k:1(int) c:2(bool)
     └── filters
          └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
               ├── variable: k [type=int]
@@ -383,7 +526,15 @@ FoldComparison
     ├── columns: k:1(int!null) c:2(bool)
   - ├── fd: ()-->(1)
   - ├── scan comp
-  - │    └── columns: k:1(int) c:2(bool)
+  - │    ├── columns: k:1(int) c:2(bool)
+  - │    └── computed column expressions
+  - │         └── c:2(bool)
+  - │              └── in [type=bool]
+  - │                   ├── variable: k [type=int]
+  - │                   └── tuple [type=tuple{int, int, int}]
+  - │                        ├── const: 1 [type=int]
+  - │                        ├── const: 2 [type=int]
+  - │                        └── const: 3 [type=int]
   - └── filters
   -      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
   -           ├── variable: k [type=int]

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -55,9 +55,7 @@ func (c *CustomFuncs) Init(e *explorer) {
 // IsCanonicalScan returns true if the given ScanPrivate is an original
 // unaltered primary index Scan operator (i.e. unconstrained and not limited).
 func (c *CustomFuncs) IsCanonicalScan(scan *memo.ScanPrivate) bool {
-	return scan.Index == cat.PrimaryIndex &&
-		scan.Constraint == nil &&
-		scan.HardLimit == 0
+	return scan.IsCanonical()
 }
 
 // GenerateIndexScans enumerates all secondary indexes on the given Scan

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -978,3 +978,8 @@ func (o *Optimizer) recomputeCostImpl(
 
 	return cost
 }
+
+// FormatExpr is a convenience wrapper for memo.FormatExpr.
+func (o *Optimizer) FormatExpr(e opt.Expr, flags memo.ExprFmtFlags) string {
+	return memo.FormatExpr(e, flags, o.mem, o.catalog)
+}

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -84,7 +84,14 @@ project
  └── select
       ├── columns: k_int:1(int!null) k_int_2:2(int)
       ├── scan t_mult
-      │    └── columns: k_int:1(int) k_int_2:2(int)
+      │    ├── columns: k_int:1(int) k_int_2:2(int)
+      │    └── computed column expressions
+      │         ├── c_int:3(int)
+      │         │    └── k_int % 4 [type=int]
+      │         ├── c_mult:4(int)
+      │         │    └── k_int_2 * (k_int * (c_mult_2 * c_int)) [type=int]
+      │         └── c_mult_2:5(int)
+      │              └── k_int + 1 [type=int]
       └── filters
            └── (k_int, k_int_2) > (1, 2) [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
 
@@ -95,7 +102,14 @@ SELECT k_int FROM t_mult WHERE k_int = 2 OR k_int = 3
 select
  ├── columns: k_int:1(int!null)
  ├── scan t_mult
- │    └── columns: k_int:1(int)
+ │    ├── columns: k_int:1(int)
+ │    └── computed column expressions
+ │         ├── c_int:3(int)
+ │         │    └── k_int % 4 [type=int]
+ │         ├── c_mult:4(int)
+ │         │    └── k_int_2 * (k_int * (c_mult_2 * c_int)) [type=int]
+ │         └── c_mult_2:5(int)
+ │              └── k_int + 1 [type=int]
  └── filters
       └── (k_int = 2) OR (k_int = 3) [type=bool, outer=(1), constraints=(/1: [/2 - /2] [/3 - /3])]
 
@@ -120,7 +134,10 @@ select
  ├── columns: k_float:1(float!null)
  ├── fd: ()-->(1)
  ├── scan t_float
- │    └── columns: k_float:1(float)
+ │    ├── columns: k_float:1(float)
+ │    └── computed column expressions
+ │         └── c_float:2(float)
+ │              └── k_float + 1.0 [type=float]
  └── filters
       └── k_float = 5.0 [type=bool, outer=(1), constraints=(/1: [/5.0 - /5.0]; tight), fd=()-->(1)]
 
@@ -132,6 +149,9 @@ select
  ├── columns: k_interval:1(interval!null)
  ├── fd: ()-->(1)
  ├── scan t_now
- │    └── columns: k_interval:1(interval)
+ │    ├── columns: k_interval:1(interval)
+ │    └── computed column expressions
+ │         └── c_ts:2(timestamp)
+ │              └── k_interval + now() [type=timestamptz]
  └── filters
       └── k_interval = '03:00:00' [type=bool, outer=(1), constraints=(/1: [/'03:00:00' - /'03:00:00']; tight), fd=()-->(1)]


### PR DESCRIPTION
#### opt: make FormatExpr easier to use

During debugging, it's sometimes useful to add a statement to print an
expression. This is fairly hard and can crash easily because the memo
or the catalog isn't set in the formatting context. In particular, it
is impossible to print a scalar expression that contains a relational
expression because `FormatExpr` only sets the memo when we print
relational expressions.

This change improves the situation by allowing the caller of
`FormatExpr` to pass the `*Memo` and by adding a convenience wrapper
method on the `Optimizer`. We also automatically unset the "fully
qualify" flag if there is no catalog (which would otherwise crash).

Release note: None

#### opt: fix optsteps crash caused by TableMeta expressions

The optbuilder creates scalar constraint and computed column
expressions and hangs them off the `TableMeta`. If a normalization
rule fires for one of these expressions, `optsteps` panics because it
can't find a path to the expression in the memo.

This change fixes the problem by adding special code in opt_steps
which effectively treats these expressions as children of Scan
expressions.

Release note: None

#### opt: show TableMeta expressions when formatting expressions

We build check constraint and computed column expressions and attach
them to `TableMeta`, to be used later by exploration rules. These are
currently invisible. This change adds them under "canonical" scans
(the normalized scan expression before any exploration rules).

Release note: None
