### PR TITLE
jobs: mark job as running after adopting

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -522,6 +522,7 @@ func (j *Job) adopt(ctx context.Context, oldLease *jobspb.Lease) error {
 		}
 		md.Payload.Lease = j.registry.newLease()
 		ju.UpdatePayload(md.Payload)
+		ju.UpdateStatus(StatusRunning)
 		return nil
 	})
 }


### PR DESCRIPTION
We could adopt a job and run it on a node without changing its status to
running.

Release note (bug fix): job can be running but shown in state pending.