### PR TITLE
 pgwire,debug: expose the HBA configuration via /debug/hba_conf

### DIFF
--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -18,7 +18,8 @@ config secure
 # Set HBA to empty in case it wasn't done before.
 set_hba
 ----
-ok
+# Cache of the HBA configuration on this node:
+# (configuration is empty)
 
 subtest root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -12,7 +12,9 @@ set_hba
 host all root 0.0.0.0/0 cert
 host all all 0.0.0.0/0 cert-password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all root 0.0.0.0/0 cert
+host all all 0.0.0.0/0 cert-password
 
 subtest root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -10,7 +10,8 @@ subtest nomatch
 set_hba
 host all all 0.0.0.0/32 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all all 0.0.0.0/32 cert
 
 connect user=testuser
 ----
@@ -37,7 +38,8 @@ subtest match_net
 set_hba
 host all all 127.0.0.0/8 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all all 127.0.0.0/8 cert
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -21,7 +21,8 @@ subtest root
 set_hba
 host all root 0.0.0.0/0 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all root 0.0.0.0/0 cert
 
 connect user=root
 ----
@@ -47,7 +48,8 @@ subtest testuser
 set_hba
 host all testuser 0.0.0.0/0 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser 0.0.0.0/0 cert
 
 connect user=testuser
 ----
@@ -73,7 +75,9 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 cert-password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser 0.0.0.0/0 cert
+host all passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -97,7 +101,8 @@ subtest multiple
 set_hba
 host all testuser,passworduser 0.0.0.0/0 cert-password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser,passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -129,7 +134,9 @@ set_hba
 host all testuser,all 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser,all 0.0.0.0/0 cert
+host all passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----
@@ -147,7 +154,9 @@ set_hba
 host all testuser,"all" 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser,"all" 0.0.0.0/0 cert
+host all passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -18,7 +18,8 @@ subtest root_always_enabled
 set_hba
 host all root 0.0.0.0/0 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all root 0.0.0.0/0 cert
 
 connect user=root sslmode=disable
 ----

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -17,7 +17,8 @@ subtest root_user_cannot_use_password
 set_hba
 host all root 0.0.0.0/0 password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all root 0.0.0.0/0 password
 
 connect user=root password=abc sslmode=verify-ca sslcert=
 ----
@@ -41,7 +42,8 @@ subtest user_has_both_cert_and_passwd/only_cert_implies_reject_password
 set_hba
 host all testuser 0.0.0.0/0 cert
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser 0.0.0.0/0 cert
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
@@ -54,7 +56,8 @@ subtest user_has_both_cert_and_passwd/only_password_implies_reject_cert
 set_hba
 host all testuser 0.0.0.0/0 password
 ----
-ok
+# Cache of the HBA configuration on this node:
+host all testuser 0.0.0.0/0 password
 
 connect user=testuser
 ----


### PR DESCRIPTION
This patch exposes, on each node, the HBA configuration cache as
computed from the cluster setting.

This is used in the authentication tests to ascertain that the parsed
configuration is equivalent to the one provided as input.

Release note: None