### PR TITLE
roachtest: add a tpcc+alter for sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -225,6 +225,8 @@ func registerSQLSmith(r *testRegistry) {
 		}
 	}
 	setups["seed-vec"] = sqlsmith.Setups["seed-vec"]
+	settings["ddl-nodrop"] = sqlsmith.Settings["ddl-nodrop"]
 	settings["vec"] = sqlsmith.SettingVectorize
 	register("seed-vec", "vec")
+	register("tpcc", "ddl-nodrop")
 }

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -17,20 +17,23 @@ import (
 )
 
 var (
-	alters = []statementWeight{
-		{1, makeRenameTable},
-		{1, makeCreateTable},
+	alters               = append(altersTableExistence, altersExistingTable...)
+	altersTableExistence = []statementWeight{
+		{10, makeCreateTable},
 		{1, makeDropTable},
+	}
+	altersExistingTable = []statementWeight{
+		{5, makeRenameTable},
 
-		{1, makeAddColumn},
-		{1, makeJSONComputedColumn},
+		{10, makeAddColumn},
+		{10, makeJSONComputedColumn},
 		{1, makeDropColumn},
-		{1, makeRenameColumn},
-		{1, makeAlterColumnType},
+		{5, makeRenameColumn},
+		{5, makeAlterColumnType},
 
-		{1, makeCreateIndex},
+		{10, makeCreateIndex},
 		{1, makeDropIndex},
-		{1, makeRenameIndex},
+		{5, makeRenameIndex},
 	}
 )
 

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -159,6 +159,7 @@ var Settings = map[string]SettingFunc{
 	"default+rand":      randSetting(Parallel),
 	"no-mutations+rand": randSetting(Parallel, DisableMutations()),
 	"no-ddl+rand":       randSetting(NoParallel, DisableDDLs()),
+	"ddl-nodrop":        randSetting(NoParallel, OnlyNoDropDDLs()),
 }
 
 // SettingVectorize is the setting for vectorizable. It is not included in

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -229,6 +229,18 @@ var DisableDDLs = simpleOption("disable DDLs", func(s *Smither) {
 	}
 })
 
+// OnlyNoDropDDLs causes the Smither to only emit DDLs, but won't ever drop
+// a table.
+var OnlyNoDropDDLs = simpleOption("only DDLs", func(s *Smither) {
+	s.stmtWeights = append([]statementWeight{
+		{1, makeBegin},
+		{2, makeRollback},
+		{6, makeCommit},
+	},
+		altersExistingTable...,
+	)
+})
+
 // DisableWith causes the Smither to not emit WITH clauses.
 var DisableWith = simpleOption("disable WITH", func(s *Smither) {
 	s.disableWith = true


### PR DESCRIPTION
This will test a large set of existing tables with schema changes.

Also rejigger the alter statement frequency. Drops are 1, renames 5, and
creates 10. This should prevent the problem of drops happening too often.

Release note: None