### PR TITLE
kv: don't close TCS interceptors on errors

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -770,15 +770,14 @@ func (tc *TxnCoordSender) updateStateLocked(
 		return roachpb.NewError(err)
 	}
 
-	// This is the non-retriable error case.
+	// This is the non-retriable error case. The client is expected to send a
+	// rollback.
 	if errTxn := pErr.GetTxn(); errTxn != nil {
 		tc.mu.txnState = txnError
 		tc.mu.storedErr = roachpb.NewError(&roachpb.TxnAlreadyEncounteredErrorError{
 			PrevError: pErr.String(),
 		})
-		// Cleanup.
 		tc.mu.txn.Update(errTxn)
-		tc.cleanupTxnLocked(ctx)
 	}
 	return pErr
 }


### PR DESCRIPTION
Before this patch, the TxnCoordSender was closing all the interceptors
when on non-retriable errors. This was a useless optimization serving to
stop the heartbeat loop early; the client was required to send a
rollback to clean up the intents.
This patch gets rid of the optimization in anticipation of the
savepoints API, which will serve for error recovery.

Release note: None