### PR TITLE
util/hlc: create LessEq timestamp comparator

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1449,7 +1449,7 @@ func doRestorePlan(
 		ok := false
 		for _, b := range mainBackupDescs {
 			// Find the backup that covers the requested time.
-			if b.StartTime.Less(endTime) && !b.EndTime.Less(endTime) {
+			if b.StartTime.Less(endTime) && endTime.LessEq(b.EndTime) {
 				ok = true
 				// Ensure that the backup actually has revision history.
 				if b.MVCCFilter != MVCCFilter_All {
@@ -1462,7 +1462,7 @@ func doRestorePlan(
 				// example if start time is 0 (full backup), the revision history was
 				// only captured since the GC window. Note that the RevisionStartTime is
 				// the latest for ranges backed up.
-				if !b.RevisionStartTime.Less(endTime) {
+				if endTime.LessEq(b.RevisionStartTime) {
 					return errors.Errorf(
 						"incompatible RESTORE timestamp: BACKUP for requested time only has revision history from %v", b.RevisionStartTime,
 					)

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -73,7 +73,7 @@ func (v *orderValidator) NoteRow(
 
 	timestamps := v.keyTimestamps[key]
 	timestampsIdx := sort.Search(len(timestamps), func(i int) bool {
-		return !timestamps[i].Less(updated)
+		return updated.LessEq(timestamps[i])
 	})
 	seen := timestampsIdx < len(timestamps) && timestamps[timestampsIdx] == updated
 
@@ -426,7 +426,7 @@ func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
 func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
 	if r, ok := v.partitionResolved[partition]; !ok {
 		return errors.Errorf(`unknown partition: %s`, partition)
-	} else if !r.Less(resolved) {
+	} else if resolved.LessEq(r) {
 		return nil
 	}
 	v.partitionResolved[partition] = resolved
@@ -440,7 +440,7 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 			newResolved = r
 		}
 	}
-	if !v.resolved.Less(newResolved) {
+	if newResolved.LessEq(v.resolved) {
 		return nil
 	}
 	v.resolved = newResolved
@@ -486,7 +486,7 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 		v.previousRowUpdateTs = row.updated
 	}
 
-	if !v.firstRowTimestamp.IsEmpty() && !resolved.Less(v.firstRowTimestamp) &&
+	if !v.firstRowTimestamp.IsEmpty() && v.firstRowTimestamp.LessEq(resolved) &&
 		lastFingerprintedAt != resolved {
 		return v.fingerprint(resolved)
 	}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -240,7 +240,7 @@ func emitEntries(
 		// it's forwarded before.
 		// TODO(dan): This should be an assertion once we're confident this can never
 		// happen under any circumstance.
-		if !sf.Frontier().Less(row.updated) {
+		if row.updated.LessEq(sf.Frontier()) {
 			log.Errorf(ctx, "cdc ux violation: detected timestamp %s that is less than "+
 				"or equal to the local frontier %s.", cloudStorageFormatTime(row.updated),
 				cloudStorageFormatTime(sf.Frontier()))

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -353,7 +353,7 @@ func TestAvroEncoder(t *testing.T) {
 			`foo: {"a":{"long":2}}->{"after":{"foo":{"a":{"long":2},"b":null}},"before":null}`,
 		})
 		resolved := expectResolvedTimestampAvro(t, reg, foo)
-		if ts := parseTimeToHLC(t, ts1); !ts.Less(resolved) {
+		if ts := parseTimeToHLC(t, ts1); resolved.LessEq(ts) {
 			t.Fatalf(`expected a resolved timestamp greater than %s got %s`, ts, resolved)
 		}
 

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -321,7 +321,7 @@ func (p *poller) rangefeedImplIter(ctx context.Context, i int) error {
 					return err
 				}
 				p.mu.Lock()
-				if len(p.mu.scanBoundaries) > 0 && !resolvedTS.Less(p.mu.scanBoundaries[0]) {
+				if len(p.mu.scanBoundaries) > 0 && p.mu.scanBoundaries[0].LessEq(resolvedTS) {
 					boundaryBreak = true
 					resolvedTS = p.mu.scanBoundaries[0]
 				}
@@ -504,7 +504,7 @@ func (p *poller) exportSpan(
 
 func (p *poller) updateTableHistory(ctx context.Context, endTS hlc.Timestamp) error {
 	startTS := p.tableHist.HighWater()
-	if !startTS.Less(endTS) {
+	if endTS.LessEq(startTS) {
 		return nil
 	}
 	descs, err := fetchTableDescriptorVersions(ctx, p.db, startTS, endTS, p.details.Targets)

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -60,7 +60,7 @@ func evalExport(
 	// note the supported time bounds for RESTORE AS OF SYSTEM TIME.
 	gcThreshold := cArgs.EvalCtx.GetGCThreshold()
 	if !args.StartTime.IsEmpty() {
-		if !gcThreshold.Less(args.StartTime) {
+		if args.StartTime.LessEq(gcThreshold) {
 			return result.Result{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)
 		}
 	} else if args.MVCCFilter == roachpb.MVCCFilter_All {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -405,7 +405,7 @@ func (tc *TxnCoordSender) commitReadOnlyTxnLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) *roachpb.Error {
 	deadline := ba.Requests[0].GetEndTxn().Deadline
-	if deadline != nil && !tc.mu.txn.WriteTimestamp.Less(*deadline) {
+	if deadline != nil && deadline.LessEq(tc.mu.txn.WriteTimestamp) {
 		txn := tc.mu.txn.Clone()
 		pErr := generateTxnDeadlineExceededErr(txn, *deadline)
 		// We need to bump the epoch and transform this retriable error.

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -1188,7 +1188,7 @@ func TestTxnRestartCount(t *testing.T) {
 		t.Fatal(err)
 	}
 	proto := txn.TestingCloneTxn()
-	if !proto.ReadTimestamp.Less(proto.WriteTimestamp) {
+	if proto.WriteTimestamp.LessEq(proto.ReadTimestamp) {
 		t.Errorf("expected timestamp to increase: %s", proto)
 	}
 

--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -254,7 +254,7 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 
 	// Check if the (read-only) txn was pushed above its deadline.
 	deadline := et.Deadline
-	if deadline != nil && !br.Txn.WriteTimestamp.Less(*deadline) {
+	if deadline != nil && deadline.LessEq(br.Txn.WriteTimestamp) {
 		return nil, generateTxnDeadlineExceededErr(ba.Txn, *deadline)
 	}
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1685,7 +1685,7 @@ func (l Lease) Equivalent(newL Lease) bool {
 		// For expiration-based leases, extensions are considered equivalent.
 		// This is the one case where Equivalent is not commutative and, as
 		// such, requires special handling beneath Raft (see checkForcedErrLocked).
-		if !newL.GetExpiration().Less(l.GetExpiration()) {
+		if l.GetExpiration().LessEq(newL.GetExpiration()) {
 			l.Expiration, newL.Expiration = nil, nil
 		}
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -306,7 +306,7 @@ func (tc *TableCollection) getTableVersion(
 		return nil, err
 	}
 
-	if !readTimestamp.Less(expiration) {
+	if expiration.LessEq(readTimestamp) {
 		log.Fatalf(ctx, "bad table for T=%s, expiration=%s", readTimestamp, expiration)
 	}
 
@@ -371,7 +371,7 @@ func (tc *TableCollection) getTableVersionByID(
 		return nil, err
 	}
 
-	if !readTimestamp.Less(expiration) {
+	if expiration.LessEq(readTimestamp) {
 		log.Fatalf(ctx, "bad table for T=%s, expiration=%s", readTimestamp, expiration)
 	}
 

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -378,7 +378,7 @@ func EndTxn(
 // IsEndTxnExceedingDeadline returns true if the transaction exceeded its
 // deadline.
 func IsEndTxnExceedingDeadline(t hlc.Timestamp, args *roachpb.EndTxnRequest) bool {
-	return args.Deadline != nil && !t.Less(*args.Deadline)
+	return args.Deadline != nil && args.Deadline.LessEq(t)
 }
 
 // IsEndTxnTriggeringRetryError returns true if the EndTxnRequest cannot be

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -101,7 +101,7 @@ func evalNewLease(
 	// a newFailedLeaseTrigger() to satisfy stats.
 
 	// Ensure either an Epoch is set or Start < Expiration.
-	if (lease.Type() == roachpb.LeaseExpiration && !lease.Start.Less(lease.GetExpiration())) ||
+	if (lease.Type() == roachpb.LeaseExpiration && lease.GetExpiration().LessEq(lease.Start)) ||
 		(lease.Type() == roachpb.LeaseEpoch && lease.Expiration != nil) {
 		// This amounts to a bug.
 		return newFailedLeaseTrigger(isTransfer),

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -184,7 +184,7 @@ func PushTxn(
 
 	// If we're trying to move the timestamp forward, and it's already
 	// far enough forward, return success.
-	if args.PushType == roachpb.PUSH_TIMESTAMP && !reply.PusheeTxn.WriteTimestamp.Less(args.PushTo) {
+	if args.PushType == roachpb.PUSH_TIMESTAMP && args.PushTo.LessEq(reply.PusheeTxn.WriteTimestamp) {
 		// Trivial noop.
 		return result.Result{}, nil
 	}

--- a/pkg/storage/batcheval/cmd_refresh.go
+++ b/pkg/storage/batcheval/cmd_refresh.go
@@ -63,7 +63,7 @@ func Refresh(
 	if err != nil {
 		return result.Result{}, err
 	} else if val != nil {
-		if ts := val.Timestamp; !ts.Less(refreshFrom) {
+		if ts := val.Timestamp; refreshFrom.LessEq(ts) {
 			return result.Result{}, errors.Errorf("encountered recently written key %s @%s", args.Key, ts)
 		}
 	}

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -64,7 +64,7 @@ func RefreshRange(
 			Tombstones:   true,
 		},
 		func(kv roachpb.KeyValue) (bool, error) {
-			if ts := kv.Value.Timestamp; !ts.Less(refreshFrom) {
+			if ts := kv.Value.Timestamp; refreshFrom.LessEq(ts) {
 				return true, errors.Errorf("encountered recently written key %s @%s", kv.Key, ts)
 			}
 			return false, nil

--- a/pkg/storage/batcheval/cmd_revert_range.go
+++ b/pkg/storage/batcheval/cmd_revert_range.go
@@ -73,7 +73,7 @@ func RevertRange(
 	reply := resp.(*roachpb.RevertRangeResponse)
 	var pd result.Result
 
-	if gc := cArgs.EvalCtx.GetGCThreshold(); !gc.Less(args.TargetTime) {
+	if gc := cArgs.EvalCtx.GetGCThreshold(); args.TargetTime.LessEq(gc) {
 		return result.Result{}, errors.Errorf("cannot revert before replica GC threshold %v", gc)
 	}
 

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -499,7 +499,7 @@ func mergeCheckingTimestampCaches(t *testing.T, disjointLeaseholders bool) {
 	ba.Add(incrementArgs(rhsKey, 1))
 	if br, pErr := lhsStore.Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
-	} else if !readTS.Less(br.Timestamp) {
+	} else if br.Timestamp.LessEq(readTS) {
 		t.Fatalf("expected write to execute after %v, but executed at %v", readTS, br.Timestamp)
 	}
 
@@ -662,7 +662,7 @@ func TestStoreRangeMergeTimestampCacheCausality(t *testing.T) {
 	ba.Add(incrementArgs(rhsKey, 1))
 	if br, pErr := mtc.Store(1).Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
-	} else if !readTS.Less(br.Timestamp) {
+	} else if br.Timestamp.LessEq(readTS) {
 		t.Fatalf("expected write to execute after %v, but executed at %v", readTS, br.Timestamp)
 	}
 }

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -84,7 +84,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 				t.Fatal(pErr)
 			}
 			found = true
-			if !ts.Less(resp.Txn.WriteTimestamp) || resp.Txn.ReadTimestamp == resp.Txn.WriteTimestamp {
+			if resp.Txn.WriteTimestamp.LessEq(ts) || resp.Txn.ReadTimestamp == resp.Txn.WriteTimestamp {
 				t.Fatal("timestamp did not get bumped")
 			}
 			break

--- a/pkg/storage/engine/gc.go
+++ b/pkg/storage/engine/gc.go
@@ -61,7 +61,7 @@ func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) (int, hlc.Tim
 	}
 
 	// find the first expired key index using binary search
-	i := sort.Search(len(keys), func(i int) bool { return !gc.Threshold.Less(keys[i].Timestamp) })
+	i := sort.Search(len(keys), func(i int) bool { return keys[i].Timestamp.LessEq(gc.Threshold) })
 
 	if i == len(keys) {
 		return -1, hlc.Timestamp{}

--- a/pkg/storage/engine/mvcc_incremental_iterator.go
+++ b/pkg/storage/engine/mvcc_incremental_iterator.go
@@ -190,7 +190,7 @@ func (i *MVCCIncrementalIterator) advance() {
 
 		metaTimestamp := hlc.Timestamp(i.meta.Timestamp)
 		if i.meta.Txn != nil {
-			if i.startTime.Less(metaTimestamp) && !i.endTime.Less(metaTimestamp) {
+			if i.startTime.Less(metaTimestamp) && metaTimestamp.LessEq(i.endTime) {
 				i.err = &roachpb.WriteIntentError{
 					Intents: []roachpb.Intent{{
 						Span:   roachpb.Span{Key: i.iter.Key().Key},
@@ -209,7 +209,7 @@ func (i *MVCCIncrementalIterator) advance() {
 			i.iter.Next()
 			continue
 		}
-		if !i.startTime.Less(metaTimestamp) {
+		if metaTimestamp.LessEq(i.startTime) {
 			i.iter.NextKey()
 			continue
 		}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -374,7 +374,7 @@ func processLocalKeyRange(
 			return err
 		}
 		infoMu.TransactionSpanTotal++
-		if !txn.LastActive().Less(cutoff) {
+		if cutoff.LessEq(txn.LastActive()) {
 			return nil
 		}
 

--- a/pkg/storage/rangefeed/resolved_timestamp.go
+++ b/pkg/storage/rangefeed/resolved_timestamp.go
@@ -246,7 +246,7 @@ func (rts *resolvedTimestamp) assertNoChange() {
 // than the current resolved timestamp. A violation of this assertion would
 // indicate a failure of the closed timestamp mechanism.
 func (rts *resolvedTimestamp) assertOpAboveRTS(op enginepb.MVCCLogicalOp, opTS hlc.Timestamp) {
-	if !rts.resolvedTS.Less(opTS) {
+	if opTS.LessEq(rts.resolvedTS) {
 		panic(fmt.Sprintf("resolved timestamp %s equal to or above timestamp of operation %v",
 			rts.resolvedTS, op))
 	}

--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -315,7 +315,7 @@ func checkForcedErr(
 	// so we must perform this check upstream and downstream of raft.
 	// See #14833.
 	ts := raftCmd.ReplicatedEvalResult.Timestamp
-	if !replicaState.GCThreshold.Less(ts) {
+	if ts.LessEq(*replicaState.GCThreshold) {
 		return leaseIndex, proposalNoReevaluation, roachpb.NewError(&roachpb.BatchTimestampBeforeGCError{
 			Timestamp: ts,
 			Threshold: *replicaState.GCThreshold,

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -431,7 +431,7 @@ func evaluateCommand(
 	// correctly, but various tests insert versioned data without going through
 	// the proper channels. See TestPushTxnUpgradeExistingTxn for an example.
 	//
-	// if header.Txn != nil && !header.Txn.Timestamp.Less(h.Timestamp) {
+	// if header.Txn != nil && h.Timestamp.LessEq(header.Txn.Timestamp) {
 	// 	if now := r.store.Clock().Now(); now.Less(header.Txn.Timestamp) {
 	// 		log.Fatalf(ctx, "hlc clock not updated: %s < %s", now, header.Txn.Timestamp)
 	// 	}

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -63,7 +63,7 @@ func (r *Replica) canServeFollowerRead(
 			ts.Forward(ba.Txn.MaxTimestamp)
 		}
 
-		canServeFollowerRead = !r.maxClosed(ctx).Less(ts)
+		canServeFollowerRead = ts.LessEq(r.maxClosed(ctx))
 		if !canServeFollowerRead {
 			// We can't actually serve the read based on the closed timestamp.
 			// Signal the clients that we want an update so that future requests can succeed.

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -942,7 +942,7 @@ func (r *Replica) redirectOnOrAcquireLease(
 				_, requestPending := r.mu.pendingLeaseRequest.RequestPending()
 				if !requestPending && r.requiresExpiringLeaseRLocked() {
 					renewal := status.Lease.Expiration.Add(-r.store.cfg.RangeLeaseRenewalDuration().Nanoseconds(), 0)
-					if !timestamp.Less(renewal) {
+					if renewal.LessEq(timestamp) {
 						if log.V(2) {
 							log.Infof(ctx, "extending lease %s at %s", status.Lease, timestamp)
 						}

--- a/pkg/storage/replica_send.go
+++ b/pkg/storage/replica_send.go
@@ -604,7 +604,7 @@ func (r *Replica) limitTxnMaxTimestamp(
 		txnClone := ba.Txn.Clone()
 		// The uncertainty window is [ReadTimestamp, maxTS), so if that window
 		// is empty, there won't be any uncertainty restarts.
-		if !ba.Txn.ReadTimestamp.Less(obsTS) {
+		if obsTS.LessEq(ba.Txn.ReadTimestamp) {
 			log.Event(ctx, "read has no clock uncertainty")
 		}
 		txnClone.MaxTimestamp.Backward(obsTS)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -886,7 +886,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 	minLeaseProposedTS := tc.repl.mu.minLeaseProposedTS
 	leaseStartTS := tc.repl.mu.state.Lease.Start
 	tc.repl.mu.Unlock()
-	if !leaseStartTS.Less(minLeaseProposedTS) {
+	if minLeaseProposedTS.LessEq(leaseStartTS) {
 		t.Fatalf("expected minLeaseProposedTS > lease start. minLeaseProposedTS: %s, "+
 			"leas start: %s", minLeaseProposedTS, leaseStartTS)
 	}
@@ -2134,7 +2134,7 @@ func TestAcquireLease(t *testing.T) {
 				if *lease.DeprecatedStartStasis != *lease.Expiration {
 					t.Errorf("%s already in stasis (or beyond): %+v", ts, lease)
 				}
-				if !ts.Less(*lease.Expiration) {
+				if lease.Expiration.LessEq(ts) {
 					t.Errorf("%s already expired: %+v", ts, lease)
 				}
 
@@ -2147,7 +2147,7 @@ func TestAcquireLease(t *testing.T) {
 				// extension, we need to wait for it to go through.
 				testutils.SucceedsSoon(t, func() error {
 					newLease, _ := tc.repl.GetLease()
-					if !lease.Expiration.Less(*newLease.Expiration) {
+					if newLease.Expiration.LessEq(*lease.Expiration) {
 						return errors.Errorf("lease did not get extended: %+v to %+v", lease, newLease)
 					}
 					return nil
@@ -8421,7 +8421,7 @@ func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
-		if !txn.WriteTimestamp.Less(resp.Timestamp) {
+		if resp.Timestamp.LessEq(txn.WriteTimestamp) {
 			t.Fatalf("expected txn ts %s < scan TS %s", txn.WriteTimestamp, resp.Timestamp)
 		}
 		return resp.Timestamp

--- a/pkg/storage/replica_tscache.go
+++ b/pkg/storage/replica_tscache.go
@@ -469,7 +469,7 @@ func (r *Replica) CanCreateTxnRecord(
 	wTS, wTxnID := r.store.tsCache.GetMaxWrite(key, nil /* end */)
 	// Compare against the minimum timestamp that the transaction could have
 	// written intents at.
-	if !wTS.Less(txnMinTS) {
+	if txnMinTS.LessEq(wTS) {
 		switch wTxnID {
 		case txnID:
 			// If we find our own transaction ID then an EndTxn request sent by

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2200,7 +2200,7 @@ func TestStoreScanResumeTSCache(t *testing.T) {
 		t.Errorf("expected timestamp cache for \"b\".Next() set to %s; got %s", e, a)
 	}
 	rTS, _ = store.tsCache.GetMaxRead(roachpb.Key("c"), nil)
-	if a, lt := rTS, makeTS(t1.Nanoseconds(), 0); !a.Less(lt) {
+	if a, lt := rTS, makeTS(t1.Nanoseconds(), 0); lt.LessEq(a) {
 		t.Errorf("expected timestamp cache for \"c\" set less than %s; got %s", lt, a)
 	}
 
@@ -2228,7 +2228,7 @@ func TestStoreScanResumeTSCache(t *testing.T) {
 		t.Errorf("expected timestamp cache for \"a\".Next() set to %s; got %s", e, a)
 	}
 	rTS, _ = store.tsCache.GetMaxRead(roachpb.Key("a"), nil)
-	if a, lt := rTS, makeTS(t2.Nanoseconds(), 0); !a.Less(lt) {
+	if a, lt := rTS, makeTS(t2.Nanoseconds(), 0); lt.LessEq(a) {
 		t.Errorf("expected timestamp cache for \"a\" set less than %s; got %s", lt, a)
 	}
 }

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -287,7 +287,7 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, val cacheValue
 
 	// If floor ts is >= requested timestamp, then no need to perform a search
 	// or add any records.
-	if !s.floorTS.Less(val.ts) {
+	if val.ts.LessEq(s.floorTS) {
 		return nil
 	}
 
@@ -417,7 +417,7 @@ func (s *intervalSkl) rotatePages(filledPage *sklPage) {
 	for s.pages.Len() >= s.minPages {
 		bp := back.Value.(*sklPage)
 		bpMaxTS := hlc.Timestamp{WallTime: bp.maxWallTime}
-		if !bpMaxTS.Less(minTSToRetain) {
+		if minTSToRetain.LessEq(bpMaxTS) {
 			// The back page's maximum timestamp is within the time
 			// window we've promised to retain, so we can't evict it.
 			break

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -832,7 +832,7 @@ func TestIntervalSklFill2(t *testing.T) {
 	for i := 0; i < n; i++ {
 		val := makeVal(makeTS(int64(i), int32(i)), txnID)
 		s.Add(key, val)
-		require.True(t, !s.LookupTimestamp(key).ts.Less(val.ts))
+		require.True(t, val.ts.LessEq(s.LookupTimestamp(key).ts))
 	}
 }
 

--- a/pkg/storage/tscache/tree_impl.go
+++ b/pkg/storage/tscache/tree_impl.go
@@ -520,7 +520,7 @@ func (tc *treeImpl) shouldEvict(size int, key, value interface{}) bool {
 	edge.WallTime -= MinRetentionWindow.Nanoseconds()
 	// We evict and update the low water mark if the proposed evictee's
 	// timestamp is <= than the edge of the window.
-	if !edge.Less(ce.ts) {
+	if ce.ts.LessEq(edge) {
 		tc.lowWater = ce.ts
 		return true
 	}

--- a/pkg/storage/txnwait/queue.go
+++ b/pkg/storage/txnwait/queue.go
@@ -75,7 +75,7 @@ func ShouldPushImmediately(req *roachpb.PushTxnRequest) bool {
 // for transactions with pushed timestamps.
 func isPushed(req *roachpb.PushTxnRequest, txn *roachpb.Transaction) bool {
 	return (txn.Status.IsFinalized() ||
-		(req.PushType == roachpb.PUSH_TIMESTAMP && !txn.WriteTimestamp.Less(req.PushTo)))
+		(req.PushType == roachpb.PUSH_TIMESTAMP && req.PushTo.LessEq(txn.WriteTimestamp)))
 }
 
 // TxnExpiration computes the timestamp after which the transaction will be

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -79,6 +79,25 @@ func TestHLCLess(t *testing.T) {
 	}
 }
 
+func TestHLCLessEq(t *testing.T) {
+	m := NewManualClock(1)
+	c := NewClock(m.UnixNano, time.Nanosecond)
+	a := c.Now()
+	b := a
+	if !a.LessEq(b) || !b.LessEq(a) {
+		t.Errorf("expected %+v == %+v", a, b)
+	}
+	m.Increment(1)
+	b = c.Now()
+	if !a.LessEq(b) || b.LessEq(a) {
+		t.Errorf("expected %+v < %+v", a, b)
+	}
+	a = c.Now() // add one to logical clock from b
+	if !b.LessEq(a) || a.LessEq(b) {
+		t.Errorf("expected %+v < %+v", b, a)
+	}
+}
+
 func TestHLCEqual(t *testing.T) {
 	m := NewManualClock(1)
 	c := NewClock(m.UnixNano, time.Nanosecond)

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -29,9 +29,14 @@ var (
 	MinTimestamp = Timestamp{WallTime: 0, Logical: 1}
 )
 
-// Less compares two timestamps.
+// Less returns whether the receiver is less than the parameter.
 func (t Timestamp) Less(s Timestamp) bool {
 	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical < s.Logical)
+}
+
+// LessEq returns whether the receiver is less than or equal to the parameter.
+func (t Timestamp) LessEq(s Timestamp) bool {
+	return t.Less(s) || t == s
 }
 
 // String implements the fmt.Formatter interface.
@@ -71,7 +76,7 @@ func (t Timestamp) AsOfSystemTime() string {
 	return fmt.Sprintf("%d.%010d", t.WallTime, t.Logical)
 }
 
-// Less compares two timestamps.
+// Less returns whether the receiver is less than the parameter.
 func (t LegacyTimestamp) Less(s LegacyTimestamp) bool {
 	return Timestamp(t).Less(Timestamp(s))
 }

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -40,6 +40,22 @@ func TestLess(t *testing.T) {
 	}
 }
 
+func TestLessEq(t *testing.T) {
+	a := Timestamp{}
+	b := Timestamp{}
+	if !a.LessEq(b) || !b.LessEq(a) {
+		t.Errorf("expected %+v == %+v", a, b)
+	}
+	b = makeTS(1, 0)
+	if !a.LessEq(b) || b.LessEq(a) {
+		t.Errorf("expected %+v < %+v", a, b)
+	}
+	a = makeTS(1, 1)
+	if !b.LessEq(a) || a.LessEq(b) {
+		t.Errorf("expected %+v < %+v", b, a)
+	}
+}
+
 func TestTimestampNext(t *testing.T) {
 	testCases := []struct {
 		ts, expNext Timestamp


### PR DESCRIPTION
This was long overdue. Every instance of `!a.Less(b)` required
more thought than should have been necessary to understand.
These are now all replaced by `b.LessEq(a)`.

Most of this was automated using the replacement:
```
s/!(\S*)\.Less\((\S*)\)/$2.LessEq($1)/g
```

Release note: None