### PR TITLE
protectedts/ptverifier: implement protectedts.Verifier

### DIFF
--- a/pkg/storage/protectedts/ptverifier/main_test.go
+++ b/pkg/storage/protectedts/ptverifier/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptverifier_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/storage/protectedts/ptverifier/verifier.go
+++ b/pkg/storage/protectedts/ptverifier/verifier.go
@@ -1,0 +1,114 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptverifier
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+)
+
+// verifier implements protectedts.Verifier.
+type verifier struct {
+	db *client.DB
+	s  protectedts.Storage
+}
+
+// New returns a new Verifier.
+func New(db *client.DB, s protectedts.Storage) protectedts.Verifier {
+	return &verifier{db: db, s: s}
+}
+
+// Verify verifies that a record with the provided id is verified.
+// If it is not verified this call will perform verification and mark the
+// record as verified.
+func (v *verifier) Verify(ctx context.Context, id uuid.UUID) error {
+	// First we go read the record and note the timestamp at which we read it.
+	r, ts, err := getRecordWithTimestamp(ctx, v.s, v.db, id)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch record %s", id)
+	}
+
+	if r.Verified { // already verified
+		return nil
+	}
+
+	b := makeVerificationBatch(r, ts)
+	if err := v.db.Run(ctx, &b); err != nil {
+		return err
+	}
+
+	// Check the responses and synthesize an error if one occurred.
+	if err := parseResponse(&b, r); err != nil {
+		return err
+	}
+	// Mark the record as verified.
+	return errors.Wrapf(v.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		return v.s.MarkVerified(ctx, txn, id)
+	}), "failed to mark %v as verified", id)
+}
+
+// getRecordWithTimestamp fetches the record with the provided id and returns
+// the hlc timestamp at which that read occurred.
+func getRecordWithTimestamp(
+	ctx context.Context, s protectedts.Storage, db *client.DB, id uuid.UUID,
+) (r *ptpb.Record, readAt hlc.Timestamp, err error) {
+	if err = db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		r, err = s.GetRecord(ctx, txn, id)
+		readAt = txn.ReadTimestamp()
+		return err
+	}); err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
+	return r, readAt, nil
+}
+
+func makeVerificationBatch(r *ptpb.Record, aliveAt hlc.Timestamp) client.Batch {
+	// Need to perform validation, build a batch and run it.
+	mergedSpans, _ := roachpb.MergeSpans(r.Spans)
+	var b client.Batch
+	for _, s := range mergedSpans {
+		var req roachpb.AdminVerifyProtectedTimestampRequest
+		req.RecordAliveAt = aliveAt
+		req.Protected = r.Timestamp
+		req.RecordID = r.ID
+		req.Key = s.Key
+		req.EndKey = s.EndKey
+		b.AddRawRequest(&req)
+	}
+	return b
+}
+
+func parseResponse(b *client.Batch, r *ptpb.Record) error {
+	rawResponse := b.RawResponse()
+	var failed []roachpb.RangeDescriptor
+	for _, r := range rawResponse.Responses {
+		resp := r.GetInner().(*roachpb.AdminVerifyProtectedTimestampResponse)
+		if len(resp.FailedRanges) == 0 {
+			continue
+		}
+		if len(failed) == 0 {
+			failed = resp.FailedRanges
+		} else {
+			failed = append(failed, resp.FailedRanges...)
+		}
+	}
+	if len(failed) > 0 {
+		return errors.Errorf("failed to verify protection %v on %v", r, failed)
+	}
+	return nil
+}

--- a/pkg/storage/protectedts/ptverifier/verifier_test.go
+++ b/pkg/storage/protectedts/ptverifier/verifier_test.go
@@ -1,0 +1,222 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ptverifier_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptstorage"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptverifier"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifier tests the business logic of verification by mocking out the
+// actual verification requests but using a real implementation of
+// protectedts.Storage.
+func TestVerifier(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	s := tc.Server(0)
+	var senderFunc atomic.Value
+	senderFunc.Store(client.SenderFunc(nil))
+	ds := s.DistSenderI().(*kv.DistSender)
+	tsf := kv.NewTxnCoordSenderFactory(
+		kv.TxnCoordSenderFactoryConfig{
+			AmbientCtx:        s.DB().AmbientContext,
+			HeartbeatInterval: time.Second,
+			Settings:          s.ClusterSettings(),
+			Clock:             s.Clock(),
+			Stopper:           s.Stopper(),
+		},
+		client.SenderFunc(func(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			if f := senderFunc.Load().(client.SenderFunc); f != nil {
+				return f(ctx, ba)
+			}
+			return ds.Send(ctx, ba)
+		}),
+	)
+
+	pts := ptstorage.New(s.ClusterSettings(), s.InternalExecutor().(sqlutil.InternalExecutorWithUser))
+	withDB := ptstorage.WithDatabase(pts, s.DB())
+	db := client.NewDB(s.DB().AmbientContext, tsf, s.Clock())
+	ptv := ptverifier.New(db, pts)
+	makeTableSpan := func(tableID uint32) roachpb.Span {
+		k := roachpb.Key(keys.MakeTablePrefix(tableID))
+		return roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
+	}
+
+	createRecord := func(t *testing.T, tables ...uint32) *ptpb.Record {
+		spans := make([]roachpb.Span, len(tables))
+		for i, tid := range tables {
+			spans[i] = makeTableSpan(tid)
+		}
+		r := ptpb.Record{
+			ID:        uuid.MakeV4(),
+			Timestamp: s.Clock().Now(),
+			Mode:      ptpb.PROTECT_AFTER,
+			Spans:     spans,
+		}
+		require.Nil(t, s.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return pts.Protect(ctx, txn, &r)
+		}))
+		return &r
+	}
+	ensureVerified := func(t *testing.T, id uuid.UUID, verified bool) {
+		got, err := withDB.GetRecord(ctx, nil, id)
+		require.NoError(t, err)
+		require.Equal(t, verified, got.Verified)
+	}
+	release := func(t *testing.T, id uuid.UUID) {
+		require.NoError(t, withDB.Release(ctx, nil, id))
+	}
+	for _, c := range []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "record doesn't exist",
+			test: func(t *testing.T) {
+				require.Regexp(t, protectedts.ErrNotExists.Error(),
+					ptv.Verify(ctx, uuid.MakeV4()).Error())
+			},
+		},
+		{
+			name: "verification failed with injected error",
+			test: func(t *testing.T) {
+				defer senderFunc.Store(senderFunc.Load())
+				r := createRecord(t, 42)
+				senderFunc.Store(client.SenderFunc(func(
+					ctx context.Context, ba roachpb.BatchRequest,
+				) (*roachpb.BatchResponse, *roachpb.Error) {
+					if _, ok := ba.GetArg(roachpb.AdminVerifyProtectedTimestamp); ok {
+						return nil, roachpb.NewError(errors.New("boom"))
+					}
+					return ds.Send(ctx, ba)
+				}))
+				require.Regexp(t, "boom", ptv.Verify(ctx, r.ID).Error())
+				ensureVerified(t, r.ID, false)
+				release(t, r.ID)
+			},
+		},
+		{
+			name: "verification failed with injected response",
+			test: func(t *testing.T) {
+				defer senderFunc.Store(senderFunc.Load())
+				r := createRecord(t, 42)
+				senderFunc.Store(client.SenderFunc(func(
+					ctx context.Context, ba roachpb.BatchRequest,
+				) (*roachpb.BatchResponse, *roachpb.Error) {
+					if _, ok := ba.GetArg(roachpb.AdminVerifyProtectedTimestamp); ok {
+						var resp roachpb.BatchResponse
+						resp.Add(&roachpb.AdminVerifyProtectedTimestampResponse{
+							FailedRanges: []roachpb.RangeDescriptor{{
+								RangeID:  42,
+								StartKey: roachpb.RKey(r.Spans[0].Key),
+								EndKey:   roachpb.RKey(r.Spans[0].EndKey),
+							}},
+						})
+						return &resp, nil
+					}
+					return ds.Send(ctx, ba)
+				}))
+				require.Regexp(t, "failed to verify protection.*r42", ptv.Verify(ctx, r.ID).Error())
+				ensureVerified(t, r.ID, false)
+				release(t, r.ID)
+			},
+		},
+		{
+			name: "verification failed with injected response over two spans",
+			test: func(t *testing.T) {
+				defer senderFunc.Store(senderFunc.Load())
+				r := createRecord(t, 42, 12)
+				senderFunc.Store(client.SenderFunc(func(
+					ctx context.Context, ba roachpb.BatchRequest,
+				) (*roachpb.BatchResponse, *roachpb.Error) {
+					if _, ok := ba.GetArg(roachpb.AdminVerifyProtectedTimestamp); ok {
+						var resp roachpb.BatchResponse
+						resp.Add(&roachpb.AdminVerifyProtectedTimestampResponse{
+							FailedRanges: []roachpb.RangeDescriptor{{
+								RangeID:  42,
+								StartKey: roachpb.RKey(r.Spans[0].Key),
+								EndKey:   roachpb.RKey(r.Spans[0].EndKey),
+							}},
+						})
+						resp.Add(&roachpb.AdminVerifyProtectedTimestampResponse{
+							FailedRanges: []roachpb.RangeDescriptor{{
+								RangeID:  12,
+								StartKey: roachpb.RKey(r.Spans[1].Key),
+								EndKey:   roachpb.RKey(r.Spans[1].EndKey),
+							}},
+						})
+						return &resp, nil
+					}
+					return ds.Send(ctx, ba)
+				}))
+				require.Regexp(t, "failed to verify protection.*r42.*r12", ptv.Verify(ctx, r.ID).Error())
+				ensureVerified(t, r.ID, false)
+				release(t, r.ID)
+			},
+		},
+		{
+			name: "verification succeeded",
+			test: func(t *testing.T) {
+				defer senderFunc.Store(senderFunc.Load())
+				r := createRecord(t, 42)
+				senderFunc.Store(client.SenderFunc(func(
+					ctx context.Context, ba roachpb.BatchRequest,
+				) (*roachpb.BatchResponse, *roachpb.Error) {
+					if _, ok := ba.GetArg(roachpb.AdminVerifyProtectedTimestamp); ok {
+						var resp roachpb.BatchResponse
+						resp.Add(&roachpb.AdminVerifyProtectedTimestampResponse{})
+						return &resp, nil
+					}
+					return ds.Send(ctx, ba)
+				}))
+				require.NoError(t, ptv.Verify(ctx, r.ID))
+				ensureVerified(t, r.ID, true)
+				// Show that we don't send again once we've already verified.
+				sawVerification := false
+				senderFunc.Store(client.SenderFunc(func(
+					ctx context.Context, ba roachpb.BatchRequest,
+				) (*roachpb.BatchResponse, *roachpb.Error) {
+					if _, ok := ba.GetArg(roachpb.AdminVerifyProtectedTimestamp); ok {
+						sawVerification = true
+					}
+					return ds.Send(ctx, ba)
+				}))
+				require.NoError(t, ptv.Verify(ctx, r.ID))
+				require.False(t, sawVerification)
+				release(t, r.ID)
+			},
+		},
+	} {
+		t.Run(c.name, c.test)
+	}
+}


### PR DESCRIPTION
This commit adds an implementation of protectedts.Verifier.
This commit does not exercise the end-to-end verification path.
In fact none of the protected timestamp subsystem is hooked into the
server as of this commit.

Release note: None