### PR TITLE
sqlmigrations: use KV puts in namespace migration

### DIFF
--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -359,7 +359,10 @@ var (
 		NextMutationID: 1,
 	}
 
-	// NamespaceTable is the descriptor for the namespace table.
+	// NamespaceTable is the descriptor for the namespace table. Note that this
+	// table should only be written to via KV puts, not via the SQL layer. Some
+	// code assumes that it only has KV entries for column family 4, not the
+	// "sentinel" column family 0 which would be written by SQL.
 	NamespaceTable = TableDescriptor{
 		Name:                    "namespace",
 		ID:                      keys.NamespaceTableID,


### PR DESCRIPTION
The original migration for the namespace table used SQL statements to
move data from the deprecated table to the new one. However, the
namespace table is normally written to and read from using raw KV
operations, not SQL. This discrepancy caused some issues when the new
rows were scanned by functions like GetAllDatabaseDescriptorIDs,
specifically because the migration created "sentinel" rows which were
not normally present. I rewrote the migration to use KV puts rather than
SQL.

Fixes #43616

Release note: None