### PR TITLE
opt: fix assertion failure due to lax empty key

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1430,3 +1430,31 @@ values
  ├── key: ()
  ├── fd: ()-->(5)
  └── prune: (5)
+
+# Regression test #43651: outer join with empty key.
+opt
+SELECT a FROM
+    (VALUES (NULL)) AS t1(a)
+  FULL JOIN
+    (VALUES ('23:59:59.999999':::TIME)) AS t2(b)
+  ON false
+----
+full-join (cross)
+ ├── columns: a:1(unknown)
+ ├── cardinality: [2 - 2]
+ ├── prune: (1)
+ ├── reject-nulls: (1)
+ ├── values
+ │    ├── columns: column1:1(unknown)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── prune: (1)
+ │    └── tuple [type=tuple{unknown}]
+ │         └── null [type=unknown]
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── filters
+      └── false [type=bool]

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -17,6 +17,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 )
 
+func TestFuncDeps_DowngradeKey(t *testing.T) {
+	fd1 := &props.FuncDepSet{}
+	fd1.AddStrictKey(c(1), c(1, 2, 3))
+	fd1.DowngradeKey()
+	fd1.Verify()
+	verifyFD(t, fd1, "lax-key(1); (1)-->(2,3)")
+
+	// Downgrading an empty strict key should not result in an empty lax key,
+	// which is invalid.
+	fd2 := &props.FuncDepSet{}
+	fd2.AddStrictKey(opt.ColSet{}, c(1, 2, 3))
+	fd2.DowngradeKey()
+	fd2.Verify()
+	verifyFD(t, fd2, "()-->(1-3)")
+}
+
 // Other tests also exercise the ColsAreKey methods.
 func TestFuncDeps_ColsAreKey(t *testing.T) {
 	// CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)


### PR DESCRIPTION
PR #43532 removed the concept of lax constant functional dependencies.
There is a left-over case when we downgrade a key: if we had a strong
empty key, the result is a lax empty key which is no longer a concept.

This change fixes this by removing the key altogether in this case.

Fixes #43651.

Release note (bug fix): fixes "expected constant FD to be strict"
internal error.