### PR TITLE
pgwire,hba: introduce the 'trust' and 'reject' auth methods

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -60,6 +60,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-7</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-8</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
@@ -188,5 +189,5 @@ func checkEntry(entry hba.Entry) error {
 }
 
 func init() {
-	pgwire.RegisterAuthMethod("gss", authGSS, checkEntry)
+	pgwire.RegisterAuthMethod("gss", authGSS, cluster.Version19_1, checkEntry)
 }

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -52,9 +52,9 @@ const (
 	VersionNamespaceTableWithSchemas
 	VersionProtectedTimestamps
 	VersionPrimaryKeyChanges
+	VersionAuthLocalAndTrustRejectMethods
 
 	// Add new versions here (step one of two).
-
 )
 
 // versionsSingleton lists all historical versions here in chronological order,
@@ -356,6 +356,17 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// It allows online primary key changes of tables.
 		Key:     VersionPrimaryKeyChanges,
 		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 7},
+	},
+	{
+		// VersionAuthLocalAndTrustRejectMethods introduces the HBA rule
+		// prefix 'local' and auth methods 'trust' and 'reject', for use
+		// in server.host_based_authentication.configuration.
+		//
+		// A separate cluster version ensures the new syntax is not
+		// introduced while previous-version nodes are still running, as
+		// this would block any new SQL client.
+		Key:     VersionAuthLocalAndTrustRejectMethods,
+		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 8},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -28,11 +28,12 @@ func _() {
 	_ = x[VersionNamespaceTableWithSchemas-17]
 	_ = x[VersionProtectedTimestamps-18]
 	_ = x[VersionPrimaryKeyChanges-19]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-20]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChanges"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethods"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493}
+var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/pgwire/hba/testdata/parse
+++ b/pkg/sql/pgwire/hba/testdata/parse
@@ -197,13 +197,14 @@ multiline
 host all all 0.0.0.0/0 trust
 # comment
 
+local all all here trust
 host all all ::1 0 reject # ip and cidr with space
 host all all fe80::7a31:c1ff:0000:0000/96 cert
 host all all all trust
 host all all hostname trust
 host all all 1.1.1.1 1 trust
 ----
-error: line 4: invalid IP mask "0": netmask not in IP numeric format
+error: line 4: authentication option not in name=value format: trust
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -20,7 +20,7 @@ host all all 0.0.0.0/0 invalid
 ERROR: unimplemented: unknown auth method "invalid" (SQLSTATE 0A000)
 HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>
 --
-Supported methods: cert, cert-password, password
+Supported methods: cert, cert-password, password, reject, trust
 
 
 # CockroachDB does not (yet?) support per-db HBA rules.
@@ -52,3 +52,11 @@ HINT: You have attempted to use a feature that is not yet implemented.<STANDARD 
 --
 List the numeric CIDR notation instead, for example: 127.0.0.1/8.
 Alternatively, use 'all' (without quotes) for any IPv4/IPv6 address.
+
+
+# CockroachDB does not yet support local rules.
+set_hba
+local all all cert
+----
+ERROR: unimplemented: unsupported connection type: local (SQLSTATE 0A000)
+HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>

--- a/pkg/sql/pgwire/testdata/auth/trust_reject
+++ b/pkg/sql/pgwire/testdata/auth/trust_reject
@@ -1,0 +1,72 @@
+config secure
+----
+
+subtest auth_reject
+
+# Smoke test: the test user can log in.
+connect user=testuser
+----
+ok defaultdb
+
+# With a 'reject' rule, they can't log in anymore even though a later
+# rule lets them.
+set_hba
+host all testuser all reject
+host all all all cert-password
+----
+# Active authentication configuration on this node:
+# TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
+host   all      root     all     cert
+host   all      testuser all     reject
+host   all      all      all     cert-password
+
+connect user=testuser
+----
+ERROR: authentication rejected by configuration
+
+subtest end
+
+
+subtest auth_trust
+
+# Create a user with a seemingly required password.
+sql
+CREATE USER nocert WITH PASSWORD 'required'
+----
+ok
+
+# Use the "trust" auth type to auth the user even without
+# a valid cert or password.
+set_hba
+host all nocert all trust
+host all all all cert
+----
+# Active authentication configuration on this node:
+# TYPE DATABASE USER   ADDRESS METHOD OPTIONS
+host   all      root   all     cert
+host   all      nocert all     trust
+host   all      all    all     cert
+
+
+connect user=nocert sslcert= sslmode=require
+----
+ok defaultdb
+
+subtest auth_trust/inexistent_user
+
+# If the user does not exist, a "trust" rule is not sufficient to
+# authorize a login.
+
+sql
+DROP USER nocert
+----
+ok
+
+connect user=nocert sslcert= sslmode=require
+----
+ERROR: password authentication failed for user nocert
+
+
+subtest end
+
+subtest end


### PR DESCRIPTION
First commits from #43734 and #43726.

The 'trust' and 'reject' methods, as their name implies,
unconditionally allow and deny authentication of matching connections.

This patch introduces them as a prerequisite to later work on Unix
socket authentication, but also to introduce a bit of infrastructure
that binds new auth methods to a minimum required cluster
version. This new infrastructure ensures that future new auth methods
do not risk hosting a mixed-version cluster. (See discussion on #43717.)

The patch also introduces support for the 'local' rule prefix, which
is still unused.
