### PR TITLE
importccl: correctly push update values

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -80,7 +80,9 @@ func (cp *readImportDataProcessor) Run(ctx context.Context) {
 	}()
 
 	for prog := range progCh {
-		cp.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog})
+		// Take a copy so that we can send the progress address to the output processor.
+		p := prog
+		cp.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
 	}
 
 	if err != nil {


### PR DESCRIPTION
Do not send an address of "prog"ress range variable;
take a copy instead.

Release note: None

#43428  hopefully fixes one of the observed data races during stressrace test