### PR TITLE
pkg/security: fix misleading comment

### DIFF
--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -127,7 +127,7 @@ func GenerateServerCert(
 		return nil, err
 	}
 
-	// Only server authentication is allowed.
+	// Both server and client authentication are allowed (for inter-node RPC).
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 	for _, h := range hosts {
 		if ip := net.ParseIP(h); ip != nil {


### PR DESCRIPTION
Forgive me if I'm wrong, but the current comment appears to be wrong. To be honest, I don't know a ton about TLS and my change might be mislead, but I figured I'd at least raise this via a PR or something.

It seems that when this was changed 5y ago (https://github.com/cockroachdb/cockroach/pull/4957) by @mberhault, the comment wasn't updated.

> One notable difference is that we now have a single certificate for
nodes with double role as server and client authentication.

Sorry for this perhaps pedantic PR.
