### PR TITLE
release-19.2: sql: stop swallowing error in getDescriptorByID

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -177,7 +177,7 @@ func getDescriptorByID(
 				"%q is not a table", desc.String())
 		}
 		if err := table.MaybeFillInDescriptor(ctx, txn); err != nil {
-			return nil
+			return err
 		}
 
 		if err := table.Validate(ctx, txn); err != nil {


### PR DESCRIPTION
Backport of change caught during #43264.

Release note (bug fix): Fixed bug which swallowed errors while looking up
table descriptors during schema changes and other transactional interactions
with schema which could cause lost writes or other undefined behavior.