### PR TITLE
sql: add cluster default setting for enabling temp tables

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -151,6 +151,12 @@ var primaryKeyChangesEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var temporaryTablesEnabledClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.experimental_temporary_tables.enabled",
+	"default value for experimental_enable_temp_tables; allows for use of temporary tables by default",
+	false,
+)
+
 var zigzagJoinClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.zigzag_join.enabled",
 	"default value for enable_zigzag_join session setting; allows use of zig-zag join by default",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -849,8 +849,7 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: func(_ *settings.Values) string { return "" },
 	},
 
-	// TODO(arul): Update this comment when temp tables work is done.
-	// Still under development
+	// CockroachDB extension.
 	`experimental_enable_temp_tables`: {
 		GetStringVal: makeBoolGetStringValFn(`experimental_enable_temp_tables`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
@@ -864,7 +863,9 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext) string {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData.TempTablesEnabled)
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(temporaryTablesEnabledClusterMode.Get(sv))
+		},
 	},
 }
 


### PR DESCRIPTION
Fixes #43739.

This PR adds a global cluster default setting for enabling
temporary tables.

The setting is `sql.defaults.temporary_tables.enabled`, and
is currently defaulted to false.

Release note (sql change): Add a global default setting for enabling
temporary tables.