### PR TITLE
sql: move Arul's TODOs to Solon

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -359,7 +359,7 @@ func qualifyFKColErrorWithDB(
 		return tree.ErrString(tree.NewUnresolvedName(tbl.Name, col))
 	}
 
-	// TODO(whomever): this ought to use a database cache.
+	// TODO(solon): this ought to use a database cache.
 	db, err := sqlbase.GetDatabaseDescFromID(ctx, txn, tbl.ParentID)
 	if err != nil {
 		return tree.ErrString(tree.NewUnresolvedName(tbl.Name, col))

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -250,7 +250,7 @@ func (dc *databaseCache) getCachedDatabaseID(name string) (sqlbase.ID, error) {
 	nameVal := dc.systemConfig.GetValue(nameKey.Key())
 	if nameVal == nil {
 		// Try the deprecated system.namespace before returning InvalidID.
-		// TODO(whomever): This can be removed in 20.2.
+		// TODO(solon): This can be removed in 20.2.
 		nameKey = sqlbase.NewDeprecatedDatabaseKey(name)
 		nameVal = dc.systemConfig.GetValue(nameKey.Key())
 		if nameVal == nil {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -62,7 +62,7 @@ func (p *planner) createDatabase(
 ) (bool, error) {
 	shouldCreatePublicSchema := true
 	dKey := sqlbase.MakeDatabaseNameKey(ctx, p.ExecCfg().Settings, desc.Name)
-	// TODO(whomever): This conditional can be removed in 20.2. Every database
+	// TODO(solon): This conditional can be removed in 20.2. Every database
 	// is created with a public schema for cluster version >= 20.1, so we can remove
 	// the `shouldCreatePublicSchema` logic as well.
 	if !cluster.Version.IsActive(ctx, p.ExecCfg().Settings, cluster.VersionNamespaceTableWithSchemas) {
@@ -88,7 +88,7 @@ func (p *planner) createDatabase(
 		return true, err
 	}
 
-	// TODO(whomever): This check should be removed and a public schema should
+	// TODO(solon): This check should be removed and a public schema should
 	// be created in every database in >= 20.2.
 	if shouldCreatePublicSchema {
 		// Every database must be initialized with the public schema.
@@ -252,7 +252,7 @@ func GetAllDatabaseDescriptorIDs(ctx context.Context, txn *client.Txn) ([]sqlbas
 	// See the comment in physical_schema_accessors.go,
 	// func (a UncachedPhysicalAccessor) GetObjectNames. Same concept
 	// applies here.
-	// TODO(whomever): This complexity can be removed in 20.2.
+	// TODO(solon): This complexity can be removed in 20.2.
 	nameKey = sqlbase.NewDeprecatedDatabaseKey("" /* name */).Key()
 	dkvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /* maxRows */)
 	if err != nil {

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -38,7 +38,7 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 		// we explicitly set the SchemaName to `public` for temporary tables, as
 		// the public schema is guaranteed to exist. This ensures the FQN can be
 		// resolved correctly.
-		// TODO(whomever): Once it is possible to drop schemas, it will no longer be
+		// TODO(solon): Once it is possible to drop schemas, it will no longer be
 		// safe to set the schema name to `public`, as it may have been dropped.
 		ct.Table.TableNamePrefix.SchemaName = tree.PublicSchemaName
 		ct.Temporary = true

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -136,7 +136,7 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	// copied into the newer system.namespace. Objects created in this window
 	// will only be present in the older system.namespace. To account for this
 	// scenario, we must do this filtering logic.
-	// TODO(whomever): This complexity can be removed in  20.2.
+	// TODO(solon): This complexity can be removed in  20.2.
 	dprefix := sqlbase.NewDeprecatedTableKey(dbDesc.ID, "").Key()
 	dsr, err := txn.Scan(ctx, dprefix, dprefix.PrefixEnd(), 0)
 	if err != nil {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -82,7 +82,7 @@ type SchemaAccessor interface {
 
 	// GetObjectNames returns the list of all objects in the given
 	// database and schema.
-	// TODO(whomever): when separate schemas are supported, this
+	// TODO(solon): when separate schemas are supported, this
 	// API should be extended to use schema descriptors.
 	GetObjectNames(ctx context.Context, txn *client.Txn, db *DatabaseDescriptor, scName string, flags tree.DatabaseListFlags) (TableNames, error)
 

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -144,7 +144,7 @@ func (ms MetadataSchema) GetInitialValues(
 		value := roachpb.Value{}
 		value.SetInt(int64(desc.GetID()))
 
-		// TODO(whomever): This if/else can be removed in 20.2, as there will be no
+		// TODO(solon): This if/else can be removed in 20.2, as there will be no
 		// need to support the deprecated namespace table.
 		if bootstrapVersion.IsActive(cluster.VersionNamespaceTableWithSchemas) {
 			if parentID != keys.RootNamespaceID {

--- a/pkg/sql/sqlbase/namespace.go
+++ b/pkg/sql/sqlbase/namespace.go
@@ -32,7 +32,7 @@ import (
 // To ensure accesses are seamless across mixed version clusters, >= 20.1 clusters,
 // and during the upgrade process, the following functions should be used
 // for adding/removing entries.
-// TODO(whomever): The fallback semantics will no longer be required in 20.2.
+// TODO(solon): The fallback semantics will no longer be required in 20.2.
 // This code should be cleaned up then, to only access the new system.namespace
 // table.
 
@@ -66,14 +66,14 @@ func RemoveObjectNamespaceEntry(
 	// or the deprecated version. Thus we try to remove the mapping from both.
 	if parentID == keys.RootNamespaceID {
 		toDelete = append(toDelete, NewDatabaseKey(name))
-		// TODO(whomever): This can be completely removed in 20.2.
+		// TODO(solon): This can be completely removed in 20.2.
 		toDelete = append(toDelete, NewDeprecatedDatabaseKey(name))
 	} else if parentSchemaID == keys.RootNamespaceID {
 		// Schemas were introduced in 20.1.
 		toDelete = append(toDelete, NewSchemaKey(parentID, name))
 	} else {
 		toDelete = append(toDelete, NewTableKey(parentID, parentSchemaID, name))
-		// TODO(whomever): This can be completely removed in 20.2.
+		// TODO(solon): This can be completely removed in 20.2.
 		toDelete = append(toDelete, NewDeprecatedTableKey(parentID, name))
 	}
 	for _, delKey := range toDelete {
@@ -117,7 +117,7 @@ func RemoveDatabaseNamespaceEntry(
 func MakeObjectNameKey(
 	ctx context.Context, settings *cluster.Settings, parentID ID, parentSchemaID ID, name string,
 ) DescriptorKey {
-	// TODO(whomever): This if condition can be removed in 20.2
+	// TODO(solon): This if condition can be removed in 20.2
 	if !cluster.Version.IsActive(ctx, settings, cluster.VersionNamespaceTableWithSchemas) {
 		return NewDeprecatedTableKey(parentID, name)
 	}
@@ -170,7 +170,7 @@ func LookupObjectID(
 	}
 	// If the key wasn't found in the new system.namespace table, it may still
 	// exist in the deprecated system.namespace in the case of mixed version clusters.
-	// TODO(whomever): This can be removed in 20.2.
+	// TODO(solon): This can be removed in 20.2.
 
 	// This fallback logic is only required if the table is under the public schema
 	// or we are resolving a database.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -141,7 +141,7 @@ type TableCollection struct {
 
 	// settings are required to correctly resolve system.namespace accesses in
 	// mixed version (19.2/20.1) clusters.
-	// TODO(whomever): This field could maybe be removed in 20.2.
+	// TODO(solon): This field could maybe be removed in 20.2.
 	settings *cluster.Settings
 }
 


### PR DESCRIPTION
There are a bunch of TODO(whomever) left over. As per the Google style
guide, a TODO is addressed to the person others can ask about the TODO.
Asking whomever is not a thing. Solon, I guess you're the closest thing.

Instead or after this patch, please do me a favor if you don't mind and
improve these TODOs. A bunch of them seem to be about code gated on a
cluster version being ok to remove in the next version. That doesn't
need a TODO.  Others seem to be about not using a DeprecatedDatabaseKey
thing. I think they can all be centralized on the struct definition,
which struct also cries for an explanation.

Release note: None