### PR TITLE
storage/intentresolver: don't capture loop iteration vars in async task

### DIFF
--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -56,6 +56,12 @@ const (
 	// up than wait too long (this helps avoid deadlocks during test shutdown).
 	asyncIntentResolutionTimeout = 30 * time.Second
 
+	// gcBatchSize is the maximum number of transaction records that will be
+	// GCed in a single batch. Batches that span many ranges (which is possible
+	// for the transaction records that spans many ranges) will be split into
+	// many batches by the DistSender.
+	gcBatchSize = 1024
+
 	// intentResolverBatchSize is the maximum number of intents that will be
 	// resolved in a single batch. Batches that span many ranges (which is
 	// possible for the commit of a transaction that spans many ranges) will be
@@ -187,21 +193,25 @@ func New(c Config) *IntentResolver {
 	}
 	ir.mu.inFlightPushes = map[uuid.UUID]int{}
 	ir.mu.inFlightTxnCleanups = map[uuid.UUID]struct{}{}
+	gcBatchSize := gcBatchSize
+	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
+		gcBatchSize = c.TestingKnobs.MaxGCBatchSize
+	}
 	ir.gcBatcher = requestbatcher.New(requestbatcher.Config{
 		Name:            "intent_resolver_gc_batcher",
-		MaxMsgsPerBatch: 1024,
+		MaxMsgsPerBatch: gcBatchSize,
 		MaxWait:         c.MaxGCBatchWait,
 		MaxIdle:         c.MaxGCBatchIdle,
 		Stopper:         c.Stopper,
 		Sender:          c.DB.NonTransactionalSender(),
 	})
-	batchSize := intentResolverBatchSize
+	intentResolutionBatchSize := intentResolverBatchSize
 	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
-		batchSize = c.TestingKnobs.MaxIntentResolutionBatchSize
+		intentResolutionBatchSize = c.TestingKnobs.MaxIntentResolutionBatchSize
 	}
 	ir.irBatcher = requestbatcher.New(requestbatcher.Config{
 		Name:            "intent_resolver_ir_batcher",
-		MaxMsgsPerBatch: batchSize,
+		MaxMsgsPerBatch: intentResolutionBatchSize,
 		MaxWait:         c.MaxIntentResolutionBatchWait,
 		MaxIdle:         c.MaxIntentResolutionBatchIdle,
 		Stopper:         c.Stopper,
@@ -493,7 +503,8 @@ func (ir *IntentResolver) CleanupIntentsAsync(
 	ctx context.Context, intents []result.IntentsWithArg, allowSyncProcessing bool,
 ) error {
 	now := ir.clock.Now()
-	for _, item := range intents {
+	for i := range intents {
+		item := &intents[i] // copy for goroutine
 		if err := ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
 			err := contextutil.RunWithTimeout(ctx, "async intent resolution",
 				asyncIntentResolutionTimeout, func(ctx context.Context) error {
@@ -593,7 +604,8 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 	allowSyncProcessing bool,
 ) error {
 	now := ir.clock.Now()
-	for _, et := range endTxns {
+	for i := range endTxns {
+		et := &endTxns[i] // copy for goroutine
 		if err := ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
 			locked, release := ir.lockInFlightTxnCleanup(ctx, et.Txn.ID)
 			if !locked {

--- a/pkg/storage/storagebase/knobs.go
+++ b/pkg/storage/storagebase/knobs.go
@@ -51,6 +51,10 @@ type IntentResolverTestingKnobs struct {
 	// to -1.
 	ForceSyncIntentResolution bool
 
+	// MaxGCBatchSize overrides the maximum number of transaction record gc
+	// requests which can be sent in a single batch.
+	MaxGCBatchSize int
+
 	// MaxIntentResolutionBatchSize overrides the maximum number of intent
 	// resolution requests which can be sent in a single batch.
 	MaxIntentResolutionBatchSize int


### PR DESCRIPTION
It's unclear if we've ever seen issues from this, but I intend to backport the
fix to v19.2, v19.1, and v2.1. I believe the worst thing that could have
happened is that a batch that observed multiple intents or pushed multiple txns
would only end up cleaning up a single one of these. It would then run into some
of these intents again when it tried to re-evaluate, forcing it to push again.
This subverts the parallelism that we were trying to achieve here, but would
never cause a stall.

Release note (bug fix): Ensure that all intents or transactions that a
batch observes are asynchronously cleaned up.