### PR TITLE
acceptance: remove TestDockerStartFlags

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -90,36 +90,3 @@ func TestDockerCLI(t *testing.T) {
 		})
 	}
 }
-
-func TestDockerStartFlags(t *testing.T) {
-	s := log.Scope(t)
-	defer s.Close(t)
-
-	containerConfig := defaultContainerConfig()
-	containerConfig.Cmd = []string{"stat", cluster.CockroachBinaryInContainer}
-	ctx := context.Background()
-	if err := testDockerOneShot(ctx, t, "start_flags_test", containerConfig); err != nil {
-		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
-	}
-
-	script := `
-set -eux
-bin=/cockroach/cockroach
-
-touch out
-function finish() {
-	cat out
-}
-trap finish EXIT
-
-HOST=$(hostname -f)
-$bin start --logtostderr=INFO --background --insecure --listen-addr="${HOST}":12345 &> out
-$bin sql --insecure --host="${HOST}":12345 -e "show databases"
-$bin quit --insecure --host="${HOST}":12345
-`
-	containerConfig.Cmd = []string{"/bin/bash", "-c", script}
-	if err := testDockerOneShot(ctx, t, "start_flags_test", containerConfig); err != nil {
-		t.Error(err)
-	}
-
-}


### PR DESCRIPTION
This test has long been made obsolete by the other CLI tests,
especially the TCL tests.

Release note: None