### PR TITLE
release-19.2: jobs: pending jobs should be adoptable

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -510,8 +510,8 @@ func (j *Job) insert(ctx context.Context, id int64, lease *jobspb.Lease) error {
 
 func (j *Job) adopt(ctx context.Context, oldLease *jobspb.Lease) error {
 	return j.Update(ctx, func(txn *client.Txn, md JobMetadata, ju *JobUpdater) error {
-		if md.Status != StatusRunning {
-			return errors.Errorf("job %d no longer running", *j.id)
+		if md.Status != StatusRunning && md.Status != StatusPending {
+			return errors.Errorf("job %d has status %v which is not elligible for adopting", *j.id, md.Status)
 		}
 		if !md.Payload.Lease.Equal(oldLease) {
 			return errors.Errorf("current lease %v did not match expected lease %v",


### PR DESCRIPTION
Backport 1/1 commits from #42880.

/cc @cockroachdb/release

---

It's possible that a job is created (so in state pending) but
due to a failure before the job is marked as started it can
be left in pending state. These jobs should be adoptable by
other nodes.

Touches #40563, #42427.

Release note (bug fix): this bug may cause jobs to be left indefinitely in pending state and never run.
