### PR TITLE
flowinfra: fix shutting down vectorized flows with wrapped processors

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -348,7 +348,8 @@ func (ds *ServerImpl) setupFlow(
 		// to use the RootTxn.
 		opt = flowinfra.FuseAggressively
 	}
-	if err := f.Setup(ctx, &req.Flow, opt); err != nil {
+	var err error
+	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
 		tracing.FinishSpan(sp)
 		ctx = opentracing.ContextWithSpan(ctx, nil)

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -69,6 +69,9 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx, err = base.Setup(ctx, nil, flowinfra.FuseAggressively)
+	require.NoError(t, err)
+
 	base.SetProcessors([]execinfra.Processor{mat})
 	// This test specifically verifies that a flow doesn't get stuck in Wait for
 	// asynchronous components that haven't been signaled to exit. To simulate

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -63,8 +63,11 @@ const (
 // Flow represents a flow which consists of processors and streams.
 type Flow interface {
 	// Setup sets up all the infrastructure for the flow as defined by the flow
-	// spec. The flow will then need to be started and run.
-	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) error
+	// spec. The flow will then need to be started and run. A new context (along
+	// with a context cancellation function) is derived. The new context must be
+	// used when running a flow so that all components running in their own
+	// goroutines could listen for a cancellation on the same context.
+	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) (context.Context, error)
 
 	// SetTxn is used to provide the transaction in which the flow will run.
 	// It needs to be called after Setup() and before Start/Run.
@@ -168,8 +171,13 @@ type FlowBase struct {
 }
 
 // Setup is part of the Flow interface.
-func (f *FlowBase) Setup(context.Context, *execinfrapb.FlowSpec, FuseOpt) error {
-	panic("Setup should not be called on FlowBase")
+func (f *FlowBase) Setup(
+	ctx context.Context, spec *execinfrapb.FlowSpec, _ FuseOpt,
+) (context.Context, error) {
+	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
+	f.ctxDone = ctx.Done()
+	f.spec = spec
+	return ctx, nil
 }
 
 // SetTxn is part of the Flow interface.
@@ -240,12 +248,6 @@ func (f *FlowBase) GetCtxDone() <-chan struct{} {
 	return f.ctxDone
 }
 
-// SetSpec sets the flow spec of this flow. This is useful for debugging
-// purposes.
-func (f *FlowBase) SetSpec(spec *execinfrapb.FlowSpec) {
-	f.spec = spec
-}
-
 // GetCancelFlowFn returns the context cancellation function of the context of
 // this flow.
 func (f *FlowBase) GetCancelFlowFn() context.CancelFunc {
@@ -275,19 +277,14 @@ func (f *FlowBase) GetLocalProcessors() []execinfra.LocalProcessor {
 
 // startInternal starts the flow. All processors are started, each in their own
 // goroutine. The caller must forward any returned error to syncFlowConsumer if
-// set. A new context is derived and returned, and it must be used when this
-// method returns so that all components running in their own goroutines could
-// listen for a cancellation on the same context.
+// set.
 func (f *FlowBase) startInternal(
 	ctx context.Context, processors []execinfra.Processor, doneFn func(),
-) (context.Context, error) {
+) error {
 	f.doneFn = doneFn
 	log.VEventf(
 		ctx, 1, "starting (%d processors, %d startables)", len(processors), len(f.startables),
 	)
-
-	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
-	f.ctxDone = ctx.Done()
 
 	// Only register the flow if there will be inbound stream connections that
 	// need to look up this flow in the flow registry.
@@ -301,7 +298,7 @@ func (f *FlowBase) startInternal(
 		if err := f.flowRegistry.RegisterFlow(
 			ctx, f.ID, f, f.inboundStreams, SettingFlowStreamTimeout.Get(&f.FlowCtx.Cfg.Settings.SV),
 		); err != nil {
-			return ctx, err
+			return err
 		}
 	}
 
@@ -321,7 +318,7 @@ func (f *FlowBase) startInternal(
 		}(i)
 	}
 	f.startedGoroutines = len(f.startables) > 0 || len(processors) > 0 || !f.IsLocal()
-	return ctx, nil
+	return nil
 }
 
 // IsLocal returns whether this flow does not have any remote execution.
@@ -336,7 +333,7 @@ func (f *FlowBase) IsVectorized() bool {
 
 // Start is part of the Flow interface.
 func (f *FlowBase) Start(ctx context.Context, doneFn func()) error {
-	if _, err := f.startInternal(ctx, f.processors, doneFn); err != nil {
+	if err := f.startInternal(ctx, f.processors, doneFn); err != nil {
 		// For sync flows, the error goes to the consumer.
 		if f.syncFlowConsumer != nil {
 			f.syncFlowConsumer.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: err})
@@ -361,7 +358,7 @@ func (f *FlowBase) Run(ctx context.Context, doneFn func()) error {
 	otherProcs := f.processors[:len(f.processors)-1]
 
 	var err error
-	if ctx, err = f.startInternal(ctx, otherProcs, doneFn); err != nil {
+	if err = f.startInternal(ctx, otherProcs, doneFn); err != nil {
 		// For sync flows, the error goes to the consumer.
 		if f.syncFlowConsumer != nil {
 			f.syncFlowConsumer.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: err})

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_shutdown
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_shutdown
@@ -1,0 +1,30 @@
+# LogicTest: fakedist-vec
+
+# This is a regression test for #43269 - incomplete shutdown of the vectorized
+# flows with wrapped processors.
+
+statement ok
+CREATE TABLE square (n INT PRIMARY KEY, sq INT)
+
+statement ok
+INSERT INTO square VALUES (1,1), (2,4), (3,9), (4,16), (5,25), (6,36)
+
+statement ok
+CREATE TABLE pairs (a INT8, b INT8, FAMILY (a), FAMILY (b))
+
+statement ok
+INSERT INTO pairs VALUES (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (2,3), (2,4), (2,5), (2,6), (3,4), (3,5), (3,6), (4,5), (4,6)
+
+statement ok
+SELECT
+	*
+FROM
+	(
+		SELECT
+			*
+		FROM
+			pairs
+			LEFT JOIN square ON b = sq AND a > 1 AND n < 6
+	)
+WHERE
+	b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a < sq)

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -48,16 +48,20 @@ func NewRowBasedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 // Setup if part of the flowinfra.Flow interface.
 func (f *rowBasedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
-) error {
-	f.SetSpec(spec)
+) (context.Context, error) {
+	var err error
+	ctx, err = f.FlowBase.Setup(ctx, spec, opt)
+	if err != nil {
+		return ctx, err
+	}
 	// First step: setup the input synchronizers for all processors.
 	inputSyncs, err := f.setupInputSyncs(ctx, spec, opt)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// Then, populate processors.
-	return f.setupProcessors(ctx, spec, inputSyncs)
+	return ctx, f.setupProcessors(ctx, spec, inputSyncs)
 }
 
 // setupProcessors creates processors for each spec in f.spec, fusing processors


### PR DESCRIPTION
flowinfra: fix shutting down vectorized flows with wrapped processors

Our flow shutdown mechanism relies on all components to listen to the
same context which is canceled by the "root" component (either
materializer or outbox) when the query needs to exit. Columnarizers
currently capture the context that is passed into their constructor
and will pass that context further into their downstream operators.
However, I believe it is possible that the cancellation of the "flow"
context will not trigger the cancellation of the columnarizer's context,
so some components are left hanging.

The problem was that we derived a new context in `startInternal` call,
but it was not returned outside of `FlowBase.Setup` method, so
ServerImpl.setupFlow used to return an old context. Now this is fixed by
doing the context derivation as the first step of `Setup` and returning
it.

Fixes: #43269.

Release note (bug fix): Previously, a query shutdown mechanism could fail
to fully cleanup the infrastructure when the query was executed via the
vectorized engine and the query plan contained wrapped row-by-row
processors (in 19.2 release those are Lookup join and Index join).