### PR TITLE
demo: round robin movr workload onto all nodes

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -486,20 +486,7 @@ func setupTransientCluster(
 	// Prepare the URL for use by the SQL shell.
 	// TODO (rohany): there should be a way that the user can request a specific node
 	//  to connect to to see the effects of the artificial latency.
-	options := url.Values{}
-	options.Add("sslmode", "disable")
-	options.Add("application_name", sqlbase.ReportableAppNamePrefix+"cockroach demo")
-	sqlURL := url.URL{
-		Scheme:   "postgres",
-		User:     url.User(security.RootUser),
-		Host:     c.s.ServingSQLAddr(),
-		RawQuery: options.Encode(),
-	}
-	if gen != nil {
-		sqlURL.Path = gen.Meta().Name
-	}
-
-	c.connURL = sqlURL.String()
+	c.connURL = makeURLForServer(c.s, gen)
 
 	// Start up the update check loop.
 	// We don't do this in (*server.Server).Start() because we don't want it
@@ -584,7 +571,11 @@ func (c *transientCluster) setupWorkload(ctx context.Context, gen workload.Gener
 
 		// Run the workload. This must occur after partitioning the database.
 		if demoCtx.runWorkload {
-			if err := c.runWorkload(ctx, gen, []string{c.connURL}); err != nil {
+			var sqlURLs []string
+			for i := range c.servers {
+				sqlURLs = append(sqlURLs, makeURLForServer(c.servers[i], gen))
+			}
+			if err := c.runWorkload(ctx, gen, sqlURLs); err != nil {
 				return errors.Wrapf(err, "starting background workload")
 			}
 		}
@@ -639,6 +630,22 @@ func (c *transientCluster) runWorkload(
 	}
 
 	return nil
+}
+
+func makeURLForServer(s *server.TestServer, gen workload.Generator) string {
+	options := url.Values{}
+	options.Add("sslmode", "disable")
+	options.Add("application_name", sqlbase.ReportableAppNamePrefix+"cockroach demo")
+	sqlURL := url.URL{
+		Scheme:   "postgres",
+		User:     url.User(security.RootUser),
+		Host:     s.ServingSQLAddr(),
+		RawQuery: options.Encode(),
+	}
+	if gen != nil {
+		sqlURL.Path = gen.Meta().Name
+	}
+	return sqlURL.String()
 }
 
 func incrementTelemetryCounters(cmd *cobra.Command) {

--- a/pkg/workload/round_robin.go
+++ b/pkg/workload/round_robin.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package workload
+
+import (
+	gosql "database/sql"
+	"sync/atomic"
+)
+
+// RoundRobinDB is a wrapper around *gosql.DB's that round robins individual
+// queries among the different databases that it was created with.
+type RoundRobinDB struct {
+	handles []*gosql.DB
+	current uint32
+}
+
+// NewRoundRobinDB creates a RoundRobinDB from the input list of
+// database connection URLs.
+func NewRoundRobinDB(urls []string) (*RoundRobinDB, error) {
+	r := &RoundRobinDB{current: 0, handles: make([]*gosql.DB, 0, len(urls))}
+	for _, url := range urls {
+		db, err := gosql.Open(`cockroach`, url)
+		if err != nil {
+			return nil, err
+		}
+		r.handles = append(r.handles, db)
+	}
+	return r, nil
+}
+
+func (db *RoundRobinDB) next() *gosql.DB {
+	return db.handles[(atomic.AddUint32(&db.current, 1)-1)%uint32(len(db.handles))]
+}
+
+// QueryRow executes (*gosql.DB).QueryRow on the next available DB.
+func (db *RoundRobinDB) QueryRow(query string, args ...interface{}) *gosql.Row {
+	return db.next().QueryRow(query, args...)
+}
+
+// Exec executes (*gosql.DB).Exec on the next available DB.
+func (db *RoundRobinDB) Exec(query string, args ...interface{}) (gosql.Result, error) {
+	return db.next().Exec(query, args...)
+}


### PR DESCRIPTION
Fixes #42591.

This PR allows the `cockroach demo --with-load` to round-robin
queries to all the nodes in the demo cluster.

Release note (cli change): allows for `cockroach demo --with-load` to
round robin queries to all nodes in the demo cluster.