### PR TITLE
batcheval: clean up remaning variable names of `{Reader,ReadWriter}` types

### DIFF
--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -33,7 +33,7 @@ func init() {
 
 // EvalAddSSTable evaluates an AddSSTable command.
 func EvalAddSSTable(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.AddSSTableRequest)
 	h := cArgs.Header
@@ -50,7 +50,7 @@ func EvalAddSSTable(
 	var skippedKVStats enginepb.MVCCStats
 	var err error
 	if args.DisallowShadowing {
-		if skippedKVStats, err = checkForKeyCollisions(ctx, batch, mvccStartKey, mvccEndKey, args.Data); err != nil {
+		if skippedKVStats, err = checkForKeyCollisions(ctx, readWriter, mvccStartKey, mvccEndKey, args.Data); err != nil {
 			return result.Result{}, errors.Wrap(err, "checking for key collisions")
 		}
 	}
@@ -192,7 +192,7 @@ func EvalAddSSTable(
 			// NB: This is *not* a general transformation of any arbitrary SST to a
 			// WriteBatch: it assumes every key in the SST is a simple Set. This is
 			// already assumed elsewhere in this RPC though, so that's OK here.
-			if err := batch.Put(dataIter.UnsafeKey(), dataIter.UnsafeValue()); err != nil {
+			if err := readWriter.Put(dataIter.UnsafeKey(), dataIter.UnsafeValue()); err != nil {
 				return result.Result{}, err
 			}
 			dataIter.Next()
@@ -211,8 +211,8 @@ func EvalAddSSTable(
 }
 
 func checkForKeyCollisions(
-	ctx context.Context,
-	batch engine.ReadWriter,
+	_ context.Context,
+	readWriter engine.ReadWriter,
 	mvccStartKey engine.MVCCKey,
 	mvccEndKey engine.MVCCKey,
 	data []byte,
@@ -220,7 +220,7 @@ func checkForKeyCollisions(
 	// We could get a spansetBatch so fetch the underlying db engine as
 	// we need access to the underlying C.DBIterator later, and the
 	// dbIteratorGetter is not implemented by a spansetBatch.
-	dbEngine := spanset.GetDBEngine(batch, roachpb.Span{Key: mvccStartKey.Key, EndKey: mvccEndKey.Key})
+	dbEngine := spanset.GetDBEngine(readWriter, roachpb.Span{Key: mvccStartKey.Key, EndKey: mvccEndKey.Key})
 
 	emptyMVCCStats := enginepb.MVCCStats{}
 

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -53,7 +53,7 @@ func declareKeysClearRange(
 // or queried any more, such as after a DROP or TRUNCATE table, or
 // DROP index.
 func ClearRange(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	if cArgs.Header.Txn != nil {
 		return result.Result{}, errors.New("cannot execute ClearRange within a transaction")
@@ -67,7 +67,7 @@ func ClearRange(
 	var pd result.Result
 
 	// Before clearing, compute the delta in MVCCStats.
-	statsDelta, err := computeStatsDelta(ctx, batch, cArgs, from, to)
+	statsDelta, err := computeStatsDelta(ctx, readWriter, cArgs, from, to)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -78,9 +78,9 @@ func ClearRange(
 	// instead of using a range tombstone (inefficient for small ranges).
 	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
-		if err := batch.Iterate(from, to,
+		if err := readWriter.Iterate(from, to,
 			func(kv engine.MVCCKeyValue) (bool, error) {
-				return false, batch.Clear(kv.Key)
+				return false, readWriter.Clear(kv.Key)
 			},
 		); err != nil {
 			return result.Result{}, err
@@ -100,7 +100,7 @@ func ClearRange(
 			},
 		},
 	}
-	if err := batch.ClearRange(engine.MakeMVCCMetadataKey(from),
+	if err := readWriter.ClearRange(engine.MakeMVCCMetadataKey(from),
 		engine.MakeMVCCMetadataKey(to)); err != nil {
 		return result.Result{}, err
 	}
@@ -116,7 +116,7 @@ func ClearRange(
 // path of simply subtracting the non-system values is accurate.
 // Returns the delta stats.
 func computeStatsDelta(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, from, to roachpb.Key,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, from, to roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	desc := cArgs.EvalCtx.Desc()
 	var delta enginepb.MVCCStats
@@ -137,7 +137,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled,
 	// compute stats across the key span to be cleared.
 	if !fast || util.RaceEnabled {
-		iter := batch.NewIterator(engine.IterOptions{UpperBound: to})
+		iter := readWriter.NewIterator(engine.IterOptions{UpperBound: to})
 		computed, err := iter.ComputeStats(from, to, delta.LastUpdateNanos)
 		iter.Close()
 		if err != nil {

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -45,7 +45,7 @@ const (
 // a particular snapshot. The checksum is later verified through a
 // CollectChecksumRequest.
 func ComputeChecksum(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	_ context.Context, _ engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ComputeChecksumRequest)
 

--- a/pkg/storage/batcheval/cmd_delete.go
+++ b/pkg/storage/batcheval/cmd_delete.go
@@ -24,10 +24,10 @@ func init() {
 
 // Delete deletes the key and value specified by key.
 func Delete(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.DeleteRequest)
 	h := cArgs.Header
 
-	return result.Result{}, engine.MVCCDelete(ctx, batch, cArgs.Stats, args.Key, h.Timestamp, h.Txn)
+	return result.Result{}, engine.MVCCDelete(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, h.Txn)
 }

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -41,7 +41,7 @@ func declareKeysDeleteRange(
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
 func DeleteRange(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.DeleteRangeRequest)
 	h := cArgs.Header
@@ -52,7 +52,7 @@ func DeleteRange(
 		timestamp = h.Timestamp
 	}
 	deleted, resumeSpan, num, err := engine.MVCCDeleteRange(
-		ctx, batch, cArgs.Stats, args.Key, args.EndKey, cArgs.MaxKeys, timestamp, h.Txn, args.ReturnKeys,
+		ctx, readWriter, cArgs.Stats, args.Key, args.EndKey, cArgs.MaxKeys, timestamp, h.Txn, args.ReturnKeys,
 	)
 	if err == nil {
 		reply.Keys = deleted

--- a/pkg/storage/batcheval/cmd_gc.go
+++ b/pkg/storage/batcheval/cmd_gc.go
@@ -53,7 +53,7 @@ func declareKeysGC(
 // listed key along with the expiration timestamp. The GC metadata
 // specified in the args is persisted after GC.
 func GC(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.GCRequest)
 	h := cArgs.Header
@@ -72,7 +72,7 @@ func GC(
 
 	// Garbage collect the specified keys by expiration timestamps.
 	if err := engine.MVCCGarbageCollect(
-		ctx, batch, cArgs.Stats, keys, h.Timestamp,
+		ctx, readWriter, cArgs.Stats, keys, h.Timestamp,
 	); err != nil {
 		return result.Result{}, err
 	}
@@ -97,7 +97,7 @@ func GC(
 	var replState storagepb.ReplicaState
 	if newThreshold != (hlc.Timestamp{}) {
 		replState.GCThreshold = &newThreshold
-		if err := stateLoader.SetGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
+		if err := stateLoader.SetGCThreshold(ctx, readWriter, cArgs.Stats, &newThreshold); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -25,13 +25,13 @@ func init() {
 
 // Get returns the value for a specified key.
 func Get(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.GetRequest)
 	h := cArgs.Header
 	reply := resp.(*roachpb.GetResponse)
 
-	val, intent, err := engine.MVCCGet(ctx, batch, args.Key, h.Timestamp, engine.MVCCGetOptions{
+	val, intent, err := engine.MVCCGet(ctx, reader, args.Key, h.Timestamp, engine.MVCCGetOptions{
 		Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:          h.Txn,
 	})
@@ -46,7 +46,7 @@ func Get(
 	reply.Value = val
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
 		var intentVals []roachpb.KeyValue
-		intentVals, err = CollectIntentRows(ctx, batch, cArgs, intents)
+		intentVals, err = CollectIntentRows(ctx, reader, cArgs, intents)
 		if err == nil {
 			switch len(intentVals) {
 			case 0:

--- a/pkg/storage/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/storage/batcheval/cmd_heartbeat_txn.go
@@ -36,7 +36,7 @@ func declareKeysHeartbeatTransaction(
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. Returns the updated transaction.
 func HeartbeatTxn(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.HeartbeatTxnRequest)
 	h := cArgs.Header
@@ -54,7 +54,7 @@ func HeartbeatTxn(
 
 	var txn roachpb.Transaction
 	if ok, err := engine.MVCCGetProto(
-		ctx, batch, key, hlc.Timestamp{}, &txn, engine.MVCCGetOptions{},
+		ctx, readWriter, key, hlc.Timestamp{}, &txn, engine.MVCCGetOptions{},
 	); err != nil {
 		return result.Result{}, err
 	} else if !ok {
@@ -74,7 +74,7 @@ func HeartbeatTxn(
 		// is up for debate.
 		txn.LastHeartbeat.Forward(args.Now)
 		txnRecord := txn.AsRecord()
-		if err := engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
+		if err := engine.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/storage/batcheval/cmd_increment.go
+++ b/pkg/storage/batcheval/cmd_increment.go
@@ -26,13 +26,13 @@ func init() {
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
 func Increment(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.IncrementRequest)
 	h := cArgs.Header
 	reply := resp.(*roachpb.IncrementResponse)
 
-	newVal, err := engine.MVCCIncrement(ctx, batch, cArgs.Stats, args.Key, h.Timestamp, h.Txn, args.Increment)
+	newVal, err := engine.MVCCIncrement(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, h.Txn, args.Increment)
 	reply.NewValue = newVal
 	return result.Result{}, err
 }

--- a/pkg/storage/batcheval/cmd_init_put.go
+++ b/pkg/storage/batcheval/cmd_init_put.go
@@ -27,22 +27,22 @@ func init() {
 // is different from the value provided. If FailOnTombstone is set to true,
 // tombstones count as mismatched values and will cause a ConditionFailedError.
 func InitPut(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.InitPutRequest)
 	h := cArgs.Header
 
 	if h.DistinctSpans {
-		if b, ok := batch.(engine.Batch); ok {
+		if b, ok := readWriter.(engine.Batch); ok {
 			// Use the distinct batch for both blind and normal ops so that we don't
 			// accidentally flush mutations to make them visible to the distinct
 			// batch.
-			batch = b.Distinct()
-			defer batch.Close()
+			readWriter = b.Distinct()
+			defer readWriter.Close()
 		}
 	}
 	if args.Blind {
-		return result.Result{}, engine.MVCCBlindInitPut(ctx, batch, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
+		return result.Result{}, engine.MVCCBlindInitPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
 	}
-	return result.Result{}, engine.MVCCInitPut(ctx, batch, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
+	return result.Result{}, engine.MVCCInitPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
 }

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -90,7 +90,7 @@ func checkCanReceiveLease(newLease *roachpb.Lease, rec EvalContext) error {
 func evalNewLease(
 	ctx context.Context,
 	rec EvalContext,
-	batch engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	lease roachpb.Lease,
 	prevLease roachpb.Lease,
@@ -157,7 +157,7 @@ func evalNewLease(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := MakeStateLoader(rec).SetLease(ctx, batch, ms, lease); err != nil {
+	if err := MakeStateLoader(rec).SetLease(ctx, readWriter, ms, lease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -32,7 +32,7 @@ func declareKeysLeaseInfo(
 
 // LeaseInfo returns information about the lease holder for the range.
 func LeaseInfo(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.LeaseInfoResponse)
 	lease, nextLease := cArgs.EvalCtx.GetLease()

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -30,7 +30,7 @@ func init() {
 // lease, all duties required of the range lease holder are commenced, including
 // releasing all latches and clearing the timestamp cache.
 func RequestLease(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	// When returning an error from this method, must always return a
 	// newFailedLeaseTrigger() to satisfy stats.
@@ -125,6 +125,6 @@ func RequestLease(
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}
 	newLease.Start = effectiveStart
-	return evalNewLease(ctx, cArgs.EvalCtx, batch, cArgs.Stats,
+	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,
 		newLease, prevLease, isExtension, false /* isTransfer */)
 }

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -43,7 +43,7 @@ func init() {
 // ex-) lease holder which must have dropped all of its lease holder powers
 // before proposing.
 func TransferLease(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	// When returning an error from this method, must always return
 	// a newFailedLeaseTrigger() to satisfy stats.
@@ -66,6 +66,6 @@ func TransferLease(
 
 	prevLease, _ := cArgs.EvalCtx.GetLease()
 	log.VEventf(ctx, 2, "lease transfer: prev lease: %+v, new lease: %+v", prevLease, args.Lease)
-	return evalNewLease(ctx, cArgs.EvalCtx, batch, cArgs.Stats,
+	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,
 		args.Lease, prevLease, false /* isExtension */, true /* isTransfer */)
 }

--- a/pkg/storage/batcheval/cmd_merge.go
+++ b/pkg/storage/batcheval/cmd_merge.go
@@ -29,10 +29,10 @@ func init() {
 // transactional, merges are not currently exposed directly to
 // clients. Merged values are explicitly not MVCC data.
 func Merge(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.MergeRequest)
 	h := cArgs.Header
 
-	return result.Result{}, engine.MVCCMerge(ctx, batch, cArgs.Stats, args.Key, h.Timestamp, args.Value)
+	return result.Result{}, engine.MVCCMerge(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value)
 }

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -102,7 +102,7 @@ func declareKeysPushTransaction(
 // records for which the transaction coordinator must have found out via
 // its heartbeats that the transaction has failed.
 func PushTxn(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.PushTxnRequest)
 	h := cArgs.Header
@@ -135,7 +135,7 @@ func PushTxn(
 
 	// Fetch existing transaction; if missing, we're allowed to abort.
 	var existTxn roachpb.Transaction
-	ok, err := engine.MVCCGetProto(ctx, batch, key, hlc.Timestamp{}, &existTxn, engine.MVCCGetOptions{})
+	ok, err := engine.MVCCGetProto(ctx, readWriter, key, hlc.Timestamp{}, &existTxn, engine.MVCCGetOptions{})
 	if err != nil {
 		return result.Result{}, err
 	} else if !ok {
@@ -303,7 +303,7 @@ func PushTxn(
 	// in the timestamp cache.
 	if ok {
 		txnRecord := reply.PusheeTxn.AsRecord()
-		if err := engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
+		if err := engine.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/storage/batcheval/cmd_query_intent.go
+++ b/pkg/storage/batcheval/cmd_query_intent.go
@@ -43,7 +43,7 @@ func declareKeysQueryIntent(
 // request is special-cased to return a SERIALIZABLE retry error if a transaction
 // queries its own intent and finds it has been pushed.
 func QueryIntent(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryIntentRequest)
 	h := cArgs.Header
@@ -52,7 +52,7 @@ func QueryIntent(
 	// Read at the specified key at the maximum timestamp. This ensures that we
 	// see an intent if one exists, regardless of what timestamp it is written
 	// at.
-	_, intent, err := engine.MVCCGet(ctx, batch, args.Key, hlc.MaxTimestamp, engine.MVCCGetOptions{
+	_, intent, err := engine.MVCCGet(ctx, reader, args.Key, hlc.MaxTimestamp, engine.MVCCGetOptions{
 		// Perform an inconsistent read so that intents are returned instead of
 		// causing WriteIntentErrors.
 		Inconsistent: true,

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -43,7 +43,7 @@ func declareKeysQueryTransaction(
 // other txns which are waiting on this transaction in order
 // to find dependency cycles.
 func QueryTxn(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryTxnRequest)
 	h := cArgs.Header
@@ -68,7 +68,7 @@ func QueryTxn(
 
 	// Fetch transaction record; if missing, attempt to synthesize one.
 	if ok, err := engine.MVCCGetProto(
-		ctx, batch, key, hlc.Timestamp{}, &reply.QueriedTxn, engine.MVCCGetOptions{},
+		ctx, reader, key, hlc.Timestamp{}, &reply.QueriedTxn, engine.MVCCGetOptions{},
 	); err != nil {
 		return result.Result{}, err
 	} else if !ok {

--- a/pkg/storage/batcheval/cmd_range_stats.go
+++ b/pkg/storage/batcheval/cmd_range_stats.go
@@ -24,7 +24,7 @@ func init() {
 
 // RangeStats returns the MVCC statistics for a range.
 func RangeStats(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	_ context.Context, _ engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.RangeStatsResponse)
 	reply.MVCCStats = cArgs.EvalCtx.GetMVCCStats()

--- a/pkg/storage/batcheval/cmd_recover_txn.go
+++ b/pkg/storage/batcheval/cmd_recover_txn.go
@@ -47,7 +47,7 @@ func declareKeysRecoverTransaction(
 // result of the recovery should be committing the abandoned transaction or
 // aborting it.
 func RecoverTxn(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RecoverTxnRequest)
 	h := cArgs.Header
@@ -67,7 +67,7 @@ func RecoverTxn(
 
 	// Fetch transaction record; if missing, attempt to synthesize one.
 	if ok, err := engine.MVCCGetProto(
-		ctx, batch, key, hlc.Timestamp{}, &reply.RecoveredTxn, engine.MVCCGetOptions{},
+		ctx, readWriter, key, hlc.Timestamp{}, &reply.RecoveredTxn, engine.MVCCGetOptions{},
 	); err != nil {
 		return result.Result{}, err
 	} else if !ok {
@@ -213,7 +213,7 @@ func RecoverTxn(
 		reply.RecoveredTxn.Status = roachpb.ABORTED
 	}
 	txnRecord := reply.RecoveredTxn.AsRecord()
-	if err := engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
+	if err := engine.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, nil, &txnRecord); err != nil {
 		return result.Result{}, err
 	}
 

--- a/pkg/storage/batcheval/cmd_refresh.go
+++ b/pkg/storage/batcheval/cmd_refresh.go
@@ -27,7 +27,7 @@ func init() {
 // Refresh checks whether the key has any values written in the interval
 // [args.RefreshFrom, header.Timestamp].
 func Refresh(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRequest)
 	h := cArgs.Header
@@ -55,7 +55,7 @@ func Refresh(
 	// specifying consistent=false. Note that we include tombstones,
 	// which must be considered as updates on refresh.
 	log.VEventf(ctx, 2, "refresh %s @[%s-%s]", args.Span(), refreshFrom, refreshTo)
-	val, intent, err := engine.MVCCGet(ctx, batch, args.Key, refreshTo, engine.MVCCGetOptions{
+	val, intent, err := engine.MVCCGet(ctx, reader, args.Key, refreshTo, engine.MVCCGetOptions{
 		Inconsistent: true,
 		Tombstones:   true,
 	})

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -27,7 +27,7 @@ func init() {
 // RefreshRange checks whether the key range specified has any values written in
 // the interval [args.RefreshFrom, header.Timestamp].
 func RefreshRange(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRangeRequest)
 	h := cArgs.Header
@@ -58,7 +58,7 @@ func RefreshRange(
 	// that we include tombstones, which must be considered as updates on refresh.
 	log.VEventf(ctx, 2, "refresh %s @[%s-%s]", args.Span(), refreshFrom, refreshTo)
 	intents, err := engine.MVCCIterate(
-		ctx, batch, args.Key, args.EndKey, refreshTo,
+		ctx, reader, args.Key, args.EndKey, refreshTo,
 		engine.MVCCScanOptions{
 			Inconsistent: true,
 			Tombstones:   true,

--- a/pkg/storage/batcheval/cmd_resolve_intent.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent.go
@@ -69,7 +69,7 @@ func resolveToMetricType(status roachpb.TransactionStatus, poison bool) *result.
 // ResolveIntent resolves a write intent from the specified key
 // according to the status of the transaction which created it.
 func ResolveIntent(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ResolveIntentRequest)
 	h := cArgs.Header
@@ -84,7 +84,7 @@ func ResolveIntent(
 		Txn:    args.IntentTxn,
 		Status: args.Status,
 	}
-	ok, err := engine.MVCCResolveWriteIntent(ctx, batch, ms, intent)
+	ok, err := engine.MVCCResolveWriteIntent(ctx, readWriter, ms, intent)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -93,7 +93,7 @@ func ResolveIntent(
 	res.Local.Metrics = resolveToMetricType(args.Status, args.Poison)
 
 	if WriteAbortSpanOnResolve(args.Status, args.Poison, ok) {
-		if err := UpdateAbortSpan(ctx, cArgs.EvalCtx, batch, ms, args.IntentTxn, args.Poison); err != nil {
+		if err := UpdateAbortSpan(ctx, cArgs.EvalCtx, readWriter, ms, args.IntentTxn, args.Poison); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -28,7 +28,7 @@ func init() {
 // maxKeys stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func ReverseScan(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ReverseScanRequest)
 	h := cArgs.Header
@@ -43,7 +43,7 @@ func ReverseScan(
 		var kvData [][]byte
 		var numKvs int64
 		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
+			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
 			engine.MVCCScanOptions{
 				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 				Txn:          h.Txn,
@@ -57,7 +57,7 @@ func ReverseScan(
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
 		rows, resumeSpan, intents, err = engine.MVCCScan(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
+			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
 				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 				Txn:          h.Txn,
 				Reverse:      true,
@@ -77,7 +77,7 @@ func ReverseScan(
 	}
 
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
-		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
+		reply.IntentRows, err = CollectIntentRows(ctx, reader, cArgs, intents)
 	}
 	return result.FromEncounteredIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -28,7 +28,7 @@ func init() {
 // stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func Scan(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ScanRequest)
 	h := cArgs.Header
@@ -43,7 +43,7 @@ func Scan(
 		var kvData [][]byte
 		var numKvs int64
 		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
+			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
 			engine.MVCCScanOptions{
 				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 				Txn:          h.Txn,
@@ -56,7 +56,7 @@ func Scan(
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
 		rows, resumeSpan, intents, err = engine.MVCCScan(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
+			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
 				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 				Txn:          h.Txn,
 			})
@@ -75,7 +75,7 @@ func Scan(
 	}
 
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {
-		reply.IntentRows, err = CollectIntentRows(ctx, batch, cArgs, intents)
+		reply.IntentRows, err = CollectIntentRows(ctx, reader, cArgs, intents)
 	}
 	return result.FromEncounteredIntents(intents), err
 }

--- a/pkg/storage/batcheval/cmd_subsume.go
+++ b/pkg/storage/batcheval/cmd_subsume.go
@@ -84,7 +84,7 @@ func declareKeysSubsume(
 // The period of time after intents have been placed but before the merge
 // transaction is complete is called the merge's "critical phase".
 func Subsume(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, readWriter engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.SubsumeRequest)
 	reply := resp.(*roachpb.SubsumeResponse)
@@ -109,14 +109,14 @@ func Subsume(
 	// Sanity check the caller has initiated a merge transaction by checking for
 	// a deletion intent on the local range descriptor.
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
-	_, intent, err := engine.MVCCGet(ctx, batch, descKey, cArgs.Header.Timestamp,
+	_, intent, err := engine.MVCCGet(ctx, readWriter, descKey, cArgs.Header.Timestamp,
 		engine.MVCCGetOptions{Inconsistent: true})
 	if err != nil {
 		return result.Result{}, fmt.Errorf("fetching local range descriptor: %s", err)
 	} else if intent == nil {
 		return result.Result{}, errors.New("range missing intent on its local descriptor")
 	}
-	val, _, err := engine.MVCCGetAsTxn(ctx, batch, descKey, cArgs.Header.Timestamp, intent.Txn)
+	val, _, err := engine.MVCCGetAsTxn(ctx, readWriter, descKey, cArgs.Header.Timestamp, intent.Txn)
 	if err != nil {
 		return result.Result{}, fmt.Errorf("fetching local range descriptor as txn: %s", err)
 	} else if val != nil {

--- a/pkg/storage/batcheval/intent.go
+++ b/pkg/storage/batcheval/intent.go
@@ -25,7 +25,7 @@ import (
 // RangeLookups and since this is how they currently collect intent values, this
 // is ok for now.
 func CollectIntentRows(
-	ctx context.Context, batch engine.Reader, cArgs CommandArgs, intents []roachpb.Intent,
+	ctx context.Context, reader engine.Reader, cArgs CommandArgs, intents []roachpb.Intent,
 ) ([]roachpb.KeyValue, error) {
 	if len(intents) == 0 {
 		return nil, nil
@@ -33,7 +33,7 @@ func CollectIntentRows(
 	res := make([]roachpb.KeyValue, 0, len(intents))
 	for _, intent := range intents {
 		val, _, err := engine.MVCCGetAsTxn(
-			ctx, batch, intent.Key, intent.Txn.WriteTimestamp, intent.Txn,
+			ctx, reader, intent.Key, intent.Txn.WriteTimestamp, intent.Txn,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/storage/batcheval/transaction.go
+++ b/pkg/storage/batcheval/transaction.go
@@ -81,7 +81,7 @@ func WriteAbortSpanOnResolve(status roachpb.TransactionStatus, poison, removedIn
 func UpdateAbortSpan(
 	ctx context.Context,
 	rec EvalContext,
-	batch engine.ReadWriter,
+	readWriter engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	txn enginepb.TxnMeta,
 	poison bool,
@@ -90,7 +90,7 @@ func UpdateAbortSpan(
 	// no changes are needed. This can help us avoid unnecessary Raft
 	// proposals.
 	var curEntry roachpb.AbortSpanEntry
-	exists, err := rec.AbortSpan().Get(ctx, batch, txn.ID, &curEntry)
+	exists, err := rec.AbortSpan().Get(ctx, readWriter, txn.ID, &curEntry)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func UpdateAbortSpan(
 		if !exists {
 			return nil
 		}
-		return rec.AbortSpan().Del(ctx, batch, ms, txn.ID)
+		return rec.AbortSpan().Del(ctx, readWriter, ms, txn.ID)
 	}
 
 	entry := roachpb.AbortSpanEntry{
@@ -113,7 +113,7 @@ func UpdateAbortSpan(
 	// curEntry already escapes, so assign entry to curEntry and pass
 	// that to Put instead of allowing entry to escape as well.
 	curEntry = entry
-	return rec.AbortSpan().Put(ctx, batch, ms, txn.ID, &curEntry)
+	return rec.AbortSpan().Put(ctx, readWriter, ms, txn.ID, &curEntry)
 }
 
 // CanPushWithPriority returns true if the given pusher can push the pushee

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -135,10 +135,6 @@ func optimizePuts(
 // evaluateBatch evaluates a batch request by splitting it up into its
 // individual commands, passing them to evaluateCommand, and combining
 // the results.
-//
-// TODO(irfansharif): We should tease out usages of `engine.Batch` in proposer
-// evaluated KV code-paths that are currently masked under `engine.ReadWriter`,
-// and only accept the more specific interface.
 func evaluateBatch(
 	ctx context.Context,
 	idKey storagebase.CmdIDKey,


### PR DESCRIPTION
Ignore first commit, reviewed in #43764. 

We should be using {reader,readWriter} for
{Reader,ReadWriter} respectively instead. I'd skipped everything under
batcheval when working on #43265, back when I thought it'd be a good
idea to plumb in an engine.Batch throughout replica read codepaths. Due
to perf penalty as seen on #43388, I'm no longer going to be doing that.
This is the remaining work.

Release note: None
