### PR TITLE
opt: factor limit hints into scan and lookup join costs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -751,16 +751,19 @@ group      ·            ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
-·               distributed  false             ·               ·
-·               vectorized   true              ·               ·
-group           ·            ·                 (min int)       ·
- │              aggregate 0  min(v)            ·               ·
- │              scalar       ·                 ·               ·
- └── render     ·            ·                 (v int)         ·
-      │         render 0     (v)[int]          ·               ·
-      └── scan  ·            ·                 (k int, v int)  ·
-·               table        opt_test@primary  ·               ·
-·               spans        -/3/# /5-         ·               ·
+·                    distributed  false                         ·               ·
+·                    vectorized   true                          ·               ·
+group                ·            ·                             (min int)       ·
+ │                   aggregate 0  any_not_null(v)               ·               ·
+ │                   scalar       ·                             ·               ·
+ └── render          ·            ·                             (v int)         ·
+      │              render 0     (v)[int]                      ·               ·
+      └── limit      ·            ·                             (k int, v int)  +v
+           │         count        (1)[int]                      ·               ·
+           └── scan  ·            ·                             (k int, v int)  +v
+·                    table        opt_test@v                    ·               ·
+·                    spans        /!NULL-                       ·               ·
+·                    filter       ((k)[int] != (4)[int])[bool]  ·               ·
 
 # Check that the optimization doesn't work when the argument is non-trivial (we
 # can't in general guarantee an ordering on a synthesized column).

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -148,18 +148,17 @@ filter     ·            ·          (k)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-·                distributed  false      ·          ·
-·                vectorized   true       ·          ·
-render           ·            ·          (k, w)     ·
- │               render 0     k          ·          ·
- │               render 1     w          ·          ·
- └── index-join  ·            ·          (k, v, w)  ·
-      │          table        t@primary  ·          ·
-      │          key columns  k          ·          ·
-      └── scan   ·            ·          (k, v)     ·
-·                table        t@t_v_idx  ·          ·
-·                spans        /1-/101    ·          ·
-·                limit        10         ·          ·
+·               distributed  false                    ·          ·
+·               vectorized   true                     ·          ·
+render          ·            ·                        (k, w)     ·
+ │              render 0     k                        ·          ·
+ │              render 1     w                        ·          ·
+ └── limit      ·            ·                        (k, v, w)  ·
+      │         count        10                       ·          ·
+      └── scan  ·            ·                        (k, v, w)  ·
+·               table        t@primary                ·          ·
+·               spans        ALL                      ·          ·
+·               filter       (v >= 1) AND (v <= 100)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -45,34 +45,36 @@ root            ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-·                    distributed   false                                                                        ·          ·
-·                    vectorized    false                                                                        ·          ·
-root                 ·             ·                                                                            (a, b, c)  ·
- ├── scan            ·             ·                                                                            (a, b, c)  ·
- │                   table         abc@primary                                                                  ·          ·
- │                   spans         ALL                                                                          ·          ·
- │                   filter        a = @S2                                                                      ·          ·
- ├── subquery        ·             ·                                                                            (a, b, c)  ·
- │    │              id            @S1                                                                          ·          ·
- │    │              original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·          ·
- │    │              exec mode     exists                                                                       ·          ·
- │    └── limit      ·             ·                                                                            (a, b, c)  ·
- │         │         count         1                                                                            ·          ·
- │         └── scan  ·             ·                                                                            (a, b, c)  ·
- │                   table         abc@primary                                                                  ·          ·
- │                   spans         ALL                                                                          ·          ·
- │                   filter        c = (a + 3)                                                                  ·          ·
- └── subquery        ·             ·                                                                            (a, b, c)  ·
-      │              id            @S2                                                                          ·          ·
-      │              original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·          ·
-      │              exec mode     one row                                                                      ·          ·
-      └── group      ·             ·                                                                            (max)      ·
-           │         aggregate 0   max(a)                                                                       ·          ·
-           │         scalar        ·                                                                            ·          ·
-           └── scan  ·             ·                                                                            (a)        ·
-·                    table         abc@primary                                                                  ·          ·
-·                    spans         ALL                                                                          ·          ·
-·                    filter        @S1                                                                          ·          ·
+·                            distributed   false                                                                        ·               ·
+·                            vectorized    false                                                                        ·               ·
+root                         ·             ·                                                                            (a, b, c)       ·
+ ├── scan                    ·             ·                                                                            (a, b, c)       ·
+ │                           table         abc@primary                                                                  ·               ·
+ │                           spans         ALL                                                                          ·               ·
+ │                           filter        a = @S2                                                                      ·               ·
+ ├── subquery                ·             ·                                                                            (a, b, c)       ·
+ │    │                      id            @S1                                                                          ·               ·
+ │    │                      original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
+ │    │                      exec mode     exists                                                                       ·               ·
+ │    └── limit              ·             ·                                                                            (a, b, c)       ·
+ │         │                 count         1                                                                            ·               ·
+ │         └── scan          ·             ·                                                                            (a, b, c)       ·
+ │                           table         abc@primary                                                                  ·               ·
+ │                           spans         ALL                                                                          ·               ·
+ │                           filter        c = (a + 3)                                                                  ·               ·
+ └── subquery                ·             ·                                                                            (a, b, c)       ·
+      │                      id            @S2                                                                          ·               ·
+      │                      original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
+      │                      exec mode     one row                                                                      ·               ·
+      └── group              ·             ·                                                                            (any_not_null)  ·
+           │                 aggregate 0   any_not_null(a)                                                              ·               ·
+           │                 scalar        ·                                                                            ·               ·
+           └── limit         ·             ·                                                                            (a)             -a
+                │            count         1                                                                            ·               ·
+                └── revscan  ·             ·                                                                            (a)             -a
+·                            table         abc@primary                                                                  ·               ·
+·                            spans         ALL                                                                          ·               ·
+·                            filter        @S1                                                                          ·               ·
 
 # IN expression transformed into semi-join.
 query TTTTT

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -148,7 +148,7 @@ memo (optimized, ~17KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G5: (const 10)
  ├── G6: (plus G11 G12)
  ├── G7: (project G13 G14 y)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 10.00]
  │    │    ├── best: (sort G7)
  │    │    └── cost: 1119.26
  │    ├── [ordering: +5]
@@ -169,7 +169,7 @@ memo (optimized, ~17KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G11: (variable y)
  ├── G12: (const 1)
  ├── G13: (select G16 G17)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 10.00]
  │    │    ├── best: (sort G13)
  │    │    └── cost: 1112.58
  │    └── []
@@ -178,7 +178,7 @@ memo (optimized, ~17KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G14: (projections G18)
  ├── G15: (eq G19 G20)
  ├── G16: (scan a)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 30.00]
  │    │    ├── best: (sort G16)
  │    │    └── cost: 1259.35
  │    └── []

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -105,8 +105,7 @@ limit
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
- │    ├── fd: ()-->(1-5)
- │    └── limit hint: -1.00
+ │    └── fd: ()-->(1-5)
  └── const: -1 [type=int]
 
 # --------------------------------------------------
@@ -281,8 +280,7 @@ limit
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── limit hint: -1.00
+ │    └── fd: (1)-->(2-5)
  └── const: -1 [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -395,8 +395,7 @@ SELECT * FROM xyzw LIMIT -100
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  ├── scan xyzw
- │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
- │    └── limit hint: -100.00
+ │    └── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  └── const: -100 [type=int]
 
 # At execution time, this will cause the error: negative value for OFFSET

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -14,13 +14,13 @@ limit
  ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
- ├── cost: 1050.13
+ ├── cost: 21.13
  ├── prune: (2)
  ├── interesting orderings: (+1,+2)
  ├── scan t.public.abc@ab
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
  │    ├── stats: [rows=1000]
- │    ├── cost: 1050.02
+ │    ├── cost: 21.02
  │    ├── ordering: +1
  │    ├── limit hint: 10.00
  │    ├── prune: (1,2)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -107,6 +107,14 @@ const (
 	// justification for this constant.
 	lookupJoinRetrieveRowCost = 2 * seqIOCostFactor
 
+	// Input rows to a join are processed in batches of this size.
+	// See joinreader.go.
+	joinReaderBatchSize = 100.0
+
+	// In the case of a limit hint, a scan will read this multiple of the expected
+	// number of rows. See scanNode.limitHint.
+	scanSoftLimitMultiplier = 2.0
+
 	// latencyCostFactor represents the throughput impact of doing scans on an
 	// index that may be remotely located in a different locality. If latencies
 	// are higher, then overall cluster throughput will suffer somewhat, as there
@@ -174,7 +182,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		cost = c.computeIndexJoinCost(candidate.(*memo.IndexJoinExpr))
 
 	case opt.LookupJoinOp:
-		cost = c.computeLookupJoinCost(candidate.(*memo.LookupJoinExpr))
+		cost = c.computeLookupJoinCost(candidate.(*memo.LookupJoinExpr), required)
 
 	case opt.ZigzagJoinOp:
 		cost = c.computeZigzagJoinCost(candidate.(*memo.ZigzagJoinExpr))
@@ -280,6 +288,10 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 	rowCount := scan.Relational().Stats.RowCount
 	perRowCost := c.rowScanCost(scan.Table, scan.Index, scan.Cols.Len())
+
+	if required.LimitHint != 0 {
+		rowCount = math.Min(rowCount, required.LimitHint*scanSoftLimitMultiplier)
+	}
 
 	if ordering.ScanIsReverse(scan, &required.Ordering) {
 		if rowCount > 1 {
@@ -394,8 +406,22 @@ func (c *coster) computeIndexJoinCost(join *memo.IndexJoinExpr) memo.Cost {
 	return memo.Cost(leftRowCount) * perRowCost
 }
 
-func (c *coster) computeLookupJoinCost(join *memo.LookupJoinExpr) memo.Cost {
-	leftRowCount := join.Input.Relational().Stats.RowCount
+func (c *coster) computeLookupJoinCost(
+	join *memo.LookupJoinExpr, required *physical.Required,
+) memo.Cost {
+	lookupCount := join.Input.Relational().Stats.RowCount
+
+	// Lookup joins can return early if enough rows have been found. An otherwise
+	// expensive lookup join might have a lower cost if its limit hint estimates
+	// that most rows will not be needed.
+	if required.LimitHint != 0 {
+		// Estimate the number of lookups needed to output LimitHint rows.
+		expectedLookupCount := required.LimitHint * lookupCount / join.Relational().Stats.RowCount
+
+		// Round up to the nearest multiple of a batch.
+		expectedLookupCount = math.Ceil(expectedLookupCount/joinReaderBatchSize) * joinReaderBatchSize
+		lookupCount = math.Min(lookupCount, expectedLookupCount)
+	}
 
 	// The rows in the (left) input are used to probe into the (right) table.
 	// Since the matching rows in the table may not all be in the same range, this
@@ -409,7 +435,7 @@ func (c *coster) computeLookupJoinCost(join *memo.LookupJoinExpr) memo.Cost {
 		// slower.
 		perLookupCost *= 5
 	}
-	cost := memo.Cost(leftRowCount) * perLookupCost
+	cost := memo.Cost(lookupCount) * perLookupCost
 
 	// Each lookup might retrieve many rows; add the IO cost of retrieving the
 	// rows (relevant when we expect many resulting rows per lookup) and the CPU

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -127,7 +127,7 @@ scalar-group-by
 # This is because we know nothing about the ordering of y
 # on the index xy after a scan on xy with x>7.
 opt
-SELECT min(y) FROM xyz WHERE x>7
+SELECT min(y) FROM xyz@xy WHERE x>7
 ----
 scalar-group-by
  ├── columns: min:4(int)
@@ -137,6 +137,7 @@ scalar-group-by
  ├── scan xyz@xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1/2: [/8 - ]
+ │    ├── flags: force-index=xy
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations
@@ -147,7 +148,7 @@ scalar-group-by
 # This is because we know nothing about the ordering of y
 # on the index xy after a scan on xy with x>7
 opt
-SELECT max(y) FROM xyz WHERE x>7
+SELECT max(y) FROM xyz@xy WHERE x>7
 ----
 scalar-group-by
  ├── columns: max:4(int)
@@ -157,6 +158,7 @@ scalar-group-by
  ├── scan xyz@xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1/2: [/8 - ]
+ │    ├── flags: force-index=xy
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations
@@ -471,7 +473,7 @@ memo (optimized, ~5KB, required=[presentation: min:5])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: +1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,cols=(1))
- │    │    └── cost: 1050.02
+ │    │    └── cost: 2.12
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1050.02
@@ -533,7 +535,7 @@ memo (optimized, ~5KB, required=[presentation: max:5])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: -1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,rev,cols=(1))
- │    │    └── cost: 1149.68
+ │    │    └── cost: 2.14
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1050.02

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -111,12 +111,12 @@ memo (optimized, ~6KB, required=[presentation: s:4])
  ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── [limit hint: 1.00]
  │         ├── best: (scan a@s_idx,cols=(4),constrained)
- │         └── cost: 10.51
+ │         └── cost: 2.11
  ├── G3: (const 1)
  ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
  │    └── [limit hint: 100.00]
  │         ├── best: (scan a@s_idx,cols=(4))
- │         └── cost: 1050.02
+ │         └── cost: 210.02
  ├── G5: (filters G6)
  ├── G6: (eq G7 G8)
  ├── G7: (variable s)
@@ -201,29 +201,28 @@ explain
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2-4)~~>(1)
       ├── ordering: -2
-      ├── sort
+      ├── select
       │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
       │    ├── cardinality: [0 - 11]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
       │    ├── ordering: -2
       │    ├── limit hint: 5.00
-      │    └── select
-      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-      │         ├── cardinality: [0 - 11]
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-      │         ├── index-join abcd
-      │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-      │         │    └── scan abcd@b
-      │         │         ├── columns: a:1(int!null) b:2(int)
-      │         │         ├── flags: force-index=b
-      │         │         ├── key: (1)
-      │         │         └── fd: (1)-->(2)
-      │         └── filters
-      │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+      │    ├── index-join abcd
+      │    │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      │    │    ├── ordering: -2
+      │    │    ├── limit hint: 454.55
+      │    │    └── scan abcd@b,rev
+      │    │         ├── columns: a:1(int!null) b:2(int)
+      │    │         ├── flags: force-index=b
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2)
+      │    │         ├── ordering: -2
+      │    │         └── limit hint: 454.55
+      │    └── filters
+      │         └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
       └── const: 5 [type=int]
 
 optsteps
@@ -349,7 +348,7 @@ ConsolidateSelectFilters
               └── const: 5 [type=int]
 ================================================================================
 GenerateIndexScans
-  Cost: 5141.10
+  Cost: 5134.91
 ================================================================================
    explain
     ├── columns: tree:5(string) field:6(string) description:7(string)
@@ -387,29 +386,28 @@ GenerateIndexScans
   -           │         └── filters
   -           │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
   -           └── const: 5 [type=int]
-  +      ├── sort
+  +      ├── select
   +      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
   +      │    ├── cardinality: [0 - 11]
   +      │    ├── key: (1)
   +      │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
   +      │    ├── ordering: -2
   +      │    ├── limit hint: 5.00
-  +      │    └── select
-  +      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-  +      │         ├── cardinality: [0 - 11]
-  +      │         ├── key: (1)
-  +      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-  +      │         ├── index-join abcd
-  +      │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-  +      │         │    ├── key: (1)
-  +      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-  +      │         │    └── scan abcd@b
-  +      │         │         ├── columns: a:1(int!null) b:2(int)
-  +      │         │         ├── flags: force-index=b
-  +      │         │         ├── key: (1)
-  +      │         │         └── fd: (1)-->(2)
-  +      │         └── filters
-  +      │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  +      │    ├── index-join abcd
+  +      │    │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │    │    ├── key: (1)
+  +      │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  +      │    │    ├── ordering: -2
+  +      │    │    ├── limit hint: 454.55
+  +      │    │    └── scan abcd@b,rev
+  +      │    │         ├── columns: a:1(int!null) b:2(int)
+  +      │    │         ├── flags: force-index=b
+  +      │    │         ├── key: (1)
+  +      │    │         ├── fd: (1)-->(2)
+  +      │    │         ├── ordering: -2
+  +      │    │         └── limit hint: 454.55
+  +      │    └── filters
+  +      │         └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
   +      └── const: 5 [type=int]
 --------------------------------------------------------------------------------
 GenerateZigzagJoins (no changes)
@@ -419,7 +417,7 @@ GenerateConstrainedScans (no changes)
 --------------------------------------------------------------------------------
 ================================================================================
 Final best expression
-  Cost: 5141.10
+  Cost: 5134.91
 ================================================================================
   explain
    ├── columns: tree:5(string) field:6(string) description:7(string)
@@ -430,29 +428,28 @@ Final best expression
         ├── key: (1)
         ├── fd: (1)-->(2-4), (2-4)~~>(1)
         ├── ordering: -2
-        ├── sort
+        ├── select
         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
         │    ├── cardinality: [0 - 11]
         │    ├── key: (1)
         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
         │    ├── ordering: -2
         │    ├── limit hint: 5.00
-        │    └── select
-        │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-        │         ├── cardinality: [0 - 11]
-        │         ├── key: (1)
-        │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-        │         ├── index-join abcd
-        │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
-        │         │    ├── key: (1)
-        │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-        │         │    └── scan abcd@b
-        │         │         ├── columns: a:1(int!null) b:2(int)
-        │         │         ├── flags: force-index=b
-        │         │         ├── key: (1)
-        │         │         └── fd: (1)-->(2)
-        │         └── filters
-        │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+        │    ├── index-join abcd
+        │    │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │    │    ├── key: (1)
+        │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        │    │    ├── ordering: -2
+        │    │    ├── limit hint: 454.55
+        │    │    └── scan abcd@b,rev
+        │    │         ├── columns: a:1(int!null) b:2(int)
+        │    │         ├── flags: force-index=b
+        │    │         ├── key: (1)
+        │    │         ├── fd: (1)-->(2)
+        │    │         ├── ordering: -2
+        │    │         └── limit hint: 454.55
+        │    └── filters
+        │         └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
         └── const: 5 [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -64,7 +64,7 @@ memo (optimized, ~3KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3))
  │    ├── [ordering: -1] [limit hint: 10.00]
  │    │    ├── best: (scan a,rev,cols=(1,3))
- │    │    └── cost: 1169.68
+ │    │    └── cost: 22.28
  │    └── []
  │         ├── best: (scan a@s_idx,cols=(1,3))
  │         └── cost: 1060.02


### PR DESCRIPTION
(This should have some more tests of the coster and limit hint propagation
before being merged.)

---

Fixes #34811; the example query in this issue now chooses a lookup join
as desired. The coster now takes limit hints into account when costing
scans and lookup joins, and propagates limit hints through lookup joins.

Release note (sql change): The optimizer now considers the likely number
of rows an operator will need to provide, and might choose query plans
based on this. In particular, the optimizer might prefer lookup joins
over alternatives in some situations where all rows of the join will
probably not be needed.