### PR TITLE
sql: pg_catalog.pg_am needs to be populated

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -309,7 +309,7 @@ oid         relname       relnamespace  reltype  reloftype  relowner  relam     
 57          t3            2332901747    0        0          NULL      2631952481  0            0
 969972501   primary       2332901747    0        0          NULL      2631952481  0            0
 969972502   t3_a_b_idx    2332901747    0        0          NULL      2631952481  0            0
-58          v1            2332901747    0        0          NULL      2631952481  0            0
+58          v1            2332901747    0        0          NULL      0           0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -534,8 +534,9 @@ query OTIIBBBBBBBBBBBOOOOOOOOOOOOOOOOOT colnames
 SELECT *
 FROM pg_catalog.pg_am
 ----
-oid         amname  amstrategies  amsupport  amcanorder  amcanorderbyop  amcanbackward  amcanunique  amcanmulticol  amoptionalkey  amsearcharray  amsearchnulls  amstorage  amclusterable  ampredlocks  amkeytype  aminsert  ambeginscan  amgettuple  amgetbitmap  amrescan  amendscan  ammarkpos  amrestrpos  ambuild  ambuildempty  ambulkdelete  amvacuumcleanup  amcanreturn  amcostestimate  amoptions  amhandler  amtype
-2631952481  prefix  0             0          true        false           true           true         true           true           true           true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
+oid         amname    amstrategies  amsupport  amcanorder  amcanorderbyop  amcanbackward  amcanunique  amcanmulticol  amoptionalkey  amsearcharray  amsearchnulls  amstorage  amclusterable  ampredlocks  amkeytype  aminsert  ambeginscan  amgettuple  amgetbitmap  amrescan  amendscan  ammarkpos  amrestrpos  ambuild  ambuildempty  ambulkdelete  amvacuumcleanup  amcanreturn  amcostestimate  amoptions  amhandler  amtype
+2631952481  prefix    0             0          true        false           true           true         true           true           true           true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
+4004609370  inverted  0             0          false       false           false          false        false          false          false          true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
 
 ## pg_catalog.pg_attrdef
 


### PR DESCRIPTION
This patch adds inverted index to the access methods listed
in pg_am.

Additionally, this patch sets pg_class.relam to zero for sequences and views,
which is more consistent with postgres.

Fixes #27766

Release note (sql change): more accurate pg_catalog access method information.