### PR TITLE
roachprod: Add garbage collection cronjob

### DIFF
--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.13
+WORKDIR /build
+COPY . .
+RUN ["/build/build.sh"]
+ENTRYPOINT ["/build/entrypoint.sh"]

--- a/pkg/cmd/roachprod/docker/README.md
+++ b/pkg/cmd/roachprod/docker/README.md
@@ -1,0 +1,11 @@
+# Roachprod Docker Image
+
+This dockerfile will build roachprod from master and create an image
+with the supporting CLI toolchains. The entrypoint for the image will
+configure the CLI tools using files to be mounted into the `/secrets`
+directory.
+
+The easiest way to build this is to run the following from this directory.
+```
+gcloud builds submit -t gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
+```

--- a/pkg/cmd/roachprod/docker/build.sh
+++ b/pkg/cmd/roachprod/docker/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script is used to build the docker image.
+
+set -e
+set -o pipefail
+
+# Install AWS, Azure, GCP SDKs per
+# https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
+# https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" |
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg |
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add -
+
+# Azure
+apt-get update -y
+apt-get install -y lsb-release
+
+curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+    apt-key --keyring /usr/share/keyrings/microsoft.gpg  add -
+
+AZ_REPO=$(lsb_release -cs)
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+    tee /etc/apt/sources.list.d/azure-cli.list
+
+# Install packages and clean up
+apt-get update -y
+apt-get install google-cloud-sdk awscli azure-cli -y
+rm -rf /var/lib/apt/lists/*
+
+go get github.com/cockroachdb/cockroach/pkg/cmd/roachprod

--- a/pkg/cmd/roachprod/docker/entrypoint.sh
+++ b/pkg/cmd/roachprod/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Unpack all of the keys, configs, etc. and then start roachperf
+gcloud auth activate-service-account --key-file /secrets/gcloud.json
+aws configure set aws_access_key_id $(cat /secrets/aws_access_key_id)
+aws configure set aws_secret_access_key $(cat /secrets/aws_secret_access_key)
+az login --service-principal -u $(cat /secrets/azure_user_id) -p $(cat /secrets/azure_password) -t $(cat /secrets/azure_tenant_id)
+exec roachprod $@

--- a/pkg/cmd/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/cmd/roachprod/k8s/roachprod-gc.yaml
@@ -1,0 +1,62 @@
+# A cronjob to run the gc subcommand.
+#
+# The various CLI login data can be configured with:
+#
+#  kubectl create secret generic roachprod-gc-cronjob-creds \
+#    --from-file gcloud.json=/path/to.json
+#    --from-literal aws_access_key_id=XYZZY
+#    --from-literal aws_secret_access_key=XYZZY
+#    --from-literal azure_user_id=XYZZY
+#    --from-literal azure_password=XYZZY
+#    --from-literal azure_tenant_id=XYZZY
+#    --from-literal slack_token=XYZZY
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: roachprod-gc-cronjob
+spec:
+  # Disallow concurrent jobs. We impose a maximum runtime below.
+  concurrencyPolicy: Forbid
+  # Run hourly.
+  schedule: "0 * * * *"
+  # Must start within 1 minute of expected time, or we'll skip
+  # to the next tick.
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: roachprod-gc-cronjob
+        spec:
+          containers:
+            - name: roachprod-gc-cronjob
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
+              args:
+                - gc
+                - --slack-token
+                - $(SLACK_TOKEN)
+              env:
+                - name: SLACK_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: roachprod-gc-cronjob-creds
+                      key: slack_token
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 1
+                  memory: 2Gi
+                limits:
+                  cpu: 1
+                  memory: 2Gi
+              volumeMounts:
+                - mountPath: /secrets
+                  name: secrets
+                  readOnly: true
+          restartPolicy: Never
+          volumes:
+            - name: secrets
+              secret:
+                secretName: roachprod-gc-cronjob-creds
+      backoffLimit: 1


### PR DESCRIPTION
This change adds a Dockerfile and a Kubernetes cronjob spec to run the
`roachprod gc` command on an hourly basis. The docker image relies on various
keys and passwords being populated into a /secrets directory.

Closes: #41804
Closes: cockroachdb/roachperf#41
Release note: None