### PR TITLE
colexec, coldata: add support for INTERVAL type

### DIFF
--- a/pkg/col/coldata/random_testutils.go
+++ b/pkg/col/coldata/random_testutils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -104,6 +105,11 @@ func RandomVec(
 			timestamps[i] = timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000))
 			loc := locations[rng.Intn(len(locations))]
 			timestamps[i] = timestamps[i].In(loc)
+		}
+	case coltypes.Interval:
+		intervals := vec.Interval()
+		for i := 0; i < n; i++ {
+			intervals[i] = duration.FromFloat64(rng.Float64())
 		}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", typ))

--- a/pkg/col/coldata/testutils.go
+++ b/pkg/col/coldata/testutils.go
@@ -82,6 +82,17 @@ func AssertEquivalentBatches(t testingT, expected, actual Batch) {
 					t.Fatalf("Timestamp mismatch at index %d:\nexpected:\n%sactual:\n%s", i, expectedTimestamp[i], resultTimestamp[i])
 				}
 			}
+		} else if typ == coltypes.Interval {
+			// Cannot use require.Equal for this type.
+			// TODO(yuzefovich): Again, why not?
+			expectedInterval := expectedVec.Interval()[0:expected.Length()]
+			resultInterval := actualVec.Interval()[0:actual.Length()]
+			require.Equal(t, len(expectedInterval), len(resultInterval))
+			for i := range expectedInterval {
+				if expectedInterval[i].Compare(resultInterval[i]) != 0 {
+					t.Fatalf("Interval mismatch at index %d:\nexpected:\n%sactual:\n%s", i, expectedInterval[i], resultInterval[i])
+				}
+			}
 		} else {
 			require.Equal(
 				t,

--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // unknown is a Vec that represents an unhandled type. Used when a batch needs a placeholder Vec.
@@ -55,6 +56,10 @@ func (u unknown) Decimal() []apd.Decimal {
 }
 
 func (u unknown) Timestamp() []time.Time {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Interval() []duration.Duration {
 	panic("Vec is of unknown type and should not be accessed")
 }
 

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // column is an interface that represents a raw array of a Go native type.
@@ -79,6 +80,8 @@ type Vec interface {
 	Decimal() []apd.Decimal
 	// Timestamp returns a time.Time slice.
 	Timestamp() []time.Time
+	// Interval returns a duration.Duration slice.
+	Interval() []duration.Duration
 
 	// Col returns the raw, typeless backing storage for this Vec.
 	Col() interface{}
@@ -171,6 +174,8 @@ func NewMemColumn(t coltypes.T, n int) Vec {
 		return &memColumn{t: t, col: make([]apd.Decimal, n), nulls: nulls}
 	case coltypes.Timestamp:
 		return &memColumn{t: t, col: make([]time.Time, n), nulls: nulls}
+	case coltypes.Interval:
+		return &memColumn{t: t, col: make([]duration.Duration, n), nulls: nulls}
 	case coltypes.Unhandled:
 		return unknown{}
 	default:
@@ -218,6 +223,10 @@ func (m *memColumn) Timestamp() []time.Time {
 	return m.col.([]time.Time)
 }
 
+func (m *memColumn) Interval() []duration.Duration {
+	return m.col.([]duration.Duration)
+}
+
 func (m *memColumn) Col() interface{} {
 	return m.col
 }
@@ -256,6 +265,8 @@ func (m *memColumn) Length() int {
 		return len(m.col.([]apd.Decimal))
 	case coltypes.Timestamp:
 		return len(m.col.([]time.Time))
+	case coltypes.Interval:
+		return len(m.col.([]duration.Duration))
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}
@@ -279,6 +290,8 @@ func (m *memColumn) SetLength(l int) {
 		m.col = m.col.([]apd.Decimal)[:l]
 	case coltypes.Timestamp:
 		m.col = m.col.([]time.Time)[:l]
+	case coltypes.Interval:
+		m.col = m.col.([]duration.Duration)[:l]
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}
@@ -302,6 +315,8 @@ func (m *memColumn) Capacity() int {
 		return cap(m.col.([]apd.Decimal))
 	case coltypes.Timestamp:
 		return cap(m.col.([]time.Time))
+	case coltypes.Interval:
+		return cap(m.col.([]duration.Duration))
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -28,10 +28,7 @@ import (
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	// */}}
-	// HACK: crlfmt removes the "*/}}" comment if it's the last line in the import
-	// block. This was picked because it sorts after "pkg/sql/exec/execgen" and
-	// has no deps.
-	_ "github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -48,6 +45,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // */}}
 

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -208,9 +208,17 @@ func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 		dataLen         = rng.Intn(maxDataLen) + 1
 		nullProbability = rng.Float64()
 		buf             = bytes.Buffer{}
+		supportedTypes  = make([]coltypes.T, 0, len(coltypes.AllTypes))
 	)
 
-	supportedTypes := coltypes.AllTypes
+	// We do not support intervals.
+	for _, t := range coltypes.AllTypes {
+		if t == coltypes.Interval {
+			continue
+		}
+		supportedTypes = append(supportedTypes, t)
+	}
+
 	for i := range typs {
 		typs[i] = supportedTypes[rng.Intn(len(supportedTypes))]
 		data[i] = randomDataFromType(rng, typs[i], dataLen, nullProbability)

--- a/pkg/col/coltypes/t_string.go
+++ b/pkg/col/coltypes/t_string.go
@@ -16,12 +16,13 @@ func _() {
 	_ = x[Int64-5]
 	_ = x[Float64-6]
 	_ = x[Timestamp-7]
-	_ = x[Unhandled-8]
+	_ = x[Interval-8]
+	_ = x[Unhandled-9]
 }
 
-const _T_name = "BoolBytesDecimalInt16Int32Int64Float64TimestampUnhandled"
+const _T_name = "BoolBytesDecimalInt16Int32Int64Float64TimestampIntervalUnhandled"
 
-var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47, 56}
+var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47, 55, 64}
 
 func (i T) String() string {
 	if i < 0 || i >= T(len(_T_index)-1) {

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // T represents an exec physical type - a bytes representation of a particular
@@ -41,6 +42,8 @@ const (
 	Float64
 	// Timestamp is a column of type time.Time
 	Timestamp
+	// Interval is a column of type duration.Duration
+	Interval
 
 	// Unhandled is a temporary value that represents an unhandled type.
 	// TODO(jordan): this should be replaced by a panic once all types are
@@ -78,6 +81,7 @@ func init() {
 	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], NumberTypes...)
 	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], NumberTypes...)
 	CompatibleTypes[Timestamp] = append(CompatibleTypes[Timestamp], Timestamp)
+	CompatibleTypes[Interval] = append(CompatibleTypes[Interval], Interval)
 }
 
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at
@@ -102,6 +106,8 @@ func FromGoType(v interface{}) T {
 		return Decimal
 	case time.Time:
 		return Timestamp
+	case duration.Duration:
+		return Interval
 	default:
 		panic(fmt.Sprintf("type %T not supported yet", t))
 	}
@@ -126,6 +132,8 @@ func (t T) GoTypeName() string {
 		return "float64"
 	case Timestamp:
 		return "time.Time"
+	case Interval:
+		return "duration.Duration"
 	default:
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -117,6 +117,7 @@ CREATE TABLE IF NOT EXISTS seed_vec AS
 		'2001-01-01'::DATE + g AS _date,
 		'2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
 		'2001-01-01'::TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+		g * '1 day'::INTERVAL AS _interval,
 		g % 2 = 1 AS _bool,
 		g::DECIMAL AS _decimal,
 		g::STRING AS _string,

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -32,6 +32,15 @@ func TestDiskQueue(t *testing.T) {
 	queueCfg, cleanup := colcontainer.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
+	availableTyps := make([]coltypes.T, 0, len(coltypes.AllTypes))
+	for _, typ := range coltypes.AllTypes {
+		// TODO(yuzefovich): We do not support interval serialization yet.
+		if typ == coltypes.Interval {
+			continue
+		}
+		availableTyps = append(availableTyps, typ)
+	}
+
 	rng, _ := randutil.NewPseudoRand()
 	for _, bufferSizeBytes := range []int{0, 16<<10 + rng.Intn(1<<20) /* 16 KiB up to 1 MiB */} {
 		for _, maxFileSizeBytes := range []int{10 << 10 /* 10 KiB */, 1<<20 + rng.Intn(64<<20) /* 1 MiB up to 64 MiB */} {
@@ -40,7 +49,7 @@ func TestDiskQueue(t *testing.T) {
 				// Create random input.
 				batches := make([]coldata.Batch, 0, 1+rng.Intn(2048))
 				op := colexec.NewRandomDataOp(testAllocator, rng, colexec.RandomDataOpArgs{
-					AvailableTyps: coltypes.AllTypes,
+					AvailableTyps: availableTyps,
 					NumBatches:    cap(batches),
 					BatchSize:     1 + rng.Intn(int(coldata.BatchSize())),
 					Nulls:         true,

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -97,6 +98,10 @@ func decodeUntaggedDatumToCol(vec coldata.Vec, idx uint16, t *types.T, buf []byt
 		var t time.Time
 		buf, t, err = encoding.DecodeUntaggedTimeValue(buf)
 		vec.Timestamp()[idx] = t
+	case types.IntervalFamily:
+		var d duration.Duration
+		buf, d, err = encoding.DecodeUntaggedDurationValue(buf)
+		vec.Interval()[idx] = d
 	default:
 		return buf, errors.AssertionFailedf(
 			"couldn't decode type: %s", log.Safe(t))

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -142,13 +143,14 @@ func (a *Allocator) Clear() {
 }
 
 const (
-	sizeOfBool    = int(unsafe.Sizeof(true))
-	sizeOfInt16   = int(unsafe.Sizeof(int16(0)))
-	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
-	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
-	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
-	sizeOfTime    = int(unsafe.Sizeof(time.Time{}))
-	sizeOfUint16  = int(unsafe.Sizeof(uint16(0)))
+	sizeOfBool     = int(unsafe.Sizeof(true))
+	sizeOfInt16    = int(unsafe.Sizeof(int16(0)))
+	sizeOfInt32    = int(unsafe.Sizeof(int32(0)))
+	sizeOfInt64    = int(unsafe.Sizeof(int64(0)))
+	sizeOfFloat64  = int(unsafe.Sizeof(float64(0)))
+	sizeOfTime     = int(unsafe.Sizeof(time.Time{}))
+	sizeOfDuration = int(unsafe.Sizeof(duration.Duration{}))
+	sizeOfUint16   = int(unsafe.Sizeof(uint16(0)))
 )
 
 // sizeOfBatchSizeSelVector is the size (in bytes) of a selection vector of
@@ -196,6 +198,8 @@ func estimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// significantly overestimate.
 			// TODO(yuzefovich): figure out whether the caching does take place.
 			acc += sizeOfTime
+		case coltypes.Interval:
+			acc += sizeOfDuration
 		case coltypes.Unhandled:
 			// Placeholder coldata.Vecs of unknown types are allowed.
 		default:

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -49,6 +50,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // _GOTYPESLICE is the template Go type slice variable for this operator. It
 // will be replaced by the Go slice representation for each type in coltypes.T, for

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -39,6 +40,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // _TYPES_T is the template type variable for coltypes.T. It will be replaced by
 // coltypes.Foo for each type Foo in the coltypes.T type.

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -99,6 +100,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 {{define "opName"}}perform{{.Name}}{{.LTyp}}{{.RTyp}}{{end}}

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -47,6 +48,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -49,6 +50,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -32,6 +32,7 @@ import (
 	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -46,6 +47,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/orderedsynchronizer_tmpl.go
+++ b/pkg/sql/colexec/orderedsynchronizer_tmpl.go
@@ -34,6 +34,7 @@ import (
 	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -45,6 +46,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // _GOTYPESLICE is the template Go type slice variable for this operator. It
 // will be replaced by the Go slice representation for each type in coltypes.T, for

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -55,6 +56,9 @@ var _ = math.MaxInt64
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -40,6 +41,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 const (
 	_FAMILY = types.Family(0)

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -48,6 +49,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "coltypes" package
 var _ coltypes.T

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -55,6 +56,9 @@ var _ = math.MaxInt64
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "coltypes" package.
 var _ = coltypes.Bool

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -47,6 +48,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/supported_sql_types.go
+++ b/pkg/sql/colexec/supported_sql_types.go
@@ -29,4 +29,5 @@ var allSupportedSQLTypes = []types.T{
 	*types.Uuid,
 	*types.Timestamp,
 	*types.TimestampTZ,
+	*types.Interval,
 }

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -59,6 +59,11 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	for _, typ := range allSupportedSQLTypes {
+		if typ.Equal(*types.Interval) {
+			// Serialization of Intervals is currently not supported.
+			// TODO(yuzefovich): remove this once it is supported.
+			continue
+		}
 		for _, numRows := range []uint16{
 			// A few interesting sizes.
 			1,

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // {{/*
@@ -47,6 +48,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "time" package.
 var _ time.Time
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -75,6 +75,8 @@ func PhysicalTypeColElemToDatum(
 		return da.NewDTimestamp(tree.DTimestamp{Time: col.Timestamp()[rowIdx]})
 	case types.TimestampTZFamily:
 		return da.NewDTimestampTZ(tree.DTimestampTZ{Time: col.Timestamp()[rowIdx]})
+	case types.IntervalFamily:
+		return da.NewDInterval(tree.DInterval{Duration: col.Interval()[rowIdx]})
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("Unsupported column type %s", ct.String()))
 		// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -15,13 +15,15 @@ CREATE TABLE all_types (
     _string      STRING,
     _uuid        UUID,
     _timestamp   TIMESTAMP,
-    _timestamptz TIMESTAMPTZ
+    _timestamptz TIMESTAMPTZ,
+    _interval  INTERVAL
 )
 
 statement ok
 INSERT
   INTO all_types
 VALUES (
+        NULL,
         NULL,
         NULL,
         NULL,
@@ -49,14 +51,15 @@ VALUES (
        '123',
        '63616665-6630-3064-6465-616462656562',
        '1-1-18 1:00:00.001',
-       '1-1-18 1:00:00.001-8'
+       '1-1-18 1:00:00.001-8',
+       '12:34:56.123456'
        )
 
-query BTTRIIIORTTTT
+query BTTRIIIORTTTTT
 SELECT * FROM all_types ORDER BY 1
 ----
-NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL                                 NULL
-false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000  2001-01-18 09:00:00.001 +0000 UTC
+NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL                                 NULL                               NULL
+false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000  2001-01-18 09:00:00.001 +0000 UTC  12:34:56.123456
 
 statement ok
 CREATE TABLE skip_unneeded_cols (

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -927,7 +927,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT n FROM num WHERE n = -'1h':::INTERVAL
 ----
 ·     distributed  false                        ·             ·
-·     vectorized   false                        ·             ·
+·     vectorized   true                         ·             ·
 scan  ·            ·                            (n interval)  ·
 ·     table        num@num_n_key                ·             ·
 ·     spans        /-01:00:00-/1 day -25:00:00  ·             ·

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stacktrace"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
 )
@@ -137,8 +137,11 @@ func (pg *Error) Format(s fmt.State, verb rune) {
 		for _, d := range pg.SafeDetail {
 			fmt.Fprintf(s, "\n-- detail --\n%s", d.SafeMessage)
 			if d.EncodedStackTrace != "" {
-				if st, ok := log.DecodeStackTrace(d.EncodedStackTrace); ok {
-					fmt.Fprintf(s, "\n%s", log.PrintStackTrace(st))
+				st, err := stacktrace.DecodeStackTrace(d.EncodedStackTrace)
+				if err != nil {
+					fmt.Fprintf(s, "unable to encode stack trace: %+v", err)
+				} else {
+					fmt.Fprintf(s, "\n%s", stacktrace.PrintStackTrace(st))
 				}
 			}
 		}

--- a/pkg/sql/pgwire/pgerror/with_candidate_code.go
+++ b/pkg/sql/pgwire/pgerror/with_candidate_code.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
 )
 
 type withCandidateCode struct {
@@ -43,8 +43,13 @@ func (w *withCandidateCode) FormatError(p errors.Printer) (next error) {
 	return w.cause
 }
 
+// decodeWithCandidateCode is a custom decoder that will be used when decoding
+// withCandidateCode error objects.
+// Note that as the last argument it takes proto.Message (and not
+// protoutil.Message which is required by linter) because the latter brings in
+// additional dependencies into this package and the former is sufficient here.
 func decodeWithCandidateCode(
-	_ context.Context, cause error, _ string, details []string, _ protoutil.SimpleMessage,
+	_ context.Context, cause error, _ string, details []string, _ proto.Message,
 ) error {
 	code := pgcode.Uncategorized
 	if len(details) > 0 {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -916,6 +916,7 @@ func TestLint(t *testing.T) {
 			"*.go",
 			":!*.pb.go",
 			":!*.pb.gw.go",
+			":!sql/pgwire/pgerror/with_candidate_code.go",
 			":!util/protoutil/jsonpb_marshal.go",
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stacktrace"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	raven "github.com/getsentry/raven-go"
@@ -265,11 +266,6 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 	})
 }
 
-var crdbPaths = []string{
-	"github.com/cockroachdb/cockroach",
-	"go.etcd.io/etcd/raft",
-}
-
 func uptimeTag(now time.Time) string {
 	uptime := now.Sub(startTime)
 	switch {
@@ -474,7 +470,7 @@ func SendCrashReport(
 		return
 	}
 	err := ReportablesToSafeError(depth+1, format, reportables)
-	ex := raven.NewException(err, NewStackTrace(depth+1))
+	ex := raven.NewException(err, stacktrace.NewStackTrace(depth+1))
 	SendReport(ctx, err.Error(), crashReportType, nil, ex)
 }
 
@@ -499,7 +495,7 @@ func SendReport(
 	errMsg string,
 	crashReportType ReportType,
 	extraDetails map[string]interface{},
-	details ...ReportableObject,
+	details ...stacktrace.ReportableObject,
 ) {
 	packet := raven.NewPacket(errMsg, details...)
 

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -15,15 +15,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 )
 
@@ -219,34 +216,4 @@ func makeTypeAssertionErr() (result runtime.Error) {
 	var x interface{}
 	_ = x.(int)
 	return nil
-}
-
-func genStack2() *StackTrace {
-	return NewStackTrace(0)
-}
-
-func genStack1() *StackTrace {
-	return genStack2()
-}
-
-func TestStackTrace(t *testing.T) {
-	st := genStack1()
-
-	t.Logf("Stack trace:\n%s", PrintStackTrace(st))
-
-	encoded := EncodeStackTrace(st)
-	t.Logf("encoded:\n%s", encoded)
-	if !strings.Contains(encoded, `"function":"genStack1"`) ||
-		!strings.Contains(encoded, `"function":"genStack2"`) {
-		t.Fatalf("function genStack not in call stack:\n%s", encoded)
-	}
-
-	st2, b := DecodeStackTrace(encoded)
-	if !b {
-		t.Fatalf("decode failed")
-	}
-
-	if !reflect.DeepEqual(st, st2) {
-		t.Fatalf("stack traces not identical: %v", pretty.Diff(st, st2))
-	}
 }

--- a/pkg/util/protoutil/marshal.go
+++ b/pkg/util/protoutil/marshal.go
@@ -25,12 +25,6 @@ type Message interface {
 	Size() int
 }
 
-// SimpleMessage aliases the proto.Message interface for use in APIs
-// that do not require/support the Message interface defined above.
-// This is needed, for example, to implement error encode/decode
-// functions without a linter error.
-type SimpleMessage = proto.Message
-
 // MaybeFuzz takes the given proto and, if nullability fuzzing is enabled, walks it using a
 // RandomZeroInsertingVisitor. A suitable copy is made and returned if fuzzing took place.
 func MaybeFuzz(pb Message) Message {

--- a/pkg/util/stacktrace/stacktrace_test.go
+++ b/pkg/util/stacktrace/stacktrace_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stacktrace_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/stacktrace"
+	"github.com/kr/pretty"
+)
+
+func genStack2() *stacktrace.StackTrace {
+	return stacktrace.NewStackTrace(0)
+}
+
+func genStack1() *stacktrace.StackTrace {
+	return genStack2()
+}
+
+func TestStackTrace(t *testing.T) {
+	st := genStack1()
+
+	t.Logf("Stack trace:\n%s", stacktrace.PrintStackTrace(st))
+
+	encoded, err := stacktrace.EncodeStackTrace(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("encoded:\n%s", encoded)
+	if !strings.Contains(encoded, `"function":"genStack1"`) ||
+		!strings.Contains(encoded, `"function":"genStack2"`) {
+		t.Fatalf("function genStack not in call stack:\n%s", encoded)
+	}
+
+	st2, err := stacktrace.DecodeStackTrace(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(st, st2) {
+		t.Fatalf("stack traces not identical: %v", pretty.Diff(st, st2))
+	}
+}

--- a/pkg/workload/dep_test.go
+++ b/pkg/workload/dep_test.go
@@ -26,11 +26,18 @@ func TestDepWhitelist(t *testing.T) {
 		[]string{
 			`github.com/cockroachdb/cockroach/pkg/col/coldata`,
 			`github.com/cockroachdb/cockroach/pkg/col/coltypes`,
+			`github.com/cockroachdb/cockroach/pkg/util/arith`,
 			`github.com/cockroachdb/cockroach/pkg/util/bufalloc`,
+			`github.com/cockroachdb/cockroach/pkg/util/duration`,
 			`github.com/cockroachdb/cockroach/pkg/util/encoding/csv`,
+			`github.com/cockroachdb/cockroach/pkg/util/stacktrace`,
 			`github.com/cockroachdb/cockroach/pkg/util/syncutil`,
 			`github.com/cockroachdb/cockroach/pkg/util/timeutil`,
 			`github.com/cockroachdb/cockroach/pkg/workload/histogram`,
+			// TODO(dan): These really shouldn't be used in util packages, but the
+			// payoff of fixing it is not worth it right now.
+			`github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode`,
+			`github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror`,
 		},
 	)
 }


### PR DESCRIPTION
**pgerror: clean up build deps**

The pgerror (and pgcode) packages are (perhaps inadvisably) used in
low-level utility packages. They had some pretty heavyweight build deps,
but this wasn't fundamentally necessary. Clean it up a bit and make
these packages more lightweight.

Release note: None

**colexec, coldata: add support for INTERVAL type**

This commit adds the support for INTERVAL type that is represented by
duration.Duration. Only comparison projections are currently supported.
The serialization is also missing.

Addresses: #42043.

Release note: None