### PR TITLE
sql: fix GetAllDatabaseDescriptorIDs panic

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -263,6 +263,12 @@ func GetAllDatabaseDescriptorIDs(ctx context.Context, txn *client.Txn) ([]sqlbas
 	descIDs := make([]sqlbase.ID, 0, len(kvs))
 	alreadySeen := make(map[sqlbase.ID]bool)
 	for _, kv := range kvs {
+		if kv.Value.GetTag() == roachpb.ValueType_TUPLE {
+			// Ignore sentinel (column family 0) KV pairs, which get written when old
+			// namespace entries are migrated. We only care about the KVs for the id
+			// column family, whose values are encoded as ints.
+			continue
+		}
 		ID := sqlbase.ID(kv.ValueInt())
 		if alreadySeen[ID] {
 			continue


### PR DESCRIPTION
The GetAllDatabaseDescriptorIDs function was panicking when it
encountered namespace rows which had been migrated from the old
namespace table. Since the migration uses the SQL layer rather than KV
puts, it writes sentinel KVs which are not normally written to this
table. GetAllDatabaseDescriptorIDs was choking when it encountered these
KVs since the value was an empty TUPLE rather than the INT it was
expecting. I added a bit of logic to skip these sentinel KVs.

Fixes #43616

Release note: None