### PR TITLE
sql: remove restriction for primary key columns to be in family 0

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -60,6 +60,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-8</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-9</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -6,7 +6,8 @@ CREATE TABLE ok1 (
     INDEX (b) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1),
         PARTITION pu VALUES IN (NULL)
-    )
+    ),
+    FAMILY "primary" (a, b)
 )
 
 query TT
@@ -34,7 +35,8 @@ CREATE TABLE ok2 (
     a INT PRIMARY KEY, b INT,
     UNIQUE (b) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1)
-    )
+    ),
+    FAMILY "primary" (a, b)
 )
 
 query TT
@@ -56,7 +58,8 @@ CREATE TABLE ok3 (
     a INT PRIMARY KEY, b INT,
     UNIQUE INDEX (b) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1)
-    )
+    ),
+    FAMILY "primary" (a, b)
 )
 
 statement ok
@@ -85,7 +88,7 @@ ok3  CREATE TABLE ok3 (
 -- Warning: Partitioned table with no zone configurations.
 
 statement ok
-CREATE TABLE indexes (a INT PRIMARY KEY, b INT)
+CREATE TABLE indexes (a INT PRIMARY KEY, b INT, FAMILY "primary" (a, b))
 
 statement ok
 INSERT INTO indexes VALUES (1,1), (2,2), (3,3)

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -9,7 +9,8 @@ CREATE TABLE t (
     k INT PRIMARY KEY,
     v STRING,
     INDEX secondary (k) STORING (v),
-    INDEX tertiary (k) STORING (v)
+    INDEX tertiary (k) STORING (v),
+    FAMILY (k, v)
 );
 
 # ------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -80,6 +82,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -142,6 +145,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -243,6 +247,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -295,6 +300,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -358,7 +364,8 @@ CREATE TABLE t36642 (
     k INT PRIMARY KEY,
     v STRING,
     INDEX secondary (k) STORING (v),
-    INDEX tertiary (k) STORING (v)
+    INDEX tertiary (k) STORING (v),
+    FAMILY (k, v)
 );
 
 statement ok
@@ -394,6 +401,7 @@ EXPLAIN (OPT, CATALOG) SELECT * FROM t
 TABLE t
  ├── k int not null
  ├── v string
+ ├── FAMILY fam_0_k_v (k, v)
  ├── INDEX primary
  │    ├── k int not null
  │    └── ZONE
@@ -424,7 +432,8 @@ CREATE TABLE t36644 (
     k INT PRIMARY KEY,
     v STRING,
     INDEX secondary (k) STORING (v),
-    INDEX tertiary (k) STORING (v)
+    INDEX tertiary (k) STORING (v),
+    FAMILY (k, v)
 );
 
 statement ok

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -53,6 +53,7 @@ const (
 	VersionProtectedTimestamps
 	VersionPrimaryKeyChanges
 	VersionAuthLocalAndTrustRejectMethods
+	VersionPrimaryKeyColumnsOutOfFamilyZero
 
 	// Add new versions here (step one of two).
 )
@@ -367,6 +368,13 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// this would block any new SQL client.
 		Key:     VersionAuthLocalAndTrustRejectMethods,
 		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 8},
+	},
+	{
+		// VersionPrimaryKeyColumnsOutOfFamilyZero allows for primary key columns
+		// to exist in column families other than 0, in order to prepare for
+		// primary key changes that move primary key columns to different families.
+		Key:     VersionPrimaryKeyColumnsOutOfFamilyZero,
+		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 9},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -29,11 +29,12 @@ func _() {
 	_ = x[VersionProtectedTimestamps-18]
 	_ = x[VersionPrimaryKeyChanges-19]
 	_ = x[VersionAuthLocalAndTrustRejectMethods-20]
+	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-21]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethods"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZero"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530}
+var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530, 569}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -42,7 +42,7 @@ DROP TABLE t
 subtest ManualGeneralChange
 
 statement ok
-CREATE TABLE t (a INT PRIMARY KEY, b STRING)
+CREATE TABLE t (a INT PRIMARY KEY, b STRING, FAMILY "primary" (a, b))
 
 statement ok
 CREATE INDEX idx ON t (b)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -745,7 +745,7 @@ foo
 
 # Create a table with a computed column that we'll de-compute
 statement ok
-CREATE TABLE decomputed_column (a INT PRIMARY KEY, b INT AS ( a + 1 ) STORED)
+CREATE TABLE decomputed_column (a INT PRIMARY KEY, b INT AS ( a + 1 ) STORED, FAMILY "primary" (a, b))
 
 statement ok
 INSERT INTO decomputed_column VALUES (1), (2)

--- a/pkg/sql/logictest/testdata/logic_test/column_families
+++ b/pkg/sql/logictest/testdata/logic_test/column_families
@@ -1,0 +1,71 @@
+# LogicTest: local local-vec
+
+# Test that different operations still succeed when the primary key is not in column family 0.
+
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, FAMILY (y), FAMILY (z), FAMILY (x));
+INSERT INTO t VALUES (1, 2, 3), (4, 5, 6)
+
+query III rowsort
+SELECT * FROM t
+----
+1 2 3
+4 5 6
+
+statement ok
+UPDATE t SET x = 2 WHERE y = 2
+
+query III rowsort
+SELECT * FROM t
+----
+2 2 3
+4 5 6
+
+statement ok
+UPDATE t SET z = 3 WHERE x = 4
+
+query III rowsort
+SELECT * FROM t
+----
+2 2 3
+4 5 3
+
+query II
+SELECT y, z FROM t WHERE x = 2
+----
+2 3
+
+statement ok
+DROP TABLE t;
+CREATE TABLE t (x DECIMAL PRIMARY KEY, y INT, FAMILY (y), FAMILY (x));
+INSERT INTO t VALUES (5.607, 1), (5.6007, 2)
+
+query TI rowsort
+SELECT * FROM t
+----
+5.607 1
+5.6007 2
+
+# Ensure that primary indexes with encoded composite values that are not in family 0 have their
+# composite values stored in the corresponding family.
+
+statement ok
+DROP TABLE t;
+CREATE TABLE t (x DECIMAL, y DECIMAL, z INT, FAMILY (z), FAMILY (y), FAMILY (x), PRIMARY KEY (x, y));
+INSERT INTO t VALUES (1.00, 2.00, 1)
+
+query TTI
+SET tracing=on,kv,results;
+SELECT * FROM t;
+SET tracing=off
+----
+1.00 2.00 1
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'fetched: /t/primary/%'
+ORDER BY message
+----
+fetched: /t/primary/1/2.00/x -> /1.00
+fetched: /t/primary/1/2/y -> /2.00
+fetched: /t/primary/1/2/z -> /1

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -184,7 +184,7 @@ statement error generate insert row: null value in column "x" violates not-null 
 CREATE TABLE foo7 (x PRIMARY KEY) AS VALUES (1), (NULL);
 
 statement ok
-BEGIN; CREATE TABLE foo8 (item PRIMARY KEY, qty) AS SELECT * FROM stock UNION VALUES ('spoons', 25), ('knives', 50); END
+BEGIN; CREATE TABLE foo8 (item PRIMARY KEY, qty, FAMILY "primary" (item, qty)) AS SELECT * FROM stock UNION VALUES ('spoons', 25), ('knives', 50); END
 
 query TT
 SHOW CREATE TABLE foo8
@@ -217,7 +217,7 @@ foo9  CREATE TABLE foo9 (
     )
 
 statement ok
-CREATE TABLE foo10 (a, PRIMARY KEY (c, b, a), b, c) AS SELECT * FROM foo9
+CREATE TABLE foo10 (a, PRIMARY KEY (c, b, a), b, c, FAMILY "primary" (a, b, c)) AS SELECT * FROM foo9
 
 query TT
 SHOW CREATE TABLE foo10

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -4,13 +4,13 @@
 # data placement.
 
 statement ok
-CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v))
 
 statement ok
 INSERT INTO kv SELECT i, i FROM generate_series(1,5) AS g(i);
 
 statement ok
-CREATE TABLE kw (k INT PRIMARY KEY, w INT)
+CREATE TABLE kw (k INT PRIMARY KEY, w INT, FAMILY (k, w))
 
 statement ok
 INSERT INTO kw SELECT i, i FROM generate_series(1,5) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -10,7 +10,7 @@ statement ok
 INSERT INTO other VALUES (9)
 
 statement ok
-CREATE TABLE t (a INT PRIMARY KEY CHECK(a > 0), f INT REFERENCES other, INDEX (f))
+CREATE TABLE t (a INT PRIMARY KEY CHECK(a > 0), f INT REFERENCES other, INDEX (f), FAMILY (a, f))
 
 statement ok
 INSERT INTO t VALUES (1, 9)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -391,7 +391,8 @@ render                ·            ·            ("?column?")                  
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,
-  v INT
+  v INT,
+  FAMILY "primary" (k, v)
 )
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -4,7 +4,8 @@ statement ok
 CREATE TABLE x (
   a INT PRIMARY KEY,
   b INT,
-  INDEX (b)
+  INDEX (b),
+  FAMILY "primary" (a, b)
 )
 
 statement ok
@@ -29,7 +30,8 @@ statement ok
 CREATE TABLE y (
   u INT PRIMARY KEY,
   v INT REFERENCES x,
-  INDEX (v)
+  INDEX (v),
+  FAMILY "primary" (u, v)
 )
 
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -166,7 +166,8 @@ CREATE TABLE b(
     b_id INT,
     a_id INT,
     FOREIGN KEY (a_id) REFERENCES a(a_id) ON UPDATE CASCADE ON DELETE CASCADE,
-    PRIMARY KEY(a_id, b_id)
+    PRIMARY KEY(a_id, b_id),
+    FAMILY "primary" (a_id, b_id)
 ) INTERLEAVE IN PARENT a(a_id)
 
 statement ok
@@ -175,7 +176,8 @@ CREATE TABLE c(
     a_id INT,
     b_id INT,
     FOREIGN KEY (a_id, b_id) REFERENCES b(a_id, b_id) ON UPDATE CASCADE ON DELETE CASCADE,
-    PRIMARY KEY(a_id, b_id, c_id)
+    PRIMARY KEY(a_id, b_id, c_id),
+    FAMILY "primary" (a_id, b_id, c_id)
 ) INTERLEAVE IN PARENT b(a_id, b_id)
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -25,7 +25,7 @@ exec stmt  rows affected: 0
 
 # More KV operations.
 statement ok
-SET tracing = on,kv,results; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT); SET tracing = off
+SET tracing = on,kv,results; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT, FAMILY "primary" (k, v)); SET tracing = off
 
 query TT
 SELECT operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), 'wall_time:\d+', 'wall_time:...') as message
@@ -233,7 +233,7 @@ exec stmt  rows affected: 0
 subtest autocommit
 
 statement ok
-CREATE TABLE t.kv3(k INT PRIMARY KEY, v INT)
+CREATE TABLE t.kv3(k INT PRIMARY KEY, v INT, FAMILY "primary" (k, v))
 
 statement ok
 SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -235,7 +235,7 @@ rows affected: 1
 
 # KV operations.
 statement ok
-CREATE DATABASE t; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)
+CREATE DATABASE t; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT, FAMILY "primary" (k, v))
 
 statement ok
 CREATE UNIQUE INDEX woo ON t.kv(v)
@@ -419,7 +419,7 @@ UPSERT INTO t35364 (x) VALUES (0)
 # ------------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUES(1,1)
+CREATE TABLE table38627 (a INT PRIMARY KEY, b INT, FAMILY (a, b)); INSERT INTO table38627 VALUES(1,1)
 
 statement ok
 BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/pkg/errors"
 )
 
 // rowHelper has the common methods for table row manipulations.
@@ -116,9 +115,6 @@ func (rh *rowHelper) skipColumnInPK(
 	}
 	if _, ok := rh.primaryIndexCols[colID]; !ok {
 		return false, nil
-	}
-	if family != 0 {
-		return false, errors.Errorf("primary index column %d must be in family 0, was %d", colID, family)
 	}
 	if cdatum, ok := value.(tree.CompositeDatum); ok {
 		// Composite columns are encoded in both the key and the value.

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -355,28 +355,6 @@ func TestValidateTableDesc(t *testing.T) {
 				NextColumnID: 2,
 				NextFamilyID: 2,
 			}},
-		{`primary key column 1 is not in column family 0`,
-			TableDescriptor{
-				ID:            2,
-				ParentID:      1,
-				Name:          "foo",
-				FormatVersion: FamilyFormatVersion,
-				Columns: []ColumnDescriptor{
-					{ID: 1, Name: "bar"},
-				},
-				Families: []ColumnFamilyDescriptor{
-					{ID: 0, Name: "baz"},
-					{ID: 1, Name: "qux", ColumnIDs: []ColumnID{1}, ColumnNames: []string{"bar"}},
-				},
-				PrimaryIndex: IndexDescriptor{ID: 1, Name: "quux",
-					ColumnIDs:        []ColumnID{1},
-					ColumnNames:      []string{"bar"},
-					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
-				},
-				NextColumnID: 2,
-				NextFamilyID: 2,
-				NextIndexID:  2,
-			}},
 		{`table must contain a primary key`,
 			TableDescriptor{
 				ID:            2,


### PR DESCRIPTION
This PR removes the restriction that primary key columns must be in
column family 0 in preparation for allowing primary key changes.

Some design decisions made here (open for discussion):

* The composite component of indexed primary key columns will
  go in the value for the family that the column is a member of.
* In the case that dropped columns result in the 0th family being
  empty, we preserve that empty family to ensure that family 0
  always has a k/v pair.

This PR additionally updates the column family randomizer to now
try randomizing the column families of primary key columns.

Release note (sql change): primary key columns are no longer
required to be in column family 0.