### PR TITLE
backupccl: fix backup test parsing host

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -438,14 +438,21 @@ func backupAndRestore(
 
 	// Start a new cluster to restore into.
 	{
-		// Check where the back up is
+		// If the backup is on nodelocal, we need to determine which node it's on.
+		// Othewise, default to 0.
+		backupNodeID := 0
 		uri, err := url.Parse(backupURIs[0])
 		if err != nil {
 			t.Fatal(err)
 		}
-		backupNodeID, err := strconv.Atoi(uri.Host)
-		if err != nil && uri.Host != "" {
-			t.Fatal(err)
+		if uri.Scheme == "nodelocal" && uri.Host != "" {
+			// If the backup is on nodelocal and has specified a host, expect it to
+			// be an integer.
+			var err error
+			backupNodeID, err = strconv.Atoi(uri.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		args := base.TestServerArgs{ExternalIODir: tc.Servers[backupNodeID].ClusterSettings().ExternalIODir}
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})


### PR DESCRIPTION
Previously, TestCloudBackupRestoreS3 was failing locally due to an error
in parsing the host. A helper function was modified to account for the
new ability to specify a particular node with nodelocal. However, the
test would try to parse all hosts as an integer rather than just
nodelocal URIs causing this test to fail.

Release note: None