### PR TITLE
colexec: miscellaneous cleanups of aggregates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,6 +801,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/avg_agg.eg.go \
   pkg/sql/colexec/cast.eg.go \
   pkg/sql/colexec/const.eg.go \
+  pkg/sql/colexec/count_agg.eg.go \
   pkg/sql/colexec/distinct.eg.go \
   pkg/sql/colexec/hashjoiner.eg.go \
   pkg/sql/colexec/like_ops.eg.go \
@@ -1484,6 +1485,7 @@ pkg/sql/colexec/any_not_null_agg.eg.go: pkg/sql/colexec/any_not_null_agg_tmpl.go
 pkg/sql/colexec/avg_agg.eg.go: pkg/sql/colexec/avg_agg_tmpl.go
 pkg/sql/colexec/cast.eg.go: pkg/sql/colexec/cast_tmpl.go
 pkg/sql/colexec/const.eg.go: pkg/sql/colexec/const_tmpl.go
+pkg/sql/colexec/count_agg.eg.go: pkg/sql/colexec/count_agg_tmpl.go
 pkg/sql/colexec/distinct.eg.go: pkg/sql/colexec/distinct_tmpl.go
 pkg/sql/colexec/hashjoiner.eg.go: pkg/sql/colexec/hashjoiner_tmpl.go
 pkg/sql/colexec/mergejoinbase.eg.go: pkg/sql/colexec/mergejoinbase_tmpl.go

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -3,6 +3,7 @@ any_not_null_agg.eg.go
 avg_agg.eg.go
 cast.eg.go
 const.eg.go
+count_agg.eg.go
 distinct.eg.go
 hashjoiner.eg.go
 like_ops.eg.go

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -63,7 +63,8 @@ type aggregateFunc interface {
 	// index is carried over. Note that calling SetOutputIndex is a noop if
 	// CurrentOutputIndex returns a negative value (i.e. the aggregate function
 	// has not yet performed any computation). This method also has the side
-	// effect of clearing the output buffer past the given index.
+	// effect of clearing the NULLs bitmap of the output buffer past the given
+	// index.
 	SetOutputIndex(idx int)
 
 	// Compute computes the aggregation on the input batch. A zero-length input
@@ -373,7 +374,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 			a.done = true
 			break
 		}
-		// zero out a.groupCol. This is necessary because distinct ors the
+		// zero out a.groupCol. This is necessary because distinct ORs the
 		// uniqueness of a value with the groupCol, allowing the operators to be
 		// linked.
 		copy(a.groupCol, zeroBoolColumn)

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -19,6 +19,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SupportedAggFns contains all aggregate functions supported by the vectorized
+// engine.
+var SupportedAggFns = []execinfrapb.AggregatorSpec_Func{
+	execinfrapb.AggregatorSpec_ANY_NOT_NULL,
+	execinfrapb.AggregatorSpec_AVG,
+	execinfrapb.AggregatorSpec_SUM,
+	execinfrapb.AggregatorSpec_SUM_INT,
+	execinfrapb.AggregatorSpec_COUNT_ROWS,
+	execinfrapb.AggregatorSpec_COUNT,
+	execinfrapb.AggregatorSpec_MIN,
+	execinfrapb.AggregatorSpec_MAX,
+}
+
 // aggregateFunc is an aggregate function that performs computation on a batch
 // when Compute(batch) is called and writes the output to the Vec passed in
 // in Init. The aggregateFunc performs an aggregation per group and outputs the

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -11,9 +11,9 @@
 // {{/*
 // +build execgen_template
 //
-// This file is the execgen template for distinct.eg.go. It's formatted in a
-// special way, so it's both valid Go and a valid text/template input. This
-// permits editing this file with editor support.
+// This file is the execgen template for any_not_null_agg.eg.go. It's formatted
+// in a special way, so it's both valid Go and a valid text/template input.
+// This permits editing this file with editor support.
 //
 // */}}
 
@@ -86,7 +86,6 @@ func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 }
 
 func (a *anyNotNull_TYPEAgg) Reset() {
-	execgen.ZERO(a.vec)
 	a.curIdx = -1
 	a.done = false
 	a.foundNonNullForCurrentGroup = false
@@ -100,9 +99,6 @@ func (a *anyNotNull_TYPEAgg) CurrentOutputIndex() int {
 func (a *anyNotNull_TYPEAgg) SetOutputIndex(idx int) {
 	if a.curIdx != -1 {
 		a.curIdx = idx
-		vecLen := execgen.LEN(a.vec)
-		target := execgen.SLICE(a.vec, idx+1, vecLen)
-		execgen.ZERO(target)
 		a.nulls.UnsetNullsAfter(uint16(idx + 1))
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genCountAgg(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/count_agg_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+
+	accumulateSum := makeFunctionRegex("_ACCUMULATE_COUNT", 4)
+	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateCount" buildDict "Global" . "ColWithNulls" $4}}`)
+
+	tmpl, err := template.New("count_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, sameTypeBinaryOpToOverloads[tree.Plus])
+}
+
+func init() {
+	registerGenerator(genCountAgg, "count_agg.eg.go")
+}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
 )
 
 // HashAggregator is an operator chain that performs an aggregation based on
@@ -120,7 +121,9 @@ func NewHashAggregator(
 
 	funcs, outTyps, err := makeAggregateFuncs(allocator, aggTyps, aggFns)
 	if err != nil {
-		return nil, err
+		return nil, errors.AssertionFailedf(
+			"this error should have been checked in isAggregateSupported\n%+v", err,
+		)
 	}
 
 	distinctCol := make([]bool, coldata.BatchSize())

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -95,6 +95,7 @@ type _AGG_TYPEAgg struct {
 	curIdx    int
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
+	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg _GOTYPE
 	// col points to the output vector we are updating.
 	col _GOTYPESLICE
@@ -118,9 +119,6 @@ func (a *_AGG_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *_AGG_TYPEAgg) Reset() {
-	// TODO(asubiotto): Zeros don't seem necessary.
-	execgen.ZERO(a.col)
-	a.curAgg = zero_TYPEColumn[0]
 	a.curIdx = -1
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
@@ -152,13 +150,14 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		// be null.
 		if !a.foundNonNullForCurrentGroup {
 			a.nulls.SetNull(uint16(a.curIdx))
+		} else {
+			a.allocator.performOperation(
+				[]coldata.Vec{a.vec},
+				func() {
+					execgen.SET(a.col, a.curIdx, a.curAgg)
+				},
+			)
 		}
-		a.allocator.performOperation(
-			[]coldata.Vec{a.vec},
-			func() {
-				execgen.SET(a.col, a.curIdx, a.curAgg)
-			},
-		)
 		a.curIdx++
 		a.done = true
 		return
@@ -219,15 +218,12 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 		if a.curIdx >= 0 {
 			if !a.foundNonNullForCurrentGroup {
 				a.nulls.SetNull(uint16(a.curIdx))
+			} else {
+				execgen.SET(a.col, a.curIdx, a.curAgg)
 			}
-			execgen.SET(a.col, a.curIdx, a.curAgg)
 		}
 		a.curIdx++
 		a.foundNonNullForCurrentGroup = false
-		// The next element of vec is guaranteed  to be initialized to the zero
-		// value. We can't use zero_TYPEColumn here because this is outside of
-		// the earlier template block.
-		a.curAgg = execgen.UNSAFEGET(a.col, a.curIdx)
 	}
 	var isNull bool
 	// {{ if .HasNulls }}

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -132,9 +132,6 @@ func (a *_AGG_TYPEAgg) CurrentOutputIndex() int {
 func (a *_AGG_TYPEAgg) SetOutputIndex(idx int) {
 	if a.curIdx != -1 {
 		a.curIdx = idx
-		vecLen := execgen.LEN(a.col)
-		target := execgen.SLICE(a.col, idx+1, vecLen)
-		execgen.ZERO(target)
 		a.nulls.UnsetNullsAfter(uint16(idx + 1))
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1025,3 +1025,17 @@ query I
 SELECT b FROM t42994_2@i
 ----
 NULL
+
+# Regression test for zeroing out an aggregate value when NULLs are present.
+statement ok
+SELECT
+	max(s)
+FROM
+	(
+		SELECT
+			s, i
+		FROM
+			(VALUES ('1', 1), (NULL, 2)) AS t (s, i)
+	)
+GROUP BY
+	i

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -511,7 +511,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT variance(x) FROM xyz WHERE x = 1
 ----
 ·          distributed  false        ·                   ·
-·          vectorized   false        ·                   ·
+·          vectorized   true         ·                   ·
 group      ·            ·            (variance decimal)  ·
  │         aggregate 0  variance(x)  ·                   ·
  │         scalar       ·            ·                   ·
@@ -1036,7 +1036,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 ·          distributed  false          ·             ·
-·          vectorized   false          ·             ·
+·          vectorized   true           ·             ·
 group      ·            ·              (concat_agg)  ·
  │         aggregate 0  concat_agg(s)  ·             ·
  │         scalar       ·              ·             ·


### PR DESCRIPTION
**colexec: add a test comparing aggregator against processor**

This commit adds a test that compares columnar aggregator against
processor. It also improves the output of the input in case any of the
operator vs processor tests fails - now, the input types as well as
input rows will be attempted to be printed as statements that can be
copy-pasted for reproduction.

Release note: None

**colexec: minor refactor of planning of aggregates**

This commit extracts the check whether aggregate functions with given
input types are supported by the vectorized engine into a separate
function. This is useful for TestAggregateAgainstProcessor because this
way, when unsupported, we will fallback to wrapping the processor
(without this change the test would get an "unsupported error" message).
This doesn't have any impact on the users though.

Release note: None

**colexec: fix interaction between min/max and Bytes with NULLs**

Previously, an internal error could be returned when performing min/max
aggregation over Bytes column when NULLs are present. The problem was
that regardless of whether we found a non-null for the group, we were
always "resetting" curAgg value. (This is actually unnecessary, and I'll
fix it in the follow-up commit.)

I believe only flat bytes implementation was affected by it, so only
20.1 alpha had this issue.

Release note (bug fix): Previously, an internal error could be returned
when performing MIN/MAX aggregation over STRING column that contains
NULL values when executed via the vectorized engine, and now this is
fixed. Only 20.1 alpha release was affected.

**colexec: template out count aggregate**

This commit templates out the logic of accumulating a value into
countAgg. The generated code is almost identically the same (the only
difference is explicit declaration of a local variable).

Release note: None

**colexec: clean up some aggregates**

This commit cleans up several aggregates so that they are setting the
value *only* if it is non-null. It also removes zeroing out of the
output vector since it is not necessary - if the output value is NULL,
then Nulls bitmap is set correctly and we don't care about the value; if
the output value is non-NULL, we were zeroing it out anyway when a new
group is encountered.

Release note: None