### PR TITLE
roachprod: add syntax to specify number of nodes per zone

### DIFF
--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
@@ -313,4 +315,26 @@ func ZonePlacement(numZones, numNodes int) (nodeZones []int) {
 		}
 	}
 	return nodeZones
+}
+
+// ExpandZonesFlag takes a slice of strings which may be of the format
+// zone:N which implies that a given zone should be repeated N times and
+// expands it. For example ["us-west1-b:2", "us-east1-a:2"] will expand to
+// ["us-west1-b", "us-west1-b", "us-east1-a", "us-east1-a"].
+func ExpandZonesFlag(zoneFlag []string) (zones []string, err error) {
+	for _, zone := range zoneFlag {
+		colonIdx := strings.Index(zone, ":")
+		if colonIdx == -1 {
+			zones = append(zones, zone)
+			continue
+		}
+		n, err := strconv.Atoi(zone[colonIdx+1:])
+		if err != nil {
+			return zones, fmt.Errorf("failed to parse %q: %v", zone, err)
+		}
+		for i := 0; i < n; i++ {
+			zones = append(zones, zone[:colonIdx])
+		}
+	}
+	return zones, nil
 }

--- a/pkg/cmd/roachprod/vm/vm_test.go
+++ b/pkg/cmd/roachprod/vm/vm_test.go
@@ -33,3 +33,38 @@ func TestZonePlacement(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandZonesFlag(t *testing.T) {
+	for i, c := range []struct {
+		input, output []string
+		expErr        string
+	}{
+		{
+			input:  []string{"us-east1-b:3", "us-west2-c:2"},
+			output: []string{"us-east1-b", "us-east1-b", "us-east1-b", "us-west2-c", "us-west2-c"},
+		},
+		{
+			input:  []string{"us-east1-b:3", "us-west2-c"},
+			output: []string{"us-east1-b", "us-east1-b", "us-east1-b", "us-west2-c"},
+		},
+		{
+			input:  []string{"us-east1-b", "us-west2-c"},
+			output: []string{"us-east1-b", "us-west2-c"},
+		},
+		{
+			input:  []string{"us-east1-b", "us-west2-c:a2"},
+			expErr: "failed to parse",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			expanded, err := ExpandZonesFlag(c.input)
+			if c.expErr != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, c.expErr, err.Error())
+				}
+			} else {
+				assert.EqualValues(t, c.output, expanded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a shorthand syntax to the zones flags in GCE and AWS to make
specifying the number of nodes per zone easier. Prior to this commit, the
mechanism by which a user of roachprod can place replicas in specific zones
is by providing a `--(gce|aws)-zones` flag with a number of zones equal to
the number of nodes in the cluster being created. This is somewhat onerous
with the suggested syntax being to shell out to python like:

`roachprod create ajwerner-test -n30 --clouds aws --geo --aws-zones $(python -c 'print(",".join(["us-east-1a"]*5 + ["us-east-1b"]*10 + ["us-east-1c"]*15))' )`

This PR instead allows users to specify the same cluster with the following:

`roachprod create ajwerner-test -n30 --clouds aws --geo --aws-zones 'us-east-1a:5,us-east-1b:10,us-east-1c:15'

Release note: None