### PR TITLE
demo: add a telemetry counter for usages of cockroach demo

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -642,6 +642,7 @@ func (c *transientCluster) runWorkload(
 }
 
 func incrementTelemetryCounters(cmd *cobra.Command) {
+	incrementDemoCounter(demo)
 	if flagSetForCmd(cmd).Lookup(cliflags.DemoNodes.Name).Changed {
 		incrementDemoCounter(nodes)
 	}

--- a/pkg/cli/demo_telemetry.go
+++ b/pkg/cli/demo_telemetry.go
@@ -21,6 +21,8 @@ type demoTelemetry int
 
 const (
 	_ demoTelemetry = iota
+	// demo represents when cockroach demo is used at all.
+	demo
 	// nodes represents when cockroach demo is started with multiple nodes.
 	nodes
 	// demoLocality represents when cockroach demo is started with user defined localities.
@@ -32,6 +34,7 @@ const (
 )
 
 var demoTelemetryMap = map[demoTelemetry]string{
+	demo:                   "demo",
 	nodes:                  "nodes",
 	demoLocality:           "demo-locality",
 	withLoad:               "withload",


### PR DESCRIPTION
Fixes #43751.

Release note (cli change): Telemetry is now recorded for whenever
the command `cockroach demo` is used.