### PR TITLE
timeutil: unify parsing of AT TIME ZONE and SET TIME ZONE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -243,3 +243,30 @@ set time zone 0
 query TT
 select * from current_timestamp_test WHERE a - interval '3h' <> b
 ----
+
+subtest regression_cockroachdb-django_97
+
+query T
+SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE '+3'
+----
+2001-01-01 04:00:00 +0000 +0000
+
+query T
+SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE '-3:00'
+----
+2000-12-31 22:00:00 +0000 +0000
+
+query T
+SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'GMT+3'
+----
+2001-01-01 04:00:00 +0000 +0000
+
+query T
+SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'UTC-3:00'
+----
+2000-12-31 22:00:00 +0000 +0000
+
+query T
+SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'Pacific/Honolulu'
+----
+2000-12-31 15:00:00 +0000 +0000

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"time"
 
@@ -215,21 +214,10 @@ func timeZoneVarGetStringVal(
 	switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
 	case *tree.DString:
 		location := string(*v)
-		loc, err = timeutil.LoadLocation(location)
+		loc, err = timeutil.TimeZoneStringToLocation(location)
 		if err != nil {
-			var err1 error
-			loc, err1 = timeutil.LoadLocation(strings.ToUpper(location))
-			if err1 != nil {
-				loc, err1 = timeutil.LoadLocation(strings.ToTitle(location))
-				if err1 != nil {
-					var ok bool
-					offset, ok = timeutil.TimeZoneOffsetStringConversion(location)
-					if !ok {
-						return "", wrapSetVarError("timezone", values[0].String(),
-							"cannot find time zone %q: %v", location, err)
-					}
-				}
-			}
+			return "", wrapSetVarError("timezone", values[0].String(),
+				"cannot find time zone %q: %v", location, err)
 		}
 
 	case *tree.DInterval:
@@ -269,13 +257,7 @@ func timeZoneVarGetStringVal(
 func timeZoneVarSet(_ context.Context, m *sessionDataMutator, s string) error {
 	loc, err := timeutil.TimeZoneStringToLocation(s)
 	if err != nil {
-		// Maybe the string is coming from pgwire as a simple number.
-		intVal, err1 := strconv.ParseInt(s, 10, 64)
-		if err1 != nil {
-			// Ignore the int conversion, the original error is good enough.
-			return wrapSetVarError("TimeZone", s, "%v", err)
-		}
-		loc = timeutil.FixedOffsetTimeZoneToLocation(int(intVal)*60*60, s)
+		return wrapSetVarError("TimeZone", s, "%v", err)
 	}
 
 	m.SetLocation(loc)

--- a/pkg/util/timeutil/time_zone_util.go
+++ b/pkg/util/timeutil/time_zone_util.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -23,7 +25,7 @@ const (
 	offsetBoundSecs   = 167*60*60 + 59*60
 )
 
-var timezoneOffsetRegex = regexp.MustCompile(`(?i)(GMT|UTC)([+-])(\d{1,3}(:[0-5]?\d){0,2})\b$`)
+var timezoneOffsetRegex = regexp.MustCompile(`(?i)^(GMT|UTC)?([+-])?(\d{1,3}(:[0-5]?\d){0,2})$`)
 
 // FixedOffsetTimeZoneToLocation creates a time.Location with a set offset and
 // with a name that can be marshaled by crdb between nodes.
@@ -36,12 +38,33 @@ func FixedOffsetTimeZoneToLocation(offset int, origRepr string) *time.Location {
 // TimeZoneStringToLocation transforms a string into a time.Location. It
 // supports the usual locations and also time zones with fixed offsets created
 // by FixedOffsetTimeZoneToLocation().
-func TimeZoneStringToLocation(location string) (*time.Location, error) {
-	offset, origRepr, parsed := ParseFixedOffsetTimeZone(location)
+func TimeZoneStringToLocation(locStr string) (*time.Location, error) {
+	offset, origRepr, parsed := ParseFixedOffsetTimeZone(locStr)
 	if parsed {
 		return FixedOffsetTimeZoneToLocation(offset, origRepr), nil
 	}
-	return LoadLocation(location)
+
+	// The time may just be a raw int value.
+	intVal, err := strconv.ParseInt(locStr, 10, 64)
+	if err == nil {
+		return FixedOffsetTimeZoneToLocation(int(intVal)*60*60, locStr), nil
+	}
+
+	locTransforms := []func(string) string{
+		func(s string) string { return s },
+		strings.ToUpper,
+		strings.ToTitle,
+	}
+	for _, transform := range locTransforms {
+		if loc, err := LoadLocation(transform(locStr)); err == nil {
+			return loc, nil
+		}
+	}
+	tzOffset, ok := timeZoneOffsetStringConversion(locStr)
+	if ok {
+		return FixedOffsetTimeZoneToLocation(int(tzOffset), locStr), nil
+	}
+	return nil, errors.Newf("could not parse %q as time zone", locStr)
 }
 
 // ParseFixedOffsetTimeZone takes the string representation of a time.Location
@@ -75,15 +98,15 @@ func ParseFixedOffsetTimeZone(location string) (offset int, origRepr string, suc
 	return offset, strings.TrimSuffix(strings.TrimPrefix(origRepr, "("), ")"), true
 }
 
-// TimeZoneOffsetStringConversion converts a time string to offset seconds.
+// timeZoneOffsetStringConversion converts a time string to offset seconds.
 // Supported time zone strings: GMT/UTC±[00:00:00 - 169:59:00].
 // Seconds/minutes omittable and is case insensitive.
-func TimeZoneOffsetStringConversion(s string) (offset int64, ok bool) {
+func timeZoneOffsetStringConversion(s string) (offset int64, ok bool) {
 	submatch := timezoneOffsetRegex.FindStringSubmatch(strings.ReplaceAll(s, " ", ""))
 	if len(submatch) == 0 {
 		return 0, false
 	}
-	prefix := string(submatch[0][3])
+	prefix := submatch[2]
 	timeString := submatch[3]
 
 	var (

--- a/pkg/util/timeutil/time_zone_util_test.go
+++ b/pkg/util/timeutil/time_zone_util_test.go
@@ -10,7 +10,44 @@
 
 package timeutil
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeZoneStringToLocation(t *testing.T) {
+	aus, err := time.LoadLocation("Australia/Sydney")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		tz             string
+		loc            *time.Location
+		expectedResult bool
+	}{
+		{"UTC", time.UTC, true},
+		{"Australia/Sydney", aus, true},
+		{"fixed offset:3600 (3600)", FixedOffsetTimeZoneToLocation(3600, "3600"), true},
+		{`GMT-3:00`, FixedOffsetTimeZoneToLocation(-3*60*60, "GMT-3:00"), true},
+		{"+10", FixedOffsetTimeZoneToLocation(10*60*60, "+10"), true},
+		{"-10:30", FixedOffsetTimeZoneToLocation(-(10*60*60 + 30*60), "-10:30"), true},
+		{"asdf", nil, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.tz, func(t *testing.T) {
+			loc, err := TimeZoneStringToLocation(tc.tz)
+			if tc.expectedResult {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.loc, loc)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
 
 func TestTimeZoneOffsetStringConversion(t *testing.T) {
 	testCases := []struct {
@@ -18,6 +55,9 @@ func TestTimeZoneOffsetStringConversion(t *testing.T) {
 		offsetSecs int64
 		ok         bool
 	}{
+		{`10`, 10 * 60 * 60, true},
+		{`10:15`, 10*60*60 + 15*60, true},
+		{`-10:15`, -(10*60*60 + 15*60), true},
 		{`GMT+00:00`, 0, true},
 		{`UTC-1:00:00`, -3600, true},
 		{`UTC-1:0:00`, -3600, true},
@@ -39,7 +79,7 @@ func TestTimeZoneOffsetStringConversion(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		offset, ok := TimeZoneOffsetStringConversion(testCase.timezone)
+		offset, ok := timeZoneOffsetStringConversion(testCase.timezone)
 		if offset != testCase.offsetSecs || ok != testCase.ok {
 			t.Errorf("%d: Expected offset: %d, success: %v for time %s, but got offset: %d, success: %v",
 				i, testCase.offsetSecs, testCase.ok, testCase.timezone, offset, ok)


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/django-cockroachdb/issues/97.

We previously had multiple permutations of parsing TIME ZONE params
using the two different syntaxes of `AT TIME ZONE` and `SET TIME ZONE`.
This aims to bring them all under one roof.

Furthermore, we upgrade SET TIME ZONE functionality to respect colons
in time names without the GMT/UTC prefix, e.g. '3:00'.

Release note (sql change, bug fix):
* We previously did not support `AT TIME ZONE` parsing for anything
other than precise location strings, e.g. only `AT TIME ZONE
'Australia/Sydney'` works. This PR adds support for parsing `AT TIME
ZONE` with various other offset behaviour that is supported by,
SET TIME ZONE e.g. `AT TIME ZONE '+3'`, `AT TIME ZONE 'GMT+4'`
* We previously did not support SET TIME ZONE with colons, e.g.
`+4:00`. This PR adds that support in.