### PR TITLE
release-19.1: jobs: pending jobs should be adoptable

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -653,8 +653,8 @@ func (j *Job) updateRow(
 
 func (j *Job) adopt(ctx context.Context, oldLease *jobspb.Lease) error {
 	return j.update(ctx, func(_ *client.Txn, status *Status, payload *jobspb.Payload, progress *jobspb.Progress) (bool, error) {
-		if *status != StatusRunning {
-			return false, errors.Errorf("job %d no longer running", *j.id)
+		if *status != StatusRunning && *status != StatusPending {
+			return false, errors.Errorf("job %d has status %v which is not eligible for adopting", *j.id, *status)
 		}
 		if !payload.Lease.Equal(oldLease) {
 			return false, errors.Errorf("current lease %v did not match expected lease %v",


### PR DESCRIPTION
It's possible that a job is created (so in state pending) but
due to a failure before the job is marked as started it can
be left in pending state. These jobs should be adoptable by
other nodes.

Touches #43375.

Release note (bug fix): this bug may cause jobs to be left indefinitely
in pending state and never run.