### PR TITLE
storage: change command registration to declare if ro/rw

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	batcheval.RegisterCommand(roachpb.Export, declareKeysExport, evalExport)
+	batcheval.RegisterReadOnlyCommand(roachpb.Export, declareKeysExport, evalExport)
 }
 
 func declareKeysExport(
@@ -41,7 +41,7 @@ func declareKeysExport(
 // evalExport dumps the requested keys into files of non-overlapping key ranges
 // in a format suitable for bulk ingest.
 func evalExport(
-	ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs batcheval.CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ExportRequest)
 	h := cArgs.Header

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	batcheval.RegisterCommand(roachpb.WriteBatch, batcheval.DefaultDeclareKeys, evalWriteBatch)
+	batcheval.RegisterReadWriteCommand(roachpb.WriteBatch, batcheval.DefaultDeclareKeys, evalWriteBatch)
 }
 
 // evalWriteBatch applies the operations encoded in a BatchRepr. Any existing

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.AddSSTable, DefaultDeclareKeys, EvalAddSSTable)
+	RegisterReadWriteCommand(roachpb.AddSSTable, DefaultDeclareKeys, EvalAddSSTable)
 }
 
 // EvalAddSSTable evaluates an AddSSTable command.

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -391,7 +391,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 				}
 			}
 
-			// After evalAddSSTable, cArgs.Stats contains a diff to the existing
+			// After EvalAddSSTable, cArgs.Stats contains a diff to the existing
 			// stats. Make sure recomputing from scratch gets the same answer as
 			// applying the diff to the stats
 			beforeStats := func() enginepb.MVCCStats {

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -33,7 +33,7 @@ import (
 const ClearRangeBytesThreshold = 512 << 10 // 512KiB
 
 func init() {
-	RegisterCommand(roachpb.ClearRange, declareKeysClearRange, ClearRange)
+	RegisterReadWriteCommand(roachpb.ClearRange, declareKeysClearRange, ClearRange)
 }
 
 func declareKeysClearRange(

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ComputeChecksum, declareKeysComputeChecksum, ComputeChecksum)
+	RegisterReadOnlyCommand(roachpb.ComputeChecksum, declareKeysComputeChecksum, ComputeChecksum)
 }
 
 func declareKeysComputeChecksum(
@@ -45,7 +45,7 @@ const (
 // a particular snapshot. The checksum is later verified through a
 // CollectChecksumRequest.
 func ComputeChecksum(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ComputeChecksumRequest)
 

--- a/pkg/storage/batcheval/cmd_conditional_put.go
+++ b/pkg/storage/batcheval/cmd_conditional_put.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ConditionalPut, DefaultDeclareKeys, ConditionalPut)
+	RegisterReadWriteCommand(roachpb.ConditionalPut, DefaultDeclareKeys, ConditionalPut)
 }
 
 // ConditionalPut sets the value for a specified key only if

--- a/pkg/storage/batcheval/cmd_delete.go
+++ b/pkg/storage/batcheval/cmd_delete.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Delete, DefaultDeclareKeys, Delete)
+	RegisterReadWriteCommand(roachpb.Delete, DefaultDeclareKeys, Delete)
 }
 
 // Delete deletes the key and value specified by key.

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.DeleteRange, declareKeysDeleteRange, DeleteRange)
+	RegisterReadWriteCommand(roachpb.DeleteRange, declareKeysDeleteRange, DeleteRange)
 }
 
 func declareKeysDeleteRange(

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -42,7 +42,7 @@ import (
 var TxnAutoGC = true
 
 func init() {
-	RegisterCommand(roachpb.EndTxn, declareKeysEndTxn, EndTxn)
+	RegisterReadWriteCommand(roachpb.EndTxn, declareKeysEndTxn, EndTxn)
 }
 
 // declareKeysWriteTransaction is the shared portion of

--- a/pkg/storage/batcheval/cmd_gc.go
+++ b/pkg/storage/batcheval/cmd_gc.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.GC, declareKeysGC, GC)
+	RegisterReadWriteCommand(roachpb.GC, declareKeysGC, GC)
 }
 
 func declareKeysGC(

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -20,12 +20,12 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Get, DefaultDeclareKeys, Get)
+	RegisterReadOnlyCommand(roachpb.Get, DefaultDeclareKeys, Get)
 }
 
 // Get returns the value for a specified key.
 func Get(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.GetRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/storage/batcheval/cmd_heartbeat_txn.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.HeartbeatTxn, declareKeysHeartbeatTransaction, HeartbeatTxn)
+	RegisterReadWriteCommand(roachpb.HeartbeatTxn, declareKeysHeartbeatTransaction, HeartbeatTxn)
 }
 
 func declareKeysHeartbeatTransaction(

--- a/pkg/storage/batcheval/cmd_increment.go
+++ b/pkg/storage/batcheval/cmd_increment.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Increment, DefaultDeclareKeys, Increment)
+	RegisterReadWriteCommand(roachpb.Increment, DefaultDeclareKeys, Increment)
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and

--- a/pkg/storage/batcheval/cmd_init_put.go
+++ b/pkg/storage/batcheval/cmd_init_put.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.InitPut, DefaultDeclareKeys, InitPut)
+	RegisterReadWriteCommand(roachpb.InitPut, DefaultDeclareKeys, InitPut)
 }
 
 // InitPut sets the value for a specified key only if it doesn't exist. It

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.LeaseInfo, declareKeysLeaseInfo, LeaseInfo)
+	RegisterReadOnlyCommand(roachpb.LeaseInfo, declareKeysLeaseInfo, LeaseInfo)
 }
 
 func declareKeysLeaseInfo(
@@ -32,7 +32,7 @@ func declareKeysLeaseInfo(
 
 // LeaseInfo returns information about the lease holder for the range.
 func LeaseInfo(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.LeaseInfoResponse)
 	lease, nextLease := cArgs.EvalCtx.GetLease()

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RequestLease, declareKeysRequestLease, RequestLease)
+	RegisterReadWriteCommand(roachpb.RequestLease, declareKeysRequestLease, RequestLease)
 }
 
 // RequestLease sets the range lease for this range. The command fails

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -34,7 +34,7 @@ func declareKeysTransferLease(
 }
 
 func init() {
-	RegisterCommand(roachpb.TransferLease, declareKeysTransferLease, TransferLease)
+	RegisterReadWriteCommand(roachpb.TransferLease, declareKeysTransferLease, TransferLease)
 }
 
 // TransferLease sets the lease holder for the range.

--- a/pkg/storage/batcheval/cmd_merge.go
+++ b/pkg/storage/batcheval/cmd_merge.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Merge, DefaultDeclareKeys, Merge)
+	RegisterReadWriteCommand(roachpb.Merge, DefaultDeclareKeys, Merge)
 }
 
 // Merge is used to merge a value into an existing key. Merge is an

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.PushTxn, declareKeysPushTransaction, PushTxn)
+	RegisterReadWriteCommand(roachpb.PushTxn, declareKeysPushTransaction, PushTxn)
 }
 
 func declareKeysPushTransaction(

--- a/pkg/storage/batcheval/cmd_put.go
+++ b/pkg/storage/batcheval/cmd_put.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Put, declareKeysPut, Put)
+	RegisterReadWriteCommand(roachpb.Put, declareKeysPut, Put)
 }
 
 func declareKeysPut(

--- a/pkg/storage/batcheval/cmd_query_intent.go
+++ b/pkg/storage/batcheval/cmd_query_intent.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.QueryIntent, declareKeysQueryIntent, QueryIntent)
+	RegisterReadOnlyCommand(roachpb.QueryIntent, declareKeysQueryIntent, QueryIntent)
 }
 
 func declareKeysQueryIntent(
@@ -43,7 +43,7 @@ func declareKeysQueryIntent(
 // request is special-cased to return a SERIALIZABLE retry error if a transaction
 // queries its own intent and finds it has been pushed.
 func QueryIntent(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryIntentRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.QueryTxn, declareKeysQueryTransaction, QueryTxn)
+	RegisterReadOnlyCommand(roachpb.QueryTxn, declareKeysQueryTransaction, QueryTxn)
 }
 
 func declareKeysQueryTransaction(
@@ -43,7 +43,7 @@ func declareKeysQueryTransaction(
 // other txns which are waiting on this transaction in order
 // to find dependency cycles.
 func QueryTxn(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryTxnRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_range_stats.go
+++ b/pkg/storage/batcheval/cmd_range_stats.go
@@ -19,12 +19,12 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RangeStats, DefaultDeclareKeys, RangeStats)
+	RegisterReadOnlyCommand(roachpb.RangeStats, DefaultDeclareKeys, RangeStats)
 }
 
 // RangeStats returns the MVCC statistics for a range.
 func RangeStats(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.RangeStatsResponse)
 	reply.MVCCStats = cArgs.EvalCtx.GetMVCCStats()

--- a/pkg/storage/batcheval/cmd_recompute_stats.go
+++ b/pkg/storage/batcheval/cmd_recompute_stats.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RecomputeStats, declareKeysRecomputeStats, RecomputeStats)
+	RegisterReadOnlyCommand(roachpb.RecomputeStats, declareKeysRecomputeStats, RecomputeStats)
 }
 
 func declareKeysRecomputeStats(
@@ -54,7 +54,7 @@ func declareKeysRecomputeStats(
 // RecomputeStats recomputes the MVCCStats stored for this range and adjust them accordingly,
 // returning the MVCCStats delta obtained in the process.
 func RecomputeStats(
-	ctx context.Context, _ engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, _ engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	desc := cArgs.EvalCtx.Desc()
 	args := cArgs.Args.(*roachpb.RecomputeStatsRequest)

--- a/pkg/storage/batcheval/cmd_recover_txn.go
+++ b/pkg/storage/batcheval/cmd_recover_txn.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RecoverTxn, declareKeysRecoverTransaction, RecoverTxn)
+	RegisterReadWriteCommand(roachpb.RecoverTxn, declareKeysRecoverTransaction, RecoverTxn)
 }
 
 func declareKeysRecoverTransaction(

--- a/pkg/storage/batcheval/cmd_refresh.go
+++ b/pkg/storage/batcheval/cmd_refresh.go
@@ -21,13 +21,13 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Refresh, DefaultDeclareKeys, Refresh)
+	RegisterReadOnlyCommand(roachpb.Refresh, DefaultDeclareKeys, Refresh)
 }
 
 // Refresh checks whether the key has any values written in the interval
 // [args.RefreshFrom, header.Timestamp].
 func Refresh(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -21,13 +21,13 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RefreshRange, DefaultDeclareKeys, RefreshRange)
+	RegisterReadOnlyCommand(roachpb.RefreshRange, DefaultDeclareKeys, RefreshRange)
 }
 
 // RefreshRange checks whether the key range specified has any values written in
 // the interval [args.RefreshFrom, header.Timestamp].
 func RefreshRange(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRangeRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_resolve_intent.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ResolveIntent, declareKeysResolveIntent, ResolveIntent)
+	RegisterReadWriteCommand(roachpb.ResolveIntent, declareKeysResolveIntent, ResolveIntent)
 }
 
 func declareKeysResolveIntentCombined(

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ResolveIntentRange, declareKeysResolveIntentRange, ResolveIntentRange)
+	RegisterReadWriteCommand(roachpb.ResolveIntentRange, declareKeysResolveIntentRange, ResolveIntentRange)
 }
 
 func declareKeysResolveIntentRange(

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ReverseScan, DefaultDeclareKeys, ReverseScan)
+	RegisterReadOnlyCommand(roachpb.ReverseScan, DefaultDeclareKeys, ReverseScan)
 }
 
 // ReverseScan scans the key range specified by start key through
@@ -28,7 +28,7 @@ func init() {
 // maxKeys stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func ReverseScan(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ReverseScanRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_revert_range.go
+++ b/pkg/storage/batcheval/cmd_revert_range.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RevertRange, declareKeysRevertRange, RevertRange)
+	RegisterReadWriteCommand(roachpb.RevertRange, declareKeysRevertRange, RevertRange)
 }
 
 func declareKeysRevertRange(

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Scan, DefaultDeclareKeys, Scan)
+	RegisterReadOnlyCommand(roachpb.Scan, DefaultDeclareKeys, Scan)
 }
 
 // Scan scans the key range specified by start key through end key
@@ -28,7 +28,7 @@ func init() {
 // stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func Scan(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ScanRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_subsume.go
+++ b/pkg/storage/batcheval/cmd_subsume.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Subsume, declareKeysSubsume, Subsume)
+	RegisterReadWriteCommand(roachpb.Subsume, declareKeysSubsume, Subsume)
 }
 
 func declareKeysSubsume(

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.TruncateLog, declareKeysTruncateLog, TruncateLog)
+	RegisterReadWriteCommand(roachpb.TruncateLog, declareKeysTruncateLog, TruncateLog)
 }
 
 func declareKeysTruncateLog(

--- a/pkg/storage/batcheval/intent.go
+++ b/pkg/storage/batcheval/intent.go
@@ -25,7 +25,7 @@ import (
 // RangeLookups and since this is how they currently collect intent values, this
 // is ok for now.
 func CollectIntentRows(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, intents []roachpb.Intent,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, intents []roachpb.Intent,
 ) ([]roachpb.KeyValue, error) {
 	if len(intents) == 0 {
 		return nil, nil

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -164,24 +164,24 @@ func BenchmarkIterOnBatch_RocksDB(b *testing.B) {
 	}
 }
 
-// BenchmarkIterOnReadOnly_RocksDB is a microbenchmark that measures the performance of creating an iterator
-// and seeking to a key if a read-only ReadWriter that caches the RocksDB iterator is used
+// BenchmarkIterOnReadOnly_RocksDB is a microbenchmark that measures the
+// performance of creating an iterator and seeking to a key if a read-only
+// ReadWriter that caches the RocksDB iterator is used
 func BenchmarkIterOnReadOnly_RocksDB(b *testing.B) {
-	ctx := context.Background()
 	for _, writes := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {
-			benchmarkIterOnReadWriter(ctx, b, writes, Engine.NewReadOnly, true)
+			benchmarkIterOnReadWriter(b, writes, Engine.NewReadOnly, true)
 		})
 	}
 }
 
-// BenchmarkIterOnEngine_RocksDB is a microbenchmark that measures the performance of creating an iterator
-// and seeking to a key without caching is used (see BenchmarkIterOnReadOnly_RocksDB)
+// BenchmarkIterOnEngine_RocksDB is a microbenchmark that measures the
+// performance of creating an iterator and seeking to a key without caching is
+// used (see BenchmarkIterOnIterCacher_RocksDB).
 func BenchmarkIterOnEngine_RocksDB(b *testing.B) {
-	ctx := context.Background()
 	for _, writes := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {
-			benchmarkIterOnReadWriter(ctx, b, writes, func(e Engine) ReadWriter { return e }, false)
+			benchmarkIterOnReadWriter(b, writes, func(e Engine) ReadWriter { return e }, false)
 		})
 	}
 }

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -372,7 +372,7 @@ func benchmarkIterOnBatch(ctx context.Context, b *testing.B, writes int) {
 }
 
 func benchmarkIterOnReadWriter(
-	ctx context.Context, b *testing.B, writes int, f func(Engine) ReadWriter, closeReadWriter bool,
+	b *testing.B, writes int, f func(Engine) ReadWriter, closeReadWriter bool,
 ) {
 	engine := createTestRocksDBEngine()
 	defer engine.Close()

--- a/pkg/storage/engine/tee.go
+++ b/pkg/storage/engine/tee.go
@@ -261,24 +261,24 @@ func (t *TeeEngine) GetTickersAndHistograms() (*enginepb.TickersAndHistograms, e
 }
 
 // GetEncryptionRegistries implements the Engine interface.
-func (t TeeEngine) GetEncryptionRegistries() (*EncryptionRegistries, error) {
+func (t *TeeEngine) GetEncryptionRegistries() (*EncryptionRegistries, error) {
 	return t.eng1.GetEncryptionRegistries()
 }
 
 // GetEnvStats implements the Engine interface.
-func (t TeeEngine) GetEnvStats() (*EnvStats, error) {
+func (t *TeeEngine) GetEnvStats() (*EnvStats, error) {
 	return t.eng2.GetEnvStats()
 }
 
 // GetAuxiliaryDir implements the Engine interface.
-func (t TeeEngine) GetAuxiliaryDir() string {
+func (t *TeeEngine) GetAuxiliaryDir() string {
 	// Treat the eng1 path as the main aux dir, so that checkpoints are made in
 	// subdirectories within it.
 	return t.eng1.GetAuxiliaryDir()
 }
 
 // NewBatch implements the Engine interface.
-func (t TeeEngine) NewBatch() Batch {
+func (t *TeeEngine) NewBatch() Batch {
 	batch1 := t.eng1.NewBatch()
 	batch2 := t.eng2.NewBatch()
 
@@ -302,7 +302,7 @@ func (t TeeEngine) NewReadOnly() ReadWriter {
 }
 
 // NewWriteOnlyBatch implements the Engine interface.
-func (t TeeEngine) NewWriteOnlyBatch() Batch {
+func (t *TeeEngine) NewWriteOnlyBatch() Batch {
 	batch1 := t.eng1.NewWriteOnlyBatch()
 	batch2 := t.eng2.NewWriteOnlyBatch()
 	return &TeeEngineBatch{
@@ -313,7 +313,7 @@ func (t TeeEngine) NewWriteOnlyBatch() Batch {
 }
 
 // NewSnapshot implements the Engine interface.
-func (t TeeEngine) NewSnapshot() Reader {
+func (t *TeeEngine) NewSnapshot() Reader {
 	snap1 := t.eng1.NewSnapshot()
 	snap2 := t.eng2.NewSnapshot()
 
@@ -325,12 +325,12 @@ func (t TeeEngine) NewSnapshot() Reader {
 }
 
 // Type implements the Engine interface.
-func (t TeeEngine) Type() enginepb.EngineType {
+func (t *TeeEngine) Type() enginepb.EngineType {
 	return enginepb.EngineTypeTeePebbleRocksDB
 }
 
 // IngestExternalFiles implements the Engine interface.
-func (t TeeEngine) IngestExternalFiles(ctx context.Context, paths []string) error {
+func (t *TeeEngine) IngestExternalFiles(ctx context.Context, paths []string) error {
 	var err, err2 error
 	// Special case: If either engine is RocksDB, run that last, since RocksDB
 	// IngestExternalFiles deletes the specified files.
@@ -345,14 +345,14 @@ func (t TeeEngine) IngestExternalFiles(ctx context.Context, paths []string) erro
 }
 
 // PreIngestDelay implements the Engine interface.
-func (t TeeEngine) PreIngestDelay(ctx context.Context) {
+func (t *TeeEngine) PreIngestDelay(ctx context.Context) {
 	// TODO(itsbilal): Test why PreIngestDelay on eng1 segfaults when
 	// eng1 = RocksDB in tests like TestDBAddSSTable.
 	t.eng2.PreIngestDelay(ctx)
 }
 
 // ApproximateDiskBytes implements the Engine interface.
-func (t TeeEngine) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+func (t *TeeEngine) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
 	bytes, err := t.eng1.ApproximateDiskBytes(from, to)
 	bytes2, err2 := t.eng2.ApproximateDiskBytes(from, to)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
@@ -363,19 +363,19 @@ func (t TeeEngine) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
 }
 
 // CompactRange implements the Engine interface.
-func (t TeeEngine) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
+func (t *TeeEngine) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
 	err := t.eng1.CompactRange(start, end, forceBottommost)
 	err2 := t.eng2.CompactRange(start, end, forceBottommost)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // InMem implements the Engine interface.
-func (t TeeEngine) InMem() bool {
+func (t *TeeEngine) InMem() bool {
 	return t.inMem
 }
 
 // CreateFile implements the FS interface.
-func (t TeeEngine) CreateFile(filename string) (File, error) {
+func (t *TeeEngine) CreateFile(filename string) (File, error) {
 	file1, err := t.eng1.CreateFile(filename)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -393,7 +393,7 @@ func (t TeeEngine) CreateFile(filename string) (File, error) {
 }
 
 // OpenFile implements the FS interface.
-func (t TeeEngine) OpenFile(filename string) (File, error) {
+func (t *TeeEngine) OpenFile(filename string) (File, error) {
 	file1, err := t.eng1.OpenFile(filename)
 	file2, err2 := t.eng2.OpenFile(filename)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
@@ -407,7 +407,7 @@ func (t TeeEngine) OpenFile(filename string) (File, error) {
 }
 
 // OpenDir implements the FS interface.
-func (t TeeEngine) OpenDir(name string) (File, error) {
+func (t *TeeEngine) OpenDir(name string) (File, error) {
 	file1, err := t.eng1.OpenDir(name)
 	file2, err2 := t.eng2.OpenDir(name)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
@@ -421,12 +421,12 @@ func (t TeeEngine) OpenDir(name string) (File, error) {
 }
 
 // ReadFile implements the Engine interface.
-func (t TeeEngine) ReadFile(filename string) ([]byte, error) {
+func (t *TeeEngine) ReadFile(filename string) ([]byte, error) {
 	return t.eng1.ReadFile(filename)
 }
 
 // WriteFile implements the Engine interface.
-func (t TeeEngine) WriteFile(filename string, data []byte) error {
+func (t *TeeEngine) WriteFile(filename string, data []byte) error {
 	err := t.eng1.WriteFile(filename, data)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -437,7 +437,7 @@ func (t TeeEngine) WriteFile(filename string, data []byte) error {
 }
 
 // DeleteFile implements the FS interface.
-func (t TeeEngine) DeleteFile(filename string) error {
+func (t *TeeEngine) DeleteFile(filename string) error {
 	err := t.eng1.DeleteFile(filename)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -448,7 +448,7 @@ func (t TeeEngine) DeleteFile(filename string) error {
 }
 
 // DeleteDirAndFiles implements the Engine interface.
-func (t TeeEngine) DeleteDirAndFiles(dir string) error {
+func (t *TeeEngine) DeleteDirAndFiles(dir string) error {
 	err := t.eng1.DeleteDirAndFiles(dir)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -459,7 +459,7 @@ func (t TeeEngine) DeleteDirAndFiles(dir string) error {
 }
 
 // LinkFile implements the FS interface.
-func (t TeeEngine) LinkFile(oldname, newname string) error {
+func (t *TeeEngine) LinkFile(oldname, newname string) error {
 	err := t.eng1.LinkFile(oldname, newname)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -470,7 +470,7 @@ func (t TeeEngine) LinkFile(oldname, newname string) error {
 }
 
 // RenameFile implements the FS interface.
-func (t TeeEngine) RenameFile(oldname, newname string) error {
+func (t *TeeEngine) RenameFile(oldname, newname string) error {
 	err := t.eng1.RenameFile(oldname, newname)
 	if !t.inMem {
 		// No need to write twice if the two engines share the same file system.
@@ -481,7 +481,7 @@ func (t TeeEngine) RenameFile(oldname, newname string) error {
 }
 
 // CreateCheckpoint implements the Engine interface.
-func (t TeeEngine) CreateCheckpoint(dir string) error {
+func (t *TeeEngine) CreateCheckpoint(dir string) error {
 	path1 := filepath.Join(dir, "eng1")
 	path2 := filepath.Join(dir, "eng2")
 	err := t.eng1.CreateCheckpoint(path1)
@@ -500,21 +500,21 @@ type TeeEngineFile struct {
 var _ File = &TeeEngineFile{}
 
 // Close implements the File interface.
-func (t TeeEngineFile) Close() error {
+func (t *TeeEngineFile) Close() error {
 	err := t.file1.Close()
 	err2 := t.file2.Close()
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Sync implements the File interface.
-func (t TeeEngineFile) Sync() error {
+func (t *TeeEngineFile) Sync() error {
 	err := t.file1.Sync()
 	err2 := t.file2.Sync()
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Write implements the File interface.
-func (t TeeEngineFile) Write(p []byte) (int, error) {
+func (t *TeeEngineFile) Write(p []byte) (int, error) {
 	n, err := t.file1.Write(p)
 	n2, err2 := t.file2.Write(p)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
@@ -527,7 +527,7 @@ func (t TeeEngineFile) Write(p []byte) (int, error) {
 }
 
 // Read implements the File interface.
-func (t TeeEngineFile) Read(p []byte) (n int, err error) {
+func (t *TeeEngineFile) Read(p []byte) (n int, err error) {
 	p2 := make([]byte, len(p))
 	n, err = t.file1.Read(p)
 	n2, err2 := t.file2.Read(p2)
@@ -741,13 +741,13 @@ type TeeEngineBatch struct {
 var _ Batch = &TeeEngineBatch{}
 
 // Close implements the Batch interface.
-func (t TeeEngineBatch) Close() {
+func (t *TeeEngineBatch) Close() {
 	t.batch1.Close()
 	t.batch2.Close()
 }
 
 // Closed implements the Batch interface.
-func (t TeeEngineBatch) Closed() bool {
+func (t *TeeEngineBatch) Closed() bool {
 	closed1 := t.batch1.Closed()
 	closed2 := t.batch2.Closed()
 	if closed1 && closed2 {
@@ -759,7 +759,7 @@ func (t TeeEngineBatch) Closed() bool {
 }
 
 // ExportToSst implements the Batch interface.
-func (t TeeEngineBatch) ExportToSst(
+func (t *TeeEngineBatch) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -778,7 +778,7 @@ func (t TeeEngineBatch) ExportToSst(
 }
 
 // Get implements the Batch interface.
-func (t TeeEngineBatch) Get(key MVCCKey) ([]byte, error) {
+func (t *TeeEngineBatch) Get(key MVCCKey) ([]byte, error) {
 	val, err := t.batch1.Get(key)
 	val2, err2 := t.batch2.Get(key)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
@@ -792,7 +792,7 @@ func (t TeeEngineBatch) Get(key MVCCKey) ([]byte, error) {
 }
 
 // GetProto implements the Batch interface.
-func (t TeeEngineBatch) GetProto(
+func (t *TeeEngineBatch) GetProto(
 	key MVCCKey, msg protoutil.Message,
 ) (ok bool, keyBytes, valBytes int64, err error) {
 	if len(key.Key) == 0 {
@@ -811,14 +811,14 @@ func (t TeeEngineBatch) GetProto(
 }
 
 // Iterate implements the Batch interface.
-func (t TeeEngineBatch) Iterate(
+func (t *TeeEngineBatch) Iterate(
 	start, end roachpb.Key, f func(MVCCKeyValue) (stop bool, err error),
 ) error {
 	return iterateOnReader(t, start, end, f)
 }
 
 // NewIterator implements the Batch interface.
-func (t TeeEngineBatch) NewIterator(opts IterOptions) Iterator {
+func (t *TeeEngineBatch) NewIterator(opts IterOptions) Iterator {
 	iter1 := t.batch1.NewIterator(opts)
 	iter2 := t.batch2.NewIterator(opts)
 	return &TeeEngineIter{
@@ -829,76 +829,76 @@ func (t TeeEngineBatch) NewIterator(opts IterOptions) Iterator {
 }
 
 // ApplyBatchRepr implements the Batch interface.
-func (t TeeEngineBatch) ApplyBatchRepr(repr []byte, sync bool) error {
+func (t *TeeEngineBatch) ApplyBatchRepr(repr []byte, sync bool) error {
 	err := t.batch1.ApplyBatchRepr(repr, sync)
 	err2 := t.batch2.ApplyBatchRepr(repr, sync)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Clear implements the Batch interface.
-func (t TeeEngineBatch) Clear(key MVCCKey) error {
+func (t *TeeEngineBatch) Clear(key MVCCKey) error {
 	err := t.batch1.Clear(key)
 	err2 := t.batch2.Clear(key)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // SingleClear implements the Batch interface.
-func (t TeeEngineBatch) SingleClear(key MVCCKey) error {
+func (t *TeeEngineBatch) SingleClear(key MVCCKey) error {
 	err := t.batch1.SingleClear(key)
 	err2 := t.batch2.SingleClear(key)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // ClearRange implements the Batch interface.
-func (t TeeEngineBatch) ClearRange(start, end MVCCKey) error {
+func (t *TeeEngineBatch) ClearRange(start, end MVCCKey) error {
 	err := t.batch1.ClearRange(start, end)
 	err2 := t.batch2.ClearRange(start, end)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // ClearIterRange implements the Batch interface.
-func (t TeeEngineBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
+func (t *TeeEngineBatch) ClearIterRange(iter Iterator, start, end roachpb.Key) error {
 	err := t.batch1.ClearIterRange(iter.(*TeeEngineIter).iter1, start, end)
 	err2 := t.batch2.ClearIterRange(iter.(*TeeEngineIter).iter2, start, end)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Merge implements the Batch interface.
-func (t TeeEngineBatch) Merge(key MVCCKey, value []byte) error {
+func (t *TeeEngineBatch) Merge(key MVCCKey, value []byte) error {
 	err := t.batch1.Merge(key, value)
 	err2 := t.batch2.Merge(key, value)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Put implements the Batch interface.
-func (t TeeEngineBatch) Put(key MVCCKey, value []byte) error {
+func (t *TeeEngineBatch) Put(key MVCCKey, value []byte) error {
 	err := t.batch1.Put(key, value)
 	err2 := t.batch2.Put(key, value)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // LogData implements the Batch interface.
-func (t TeeEngineBatch) LogData(data []byte) error {
+func (t *TeeEngineBatch) LogData(data []byte) error {
 	err := t.batch1.LogData(data)
 	err2 := t.batch2.LogData(data)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // LogLogicalOp implements the Batch interface.
-func (t TeeEngineBatch) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+func (t *TeeEngineBatch) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
 	t.batch1.LogLogicalOp(op, details)
 	t.batch2.LogLogicalOp(op, details)
 }
 
 // Commit implements the Batch interface.
-func (t TeeEngineBatch) Commit(sync bool) error {
+func (t *TeeEngineBatch) Commit(sync bool) error {
 	err := t.batch1.Commit(sync)
 	err2 := t.batch2.Commit(sync)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
 // Distinct implements the Batch interface.
-func (t TeeEngineBatch) Distinct() ReadWriter {
+func (t *TeeEngineBatch) Distinct() ReadWriter {
 	distinct1 := t.batch1.Distinct()
 	distinct2 := t.batch2.Distinct()
 	return &TeeEngineReadWriter{TeeEngineReader{
@@ -909,7 +909,7 @@ func (t TeeEngineBatch) Distinct() ReadWriter {
 }
 
 // Empty implements the Batch interface.
-func (t TeeEngineBatch) Empty() bool {
+func (t *TeeEngineBatch) Empty() bool {
 	empty := t.batch1.Empty()
 	empty2 := t.batch2.Empty()
 	if empty != empty2 {
@@ -919,7 +919,7 @@ func (t TeeEngineBatch) Empty() bool {
 }
 
 // Len implements the Batch interface.
-func (t TeeEngineBatch) Len() int {
+func (t *TeeEngineBatch) Len() int {
 	len1 := t.batch1.Len()
 	len2 := t.batch2.Len()
 
@@ -930,7 +930,7 @@ func (t TeeEngineBatch) Len() int {
 }
 
 // Repr implements the Batch interface.
-func (t TeeEngineBatch) Repr() []byte {
+func (t *TeeEngineBatch) Repr() []byte {
 	repr := t.batch1.Repr()
 	repr2 := t.batch2.Repr()
 	if !bytes.Equal(repr, repr2) {
@@ -951,14 +951,14 @@ type TeeEngineIter struct {
 var _ MVCCIterator = &TeeEngineIter{}
 
 // Close implements the Iterator interface.
-func (t TeeEngineIter) Close() {
+func (t *TeeEngineIter) Close() {
 	t.iter1.Close()
 	t.iter2.Close()
 }
 
 // check checks if the two underlying iterators have matching validity states
 // and keys.
-func (t TeeEngineIter) check() {
+func (t *TeeEngineIter) check() {
 	valid, err := t.iter1.Valid()
 	valid2, err2 := t.iter2.Valid()
 	_ = fatalOnErrorMismatch(t.ctx, err, err2)
@@ -979,61 +979,61 @@ func (t TeeEngineIter) check() {
 }
 
 // SeekGE implements the Iterator interface.
-func (t TeeEngineIter) SeekGE(key MVCCKey) {
+func (t *TeeEngineIter) SeekGE(key MVCCKey) {
 	t.iter1.SeekGE(key)
 	t.iter2.SeekGE(key)
 	t.check()
 }
 
 // Valid implements the Iterator interface.
-func (t TeeEngineIter) Valid() (bool, error) {
+func (t *TeeEngineIter) Valid() (bool, error) {
 	return t.iter1.Valid()
 }
 
 // Next implements the Iterator interface.
-func (t TeeEngineIter) Next() {
+func (t *TeeEngineIter) Next() {
 	t.iter1.Next()
 	t.iter2.Next()
 	t.check()
 }
 
 // NextKey implements the Iterator interface.
-func (t TeeEngineIter) NextKey() {
+func (t *TeeEngineIter) NextKey() {
 	t.iter1.NextKey()
 	t.iter2.NextKey()
 	t.check()
 }
 
 // UnsafeKey implements the Iterator interface.
-func (t TeeEngineIter) UnsafeKey() MVCCKey {
+func (t *TeeEngineIter) UnsafeKey() MVCCKey {
 	return t.iter1.UnsafeKey()
 }
 
 // UnsafeValue implements the Iterator interface.
-func (t TeeEngineIter) UnsafeValue() []byte {
+func (t *TeeEngineIter) UnsafeValue() []byte {
 	return t.iter1.UnsafeValue()
 }
 
 // SeekLT implements the Iterator interface.
-func (t TeeEngineIter) SeekLT(key MVCCKey) {
+func (t *TeeEngineIter) SeekLT(key MVCCKey) {
 	t.iter1.SeekLT(key)
 	t.iter2.SeekLT(key)
 	t.check()
 }
 
 // Prev implements the Iterator interface.
-func (t TeeEngineIter) Prev() {
+func (t *TeeEngineIter) Prev() {
 	t.iter1.Prev()
 	t.iter2.Prev()
 	t.check()
 }
 
 // Key implements the Iterator interface.
-func (t TeeEngineIter) Key() MVCCKey {
+func (t *TeeEngineIter) Key() MVCCKey {
 	return t.iter1.Key()
 }
 
-func (t TeeEngineIter) unsafeRawKey() []byte {
+func (t *TeeEngineIter) unsafeRawKey() []byte {
 	type unsafeRawKeyGetter interface {
 		unsafeRawKey() []byte
 	}
@@ -1041,17 +1041,17 @@ func (t TeeEngineIter) unsafeRawKey() []byte {
 }
 
 // Value implements the Iterator interface.
-func (t TeeEngineIter) Value() []byte {
+func (t *TeeEngineIter) Value() []byte {
 	return t.iter1.UnsafeValue()
 }
 
 // ValueProto implements the Iterator interface.
-func (t TeeEngineIter) ValueProto(msg protoutil.Message) error {
+func (t *TeeEngineIter) ValueProto(msg protoutil.Message) error {
 	return t.iter1.ValueProto(msg)
 }
 
 // ComputeStats implements the Iterator interface.
-func (t TeeEngineIter) ComputeStats(
+func (t *TeeEngineIter) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	stats1, err := t.iter1.ComputeStats(start, end, nowNanos)
@@ -1066,7 +1066,7 @@ func (t TeeEngineIter) ComputeStats(
 }
 
 // FindSplitKey implements the Iterator interface.
-func (t TeeEngineIter) FindSplitKey(
+func (t *TeeEngineIter) FindSplitKey(
 	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (MVCCKey, error) {
 	splitKey1, err := t.iter1.FindSplitKey(start, end, minSplitKey, targetSize)
@@ -1081,7 +1081,7 @@ func (t TeeEngineIter) FindSplitKey(
 }
 
 // CheckForKeyCollisions implements the Iterator interface.
-func (t TeeEngineIter) CheckForKeyCollisions(
+func (t *TeeEngineIter) CheckForKeyCollisions(
 	sstData []byte, start, end roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	stats1, err := t.iter1.CheckForKeyCollisions(sstData, start, end)
@@ -1096,23 +1096,23 @@ func (t TeeEngineIter) CheckForKeyCollisions(
 }
 
 // SetUpperBound implements the Iterator interface.
-func (t TeeEngineIter) SetUpperBound(key roachpb.Key) {
+func (t *TeeEngineIter) SetUpperBound(key roachpb.Key) {
 	t.iter1.SetUpperBound(key)
 	t.iter2.SetUpperBound(key)
 }
 
 // Stats implements the Iterator interface.
-func (t TeeEngineIter) Stats() IteratorStats {
+func (t *TeeEngineIter) Stats() IteratorStats {
 	return t.iter1.Stats()
 }
 
 // MVCCOpsSpecialized implements the MVCCIterator interface.
-func (t TeeEngineIter) MVCCOpsSpecialized() bool {
+func (t *TeeEngineIter) MVCCOpsSpecialized() bool {
 	return true
 }
 
 // MVCCGet implements the MVCCIterator interface.
-func (t TeeEngineIter) MVCCGet(
+func (t *TeeEngineIter) MVCCGet(
 	key roachpb.Key, timestamp hlc.Timestamp, opts MVCCGetOptions,
 ) (*roachpb.Value, *roachpb.Intent, error) {
 	value1, intent1, err := mvccGet(t.ctx, t.iter1, key, timestamp, opts)
@@ -1152,7 +1152,7 @@ func kvDataEqual(ctx context.Context, data1 []byte, data2 [][]byte) bool {
 }
 
 // MVCCScan implements the MVCCIterator interface.
-func (t TeeEngineIter) MVCCScan(
+func (t *TeeEngineIter) MVCCScan(
 	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
 ) (kvData [][]byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
 	kvData1, numKvs1, resumeSpan1, intents1, err := mvccScanToBytes(t.ctx, t.iter1, start, end, max, timestamp, opts)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -437,10 +437,10 @@ func SetMockAddSSTable() (undo func()) {
 	}
 
 	batcheval.UnregisterCommand(roachpb.AddSSTable)
-	batcheval.RegisterCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
+	batcheval.RegisterReadWriteCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
 	return func() {
 		batcheval.UnregisterCommand(roachpb.AddSSTable)
-		batcheval.RegisterCommand(roachpb.AddSSTable, prev.DeclareKeys, prev.Eval)
+		batcheval.RegisterReadWriteCommand(roachpb.AddSSTable, prev.DeclareKeys, prev.EvalRW)
 	}
 }
 

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -411,7 +411,11 @@ func evaluateCommand(
 			MaxKeys: maxKeys,
 			Stats:   ms,
 		}
-		pd, err = cmd.Eval(ctx, readWriter, cArgs, reply)
+		if cmd.EvalRW != nil {
+			pd, err = cmd.EvalRW(ctx, readWriter, cArgs, reply)
+		} else {
+			pd, err = cmd.EvalRO(ctx, readWriter, cArgs, reply)
+		}
 	} else {
 		err = errors.Errorf("unrecognized command %s", args.Method())
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -12246,10 +12246,10 @@ func setMockPutWithEstimates(containsEstimatesDelta int64) (undo func()) {
 	}
 
 	batcheval.UnregisterCommand(roachpb.Put)
-	batcheval.RegisterCommand(roachpb.Put, batcheval.DefaultDeclareKeys, mockPut)
+	batcheval.RegisterReadWriteCommand(roachpb.Put, batcheval.DefaultDeclareKeys, mockPut)
 	return func() {
 		batcheval.UnregisterCommand(roachpb.Put)
-		batcheval.RegisterCommand(roachpb.Put, prev.DeclareKeys, prev.Eval)
+		batcheval.RegisterReadWriteCommand(roachpb.Put, prev.DeclareKeys, prev.EvalRW)
 	}
 }
 


### PR DESCRIPTION
This PR reworks parts of #26916. It's not strictly necessary, but is a
quality of life improvement. There are also miscellaneous cleanups
around TeeEngine, RocksDB benchmarks, etc.

Previous to this we relied on engine.NewReadOnly's runtime panics when
receiving writes to ensure that read-only commands do not accidentally
write data. By changing the command registration process to have
commands declare upfront whether they are read-only or read-write, we
can plumb in engine.Reader or engine.ReadWriter respectively. It's nice
rely on the type system to assert these guarantees.

NB: There's still the unaddressed wart that is replica read code paths
operating off an engine.ReadWriter. Changing this out would require a
refactor of replica evaluation code paths, which I'm not doing now. This
PR however paves the way for that.

Release note: None
