### PR TITLE
release-19.2: importccl: resilient import over http

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -40,7 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/workload"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -435,13 +435,120 @@ func (h *httpStorage) Conf() roachpb.ExportStorage {
 	}
 }
 
+type reqSender = func(reqHeaders map[string]string) (io.ReadCloser, http.Header, error)
+
+type resumingHTTPReader struct {
+	b         io.ReadCloser
+	canResume bool      // Can we resume if download aborts prematurely?
+	pos       int64     // How much data was received so far.
+	retryReq  reqSender // Retry request
+}
+
+var _ io.ReadCloser = &resumingHTTPReader{}
+
+const maxNoProgressHTTPRetries = 16
+
+func (r *resumingHTTPReader) Close() error {
+	return r.b.Close()
+}
+
+// checkHTTPContentRangeHeader parses Content-Range header and
+// ensures that range start offset is the same as 'pos'
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
+func checkHTTPContentRangeHeader(h string, pos int64) error {
+	if len(h) == 0 {
+		return errors.New("http server does not honor download resume")
+	}
+
+	h = strings.TrimPrefix(h, "bytes ")
+	dash := strings.IndexByte(h, '-')
+	if dash <= 0 {
+		return errors.Errorf("malformed Content-Range header: %s", h)
+	}
+
+	resume, err := strconv.ParseInt(h[:dash], 10, 64)
+	if err != nil {
+		return errors.Errorf("malformed start offset in Content-Range header: %s", h)
+	}
+
+	if resume != pos {
+		return errors.Errorf(
+			"expected resume position %d, found %d instead in Content-Range header: %s",
+			pos, resume, h)
+	}
+	return nil
+}
+
+// requestNextRanges issues additional http request
+// to continue downloading next range of bytes.
+func (r *resumingHTTPReader) requestNextRange() (err error) {
+	if err := r.b.Close(); err != nil {
+		return err
+	}
+
+	var header http.Header
+	r.b, header, err = r.retryReq(map[string]string{"Range": fmt.Sprintf("bytes=%d-", r.pos)})
+
+	if err != nil {
+		return err
+	}
+
+	return checkHTTPContentRangeHeader(header.Get("Content-Range"), r.pos)
+}
+
+// Read implements io.Reader interface to read the data from the underlying
+// http stream, issuing additional requests in case download is interrupted.
+func (r *resumingHTTPReader) Read(p []byte) (n int, err error) {
+	retries := 0
+
+	for n == 0 && err == nil && retries < maxNoProgressHTTPRetries {
+		n, err = r.b.Read(p)
+		r.pos += int64(n)
+
+		if n > 0 {
+			// As long as download progresses, reset the retries.
+			retries = 0
+		}
+
+		// Resume download if the http server supports this.
+		// We can attempt to resume download iff the error is ErrUnexpectedEOF.
+		// In particular, we should not worry about a case when error is io.EOF.
+		// The reason for this is two-fold:
+		//   1. The underlying http library converts io.EOF to io.ErrUnexpectedEOF
+		//   if the number of bytes transferred is less than the number of
+		//   bytes advertised in the Content-Length header.  So if we see
+		//   io.ErrUnexpectedEOF we can simply request the next range.
+		//   2. If the server did *not* advertise Content-Length, then
+		//   there is really nothing we can do: http standard says that
+		//   the stream ends when the server terminates connection.
+		if errors.Is(err, io.ErrUnexpectedEOF) && r.canResume {
+			retries++
+			err = r.requestNextRange()
+		}
+	}
+	return
+}
+
 func (h *httpStorage) ReadFile(ctx context.Context, basename string) (io.ReadCloser, error) {
 	// https://github.com/cockroachdb/cockroach/issues/23859
-	resp, err := h.req(ctx, "GET", basename, nil)
+	sender := func(reqHeaders map[string]string) (io.ReadCloser, http.Header, error) {
+		resp, err := h.req(ctx, "GET", basename, nil, reqHeaders)
+		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Body, resp.Header, nil
+	}
+
+	body, headers, err := sender(nil)
 	if err != nil {
 		return nil, err
 	}
-	return resp.Body, nil
+	return &resumingHTTPReader{
+		b:         body,
+		canResume: headers.Get("Accept-Ranges") == "bytes",
+		pos:       0,
+		retryReq:  sender,
+	}, nil
 }
 
 func (h *httpStorage) WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error {
@@ -484,7 +591,7 @@ func (h *httpStorage) Close() error {
 func (h *httpStorage) reqNoBody(
 	ctx context.Context, method, file string, body io.Reader,
 ) (*http.Response, error) {
-	resp, err := h.req(ctx, method, file, body)
+	resp, err := h.req(ctx, method, file, body, nil)
 	if resp != nil {
 		resp.Body.Close()
 	}
@@ -492,7 +599,7 @@ func (h *httpStorage) reqNoBody(
 }
 
 func (h *httpStorage) req(
-	ctx context.Context, method, file string, body io.Reader,
+	ctx context.Context, method, file string, body io.Reader, headers map[string]string,
 ) (*http.Response, error) {
 	dest := *h.base
 	if hosts := len(h.hosts); hosts > 1 {
@@ -509,6 +616,11 @@ func (h *httpStorage) req(
 	url := dest.String()
 	req, err := http.NewRequest(method, url, body)
 	req = req.WithContext(ctx)
+
+	for key, val := range headers {
+		req.Header.Add(key, val)
+	}
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "error constructing request %s %q", method, url)
 	}
@@ -517,8 +629,8 @@ func (h *httpStorage) req(
 		return nil, errors.Wrapf(err, "error executing request %s %q", method, url)
 	}
 	switch resp.StatusCode {
-	case 200, 201, 204:
-		// ignore
+	case 200, 201, 204, 206:
+		// Pass.
 	default:
 		body, _ := ioutil.ReadAll(resp.Body)
 		_ = resp.Body.Close()

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -38,7 +38,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/oauth2/google"
@@ -375,6 +377,22 @@ type httpStorage struct {
 
 var _ ExportStorage = &httpStorage{}
 
+type retryableHTTPError struct {
+	cause error
+}
+
+func (e *retryableHTTPError) Error() string {
+	return fmt.Sprintf("retryable http error: %s", e.cause)
+}
+
+// package visible for test.
+var httpRetryOptions = retry.Options{
+	InitialBackoff: 100 * time.Millisecond,
+	MaxBackoff:     2 * time.Second,
+	MaxRetries:     32,
+	Multiplier:     4,
+}
+
 func makeHTTPClient(settings *cluster.Settings) (*http.Client, error) {
 	var tlsConf *tls.Config
 	if pem := httpCustomCA.Get(&settings.SV); pem != "" {
@@ -435,21 +453,41 @@ func (h *httpStorage) Conf() roachpb.ExportStorage {
 	}
 }
 
-type reqSender = func(reqHeaders map[string]string) (io.ReadCloser, http.Header, error)
-
 type resumingHTTPReader struct {
-	b         io.ReadCloser
-	canResume bool      // Can we resume if download aborts prematurely?
-	pos       int64     // How much data was received so far.
-	retryReq  reqSender // Retry request
+	body      io.ReadCloser
+	canResume bool  // Can we resume if download aborts prematurely?
+	pos       int64 // How much data was received so far.
+	ctx       context.Context
+	url       string
+	client    *httpStorage
 }
 
 var _ io.ReadCloser = &resumingHTTPReader{}
 
-const maxNoProgressHTTPRetries = 16
+func newResumingHTTPReader(
+	ctx context.Context, client *httpStorage, url string,
+) (*resumingHTTPReader, error) {
+	r := &resumingHTTPReader{
+		ctx:    ctx,
+		client: client,
+		url:    url,
+	}
+
+	resp, err := r.sendRequest(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r.canResume = resp.Header.Get("Accept-Ranges") == "bytes"
+	r.body = resp.Body
+	return r, nil
+}
 
 func (r *resumingHTTPReader) Close() error {
-	return r.b.Close()
+	if r.body != nil {
+		return r.body.Close()
+	}
+	return nil
 }
 
 // checkHTTPContentRangeHeader parses Content-Range header and
@@ -479,76 +517,97 @@ func checkHTTPContentRangeHeader(h string, pos int64) error {
 	return nil
 }
 
+func (r *resumingHTTPReader) sendRequest(
+	reqHeaders map[string]string,
+) (resp *http.Response, err error) {
+	for attempt, retries := 0,
+		retry.StartWithCtx(r.ctx, httpRetryOptions); retries.Next(); attempt++ {
+		resp, err = r.client.req(r.ctx, "GET", r.url, nil, reqHeaders)
+
+		if err == nil {
+			return
+		}
+
+		log.Errorf(r.ctx, "HTTP:Req error: err=%s (attempt %d)", err, attempt)
+
+		if _, ok := err.(*retryableHTTPError); !ok {
+			break
+		}
+	}
+
+	return
+}
+
 // requestNextRanges issues additional http request
 // to continue downloading next range of bytes.
 func (r *resumingHTTPReader) requestNextRange() (err error) {
-	if err := r.b.Close(); err != nil {
+	if err := r.body.Close(); err != nil {
 		return err
 	}
 
-	var header http.Header
-	r.b, header, err = r.retryReq(map[string]string{"Range": fmt.Sprintf("bytes=%d-", r.pos)})
+	r.body = nil
+	var resp *http.Response
+	resp, err = r.sendRequest(map[string]string{"Range": fmt.Sprintf("bytes=%d-", r.pos)})
 
-	if err != nil {
-		return err
+	if err == nil {
+		err = checkHTTPContentRangeHeader(resp.Header.Get("Content-Range"), r.pos)
 	}
 
-	return checkHTTPContentRangeHeader(header.Get("Content-Range"), r.pos)
+	if err == nil {
+		r.body = resp.Body
+	}
+	return
 }
+
+// isResumableHTTPError returns true if we can
+// resume download after receiving an error 'err'.
+// We can attempt to resume download if the error is ErrUnexpectedEOF.
+// In particular, we should not worry about a case when error is io.EOF.
+// The reason for this is two-fold:
+//   1. The underlying http library converts io.EOF to io.ErrUnexpectedEOF
+//   if the number of bytes transferred is less than the number of
+//   bytes advertised in the Content-Length header.  So if we see
+//   io.ErrUnexpectedEOF we can simply request the next range.
+//   2. If the server did *not* advertise Content-Length, then
+//   there is really nothing we can do: http standard says that
+//   the stream ends when the server terminates connection.
+// In addition, we treat connection reset by peer errors (which can
+// happen if we didn't read from the connection too long due to e.g. load),
+// the same was as unexpected eof errors.
+func isResumableHTTPError(err error) bool {
+	return errors.Is(err, io.ErrUnexpectedEOF) || sysutil.IsErrConnectionReset(err)
+}
+
+const maxNoProgressReads = 3
 
 // Read implements io.Reader interface to read the data from the underlying
 // http stream, issuing additional requests in case download is interrupted.
 func (r *resumingHTTPReader) Read(p []byte) (n int, err error) {
-	retries := 0
-
-	for n == 0 && err == nil && retries < maxNoProgressHTTPRetries {
-		n, err = r.b.Read(p)
+	for retries := 0; n == 0 && err == nil; retries++ {
+		n, err = r.body.Read(p)
 		r.pos += int64(n)
 
-		if n > 0 {
-			// As long as download progresses, reset the retries.
-			retries = 0
+		if err != nil && !errors.IsAny(err, io.EOF, io.ErrUnexpectedEOF) {
+			log.Errorf(r.ctx, "HTTP:Read err: %s", err)
 		}
 
 		// Resume download if the http server supports this.
-		// We can attempt to resume download iff the error is ErrUnexpectedEOF.
-		// In particular, we should not worry about a case when error is io.EOF.
-		// The reason for this is two-fold:
-		//   1. The underlying http library converts io.EOF to io.ErrUnexpectedEOF
-		//   if the number of bytes transferred is less than the number of
-		//   bytes advertised in the Content-Length header.  So if we see
-		//   io.ErrUnexpectedEOF we can simply request the next range.
-		//   2. If the server did *not* advertise Content-Length, then
-		//   there is really nothing we can do: http standard says that
-		//   the stream ends when the server terminates connection.
-		if errors.Is(err, io.ErrUnexpectedEOF) && r.canResume {
-			retries++
+		if r.canResume && isResumableHTTPError(err) {
+			log.Errorf(r.ctx, "HTTP:Retry: error %s", err)
+			if retries > maxNoProgressReads {
+				err = errors.Wrap(err, "multiple Read calls return no data")
+				return
+			}
 			err = r.requestNextRange()
 		}
 	}
+
 	return
 }
 
 func (h *httpStorage) ReadFile(ctx context.Context, basename string) (io.ReadCloser, error) {
 	// https://github.com/cockroachdb/cockroach/issues/23859
-	sender := func(reqHeaders map[string]string) (io.ReadCloser, http.Header, error) {
-		resp, err := h.req(ctx, "GET", basename, nil, reqHeaders)
-		if err != nil {
-			return nil, nil, err
-		}
-		return resp.Body, resp.Header, nil
-	}
-
-	body, headers, err := sender(nil)
-	if err != nil {
-		return nil, err
-	}
-	return &resumingHTTPReader{
-		b:         body,
-		canResume: headers.Get("Accept-Ranges") == "bytes",
-		pos:       0,
-		retryReq:  sender,
-	}, nil
+	return newResumingHTTPReader(ctx, h, basename)
 }
 
 func (h *httpStorage) WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error {
@@ -615,19 +674,25 @@ func (h *httpStorage) req(
 	dest.Path = path.Join(dest.Path, file)
 	url := dest.String()
 	req, err := http.NewRequest(method, url, body)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "error constructing request %s %q", method, url)
+	}
 	req = req.WithContext(ctx)
 
 	for key, val := range headers {
 		req.Header.Add(key, val)
 	}
 
-	if err != nil {
-		return nil, errors.Wrapf(err, "error constructing request %s %q", method, url)
-	}
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error executing request %s %q", method, url)
+		// We failed to establish connection to the server (we don't even have
+		// a response object/server response code). Those errors (e.g. due to
+		// network blip, or DNS resolution blip, etc) are usually transient. The
+		// client may choose to retry the request few times before giving up.
+		return nil, &retryableHTTPError{err}
 	}
+
 	switch resp.StatusCode {
 	case 200, 201, 204, 206:
 		// Pass.

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -629,4 +630,64 @@ func TestWorkloadStorage(t *testing.T) {
 	require.EqualError(t, err, `expected bank version "" but got "1.0.0"`)
 	_, err = ExportStorageFromURI(ctx, `workload:///csv/bank/bank?version=nope`, settings)
 	require.EqualError(t, err, `expected bank version "nope" but got "1.0.0"`)
+}
+
+func rangeStart(r string) (int, error) {
+	if len(r) == 0 {
+		return 0, nil
+	}
+	r = strings.TrimPrefix(r, "bytes=")
+
+	return strconv.Atoi(r[:strings.IndexByte(r, '-')])
+}
+
+func TestHttpGet(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	data := []byte("to serve, or not to serve.  c'est la question")
+
+	for _, tc := range []int{1, 2, 5, 16, 32, len(data) - 1, len(data)} {
+		t.Run(fmt.Sprintf("read-%d", tc), func(t *testing.T) {
+			limit := tc
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				start, err := rangeStart(r.Header.Get("Range"))
+				if start < 0 || start >= len(data) {
+					t.Errorf("invalid start offset %d in range header %s",
+						start, r.Header.Get("Range"))
+				}
+				end := start + limit
+				if end > len(data) {
+					end = len(data)
+				}
+
+				w.Header().Add("Accept-Ranges", "bytes")
+				w.Header().Add("Content-Length", strconv.Itoa(len(data)-start))
+
+				if start > 0 {
+					w.Header().Add(
+						"Content-Range",
+						fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+				}
+
+				if err == nil {
+					_, err = w.Write(data[start:end])
+				}
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+
+			defer s.Close()
+			store, err := makeHTTPStorage(s.URL, testSettings)
+			require.NoError(t, err)
+
+			defer store.Close()
+			f, err := store.ReadFile(context.Background(), "/something")
+			require.NoError(t, err)
+			defer f.Close()
+			b, err := ioutil.ReadAll(f)
+			require.NoError(t, err)
+			require.EqualValues(t, data, b)
+		})
+	}
+
 }

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -26,11 +26,14 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/spf13/pflag"
@@ -645,6 +648,10 @@ func TestHttpGet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	data := []byte("to serve, or not to serve.  c'est la question")
 
+	httpRetryOptions.InitialBackoff = 1 * time.Microsecond
+	httpRetryOptions.MaxBackoff = 10 * time.Millisecond
+	httpRetryOptions.MaxRetries = 100
+
 	for _, tc := range []int{1, 2, 5, 16, 32, len(data) - 1, len(data)} {
 		t.Run(fmt.Sprintf("read-%d", tc), func(t *testing.T) {
 			limit := tc
@@ -676,18 +683,45 @@ func TestHttpGet(t *testing.T) {
 				}
 			}))
 
-			defer s.Close()
+			// Start antagonist function that aggressively closes client connections.
+			ctx, cancelAntagonist := context.WithCancel(context.Background())
+			g := ctxgroup.WithContext(ctx)
+			g.GoCtx(func(ctx context.Context) error {
+				opts := retry.Options{
+					InitialBackoff: 500 * time.Microsecond,
+					MaxBackoff:     1 * time.Millisecond,
+				}
+				for attempt := retry.StartWithCtx(ctx, opts); attempt.Next(); {
+					s.CloseClientConnections()
+				}
+				return nil
+			})
+
 			store, err := makeHTTPStorage(s.URL, testSettings)
 			require.NoError(t, err)
 
-			defer store.Close()
-			f, err := store.ReadFile(context.Background(), "/something")
+			var file io.ReadCloser
+
+			// Cleanup.
+			defer func() {
+				s.Close()
+				if store != nil {
+					require.NoError(t, store.Close())
+				}
+				if file != nil {
+					require.NoError(t, file.Close())
+				}
+				cancelAntagonist()
+				_ = g.Wait()
+			}()
+
+			// Read the file and verify results.
+			file, err = store.ReadFile(ctx, "/something")
 			require.NoError(t, err)
-			defer f.Close()
-			b, err := ioutil.ReadAll(f)
+
+			b, err := ioutil.ReadAll(file)
 			require.NoError(t, err)
 			require.EqualValues(t, data, b)
 		})
 	}
-
 }

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -15,6 +15,7 @@
 package sysutil
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -58,4 +59,15 @@ func RefreshSignaledChan() <-chan os.Signal {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, refreshSignal)
 	return ch
+}
+
+// IsErrConnectionReset returns true if an
+// error is a "connection reset by peer" error.
+func IsErrConnectionReset(err error) bool {
+	if opErr, ok := err.(*net.OpError); ok {
+		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
+			return sysErr.Err == syscall.ECONNRESET
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "importccl: Resume interrupted http download during import." (#43374)
  * 1/1 commits from "importccl: improve handling of transient errors when importing over http" (#43558)

Please see individual PRs for details.

/cc @cockroachdb/release
