### PR TITLE
release-19.1: storage/intentresolver: don't capture loop iteration vars in async task

### DIFF
--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -61,6 +61,12 @@ const (
 	// (this helps avoid deadlocks during test shutdown).
 	intentResolverTimeout = 30 * time.Second
 
+	// gcBatchSize is the maximum number of transaction records that will be
+	// GCed in a single batch. Batches that span many ranges (which is possible
+	// for the transaction records that spans many ranges) will be split into
+	// many batches by the DistSender.
+	gcBatchSize = 1024
+
 	// intentResolverBatchSize is the maximum number of intents that will be
 	// resolved in a single batch. Batches that span many ranges (which is
 	// possible for the commit of a transaction that spans many ranges) will be
@@ -193,21 +199,25 @@ func New(c Config) *IntentResolver {
 	}
 	ir.mu.inFlightPushes = map[uuid.UUID]int{}
 	ir.mu.inFlightTxnCleanups = map[uuid.UUID]struct{}{}
+	gcBatchSize := gcBatchSize
+	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
+		gcBatchSize = c.TestingKnobs.MaxGCBatchSize
+	}
 	ir.gcBatcher = requestbatcher.New(requestbatcher.Config{
 		Name:            "intent_resolver_gc_batcher",
-		MaxMsgsPerBatch: 1024,
+		MaxMsgsPerBatch: gcBatchSize,
 		MaxWait:         c.MaxGCBatchWait,
 		MaxIdle:         c.MaxGCBatchIdle,
 		Stopper:         c.Stopper,
 		Sender:          c.DB.NonTransactionalSender(),
 	})
-	batchSize := intentResolverBatchSize
+	intentResolutionBatchSize := intentResolverBatchSize
 	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
-		batchSize = c.TestingKnobs.MaxIntentResolutionBatchSize
+		intentResolutionBatchSize = c.TestingKnobs.MaxIntentResolutionBatchSize
 	}
 	ir.irBatcher = requestbatcher.New(requestbatcher.Config{
 		Name:            "intent_resolver_ir_batcher",
-		MaxMsgsPerBatch: batchSize,
+		MaxMsgsPerBatch: intentResolutionBatchSize,
 		MaxWait:         c.MaxIntentResolutionBatchWait,
 		MaxIdle:         c.MaxIntentResolutionBatchIdle,
 		Stopper:         c.Stopper,
@@ -502,7 +512,8 @@ func (ir *IntentResolver) CleanupIntentsAsync(
 	ctx context.Context, intents []result.IntentsWithArg, allowSyncProcessing bool,
 ) error {
 	now := ir.clock.Now()
-	for _, item := range intents {
+	for i := range intents {
+		item := &intents[i] // copy for goroutine
 		if err := ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
 			if _, err := ir.CleanupIntents(ctx, item.Intents, now, roachpb.PUSH_TOUCH); err != nil {
 				if ir.every.ShouldLog() {
@@ -599,7 +610,8 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 	allowSyncProcessing bool,
 ) error {
 	now := ir.clock.Now()
-	for _, et := range endTxns {
+	for i := range endTxns {
+		et := &endTxns[i] // copy for goroutine
 		if err := ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
 			locked, release := ir.lockInFlightTxnCleanup(ctx, et.Txn.ID)
 			if !locked {

--- a/pkg/storage/intentresolver/intent_resolver_test.go
+++ b/pkg/storage/intentresolver/intent_resolver_test.go
@@ -18,6 +18,7 @@ package intentresolver
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -551,16 +553,92 @@ func TestCleanupIntentsAsync(t *testing.T) {
 			}
 			ir := newIntentResolverWithSendFuncs(cfg, sf)
 			err := ir.CleanupIntentsAsync(context.Background(), c.intents, true)
-			testutils.SucceedsSoon(t, func() error {
-				if l := sf.len(); l > 0 {
-					return fmt.Errorf("Still have %d funcs to send", l)
-				}
-				return nil
-			})
+			sf.drain(t)
 			stopper.Stop(context.Background())
 			assert.Nil(t, err, "error from CleanupIntentsAsync")
 		})
 	}
+}
+
+// TestCleanupMultipleIntentsAsync verifies that CleanupIntentsAsync sends the
+// expected requests when multiple IntentsWithArg are provided to it.
+func TestCleanupMultipleIntentsAsync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	txn1 := newTransaction("txn1", roachpb.Key("a"), 1, clock)
+	txn2 := newTransaction("txn2", roachpb.Key("c"), 1, clock)
+	testIntentsWithArg := []result.IntentsWithArg{
+		{Intents: []roachpb.Intent{
+			{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn1.TxnMeta},
+			{Span: roachpb.Span{Key: roachpb.Key("b")}, Txn: txn1.TxnMeta},
+		}},
+		{Intents: []roachpb.Intent{
+			{Span: roachpb.Span{Key: roachpb.Key("c")}, Txn: txn2.TxnMeta},
+			{Span: roachpb.Span{Key: roachpb.Key("d")}, Txn: txn2.TxnMeta},
+		}},
+	}
+
+	// We expect to see a PushTxn req for each pair of intents and a
+	// ResolveIntent req for each intent. However, because these requests are
+	// all async, it's unclear which order these will be issued in. Handle all
+	// orders and record the resolved intents.
+	var reqs struct {
+		syncutil.Mutex
+		pushed   []string
+		resolved []string
+	}
+	pushOrResolveFunc := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		if len(ba.Requests) != 1 {
+			return nil, roachpb.NewErrorf("unexpected")
+		}
+		ru := ba.Requests[0]
+		switch ru.GetInner().Method() {
+		case roachpb.PushTxn:
+			reqs.Lock()
+			reqs.pushed = append(reqs.pushed, string(ru.GetPushTxn().Key))
+			reqs.Unlock()
+			return pushTxnSendFunc(t, len(ba.Requests))(ba)
+		case roachpb.ResolveIntent:
+			reqs.Lock()
+			reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
+			reqs.Unlock()
+			return resolveIntentsSendFunc(t)(ba)
+		default:
+			return nil, roachpb.NewErrorf("unexpected")
+		}
+	}
+	sf := newSendFuncs(t, repeat(pushOrResolveFunc, 6)...)
+
+	stopper := stop.NewStopper()
+	cfg := Config{
+		Stopper: stopper,
+		Clock:   clock,
+		// Don't let the  intent resolution requests be batched with each other.
+		// This would make it harder to determine how to drain sf.
+		TestingKnobs: storagebase.IntentResolverTestingKnobs{
+			MaxIntentResolutionBatchSize: 1,
+		},
+	}
+	ir := newIntentResolverWithSendFuncs(cfg, sf)
+	err := ir.CleanupIntentsAsync(ctx, testIntentsWithArg, false)
+	sf.drain(t)
+	stopper.Stop(ctx)
+	assert.Nil(t, err)
+
+	// Both txns should be pushed and all four intents should be resolved.
+	sort.Strings(reqs.pushed)
+	sort.Strings(reqs.resolved)
+	assert.Equal(t, []string{"a", "c"}, reqs.pushed)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, reqs.resolved)
+}
+
+func repeat(f sendFunc, n int) []sendFunc {
+	fns := make([]sendFunc, n)
+	for i := range fns {
+		fns[i] = f
+	}
+	return fns
 }
 
 func newSendFuncs(t *testing.T, sf ...sendFunc) *sendFuncs {
@@ -590,6 +668,15 @@ func (sf *sendFuncs) popLocked() sendFunc {
 	ret := sf.sendFuncs[0]
 	sf.sendFuncs = sf.sendFuncs[1:]
 	return ret
+}
+
+func (sf *sendFuncs) drain(t *testing.T) {
+	testutils.SucceedsSoon(t, func() error {
+		if l := sf.len(); l > 0 {
+			return errors.Errorf("still have %d funcs to send", l)
+		}
+		return nil
+	})
 }
 
 // TestCleanupTxnIntentsAsync verifies that CleanupTxnIntentsAsync sends the
@@ -659,6 +746,91 @@ func TestCleanupTxnIntentsAsync(t *testing.T) {
 			assert.Equal(t, sf.len(), 0)
 		})
 	}
+}
+
+// TestCleanupMultipleTxnIntentsAsync verifies that CleanupTxnIntentsAsync sends
+// the expected requests when multiple EndTxnIntents are provided to it.
+func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	txn1 := newTransaction("txn1", roachpb.Key("a"), 1, clock)
+	txn2 := newTransaction("txn2", roachpb.Key("c"), 1, clock)
+	testEndTxnIntents := []result.EndTxnIntents{
+		{
+			Txn: roachpb.Transaction{
+				TxnMeta: txn1.TxnMeta,
+				Intents: []roachpb.Span{
+					{Key: roachpb.Key("a")},
+					{Key: roachpb.Key("b")},
+				},
+			},
+		},
+		{
+			Txn: roachpb.Transaction{
+				TxnMeta: txn2.TxnMeta,
+				Intents: []roachpb.Span{
+					{Key: roachpb.Key("c")},
+					{Key: roachpb.Key("d")},
+				},
+			},
+		},
+	}
+
+	// We expect to see a ResolveIntent req for each intent and a GC req for
+	// each txn. However, because these requests are all async, it's unclear
+	// which order these will be issued in. Handle all orders and record the
+	// GCed transaction records.
+	var reqs struct {
+		syncutil.Mutex
+		resolved []string
+		gced     []string
+	}
+	resolveOrGCFunc := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		if len(ba.Requests) != 1 {
+			return nil, roachpb.NewErrorf("unexpected")
+		}
+		ru := ba.Requests[0]
+		switch ru.GetInner().Method() {
+		case roachpb.ResolveIntent:
+			reqs.Lock()
+			reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
+			reqs.Unlock()
+			return resolveIntentsSendFunc(t)(ba)
+		case roachpb.GC:
+			reqs.Lock()
+			reqs.gced = append(reqs.gced, string(ru.GetGc().Key))
+			reqs.Unlock()
+			return gcSendFunc(t)(ba)
+		default:
+			return nil, roachpb.NewErrorf("unexpected")
+		}
+	}
+	sf := newSendFuncs(t, repeat(resolveOrGCFunc, 6)...)
+
+	stopper := stop.NewStopper()
+	cfg := Config{
+		Stopper: stopper,
+		Clock:   clock,
+		// Don't let the transaction record GC requests or the intent resolution
+		// requests be batched with each other. This would make it harder to
+		// determine how to drain sf.
+		TestingKnobs: storagebase.IntentResolverTestingKnobs{
+			MaxGCBatchSize:               1,
+			MaxIntentResolutionBatchSize: 1,
+		},
+	}
+	ir := newIntentResolverWithSendFuncs(cfg, sf)
+	err := ir.CleanupTxnIntentsAsync(ctx, 1, testEndTxnIntents, false)
+	sf.drain(t)
+	stopper.Stop(ctx)
+	assert.Nil(t, err)
+
+	// All four intents should be resolved and both txn records should be GCed.
+	sort.Strings(reqs.resolved)
+	sort.Strings(reqs.gced)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, reqs.resolved)
+	assert.Equal(t, []string{"a", "c"}, reqs.gced)
 }
 
 func counterSendFuncs(counter *int64, funcs []sendFunc) []sendFunc {

--- a/pkg/storage/storagebase/knobs.go
+++ b/pkg/storage/storagebase/knobs.go
@@ -49,6 +49,10 @@ type IntentResolverTestingKnobs struct {
 	// to -1.
 	ForceSyncIntentResolution bool
 
+	// MaxGCBatchSize overrides the maximum number of transaction record gc
+	// requests which can be sent in a single batch.
+	MaxGCBatchSize int
+
 	// MaxIntentResolutionBatchSize overrides the maximum number of intent
 	// resolution requests which can be sent in a single batch.
 	MaxIntentResolutionBatchSize int


### PR DESCRIPTION
Backport 1/1 commits from #43563.

/cc @cockroachdb/release

---

It's unclear if we've ever seen issues from this, but I intend to backport the
fix to v19.2, v19.1, and v2.1. I believe the worst thing that could have
happened is that a batch that observed multiple intents or pushed multiple txns
would only end up cleaning up a single one of these. It would then run into some
of these intents again when it tried to re-evaluate, forcing it to push again.
This subverts the parallelism that we were trying to achieve here, but would
never cause a stall.

Release note (bug fix): Ensure that all intents or transactions that a
batch observes are asynchronously cleaned up.
