### PR TITLE
colexec: add external sort

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -256,8 +256,8 @@ func main() {
 			log.Fatal(err)
 		}
 		if len(pkgs) > 0 {
-			// 5 minutes total seems OK, but at least a minute per test.
-			duration := (5 * time.Minute) / time.Duration(len(pkgs))
+			// 10 minutes total seems OK, but at least a minute per test.
+			duration := (10 * time.Minute) / time.Duration(len(pkgs))
 			if duration < time.Minute {
 				duration = time.Minute
 			}
@@ -267,7 +267,7 @@ func main() {
 			for name, pkg := range pkgs {
 				tests := "-"
 				if len(pkg.tests) > 0 {
-					tests = "(" + strings.Join(pkg.tests, "|") + ")"
+					tests = "(" + strings.Join(pkg.tests, "$$|") + "$$)"
 				}
 
 				cmd := exec.Command(

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -73,7 +73,7 @@ func (b *Bytes) AssertOffsetsAreNonDecreasing(n uint64) {
 // set on it.
 func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n uint64) {
 	// Note that we're not checking whether this Bytes is a window because
-	// although this function modifies the "window" Bytes, it maintains the
+	// although this function might modify the "window" Bytes, it maintains the
 	// invariant that we need to have.
 	prev := b.offsets[0]
 	for j := uint64(1); j <= n; j++ {
@@ -90,9 +90,9 @@ func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n uint64) {
 // b.maxSetIndex+1 are non-decreasing. Note that this method can be a noop when
 // i <= b.maxSetIndex+1.
 func (b *Bytes) maybeBackfillOffsets(i int) {
-	if b.isWindow {
-		panic("maybeBackfillOffsets is called on a window into Bytes")
-	}
+	// Note that we're not checking whether this Bytes is a window because
+	// although this function might modify the "window" Bytes, it maintains the
+	// invariant that we need to have.
 	for j := b.maxSetIndex + 2; j <= i; j++ {
 		b.offsets[j] = b.offsets[b.maxSetIndex+1]
 	}

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -108,9 +108,15 @@ func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
 	}
 }
 
-// TODO(yuzefovich): extend Allocator so that it could free up the memory (and
-// resize the memory account accordingly) when the caller is done with the
-// batches.
+// Used returns the number of bytes currently allocated through this allocator.
+func (a *Allocator) Used() int64 {
+	return a.acc.Used()
+}
+
+// Clear clears up the memory account of the allocator.
+func (a *Allocator) Clear() {
+	a.acc.Clear(a.ctx)
+}
 
 const (
 	sizeOfBool    = int(unsafe.Sizeof(true))

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -208,11 +208,11 @@ func TestAndOrOps(t *testing.T) {
 							},
 						}
 						args := NewColOperatorArgs{
-							Spec:                               spec,
-							Inputs:                             input,
-							StreamingMemAccount:                testMemAcc,
-							UseStreamingMemAccountForBuffering: true,
+							Spec:                spec,
+							Inputs:              input,
+							StreamingMemAccount: testMemAcc,
 						}
+						args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 						result, err := NewColOperator(ctx, flowCtx, args)
 						if err != nil {
 							return nil, err
@@ -279,11 +279,11 @@ func benchmarkLogicalProjOp(
 	}
 
 	args := NewColOperatorArgs{
-		Spec:                               spec,
-		Inputs:                             []Operator{input},
-		StreamingMemAccount:                testMemAcc,
-		UseStreamingMemAccountForBuffering: true,
+		Spec:                spec,
+		Inputs:              []Operator{input},
+		StreamingMemAccount: testMemAcc,
 	}
+	args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 	result, err := NewColOperator(ctx, flowCtx, args)
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -83,11 +83,11 @@ func TestCaseOp(t *testing.T) {
 			spec.Input[0].ColumnTypes = tc.inputTypes
 			spec.Post.RenderExprs[0].Expr = tc.renderExpr
 			args := NewColOperatorArgs{
-				Spec:                               spec,
-				Inputs:                             inputs,
-				StreamingMemAccount:                testMemAcc,
-				UseStreamingMemAccountForBuffering: true,
+				Spec:                spec,
+				Inputs:              inputs,
+				StreamingMemAccount: testMemAcc,
 			}
+			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -35,10 +35,7 @@ type bufferingInMemoryOperator interface {
 	//
 	// Calling ExportBuffered may invalidate the contents of the last batch
 	// returned by ExportBuffered.
-	// TODO(yuzefovich): it might be possible to avoid the need for an Allocator
-	// when exporting buffered tuples. This will require the refactor of the
-	// buffering in-memory operators.
-	ExportBuffered(*Allocator) coldata.Batch
+	ExportBuffered() coldata.Batch
 }
 
 // oneInputDiskSpiller is an Operator that manages the fallback from an
@@ -92,8 +89,6 @@ var _ Operator = &oneInputDiskSpiller{}
 
 // newOneInputDiskSpiller returns a new oneInputDiskSpiller. It takes the
 // following arguments:
-// - allocator - this Allocator is used (if spilling occurs) when copying the
-//   buffered tuples from the in-memory operator into the disk-backed one.
 // - inMemoryOp - the in-memory operator that will be consuming input and doing
 //   computations until it either successfully processes the whole input or
 //   reaches its memory limit.
@@ -107,14 +102,13 @@ var _ Operator = &oneInputDiskSpiller{}
 // - spillingCallbackFn will be called when the spilling from in-memory to disk
 //   backed operator occurs. It should only be set in tests.
 func newOneInputDiskSpiller(
-	allocator *Allocator,
 	input Operator,
 	inMemoryOp bufferingInMemoryOperator,
 	inMemoryMemMonitorName string,
 	diskBackedOpConstructor func(input Operator) Operator,
 	spillingCallbackFn func(),
 ) Operator {
-	diskBackedOpInput := newBufferExportingOperator(allocator, inMemoryOp, input)
+	diskBackedOpInput := newBufferExportingOperator(inMemoryOp, input)
 	return &oneInputDiskSpiller{
 		input:                  input,
 		inMemoryOp:             inMemoryOp,
@@ -209,7 +203,6 @@ type bufferExportingOperator struct {
 	ZeroInputNode
 	NonExplainable
 
-	allocator       *Allocator
 	firstSource     bufferingInMemoryOperator
 	secondSource    Operator
 	firstSourceDone bool
@@ -218,10 +211,9 @@ type bufferExportingOperator struct {
 var _ Operator = &bufferExportingOperator{}
 
 func newBufferExportingOperator(
-	allocator *Allocator, firstSource bufferingInMemoryOperator, secondSource Operator,
+	firstSource bufferingInMemoryOperator, secondSource Operator,
 ) Operator {
 	return &bufferExportingOperator{
-		allocator:    allocator,
 		firstSource:  firstSource,
 		secondSource: secondSource,
 	}
@@ -236,7 +228,7 @@ func (b *bufferExportingOperator) Next(ctx context.Context) coldata.Batch {
 	if b.firstSourceDone {
 		return b.secondSource.Next(ctx)
 	}
-	batch := b.firstSource.ExportBuffered(b.allocator)
+	batch := b.firstSource.ExportBuffered()
 	if batch.Length() == 0 {
 		b.firstSourceDone = true
 		return b.Next(ctx)

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -793,17 +793,7 @@ func NewColOperator(
 				if err != nil {
 					return result, err
 				}
-				var diskSpillerMemAccount *mon.BoundAccount
-				if useStreamingMemAccountForBuffering {
-					diskSpillerMemAccount = streamingMemAccount
-				} else {
-					diskSpillerMemAccount = result.createBufferingUnlimitedMemAccount(
-						ctx, flowCtx, "disk-spiller-sort-all",
-					)
-				}
-				diskSpillerAllocator := NewAllocator(ctx, diskSpillerMemAccount)
 				result.Op = newOneInputDiskSpiller(
-					diskSpillerAllocator,
 					input, inMemorySorter.(bufferingInMemoryOperator),
 					sorterMemMonitorName,
 					func(input Operator) Operator {

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -89,14 +89,23 @@ func wrapRowSources(
 // NewColOperatorArgs is a helper struct that encompasses all of the input
 // arguments to NewColOperator call.
 type NewColOperatorArgs struct {
-	Spec                *execinfrapb.ProcessorSpec
-	Inputs              []Operator
-	StreamingMemAccount *mon.BoundAccount
-	// UseStreamingMemAccountForBuffering specifies whether to use
-	// StreamingMemAccount when creating buffering operators and should only be
-	// set to 'true' in tests.
-	UseStreamingMemAccountForBuffering bool
-	ProcessorConstructor               execinfra.ProcessorConstructor
+	Spec                 *execinfrapb.ProcessorSpec
+	Inputs               []Operator
+	StreamingMemAccount  *mon.BoundAccount
+	ProcessorConstructor execinfra.ProcessorConstructor
+	TestingKnobs         struct {
+		// UseStreamingMemAccountForBuffering specifies whether to use
+		// StreamingMemAccount when creating buffering operators and should only be
+		// set to 'true' in tests. The idea behind this flag is reducing the number
+		// of memory accounts and monitors we need to close, so we plumbed it into
+		// the planning code so that it doesn't create extra memory monitoring
+		// infrastructure (and so that we could use testMemAccount defined in
+		// main_test.go).
+		UseStreamingMemAccountForBuffering bool
+		// SpillingCallbackFn will be called when the spilling from an in-memory to
+		// disk-backed operator occurs. It should only be set in tests.
+		SpillingCallbackFn func()
+	}
 }
 
 // NewColOperatorResult is a helper struct that encompasses all of the return
@@ -364,7 +373,7 @@ func NewColOperator(
 	spec := args.Spec
 	inputs := args.Inputs
 	streamingMemAccount := args.StreamingMemAccount
-	useStreamingMemAccountForBuffering := args.UseStreamingMemAccountForBuffering
+	useStreamingMemAccountForBuffering := args.TestingKnobs.UseStreamingMemAccountForBuffering
 	processorConstructor := args.ProcessorConstructor
 
 	log.VEventf(ctx, 2, "planning col operator for spec %q", spec)
@@ -557,7 +566,7 @@ func NewColOperator(
 			if needHash {
 				hashAggregatorMemAccount := streamingMemAccount
 				if !useStreamingMemAccountForBuffering {
-					hashAggregatorMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "hash-aggregator-limited")
+					hashAggregatorMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "hash-aggregator")
 				}
 				result.Op, err = NewHashAggregator(
 					NewAllocator(ctx, hashAggregatorMemAccount), inputs[0], typs, aggFns,
@@ -627,7 +636,7 @@ func NewColOperator(
 
 				hashJoinerMemAccount := streamingMemAccount
 				if !useStreamingMemAccountForBuffering {
-					hashJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "hash-joiner-limited")
+					hashJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "hash-joiner")
 				}
 				result.Op, err = NewEqHashJoinerOp(
 					NewAllocator(ctx, hashJoinerMemAccount),
@@ -708,7 +717,7 @@ func NewColOperator(
 				mergeJoinerMemAccount := streamingMemAccount
 				if !result.IsStreaming && !useStreamingMemAccountForBuffering {
 					// Whether the merge joiner is streaming is already set above.
-					mergeJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "merge-joiner-limited")
+					mergeJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "merge-joiner")
 				}
 				result.Op, err = NewMergeJoinOp(
 					NewAllocator(ctx, mergeJoinerMemAccount),
@@ -751,7 +760,7 @@ func NewColOperator(
 				if useStreamingMemAccountForBuffering {
 					sortChunksMemAccount = streamingMemAccount
 				} else {
-					sortChunksMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "sort-chunks-limited")
+					sortChunksMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "sort-chunks")
 				}
 				result.Op, err = NewSortChunks(
 					NewAllocator(ctx, sortChunksMemAccount), input, inputTypes,
@@ -769,7 +778,7 @@ func NewColOperator(
 				result.IsStreaming = true
 			} else {
 				// No optimizations possible. Default to the standard sort operator.
-				sorterMemMonitorName := fmt.Sprintf("sort-all-limited-%d", spec.ProcessorID)
+				sorterMemMonitorName := fmt.Sprintf("sort-all-%d", spec.ProcessorID)
 				var sorterMemAccount *mon.BoundAccount
 				if useStreamingMemAccountForBuffering {
 					sorterMemAccount = streamingMemAccount
@@ -788,8 +797,8 @@ func NewColOperator(
 				if useStreamingMemAccountForBuffering {
 					diskSpillerMemAccount = streamingMemAccount
 				} else {
-					diskSpillerMemAccount = result.createBufferingMemAccount(
-						ctx, flowCtx, "disk-spiller-sort-all-limited",
+					diskSpillerMemAccount = result.createBufferingUnlimitedMemAccount(
+						ctx, flowCtx, "disk-spiller-sort-all",
 					)
 				}
 				diskSpillerAllocator := NewAllocator(ctx, diskSpillerMemAccount)
@@ -798,8 +807,27 @@ func NewColOperator(
 					input, inMemorySorter.(bufferingInMemoryOperator),
 					sorterMemMonitorName,
 					func(input Operator) Operator {
-						return newExternalSorter(diskSpillerAllocator, input, inputTypes, orderingCols)
-					})
+						monitorNamePrefix := "external-sorter-"
+						// We are using an unlimited memory monitor here because external
+						// sort itself is responsible for making sure that we stay within
+						// the memory limit.
+						unlimitedAllocator := NewAllocator(
+							ctx, result.createBufferingUnlimitedMemAccount(
+								ctx, flowCtx, monitorNamePrefix,
+							))
+						diskQueuesUnlimitedAllocator := NewAllocator(
+							ctx, result.createBufferingUnlimitedMemAccount(
+								ctx, flowCtx, monitorNamePrefix+"disk-queues",
+							))
+						return newExternalSorter(
+							unlimitedAllocator,
+							input, inputTypes, core.Sorter.OutputOrdering,
+							execinfra.GetWorkMemLimit(flowCtx.Cfg),
+							diskQueuesUnlimitedAllocator,
+						)
+					},
+					args.TestingKnobs.SpillingCallbackFn,
+				)
 			}
 			result.ColumnTypes = spec.Input[0].ColumnTypes
 
@@ -821,7 +849,7 @@ func NewColOperator(
 				// which kind of partitioner to use should come from the optimizer.
 				windowSortingPartitionerMemAccount := streamingMemAccount
 				if !useStreamingMemAccountForBuffering {
-					windowSortingPartitionerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "window-sorting-partitioner-limited")
+					windowSortingPartitionerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "window-sorting-partitioner")
 				}
 				input, err = NewWindowSortingPartitioner(
 					NewAllocator(ctx, windowSortingPartitionerMemAccount), input, typs,
@@ -832,7 +860,7 @@ func NewColOperator(
 				if len(wf.Ordering.Columns) > 0 {
 					windowSorterMemAccount := streamingMemAccount
 					if !useStreamingMemAccountForBuffering {
-						windowSorterMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "window-sorter-limited")
+						windowSorterMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "window-sorter")
 					}
 					input, err = NewSorter(
 						NewAllocator(ctx, windowSorterMemAccount), input, typs,
@@ -1097,10 +1125,25 @@ func (r *NewColOperatorResult) createBufferingMemAccount(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BoundAccount {
 	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
-		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name,
+		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name+"-limited",
 	)
 	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
+	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &bufferingMemAccount)
+	return &bufferingMemAccount
+}
+
+// createBufferingUnlimitedMemAccount instantiates an unlimited memory monitor
+// and a memory account to be used with a buffering disk-backed Operator. The
+// receiver is updated to have references to both objects.
+func (r *NewColOperatorResult) createBufferingUnlimitedMemAccount(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
+) *mon.BoundAccount {
+	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+	)
+	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpUnlimitedMemMonitor)
+	bufferingMemAccount := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
 	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &bufferingMemAccount)
 	return &bufferingMemAccount
 }

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -12,42 +12,407 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/errors"
 )
 
-// TODO(yuzefovich): add actual implementation.
-
-// newExternalSorter returns a disk-backed general sort operator.
-func newExternalSorter(
-	allocator *Allocator,
-	input Operator,
-	inputTypes []coltypes.T,
-	orderingCols []execinfrapb.Ordering_Column,
-) Operator {
-	inMemSorter, err := newSorter(
-		allocator, newAllSpooler(allocator, input, inputTypes),
-		inputTypes, orderingCols,
-	)
-	if err != nil {
-		execerror.VectorizedInternalPanic(err)
-	}
-	return &externalSorter{OneInputNode: NewOneInputNode(inMemSorter)}
+// Partitioner is the abstraction for on-disk storage.
+type Partitioner interface {
+	// Enqueue adds the batch to the end of the partitionIdx'th partition.
+	Enqueue(partitionIdx int, batch coldata.Batch) error
+	// Dequeue removes and returns the batch from the front of the
+	// partitionIdx'th partition.
+	Dequeue(partitionIdx int, batch coldata.Batch) error
+	// Close closes the partitioner.
+	Close() error
 }
 
+// externalSorterState indicates the current state of the external sorter.
+type externalSorterState int
+
+const (
+	// externalSorterNewPartition indicates that the next batch we read should
+	// start a new partition. A zero-length batch in this state indicates that
+	// the input to the external sorter has been fully consumed and we should
+	// proceed to merging the partitions.
+	externalSorterNewPartition externalSorterState = iota
+	// externalSorterSpillPartition indicates that the next batch we read should
+	// be added to the last partition so far. A zero-length batch in this state
+	// indicates that the end of the partition has been reached and we should
+	// transition to starting a new partition.
+	externalSorterSpillPartition
+	// externalSorterMerging indicates that we have fully consumed the input and
+	// should proceed to merging the partitions and emitting the batches.
+	externalSorterMerging
+	// externalSorterFinished indicates that all tuples from all partitions have
+	// been emitted and from now on only a zero-length batch will be emitted by
+	// the external sorter. This state is also responsible for closing the
+	// partitions.
+	externalSorterFinished
+)
+
+// externalSorter is an Operator that performs external merge sort. It works in
+// two stages:
+// 1. it will use a combination of an input partitioner and in-memory sorter to
+// divide up all batches from the input into partitions, sort each partition in
+// memory, and write sorted partitions to disk
+// 2. it will use OrderedSynchronizer to merge the partitions.
+// TODO(yuzefovich): we probably want to have a maximum number of partitions at
+// a time. In that case, we might need several stages of mergers.
+//
+// The diagram of the components involved is as follows:
+//
+//                      input
+//                        |
+//                        ↓
+//                 input partitioner
+//                        |
+//                        ↓
+//                 in-memory sorter
+//                        |
+//                        ↓
+//    ------------------------------------------
+//   |             external sorter              |
+//   |             ---------------              |
+//   |                                          |
+//   | partition1     partition2 ... partitionN |
+//   |     |              |              |      |
+//   |     ↓              ↓              ↓      |
+//   |      merger (ordered synchronizer)       |
+//    ------------------------------------------
+//                        |
+//                        ↓
+//                      output
+//
+// There are a couple of implicit upstream links in the setup:
+// - input partitioner checks the allocator used by the in-memory sorter to see
+// whether a new partition must be started
+// - external sorter resets in-memory sorter (which, in turn, resets input
+// partitioner) once the full partition has been spilled to disk.
 type externalSorter struct {
 	OneInputNode
+	NonExplainable
+
+	unlimitedAllocator    *Allocator
+	state                 externalSorterState
+	inputTypes            []coltypes.T
+	ordering              execinfrapb.Ordering
+	inMemSorter           resettableOperator
+	partitioner           Partitioner
+	numPartitions         int
+	merger                Operator
+	singlePartitionOutput Operator
+
+	// TODO(yuzefovich): remove this once actual disk queues are in-place.
+	diskQueuesUnlimitedAllocator *Allocator
 }
 
 var _ Operator = &externalSorter{}
 
+// newExternalSorter returns a disk-backed general sort operator.
+// - unlimitedAllocator must have been created with a memory account derived
+// from an unlimited memory monitor. It will be used by several internal
+// components of the external sort which is responsible for making sure that
+// the components stay within the memory limit.
+// - diskQueuesUnlimitedAllocator is a (temporary) unlimited allocator that
+// will be used to create dummy queues and will be removed once we have actual
+// disk-backed queues.
+func newExternalSorter(
+	unlimitedAllocator *Allocator,
+	input Operator,
+	inputTypes []coltypes.T,
+	ordering execinfrapb.Ordering,
+	memoryLimit int64,
+	// TODO(yuzefovich): remove this once actual disk queues are in-place.
+	diskQueuesUnlimitedAllocator *Allocator,
+) Operator {
+	inputPartitioner := newInputPartitioningOperator(unlimitedAllocator, input, memoryLimit)
+	inMemSorter, err := newSorter(
+		unlimitedAllocator, newAllSpooler(unlimitedAllocator, inputPartitioner, inputTypes),
+		inputTypes, ordering.Columns,
+	)
+	if err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	return &externalSorter{
+		OneInputNode:                 NewOneInputNode(inMemSorter),
+		diskQueuesUnlimitedAllocator: diskQueuesUnlimitedAllocator,
+		unlimitedAllocator:           unlimitedAllocator,
+		inMemSorter:                  inMemSorter,
+		partitioner:                  newDummyPartitioner(diskQueuesUnlimitedAllocator, inputTypes),
+		inputTypes:                   inputTypes,
+		ordering:                     ordering,
+	}
+}
+
 func (s *externalSorter) Init() {
 	s.input.Init()
+	s.state = externalSorterNewPartition
 }
 
 func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
-	return s.input.Next(ctx)
+	for {
+		switch s.state {
+		case externalSorterNewPartition:
+			b := s.input.Next(ctx)
+			if b.Length() == 0 {
+				// The input has been fully exhausted, so we transition to "merging
+				// partitions" state.
+				s.state = externalSorterMerging
+				continue
+			}
+			if err := s.partitioner.Enqueue(s.numPartitions, b); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			s.state = externalSorterSpillPartition
+			continue
+		case externalSorterSpillPartition:
+			b := s.input.Next(ctx)
+			if b.Length() == 0 {
+				// The partition has been fully spilled, so we reset the in-memory
+				// sorter (which will reset inputPartitioningOperator) and transition
+				// to "new partition" state.
+				s.inMemSorter.reset()
+				s.state = externalSorterNewPartition
+				s.numPartitions++
+				continue
+			}
+			if err := s.partitioner.Enqueue(s.numPartitions, b); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			continue
+		case externalSorterMerging:
+			// Ideally, we should not be in such a state that we have zero or one
+			// partition (we should have not spilled in such scenario), but we want
+			// to be safe and handle those cases anyway.
+			if s.numPartitions == 0 {
+				s.state = externalSorterFinished
+				continue
+			} else if s.numPartitions == 1 {
+				if s.singlePartitionOutput == nil {
+					s.singlePartitionOutput = newPartitionerToOperator(
+						s.unlimitedAllocator, s.inputTypes, s.partitioner, 0, /* partitionIdx */
+					)
+				}
+				b := s.singlePartitionOutput.Next(ctx)
+				if b.Length() == 0 {
+					s.state = externalSorterFinished
+					continue
+				}
+				return b
+			} else {
+				if s.merger == nil {
+					syncInputs := make([]Operator, s.numPartitions)
+					for i := range syncInputs {
+						syncInputs[i] = newPartitionerToOperator(
+							s.diskQueuesUnlimitedAllocator, s.inputTypes, s.partitioner, i,
+						)
+					}
+					s.merger = NewOrderedSynchronizer(
+						s.unlimitedAllocator,
+						syncInputs,
+						s.inputTypes,
+						execinfrapb.ConvertToColumnOrdering(s.ordering),
+					)
+					s.merger.Init()
+				}
+				b := s.merger.Next(ctx)
+				if b.Length() == 0 {
+					s.state = externalSorterFinished
+					continue
+				}
+				return b
+			}
+		case externalSorterFinished:
+			if err := s.partitioner.Close(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			return coldata.ZeroBatch
+		default:
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected externalSorterState %d", s.state))
+		}
+	}
+}
+
+func newInputPartitioningOperator(
+	unlimitedAllocator *Allocator, input Operator, memoryLimit int64,
+) resettableOperator {
+	return &inputPartitioningOperator{
+		OneInputNode:       NewOneInputNode(input),
+		unlimitedAllocator: unlimitedAllocator,
+		memoryLimit:        memoryLimit,
+	}
+}
+
+// inputPartitioningOperator is an operator that returns the batches from its
+// input until the unlimited allocator (which the output operator must be
+// using) reaches the memory limit. From that point, the operator returns a
+// zero-length batch (until it is reset).
+type inputPartitioningOperator struct {
+	OneInputNode
+	NonExplainable
+
+	unlimitedAllocator *Allocator
+	memoryLimit        int64
+}
+
+var _ resettableOperator = &inputPartitioningOperator{}
+
+func (o *inputPartitioningOperator) Init() {
+	o.input.Init()
+}
+
+func (o *inputPartitioningOperator) Next(ctx context.Context) coldata.Batch {
+	if o.unlimitedAllocator.Used() >= o.memoryLimit {
+		return coldata.ZeroBatch
+	}
+	return o.input.Next(ctx)
+}
+
+func (o *inputPartitioningOperator) reset() {
+	o.unlimitedAllocator.Clear()
+}
+
+func newPartitionerToOperator(
+	allocator *Allocator, types []coltypes.T, partitioner Partitioner, partitionIdx int,
+) Operator {
+	return &partitionerToOperator{
+		partitioner:  partitioner,
+		partitionIdx: partitionIdx,
+		batch:        allocator.NewMemBatch(types),
+	}
+}
+
+// partitionerToOperator is an Operator that Dequeue's from the corresponding
+// partition on every call to Next. It is a converter from filled in
+// Partitioner to Operator.
+type partitionerToOperator struct {
+	ZeroInputNode
+	NonExplainable
+
+	partitioner  Partitioner
+	partitionIdx int
+	batch        coldata.Batch
+}
+
+var _ Operator = &partitionerToOperator{}
+
+func (p *partitionerToOperator) Init() {}
+
+func (p *partitionerToOperator) Next(context.Context) coldata.Batch {
+	if err := p.partitioner.Dequeue(p.partitionIdx, p.batch); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	return p.batch
+}
+
+func newDummyPartitioner(allocator *Allocator, types []coltypes.T) Partitioner {
+	return &dummyPartitioner{allocator: allocator, types: types}
+}
+
+// dummyPartitioner is a simple implementation of Partitioner interface that
+// uses dummy in-memory queues.
+type dummyPartitioner struct {
+	allocator  *Allocator
+	types      []coltypes.T
+	partitions []*dummyQueue
+}
+
+var _ Partitioner = &dummyPartitioner{}
+
+func (d *dummyPartitioner) Enqueue(partitionIdx int, batch coldata.Batch) error {
+	if len(d.partitions) <= partitionIdx {
+		d.partitions = append(d.partitions, make([]*dummyQueue, partitionIdx-len(d.partitions)+1)...)
+	}
+	if d.partitions[partitionIdx] == nil {
+		d.partitions[partitionIdx] = newDummyQueue(d.allocator, d.types)
+	}
+	return d.partitions[partitionIdx].Enqueue(batch)
+}
+
+func (d *dummyPartitioner) Dequeue(partitionIdx int, batch coldata.Batch) error {
+	var partition *dummyQueue
+	if partitionIdx < len(d.partitions) {
+		partition = d.partitions[partitionIdx]
+	}
+	if partition == nil {
+		return errors.Newf("partition %d not found (len(partitions) = %d)", partitionIdx, len(d.partitions))
+	}
+	return partition.Dequeue(batch)
+}
+
+func (d *dummyPartitioner) Close() error {
+	for _, partition := range d.partitions {
+		if err := partition.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newDummyQueue(allocator *Allocator, types []coltypes.T) *dummyQueue {
+	return &dummyQueue{allocator: allocator, types: types}
+}
+
+// dummyQueue is an in-memory queue that simply copies the passed in batches.
+type dummyQueue struct {
+	allocator *Allocator
+	queue     []coldata.Batch
+	types     []coltypes.T
+}
+
+func (d *dummyQueue) Enqueue(batch coldata.Batch) error {
+	if batch.Length() == 0 {
+		return nil
+	}
+	batchCopy := d.allocator.NewMemBatchWithSize(d.types, int(batch.Length()))
+	d.allocator.PerformOperation(batchCopy.ColVecs(), func() {
+		for i, vec := range batchCopy.ColVecs() {
+			vec.Append(
+				coldata.SliceArgs{
+					ColType:     d.types[i],
+					Src:         batch.ColVec(i),
+					Sel:         batch.Selection(),
+					DestIdx:     0,
+					SrcStartIdx: 0,
+					SrcEndIdx:   uint64(batch.Length()),
+				})
+		}
+	})
+	batchCopy.SetLength(batch.Length())
+	d.queue = append(d.queue, batchCopy)
+	return nil
+}
+
+func (d *dummyQueue) Dequeue(batch coldata.Batch) error {
+	if len(d.queue) == 0 {
+		batch.SetLength(0)
+		return nil
+	}
+	batch.ResetInternalBatch()
+	batchToCopy := d.queue[0]
+	d.queue = d.queue[1:]
+	d.allocator.PerformOperation(batch.ColVecs(), func() {
+		for i, colVecToCopy := range batchToCopy.ColVecs() {
+			batch.ColVec(i).Append(coldata.SliceArgs{
+				ColType:     d.types[i],
+				Src:         colVecToCopy,
+				Sel:         batchToCopy.Selection(),
+				DestIdx:     0,
+				SrcStartIdx: 0,
+				SrcEndIdx:   uint64(batchToCopy.Length()),
+			})
+		}
+	})
+	batch.SetLength(batchToCopy.Length())
+	return nil
+}
+
+func (d *dummyQueue) Close() error {
+	return nil
 }

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -1,0 +1,262 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalSort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	var (
+		memAccounts []*mon.BoundAccount
+		memMonitors []*mon.BytesMonitor
+	)
+	// Interesting memory limits:
+	// 0 - the default 64MiB value is used, so we exercise that the disk spilling
+	//     machinery doesn't affect the correctness.
+	// 1 - this will force the in-memory sorter to hit the memory limit right
+	//     after it spools the first batch (i.e. it will buffer up a single batch
+	//     and then will hit OOM) which will trigger the external sort.
+	for _, memoryLimit := range []int64{0, 1} {
+		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+		t.Run(fmt.Sprintf("MemoryLimit=%d", memoryLimit), func(t *testing.T) {
+			for _, tc := range sortTestCases {
+				runTests(
+					t,
+					[]tuples{tc.tuples},
+					tc.expected,
+					orderedVerifier,
+					func(input []Operator) (Operator, error) {
+						sorter, accounts, monitors, err := createDiskBackedSorter(
+							ctx, flowCtx, input, tc.logTypes, tc.ordCols, func() {},
+						)
+						memAccounts = append(memAccounts, accounts...)
+						memMonitors = append(memMonitors, monitors...)
+						return sorter, err
+					})
+			}
+		})
+	}
+	for _, account := range memAccounts {
+		account.Close(ctx)
+	}
+	for _, monitor := range memMonitors {
+		monitor.Stop(ctx)
+	}
+}
+
+func TestExternalSortRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+	rng, _ := randutil.NewPseudoRand()
+	nTups := int(coldata.BatchSize()*4 + 1)
+	maxCols := 3
+	// TODO(yuzefovich): randomize types as well.
+	logTypes := make([]types.T, maxCols)
+	for i := range logTypes {
+		logTypes[i] = *types.Int
+	}
+
+	var (
+		memAccounts []*mon.BoundAccount
+		memMonitors []*mon.BytesMonitor
+	)
+	// Interesting memory limits:
+	// 1 - this will force the in-memory sorter to hit the memory limit right
+	//     after it spools the first batch (i.e. it will buffer up a single batch
+	//     and then will hit OOM) which will trigger the external sort.
+	// 10240 (mon.DefaultPoolAllocationSize) - this will allow the in-memory sorter
+	//     to spool several batches before hitting the memory limit.
+	for _, memoryLimit := range []int64{1, mon.DefaultPoolAllocationSize} {
+		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+		for nCols := 1; nCols < maxCols; nCols++ {
+			for nOrderingCols := 1; nOrderingCols <= nCols; nOrderingCols++ {
+				name := fmt.Sprintf("MemoryLimit=%d/nCols=%d/nOrderingCols=%d", memoryLimit, nCols, nOrderingCols)
+				t.Run(name, func(t *testing.T) {
+					tups, expected, ordCols := generateRandomDataForTestSort(rng, nTups, nCols, nOrderingCols)
+					runTests(
+						t,
+						[]tuples{tups},
+						expected,
+						orderedVerifier,
+						func(input []Operator) (Operator, error) {
+							sorter, accounts, monitors, err := createDiskBackedSorter(
+								ctx, flowCtx, input, logTypes[:nCols], ordCols, func() {},
+							)
+							memAccounts = append(memAccounts, accounts...)
+							memMonitors = append(memMonitors, monitors...)
+							return sorter, err
+						})
+				})
+			}
+		}
+	}
+	for _, account := range memAccounts {
+		account.Close(ctx)
+	}
+	for _, monitor := range memMonitors {
+		monitor.Stop(ctx)
+	}
+}
+
+func BenchmarkExternalSort(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+	rng, _ := randutil.NewPseudoRand()
+	var (
+		memAccounts []*mon.BoundAccount
+		memMonitors []*mon.BytesMonitor
+	)
+
+	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
+		for _, nCols := range []int{1, 2, 4} {
+			for _, memoryLimit := range []int64{0, 1} {
+				flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+				shouldSpill := memoryLimit > 0
+				name := fmt.Sprintf("rows=%d/cols=%d/spilled=%t", nBatches*int(coldata.BatchSize()), nCols, shouldSpill)
+				b.Run(name, func(b *testing.B) {
+					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /
+					// batch) * nCols (number of columns / row).
+					b.SetBytes(int64(8 * nBatches * int(coldata.BatchSize()) * nCols))
+					logTypes := make([]types.T, nCols)
+					for i := range logTypes {
+						logTypes[i] = *types.Int
+					}
+					physTypes, err := typeconv.FromColumnTypes(logTypes)
+					require.NoError(b, err)
+					batch := testAllocator.NewMemBatch(physTypes)
+					batch.SetLength(coldata.BatchSize())
+					ordCols := make([]execinfrapb.Ordering_Column, nCols)
+					for i := range ordCols {
+						ordCols[i].ColIdx = uint32(i)
+						ordCols[i].Direction = execinfrapb.Ordering_Column_Direction(rng.Int() % 2)
+						col := batch.ColVec(i).Int64()
+						for j := 0; j < int(coldata.BatchSize()); j++ {
+							col[j] = rng.Int63() % int64((i*1024)+1)
+						}
+					}
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						source := newFiniteBatchSource(batch, nBatches)
+						var (
+							resultBatches int
+							spilled       bool
+						)
+						sorter, accounts, monitors, err := createDiskBackedSorter(
+							ctx, flowCtx, []Operator{source}, logTypes, ordCols, func() { spilled = true },
+						)
+						memAccounts = append(memAccounts, accounts...)
+						memMonitors = append(memMonitors, monitors...)
+						if err != nil {
+							b.Fatal(err)
+						}
+						resultBatches = nBatches
+						sorter.Init()
+						for i := 0; i < resultBatches; i++ {
+							out := sorter.Next(ctx)
+							if out.Length() == 0 {
+								b.Fail()
+							}
+						}
+						require.Equal(b, shouldSpill, spilled, fmt.Sprintf(
+							"expected: spilled=%t\tactual: spilled=%t", shouldSpill, spilled,
+						))
+					}
+				})
+			}
+		}
+	}
+	for _, account := range memAccounts {
+		account.Close(ctx)
+	}
+	for _, monitor := range memMonitors {
+		monitor.Stop(ctx)
+	}
+}
+
+// createDiskBackedSorter is a helper function that instantiates a disk-backed
+// sort operator. The desired memory limit must have been already set on
+// flowCtx. It returns an operator and an error as well as memory monitors and
+// memory accounts that will need to be closed once the caller is done with the
+// operator.
+func createDiskBackedSorter(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	input []Operator,
+	logTypes []types.T,
+	ordCols []execinfrapb.Ordering_Column,
+	spillingCallbackFn func(),
+) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
+	sorterSpec := &execinfrapb.SorterSpec{}
+	sorterSpec.OutputOrdering.Columns = ordCols
+	spec := &execinfrapb.ProcessorSpec{
+		Input: []execinfrapb.InputSyncSpec{{ColumnTypes: logTypes}},
+		Core: execinfrapb.ProcessorCoreUnion{
+			Sorter: sorterSpec,
+		},
+		Post: execinfrapb.PostProcessSpec{},
+	}
+	args := NewColOperatorArgs{
+		Spec:                spec,
+		Inputs:              input,
+		StreamingMemAccount: testMemAcc,
+	}
+	// External sorter relies on different memory accounts to
+	// understand when to start a new partition, so we will not use
+	// the streaming memory account.
+	args.TestingKnobs.SpillingCallbackFn = spillingCallbackFn
+	result, err := NewColOperator(ctx, flowCtx, args)
+	return result.Op, result.BufferingOpMemAccounts, result.BufferingOpMemMonitors, err
+}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -924,11 +924,11 @@ func TestHashJoiner(t *testing.T) {
 			runTestsWithTyps(t, inputs, typs, tc.expectedTuples, unorderedVerifier, func(sources []Operator) (Operator, error) {
 				spec := createSpecForHashJoiner(tc)
 				args := NewColOperatorArgs{
-					Spec:                               spec,
-					Inputs:                             sources,
-					StreamingMemAccount:                testMemAcc,
-					UseStreamingMemAccountForBuffering: true,
+					Spec:                spec,
+					Inputs:              sources,
+					StreamingMemAccount: testMemAcc,
 				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
@@ -1141,11 +1141,11 @@ func TestHashJoinerProjection(t *testing.T) {
 	leftSource := newOpTestInput(1, leftTuples, leftColTypes)
 	rightSource := newOpTestInput(1, rightTuples, rightColTypes)
 	args := NewColOperatorArgs{
-		Spec:                               spec,
-		Inputs:                             []Operator{leftSource, rightSource},
-		StreamingMemAccount:                testMemAcc,
-		UseStreamingMemAccountForBuffering: true,
+		Spec:                spec,
+		Inputs:              []Operator{leftSource, rightSource},
+		StreamingMemAccount: testMemAcc,
 	}
+	args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 	hjOp, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
 	hjOp.Op.Init()

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -100,11 +100,11 @@ func TestIsNullProjOp(t *testing.T) {
 					},
 				}
 				args := NewColOperatorArgs{
-					Spec:                               spec,
-					Inputs:                             input,
-					StreamingMemAccount:                testMemAcc,
-					UseStreamingMemAccountForBuffering: true,
+					Spec:                spec,
+					Inputs:              input,
+					StreamingMemAccount: testMemAcc,
 				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err
@@ -190,11 +190,11 @@ func TestIsNullSelOp(t *testing.T) {
 					},
 				}
 				args := NewColOperatorArgs{
-					Spec:                               spec,
-					Inputs:                             input,
-					StreamingMemAccount:                testMemAcc,
-					UseStreamingMemAccountForBuffering: true,
+					Spec:                spec,
+					Inputs:              input,
+					StreamingMemAccount: testMemAcc,
 				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1646,11 +1646,11 @@ func TestMergeJoiner(t *testing.T) {
 			func(input []Operator) (Operator, error) {
 				spec := createSpecForMergeJoiner(tc)
 				args := NewColOperatorArgs{
-					Spec:                               spec,
-					Inputs:                             input,
-					StreamingMemAccount:                testMemAcc,
-					UseStreamingMemAccountForBuffering: true,
+					Spec:                spec,
+					Inputs:              input,
+					StreamingMemAccount: testMemAcc,
 				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 				result, err := NewColOperator(ctx, flowCtx, args)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -83,6 +83,14 @@ type spooler interface {
 	// spooled tuples. It should return nil if all the tuples belong to the same
 	// partition.
 	getPartitionsCol() []bool
+	// getWindowedBatch returns a batch that is a "window" into all Vecs of the
+	// already spooled data, with tuples in range [startIdx, endIdx). This batch
+	// is not allowed to be modified and is only safe to use until the next call
+	// to this method.
+	// TODO(yuzefovich): one idea we might want to implement at some point is
+	// adding a wrapper on top of a coldata.Batch that is coldata.ImmutableBatch
+	// that returns coldata.ImmutableVecs to enforce immutability.
+	getWindowedBatch(startIdx, endIdx uint64) coldata.Batch
 }
 
 // allSpooler is the spooler that spools all tuples from the input. It is used
@@ -98,7 +106,8 @@ type allSpooler struct {
 	// Vec in this slice is the entire column from the input.
 	bufferedTuples *bufferedBatch
 	// spooled indicates whether spool() has already been called.
-	spooled bool
+	spooled       bool
+	windowedBatch coldata.Batch
 }
 
 var _ spooler = &allSpooler{}
@@ -114,6 +123,7 @@ func newAllSpooler(allocator *Allocator, input Operator, inputTypes []coltypes.T
 func (p *allSpooler) init() {
 	p.input.Init()
 	p.bufferedTuples = newBufferedBatch(p.allocator, p.inputTypes, 0 /* initialSize */)
+	p.windowedBatch = p.allocator.NewMemBatchWithSize(p.inputTypes, 0 /* size */)
 }
 
 func (p *allSpooler) spool(ctx context.Context) {
@@ -159,6 +169,16 @@ func (p *allSpooler) getPartitionsCol() []bool {
 		execerror.VectorizedInternalPanic("getPartitionsCol() is called before spool()")
 	}
 	return nil
+}
+
+func (p *allSpooler) getWindowedBatch(startIdx, endIdx uint64) coldata.Batch {
+	for i, t := range p.inputTypes {
+		window := p.bufferedTuples.colVecs[i].Window(t, startIdx, endIdx)
+		p.windowedBatch.ColVec(i).SetCol(window.Col())
+		p.windowedBatch.ColVec(i).SetNulls(window.Nulls())
+	}
+	p.windowedBatch.SetLength(uint16(endIdx - startIdx))
+	return p.windowedBatch
 }
 
 func (p *allSpooler) reset() {
@@ -413,38 +433,15 @@ func (p *sortOp) Child(nth int, verbose bool) execinfra.OpNode {
 	return nil
 }
 
-func (p *sortOp) ExportBuffered(allocator *Allocator) coldata.Batch {
+func (p *sortOp) ExportBuffered() coldata.Batch {
 	if p.exported == p.input.getNumTuples() {
 		return coldata.ZeroBatch
-	}
-	if p.output == nil {
-		p.output = allocator.NewMemBatch(p.inputTypes)
-	} else {
-		p.output.ResetInternalBatch()
 	}
 	newExported := p.exported + uint64(coldata.BatchSize())
 	if newExported > p.input.getNumTuples() {
 		newExported = p.input.getNumTuples()
 	}
-	// TODO(yuzefovich): refactor spooler interface so that the spooler could
-	// return buffered tuples as batches and we didn't need to copy the data.
-	// We're using the provided Allocator.
-	allocator.PerformOperation(p.output.ColVecs(), func() {
-		for j := 0; j < len(p.inputTypes); j++ {
-			p.output.ColVec(j).Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						ColType:     p.inputTypes[j],
-						Src:         p.input.getValues(j),
-						SrcStartIdx: p.exported,
-						SrcEndIdx:   newExported,
-					},
-				},
-			)
-		}
-
-	})
-	p.output.SetLength(uint16(newExported - p.exported))
+	b := p.input.getWindowedBatch(p.exported, newExported)
 	p.exported = newExported
-	return p.output
+	return b
 }

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -442,6 +442,12 @@ func (s *chunker) getPartitionsCol() []bool {
 	}
 }
 
+func (s *chunker) getWindowedBatch(startIdx, endIdx uint64) coldata.Batch {
+	execerror.VectorizedInternalPanic("getWindowedBatch is not implemented on chunker spooler")
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
 func (s *chunker) emptyBuffer() {
 	s.bufferedTuples.reset()
 }

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -140,11 +140,11 @@ func TestRank(t *testing.T) {
 				},
 			}
 			args := NewColOperatorArgs{
-				Spec:                               spec,
-				Inputs:                             inputs,
-				StreamingMemAccount:                testMemAcc,
-				UseStreamingMemAccountForBuffering: true,
+				Spec:                spec,
+				Inputs:              inputs,
+				StreamingMemAccount: testMemAcc,
 			}
+			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err
@@ -214,11 +214,11 @@ func TestRowNumber(t *testing.T) {
 				},
 			}
 			args := NewColOperatorArgs{
-				Spec:                               spec,
-				Inputs:                             inputs,
-				StreamingMemAccount:                testMemAcc,
-				UseStreamingMemAccountForBuffering: true,
+				Spec:                spec,
+				Inputs:              inputs,
+				StreamingMemAccount: testMemAcc,
 			}
+			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := NewColOperator(ctx, flowCtx, args)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -79,10 +79,10 @@ func BenchmarkColBatchScan(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				args := colexec.NewColOperatorArgs{
-					Spec:                               &spec,
-					StreamingMemAccount:                testMemAcc,
-					UseStreamingMemAccountForBuffering: true,
+					Spec:                &spec,
+					StreamingMemAccount: testMemAcc,
 				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 				res, err := colexec.NewColOperator(ctx, &flowCtx, args)
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -883,10 +883,7 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon
 func NewLimitedMonitor(
 	ctx context.Context, parent *mon.BytesMonitor, config *ServerConfig, name string,
 ) *mon.BytesMonitor {
-	limit := config.TestingKnobs.MemoryLimitBytes
-	if limit <= 0 {
-		limit = SettingWorkMemBytes.Get(&config.Settings.SV)
-	}
+	limit := GetWorkMemLimit(config)
 	limitedMon := mon.MakeMonitorInheritWithLimit(name, limit, parent)
 	limitedMon.Start(ctx, parent, mon.BoundAccount{})
 	return &limitedMon

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -232,3 +232,13 @@ const (
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*TestingKnobs) ModuleTestingKnobs() {}
+
+// GetWorkMemLimit returns the number of bytes determining the amount of RAM
+// available to a single processor or operator.
+func GetWorkMemLimit(config *ServerConfig) int64 {
+	limit := config.TestingKnobs.MemoryLimitBytes
+	if limit <= 0 {
+		limit = SettingWorkMemBytes.Get(&config.Settings.SV)
+	}
+	return limit
+}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -179,10 +179,7 @@ func newHashJoiner(
 	if h.useTempStorage {
 		// Limit the memory use by creating a child monitor with a hard limit.
 		// The hashJoiner will overflow to disk if this limit is not enough.
-		limit := h.FlowCtx.Cfg.TestingKnobs.MemoryLimitBytes
-		if limit <= 0 {
-			limit = execinfra.SettingWorkMemBytes.Get(&st.SV)
-		}
+		limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
 		h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "hashjoiner-limited")
 		h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "hashjoiner-disk")
 		// Override initialBufferSize to be half of this processor's memory

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -228,10 +228,7 @@ func newJoinReader(
 	if execinfra.SettingUseTempStorageJoins.Get(&st.SV) {
 		// Limit the memory use by creating a child monitor with a hard limit.
 		// joinReader will overflow to disk if this limit is not enough.
-		limit := flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
-		if limit <= 0 {
-			limit = execinfra.SettingWorkMemBytes.Get(&st.SV)
-		}
+		limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
 		jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joiner-limited")
 		jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "joinreader-disk")
 		drc := rowcontainer.NewDiskBackedIndexedRowContainer(

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -220,9 +220,9 @@ func TestEval(t *testing.T) {
 						},
 					},
 				},
-				StreamingMemAccount:                &acc,
-				UseStreamingMemAccountForBuffering: true,
+				StreamingMemAccount: &acc,
 			}
+			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := colexec.NewColOperator(ctx, flowCtx, args)
 			if testutils.IsError(err, "unable to columnarize") {
 				// Skip this test as execution is not supported by the vectorized


### PR DESCRIPTION
**execinfra: minor refactor of getting working memory limit**

This commit introduces a helper method for getting the working memory
limit in bytes from a combination of testing knobs and a cluster
setting.

Release note: None

**colexec: add simple implementation of an external sort**

This commit adds a simple implementation of external sort that works
in two stages:
1. it will use a combination of a newly introduced input partitioner
and in-memory sorter to divide up all batches from the input into
partitions, sort each partition in memory, and write sorted partitions
to disk
2. it will use OrderedSynchronizer to merge the partitions.

Closes: #42409.

Release note: None

**colexec: refactor all spooler to not require allocator when exporting**

This commit modifies 'spooler' interface to add a method that allows
accessing spooled tuples as "windowed batches" so that when exporting
buffered tuples an allocator is not required and no copying is not
necessary. Instead, windowed batches are returned which are safe to use
until the next call and need to be copied somewhere else. Such behavior
is acceptable because these batches will be spilled to disk.

Release note: None

**cmd: increase timeout and make TESTS regex more specific in pull-request-make**

This commit increases the timeout from 5 to 10 minutes (I ran into
a situation where the CI `testrace` was timing out). Also, it adds `$$`
symbols to the end of each test so that full length matching occurred
instead of prefix matching (e.g. `TestSort` also matches
`TestSortedDistinct` which could be not modified in the PR to run
`testrace` for).

Release note: None