### PR TITLE
release-19.2: sql: stop swallowing error in crdb_internal.gossip_nodes

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2306,7 +2306,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 		g := p.ExecCfg().Gossip
 		descriptors, err := getAllNodeDescriptors(p)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		alive := make(map[roachpb.NodeID]tree.DBool)


### PR DESCRIPTION
Backport commit of issue found in #43264.

Release note (bug fix): Fixed bug which swallowed errors while reading from
crdb_internal.gossip_nodes which could lead to lost writes or other undefined
behavior.