### PR TITLE
protectedts,storage,server: finish plumbing for the protected timestamp subsystem

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -556,12 +556,13 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	for _, desc := range descs {
 		snap := db.NewSnapshot()
 		defer snap.Close()
+		policy := zonepb.GCPolicy{TTLSeconds: int32(gcTTLInSeconds)}
+		now := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+		thresh := gc.CalculateThreshold(now, policy)
 		info, err := gc.Run(
 			context.Background(),
-			&desc,
-			snap,
-			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
-			zonepb.GCPolicy{TTLSeconds: int32(gcTTLInSeconds)},
+			&desc, snap,
+			now, thresh, policy,
 			gc.NoopGCer{},
 			func(_ context.Context, _ []roachpb.Intent) error { return nil },
 			func(_ context.Context, _ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -662,4 +663,9 @@ func (c *Constraint) GetKey() string {
 // GetValue is part of the cat.Constraint interface.
 func (c *Constraint) GetValue() string {
 	return c.Value
+}
+
+// TTL returns the implies TTL as a time.Duration.
+func (m *GCPolicy) TTL() time.Duration {
+	return time.Duration(m.TTLSeconds) * time.Second
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -847,6 +847,18 @@ func (p *planner) EvalAsOfTimestamp(asOf tree.AsOfClause) (_ hlc.Timestamp, err 
 }
 
 // ParseHLC parses a string representation of an `hlc.Timestamp`.
+// This differs from hlc.ParseTimestamp in that it parses the decimal
+// serialization of an hlc timestamp as opposed to the string serialization
+// performed by hlc.Timestamp.String().
+//
+// This function is used to parse:
+//
+//   1580361670629466905.0000000001
+//
+// hlc.ParseTimestamp() would be used to parse:
+//
+//   1580361670.629466905,1
+//
 func ParseHLC(s string) (hlc.Timestamp, error) {
 	dec, _, err := apd.NewFromString(s)
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -552,6 +553,9 @@ type ExecutorConfig struct {
 
 	// Role membership cache.
 	RoleMemberCache *MembershipCache
+
+	// ProtectedTimestampProvider encapsulates the protected timestamp subsystem.
+	ProtectedTimestampProvider protectedts.Provider
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/storage/client_protectedts_test.go
+++ b/pkg/storage/client_protectedts_test.go
@@ -1,0 +1,224 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage_test
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptstorage"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptverifier"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProtectedTimestamps is an end-to-end test for protected timestamps.
+// It works by writing a lot of data and waiting for the GC heuristic to allow
+// for GC. Because of this, it's very slow and expensive. It should
+// potentially be made cheaper by injecting hooks to force GC.
+//
+// Probably this test should always be skipped until it is made cheaper,
+// nevertheless it's a useful test.
+func TestProtectedTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	if util.RaceEnabled || testing.Short() {
+		t.Skip("this test is too slow to run with race")
+	}
+
+	args := base.TestClusterArgs{}
+	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{DisableGCQueue: true}
+	tc := testcluster.StartTestCluster(t, 3, args)
+	defer tc.Stopper().Stop(ctx)
+	s0 := tc.Server(0)
+
+	conn := tc.ServerConn(0)
+	_, err := conn.Exec("CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
+	require.NoError(t, err)
+
+	_, err = conn.Exec("SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms';")
+	require.NoError(t, err)
+
+	_, err = conn.Exec("ALTER TABLE foo CONFIGURE ZONE USING " +
+		"gc.ttlseconds = 1, range_max_bytes = 1<<18, range_min_bytes = 1<<10;")
+	require.NoError(t, err)
+
+	rRand, _ := randutil.NewPseudoRand()
+	upsertUntilBackpressure := func() {
+		for {
+			_, err := conn.Exec("UPSERT INTO foo VALUES (1, $1)",
+				randutil.RandBytes(rRand, 1<<15))
+			if testutils.IsError(err, "backpressure") {
+				break
+			}
+			require.NoError(t, err)
+		}
+	}
+	const processedPattern = `(?s)shouldQueue=true.*processing replica.*GC score after GC`
+	processedRegexp := regexp.MustCompile(processedPattern)
+
+	getTableStartKey := func(table string) roachpb.Key {
+		row := conn.QueryRow(
+			"SELECT start_key "+
+				"FROM crdb_internal.ranges_no_leases "+
+				"WHERE table_name = $1 "+
+				"AND database_name = current_database() "+
+				"ORDER BY start_key ASC "+
+				"LIMIT 1",
+			"foo")
+
+		var startKey roachpb.Key
+		require.NoError(t, row.Scan(&startKey))
+		return startKey
+	}
+
+	getStoreAndReplica := func() (*storage.Store, *storage.Replica) {
+		startKey := getTableStartKey("foo")
+		// Okay great now we have a key and can go find replicas and stores and what not.
+		r := tc.LookupRangeOrFatal(t, startKey)
+		l, _, err := tc.FindRangeLease(r, nil)
+		require.NoError(t, err)
+
+		lhServer := tc.Server(int(l.Replica.NodeID) - 1)
+		return getFirstStoreReplica(t, lhServer, startKey)
+	}
+
+	gcSoon := func() {
+		testutils.SucceedsSoon(t, func() error {
+			upsertUntilBackpressure()
+			s, repl := getStoreAndReplica()
+			trace, _, err := s.ManuallyEnqueue(ctx, "gc", repl, false)
+			require.NoError(t, err)
+			if !processedRegexp.MatchString(trace.String()) {
+				return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)
+			}
+			return nil
+		})
+	}
+
+	thresholdRE := regexp.MustCompile(`(?s).*Threshold:(?P<threshold>[^\s]*)`)
+	thresholdFromTrace := func(trace tracing.Recording) hlc.Timestamp {
+		threshStr := string(thresholdRE.ExpandString(nil, "$threshold",
+			trace.String(), thresholdRE.FindStringSubmatchIndex(trace.String())))
+		thresh, err := hlc.ParseTimestamp(threshStr)
+		require.NoError(t, err)
+		return thresh
+	}
+
+	beforeWrites := s0.Clock().Now()
+	gcSoon()
+
+	pts := ptstorage.New(s0.ClusterSettings(), s0.InternalExecutor().(*sql.InternalExecutor))
+	ptsWithDB := ptstorage.WithDatabase(pts, s0.DB())
+	startKey := getTableStartKey("foo")
+	ptsRec := ptpb.Record{
+		ID:        uuid.MakeV4(),
+		Timestamp: s0.Clock().Now(),
+		Mode:      ptpb.PROTECT_AFTER,
+		Spans: []roachpb.Span{
+			{
+				Key:    startKey,
+				EndKey: startKey.PrefixEnd(),
+			},
+		},
+	}
+	require.NoError(t, ptsWithDB.Protect(ctx, nil /* txn */, &ptsRec))
+	upsertUntilBackpressure()
+	// We need to be careful choosing a time. We're a little limited because the
+	// ttl is defined in seconds and we need to wait for the threshold to be
+	// 2x the threshold with the scale factor as time since threshold. The
+	// gc threshold we'll be able to set precedes this timestamp which we'll
+	// put in the record below.
+	afterWrites := s0.Clock().Now().Add(2*time.Second.Nanoseconds(), 0)
+	s, repl := getStoreAndReplica()
+	// The protectedts record will prevent us from aging the MVCC garbage bytes
+	// past the oldest record so shouldQueue should be false. Verify that.
+	trace, _, err := s.ManuallyEnqueue(ctx, "gc", repl, false /* skipShouldQueue */)
+	require.NoError(t, err)
+	require.Regexp(t, "(?s)shouldQueue=false", trace.String())
+
+	// If we skipShouldQueue then gc will run but it should only run up to the
+	// timestamp of our record at the latest.
+	trace, _, err = s.ManuallyEnqueue(ctx, "gc", repl, true /* skipShouldQueue */)
+	require.NoError(t, err)
+	require.Regexp(t, "(?s)done with GC evaluation for 0 keys", trace.String())
+	thresh := thresholdFromTrace(trace)
+	require.Truef(t, thresh.Less(ptsRec.Timestamp), "threshold: %v, protected %v %q", thresh, ptsRec.Timestamp, trace)
+
+	// Verify that the record indeed did apply as far as the replica is concerned.
+	ptv := ptverifier.New(s0.DB(), pts)
+	require.NoError(t, ptv.Verify(ctx, ptsRec.ID))
+	ptsRecVerified, err := ptsWithDB.GetRecord(ctx, nil /* txn */, ptsRec.ID)
+	require.NoError(t, err)
+	require.True(t, ptsRecVerified.Verified)
+
+	// Make a new record that is doomed to fail.
+	failedRec := ptsRec
+	failedRec.ID = uuid.MakeV4()
+	failedRec.Timestamp = beforeWrites
+	failedRec.Timestamp.Logical = 0
+	require.NoError(t, ptsWithDB.Protect(ctx, nil /* txn */, &failedRec))
+	_, err = ptsWithDB.GetRecord(ctx, nil /* txn */, failedRec.ID)
+	require.NoError(t, err)
+
+	// Verify that it indeed did fail.
+	verifyErr := ptv.Verify(ctx, failedRec.ID)
+	require.Regexp(t, "failed to verify protection", verifyErr)
+
+	// Add a new record that is after the old record.
+	laterRec := ptsRec
+	laterRec.ID = uuid.MakeV4()
+	laterRec.Timestamp = afterWrites
+	laterRec.Timestamp.Logical = 0
+	require.NoError(t, ptsWithDB.Protect(ctx, nil /* txn */, &laterRec))
+	require.NoError(t, ptv.Verify(ctx, laterRec.ID))
+
+	// Release the record that had succeeded and ensure that GC eventually
+	// happens up to the protected timestamp of the new record.
+	require.NoError(t, ptsWithDB.Release(ctx, nil, ptsRec.ID))
+	testutils.SucceedsSoon(t, func() error {
+		trace, _, err = s.ManuallyEnqueue(ctx, "gc", repl, false)
+		require.NoError(t, err)
+		if !processedRegexp.MatchString(trace.String()) {
+			return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)
+		}
+		thresh := thresholdFromTrace(trace)
+		require.Truef(t, ptsRec.Timestamp.Less(thresh), "%v >= %v",
+			ptsRec.Timestamp, thresh)
+		require.Truef(t, thresh.Less(laterRec.Timestamp), "%v >= %v",
+			thresh, laterRec.Timestamp)
+		return nil
+	})
+
+	// Release the failed record.
+	require.NoError(t, ptsWithDB.Release(ctx, nil, failedRec.ID))
+	require.NoError(t, ptsWithDB.Release(ctx, nil, laterRec.ID))
+	state, err := ptsWithDB.GetState(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, state.Records, 0)
+	require.Equal(t, int(state.NumRecords), len(state.Records))
+}

--- a/pkg/storage/gc/gc_old_test.go
+++ b/pkg/storage/gc/gc_old_test.go
@@ -43,6 +43,7 @@ func runGCOld(
 	desc *roachpb.RangeDescriptor,
 	snap engine.Reader,
 	now hlc.Timestamp,
+	_ hlc.Timestamp, // exists to make signature match RunGC
 	policy zonepb.GCPolicy,
 	gcer GCer,
 	cleanupIntentsFn CleanupIntentsFunc,

--- a/pkg/storage/gc/gc_random_test.go
+++ b/pkg/storage/gc/gc_random_test.go
@@ -92,8 +92,10 @@ func TestRunNewVsOld(t *testing.T) {
 			snap := eng.NewSnapshot()
 
 			oldGCer := makeFakeGCer()
+			policy := zonepb.GCPolicy{TTLSeconds: tc.ttl}
+			newThreshold := CalculateThreshold(tc.now, policy)
 			gcInfoOld, err := runGCOld(ctx, tc.ds.desc(), snap, tc.now,
-				zonepb.GCPolicy{TTLSeconds: tc.ttl},
+				newThreshold, policy,
 				&oldGCer,
 				oldGCer.resolveIntents,
 				oldGCer.resolveIntentsAsync)
@@ -101,7 +103,7 @@ func TestRunNewVsOld(t *testing.T) {
 
 			newGCer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, tc.ds.desc(), snap, tc.now,
-				zonepb.GCPolicy{TTLSeconds: tc.ttl},
+				newThreshold, policy,
 				&newGCer,
 				newGCer.resolveIntents,
 				newGCer.resolveIntentsAsync)
@@ -126,8 +128,10 @@ func BenchmarkRun(b *testing.B) {
 			runGCFunc = runGCOld
 		}
 		snap := eng.NewSnapshot()
+		policy := zonepb.GCPolicy{TTLSeconds: spec.ttl}
 		return runGCFunc(ctx, spec.ds.desc(), snap, spec.now,
-			zonepb.GCPolicy{TTLSeconds: spec.ttl},
+			CalculateThreshold(spec.now, policy),
+			policy,
 			NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
 				return nil

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateThreshold(t *testing.T) {
+	for _, c := range []struct {
+		ttlSeconds int32
+		ts         hlc.Timestamp
+	}{
+		{
+			ts:         hlc.Timestamp{WallTime: time.Hour.Nanoseconds(), Logical: 0},
+			ttlSeconds: 1,
+		},
+	} {
+		policy := zonepb.GCPolicy{TTLSeconds: c.ttlSeconds}
+		require.Equal(t, c.ts, TimestampForThreshold(CalculateThreshold(c.ts, policy), policy))
+	}
+}

--- a/pkg/storage/protectedts/protectedts.go
+++ b/pkg/storage/protectedts/protectedts.go
@@ -113,6 +113,8 @@ type Cache interface {
 	// Nil values for from or to are equivalent to Key{}. The order of records
 	// between independent calls to Iterate is not defined; the order of records
 	// may differ even for the same key range that occurs at the same timestamp.
+	// The Records passed to the iterator are safe to be retained but must not be
+	// modified.
 	Iterate(_ context.Context, from, to roachpb.Key, it Iterator) (asOf hlc.Timestamp)
 
 	// QueryRecord determines whether a Record with the provided ID exists in

--- a/pkg/storage/protectedts/ptprovider/provider.go
+++ b/pkg/storage/protectedts/ptprovider/provider.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package ptprovider encapsulates the concrete implementation of the
+// protectedts.Provider.
+package ptprovider
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptcache"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptstorage"
+	"github.com/cockroachdb/cockroach/pkg/storage/protectedts/ptverifier"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// Config configures the Provider.
+type Config struct {
+	Settings         *cluster.Settings
+	DB               *client.DB
+	InternalExecutor sqlutil.InternalExecutorWithUser
+}
+
+type provider struct {
+	protectedts.Storage
+	protectedts.Verifier
+
+	*ptcache.Cache
+}
+
+// New creates a new protectedts.Provider.
+func New(config Config) protectedts.Provider {
+	storage := ptstorage.New(config.Settings, config.InternalExecutor)
+	verifier := ptverifier.New(config.DB, storage)
+	cache := ptcache.New(ptcache.Config{
+		DB:       config.DB,
+		Storage:  storage,
+		Settings: config.Settings,
+	})
+	return &provider{
+		Storage:  storage,
+		Cache:    cache,
+		Verifier: verifier,
+	}
+}
+
+func (p *provider) Start(ctx context.Context, stopper *stop.Stopper) error {
+	return p.Cache.Start(ctx, stopper)
+}

--- a/pkg/storage/protectedts/ptprovider/provider.go
+++ b/pkg/storage/protectedts/ptprovider/provider.go
@@ -29,7 +29,7 @@ import (
 type Config struct {
 	Settings         *cluster.Settings
 	DB               *client.DB
-	InternalExecutor sqlutil.InternalExecutorWithUser
+	InternalExecutor sqlutil.InternalExecutor
 }
 
 type provider struct {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -163,6 +163,7 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		HistogramWindowInterval:     metric.TestSampleInterval,
 		EnableEpochRangeLeases:      true,
 		ClosedTimestamp:             container.NoopContainer(),
+		ProtectedTimestampCache:     protectedts.EmptyCache(clock),
 	}
 
 	// Use shorter Raft tick settings in order to minimize start up and failover
@@ -747,10 +748,6 @@ func (sc *StoreConfig) SetDefaults() {
 
 	if sc.GossipWhenCapacityDeltaExceedsFraction == 0 {
 		sc.GossipWhenCapacityDeltaExceedsFraction = defaultGossipWhenCapacityDeltaExceedsFraction
-	}
-
-	if sc.ProtectedTimestampCache == nil {
-		sc.ProtectedTimestampCache = protectedts.EmptyCache(sc.Clock)
 	}
 }
 

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -132,6 +132,38 @@ func TestTimestampString(t *testing.T) {
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.exp, c.ts.String())
+		parsed, err := ParseTimestamp(c.ts.String())
+		assert.NoError(t, err)
+		assert.Equal(t, c.ts, parsed)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	for _, c := range []struct {
+		s      string
+		expErr string
+	}{
+		{
+			"asdf",
+			"failed to parse \"asdf\" as Timestamp",
+		},
+		{
+			"-1.-1,0",
+			"failed to parse \"-1.-1,0\" as Timestamp",
+		},
+		{
+			"9999999999999999999,0",
+			"failed to parse \"9999999999999999999,0\" as Timestamp: strconv.ParseInt: parsing \"9999999999999999999\": value out of range",
+		},
+		{
+			"1.9999999999999999999,0",
+			"failed to parse \"1.9999999999999999999,0\" as Timestamp: strconv.ParseInt: parsing \"9999999999999999999\": value out of range",
+		},
+	} {
+		_, err := ParseTimestamp(c.s)
+		if assert.Error(t, err) {
+			assert.Regexp(t, c.expErr, err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
These commits represent the currently unmerged portion of the basic protected timestamp subsystem.

* The first commit adds a `protectedts.Provider` implementation to encapsulate the subsystem.
* The second commit constructs the provider and plumbs it through to the storage layer.
* The third commit is an end-to-end test in the storage package
    * This test is relatively slow. It certainly isn't the slowest test out there but it does take ~7s.

After these merge the remaining steps for the project on the whole are:

* Adoption in jobs
     * IMPORT INTO
     * Index backfills
     * CDC table scans due to initial startup and schema changes
     * Backups
* Background reconciliation mechanism between jobs and protected timestamps
* Metrics
* Add an interval tree to the `Cache` to make `Iterate` more efficient
* Memory monitoring
    * Not obviously that important given the entire subsystem should consume less than 1MB

