### PR TITLE
roachprod/vm/aws: distribute nodes over zones rather than regions for geo

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -99,15 +99,9 @@ var defaultConfig = func() (cfg *awsConfig) {
 // cluster creation. If the geo flag is specified, one zone from each region
 // is randomly chosen.
 var defaultCreateZones = []string{
-	"us-east-2a",
 	"us-east-2b",
-	"us-east-2c",
-	"us-west-2a",
 	"us-west-2b",
-	"us-west-2c",
-	"eu-west-2a",
 	"eu-west-2b",
-	"eu-west-2c",
 }
 
 // ConfigureCreateFlags is part of the vm.ProviderFlags interface.
@@ -236,21 +230,10 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		}
 	} else {
 		// Distribute the nodes amongst availability zones if geo distributed.
-		zonesPerRegion := len(names) / len(regions)
-		leftover := len(names) % len(regions)
-		for i, region := range regions {
-			regionZones, err := p.regionZones(region, p.opts.CreateZones)
-			if err != nil {
-				return err
-			}
-			totalZonesPerRegion := zonesPerRegion
-			if leftover > i {
-				totalZonesPerRegion++
-			}
-			for j := 0; j < totalZonesPerRegion; j++ {
-				zoneIndex := j % len(regionZones)
-				zones = append(zones, regionZones[zoneIndex])
-			}
+		nodeZones := vm.ZonePlacement(len(p.opts.CreateZones), len(names))
+		zones = make([]string, len(nodeZones))
+		for i := range nodeZones {
+			zones[i] = p.opts.CreateZones[i]
 		}
 	}
 	var g errgroup.Group


### PR DESCRIPTION
Before this commit, for `--geo` AWS cluster creation we'd evenly distribute
nodes over the regions represented by the zones in the `--aws-zones` flag.
Within each region we'd then round-robin over the available zones in that
region. My hunch is that this was done so that multiple AZs per region can
be provided as the defaults for the `--aws-zones` flag and that nodes would
still be spread out over all of the regions. This is an unnecessary departure
from the logic for the gcloud vm provider.

This PR brings the `--aws-zones` behavior into conformance with that of the
`--gce-zones` flag. In doing so it also chooses specific AZs in the default
regions. This should only end up becoming problematic if we start to observe
that there are an insufficient number of instances in any of those regions.

Release note: None