### PR TITLE
sql: enable primary key changes on tables with multiple column families

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -379,12 +379,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 
-			// TODO (rohany,solongordon): Until it is clear what to do with column families, disallow primary key changes
-			//  on tables with multiple column families.
-			if len(n.tableDesc.Families) > 1 {
-				return errors.New("unable to perform primary key change on tables with multiple column families")
-			}
-
 			// TODO (rohany,solongordon): Until it is clear how to handle foreign keys, disallow primary key changes
 			//  that are referenced by other tables through foreign key relationships.
 			if len(n.tableDesc.InboundFKs) > 0 || len(n.tableDesc.OutboundFKs) > 0 {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,9 +1,8 @@
-# TODO (rohany,solongordon): we still have to figure out what happens with multiple families, so fix that right now.
 statement ok
 SET experimental_enable_primary_key_changes = true
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX i (x), INDEX i2 (z), FAMILY (x, y, z, w))
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX i (x), INDEX i2 (z))
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
@@ -17,9 +16,56 @@ SELECT * FROM t@primary
 1 2 3 4
 5 6 7 8
 
+statement ok
+INSERT INTO t VALUES (9, 10, 11, 12)
+
+query IIII rowsort
+SELECT * from t@primary
+----
+1 2 3 4
+5 6 7 8
+9 10 11 12
+
+statement ok
+UPDATE t SET x = 2 WHERE z = 7
+
+query IIII rowsort
+SELECT * from t@primary
+----
+1 2 3 4
+2 6 7 8
+9 10 11 12
+
+# Test primary key changes on storing indexes with different column families (the randomizer will do this for us).
+statement ok
+DROP TABLE t;
+CREATE TABLE t (
+  x INT PRIMARY KEY, y INT, z INT NOT NULL, w INT, v INT,
+  INDEX i1 (y) STORING (w, v), INDEX i2 (z) STORING (y, v)
+);
+INSERT INTO t VALUES (1, 2, 3, 4, 5), (6, 7, 8, 9, 10), (11, 12, 13, 14, 15);
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (z);
+INSERT INTO t VALUES (16, 17, 18, 19, 20)
+
+query III rowsort
+SELECT y, w, v FROM t@i1
+----
+2 4 5
+7 9 10
+12 14 15
+17 19 20
+
+query III rowsort
+SELECT y, z, v FROM t@i2
+----
+2 3 5
+7 8 10
+12 13 15
+17 18 20
+
 # Test that composite values are encoded correctly in covering indexes.
 statement ok
-CREATE TABLE t_composite (x INT PRIMARY KEY, y DECIMAL NOT NULL, FAMILY (x, y));
+CREATE TABLE t_composite (x INT PRIMARY KEY, y DECIMAL NOT NULL);
 INSERT INTO t_composite VALUES (1, 1.0), (2, 1.001)
 
 statement ok

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -761,6 +761,9 @@ func EncodeInvertedIndexTableKeys(val tree.Datum, inKey []byte) (key [][]byte, e
 }
 
 // EncodePrimaryIndex constructs a list of k/v pairs for a row encoded as a primary index.
+// This function mirrors the encoding logic in prepareInsertOrUpdateBatch in pkg/sql/row/writer.go.
+// It is somewhat duplicated here due to the different arguments that prepareOrInsertUpdateBatch needs
+// and uses to generate the k/v's for the row it inserts.
 func EncodePrimaryIndex(
 	tableDesc *TableDescriptor, index *IndexDescriptor, colMap map[ColumnID]int, values []tree.Datum,
 ) ([]IndexEntry, error) {
@@ -786,7 +789,9 @@ func EncodePrimaryIndex(
 			columnsToEncode = columnsToEncode[:0]
 		}
 		familyKey := keys.MakeFamilyKey(indexKey, uint32(family.ID))
-		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
+		// The decoders expect that column family 0 is encoded with a TUPLE value tag, so we
+		// don't want to use the untagged value encoding.
+		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID && family.ID != 0 {
 			datum := values[colMap[family.DefaultColumnID]]
 			if datum != tree.DNull {
 				col, err := tableDesc.FindColumnByID(family.DefaultColumnID)


### PR DESCRIPTION
Fixes #43760.

Release note (sql change): enable primary key changes on tables with
multiple column families.