### PR TITLE
protectedts/ptcache: implement the Cache to watch protectedts state

### DIFF
--- a/pkg/storage/protectedts/protectedts.go
+++ b/pkg/storage/protectedts/protectedts.go
@@ -110,7 +110,9 @@ type Iterator func(*ptpb.Record) (wantMore bool)
 type Cache interface {
 
 	// Iterate examines the records with spans which overlap with [from, to).
-	// Nil values for from or to are equivalent to Key{}.
+	// Nil values for from or to are equivalent to Key{}. The order of records
+	// between independent calls to Iterate is not defined; the order of records
+	// may differ even for the same key range that occurs at the same timestamp.
 	Iterate(_ context.Context, from, to roachpb.Key, it Iterator) (asOf hlc.Timestamp)
 
 	// QueryRecord determines whether a Record with the provided ID exists in

--- a/pkg/storage/protectedts/ptcache/cache.go
+++ b/pkg/storage/protectedts/ptcache/cache.go
@@ -1,0 +1,263 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptcache
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+)
+
+// Cache implements protectedts.Cache.
+type Cache struct {
+	db       *client.DB
+	storage  protectedts.Storage
+	stopper  *stop.Stopper
+	settings *cluster.Settings
+	sf       singleflight.Group
+	mu       struct {
+		syncutil.RWMutex
+
+		started bool
+
+		// updated in fetch()
+		lastUpdate  hlc.Timestamp
+		state       ptpb.State
+		recordsByID map[uuid.UUID]*ptpb.Record
+
+		// TODO(ajwerner): add a more efficient lookup structure such as an
+		// interval.Tree for Iterate.
+	}
+}
+
+// Config configures a Cache.
+type Config struct {
+	DB       *client.DB
+	Storage  protectedts.Storage
+	Settings *cluster.Settings
+}
+
+// New returns a new cache.
+func New(config Config) *Cache {
+	c := &Cache{
+		db:       config.DB,
+		storage:  config.Storage,
+		settings: config.Settings,
+	}
+	c.mu.recordsByID = make(map[uuid.UUID]*ptpb.Record)
+	return c
+}
+
+var _ protectedts.Cache = (*Cache)(nil)
+
+// Iterate is part of the protectedts.Cache interface.
+func (c *Cache) Iterate(
+	_ context.Context, from, to roachpb.Key, it protectedts.Iterator,
+) (asOf hlc.Timestamp) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	sp := roachpb.Span{
+		Key:    from,
+		EndKey: to,
+	}
+	for i := range c.mu.state.Records {
+		r := &c.mu.state.Records[i]
+		if !overlaps(r, sp) {
+			continue
+		}
+		if wantMore := it(r); !wantMore {
+			break
+		}
+	}
+	return c.mu.lastUpdate
+}
+
+// QueryRecord is part of the protectedts.Cache interface.
+func (c *Cache) QueryRecord(_ context.Context, id uuid.UUID) (exists bool, asOf hlc.Timestamp) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	_, exists = c.mu.recordsByID[id]
+	return exists, c.mu.lastUpdate
+}
+
+// refreshKey is used for the singleflight.
+const refreshKey = ""
+
+// Refresh is part of the protectedts.Cache interface.
+func (c *Cache) Refresh(ctx context.Context, asOf hlc.Timestamp) error {
+	for !c.upToDate(asOf) {
+		ch, _ := c.sf.DoChan(refreshKey, c.doSingleFlightUpdate)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case res := <-ch:
+			if res.Err != nil {
+				return res.Err
+			}
+		}
+	}
+	return nil
+}
+
+// Start starts the periodic fetching of the Cache. A Cache must not be used
+// until after it has been started. An error will be returned if it has
+// already been started.
+func (c *Cache) Start(ctx context.Context, stopper *stop.Stopper) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mu.started {
+		return errors.New("cannot start a Cache more than once")
+	}
+	c.mu.started = true
+	c.stopper = stopper
+	return c.stopper.RunAsyncTask(ctx, "periodically-refresh-protectedts-cache",
+		c.periodicallyRefreshProtectedtsCache)
+}
+
+func (c *Cache) periodicallyRefreshProtectedtsCache(ctx context.Context) {
+	settingChanged := make(chan struct{}, 1)
+	protectedts.PollInterval.SetOnChange(&c.settings.SV, func() {
+		select {
+		case settingChanged <- struct{}{}:
+		default:
+		}
+	})
+	timer := timeutil.NewTimer()
+	defer timer.Stop()
+	timer.Reset(0) // Read immediately upon startup
+	var lastReset time.Time
+	var doneCh <-chan singleflight.Result
+	// TODO(ajwerner): consider resetting the timer when the state is updated
+	// due to a call to Refresh.
+	for {
+		select {
+		case <-timer.C:
+			// Let's not reset the timer until we get our response.
+			timer.Read = true
+			doneCh, _ = c.sf.DoChan(refreshKey, c.doSingleFlightUpdate)
+		case <-settingChanged:
+			if timer.Read { // we're currently fetching
+				continue
+			}
+			interval := protectedts.PollInterval.Get(&c.settings.SV)
+			// NB: It's okay if nextUpdate is a negative duration; timer.Reset will
+			// treat a negative duration as zero and send a notification immediately.
+			nextUpdate := interval - timeutil.Since(lastReset)
+			timer.Reset(nextUpdate)
+			lastReset = timeutil.Now()
+		case res := <-doneCh:
+			if res.Err != nil {
+				if ctx.Err() == nil {
+					log.Errorf(ctx, "failed to refresh protected timestamps: %v", res.Err)
+				}
+			}
+			timer.Reset(protectedts.PollInterval.Get(&c.settings.SV))
+			lastReset = timeutil.Now()
+		case <-c.stopper.ShouldQuiesce():
+			return
+		}
+	}
+}
+
+func (c *Cache) doSingleFlightUpdate() (interface{}, error) {
+	// TODO(ajwerner): add log tags to the context.
+	ctx, cancel := c.stopper.WithCancelOnQuiesce(context.Background())
+	defer cancel()
+	return nil, c.stopper.RunTaskWithErr(ctx,
+		"refresh-protectedts-cache", c.doUpdate)
+}
+
+func (c *Cache) getMetadata() ptpb.Metadata {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.state.Metadata
+}
+
+func (c *Cache) doUpdate(ctx context.Context) error {
+	// NB: doUpdate is only ever called underneath c.singleFlight and thus is
+	// never called concurrently. Due to the lack of concurrency there are no
+	// concerns about races as this is the only method which writes to the Cache's
+	// state.
+	prev := c.getMetadata()
+	var (
+		versionChanged bool
+		state          ptpb.State
+		ts             hlc.Timestamp
+	)
+	err := c.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) (err error) {
+		// NB: because this is a read-only transaction, the commit will be a no-op;
+		// returning nil here means the transaction will commit and will never need
+		// to change its read timestamp.
+		defer func() {
+			if err == nil {
+				ts = txn.ReadTimestamp()
+			}
+		}()
+		md, err := c.storage.GetMetadata(ctx, txn)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch protectedts metadata")
+		}
+		if versionChanged = md.Version != prev.Version; !versionChanged {
+			return nil
+		}
+		if state, err = c.storage.GetState(ctx, txn); err != nil {
+			return errors.Wrap(err, "failed to fetch protectedts state")
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.lastUpdate = ts
+	if versionChanged {
+		c.mu.state = state
+		for id := range c.mu.recordsByID {
+			delete(c.mu.recordsByID, id)
+		}
+		for i := range state.Records {
+			r := &state.Records[i]
+			c.mu.recordsByID[r.ID] = r
+		}
+	}
+	return nil
+}
+
+// upToDate returns true if the lastUpdate for the cache is at least asOf.
+func (c *Cache) upToDate(asOf hlc.Timestamp) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return asOf.LessEq(c.mu.lastUpdate)
+}
+
+func overlaps(r *ptpb.Record, sp roachpb.Span) bool {
+	for i := range r.Spans {
+		if r.Spans[i].Overlaps(sp) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/protectedts/ptcache/cache_test.go
+++ b/pkg/storage/protectedts/ptcache/cache_test.go
@@ -1,0 +1,469 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptcache_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptcache"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptstorage"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheBasic exercises the basic behavior of the Cache.
+func TestCacheBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	s := tc.Server(0)
+	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
+		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+
+	// Set the poll interval to be very short.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Microsecond)
+
+	c := ptcache.New(ptcache.Config{
+		Settings: s.ClusterSettings(),
+		DB:       s.DB(),
+		Storage:  p,
+	})
+	require.NoError(t, c.Start(ctx, tc.Stopper()))
+
+	// Make sure that protected timestamp gets updated.
+	ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
+
+	// Make sure that it gets updated again.
+	waitForAsOfAfter(t, c, ts)
+
+	// Then we'll add a record and make sure it gets seen.
+	sp := tableSpan(42)
+	r, createdAt := protect(t, tc.Server(0), p, sp)
+	testutils.SucceedsSoon(t, func() error {
+		var coveredBy []*ptpb.Record
+		seenTS := c.Iterate(ctx, sp.Key, sp.EndKey,
+			func(r *ptpb.Record) (wantMore bool) {
+				coveredBy = append(coveredBy, r)
+				return true
+			})
+		if len(coveredBy) == 0 {
+			assert.True(t, seenTS.Less(createdAt), "%v %v", seenTS, createdAt)
+			return errors.Errorf("expected %v to be covered", sp)
+		}
+		require.True(t, !seenTS.Less(createdAt), "%v %v", seenTS, createdAt)
+		require.EqualValues(t, []*ptpb.Record{r}, coveredBy)
+		return nil
+	})
+
+	// Then release the record and make sure that that gets seen.
+	require.Nil(t, p.Release(ctx, nil /* txn */, r.ID))
+	testutils.SucceedsSoon(t, func() error {
+		var coveredBy []*ptpb.Record
+		_ = c.Iterate(ctx, sp.Key, sp.EndKey,
+			func(r *ptpb.Record) (wantMore bool) {
+				coveredBy = append(coveredBy, r)
+				return true
+			})
+		if len(coveredBy) > 0 {
+			return errors.Errorf("expected %v not to be covered", sp)
+		}
+		return nil
+	})
+}
+
+func TestRefresh(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := &scanTracker{}
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &storage.StoreTestingKnobs{
+					TestingRequestFilter: storagebase.ReplicaRequestFilter(st.requestFilter),
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	s := tc.Server(0)
+	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
+		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+
+	// Set the poll interval to be very long.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
+
+	c := ptcache.New(ptcache.Config{
+		Settings: s.ClusterSettings(),
+		DB:       s.DB(),
+		Storage:  p,
+	})
+	require.NoError(t, c.Start(ctx, tc.Stopper()))
+	t.Run("already up-to-date", func(t *testing.T) {
+		ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
+		st.resetCounters()
+		require.NoError(t, c.Refresh(ctx, ts))
+		st.verifyCounters(t, 0, 0) // already up to date
+	})
+	t.Run("needs refresh, no change", func(t *testing.T) {
+		ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
+		require.NoError(t, c.Refresh(ctx, ts.Next()))
+		st.verifyCounters(t, 1, 0) // just need to scan meta
+	})
+	t.Run("needs refresh, with change", func(t *testing.T) {
+		_, createdAt := protect(t, s, p, metaTableSpan)
+		st.resetCounters()
+		require.NoError(t, c.Refresh(ctx, createdAt))
+		st.verifyCounters(t, 2, 1) // need to scan meta and then scan everything
+	})
+	t.Run("cancelation returns early", func(t *testing.T) {
+		withCancel, cancel := context.WithCancel(ctx)
+		defer cancel()
+		done := make(chan struct{})
+		st.setFilter(func(ba roachpb.BatchRequest) *roachpb.Error {
+			if scanReq, ok := ba.GetArg(roachpb.Scan); ok {
+				scan := scanReq.(*roachpb.ScanRequest)
+				if scan.Span().Overlaps(metaTableSpan) {
+					<-done
+				}
+			}
+			return nil
+		})
+		go func() { time.Sleep(time.Millisecond); cancel() }()
+		require.EqualError(t, c.Refresh(withCancel, s.Clock().Now()),
+			context.Canceled.Error())
+		close(done)
+	})
+	t.Run("error propagates while fetching metadata", func(t *testing.T) {
+		st.setFilter(func(ba roachpb.BatchRequest) *roachpb.Error {
+			if scanReq, ok := ba.GetArg(roachpb.Scan); ok {
+				scan := scanReq.(*roachpb.ScanRequest)
+				if scan.Span().Overlaps(metaTableSpan) {
+					return roachpb.NewError(errors.New("boom"))
+				}
+			}
+			return nil
+		})
+		defer st.setFilter(nil)
+		require.Regexp(t, "boom", c.Refresh(ctx, s.Clock().Now()).Error())
+	})
+	t.Run("error propagates while fetching records", func(t *testing.T) {
+		protect(t, s, p, metaTableSpan)
+		st.setFilter(func(ba roachpb.BatchRequest) *roachpb.Error {
+			if scanReq, ok := ba.GetArg(roachpb.Scan); ok {
+				scan := scanReq.(*roachpb.ScanRequest)
+				if scan.Span().Overlaps(recordsTableSpan) {
+					return roachpb.NewError(errors.New("boom"))
+				}
+			}
+			return nil
+		})
+		defer st.setFilter(nil)
+		require.Regexp(t, "boom", c.Refresh(ctx, s.Clock().Now()).Error())
+	})
+}
+
+func TestStart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	setup := func() (*testcluster.TestCluster, *ptcache.Cache) {
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+		s := tc.Server(0)
+		p := ptstorage.New(s.ClusterSettings(),
+			s.InternalExecutor().(sqlutil.InternalExecutorWithUser))
+		// Set the poll interval to be very long.
+		protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
+		c := ptcache.New(ptcache.Config{
+			Settings: s.ClusterSettings(),
+			DB:       s.DB(),
+			Storage:  p,
+		})
+		return tc, c
+	}
+
+	t.Run("double start", func(t *testing.T) {
+		tc, c := setup()
+		defer tc.Stopper().Stop(ctx)
+		require.NoError(t, c.Start(ctx, tc.Stopper()))
+		require.EqualError(t, c.Start(ctx, tc.Stopper()),
+			"cannot start a Cache more than once")
+	})
+	t.Run("already stopped", func(t *testing.T) {
+		tc, c := setup()
+		tc.Stopper().Stop(ctx)
+		require.EqualError(t, c.Start(ctx, tc.Stopper()),
+			stop.ErrUnavailable.Error())
+	})
+}
+
+func TestQueryRecord(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	s := tc.Server(0)
+	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
+		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+	// Set the poll interval to be very long.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
+	c := ptcache.New(ptcache.Config{
+		Settings: s.ClusterSettings(),
+		DB:       s.DB(),
+		Storage:  p,
+	})
+	require.NoError(t, c.Start(ctx, tc.Stopper()))
+
+	// Wait for the initial fetch.
+	waitForAsOfAfter(t, c, hlc.Timestamp{})
+	// Create two records.
+	sp42 := tableSpan(42)
+	r1, createdAt1 := protect(t, s, p, sp42)
+	r2, createdAt2 := protect(t, s, p, sp42)
+	// Ensure they both don't exist and that the read timestamps precede the
+	// create timestamps.
+	exists1, asOf := c.QueryRecord(ctx, r1.ID)
+	require.False(t, exists1)
+	require.True(t, asOf.Less(createdAt1))
+	exists2, asOf := c.QueryRecord(ctx, r2.ID)
+	require.False(t, exists2)
+	require.True(t, asOf.Less(createdAt2))
+	// Go refresh the state and make sure they both exist.
+	require.NoError(t, c.Refresh(ctx, createdAt2))
+	exists1, asOf = c.QueryRecord(ctx, r1.ID)
+	require.True(t, exists1)
+	require.True(t, !asOf.Less(createdAt1))
+	exists2, asOf = c.QueryRecord(ctx, r2.ID)
+	require.True(t, exists2)
+	require.True(t, !asOf.Less(createdAt2))
+	// Release 2 and then create 3.
+	require.NoError(t, p.Release(ctx, nil /* txn */, r2.ID))
+	r3, createdAt3 := protect(t, s, p, sp42)
+	exists2, asOf = c.QueryRecord(ctx, r2.ID)
+	require.True(t, exists2)
+	require.True(t, asOf.Less(createdAt3))
+	exists3, asOf := c.QueryRecord(ctx, r3.ID)
+	require.False(t, exists3)
+	require.True(t, asOf.Less(createdAt3))
+	// Go refresh the state and make sure 1 and 3 exist.
+	require.NoError(t, c.Refresh(ctx, createdAt3))
+	exists1, _ = c.QueryRecord(ctx, r1.ID)
+	require.True(t, exists1)
+	exists2, _ = c.QueryRecord(ctx, r2.ID)
+	require.False(t, exists2)
+	exists3, _ = c.QueryRecord(ctx, r3.ID)
+	require.True(t, exists3)
+}
+
+func TestIterate(t *testing.T) {
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	s := tc.Server(0)
+	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
+		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+
+	// Set the poll interval to be very long.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
+
+	c := ptcache.New(ptcache.Config{
+		Settings: s.ClusterSettings(),
+		DB:       s.DB(),
+		Storage:  p,
+	})
+	require.NoError(t, c.Start(ctx, tc.Stopper()))
+
+	sp42 := tableSpan(42)
+	sp43 := tableSpan(43)
+	sp44 := tableSpan(44)
+	r1, _ := protect(t, s, p, sp42)
+	r2, _ := protect(t, s, p, sp43)
+	r3, _ := protect(t, s, p, sp44)
+	r4, _ := protect(t, s, p, sp42, sp43)
+	require.NoError(t, c.Refresh(ctx, s.Clock().Now()))
+	t.Run("all", func(t *testing.T) {
+		var recs records
+		c.Iterate(ctx, sp42.Key, sp44.EndKey, recs.accumulate)
+		require.EqualValues(t, recs.sorted(), (&records{r1, r2, r3, r4}).sorted())
+	})
+	t.Run("some", func(t *testing.T) {
+		var recs records
+		c.Iterate(ctx, sp42.Key, sp42.EndKey, recs.accumulate)
+		require.EqualValues(t, recs.sorted(), (&records{r1, r4}).sorted())
+	})
+	t.Run("none", func(t *testing.T) {
+		var recs records
+		c.Iterate(ctx, sp42.Key, sp42.EndKey, recs.accumulate)
+		require.EqualValues(t, recs.sorted(), (&records{r1, r4}).sorted())
+	})
+	t.Run("early return from iteration", func(t *testing.T) {
+		var called int
+		c.Iterate(ctx, sp42.Key, sp44.EndKey, func(*ptpb.Record) (wantMore bool) {
+			called++
+			return false
+		})
+		require.Equal(t, 1, called)
+	})
+}
+
+type records []*ptpb.Record
+
+func (recs *records) accumulate(r *ptpb.Record) (wantMore bool) {
+	(*recs) = append(*recs, r)
+	return true
+}
+
+func (recs *records) sorted() []*ptpb.Record {
+	sort.Slice(*recs, func(i, j int) bool {
+		return bytes.Compare((*recs)[i].ID[:], (*recs)[j].ID[:]) < 0
+	})
+	return *recs
+}
+
+func TestSettingChangedLeadsToFetch(t *testing.T) {
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	s := tc.Server(0)
+	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
+		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+
+	// Set the poll interval to be very long.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
+
+	c := ptcache.New(ptcache.Config{
+		Settings: s.ClusterSettings(),
+		DB:       s.DB(),
+		Storage:  p,
+	})
+	require.NoError(t, c.Start(ctx, tc.Stopper()))
+
+	// Make sure that the initial state has been fetched.
+	ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
+	// Make sure there isn't another rapid fetch.
+	// If there were a bug it might fail under stress.
+	time.Sleep(time.Millisecond)
+	_, asOf := c.QueryRecord(ctx, uuid.UUID{})
+	require.Equal(t, asOf, ts)
+	// Set the polling interval back to something very short.
+	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 100*time.Microsecond)
+	// Ensure that the state is updated again soon.
+	waitForAsOfAfter(t, c, ts)
+}
+
+func waitForAsOfAfter(t *testing.T, c protectedts.Cache, ts hlc.Timestamp) (asOf hlc.Timestamp) {
+	testutils.SucceedsSoon(t, func() error {
+		var exists bool
+		exists, asOf = c.QueryRecord(context.Background(), uuid.UUID{})
+		require.False(t, exists)
+		if !ts.Less(asOf) {
+			return errors.Errorf("expected an update to occur")
+		}
+		return nil
+	})
+	return asOf
+}
+
+func tableSpan(tableID uint32) roachpb.Span {
+	return roachpb.Span{
+		Key:    roachpb.Key(keys.MakeTablePrefix(tableID)),
+		EndKey: roachpb.Key(keys.MakeTablePrefix(tableID)).PrefixEnd(),
+	}
+}
+
+func protect(
+	t *testing.T, s serverutils.TestServerInterface, p protectedts.Storage, spans ...roachpb.Span,
+) (r *ptpb.Record, createdAt hlc.Timestamp) {
+	protectTS := s.Clock().Now()
+	r = &ptpb.Record{
+		ID:        uuid.MakeV4(),
+		Timestamp: protectTS,
+		Mode:      ptpb.PROTECT_AFTER,
+		Spans:     spans,
+	}
+	ctx := context.Background()
+	txn := s.DB().NewTxn(ctx, "test")
+	require.NoError(t, p.Protect(ctx, txn, r))
+	require.NoError(t, txn.Commit(ctx))
+	_, err := p.GetRecord(ctx, nil, r.ID)
+	require.NoError(t, err)
+	createdAt = txn.CommitTimestamp()
+	return r, createdAt
+}
+
+var (
+	metaTableSpan    = tableSpan(keys.ProtectedTimestampsMetaTableID)
+	recordsTableSpan = tableSpan(keys.ProtectedTimestampsRecordsTableID)
+)
+
+type scanTracker struct {
+	mu                syncutil.Mutex
+	metaTableScans    int
+	recordsTableScans int
+	filterFunc        func(ba roachpb.BatchRequest) *roachpb.Error
+}
+
+func (st *scanTracker) resetCounters() {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.metaTableScans, st.recordsTableScans = 0, 0
+}
+
+func (st *scanTracker) verifyCounters(t *testing.T, expMeta, expRecords int) {
+	t.Helper()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	require.Equal(t, expMeta, st.metaTableScans)
+	require.Equal(t, expRecords, st.recordsTableScans)
+}
+
+func (st *scanTracker) setFilter(f func(roachpb.BatchRequest) *roachpb.Error) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.filterFunc = f
+}
+
+func (st *scanTracker) requestFilter(ba roachpb.BatchRequest) *roachpb.Error {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if scanReq, ok := ba.GetArg(roachpb.Scan); ok {
+		scan := scanReq.(*roachpb.ScanRequest)
+		if scan.Span().Overlaps(metaTableSpan) {
+			st.metaTableScans++
+		} else if scan.Span().Overlaps(recordsTableSpan) {
+			st.recordsTableScans++
+		}
+	}
+	if st.filterFunc != nil {
+		return st.filterFunc(ba)
+	}
+	return nil
+}

--- a/pkg/storage/protectedts/ptcache/main_test.go
+++ b/pkg/storage/protectedts/ptcache/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptcache_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/storage/protectedts/ptstorage/storage_with_database.go
+++ b/pkg/storage/protectedts/ptstorage/storage_with_database.go
@@ -1,0 +1,99 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptstorage
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// WithDatabase wraps s such that any calls made with a nil *Txn will be wrapped
+// in a call to db.Txn. This is often convenient in testing.
+func WithDatabase(s protectedts.Storage, db *client.DB) protectedts.Storage {
+	return &storageWithDatabase{s: s, db: db}
+}
+
+type storageWithDatabase struct {
+	db *client.DB
+	s  protectedts.Storage
+}
+
+func (s *storageWithDatabase) Protect(ctx context.Context, txn *client.Txn, r *ptpb.Record) error {
+	if txn == nil {
+		return s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return s.s.Protect(ctx, txn, r)
+		})
+	}
+	return s.s.Protect(ctx, txn, r)
+}
+
+func (s *storageWithDatabase) GetRecord(
+	ctx context.Context, txn *client.Txn, id uuid.UUID,
+) (r *ptpb.Record, err error) {
+	if txn == nil {
+		err = s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			r, err = s.s.GetRecord(ctx, txn, id)
+			return err
+		})
+		return r, err
+	}
+	return s.s.GetRecord(ctx, txn, id)
+}
+
+func (s *storageWithDatabase) MarkVerified(
+	ctx context.Context, txn *client.Txn, id uuid.UUID,
+) error {
+	if txn == nil {
+		return s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return s.s.Release(ctx, txn, id)
+		})
+	}
+	return s.s.Release(ctx, txn, id)
+}
+
+func (s *storageWithDatabase) Release(ctx context.Context, txn *client.Txn, id uuid.UUID) error {
+	if txn == nil {
+		return s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return s.s.Release(ctx, txn, id)
+		})
+	}
+	return s.s.Release(ctx, txn, id)
+}
+
+func (s *storageWithDatabase) GetMetadata(
+	ctx context.Context, txn *client.Txn,
+) (md ptpb.Metadata, err error) {
+	if txn == nil {
+		err = s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			md, err = s.s.GetMetadata(ctx, txn)
+			return err
+		})
+		return md, err
+	}
+	return s.s.GetMetadata(ctx, txn)
+}
+
+func (s *storageWithDatabase) GetState(
+	ctx context.Context, txn *client.Txn,
+) (state ptpb.State, err error) {
+	if txn == nil {
+		err = s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			state, err = s.s.GetState(ctx, txn)
+			return err
+		})
+		return state, err
+	}
+	return s.s.GetState(ctx, txn)
+}


### PR DESCRIPTION
The Cache periodically polls the protectedts state. The Cache polls
the meta row from each node at a period defined by a cluster setting.
Clients can toggle a manual refresh.

Release note: None.