### PR TITLE
hba: stricter parsing and better pretty-printing

### DIFF
--- a/pkg/sql/pgwire/hba/hba.go
+++ b/pkg/sql/pgwire/hba/hba.go
@@ -35,7 +35,7 @@ type Conf struct {
 
 // Entry is a single line of a configuration.
 type Entry struct {
-	Type string
+	Type String
 	// Database is the list of databases to match. An empty list means
 	// "match any database".
 	Database []String
@@ -44,10 +44,11 @@ type Entry struct {
 	User []String
 	// Address is either AnyAddr, *net.IPNet or (unsupported) String for a hostname.
 	Address interface{}
-	Method  string
+	Method  String
 	// MethodFn is populated during name resolution of Method.
-	MethodFn interface{}
-	Options  [][2]string
+	MethodFn     interface{}
+	Options      [][2]string
+	OptionQuotes []bool
 }
 
 func (c Conf) String() string {
@@ -67,11 +68,11 @@ func (c Conf) String() string {
 	row := []string{"# TYPE", "DATABASE", "USER", "ADDRESS", "METHOD", "OPTIONS"}
 	table.Append(row)
 	for _, e := range c.Entries {
-		row[0] = e.Type
+		row[0] = e.Type.String()
 		row[1] = e.DatabaseString()
 		row[2] = e.UserString()
 		row[3] = e.AddressString()
-		row[4] = e.Method
+		row[4] = e.Method.String()
 		row[5] = e.OptionsString()
 		table.Append(row)
 	}
@@ -190,8 +191,9 @@ func (h Entry) AddressString() string {
 func (h Entry) OptionsString() string {
 	var sb strings.Builder
 	sp := ""
-	for _, opt := range h.Options {
-		fmt.Fprintf(&sb, "%s%s=%s", sp, opt[0], opt[1])
+	for i, opt := range h.Options {
+		sb.WriteString(sp)
+		sb.WriteString(String{Value: opt[0] + "=" + opt[1], Quoted: h.OptionQuotes[i]}.String())
 		sp = " "
 	}
 	return sb.String()

--- a/pkg/sql/pgwire/hba/parser.go
+++ b/pkg/sql/pgwire/hba/parser.go
@@ -71,7 +71,10 @@ func parseHbaLine(line [][]String) (Entry, error) {
 			errors.New("multiple values specified for connection type"),
 			"Specify exactly one connection type per line.")
 	}
-	entry.Type = line[fieldIdx][0].Value
+	entry.Type = line[fieldIdx][0]
+	if entry.Type.Value == "" {
+		return entry, errors.New("cannot use empty string as connection type")
+	}
 
 	// Get the databases.
 	fieldIdx++
@@ -87,7 +90,7 @@ func parseHbaLine(line [][]String) (Entry, error) {
 	}
 	entry.User = line[fieldIdx]
 
-	if entry.Type != "local" {
+	if entry.Type.Value != "local" {
 		fieldIdx++
 		if fieldIdx >= len(line) {
 			return entry, errors.New("end-of-line before IP address specification")
@@ -100,6 +103,8 @@ func parseHbaLine(line [][]String) (Entry, error) {
 		}
 		token := tokens[0]
 		switch {
+		case token.Value == "":
+			return entry, errors.New("cannot use empty string as address")
 		case token.IsKeyword("all"):
 			entry.Address = token
 		case token.IsKeyword("samehost"), token.IsKeyword("samenet"):
@@ -158,7 +163,10 @@ func parseHbaLine(line [][]String) (Entry, error) {
 			errors.New("multiple values specified for authentication method"),
 			"Specify exactly one authentication method per line.")
 	}
-	entry.Method = line[fieldIdx][0].Value
+	entry.Method = line[fieldIdx][0]
+	if entry.Method.Value == "" {
+		return entry, errors.New("cannot use empty string as authentication method")
+	}
 
 	// Parse remaining arguments.
 	for fieldIdx++; fieldIdx < len(line); fieldIdx++ {
@@ -168,6 +176,7 @@ func parseHbaLine(line [][]String) (Entry, error) {
 				return entry, errors.Newf("authentication option not in name=value format: %s", tok.Value)
 			}
 			entry.Options = append(entry.Options, [2]string{kv[0], kv[1]})
+			entry.OptionQuotes = append(entry.OptionQuotes, tok.Quoted)
 		}
 	}
 

--- a/pkg/sql/pgwire/hba/scanner_test.go
+++ b/pkg/sql/pgwire/hba/scanner_test.go
@@ -18,6 +18,28 @@ import (
 	"github.com/kr/pretty"
 )
 
+func TestSpecialCharacters(t *testing.T) {
+	// We use Go test cases here instead of datadriven because the input
+	// strings would be stripped of whitespace or considered invalid by
+	// datadriven.
+	testData := []struct {
+		input  string
+		expErr string
+	}{
+		{"\"ab\tcd\"", `line 1: invalid characters in quoted string`},
+		{"\"ab\fcd\"", `line 1: invalid characters in quoted string`},
+		{`0 0 0 0 ` + "\f", `line 1: unsupported character: "\f"`},
+		{`0 0 0 0 ` + "\x00", `line 1: unsupported character: "\x00"`},
+	}
+
+	for _, tc := range testData {
+		_, err := tokenize(tc.input)
+		if err == nil || err.Error() != tc.expErr {
+			t.Errorf("expected:\n%s\ngot:\n%v", tc.expErr, err)
+		}
+	}
+}
+
 func TestScanner(t *testing.T) {
 	datadriven.RunTest(t, "testdata/scan", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/pkg/sql/pgwire/hba/testdata/parse
+++ b/pkg/sql/pgwire/hba/testdata/parse
@@ -41,25 +41,25 @@ error: authentication option not in name=value format: d
 
 subtest end
 
-subtest ignored_quotes
+subtest quoted_columns
 
 line
 "local" a b c
 ----
-# TYPE DATABASE USER ADDRESS METHOD OPTIONS
-local  a        b            c
+# TYPE  DATABASE USER ADDRESS METHOD OPTIONS
+"local" a        b            c
 
 line
 local a b "method"
 ----
-# TYPE DATABASE USER ADDRESS METHOD OPTIONS
-local  a        b            method
+# TYPE DATABASE USER ADDRESS METHOD   OPTIONS
+local  a        b            "method"
 
 line
-local a b c "k=v"
+host all all all gss k=v " someopt = withspaces "
 ----
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
-local  a        b            c      k=v
+host   all      all  all     gss    k=v " someopt = withspaces "
 
 subtest end
 
@@ -226,7 +226,7 @@ host   all      testuser,"all" 0.0.0.0/0 cert
 &hba.Conf{
     Entries: {
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"a", Quoted:false},
                 {Value:"b", Quoted:false},
@@ -235,13 +235,14 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             User: {
                 {Value:"all", Quoted:false},
             },
-            Address:  hba.String{Value:"all", Quoted:false},
-            Method:   "trust",
-            MethodFn: nil,
-            Options:  nil,
+            Address:      hba.String{Value:"all", Quoted:false},
+            Method:       hba.String{Value:"trust", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -250,13 +251,14 @@ host   all      testuser,"all" 0.0.0.0/0 cert
                 {Value:"b", Quoted:false},
                 {Value:"c", Quoted:false},
             },
-            Address:  hba.String{Value:"all", Quoted:false},
-            Method:   "trust",
-            MethodFn: nil,
-            Options:  nil,
+            Address:      hba.String{Value:"all", Quoted:false},
+            Method:       hba.String{Value:"trust", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"a", Quoted:false},
                 {Value:"b", Quoted:false},
@@ -267,13 +269,14 @@ host   all      testuser,"all" 0.0.0.0/0 cert
                 {Value:"e", Quoted:false},
                 {Value:"f", Quoted:false},
             },
-            Address:  hba.String{Value:"all", Quoted:false},
-            Method:   "trust",
-            MethodFn: nil,
-            Options:  nil,
+            Address:      hba.String{Value:"all", Quoted:false},
+            Method:       hba.String{Value:"trust", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -285,9 +288,10 @@ host   all      testuser,"all" 0.0.0.0/0 cert
                 IP:   {0x0, 0x0, 0x0, 0x0},
                 Mask: {0x0, 0x0, 0x0, 0x0},
             },
-            Method:   "cert",
-            MethodFn: nil,
-            Options:  nil,
+            Method:       hba.String{Value:"cert", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
     },
 }
@@ -303,7 +307,7 @@ host   "all","test space",something some,"us ers" all     cert
 &hba.Conf{
     Entries: {
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:true},
                 {Value:"test space", Quoted:true},
@@ -313,10 +317,63 @@ host   "all","test space",something some,"us ers" all     cert
                 {Value:"some", Quoted:false},
                 {Value:"us ers", Quoted:true},
             },
+            Address:      hba.String{Value:"all", Quoted:false},
+            Method:       hba.String{Value:"cert", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
+        },
+    },
+}
+
+subtest end
+
+subtest empty_strings
+
+multiline
+"" all all all trust
+----
+error: line 1: cannot use empty string as connection type
+
+multiline
+host all all all ""
+----
+error: line 1: cannot use empty string as authentication method
+
+multiline
+host all all "" cert
+----
+error: line 1: cannot use empty string as address
+
+subtest end
+
+subtest quoted_options
+
+multiline
+host all all all gss k=v " someopt = withspaces "
+----
+# String render check:
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+host   all      all  all     gss    k=v " someopt = withspaces "
+# Detail:
+&hba.Conf{
+    Entries: {
+        {
+            Type:     hba.String{Value:"host", Quoted:false},
+            Database: {
+                {Value:"all", Quoted:false},
+            },
+            User: {
+                {Value:"all", Quoted:false},
+            },
             Address:  hba.String{Value:"all", Quoted:false},
-            Method:   "cert",
+            Method:   hba.String{Value:"gss", Quoted:false},
             MethodFn: nil,
-            Options:  nil,
+            Options:  {
+                {"k", "v"},
+                {" someopt ", " withspaces "},
+            },
+            OptionQuotes: {false, true},
         },
     },
 }
@@ -370,7 +427,7 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
 &hba.Conf{
     Entries: {
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -378,14 +435,15 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
                 {Value:"all", Quoted:false},
             },
             Address:  hba.String{Value:"root", Quoted:false},
-            Method:   "cert-password",
+            Method:   hba.String{Value:"cert-password", Quoted:false},
             MethodFn: nil,
             Options:  {
                 {"ignored", "value"},
             },
+            OptionQuotes: {false},
         },
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -393,13 +451,14 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
                 {Value:"all", Quoted:false},
             },
             Address:  hba.String{Value:"all", Quoted:false},
-            Method:   "gss",
+            Method:   hba.String{Value:"gss", Quoted:false},
             MethodFn: nil,
             Options:  {
                 {"krb_realm", "other"},
                 {"include_realm", "0"},
                 {"krb_realm", "te-st12.COM"},
             },
+            OptionQuotes: {false, false, false},
         },
     },
 }
@@ -420,7 +479,7 @@ host   "all"    "all" 0.0.0.0/0 cert
 &hba.Conf{
     Entries: {
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"db", Quoted:false},
             },
@@ -431,12 +490,13 @@ host   "all"    "all" 0.0.0.0/0 cert
                 IP:   {0x0, 0x0, 0x0, 0x0},
                 Mask: {0x0, 0x0, 0x0, 0x0},
             },
-            Method:   "cert",
-            MethodFn: nil,
-            Options:  nil,
+            Method:       hba.String{Value:"cert", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
         {
-            Type:     "host",
+            Type:     hba.String{Value:"host", Quoted:false},
             Database: {
                 {Value:"all", Quoted:true},
             },
@@ -447,9 +507,10 @@ host   "all"    "all" 0.0.0.0/0 cert
                 IP:   {0x0, 0x0, 0x0, 0x0},
                 Mask: {0x0, 0x0, 0x0, 0x0},
             },
-            Method:   "cert",
-            MethodFn: nil,
-            Options:  nil,
+            Method:       hba.String{Value:"cert", Quoted:false},
+            MethodFn:     nil,
+            Options:      nil,
+            OptionQuotes: nil,
         },
     },
 }


### PR DESCRIPTION
The following defects were found by @mjibson using
`go-fuzz` (#43805) and are fixed by this patch:

- the code would parse then fail to pretty-print an empty connection
  type and auth method.
- the code would parse then pretty-print incorrectly a connection
  type or auth method containing commas or other special characters.
- the code would accept an empty string as address.
- the code would accept then fail to pretty-print columns containing
  special (control) characters.

Note that the code previously supported tabs (\t) and carriage
returns (\r) inside quoted strings, and this is now rejected. For most
fields, this does not matter, as these special characters were not
valid semantically anyway.

However, for the method options in the last column it is theoretically
possible for a method to wish to use such special characters. This is
not currently the case for the CCL `gss` method already implemented,
so this change is not introducing a regression. A comment is left in
the code to indicate what needs to be changed if a future method needs
this support.

Release note (security): CockroachDB now properly rejects control
characters in the value of the cluster setting
`server.host_based_authentication.configuration`. These characters
were previously accepted and would silently yield rules matching
differently from intended. Deployments careful to strip control
characters from their HBA configuration are not affected.