### PR TITLE
cli: stop swallowing errors when generating shell autocomplete script

### DIFF
--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -118,7 +118,7 @@ func runGenAutocompleteCmd(cmd *cobra.Command, args []string) error {
 		err = cmd.Root().GenZshCompletionFile(autoCompletePath)
 	}
 	if err != nil {
-		return nil
+		return err
 	}
 
 	fmt.Printf("Generated %s completion file: %s\n", shell, autoCompletePath)


### PR DESCRIPTION
Backport of bug caught by #43264.

Release note (bug fix): Properly report errors generating shell autocomplete
scripts.