### PR TITLE
release-19.2: backupccl: stop swallowing error when failing to get URI by locality

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1033,7 +1033,7 @@ func backupPlanHook(
 
 		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to)
 		if err != nil {
-			return nil
+			return err
 		}
 		defaultStore, err := storageccl.ExportStorageFromURI(ctx, defaultURI, p.ExecCfg().Settings)
 		if err != nil {


### PR DESCRIPTION
Commit for backport of problem found in #43264.

Release note (bug fix): Properly return errors when failing to parse URIs
for multi-locality backup.