### PR TITLE
colexec/typeconv: remove orphaned Int1 case

### DIFF
--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -128,14 +128,6 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 		}
 	case types.IntFamily:
 		switch ct.Width() {
-		case 8:
-			return func(datum tree.Datum) (interface{}, error) {
-				d, ok := datum.(*tree.DInt)
-				if !ok {
-					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
-				}
-				return int8(*d), nil
-			}
 		case 16:
 			return func(datum tree.Datum) (interface{}, error) {
 				d, ok := datum.(*tree.DInt)


### PR DESCRIPTION
At some point we had support for Int1 (8 bit integer) in the vectorized
engine, but it has been removed. This commit removes one of the leftover
pieces.

Release note: None