### PR TITLE
storage/batcheval/result: perform various cleanup on LocalResult struct

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -372,7 +372,7 @@ func EndTxn(
 	// don't want the intents to be up for resolution. That should happen only
 	// if the commit actually happens; otherwise, we risk losing writes.
 	intentsResult := result.FromEndTxn(reply.Txn, false /* alwaysReturn */, args.Poison)
-	intentsResult.Local.UpdatedTxns = &[]*roachpb.Transaction{reply.Txn}
+	intentsResult.Local.UpdatedTxns = []*roachpb.Transaction{reply.Txn}
 	if err := pd.MergeAndDestroy(intentsResult); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -57,5 +57,5 @@ func Get(
 			}
 		}
 	}
-	return result.FromIntents(intents), err
+	return result.FromEncounteredIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -57,5 +57,5 @@ func Get(
 			}
 		}
 	}
-	return result.FromIntents(intents, args), err
+	return result.FromIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -168,7 +168,7 @@ func PushTxn(
 			// that only the transaction's own coordinator can create its
 			// transaction record.
 			result := result.Result{}
-			result.Local.UpdatedTxns = &[]*roachpb.Transaction{&reply.PusheeTxn}
+			result.Local.UpdatedTxns = []*roachpb.Transaction{&reply.PusheeTxn}
 			return result, nil
 		}
 	} else {
@@ -309,6 +309,6 @@ func PushTxn(
 	}
 
 	result := result.Result{}
-	result.Local.UpdatedTxns = &[]*roachpb.Transaction{&reply.PusheeTxn}
+	result.Local.UpdatedTxns = []*roachpb.Transaction{&reply.PusheeTxn}
 	return result, nil
 }

--- a/pkg/storage/batcheval/cmd_recover_txn.go
+++ b/pkg/storage/batcheval/cmd_recover_txn.go
@@ -222,6 +222,6 @@ func RecoverTxn(
 	// that, we might need to plumb in a "poison" flag on the RecoverTxn
 	// request.
 	result := result.Result{}
-	result.Local.UpdatedTxns = &[]*roachpb.Transaction{&reply.RecoveredTxn}
+	result.Local.UpdatedTxns = []*roachpb.Transaction{&reply.RecoveredTxn}
 	return result, nil
 }

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -79,5 +79,5 @@ func ReverseScan(
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
 		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
 	}
-	return result.FromIntents(intents), err
+	return result.FromEncounteredIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -79,5 +79,5 @@ func ReverseScan(
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
 		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
 	}
-	return result.FromIntents(intents, args), err
+	return result.FromIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -77,5 +77,5 @@ func Scan(
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
 		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
 	}
-	return result.FromIntents(intents), err
+	return result.FromEncounteredIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -77,5 +77,5 @@ func Scan(
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
 		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
 	}
-	return result.FromIntents(intents, args), err
+	return result.FromIntents(intents), err
 }

--- a/pkg/storage/batcheval/result/intent.go
+++ b/pkg/storage/batcheval/result/intent.go
@@ -27,7 +27,7 @@ func FromEncounteredIntents(intents []roachpb.Intent) Result {
 // which indicates whether the intents should be resolved whether or
 // not the command succeeds through Raft.
 type EndTxnIntents struct {
-	Txn    roachpb.Transaction
+	Txn    *roachpb.Transaction
 	Always bool
 	Poison bool
 }
@@ -39,6 +39,6 @@ func FromEndTxn(txn *roachpb.Transaction, alwaysReturn, poison bool) Result {
 	if len(txn.IntentSpans) == 0 {
 		return pd
 	}
-	pd.Local.EndTxns = &[]EndTxnIntents{{Txn: *txn, Always: alwaysReturn, Poison: poison}}
+	pd.Local.EndTxns = &[]EndTxnIntents{{Txn: txn, Always: alwaysReturn, Poison: poison}}
 	return pd
 }

--- a/pkg/storage/batcheval/result/intent.go
+++ b/pkg/storage/batcheval/result/intent.go
@@ -19,7 +19,7 @@ func FromEncounteredIntents(intents []roachpb.Intent) Result {
 	if len(intents) == 0 {
 		return pd
 	}
-	pd.Local.EncounteredIntents = &intents
+	pd.Local.EncounteredIntents = intents
 	return pd
 }
 
@@ -39,6 +39,6 @@ func FromEndTxn(txn *roachpb.Transaction, alwaysReturn, poison bool) Result {
 	if len(txn.IntentSpans) == 0 {
 		return pd
 	}
-	pd.Local.EndTxns = &[]EndTxnIntents{{Txn: txn, Always: alwaysReturn, Poison: poison}}
+	pd.Local.EndTxns = []EndTxnIntents{{Txn: txn, Always: alwaysReturn, Poison: poison}}
 	return pd
 }

--- a/pkg/storage/batcheval/result/intent.go
+++ b/pkg/storage/batcheval/result/intent.go
@@ -12,14 +12,14 @@ package result
 
 import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
-// FromIntents creates a Result communicating that the intents were encountered
+// FromEncounteredIntents creates a Result communicating that the intents were encountered
 // by the given request and should be handled.
-func FromIntents(intents []roachpb.Intent) Result {
+func FromEncounteredIntents(intents []roachpb.Intent) Result {
 	var pd Result
 	if len(intents) == 0 {
 		return pd
 	}
-	pd.Local.Intents = &intents
+	pd.Local.EncounteredIntents = &intents
 	return pd
 }
 

--- a/pkg/storage/batcheval/result/intent.go
+++ b/pkg/storage/batcheval/result/intent.go
@@ -12,20 +12,14 @@ package result
 
 import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
-// IntentsWithArg contains a request and the intents it discovered.
-type IntentsWithArg struct {
-	Arg     roachpb.Request
-	Intents []roachpb.Intent
-}
-
 // FromIntents creates a Result communicating that the intents were encountered
 // by the given request and should be handled.
-func FromIntents(intents []roachpb.Intent, args roachpb.Request) Result {
+func FromIntents(intents []roachpb.Intent) Result {
 	var pd Result
 	if len(intents) == 0 {
 		return pd
 	}
-	pd.Local.Intents = &[]IntentsWithArg{{Arg: args, Intents: intents}}
+	pd.Local.Intents = &intents
 	return pd
 }
 

--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -34,7 +34,7 @@ type LocalResult struct {
 	//
 	// This is a pointer to allow the zero (and as an unwelcome side effect,
 	// all) values to be compared.
-	Intents *[]IntentsWithArg
+	Intents *[]roachpb.Intent
 	// UpdatedTxns stores transaction records that have been updated by
 	// calls to EndTxn, PushTxn, and RecoverTxn.
 	//
@@ -104,11 +104,11 @@ func (lResult *LocalResult) DetachMaybeWatchForMerge() bool {
 
 // DetachIntents returns (and removes) those intents from the
 // LocalEvalResult which are supposed to be handled.
-func (lResult *LocalResult) DetachIntents() []IntentsWithArg {
+func (lResult *LocalResult) DetachIntents() []roachpb.Intent {
 	if lResult == nil {
 		return nil
 	}
-	var r []IntentsWithArg
+	var r []roachpb.Intent
 	if lResult.Intents != nil {
 		r = *lResult.Intents
 	}

--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -91,18 +91,6 @@ func (lResult *LocalResult) String() string {
 		lResult.MaybeGossipNodeLiveness, lResult.MaybeWatchForMerge)
 }
 
-// DetachMaybeWatchForMerge returns and clears the MaybeWatchForMerge flag
-// from the local result.
-func (lResult *LocalResult) DetachMaybeWatchForMerge() bool {
-	if lResult == nil {
-		return false
-	} else if lResult.MaybeWatchForMerge {
-		lResult.MaybeWatchForMerge = false
-		return true
-	}
-	return false
-}
-
 // DetachEncounteredIntents returns (and removes) those encountered
 // intents from the LocalEvalResult which are supposed to be handled.
 func (lResult *LocalResult) DetachEncounteredIntents() []roachpb.Intent {

--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -500,25 +500,22 @@ func (ir *IntentResolver) runAsyncTask(
 // execution of that command. This occurs during inconsistent
 // reads.
 func (ir *IntentResolver) CleanupIntentsAsync(
-	ctx context.Context, intents []result.IntentsWithArg, allowSyncProcessing bool,
+	ctx context.Context, intents []roachpb.Intent, allowSyncProcessing bool,
 ) error {
-	now := ir.clock.Now()
-	for i := range intents {
-		item := &intents[i] // copy for goroutine
-		if err := ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
-			err := contextutil.RunWithTimeout(ctx, "async intent resolution",
-				asyncIntentResolutionTimeout, func(ctx context.Context) error {
-					_, err := ir.CleanupIntents(ctx, item.Intents, now, roachpb.PUSH_TOUCH)
-					return err
-				})
-			if err != nil && ir.every.ShouldLog() {
-				log.Warning(ctx, err)
-			}
-		}); err != nil {
-			return err
-		}
+	if len(intents) == 0 {
+		return nil
 	}
-	return nil
+	now := ir.clock.Now()
+	return ir.runAsyncTask(ctx, allowSyncProcessing, func(ctx context.Context) {
+		err := contextutil.RunWithTimeout(ctx, "async intent resolution",
+			asyncIntentResolutionTimeout, func(ctx context.Context) error {
+				_, err := ir.CleanupIntents(ctx, intents, now, roachpb.PUSH_TOUCH)
+				return err
+			})
+		if err != nil && ir.every.ShouldLog() {
+			log.Warning(ctx, err)
+		}
+	})
 }
 
 // CleanupIntents processes a collection of intents by pushing each

--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -609,8 +609,8 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 				return
 			}
 			defer release()
-			intents := roachpb.AsIntents(et.Txn.IntentSpans, &et.Txn)
-			if err := ir.cleanupFinishedTxnIntents(ctx, rangeID, &et.Txn, intents, now, et.Poison, nil); err != nil {
+			intents := roachpb.AsIntents(et.Txn.IntentSpans, et.Txn)
+			if err := ir.cleanupFinishedTxnIntents(ctx, rangeID, et.Txn, intents, now, et.Poison, nil); err != nil {
 				if ir.every.ShouldLog() {
 					log.Warningf(ctx, "failed to cleanup transaction intents: %v", err)
 				}

--- a/pkg/storage/intentresolver/intent_resolver_test.go
+++ b/pkg/storage/intentresolver/intent_resolver_test.go
@@ -592,19 +592,17 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 		}
 	}
 	wg.Wait()
-	testIntentsWithArg := []result.IntentsWithArg{
-		{Intents: []roachpb.Intent{
-			{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn.TxnMeta},
-		}},
+	testIntents := []roachpb.Intent{
+		{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn.TxnMeta},
 	}
 	// Running with allowSyncProcessing = false should result in an error and no
 	// requests being sent.
-	err := ir.CleanupIntentsAsync(context.Background(), testIntentsWithArg, false)
+	err := ir.CleanupIntentsAsync(context.Background(), testIntents, false)
 	assert.Equal(t, errors.Cause(err), stop.ErrThrottled)
 	// Running with allowSyncProcessing = true should result in the synchronous
 	// processing of the intents resulting in no error and the consumption of the
 	// sendFuncs.
-	err = ir.CleanupIntentsAsync(context.Background(), testIntentsWithArg, true)
+	err = ir.CleanupIntentsAsync(context.Background(), testIntents, true)
 	assert.Nil(t, err)
 	assert.Equal(t, sf.len(), 0)
 }
@@ -614,33 +612,31 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 func TestCleanupIntentsAsync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	type testCase struct {
-		intents   []result.IntentsWithArg
+		intents   []roachpb.Intent
 		sendFuncs []sendFunc
 	}
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	txn := newTransaction("txn", roachpb.Key("a"), 1, clock)
-	testIntentsWithArg := []result.IntentsWithArg{
-		{Intents: []roachpb.Intent{
-			{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn.TxnMeta},
-		}},
+	testIntents := []roachpb.Intent{
+		{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn.TxnMeta},
 	}
 	cases := []testCase{
 		{
-			intents: testIntentsWithArg,
+			intents: testIntents,
 			sendFuncs: []sendFunc{
 				singlePushTxnSendFunc(t),
 				resolveIntentsSendFunc(t),
 			},
 		},
 		{
-			intents: testIntentsWithArg,
+			intents: testIntents,
 			sendFuncs: []sendFunc{
 				singlePushTxnSendFunc(t),
 				failSendFunc,
 			},
 		},
 		{
-			intents: testIntentsWithArg,
+			intents: testIntents,
 			sendFuncs: []sendFunc{
 				failSendFunc,
 			},
@@ -671,18 +667,14 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	txn1 := newTransaction("txn1", roachpb.Key("a"), 1, clock)
 	txn2 := newTransaction("txn2", roachpb.Key("c"), 1, clock)
-	testIntentsWithArg := []result.IntentsWithArg{
-		{Intents: []roachpb.Intent{
-			{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn1.TxnMeta},
-			{Span: roachpb.Span{Key: roachpb.Key("b")}, Txn: txn1.TxnMeta},
-		}},
-		{Intents: []roachpb.Intent{
-			{Span: roachpb.Span{Key: roachpb.Key("c")}, Txn: txn2.TxnMeta},
-			{Span: roachpb.Span{Key: roachpb.Key("d")}, Txn: txn2.TxnMeta},
-		}},
+	testIntents := []roachpb.Intent{
+		{Span: roachpb.Span{Key: roachpb.Key("a")}, Txn: txn1.TxnMeta},
+		{Span: roachpb.Span{Key: roachpb.Key("b")}, Txn: txn1.TxnMeta},
+		{Span: roachpb.Span{Key: roachpb.Key("c")}, Txn: txn2.TxnMeta},
+		{Span: roachpb.Span{Key: roachpb.Key("d")}, Txn: txn2.TxnMeta},
 	}
 
-	// We expect to see a PushTxn req for each pair of intents and a
+	// We expect to see a single PushTxn req for all four intents and a
 	// ResolveIntent req for each intent. However, because these requests are
 	// all async, it's unclear which order these will be issued in. Handle all
 	// orders and record the resolved intents.
@@ -692,26 +684,26 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 		resolved []string
 	}
 	pushOrResolveFunc := func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		if len(ba.Requests) != 1 {
-			return nil, roachpb.NewErrorf("unexpected")
-		}
-		ru := ba.Requests[0]
-		switch ru.GetInner().Method() {
+		switch ba.Requests[0].GetInner().Method() {
 		case roachpb.PushTxn:
-			reqs.Lock()
-			reqs.pushed = append(reqs.pushed, string(ru.GetPushTxn().Key))
-			reqs.Unlock()
+			for _, ru := range ba.Requests {
+				reqs.Lock()
+				reqs.pushed = append(reqs.pushed, string(ru.GetPushTxn().Key))
+				reqs.Unlock()
+			}
 			return pushTxnSendFunc(t, len(ba.Requests))(ba)
 		case roachpb.ResolveIntent:
-			reqs.Lock()
-			reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
-			reqs.Unlock()
+			for _, ru := range ba.Requests {
+				reqs.Lock()
+				reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
+				reqs.Unlock()
+			}
 			return resolveIntentsSendFunc(t)(ba)
 		default:
 			return nil, roachpb.NewErrorf("unexpected")
 		}
 	}
-	sf := newSendFuncs(t, repeat(pushOrResolveFunc, 6)...)
+	sf := newSendFuncs(t, repeat(pushOrResolveFunc, 5)...)
 
 	stopper := stop.NewStopper()
 	cfg := Config{
@@ -724,7 +716,7 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 		},
 	}
 	ir := newIntentResolverWithSendFuncs(cfg, sf)
-	err := ir.CleanupIntentsAsync(ctx, testIntentsWithArg, false)
+	err := ir.CleanupIntentsAsync(ctx, testIntents, false)
 	sf.drain(t)
 	stopper.Stop(ctx)
 	assert.Nil(t, err)

--- a/pkg/storage/intentresolver/intent_resolver_test.go
+++ b/pkg/storage/intentresolver/intent_resolver_test.go
@@ -785,7 +785,7 @@ func TestCleanupTxnIntentsAsync(t *testing.T) {
 	}
 	testEndTxnIntents := []result.EndTxnIntents{
 		{
-			Txn: roachpb.Transaction{
+			Txn: &roachpb.Transaction{
 				TxnMeta: enginepb.TxnMeta{
 					ID:           uuid.MakeV4(),
 					MinTimestamp: hlc.Timestamp{WallTime: 123},
@@ -854,7 +854,7 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 	txn2 := newTransaction("txn2", roachpb.Key("c"), 1, clock)
 	testEndTxnIntents := []result.EndTxnIntents{
 		{
-			Txn: roachpb.Transaction{
+			Txn: &roachpb.Transaction{
 				TxnMeta: txn1.TxnMeta,
 				IntentSpans: []roachpb.Span{
 					{Key: roachpb.Key("a")},
@@ -863,7 +863,7 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 			},
 		},
 		{
-			Txn: roachpb.Transaction{
+			Txn: &roachpb.Transaction{
 				TxnMeta: txn2.TxnMeta,
 				IntentSpans: []roachpb.Span{
 					{Key: roachpb.Key("c")},

--- a/pkg/storage/replica_application_cmd.go
+++ b/pkg/storage/replica_application_cmd.go
@@ -147,7 +147,7 @@ func (c *replicatedCmd) AckSuccess() error {
 	reply := *c.proposal.Local.Reply
 	reply.Responses = append([]roachpb.ResponseUnion(nil), reply.Responses...)
 	resp.Reply = &reply
-	resp.Intents = c.proposal.Local.DetachIntents()
+	resp.EncounteredIntents = c.proposal.Local.DetachEncounteredIntents()
 	resp.EndTxns = c.proposal.Local.DetachEndTxns(false /* alwaysOnly */)
 	c.proposal.signalProposalResult(resp)
 	return nil

--- a/pkg/storage/replica_application_result.go
+++ b/pkg/storage/replica_application_result.go
@@ -160,7 +160,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 	} else {
 		log.Fatalf(ctx, "proposal must return either a reply or an error: %+v", cmd.proposal)
 	}
-	cmd.response.Intents = cmd.proposal.Local.DetachIntents()
+	cmd.response.EncounteredIntents = cmd.proposal.Local.DetachEncounteredIntents()
 	cmd.response.EndTxns = cmd.proposal.Local.DetachEndTxns(pErr != nil)
 	if pErr == nil {
 		cmd.localResult = cmd.proposal.Local

--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -1022,7 +1022,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 		sm.r.handleNoRaftLogDeltaResult(ctx)
 	}
 	if cmd.localResult != nil {
-		sm.r.handleLocalEvalResult(ctx, *cmd.localResult)
+		sm.r.handleReadWriteLocalEvalResult(ctx, *cmd.localResult)
 	}
 	if err := sm.maybeApplyConfChange(ctx, cmd); err != nil {
 		return nil, wrapWithNonDeterministicFailure(err, "unable to apply conf change")

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -138,8 +138,8 @@ func (r *Replica) MaybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}
-	if result.Local.Intents != nil && len(*result.Local.Intents) > 0 {
-		return errors.Errorf("unexpected intents on node liveness span %s: %+v", span, *result.Local.Intents)
+	if result.Local.EncounteredIntents != nil && len(*result.Local.EncounteredIntents) > 0 {
+		return errors.Errorf("unexpected intents on node liveness span %s: %+v", span, *result.Local.EncounteredIntents)
 	}
 	kvs := br.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
 	log.VEventf(ctx, 2, "gossiping %d node liveness record(s) from span %s", len(kvs), span)
@@ -179,7 +179,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 	if pErr != nil {
 		return nil, pErr.GoError()
 	}
-	if intents := result.Local.DetachIntents(); len(intents) > 0 {
+	if intents := result.Local.DetachEncounteredIntents(); len(intents) > 0 {
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -138,8 +138,8 @@ func (r *Replica) MaybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}
-	if result.Local.EncounteredIntents != nil && len(*result.Local.EncounteredIntents) > 0 {
-		return errors.Errorf("unexpected intents on node liveness span %s: %+v", span, *result.Local.EncounteredIntents)
+	if len(result.Local.EncounteredIntents) > 0 {
+		return errors.Errorf("unexpected intents on node liveness span %s: %+v", span, result.Local.EncounteredIntents)
 	}
 	kvs := br.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
 	log.VEventf(ctx, 2, "gossiping %d node liveness record(s) from span %s", len(kvs), span)

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -183,9 +183,9 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.
-		// This is called from handleLocalEvalResult (with raftMu locked),
-		// so disallow synchronous processing (which blocks that mutex for
-		// too long and is a potential deadlock).
+		// This is called from handleReadWriteLocalEvalResult (with raftMu
+		// locked), so disallow synchronous processing (which blocks that mutex
+		// for too long and is a potential deadlock).
 		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, false /* allowSync */); err != nil {
 			log.Warning(ctx, err)
 		}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -610,7 +610,7 @@ func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult re
 	}
 
 	if lResult.UpdatedTxns != nil {
-		for _, txn := range *lResult.UpdatedTxns {
+		for _, txn := range lResult.UpdatedTxns {
 			r.txnWaitQueue.UpdateTxn(ctx, txn)
 		}
 		lResult.UpdatedTxns = nil
@@ -664,7 +664,7 @@ func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult re
 		lResult.Metrics = nil
 	}
 
-	if (lResult != result.LocalResult{}) {
+	if !lResult.IsZero() {
 		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, result.LocalResult{}))
 	}
 }
@@ -723,8 +723,8 @@ func (r *Replica) evaluateProposal(
 		intents := res.Local.DetachEncounteredIntents()
 		endTxns := res.Local.DetachEndTxns(true /* alwaysOnly */)
 		res.Local = result.LocalResult{
-			EncounteredIntents: &intents,
-			EndTxns:            &endTxns,
+			EncounteredIntents: intents,
+			EndTxns:            endTxns,
 			Metrics:            res.Local.Metrics,
 		}
 		res.Replicated.Reset()

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -678,7 +678,7 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.Loca
 type proposalResult struct {
 	Reply   *roachpb.BatchResponse
 	Err     *roachpb.Error
-	Intents []result.IntentsWithArg
+	Intents []roachpb.Intent
 	EndTxns []result.EndTxnIntents
 }
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -603,8 +603,8 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.Loca
 	// ======================
 
 	// The caller is required to detach and handle the following three fields.
-	if lResult.Intents != nil {
-		log.Fatalf(ctx, "LocalEvalResult.Intents should be nil: %+v", lResult.Intents)
+	if lResult.EncounteredIntents != nil {
+		log.Fatalf(ctx, "LocalEvalResult.EncounteredIntents should be nil: %+v", lResult.EncounteredIntents)
 	}
 	if lResult.EndTxns != nil {
 		log.Fatalf(ctx, "LocalEvalResult.EndTxns should be nil: %+v", lResult.EndTxns)
@@ -676,10 +676,10 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.Loca
 // proposalResult indicates the result of a proposal. Exactly one of
 // Reply and Err is set, and it represents the result of the proposal.
 type proposalResult struct {
-	Reply   *roachpb.BatchResponse
-	Err     *roachpb.Error
-	Intents []roachpb.Intent
-	EndTxns []result.EndTxnIntents
+	Reply              *roachpb.BatchResponse
+	Err                *roachpb.Error
+	EncounteredIntents []roachpb.Intent
+	EndTxns            []result.EndTxnIntents
 }
 
 // evaluateProposal generates a Result from the given request by
@@ -724,12 +724,12 @@ func (r *Replica) evaluateProposal(
 
 		// Failed proposals can't have any Result except for what's
 		// whitelisted here.
-		intents := res.Local.DetachIntents()
+		intents := res.Local.DetachEncounteredIntents()
 		endTxns := res.Local.DetachEndTxns(true /* alwaysOnly */)
 		res.Local = result.LocalResult{
-			Intents: &intents,
-			EndTxns: &endTxns,
-			Metrics: res.Local.Metrics,
+			EncounteredIntents: &intents,
+			EndTxns:            &endTxns,
+			Metrics:            res.Local.Metrics,
 		}
 		res.Replicated.Reset()
 		return &res, false /* needConsensus */, pErr

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -590,17 +590,13 @@ func addSSTablePreApply(
 	return copied
 }
 
-func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.LocalResult) {
+func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult result.LocalResult) {
 	// Fields for which no action is taken in this method are zeroed so that
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
 	{
 		lResult.Reply = nil
 	}
-
-	// ======================
-	// Non-state updates and actions.
-	// ======================
 
 	// The caller is required to detach and handle the following three fields.
 	if lResult.EncounteredIntents != nil {

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -97,7 +97,7 @@ func (r *Replica) evalAndPropose(
 	if proposal.command == nil {
 		intents := proposal.Local.DetachEncounteredIntents()
 		endTxns := proposal.Local.DetachEndTxns(pErr != nil /* alwaysOnly */)
-		r.handleLocalEvalResult(ctx, *proposal.Local)
+		r.handleReadWriteLocalEvalResult(ctx, *proposal.Local)
 
 		pr := proposalResult{
 			Reply:              proposal.Local.Reply,

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -95,15 +95,15 @@ func (r *Replica) evalAndPropose(
 	// 2. pErr != nil corresponds to a failed proposal - the command resulted
 	//    in an error.
 	if proposal.command == nil {
-		intents := proposal.Local.DetachIntents()
+		intents := proposal.Local.DetachEncounteredIntents()
 		endTxns := proposal.Local.DetachEndTxns(pErr != nil /* alwaysOnly */)
 		r.handleLocalEvalResult(ctx, *proposal.Local)
 
 		pr := proposalResult{
-			Reply:   proposal.Local.Reply,
-			Err:     pErr,
-			Intents: intents,
-			EndTxns: endTxns,
+			Reply:              proposal.Local.Reply,
+			Err:                pErr,
+			EncounteredIntents: intents,
+			EndTxns:            endTxns,
 		}
 		proposal.finishApplication(pr)
 		return proposalCh, func() {}, 0, nil
@@ -129,8 +129,8 @@ func (r *Replica) evalAndPropose(
 		reply := *proposal.Local.Reply
 		reply.Responses = append([]roachpb.ResponseUnion(nil), reply.Responses...)
 		pr := proposalResult{
-			Reply:   &reply,
-			Intents: proposal.Local.DetachIntents(),
+			Reply:              &reply,
+			EncounteredIntents: proposal.Local.DetachEncounteredIntents(),
 		}
 		proposal.signalProposalResult(pr)
 

--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -105,8 +105,8 @@ func (tp *rangefeedTxnPusher) CleanupTxnIntentsAsync(
 	ctx context.Context, txns []roachpb.Transaction,
 ) error {
 	endTxns := make([]result.EndTxnIntents, len(txns))
-	for i, txn := range txns {
-		endTxns[i].Txn = txn
+	for i := range txns {
+		endTxns[i].Txn = &txns[i]
 		endTxns[i].Poison = true
 	}
 	return tp.ir.CleanupTxnIntentsAsync(ctx, tp.r.RangeID, endTxns, true /* allowSyncProcessing */)

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -78,7 +78,7 @@ func (r *Replica) executeReadOnlyBatch(
 		}
 	}
 
-	if intents := result.Local.DetachIntents(); len(intents) > 0 {
+	if intents := result.Local.DetachEncounteredIntents(); len(intents) > 0 {
 		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))
 		// We only allow synchronous intent resolution for consistent requests.
 		// Intent resolution is async/best-effort for inconsistent requests.

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/kr/pretty"
 )
 
 // executeReadOnlyBatch is the execution logic for client requests which do not
@@ -68,17 +69,39 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 	defer readOnly.Close()
 	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba, true /* readOnly */)
-
-	// A merge is (likely) about to be carried out, and this replica
-	// needs to block all traffic until the merge either commits or
-	// aborts. See docs/tech-notes/range-merges.md.
-	if result.Local.DetachMaybeWatchForMerge() {
-		if err := r.maybeWatchForMerge(ctx); err != nil {
-			return nil, roachpb.NewError(err)
-		}
+	if err := r.handleReadOnlyLocalEvalResult(ctx, ba, result.Local); err != nil {
+		pErr = roachpb.NewError(err)
 	}
 
-	if intents := result.Local.DetachEncounteredIntents(); len(intents) > 0 {
+	if pErr != nil {
+		log.VErrEvent(ctx, 3, pErr.String())
+	} else {
+		log.Event(ctx, "read completed")
+	}
+	return br, pErr
+}
+
+func (r *Replica) handleReadOnlyLocalEvalResult(
+	ctx context.Context, ba *roachpb.BatchRequest, lResult result.LocalResult,
+) error {
+	// Fields for which no action is taken in this method are zeroed so that
+	// they don't trigger an assertion at the end of the method (which checks
+	// that all fields were handled).
+	{
+		lResult.Reply = nil
+	}
+
+	if lResult.MaybeWatchForMerge {
+		// A merge is (likely) about to be carried out, and this replica needs
+		// to block all traffic until the merge either commits or aborts. See
+		// docs/tech-notes/range-merges.md.
+		if err := r.maybeWatchForMerge(ctx); err != nil {
+			return err
+		}
+		lResult.MaybeWatchForMerge = false
+	}
+
+	if intents := lResult.DetachEncounteredIntents(); len(intents) > 0 {
 		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))
 		// We only allow synchronous intent resolution for consistent requests.
 		// Intent resolution is async/best-effort for inconsistent requests.
@@ -93,10 +116,9 @@ func (r *Replica) executeReadOnlyBatch(
 			log.Warning(ctx, err)
 		}
 	}
-	if pErr != nil {
-		log.VErrEvent(ctx, 3, pErr.String())
-	} else {
-		log.Event(ctx, "read completed")
+
+	if (lResult != result.LocalResult{}) {
+		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, result.LocalResult{}))
 	}
-	return br, pErr
+	return nil
 }

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -117,7 +117,7 @@ func (r *Replica) handleReadOnlyLocalEvalResult(
 		}
 	}
 
-	if (lResult != result.LocalResult{}) {
+	if !lResult.IsZero() {
 		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, result.LocalResult{}))
 	}
 	return nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9136,8 +9136,8 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	if !testutils.IsPError(propRes.Err, "boom") {
 		t.Fatalf("expected injected error, got: %v", propRes.Err)
 	}
-	if len(propRes.Intents) != 0 {
-		t.Fatal("expected intents to have been cleared")
+	if len(propRes.EncounteredIntents) != 0 {
+		t.Fatal("expected encountered intents to have been cleared")
 	}
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8292,7 +8292,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 		// is proposed and we're going to hackily decrease its MaxLeaseIndex, so
 		// that the processing gets rejected further on.
 		ut := p.Local.UpdatedTxns
-		if atomic.LoadInt64(&proposalRecognized) == 0 && ut != nil && len(*ut) == 1 && (*ut)[0].ID == txn.ID {
+		if atomic.LoadInt64(&proposalRecognized) == 0 && ut != nil && len(ut) == 1 && ut[0].ID == txn.ID {
 			atomic.StoreInt64(&proposalRecognized, 1)
 			return p.command.MaxLeaseIndex - 1, nil
 		}

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -184,17 +184,21 @@ func (r *Replica) executeWriteBatch(
 			// resolution is semi-synchronous in that there is a limited number of
 			// outstanding asynchronous resolution tasks allowed after which
 			// further calls will block.
-			if len(propResult.Intents) > 0 {
+			if len(propResult.EncounteredIntents) > 0 {
 				// TODO(peter): Re-proposed and canceled (but executed) commands can
 				// both leave intents to GC that don't hit this code path. No good
 				// solution presents itself at the moment and such intents will be
 				// resolved on reads.
-				if err := r.store.intentResolver.CleanupIntentsAsync(ctx, propResult.Intents, true /* allowSync */); err != nil {
+				if err := r.store.intentResolver.CleanupIntentsAsync(
+					ctx, propResult.EncounteredIntents, true, /* allowSync */
+				); err != nil {
 					log.Warning(ctx, err)
 				}
 			}
 			if len(propResult.EndTxns) > 0 {
-				if err := r.store.intentResolver.CleanupTxnIntentsAsync(ctx, r.RangeID, propResult.EndTxns, true /* allowSync */); err != nil {
+				if err := r.store.intentResolver.CleanupTxnIntentsAsync(
+					ctx, r.RangeID, propResult.EndTxns, true, /* allowSync */
+				); err != nil {
 					log.Warning(ctx, err)
 				}
 			}


### PR DESCRIPTION
This PR contains a series of cleanups to the `result.LocalResult` struct. It leaves the structure in a good position to be extended to include information about newly written, updated, and removed intents, which are hooked into the `concurrency` package in future commits the same way that `UpdatedTxns` is currently hooked into the TxnWaitQueue.

The changes are broken into a series of incremental steps to make them easier to review in isolation.