### PR TITLE
coldata: fix a bug with copying over nulls

### DIFF
--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -242,6 +242,9 @@ func (n *Nulls) set(args SliceArgs) {
 	if current < needed {
 		n.nulls = append(n.nulls, filledNulls[:needed-current]...)
 	}
+	// First, we unset the whole range that is overwritten. If there are any NULL
+	// values in the source, those will be copied over below, one at a time.
+	n.UnsetNullRange(args.DestIdx, args.DestIdx+toDuplicate)
 	if args.Src.MaybeHasNulls() {
 		src := args.Src.Nulls()
 		if args.Sel != nil {
@@ -259,8 +262,6 @@ func (n *Nulls) set(args SliceArgs) {
 				}
 			}
 		}
-	} else {
-		n.UnsetNullRange(args.DestIdx, args.DestIdx+toDuplicate)
 	}
 }
 


### PR DESCRIPTION
Previously, when setting nulls (which occurs when we Append or Copy
a coldata.Vec) we would not reset the nulls range of the destination in
case that there are null values in the source. This could result in
incorrect thinking that a copied value is NULL when it wasn't. I think
the impact here is limited because nulls are fully reset as a part of
ResetInternalBatch call, and there are a few cases where we don't do
that: only when we need to buffer up more tuples than can fit in
a single batch (general sort, merge joiner, hash joiner), and those are
planned only with `experimental_on`.

Release note (bug fix): Previously, CockroachDB could incorrectly say
that some values were NULL when, in fact, they weren't. This could occur
only when vectorized execution engine was used with
`vectorize=experimental_on` and now has been fixed.