### PR TITLE
sql/lex: disallow overflowing octal escape in bytes input

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -320,7 +320,7 @@ func DecodeRawBytesToByteArray(data string, be sessiondata.BytesEncodeFormat) ([
 			b := byte(0)
 			for j := 1; j <= 3; j++ {
 				octDigit := data[i+j]
-				if octDigit < '0' || octDigit > '7' {
+				if octDigit < '0' || octDigit > '7' || (j == 1 && octDigit > '3') {
 					return nil, pgerror.New(pgcode.InvalidEscapeSequence,
 						"invalid bytea escape sequence")
 				}

--- a/pkg/sql/lex/encode_test.go
+++ b/pkg/sql/lex/encode_test.go
@@ -147,6 +147,8 @@ func TestByteArrayDecoding(t *testing.T) {
 		{`a\'bcd`, false, fmtEsc, "", "invalid bytea escape sequence"},
 		{`a\00`, false, fmtEsc, "", "bytea encoded value ends with incomplete escape sequence"},
 		{`a\099`, false, fmtEsc, "", "invalid bytea escape sequence"},
+		{`a\400`, false, fmtEsc, "", "invalid bytea escape sequence"},
+		{`a\777`, false, fmtEsc, "", "invalid bytea escape sequence"},
 		{`a'b`, false, fmtEsc, "a'b", ""},
 		{`a''b`, false, fmtEsc, "a''b", ""},
 		{`a\\b`, false, fmtEsc, "a\\b", ""},

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -49,6 +49,9 @@ SELECT '日本語':::STRING::BYTES::STRING
 ----
 \xe697a5e69cace8aa9e
 
+query error invalid bytea escape sequence
+SELECT '\400'::bytea
+
 statement ok
 SET bytea_output = escape
 


### PR DESCRIPTION
Not actually causing (known) problems in the wild, but I noticed this whilst investigating the behavior of string -> bytes casting for Materialize, and seemed easy enough to fix. 

---

The bytes input routine would previously allow escape codes like `\401`,
which overflows the maximum allowable value for a byte, which is 377oct
(255dec). These escape codes would cause silent wrapping, so e.g.
`\401` would be misinterpreted as `\001`.

This patch causes the bytes input to return an error upon encountering
octal escape codes that exceed `\377`, matching PostgreSQL's behavior.

Release note (bug fix): when casting a string to bytes, octal escapes
greater than `\377` will now generate an error, rather than silently
wrapping around.