### PR TITLE
sql: remove restriction of foreign key on multiple outbound columns

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -346,10 +346,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// Make a new index that is suitable to be a primary index.
-			baseName, name := "new_primary_key", "new_primary_key"
-			for try := 1; nameExists(name); try++ {
-				name = fmt.Sprintf("%s_%d", baseName, try)
-			}
+			name := generateUniqueConstraintName(
+				"new_primary_key",
+				nameExists,
+			)
 			newPrimaryIndexDesc := &sqlbase.IndexDescriptor{
 				Name:              name,
 				Unique:            true,
@@ -398,10 +398,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 			//  automatically created one?
 			if len(n.tableDesc.PrimaryIndex.ColumnNames) == 1 && n.tableDesc.PrimaryIndex.ColumnNames[0] != "rowid" {
 				oldPrimaryIndexCopy := protoutil.Clone(&n.tableDesc.PrimaryIndex).(*sqlbase.IndexDescriptor)
-				baseName, name := "old_primary_key", "old_primary_key"
-				for try := 1; nameExists(name); try++ {
-					name = fmt.Sprintf("%s_%d", baseName, try)
-				}
+				name := generateUniqueConstraintName(
+					"old_primary_key",
+					nameExists,
+				)
 				oldPrimaryIndexCopy.Name = name
 				oldPrimaryIndexCopy.StoreColumnIDs = nil
 				oldPrimaryIndexCopy.StoreColumnNames = nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -554,13 +554,14 @@ func ResolveFK(
 	}
 	constraintName := string(d.Name)
 	if constraintName == "" {
-		constraintName = fmt.Sprintf("fk_%s_ref_%s", string(d.FromCols[0]), target.Name)
+		constraintName = generateUniqueConstraintName(
+			fmt.Sprintf("fk_%s_ref_%s", string(d.FromCols[0]), target.Name),
+			func(p string) bool {
+				_, ok := constraintInfo[p]
+				return ok
+			},
+		)
 	} else {
-		// Only do this check if constraint name is not empty.
-		// Otherwise, the more helpful error message of
-		// "cannot be used by multiple foreign key constraints"
-		// is hidden.
-		// TODO(#38850): revisit this.
 		if _, ok := constraintInfo[constraintName]; ok {
 			return pgerror.Newf(pgcode.DuplicateObject, "duplicate constraint name: %q", constraintName)
 		}
@@ -669,27 +670,19 @@ func ResolveFK(
 		tbl.AddForeignKeyMutation(&ref, sqlbase.DescriptorMutation_ADD)
 	}
 
-	// Multiple FKs from the same column would potentially result in ambiguous or
-	// unexpected behavior with conflicting CASCADE/RESTRICT/etc behaviors.
-	// TODO(jordan,lucy): can we lift this restriction?
-	colsInFKs := make(map[sqlbase.ColumnID]struct{})
-
-	fks := tbl.AllActiveAndInactiveForeignKeys()
-	for _, fk := range fks {
-		for _, id := range fk.OriginColumnIDs {
-			if _, ok := colsInFKs[id]; ok {
-				col, err := tbl.FindColumnByID(id)
-				if err != nil {
-					return errors.AssertionFailedf("trying to add foreign key for column %d that doesn't exist", id)
-				}
-				return pgerror.Newf(pgcode.ForeignKeyViolation,
-					"column %q cannot be used by multiple foreign key constraints", col.Name)
-			}
-			colsInFKs[id] = struct{}{}
-		}
-	}
-
 	return nil
+}
+
+// generateUniqueConstraintName attempts to generate a unique constraint name
+// with the given prefix.
+// It will first try prefix by itself, then it will subsequently try
+// adding numeric digits at the end, starting from 1.
+func generateUniqueConstraintName(prefix string, nameExistsFunc func(name string) bool) string {
+	name := prefix
+	for i := 1; nameExistsFunc(name); i++ {
+		name = fmt.Sprintf("%s_%d", prefix, i)
+	}
+	return name
 }
 
 // Adds an index to a table descriptor (that is in the process of being created)

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -44,16 +44,6 @@ CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
 statement error type of "customer" \(int\) does not match foreign key "customers"."email" \(string\)
 CREATE TABLE mismatch (customer INT REFERENCES customers (email))
 
-statement error column "product" cannot be used by multiple foreign key constraints
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products,
-  customer INT CONSTRAINT valid_customer REFERENCES customers (id),
-  CONSTRAINT fk FOREIGN KEY (product) REFERENCES products,
-  INDEX (product),
-  INDEX (customer)
-)
-
 statement ok
 CREATE TABLE orders (
   id INT,
@@ -71,9 +61,6 @@ ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE NO ACTION
-
-statement error column "product" cannot be used by multiple foreign key constraints
-ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE NO ACTION
 
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
@@ -629,9 +616,9 @@ query T rowsort
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE 'FKScan%'
 ----
+FKScan /Table/84/3/100/"one"{-/#}
 FKScan /Table/85/3/100/"one"{-/#}
-FKScan /Table/86/3/100/"one"{-/#}
-FKScan /Table/87/2/100/"one"{-/PrefixEnd}
+FKScan /Table/86/2/100/"one"{-/PrefixEnd}
 
 # since PKs are handled differently than other indexes, check pk<->pk ref with no other indexes in play.
 statement ok
@@ -716,8 +703,8 @@ query T rowsort
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE 'FKScan%'
 ----
-FKScan /Table/93/1/3{-/#}
-FKScan /Table/94/1/2{-/#}
+FKScan /Table/93/1/2{-/#}
+FKScan /Table/92/1/3{-/#}
 
 statement ok
 CREATE TABLE tx (
@@ -1397,54 +1384,6 @@ statement ok
 DROP TABLE a, no_default_table, no_default_table_on_update, no_default_table_ref2_default_on_delete,
 no_default_table_ref2_default_on_update, no_default_table_ref1_default_on_delete,
 no_default_table_ref1_default_on_update
-
-# Test that no column can have more than 1 FK constraint
-subtest column_uniqueness
-
-statement ok
-CREATE TABLE t (a INT, b INT, c INT, INDEX (a, b), INDEX (b, c))
-
-statement ok
-CREATE TABLE t2 (x INT, y INT, z INT, w INT, UNIQUE INDEX (x, y), UNIQUE INDEX (z, w))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t2 (x, y)
-
-statement error column "b" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (b, c) REFERENCES t2 (z, w)
-
-statement ok
-DROP TABLE t, t2
-
-# Also test the case where one of the FKs is on the primary key
-statement ok
-CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b), INDEX (b, c))
-
-statement ok
-CREATE TABLE t2 (x INT, y INT, z INT, w INT, UNIQUE INDEX (x, y), UNIQUE INDEX (z, w))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t2 (x, y)
-
-statement error column "b" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (b, c) REFERENCES t2 (z, w)
-
-statement ok
-DROP TABLE t, t2
-
-subtest 24664
-
-statement ok
-CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a), UNIQUE INDEX (a, b))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a) REFERENCES t (a)
-
-statement error column "a" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t (a, b)
-
-statement ok
-DROP TABLE t
 
 subtest unvalidated_fk_plan
 
@@ -2757,3 +2696,510 @@ CREATE TABLE source (a INT, INDEX (a));
 
 statement error there is no unique constraint matching given keys for referenced table target
 ALTER TABLE source ADD FOREIGN KEY (a) REFERENCES target (a);
+
+subtest foreign_key_multiple_key_references
+
+# Create a recursive table: messages refs good_users refs users.
+# Sometimes, messages refs users directly.
+
+statement ok
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE good_users (
+  id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  id2 INTEGER UNIQUE
+)
+
+statement ok
+CREATE SEQUENCE message_seq START 1 INCREMENT 1
+
+statement ok
+CREATE TABLE messages (
+  message_id INT PRIMARY KEY DEFAULT nextval('message_seq'),
+  user_id_1 integer REFERENCES good_users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  user_id_2 integer REFERENCES good_users(id) ON DELETE CASCADE ON UPDATE CASCADE, -- this is recursive through good_users
+  text string
+)
+
+# Add the same foreign key twice onto user.
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+
+# Insert some rows
+statement ok
+INSERT INTO users(id) VALUES (1), (2), (3)
+
+statement ok
+INSERT INTO good_users(id, id2) VALUES (1, 10), (2, 20), (3, 30)
+
+statement ok
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (1, 2, 'hi jordan'),
+  (2, 1, 'hi oliver'),
+  (1, 2, 'you are a good user jordan'),
+  (1, 3, 'you are a good user too rohan'),
+  (3, 1, 'lucy is a good user')
+
+query error 999.*good_users
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (999, 1, 'you are a bad user')
+
+# Now try and update the user_id.
+statement ok
+update users set id = id * 10
+
+# See that it propagates.
+query I
+SELECT * FROM users ORDER BY id ASC
+----
+10
+20
+30
+
+query II
+SELECT * FROM good_users ORDER BY id ASC
+----
+10  10
+20  20
+30  30
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+4  10  30  you are a good user too rohan
+5  30  10  lucy is a good user
+
+# Delete from users should work as well
+statement ok
+DELETE FROM users WHERE id = 30
+
+# See that it propagates.
+query I
+SELECT * FROM users ORDER BY id ASC
+----
+10
+20
+
+query II
+SELECT * FROM good_users ORDER BY id ASC
+----
+10  10
+20  20
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+
+# Add a foreign key on id2, which is a different column.
+# This one is restrictive on updates and deletes.
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES good_users(id2)
+
+statement ok
+ALTER TABLE good_users ADD FOREIGN KEY (id2) REFERENCES users(id)
+
+# Updating should no longer work, since we have a restrict.
+statement error value \[2000\] not found in good_users@good_users_id2_key \[id2\]
+UPDATE users SET id = id * 100 WHERE id = 20
+
+# Insert some more stuff -- make sure it still behaves as expected.
+statement ok
+INSERT INTO users VALUES (40)
+
+statement ok
+INSERT INTO good_users VALUES (40, 40)
+
+statement ok
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (10, 40, 'oh hi mark'),
+  (40, 10, 'youre tearing me apart lisa!')
+
+query error 999.*good_users
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (999, 40, 'johnny is my best friend')
+
+# And sanity check everything.
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+7  10  40  oh hi mark
+8  40  10  youre tearing me apart lisa!
+
+# Delete should still be okay since the cascade from id1 should "win".
+statement ok
+DELETE FROM users WHERE id = 20
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+7  10  40  oh hi mark
+8  40  10  youre tearing me apart lisa!
+
+# Drop everything.
+statement ok
+DROP TABLE users CASCADE
+
+statement ok
+DROP TABLE good_users CASCADE
+
+statement ok
+DROP TABLE messages
+
+# Test conflicting foreign keys ON DELETE and ON UPDATE - some known corner cases.
+# SET NULL/SET DEFAULT/CASCADE have priority and are evaluated in order, followed
+# by RESTRICT/NO ACTION.
+
+#
+# ON DELETE
+#
+
+statement ok
+CREATE TABLE t1 (a INT PRIMARY KEY); CREATE TABLE t2 (a INT DEFAULT 1)
+
+# 'ON DELETE NO ACTION', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE NO ACTION', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE RESTRICT', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE RESTRICT', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE CASCADE', followed by 'ON DELETE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE CASCADE', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET DEFAULT', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET DEFAULT', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET NULL', followed by 'ON DELETE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+statement ok
+DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE
+
+#
+# ON UPDATE
+#
+
+statement ok
+CREATE TABLE t1 (a INT PRIMARY KEY); CREATE TABLE t2 (a INT DEFAULT 1)
+
+# 'ON UPDATE NO ACTION', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE NO ACTION', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE RESTRICT', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE RESTRICT', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE CASCADE', followed by 'ON UPDATE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE CASCADE', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET NULL', followed by 'ON UPDATE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+statement ok
+DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -173,16 +173,6 @@ CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
 statement error type of "customer" \(int\) does not match foreign key "customers"."email" \(string\)
 CREATE TABLE mismatch (customer INT REFERENCES customers (email))
 
-statement error column "product" cannot be used by multiple foreign key constraints
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products,
-  customer INT CONSTRAINT valid_customer REFERENCES customers (id),
-  CONSTRAINT fk FOREIGN KEY (product) REFERENCES products,
-  INDEX (product),
-  INDEX (customer)
-)
-
 statement ok
 CREATE TABLE orders (
   id INT,
@@ -199,9 +189,6 @@ ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE NO ACTION
-
-statement error column "product" cannot be used by multiple foreign key constraints
-ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE NO ACTION
 
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
@@ -1490,54 +1477,6 @@ statement ok
 DROP TABLE a, no_default_table, no_default_table_on_update, no_default_table_ref2_default_on_delete,
 no_default_table_ref2_default_on_update, no_default_table_ref1_default_on_delete,
 no_default_table_ref1_default_on_update
-
-# Test that no column can have more than 1 FK constraint
-subtest column_uniqueness
-
-statement ok
-CREATE TABLE t (a INT, b INT, c INT, INDEX (a, b), INDEX (b, c))
-
-statement ok
-CREATE TABLE t2 (x INT, y INT, z INT, w INT, UNIQUE INDEX (x, y), UNIQUE INDEX (z, w))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t2 (x, y)
-
-statement error column "b" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (b, c) REFERENCES t2 (z, w)
-
-statement ok
-DROP TABLE t, t2
-
-# Also test the case where one of the FKs is on the primary key
-statement ok
-CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b), INDEX (b, c))
-
-statement ok
-CREATE TABLE t2 (x INT, y INT, z INT, w INT, UNIQUE INDEX (x, y), UNIQUE INDEX (z, w))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t2 (x, y)
-
-statement error column "b" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (b, c) REFERENCES t2 (z, w)
-
-statement ok
-DROP TABLE t, t2
-
-subtest 24664
-
-statement ok
-CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a), UNIQUE INDEX (a, b))
-
-statement ok
-ALTER TABLE t ADD FOREIGN KEY (a) REFERENCES t (a)
-
-statement error column "a" cannot be used by multiple foreign key constraints
-ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t (a, b)
-
-statement ok
-DROP TABLE t
 
 subtest unvalidated_fk_plan
 
@@ -2935,3 +2874,510 @@ user root
 
 statement ok
 COMMIT
+
+subtest foreign_key_multiple_output_columns
+
+# Create a recursive table: messages refs good_users refs users.
+# Sometimes, messages refs users directly.
+
+statement ok
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE good_users (
+  id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  id2 INTEGER UNIQUE
+)
+
+statement ok
+CREATE SEQUENCE message_seq START 1 INCREMENT 1
+
+statement ok
+CREATE TABLE messages (
+  message_id INT PRIMARY KEY DEFAULT nextval('message_seq'),
+  user_id_1 integer REFERENCES good_users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  user_id_2 integer REFERENCES good_users(id) ON DELETE CASCADE ON UPDATE CASCADE, -- this is recursive through good_users
+  text string
+)
+
+# Add the same foreign key twice onto user.
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+
+# Insert some rows
+statement ok
+INSERT INTO users(id) VALUES (1), (2), (3)
+
+statement ok
+INSERT INTO good_users(id, id2) VALUES (1, 10), (2, 20), (3, 30)
+
+statement ok
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (1, 2, 'hi jordan'),
+  (2, 1, 'hi oliver'),
+  (1, 2, 'you are a good user jordan'),
+  (1, 3, 'you are a good user too rohan'),
+  (3, 1, 'lucy is a good user')
+
+query error 999.*good_users
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (999, 1, 'you are a bad user')
+
+# Now try and update the user_id.
+statement ok
+update users set id = id * 10
+
+# See that it propagates.
+query I
+SELECT * FROM users ORDER BY id ASC
+----
+10
+20
+30
+
+query II
+SELECT * FROM good_users ORDER BY id ASC
+----
+10  10
+20  20
+30  30
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+4  10  30  you are a good user too rohan
+5  30  10  lucy is a good user
+
+# Delete from users should work as well
+statement ok
+DELETE FROM users WHERE id = 30
+
+# See that it propagates.
+query I
+SELECT * FROM users ORDER BY id ASC
+----
+10
+20
+
+query II
+SELECT * FROM good_users ORDER BY id ASC
+----
+10  10
+20  20
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+
+# Add a foreign key on id2, which is a different column.
+# This one is restrictive on updates and deletes.
+statement ok
+ALTER TABLE messages ADD FOREIGN KEY (user_id_1) REFERENCES good_users(id2)
+
+statement ok
+ALTER TABLE good_users ADD FOREIGN KEY (id2) REFERENCES users(id)
+
+# Updating should no longer work, since we have a restrict.
+statement error value \[2000\] not found in good_users@good_users_id2_key \[id2\]
+UPDATE users SET id = id * 100 WHERE id = 20
+
+# Insert some more stuff -- make sure it still behaves as expected.
+statement ok
+INSERT INTO users VALUES (40)
+
+statement ok
+INSERT INTO good_users VALUES (40, 40)
+
+statement ok
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (10, 40, 'oh hi mark'),
+  (40, 10, 'youre tearing me apart lisa!')
+
+query error 999.*good_users
+INSERT INTO messages (user_id_1, user_id_2, text) VALUES
+  (999, 40, 'johnny is my best friend')
+
+# And sanity check everything.
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+1  10  20  hi jordan
+2  20  10  hi oliver
+3  10  20  you are a good user jordan
+7  10  40  oh hi mark
+8  40  10  youre tearing me apart lisa!
+
+# Delete should still be okay since the cascade from id1 should "win".
+statement ok
+DELETE FROM users WHERE id = 20
+
+query IIIT
+SELECT * FROM messages ORDER BY message_id ASC
+----
+7  10  40  oh hi mark
+8  40  10  youre tearing me apart lisa!
+
+# Drop everything.
+statement ok
+DROP TABLE users CASCADE
+
+statement ok
+DROP TABLE good_users CASCADE
+
+statement ok
+DROP TABLE messages
+
+# Test conflicting foreign keys ON DELETE and ON UPDATE - some known corner cases.
+# SET NULL/SET DEFAULT/CASCADE have priority and are evaluated in order, followed
+# by RESTRICT/NO ACTION.
+
+#
+# ON DELETE
+#
+
+statement ok
+CREATE TABLE t1 (a INT PRIMARY KEY); CREATE TABLE t2 (a INT DEFAULT 1)
+
+# 'ON DELETE NO ACTION', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE NO ACTION', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE RESTRICT', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE RESTRICT', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE CASCADE', followed by 'ON DELETE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE CASCADE', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET DEFAULT', followed by 'ON DELETE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET DEFAULT', followed by 'ON DELETE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON DELETE SET NULL', followed by 'ON DELETE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NULL; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+DELETE FROM t1 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+statement ok
+DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE
+
+#
+# ON UPDATE
+#
+
+statement ok
+CREATE TABLE t1 (a INT PRIMARY KEY); CREATE TABLE t2 (a INT DEFAULT 1)
+
+# 'ON UPDATE NO ACTION', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE NO ACTION', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE NO ACTION; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE RESTRICT', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE RESTRICT', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE RESTRICT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE CASCADE', followed by 'ON UPDATE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE CASCADE', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+2
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE CASCADE'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE CASCADE
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE SET NULL'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement error value \[1\] not found in t1@primary \[a\]
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+123
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+# 'ON UPDATE SET NULL', followed by 'ON UPDATE SET DEFAULT'
+statement ok
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET NULL; ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON UPDATE SET DEFAULT
+
+statement ok
+insert into t1 values (123); insert into t2 values (123)
+
+statement ok
+UPDATE t1 SET a = 2 WHERE a = 123
+
+query I
+SELECT * FROM t2
+----
+NULL
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE TABLE t2; TRUNCATE TABLE t1
+
+statement ok
+DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/38850.

Removing the restriction of foreign keys on multiple outbound columns.
There is one minor issue we need to address which is done here -- if the
constraint name already exists, append a number next to it as postgres
does as well. We can make this fancier if we wish later.

This PR comes with a test suite of corner cases that we suspect may be
hinted at being wrong. It uses both legacy and the new optimizer
settings for foreign key checks.

Release note (sql change): We previously had a restriction that foreign
keys can only reference one outbound column at any given point in time,
e.g. in `CREATE TABLE test(a int)`, we cannot have two foreign keys
on column a. This PR removes this restriction.