### PR TITLE
release-19.2: sql: return duplicate constraint error for duplicate FK names

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -525,9 +525,27 @@ func ResolveFK(
 		}
 	}
 
+	// Verify we are not writing a constraint over the same name.
+	// This check is done in Verify(), but we must do it earlier
+	// or else we can hit other checks that break things with
+	// undesired error codes, e.g. #42858.
+	// It may be removable after #37255 is complete.
+	constraintInfo, err := tbl.GetConstraintInfo(ctx, nil)
+	if err != nil {
+		return err
+	}
 	constraintName := string(d.Name)
 	if constraintName == "" {
 		constraintName = fmt.Sprintf("fk_%s_ref_%s", string(d.FromCols[0]), target.Name)
+	} else {
+		// Only do this check if constraint name is not empty.
+		// Otherwise, the more helpful error message of
+		// "cannot be used by multiple foreign key constraints"
+		// is hidden.
+		// TODO(#38850): revisit this.
+		if _, ok := constraintInfo[constraintName]; ok {
+			return pgerror.Newf(pgcode.DuplicateObject, "duplicate constraint name: %q", constraintName)
+		}
 	}
 
 	targetColIDs := make(sqlbase.ColumnIDs, len(targetCols))

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1010,3 +1010,20 @@ SHOW CONSTRAINTS FROM t
 ----
 t  check_a   CHECK  CHECK  ((a < 100))  true
 t  check_a1  CHECK  CHECK  ((a < 16))   true
+
+subtest regression_42858
+
+statement ok
+CREATE TABLE TEST2 (COL1 SERIAL PRIMARY KEY, COL2 INT8)
+
+statement ok
+CREATE TABLE TEST1 (COL1 SERIAL PRIMARY KEY, COL2 INT8, COL3 INT8)
+
+statement ok
+ALTER TABLE TEST1 ADD CONSTRAINT duplicate_name FOREIGN KEY (COL2) REFERENCES TEST2 (COL1)
+
+statement error pq: duplicate constraint name: "duplicate_name"
+ALTER TABLE TEST1 ADD CONSTRAINT duplicate_name FOREIGN KEY (COL3) REFERENCES TEST2 (COL1)
+
+statement ok
+DROP TABLE test1; DROP TABLE test2

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1,0 +1,10 @@
+subtest regression_42858
+
+statement ok
+CREATE TABLE TEST2 (COL1 SERIAL PRIMARY KEY, COL2 INT8)
+
+statement error pq: duplicate constraint name: "duplicate_name"
+CREATE TABLE TEST1 (COL1 SERIAL PRIMARY KEY, COL2 INT8, COL3 INT8, CONSTRAINT duplicate_name FOREIGN KEY (col2) REFERENCES TEST2(COL1), CONSTRAINT duplicate_name FOREIGN KEY (col3) REFERENCES TEST2(COL1))
+
+statement ok
+DROP TABLE TEST2

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -388,7 +388,8 @@ func (desc *TableDescriptor) collectConstraintInfo(
 
 	for _, c := range desc.AllActiveAndInactiveChecks() {
 		if _, ok := info[c.Name]; ok {
-			return nil, errors.Errorf("duplicate constraint name: %q", c.Name)
+			return nil, pgerror.Newf(pgcode.DuplicateObject,
+				"duplicate constraint name: %q", c.Name)
 		}
 		detail := ConstraintDetail{Kind: ConstraintTypeCheck}
 		// Constraints in the Validating state are considered Unvalidated for this purpose


### PR DESCRIPTION
Backport 1/1 commits from #43210.

/cc @cockroachdb/release

---

Resolves https://github.com/cockroachdb/cockroach/issues/42858.

We previously returned error code 42830 and 23503 for duplicate FK
names, which should instead be 42710 which matches postgres.

This was the case as other checks happened before Validate() is called,
resulting in an error code that doesn't quite match (e.g. index is
invalid or multiple FKs referencing the same column).

This addresses this change by checking in-use names in `ResolveFK`
before any of these other errors can trigger. AFAICT, it is contained to
FK issues only.

Will backport to 19.2.

Release note (sql change): Previously, we error coded duplicate FK
constraint names with 42830 or 23503. In this PR, we instead change this
to be 42710 to be in line with postgres.
