### PR TITLE
roachtest: add a mixed cluster version test for secondary indexes

### DIFF
--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -33,17 +33,8 @@ func registerEncryption(r *testRegistry) {
 			}
 		}
 
-		stop := func(node int) error {
-			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
-				return err
-			}
-			c.Stop(ctx, c.Node(node))
-			return nil
-		}
-
 		for i := 1; i <= nodes; i++ {
-			if err := stop(i); err != nil {
+			if err := c.StopCockroachGracefullyOnNode(ctx, i); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -72,6 +72,7 @@ func registerTests(r *testRegistry) {
 	registerSchemaChangeInvertedIndex(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)
+	registerSecondaryIndexesMultiVersionCluster(r)
 	registerSQLAlchemy(r)
 	registerSQLSmith(r)
 	registerSyncTest(r)

--- a/pkg/cmd/roachtest/secondary_indexes.go
+++ b/pkg/cmd/roachtest/secondary_indexes.go
@@ -1,0 +1,110 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"runtime"
+
+	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
+	"github.com/stretchr/testify/require"
+)
+
+func registerSecondaryIndexesMultiVersionCluster(r *testRegistry) {
+	runTest := func(ctx context.Context, t *test, c *cluster) {
+		// Start a 3 node 19.2 cluster.
+		goos := ifLocal(runtime.GOOS, "linux")
+		b, err := binfetcher.Download(ctx, binfetcher.Options{
+			Binary:  "cockroach",
+			Version: "v19.2.2",
+			GOOS:    goos,
+			GOARCH:  "amd64",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Put(ctx, b, "./cockroach", c.All())
+		c.Start(ctx, t, c.All())
+		// Create a table with some data, and a secondary index.
+		conn := c.Conn(ctx, 1)
+		if _, err := conn.Exec(`
+CREATE TABLE t (
+	x INT PRIMARY KEY, y INT, z INT, w INT, 
+	INDEX i (y) STORING (z, w), 
+	FAMILY (x), FAMILY (y), FAMILY (z), FAMILY (w)
+);
+INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
+`); err != nil {
+			t.Fatal(err)
+		}
+		t.Status("created sample data")
+
+		upgradeNode := func(node int) {
+			if err := c.StopCockroachGracefullyOnNode(ctx, node); err != nil {
+				t.Fatal(err)
+			}
+			c.Put(ctx, cockroach, "./cockroach", c.Node(node))
+			c.Start(ctx, t, c.Node(node))
+		}
+
+		// Upgrade one of the nodes to the current cockroach version.
+		upgradeNode(1)
+		t.Status("done upgrading node 1")
+
+		// Get a connection to the new node and ensure that we can read the index fine, and
+		// an insert in the mixed cluster setting doesn't result in unreadable data.
+		conn = c.Conn(ctx, 1)
+		if _, err := conn.Exec(`INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {
+			t.Fatal(err)
+		}
+		verifyTable := func(conn *gosql.DB) {
+			rows, err := conn.Query(`SELECT y, z, w FROM t@i ORDER BY y`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := [][]int{
+				{2, 3, 4},
+				{6, 7, 8},
+				{10, 11, 12},
+				{14, 15, 16},
+			}
+			var y, z, w int
+			count := 0
+			for ; rows.Next(); count++ {
+				if err := rows.Scan(&y, &z, &w); err != nil {
+					t.Fatal(err)
+				}
+				found := []int{y, z, w}
+				require.Equal(t, found, expected[count])
+			}
+		}
+		for i := 1; i <= c.spec.NodeCount; i++ {
+			verifyTable(c.Conn(ctx, i))
+		}
+		t.Status("mixed version cluster passed test")
+
+		// Fully upgrade the cluster and ensure that the data is still valid.
+		for i := 2; i <= c.spec.NodeCount; i++ {
+			upgradeNode(i)
+		}
+		for i := 1; i <= c.spec.NodeCount; i++ {
+			verifyTable(c.Conn(ctx, i))
+		}
+		t.Status("passed on fully upgraded cluster")
+	}
+	r.Add(testSpec{
+		Name:       "secondary-index-multi-version",
+		Cluster:    makeClusterSpec(3),
+		MinVersion: "v20.1.0",
+		Run:        runTest,
+	})
+}

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -251,6 +251,16 @@ func (t *test) Fatalf(format string, args ...interface{}) {
 	t.fatalfInner(format, args...)
 }
 
+// FailNow implements the TestingT interface.
+func (t *test) FailNow() {
+	t.Fatal()
+}
+
+// Errorf implements the TestingT interface.
+func (t *test) Errorf(format string, args ...interface{}) {
+	t.Fatalf(format, args...)
+}
+
 func (t *test) fatalfInner(format string, args ...interface{}) {
 	// Skip two frames: our own and the caller.
 	if format != "" {

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -129,24 +129,7 @@ func registerVersion(r *testRegistry) {
 			stop := func(node int) error {
 				m.ExpectDeath()
 				l.Printf("stopping node %d\n", node)
-				port := fmt.Sprintf("{pgport:%d}", node)
-				// Note that the following command line needs to run against both v2.0
-				// and the current branch. Do not change it in a manner that is
-				// incompatible with 2.0.
-				if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port="+port); err != nil {
-					return err
-				}
-				// NB: we still call Stop to make sure the process is dead when we try
-				// to restart it (or we'll catch an error from the RocksDB dir being
-				// locked). This won't happen unless run with --local due to timing.
-				// However, it serves as a reminder that `./cockroach quit` doesn't yet
-				// work well enough -- ideally all listeners and engines are closed by
-				// the time it returns to the client.
-				//
-				// TODO(tschottdorf): should return an error. I doubt that we want to
-				// call these *testing.T-style methods on goroutines.
-				c.Stop(ctx, c.Node(node))
-				return nil
+				return c.StopCockroachGracefullyOnNode(ctx, node)
 			}
 
 			var oldVersion string


### PR DESCRIPTION
In 20.1, secondary indexes that store columns were extended to
respect column families. However, this changed the disk encoding
of these indexes. This roachtest adds a true mixed version cluster
with existing data before an upgrade, and ensures that the new index
encoding/decoding paths are indeed backwards compatible with previous
cockroach versions.

Release note: None