### PR TITLE
opt: add a rule to push filters into project-set

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1496,3 +1496,29 @@ WHERE message IN
 querying next range at /Table/73/1/0
 === SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/73/1/10
+
+# Test for 42202 -- ensure filters can get pushed down through project-set.
+statement ok
+CREATE TABLE e (x INT PRIMARY KEY, y INT, z STRING);
+CREATE TABLE s (x INT PRIMARY KEY, y INT, z INT)
+
+query TTT
+EXPLAIN SELECT e.z, s.z, n FROM e, s, generate_series(0, s.z, 1000) as n WHERE e.y = s.y ORDER BY s.z LIMIT 10
+----
+·                              distributed  false
+·                              vectorized   false
+render                         ·            ·
+ └── limit                     ·            ·
+      │                        count        10
+      └── sort                 ·            ·
+           │                   order        +z
+           └── project set     ·            ·
+                └── hash-join  ·            ·
+                     │         type         inner
+                     │         equality     (y) = (y)
+                     ├── scan  ·            ·
+                     │         table        e@primary
+                     │         spans        ALL
+                     └── scan  ·            ·
+·                              table        s@primary
+·                              spans        ALL

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -316,3 +316,31 @@
     $input
     (InlineConstVar $filters)
 )
+
+# PushSelectIntoProjectSet pushes filters into a ProjectSet. In particular,
+# the filters that are bound to the input columns of the ProjectSet are
+# pushed down into it, in hopes of being pushed down further into joins
+# and scans underneath the ProjectSet.
+[PushSelectIntoProjectSet, Normalize]
+(Select
+    (ProjectSet
+        $input:*
+        $zip:*
+    )
+    $filters:[
+        ...
+        $item:* & (IsBoundBy $item $inputCols:(OutputCols $input))
+        ...
+    ]
+)
+=>
+(Select
+    (ProjectSet
+        (Select
+            $input
+            (ExtractBoundConditions $filters $inputCols)
+        )
+        $zip
+    )
+    (ExtractUnboundConditions $filters $inputCols)
+)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1451,3 +1451,81 @@ select
       ├── column1 = 0 [type=bool, outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
       ├── column1::STRING = '0.00' [type=bool, outer=(1)]
       └── column2 = 'b' [type=bool, outer=(2), constraints=(/2: [/'b' - /'b']; tight), fd=()-->(2)]
+
+
+# --------------------------------------------------
+# PushSelectIntoProjectSet
+# --------------------------------------------------
+norm expect=PushSelectIntoProjectSet
+SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE k = 1
+----
+project-set
+ ├── columns: k:1(int!null) g:6(int)
+ ├── side-effects
+ ├── fd: ()-->(1)
+ ├── select
+ │    ├── columns: k:1(int!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ └── zip
+      └── function: generate_series [type=int, outer=(1), side-effects]
+           ├── const: 0 [type=int]
+           ├── variable: k [type=int]
+           └── const: 10 [type=int]
+
+# Make sure that filters aren't pushed down when not bound by the input, so PushSelectIntoProjectSet is not triggered.
+norm expect-not=PushSelectIntoProjectSet
+SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE g > 1
+----
+select
+ ├── columns: k:1(int!null) g:6(int!null)
+ ├── side-effects
+ ├── project-set
+ │    ├── columns: k:1(int!null) generate_series:6(int)
+ │    ├── side-effects
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── zip
+ │         └── function: generate_series [type=int, outer=(1), side-effects]
+ │              ├── const: 0 [type=int]
+ │              ├── variable: k [type=int]
+ │              └── const: 10 [type=int]
+ └── filters
+      └── generate_series > 1 [type=bool, outer=(6), constraints=(/6: [/2 - ]; tight)]
+
+# Expect that only the applicable filters are pushed down into the project-set.
+norm expect=PushSelectIntoProjectSet
+SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE g > 1 AND k = 1
+----
+select
+ ├── columns: k:1(int!null) g:6(int!null)
+ ├── side-effects
+ ├── fd: ()-->(1)
+ ├── project-set
+ │    ├── columns: k:1(int!null) generate_series:6(int)
+ │    ├── side-effects
+ │    ├── fd: ()-->(1)
+ │    ├── select
+ │    │    ├── columns: k:1(int!null)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null)
+ │    │    │    └── key: (1)
+ │    │    └── filters
+ │    │         └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    └── zip
+ │         └── function: generate_series [type=int, outer=(1), side-effects]
+ │              ├── const: 0 [type=int]
+ │              ├── variable: k [type=int]
+ │              └── const: 10 [type=int]
+ └── filters
+      └── generate_series > 1 [type=bool, outer=(6), constraints=(/6: [/2 - ]; tight)]


### PR DESCRIPTION
Fixes #42202.

This PR adds an optimizer rule to push filters down into
project-set operations.

Release note: None