### PR TITLE
opt: change ScalarBuilder to take non-typed Expr

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/tuple
+++ b/pkg/sql/opt/idxconstraint/testdata/tuple
@@ -10,13 +10,13 @@ index-constraints vars=(int) index=(@1 desc)
 ----
 [/3 - /1]
 
-index-constraints vars=(int) index=(@1) semtree-normalize
+index-constraints vars=(int) index=(@1)
 @1 IN (1, 5, 1, 4)
 ----
 [/1 - /1]
 [/4 - /5]
 
-index-constraints vars=(int) index=(@1 desc) semtree-normalize
+index-constraints vars=(int) index=(@1 desc)
 @1 IN (1, 5, 1, 4)
 ----
 [/5 - /4]
@@ -264,13 +264,13 @@ index-constraints vars=(int, int) index=(@1, @2)
 [/1/2 - /3/4]
 Remaining filter: (@1, @2) <= (3, 4)
 
-index-constraints vars=(int, int) index=(@1, @2) semtree-normalize
+index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) BETWEEN (1, 2) AND (3, 4)
 ----
 [/1/2 - /3/4]
 Remaining filter: (@1, @2) <= (3, 4)
 
-index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) semtree-normalize
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
 (@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
 ----
 [/1/2 - /4/5]

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -61,7 +61,6 @@ func TestExprIsNeverNull(t *testing.T) {
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var varTypes []*types.T
-			var iVarHelper tree.IndexedVarHelper
 			var err error
 
 			tester := opttester.New(catalog, d.Input)
@@ -83,8 +82,6 @@ func TestExprIsNeverNull(t *testing.T) {
 							d.Fatalf(t, "%v", err)
 						}
 
-						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
-
 					default:
 						if err := tester.Flags.Set(arg); err != nil {
 							d.Fatalf(t, "%s", err)
@@ -92,7 +89,7 @@ func TestExprIsNeverNull(t *testing.T) {
 					}
 				}
 
-				typedExpr, err := testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
+				expr, err := parser.ParseExpr(d.Input)
 				if err != nil {
 					d.Fatalf(t, "%v", err)
 				}
@@ -107,7 +104,7 @@ func TestExprIsNeverNull(t *testing.T) {
 					o.Memo().Metadata().AddColumn(fmt.Sprintf("@%d", i+1), typ)
 				}
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
-				err = b.Build(typedExpr)
+				err = b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -59,7 +59,6 @@ func TestBuilder(t *testing.T) {
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var varTypes []*types.T
-			var iVarHelper tree.IndexedVarHelper
 			var err error
 
 			tester := opttester.New(catalog, d.Input)
@@ -82,8 +81,6 @@ func TestBuilder(t *testing.T) {
 							d.Fatalf(t, "%v", err)
 						}
 
-						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
-
 					default:
 						if err := tester.Flags.Set(arg); err != nil {
 							d.Fatalf(t, "%s", err)
@@ -91,7 +88,7 @@ func TestBuilder(t *testing.T) {
 					}
 				}
 
-				typedExpr, err := testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
+				expr, err := parser.ParseExpr(d.Input)
 				if err != nil {
 					d.Fatalf(t, "%v", err)
 				}
@@ -111,7 +108,7 @@ func TestBuilder(t *testing.T) {
 				o.DisableOptimizations()
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
 				b.AllowUnsupportedExpr = tester.Flags.AllowUnsupportedExpr
-				err = b.Build(typedExpr)
+				err = b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -742,7 +742,7 @@ func NewScalar(
 
 // Build a memo structure from a TypedExpr: the root group represents a scalar
 // expression equivalent to expr.
-func (sb *ScalarBuilder) Build(expr tree.TypedExpr) (err error) {
+func (sb *ScalarBuilder) Build(expr tree.Expr) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// This code allows us to propagate errors without adding lots of checks
@@ -757,7 +757,8 @@ func (sb *ScalarBuilder) Build(expr tree.TypedExpr) (err error) {
 		}
 	}()
 
-	scalar := sb.buildScalar(expr, &sb.scope, nil, nil, nil)
+	typedExpr := sb.scope.resolveType(expr, types.Any)
+	scalar := sb.buildScalar(typedExpr, &sb.scope, nil, nil, nil)
 	sb.factory.Memo().SetScalarRoot(scalar)
 	return nil
 }

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -6,9 +6,7 @@ const: 1 [type=int]
 build-scalar
 1 + 2
 ----
-plus [type=int]
- ├── const: 1 [type=int]
- └── const: 2 [type=int]
+const: 3 [type=int]
 
 build-scalar vars=(string)
 @1
@@ -1011,9 +1009,7 @@ tuple [type=tuple{int, string, float}]
  │    └── const: 1 [type=int]
  ├── indirection [type=string]
  │    ├── variable: @2 [type=string[]]
- │    └── plus [type=int]
- │         ├── const: 1 [type=int]
- │         └── const: 1 [type=int]
+ │    └── const: 2 [type=int]
  └── indirection [type=float]
       ├── variable: @3 [type=float[]]
       └── variable: @4 [type=int]

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -13,25 +13,7 @@ package testutils
 import (
 	"path/filepath"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
-
-// ParseScalarExpr parses a scalar expression and converts it to a
-// tree.TypedExpr.
-func ParseScalarExpr(sql string, ivc tree.IndexedVarContainer) (tree.TypedExpr, error) {
-	expr, err := parser.ParseExpr(sql)
-	if err != nil {
-		return nil, err
-	}
-
-	sema := tree.MakeSemaContext()
-	sema.IVarContainer = ivc
-
-	return expr.TypeCheck(&sema, types.Any)
-}
 
 // GetTestFiles returns the set of test files that matches the Glob pattern.
 func GetTestFiles(tb testing.TB, testdataGlob string) []string {


### PR DESCRIPTION
Currently, ScalarBuilder takes a TypedExpr. This in turn requires callers
to convert Expr into TypedExpr by calling TypeCheck. Since we'll eventually
move towards integrating type-checking into optbuilder anyway, change this
interface to take Expr to prepare for that.

Release note: None