### PR TITLE
release-2.1: sqlmigrations: fix deadlock when ensuring privileges on Lease table

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -636,6 +636,7 @@ func ensureMaxPrivileges(ctx context.Context, r runner) error {
 }
 
 var upgradeDescBatchSize int64 = 10
+var errTxnRestarted = errors.New("upgradeDescsWithFn transaction restarted")
 
 // upgradeTableDescsWithFn runs the provided upgrade functions on each table
 // and database descriptor, persisting any upgrades if the function indicates that the
@@ -648,103 +649,134 @@ func upgradeDescsWithFn(
 	upgradeTableDescFn func(desc *sqlbase.TableDescriptor) (upgraded bool, err error),
 	upgradeDatabaseDescFn func(desc *sqlbase.DatabaseDescriptor) (upgraded bool, err error),
 ) error {
-	// use multiple transactions to prevent blocking reads on the
+	// Use multiple transactions to prevent blocking reads on the
 	// table descriptors while running this upgrade process.
 	startKey := sqlbase.MakeAllDescsMetadataKey()
 	span := roachpb.Span{Key: startKey, EndKey: startKey.PrefixEnd()}
 	for resumeSpan := (roachpb.Span{}); span.Key != nil; span = resumeSpan {
 		// It's safe to use multiple transactions here because it is assumed
 		// that a new table created will be created upgraded.
-		if err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			// Scan a limited batch of keys.
-			b := txn.NewBatch()
-			b.Header.MaxSpanRequestKeys = upgradeDescBatchSize
-			b.Scan(span.Key, span.EndKey)
-			if err := txn.Run(ctx, b); err != nil {
-				return err
-			}
-			result := b.Results[0]
-			kvs := result.Rows
-			// Store away the span for the next batch.
-			resumeSpan = result.ResumeSpan
+		//
+		// However, if a migration transaction encounters an error, we need to
+		// trigger a full abort and try again with a new transaction. Why? An
+		// epoch of the transaction may leave intents on table descriptors. If
+		// a future epoch attempted to read one of these descriptors in a
+		// dependent but separate transaction (e.g. in CountLeases) then we
+		// could create a deadlock scenario. Aborting the txn on each retry
+		// avoids this hazard.
+		//
+		// Note that db.Txn performs retries using the same transaction, so we
+		// have to use our own retry loop outside of it. It would probably be
+		// cleaner and more efficient to avoid db.Txn entirely, but that would
+		// require modifying the runner interface, which isn't worth it.
+	TxnLoop:
+		for {
+			err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+				// Detect retries and abort if necessary.
+				if txn.Serialize().Epoch != 0 {
+					return errTxnRestarted
+				}
 
-			var idVersions []sql.IDVersion
-			var now hlc.Timestamp
-			b = txn.NewBatch()
-			for _, kv := range kvs {
-				var sqlDesc sqlbase.Descriptor
-				if err := kv.ValueProto(&sqlDesc); err != nil {
+				// Scan a limited batch of keys.
+				b := txn.NewBatch()
+				b.Header.MaxSpanRequestKeys = upgradeDescBatchSize
+				b.Scan(span.Key, span.EndKey)
+				if err := txn.Run(ctx, b); err != nil {
 					return err
 				}
-				switch t := sqlDesc.Union.(type) {
-				case *sqlbase.Descriptor_Table:
-					if table := sqlDesc.GetTable(); table != nil && upgradeTableDescFn != nil {
-						if upgraded, err := upgradeTableDescFn(table); err != nil {
-							return err
-						} else if upgraded {
-							// It's safe to ignore the DROP state here and
-							// unconditionally set UpVersion. For proof, see
-							// TestDropTableWhileUpgradingFormat.
-							//
-							// In fact, it's of the utmost importance that this migration
-							// upgrades every last old-format table descriptor, including those
-							// that are dropping. Otherwise, the user could upgrade to a version
-							// without support for reading the old format before the drop
-							// completes, leaving a broken table descriptor and the table's
-							// remaining data around forever. This isn't just a theoretical
-							// concern: consider that dropping a large table can take several
-							// days, while upgrading to a new version can take as little as a
-							// few minutes.
-							table.Version++
-							now = txn.CommitTimestamp()
-							idVersions = append(idVersions,
-								sql.NewIDVersion(
-									table.Name, table.ID, table.Version-2,
-								))
-							// Use ValidateTable() instead of Validate()
-							// because of #26422. We still do not know why
-							// a table can reference a dropped database.
-							if err := table.ValidateTable(nil); err != nil {
-								return err
-							}
+				result := b.Results[0]
+				kvs := result.Rows
+				// Store away the span for the next batch.
+				resumeSpan = result.ResumeSpan
 
-							b.Put(kv.Key, sqlbase.WrapDescriptor(table))
-						}
+				var idVersions []sql.IDVersion
+				b = txn.NewBatch()
+				for _, kv := range kvs {
+					var sqlDesc sqlbase.Descriptor
+					if err := kv.ValueProto(&sqlDesc); err != nil {
+						return err
 					}
-				case *sqlbase.Descriptor_Database:
-					if database := sqlDesc.GetDatabase(); database != nil && upgradeDatabaseDescFn != nil {
-						if upgraded, err := upgradeDatabaseDescFn(database); err != nil {
-							return err
-						} else if upgraded {
-							if err := database.Validate(); err != nil {
+					switch t := sqlDesc.Union.(type) {
+					case *sqlbase.Descriptor_Table:
+						if table := sqlDesc.GetTable(); table != nil && upgradeTableDescFn != nil {
+							if upgraded, err := upgradeTableDescFn(table); err != nil {
 								return err
+							} else if upgraded {
+								// It's safe to ignore the DROP state here and
+								// unconditionally set UpVersion. For proof, see
+								// TestDropTableWhileUpgradingFormat.
+								//
+								// In fact, it's of the utmost importance that this migration
+								// upgrades every last old-format table descriptor, including those
+								// that are dropping. Otherwise, the user could upgrade to a version
+								// without support for reading the old format before the drop
+								// completes, leaving a broken table descriptor and the table's
+								// remaining data around forever. This isn't just a theoretical
+								// concern: consider that dropping a large table can take several
+								// days, while upgrading to a new version can take as little as a
+								// few minutes.
+								table.Version++
+								idVersions = append(idVersions,
+									sql.NewIDVersion(
+										table.Name, table.ID, table.Version-2,
+									))
+								// Use ValidateTable() instead of Validate()
+								// because of #26422. We still do not know why
+								// a table can reference a dropped database.
+								if err := table.ValidateTable(nil); err != nil {
+									return err
+								}
+
+								b.Put(kv.Key, sqlbase.WrapDescriptor(table))
 							}
-
-							b.Put(kv.Key, sqlbase.WrapDescriptor(database))
 						}
-					}
+					case *sqlbase.Descriptor_Database:
+						if database := sqlDesc.GetDatabase(); database != nil && upgradeDatabaseDescFn != nil {
+							if upgraded, err := upgradeDatabaseDescFn(database); err != nil {
+								return err
+							} else if upgraded {
+								if err := database.Validate(); err != nil {
+									return err
+								}
 
-				default:
-					return errors.Errorf("Descriptor.Union has unexpected type %T", t)
+								b.Put(kv.Key, sqlbase.WrapDescriptor(database))
+							}
+						}
+
+					default:
+						return errors.Errorf("Descriptor.Union has unexpected type %T", t)
+					}
 				}
-			}
-			if err := txn.SetSystemConfigTrigger(); err != nil {
-				return err
-			}
-			if idVersions != nil {
-				count, err := sql.CountLeases(ctx, r.sqlExecutor, idVersions, now)
-				if err != nil {
+				if err := txn.SetSystemConfigTrigger(); err != nil {
 					return err
 				}
-				if count > 0 {
-					return errors.Errorf(
-						`penultimate schema version is leased, upgrade again with no outstanding schema changes`,
-					)
+				if idVersions != nil {
+					// Count the leases at the transaction's original timestamp,
+					// which requires a scan of the system.lease table. This
+					// will force the transaction to push its timestamp if it's
+					// migrating the system.lease descriptor, but it should
+					// still be able to commit.
+					count, err := sql.CountLeases(ctx, r.sqlExecutor, idVersions, txn.OrigTimestamp())
+					if err != nil {
+						return err
+					}
+					if count > 0 {
+						return errors.Errorf(
+							`penultimate schema version is leased, upgrade again with no outstanding schema changes`,
+						)
+					}
 				}
+				return txn.CommitInBatch(ctx, b)
+			})
+
+			switch err {
+			case nil:
+				break TxnLoop
+			case errTxnRestarted:
+				// Loop around and retry.
+			default:
+				return err
 			}
-			return txn.Run(ctx, b)
-		}); err != nil {
-			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Backport 1/1 commits from #43508.

This was a clean backport outside of the diff in https://github.com/cockroachdb/cockroach/commit/47f6af7670164375dc70f2f9ba387ff6f1238552#diff-87d7b6600bf9a8becfc52392f1cdd19d.

/cc @cockroachdb/release

---

Closes #43497.

This commit resolves a deadlock that could occur when running the "ensure admin
role privileges in all descriptors" SQL migration. If the `system.lease` table
needed to be migrated then the migration transaction would deadlock on an inner
transaction that would query the system.lease table to enforce the "two leased
versions" descriptor invariant. The solution to this is to use a timestamp from
before the migration transaction to query the `system.lease` table, which
ensures that the two transactions don't conflict.

This fix is needed in the release-19.1 branch and the release-2.1 branch. I'll
send a PR to patch the latter once this review is signed off on.

Release note (bug fix): Migrating the privileges on the system.lease
table no longer creates a deadlock during a cluster upgrade.
