### PR TITLE
pgwire: clarify the special cases as pre-defined HBA rules

### DIFF
--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -33,7 +33,7 @@ import (
 // e.g. in the CCL modules to add support for GSS authentication using
 // Kerberos.
 
-func init() {
+func loadDefaultMethods() {
 	// The "password" method requires a clear text password.
 	//
 	// Care should be taken by administrators to only accept this auth

--- a/pkg/sql/pgwire/hba/hba_test.go
+++ b/pkg/sql/pgwire/hba/hba_test.go
@@ -13,6 +13,7 @@ package hba
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
@@ -28,7 +29,10 @@ func TestParse(t *testing.T) {
 				if err != nil {
 					return fmt.Sprintf("error: %v\n", err)
 				}
-				return fmt.Sprintf("%# v", pretty.Formatter(conf))
+				var out strings.Builder
+				fmt.Fprintf(&out, "# String render check:\n%s", conf)
+				fmt.Fprintf(&out, "# Detail:\n%# v", pretty.Formatter(conf))
+				return out.String()
 
 			case "line":
 				tokens, err := tokenize(td.Input)
@@ -48,6 +52,23 @@ func TestParse(t *testing.T) {
 			default:
 				return fmt.Sprintf("unknown directive: %s", td.Cmd)
 			}
+		})
+}
+
+func TestParseAndNormalizeAuthConfig(t *testing.T) {
+	datadriven.RunTest(t, filepath.Join("testdata", "normalization"),
+		func(t *testing.T, td *datadriven.TestData) string {
+			switch td.Cmd {
+			case "hba":
+				conf, err := ParseAndNormalize(td.Input)
+				if err != nil {
+					return fmt.Sprintf("error: %v\n", err)
+				}
+				return conf.String()
+			default:
+				t.Fatalf("unknown directive: %s", td.Cmd)
+			}
+			return ""
 		})
 }
 

--- a/pkg/sql/pgwire/hba/parser.go
+++ b/pkg/sql/pgwire/hba/parser.go
@@ -55,10 +55,6 @@ func Parse(input string) (*Conf, error) {
 		entries = append(entries, entry)
 	}
 
-	if len(entries) == 0 {
-		return nil, errors.New("no entries")
-	}
-
 	return &Conf{Entries: entries}, nil
 }
 
@@ -125,7 +121,7 @@ func parseHbaLine(line [][]String) (Entry, error) {
 					hostname = ""
 				}
 				if hostname != "" {
-					entry.Address = String{Value: addr, Quoted: false}
+					entry.Address = String{Value: addr, Quoted: token.Quoted}
 				} else {
 					// First field was an IP address.
 					fieldIdx++

--- a/pkg/sql/pgwire/hba/testdata/normalization
+++ b/pkg/sql/pgwire/hba/testdata/normalization
@@ -1,0 +1,70 @@
+subtest empty_conf
+
+hba
+# nothing
+----
+# (empty configuration)
+
+hba
+----
+# (empty configuration)
+
+subtest end
+
+subtest unicode_normalization
+
+hba
+host all Ὀδυσσεύς all cert-password
+----
+# TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
+host   all      ὀδυσσεύς all     cert-password
+
+subtest end
+
+subtest db_normalization
+
+hba
+host some foo all cert-password
+host some,more bar all cert-password
+----
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      foo  all     cert-password
+host   all      bar  all     cert-password
+
+subtest end
+
+subtest quoted_all_host
+
+hba
+host all all "all" cert-password
+----
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      all  "all"   cert-password
+
+subtest end
+
+subtest all_in_user_list
+
+hba
+host all a,all,b all cert-password
+host all a,"all",b all cert-password
+----
+# TYPE DATABASE USER  ADDRESS METHOD        OPTIONS
+host   all      all   all     cert-password
+host   all      a     all     cert-password
+host   all      "all" all     cert-password
+host   all      b     all     cert-password
+
+subtest end
+
+subtest rule_expansion
+
+hba
+host all a,b,c all cert-password
+----
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      a    all     cert-password
+host   all      b    all     cert-password
+host   all      c    all     cert-password
+
+subtest end

--- a/pkg/sql/pgwire/hba/testdata/parse
+++ b/pkg/sql/pgwire/hba/testdata/parse
@@ -46,17 +46,20 @@ subtest ignored_quotes
 line
 "local" a b c
 ----
-local a b c
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+local  a        b            c
 
 line
 local a b "method"
 ----
-local a b method
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+local  a        b            method
 
 line
 local a b c "k=v"
 ----
-local a b c k=v
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+local  a        b            c      k=v
 
 subtest end
 
@@ -65,27 +68,32 @@ subtest keyword_all
 line
 host all b c d
 ----
-host all b c d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   all      b    c       d
 
 line
 host "all" b c d
 ----
-host "all" b c d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   "all"    b    c       d
 
 line
 host a all c d
 ----
-host a all c d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   a        all  c       d
 
 line
 host a "all" c d
 ----
-host a "all" c d
+# TYPE DATABASE USER  ADDRESS METHOD OPTIONS
+host   a        "all" c       d
 
 line
 host a b all d
 ----
-host a b all d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   a        b    all     d
 
 subtest end
 
@@ -114,13 +122,15 @@ error: multiple values specified for host address
 line
 local a b 1.1.1.1
 ----
-local a b 1.1.1.1
+# TYPE DATABASE USER ADDRESS METHOD  OPTIONS
+local  a        b            1.1.1.1
 
 
 line
 host a b 0.0.0.0/0 d
 ----
-host a b 0.0.0.0/0 d
+# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
+host   a        b    0.0.0.0/0 d
 
 parse
 host all all 0.0/0 trust
@@ -130,17 +140,20 @@ unknown directive: parse
 line
 host a b ::1/0 d
 ----
-host a b ::/0 d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   a        b    ::/0    d
 
 line
 host a b 2.3.4.5/8 d
 ----
-host a b 2.0.0.0/8 d
+# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
+host   a        b    2.0.0.0/8 d
 
 line
 host all all fe80::7a31:c1ff:0000:0000/96 cert
 ----
-host all all fe80::7a31:c1ff:0:0/96 cert
+# TYPE DATABASE USER ADDRESS                METHOD OPTIONS
+host   all      all  fe80::7a31:c1ff:0:0/96 cert
 
 line
 host a b 1.1.1.1 255.0.0.0,255.255.0.0 d
@@ -151,12 +164,14 @@ error: multiple values specified for netmask
 line
 host a b 2.3.4.5 255.255.0.0 d
 ----
-host a b 2.3.0.0/16 d
+# TYPE DATABASE USER ADDRESS    METHOD OPTIONS
+host   a        b    2.3.0.0/16 d
 
 line
 host a b fe80:7a31:c1ff:: ffff:fff0:: d
 ----
-host a b fe80:7a30::/28 d
+# TYPE DATABASE USER ADDRESS        METHOD OPTIONS
+host   a        b    fe80:7a30::/28 d
 
 line
 host a b 1.1.1.1 abc d
@@ -171,7 +186,8 @@ error: invalid IP mask "8.0.0.8": address is not a mask
 line
 host a b myhost d
 ----
-host a b myhost d
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   a        b    myhost  d
 
 subtest end
 
@@ -199,6 +215,13 @@ host all a,b,c all trust
 host a,b,c d,e,f all trust
 host all testuser,"all" 0.0.0.0/0 cert
 ----
+# String render check:
+# TYPE DATABASE USER           ADDRESS   METHOD OPTIONS
+host   a,b,c    all            all       trust
+host   all      a,b,c          all       trust
+host   a,b,c    d,e,f          all       trust
+host   all      testuser,"all" 0.0.0.0/0 cert
+# Detail:
 &hba.Conf{
     Entries: {
         {
@@ -211,9 +234,10 @@ host all testuser,"all" 0.0.0.0/0 cert
             User: {
                 {Value:"all", Quoted:false},
             },
-            Address: hba.String{Value:"all", Quoted:false},
-            Method:  "trust",
-            Options: nil,
+            Address:  hba.String{Value:"all", Quoted:false},
+            Method:   "trust",
+            MethodFn: nil,
+            Options:  nil,
         },
         {
             Type:     "host",
@@ -225,9 +249,10 @@ host all testuser,"all" 0.0.0.0/0 cert
                 {Value:"b", Quoted:false},
                 {Value:"c", Quoted:false},
             },
-            Address: hba.String{Value:"all", Quoted:false},
-            Method:  "trust",
-            Options: nil,
+            Address:  hba.String{Value:"all", Quoted:false},
+            Method:   "trust",
+            MethodFn: nil,
+            Options:  nil,
         },
         {
             Type:     "host",
@@ -241,9 +266,10 @@ host all testuser,"all" 0.0.0.0/0 cert
                 {Value:"e", Quoted:false},
                 {Value:"f", Quoted:false},
             },
-            Address: hba.String{Value:"all", Quoted:false},
-            Method:  "trust",
-            Options: nil,
+            Address:  hba.String{Value:"all", Quoted:false},
+            Method:   "trust",
+            MethodFn: nil,
+            Options:  nil,
         },
         {
             Type:     "host",
@@ -258,15 +284,21 @@ host all testuser,"all" 0.0.0.0/0 cert
                 IP:   {0x0, 0x0, 0x0, 0x0},
                 Mask: {0x0, 0x0, 0x0, 0x0},
             },
-            Method:  "cert",
-            Options: nil,
+            Method:   "cert",
+            MethodFn: nil,
+            Options:  nil,
         },
     },
 }
 
+
 multiline
 host "all","test space",something some,"us ers" all cert
 ----
+# String render check:
+# TYPE DATABASE                     USER          ADDRESS METHOD OPTIONS
+host   "all","test space",something some,"us ers" all     cert
+# Detail:
 &hba.Conf{
     Entries: {
         {
@@ -280,9 +312,10 @@ host "all","test space",something some,"us ers" all cert
                 {Value:"some", Quoted:false},
                 {Value:"us ers", Quoted:true},
             },
-            Address: hba.String{Value:"all", Quoted:false},
-            Method:  "cert",
-            Options: nil,
+            Address:  hba.String{Value:"all", Quoted:false},
+            Method:   "cert",
+            MethodFn: nil,
+            Options:  nil,
         },
     },
 }
@@ -305,7 +338,10 @@ multiline
 
 # to be found here
 ----
-error: no entries
+# String render check:
+# (empty configuration)
+# Detail:
+&hba.Conf{}
 
 subtest end
 
@@ -322,8 +358,14 @@ subtest end
 subtest options
 
 multiline
+host all all root cert-password ignored=value
 host all all all gss krb_realm=other include_realm=0 krb_realm=te-st12.COM
 ----
+# String render check:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      all  root    cert-password ignored=value
+host   all      all  all     gss           krb_realm=other include_realm=0 krb_realm=te-st12.COM
+# Detail:
 &hba.Conf{
     Entries: {
         {
@@ -334,13 +376,79 @@ host all all all gss krb_realm=other include_realm=0 krb_realm=te-st12.COM
             User: {
                 {Value:"all", Quoted:false},
             },
-            Address: hba.String{Value:"all", Quoted:false},
-            Method:  "gss",
-            Options: {
+            Address:  hba.String{Value:"root", Quoted:false},
+            Method:   "cert-password",
+            MethodFn: nil,
+            Options:  {
+                {"ignored", "value"},
+            },
+        },
+        {
+            Type:     "host",
+            Database: {
+                {Value:"all", Quoted:false},
+            },
+            User: {
+                {Value:"all", Quoted:false},
+            },
+            Address:  hba.String{Value:"all", Quoted:false},
+            Method:   "gss",
+            MethodFn: nil,
+            Options:  {
                 {"krb_realm", "other"},
                 {"include_realm", "0"},
                 {"krb_realm", "te-st12.COM"},
             },
+        },
+    },
+}
+
+subtest end
+
+subtest more_all_tests
+
+multiline
+host db all 0.0.0.0/0 cert
+host "all" "all" 0.0.0.0/0 cert
+----
+# String render check:
+# TYPE DATABASE USER  ADDRESS   METHOD OPTIONS
+host   db       all   0.0.0.0/0 cert
+host   "all"    "all" 0.0.0.0/0 cert
+# Detail:
+&hba.Conf{
+    Entries: {
+        {
+            Type:     "host",
+            Database: {
+                {Value:"db", Quoted:false},
+            },
+            User: {
+                {Value:"all", Quoted:false},
+            },
+            Address: &net.IPNet{
+                IP:   {0x0, 0x0, 0x0, 0x0},
+                Mask: {0x0, 0x0, 0x0, 0x0},
+            },
+            Method:   "cert",
+            MethodFn: nil,
+            Options:  nil,
+        },
+        {
+            Type:     "host",
+            Database: {
+                {Value:"all", Quoted:true},
+            },
+            User: {
+                {Value:"all", Quoted:true},
+            },
+            Address: &net.IPNet{
+                IP:   {0x0, 0x0, 0x0, 0x0},
+                Mask: {0x0, 0x0, 0x0, 0x0},
+            },
+            Method:   "cert",
+            MethodFn: nil,
+            Options:  nil,
         },
     },
 }

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -517,10 +517,6 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			baseSQLMemoryBudget, err)
 	}
 
-	s.auth.RLock()
-	auth := s.auth.conf
-	s.auth.RUnlock()
-
 	var authHook func(context.Context) error
 	if k := s.execCfg.PGWireTestingKnobs; k != nil {
 		authHook = k.AuthHook
@@ -533,7 +529,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		authOptions{
 			insecure: s.cfg.Insecure,
 			ie:       s.execCfg.InternalExecutor,
-			auth:     auth,
+			auth:     s.GetAuthenticationConfiguration(),
 			authHook: authHook,
 		},
 		s.stopper)

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -1,6 +1,6 @@
 # These tests exercise the code when the HBA configuration is empty.
 #
-# An empty config is somewhat equivalent to:
+# An empty config is equivalent to:
 #
 #     host all root 0.0.0.0/0 cert
 #     host all all  0.0.0.0/0 cert-password
@@ -18,8 +18,10 @@ config secure
 # Set HBA to empty in case it wasn't done before.
 set_hba
 ----
-# Cache of the HBA configuration on this node:
-# (configuration is empty)
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      root all     cert
+host   all      all  all     cert-password
 
 subtest root
 
@@ -32,7 +34,7 @@ ok defaultdb
 # password auth. However, root password auth is rejected in any case.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
-ERROR: user root must use certificate authentication instead of password authentication
+ERROR: no TLS peer certificates, but required for auth
 
 subtest end root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -9,12 +9,13 @@ config secure
 ----
 
 set_hba
-host all root 0.0.0.0/0 cert
-host all all 0.0.0.0/0 cert-password
+host all root all cert
+host all all all cert-password
 ----
-# Cache of the HBA configuration on this node:
-host all root 0.0.0.0/0 cert
-host all all 0.0.0.0/0 cert-password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      root all     cert
+host   all      all  all     cert-password
 
 subtest root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -10,8 +10,10 @@ subtest nomatch
 set_hba
 host all all 0.0.0.0/32 cert
 ----
-# Cache of the HBA configuration on this node:
-host all all 0.0.0.0/32 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS    METHOD OPTIONS
+host   all      root all        cert
+host   all      all  0.0.0.0/32 cert
 
 connect user=testuser
 ----
@@ -38,8 +40,10 @@ subtest match_net
 set_hba
 host all all 127.0.0.0/8 cert
 ----
-# Cache of the HBA configuration on this node:
-host all all 127.0.0.0/8 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS     METHOD OPTIONS
+host   all      root all         cert
+host   all      all  127.0.0.0/8 cert
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -7,6 +7,7 @@ set_hba
 #empty
 ----
 ERROR: no entries
+HINT: To use the default configuration, assign the empty string ('').
 
 set_hba
 host all all 1.1.1/0 cert
@@ -50,3 +51,4 @@ ERROR: unimplemented: hostname-based HBA rules are not supported (SQLSTATE 0A000
 HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>
 --
 List the numeric CIDR notation instead, for example: 127.0.0.1/8.
+Alternatively, use 'all' (without quotes) for any IPv4/IPv6 address.

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -21,8 +21,10 @@ subtest root
 set_hba
 host all root 0.0.0.0/0 cert
 ----
-# Cache of the HBA configuration on this node:
-host all root 0.0.0.0/0 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
+host   all      root all       cert
+host   all      root 0.0.0.0/0 cert
 
 connect user=root
 ----
@@ -48,8 +50,10 @@ subtest testuser
 set_hba
 host all testuser 0.0.0.0/0 cert
 ----
-# Cache of the HBA configuration on this node:
-host all testuser 0.0.0.0/0 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER     ADDRESS   METHOD OPTIONS
+host   all      root     all       cert
+host   all      testuser 0.0.0.0/0 cert
 
 connect user=testuser
 ----
@@ -68,6 +72,23 @@ ok defaultdb
 subtest end testuser
 
 
+subtest quoted_users
+
+set_hba
+host all "a","b","testuser" 0.0.0.0/0 cert
+----
+# Active authentication configuration on this node:
+# TYPE DATABASE USER       ADDRESS   METHOD OPTIONS
+host   all      root       all       cert
+host   all      "a"        0.0.0.0/0 cert
+host   all      "b"        0.0.0.0/0 cert
+host   all      "testuser" 0.0.0.0/0 cert
+
+connect user=testuser
+----
+ok defaultdb
+
+subtest end
 
 subtest side_by_side
 
@@ -75,9 +96,11 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 cert-password
 ----
-# Cache of the HBA configuration on this node:
-host all testuser 0.0.0.0/0 cert
-host all passworduser 0.0.0.0/0 cert-password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
+host   all      root         all       cert
+host   all      testuser     0.0.0.0/0 cert
+host   all      passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -101,8 +124,11 @@ subtest multiple
 set_hba
 host all testuser,passworduser 0.0.0.0/0 cert-password
 ----
-# Cache of the HBA configuration on this node:
-host all testuser,passworduser 0.0.0.0/0 cert-password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
+host   all      root         all       cert
+host   all      testuser     0.0.0.0/0 cert-password
+host   all      passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -134,9 +160,11 @@ set_hba
 host all testuser,all 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
-# Cache of the HBA configuration on this node:
-host all testuser,all 0.0.0.0/0 cert
-host all passworduser 0.0.0.0/0 password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER         ADDRESS   METHOD   OPTIONS
+host   all      root         all       cert
+host   all      all          0.0.0.0/0 cert
+host   all      passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----
@@ -154,9 +182,12 @@ set_hba
 host all testuser,"all" 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
-# Cache of the HBA configuration on this node:
-host all testuser,"all" 0.0.0.0/0 cert
-host all passworduser 0.0.0.0/0 password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER         ADDRESS   METHOD   OPTIONS
+host   all      root         all       cert
+host   all      testuser     0.0.0.0/0 cert
+host   all      "all"        0.0.0.0/0 cert
+host   all      passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -18,8 +18,10 @@ subtest root_always_enabled
 set_hba
 host all root 0.0.0.0/0 cert
 ----
-# Cache of the HBA configuration on this node:
-host all root 0.0.0.0/0 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
+host   all      root all       cert
+host   all      root 0.0.0.0/0 cert
 
 connect user=root sslmode=disable
 ----

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -17,8 +17,10 @@ subtest root_user_cannot_use_password
 set_hba
 host all root 0.0.0.0/0 password
 ----
-# Cache of the HBA configuration on this node:
-host all root 0.0.0.0/0 password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER ADDRESS   METHOD   OPTIONS
+host   all      root all       cert
+host   all      root 0.0.0.0/0 password
 
 connect user=root password=abc sslmode=verify-ca sslcert=
 ----
@@ -42,8 +44,10 @@ subtest user_has_both_cert_and_passwd/only_cert_implies_reject_password
 set_hba
 host all testuser 0.0.0.0/0 cert
 ----
-# Cache of the HBA configuration on this node:
-host all testuser 0.0.0.0/0 cert
+# Active authentication configuration on this node:
+# TYPE DATABASE USER     ADDRESS   METHOD OPTIONS
+host   all      root     all       cert
+host   all      testuser 0.0.0.0/0 cert
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
@@ -56,8 +60,10 @@ subtest user_has_both_cert_and_passwd/only_password_implies_reject_cert
 set_hba
 host all testuser 0.0.0.0/0 password
 ----
-# Cache of the HBA configuration on this node:
-host all testuser 0.0.0.0/0 password
+# Active authentication configuration on this node:
+# TYPE DATABASE USER     ADDRESS   METHOD   OPTIONS
+host   all      root     all       cert
+host   all      testuser 0.0.0.0/0 password
 
 connect user=testuser
 ----


### PR DESCRIPTION
First commit from #43779.
This PR is needed ahead of fixing #31113, which will require supporting `local` HBA rules.

Prior to this patch, the authentication code was relatively complex to
understand:

- the code path to use the HBA configuration would only be activated
  if the cluster setting was set. There was a special case if it
  wasn't. The special case was in the per-conn auth logic.
- the special case for the root login escape was also present in the
  per-conn auth logic.
- every time the cluster setting would be updated, the result of
  parsing the setting was cached as-is, and the textual strings
  re-interpreted over and over upon every connection.

This complexity can be interpreted as a defect, for the main reason
that **the per-conn auth code should be as simple as possible** to
facilitate security audits and future maintainance. Additionally, an
argument could be made that the per-conn re-interpretation of the
result was a performance mishap.

This patch aims to simplify the per-conn auth logic by folding all the
special casing as pre-defined rules in the HBA configuration:

- the default logic (when the cluster setting is empty or invalid)
  becomes a predefined HBA configuration with just two rules:

         host all root all cert
         host all all  all cert-password

- each time the config is loaded from a cluster setting, the
  root escape is implemented by force-inserting `host all root all
  cert` at the start of the configuration.

With this in place, the auth logic can be simplified to always
and exclusively use the HBA rules.

This special casing can also be inspected in the output of
`/debug/hba_conf`.

Additionally, this patch optimizes the code by pre-normalizing upfront
when the setting is updated. Normalizing includes:

- unicode-normalizing and case-folding usernames, since the username
  upon new connection is also normalized and case-folded.
- expanding lists of multiple usernames into multiple rules, so
  that the checking code can be simplified to only check one username
  per rule.

Release note (security): The authentication code for new SQL
connections has been simplified to always use the HBA configuration
defined per `server.host_based_authentication.configuration`.

The format of this file generally follows that of `pg_hba.conf` as
defined here:
https://www.postgresql.org/docs/current/auth-pg-hba-conf.html.

Upon each configuration change, CockroachDB auto-magically inserts the
entry `host all root all cert` as a first rule, to ensure the root
user can always log in with a valid client certificate.

If the configuration is set to empty, or found to be invalid in the
cluster setting, the following default configuration is automatically
used:

         host all root all cert
         host all all  all cert-password

At any moment the current configuration on each node can be inspected
using the `/debug/hba_conf` URL on the HTTP endpoint.

The list of valid authentication methods is currently:

- `cert`, for certificate-based authentication over a SSL connection
  exclusively;
- `cert-password`, which allows either cert-based or password-based
  authentication over a SSL connection;
- `password` for password-based authentication over a SSL connection;
- `gss` for Kerberos-based authentication over a SSL connection,
  enabled when running a CCL binary and an Enterprise license.

In effect CockroachDB treats all the `host` rules as `hostssl`, and
behaves as per a default of `hostnossl all all all reject`.

It is not currently possible to define authentication rules over
non-SSL connections: as of this writing, non-SSL connections are only
possible when running with `--insecure`, and on insecure nodes all the
authentication logic is entirely disabled.

This behavior remains equivalent to previous CockroachDB versions,
and this change is only discussed here for clarity.
