### PR TITLE
importccl: limit concurrent IMPORT workers

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -28,11 +28,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
+
+var concurrentImportLimiter = limit.MakeConcurrentRequestLimiter("import-worker", envutil.EnvOrDefaultInt("COCKROACH_IMPORT_WORKER_CONCURRENCY", 10))
 
 var csvOutputTypes = []types.T{
 	*types.Bytes,
@@ -70,6 +74,12 @@ func (cp *readImportDataProcessor) Run(ctx context.Context) {
 	defer tracing.FinishSpan(span)
 
 	defer cp.output.ProducerDone()
+
+	if err := concurrentImportLimiter.Begin(ctx); err != nil {
+		cp.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+		return
+	}
+	defer concurrentImportLimiter.Finish()
 
 	group := ctxgroup.WithContext(ctx)
 	kvCh := make(chan row.KVBatch, 10)


### PR DESCRIPTION
This change limits the number of IMPORT worker processors that can execute concurrently.
This is motivated by observations of a customer cluster that is being sent hundreds of
IMPORT jobs and attempting to execute all of them simultainiously and then seeing flakes
from the network connections and transports, potentially because the extreme concurrency
means individual workers are left blocked or unscheduled and fail to read from their
connection for long periods of time, or more generally that the over-taxed node fails to
maintain connections for other reasons.

While some concurency likely does improve utilization, excessive concurrency is likely
harmful beyond the above discussed network flakes -- due to cache evictions thoughout
the pipeline, context switches, etc so a reasonable limit here is unlikely to make
concurrent IMPORTs slower and may in fact make them faster.

The ideal value for this setting is almost certainly different for different clusters
and differnt hardware or deployments, so ideally this would at least be an easy to
tune cluster setting, however the plumbing involved for that is significant for a
change in a patch release. Thus a env var is used here (for 19.2).

Release note (performance improvement): add a limit on the number of concurrent IMPORT workers per node.