### PR TITLE
demo: add splits to movr dataset

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -559,17 +559,22 @@ func (c *transientCluster) setupWorkload(ctx context.Context, gen workload.Gener
 
 		ctx := context.TODO()
 		var l workloadsql.InsertsDataLoader
+		if cliCtx.isInteractive {
+			fmt.Printf("#\n# Beginning initialization of the %s dataset, please wait...\n", gen.Meta().Name)
+		}
 		if _, err := workloadsql.Setup(ctx, db, gen, l); err != nil {
 			return err
 		}
-
 		// Perform partitioning if requested by configuration.
 		if demoCtx.geoPartitionedReplicas {
 			// Wait until the license has been acquired to trigger partitioning.
-			fmt.Println("#\n# Waiting for license acquisition to complete...")
+			if cliCtx.isInteractive {
+				fmt.Println("#\n# Waiting for license acquisition to complete...")
+			}
 			<-licenseDone
-
-			fmt.Println("#\n# Partitioning the demo database, please wait...")
+			if cliCtx.isInteractive {
+				fmt.Println("#\n# Partitioning the demo database, please wait...")
+			}
 
 			db, err := gosql.Open("postgres", c.connURL)
 			if err != nil {

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -21,8 +21,10 @@ expect {
       report "License server could not be reached - skipping with no error"
       exit 0
   }
-  "movr>" {}
+  "Partitioning the demo database, please wait..." {}
 }
+
+eexpect "movr>"
 
 send "SELECT count(*) AS NRPARTS FROM \[SHOW PARTITIONS FROM DATABASE movr\];\r"
 eexpect "nrparts"

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -34,3 +34,19 @@ if {!$workloadRunning} {
 interrupt
 eexpect eof
 end_test
+
+# Ensure that cockroach demo with the movr workload can control the number of ranges that tables are split into.
+start_test "Check that controlling ranges of the movr dataset works"
+# Reset the timeout.
+set timeout 30
+spawn $argv demo movr --num-ranges=6
+
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW RANGES FROM TABLE USERS\];\r"
+eexpect "6"
+eexpect "(1 row)"
+
+interrupt
+eexpect eof
+end_test

--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -43,6 +43,13 @@ const movrUsersSchema = `(
   credit_card VARCHAR NULL,
   PRIMARY KEY (city ASC, id ASC)
 )`
+
+// Indexes into the rows in movrUsers.
+const (
+	usersIDIdx   = 0
+	usersCityIdx = 1
+)
+
 const movrVehiclesSchema = `(
   id UUID NOT NULL,
   city VARCHAR NOT NULL,
@@ -55,6 +62,13 @@ const movrVehiclesSchema = `(
   PRIMARY KEY (city ASC, id ASC),
   INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC)
 )`
+
+// Indexes into the rows in movrVehicles.
+const (
+	vehiclesIDIdx   = 0
+	vehiclesCityIdx = 1
+)
+
 const movrRidesSchema = `(
   id UUID NOT NULL,
   city VARCHAR NOT NULL,
@@ -71,6 +85,13 @@ const movrRidesSchema = `(
   INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),
   CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)
 )`
+
+// Indexes into the rows in movrRides.
+const (
+	ridesIDIdx   = 0
+	ridesCityIdx = 1
+)
+
 const movrVehicleLocationHistoriesSchema = `(
   city VARCHAR NOT NULL,
   ride_id UUID NOT NULL,
@@ -122,6 +143,7 @@ type movr struct {
 	seed                              uint64
 	users, vehicles, rides, histories cityDistributor
 	numPromoCodes                     int
+	ranges                            int
 
 	creationTime time.Time
 
@@ -148,6 +170,7 @@ var movrMeta = workload.Meta{
 		g.flags.IntVar(&g.histories.numRows, `num-histories`, 1000,
 			`Initial number of ride location histories.`)
 		g.flags.IntVar(&g.numPromoCodes, `num-promo-codes`, 1000, `Initial number of promo codes.`)
+		g.flags.IntVar(&g.ranges, `num-ranges`, 9, `Initial number of ranges to break the tables into`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		g.creationTime = time.Date(2019, 1, 2, 3, 4, 5, 6, time.UTC)
 		return g
@@ -327,6 +350,14 @@ func (g *movr) Tables() []workload.Table {
 			g.users.numRows,
 			g.movrUsersInitialRow,
 		),
+		Splits: workload.Tuples(
+			g.ranges-1,
+			func(splitIdx int) []interface{} {
+				row := g.movrUsersInitialRow((splitIdx + 1) * (g.users.numRows / g.ranges))
+				// The split tuples returned must be valid primary key columns.
+				return []interface{}{row[usersCityIdx], row[usersIDIdx]}
+			},
+		),
 	}
 	tables[TablesVehiclesIdx] = workload.Table{
 		Name:   `vehicles`,
@@ -335,6 +366,14 @@ func (g *movr) Tables() []workload.Table {
 			g.vehicles.numRows,
 			g.movrVehiclesInitialRow,
 		),
+		Splits: workload.Tuples(
+			g.ranges-1,
+			func(splitIdx int) []interface{} {
+				row := g.movrVehiclesInitialRow((splitIdx + 1) * (g.vehicles.numRows / g.ranges))
+				// The split tuples returned must be valid primary key columns.
+				return []interface{}{row[vehiclesCityIdx], row[vehiclesIDIdx]}
+			},
+		),
 	}
 	tables[TablesRidesIdx] = workload.Table{
 		Name:   `rides`,
@@ -342,6 +381,14 @@ func (g *movr) Tables() []workload.Table {
 		InitialRows: workload.Tuples(
 			g.rides.numRows,
 			g.movrRidesInitialRow,
+		),
+		Splits: workload.Tuples(
+			g.ranges-1,
+			func(splitIdx int) []interface{} {
+				row := g.movrRidesInitialRow((splitIdx + 1) * (g.rides.numRows / g.ranges))
+				// The split tuples returned must be valid primary key columns.
+				return []interface{}{row[ridesCityIdx], row[ridesIDIdx]}
+			},
 		),
 	}
 	tables[TablesVehicleLocationHistoriesIdx] = workload.Table{


### PR DESCRIPTION
Fixes #42592.

This PR adds split points to the movr dataset so that ranges
will be spread out among all of the nodes in the cluster.

Release note (cli change): The movr dataset will be split among
all nodes in the demo cluster.