### PR TITLE
sql: add family specific span generation to secondary indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
+++ b/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
@@ -230,3 +230,63 @@ query II
 SELECT y, z FROM t42992@i
 ----
 NULL 2
+
+# Ensure that reads only scan the necessary k/v's.
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (
+  x INT, y INT, z INT,
+  FAMILY (x), FAMILY (y), FAMILY (z),
+  UNIQUE INDEX i (x) STORING (y, z),
+  INDEX i2 (x) STORING (y, z)
+);
+INSERT INTO t VALUES (1, 2, 3)
+
+query I
+SET TRACING=on,kv,results;
+SELECT y FROM t@i WHERE x = 1;
+SET TRACING=off
+----
+2
+
+# In this case, we scan only families 0 and 1.
+# We don't really need family 0, but removing that
+# from the needed families code is a further optimization.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Scan%'
+ORDER BY message
+----
+Scan /Table/55/2/1/{0-1/2}
+
+# Make sure that family splitting doesn't affect
+# lookups when there are null values along the
+# secondary index.
+statement ok
+INSERT INTO t VALUES (NULL, 3, 4)
+
+query I
+SET TRACING=on,kv,results;
+SELECT y FROM t@i WHERE x IS NULL;
+SET TRACING=off
+----
+3
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Scan%'
+ORDER BY message
+----
+Scan /Table/55/2/{NULL-!NULL}
+
+# Ensure that updates only touch the changed column families.
+query T
+SET TRACING=on,kv,results;
+UPDATE t SET y = 5 WHERE x = 1;
+SET TRACING=off;
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'CPut /Table/55/2%'
+ORDER BY message
+----
+CPut /Table/55/2/1/1/1 -> /TUPLE/2:2:Int/5 (replacing raw_bytes:"\000\000\000\000\n#\004" timestamp:<> , if exists)

--- a/pkg/sql/rowexec/indexjoiner.go
+++ b/pkg/sql/rowexec/indexjoiner.go
@@ -207,11 +207,11 @@ func (ij *indexJoiner) generateSpans(row sqlbase.EncDatumRow) (roachpb.Spans, er
 	// There may be extra values on the row, e.g. to allow an ordered
 	// synchronizer to interleave multiple input streams. Will need at most
 	// numKeyCols.
-	span, err := ij.spanBuilder.SpanFromEncDatums(row, numKeyCols)
+	span, containsNull, err := ij.spanBuilder.SpanFromEncDatums(row, numKeyCols)
 	if err != nil {
 		return nil, err
 	}
-	return ij.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(span, numKeyCols), nil
+	return ij.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(span, numKeyCols, containsNull), nil
 }
 
 // outputStatsToTrace outputs the collected indexJoiner stats to the trace. Will

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -618,7 +618,8 @@ func (z *zigzagJoiner) produceSpanFromBaseRow() (roachpb.Span, error) {
 		return z.produceInvertedIndexKey(info, neededDatums)
 	}
 
-	return info.spanBuilder.SpanFromEncDatums(neededDatums, len(neededDatums))
+	s, _, err := info.spanBuilder.SpanFromEncDatums(neededDatums, len(neededDatums))
+	return s, err
 }
 
 // Returns the column types of the equality columns.

--- a/pkg/sql/span_builder_test.go
+++ b/pkg/sql/span_builder_test.go
@@ -36,6 +36,7 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 		index             string
 		prefixLen         int
 		numNeededFamilies int
+		containsNull      bool
 		canSplit          bool
 	}{
 		{
@@ -66,26 +67,45 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 			numNeededFamilies: 1,
 			canSplit:          false,
 		},
+		{
+			sql:               "a INT, b INT, c INT, UNIQUE INDEX i (b) STORING (a, c), FAMILY (a), FAMILY (b), FAMILY (c)",
+			index:             "i",
+			prefixLen:         1,
+			numNeededFamilies: 1,
+			containsNull:      true,
+			canSplit:          false,
+		},
+		{
+			sql:               "a INT, b INT, c INT, UNIQUE INDEX i (b) STORING (a, c), FAMILY (a), FAMILY (b), FAMILY (c)",
+			index:             "i",
+			prefixLen:         1,
+			numNeededFamilies: 1,
+			containsNull:      false,
+			canSplit:          true,
+		},
 	}
 	if _, err := sqlDB.Exec("CREATE DATABASE t"); err != nil {
 		t.Fatal(err)
 	}
 	for _, tc := range tcs {
-		if _, err := sqlDB.Exec("DROP TABLE IF EXISTS t.t"); err != nil {
-			t.Fatal(err)
-		}
-		sql := fmt.Sprintf("CREATE TABLE t.t (%s)", tc.sql)
-		if _, err := sqlDB.Exec(sql); err != nil {
-			t.Fatal(err)
-		}
-		desc := sqlbase.GetTableDescriptor(kvDB, "t", "t")
-		idx, _, err := desc.FindIndexByName(tc.index)
-		if err != nil {
-			t.Fatal(err)
-		}
-		builder := span.MakeBuilder(desc, idx)
-		if res := builder.CanSplitSpanIntoSeparateFamilies(tc.numNeededFamilies, tc.prefixLen); res != tc.canSplit {
-			t.Errorf("expected result to be %v, but found %v", tc.canSplit, res)
-		}
+		t.Run(tc.sql, func(t *testing.T) {
+			if _, err := sqlDB.Exec("DROP TABLE IF EXISTS t.t"); err != nil {
+				t.Fatal(err)
+			}
+			sql := fmt.Sprintf("CREATE TABLE t.t (%s)", tc.sql)
+			if _, err := sqlDB.Exec(sql); err != nil {
+				t.Fatal(err)
+			}
+			desc := sqlbase.GetTableDescriptor(kvDB, "t", "t")
+			idx, _, err := desc.FindIndexByName(tc.index)
+			if err != nil {
+				t.Fatal(err)
+			}
+			builder := span.MakeBuilder(desc, idx)
+			if res := builder.CanSplitSpanIntoSeparateFamilies(
+				tc.numNeededFamilies, tc.prefixLen, tc.containsNull); res != tc.canSplit {
+				t.Errorf("expected result to be %v, but found %v", tc.canSplit, res)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #42956.

This PR adds family specific span generation to secondary indexes,
when applicable. In particular, we can generate family specific spans
for secondary indexes if the secondary index is unique, and the
constraints in the indexed columns do not contain null.

Release note (performance improvement): secondary indexes that store
columns on tables with column families can now perform reads on
only the needed columns in single row reads.