### PR TITLE
release-19.2: execinfrapb: stop swallowing errors in GeneratePlanDiagramURL

### DIFF
--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -714,7 +714,7 @@ func GeneratePlanDiagramURL(
 ) (string, url.URL, error) {
 	d, err := GeneratePlanDiagram(sql, flows)
 	if err != nil {
-		return "", url.URL{}, nil
+		return "", url.URL{}, err
 	}
 	return d.ToURL()
 }


### PR DESCRIPTION
Backport of problem caught by #43264.

Release note (bug fix): Properly report errors when generating plan diagrams
rather than silently reporting no result.