### PR TITLE
release-19.2: util/json: stop swallowing errors in contains

### DIFF
--- a/pkg/util/json/contains.go
+++ b/pkg/util/json/contains.go
@@ -202,7 +202,7 @@ func (j containsableArray) contains(other containsable) (bool, error) {
 		// objects and arrays, but for now just do the quadratic check.
 		objectsMatch, err := quadraticJSONArrayContains(j.objects, contained.objects)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if !objectsMatch {
 			return false, nil
@@ -210,7 +210,7 @@ func (j containsableArray) contains(other containsable) (bool, error) {
 
 		arraysMatch, err := quadraticJSONArrayContains(j.arrays, contained.arrays)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if !arraysMatch {
 			return false, nil


### PR DESCRIPTION
Backport of change caught during #43264.

Release note (bug fix): Fix bug where errors from json containment
operations were silently ignored rather than being returned.