### PR TITLE
release-19.2: sql/flowinfra: stop swallowing error while flushing

### DIFF
--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -282,7 +282,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 				if m.statsCollectionEnabled {
 					err := m.flush(ctx)
 					if err != nil {
-						return nil
+						return err
 					}
 					if m.flowCtx.Cfg.TestingKnobs.DeterministicStats {
 						m.stats.BytesSent = 0


### PR DESCRIPTION
@solongordon I omitted a release note because I can't think of what the
user-visible impact of not returning this error might be. If you can
think of one let me know and I'll update the commit message.

Release note: None