### PR TITLE
colexec: refactor allocator to reduce the number of function calls

### DIFF
--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -72,9 +72,11 @@ func (a *Allocator) AppendColumn(b coldata.Batch, t coltypes.T) {
 	b.AppendCol(col)
 }
 
-// performOperation executes 'operation' (that somehow modifies 'destVecs') and
+// PerformOperation executes 'operation' (that somehow modifies 'destVecs') and
 // updates the memory account accordingly.
-func (a *Allocator) performOperation(destVecs []coldata.Vec, operation func()) {
+// NOTE: if some columnar vectors are not modified, they should not be included
+// in 'destVecs' to reduce the performance hit of memory accounting.
+func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
 	var before, after, delta int64
 	for _, dest := range destVecs {
 		// To simplify the accounting, we perform the operation first and then will
@@ -104,18 +106,6 @@ func (a *Allocator) performOperation(destVecs []coldata.Vec, operation func()) {
 	} else {
 		a.acc.Shrink(a.ctx, -delta)
 	}
-}
-
-// Append appends elements of a source coldata.Vec into dest according to
-// coldata.SliceArgs.
-func (a *Allocator) Append(dest coldata.Vec, args coldata.SliceArgs) {
-	a.performOperation([]coldata.Vec{dest}, func() { dest.Append(args) })
-}
-
-// Copy copies elements of a source coldata.Vec into dest according to
-// coldata.CopySliceArgs.
-func (a *Allocator) Copy(dest coldata.Vec, args coldata.CopySliceArgs) {
-	a.performOperation([]coldata.Vec{dest}, func() { dest.Copy(args) })
 }
 
 // TODO(yuzefovich): extend Allocator so that it could free up the memory (and

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -72,7 +72,8 @@ type anyNotNull_TYPEAgg struct {
 	allocator                   *Allocator
 	done                        bool
 	groups                      []bool
-	vec                         _GOTYPESLICE
+	vec                         coldata.Vec
+	col                         _GOTYPESLICE
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	foundNonNullForCurrentGroup bool
@@ -80,7 +81,8 @@ type anyNotNull_TYPEAgg struct {
 
 func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups
-	a.vec = vec._TemplateType()
+	a.vec = vec
+	a.col = vec._TemplateType()
 	a.nulls = vec.Nulls()
 	a.Reset()
 }
@@ -122,7 +124,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	col, nulls := vec._TemplateType(), vec.Nulls()
 
 	a.allocator.PerformOperation(
-		[]coldata.Vec{vec},
+		[]coldata.Vec{a.vec},
 		func() {
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -191,7 +193,7 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// from the rest of the template file.
 		// TODO(asubiotto): Figure out a way to alias this.
 		// v := {{ .Global.Get "col" "int(i)" }}
-		// {{ .Global.Set "a.vec" "a.curIdx" "v" }}
+		// {{ .Global.Set "a.col" "a.curIdx" "v" }}
 		a.foundNonNullForCurrentGroup = true
 	}
 	// {{end}}

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -121,7 +121,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec._TemplateType(), vec.Nulls()
 
-	a.allocator.performOperation(
+	a.allocator.PerformOperation(
 		[]coldata.Vec{vec},
 		func() {
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -58,7 +58,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 	sel := batch.Selection()
 	output := batch.ColVec(b.outputIdx)
-	b.allocator.performOperation(
+	b.allocator.PerformOperation(
 		[]coldata.Vec{output},
 		func() {
 			for i := uint16(0); i < n; i++ {
@@ -135,7 +135,7 @@ func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
 	lengthVec := batch.ColVec(s.argumentCols[2]).Int64()
 	outputVec := batch.ColVec(s.outputIdx)
 	outputCol := outputVec.Bytes()
-	s.allocator.performOperation(
+	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
 			for i := uint16(0); i < n; i++ {

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -148,18 +148,19 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 		// Copy the results into the output vector, using the toSubtract selection
 		// vector to copy only the elements that we actually wrote according to the
 		// current case arm.
-		c.allocator.Copy(
-			outputCol,
-			coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					ColType:     c.typ,
-					Src:         inputCol,
-					Sel:         toSubtract,
-					SrcStartIdx: 0,
-					SrcEndIdx:   uint64(len(toSubtract)),
-				},
-				SelOnDest: true,
-			})
+		c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+			outputCol.Copy(
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						ColType:     c.typ,
+						Src:         inputCol,
+						Sel:         toSubtract,
+						SrcStartIdx: 0,
+						SrcEndIdx:   uint64(len(toSubtract)),
+					},
+					SelOnDest: true,
+				})
+		})
 		if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
 			// We have an old selection vector, which represents the tuples that
 			// haven't yet been matched. Remove the ones that just matched from the
@@ -201,18 +202,19 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	// that's done, restore the original selection vector and return the batch.
 	batch := c.elseOp.Next(ctx)
 	inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
-	c.allocator.Copy(
-		outputCol,
-		coldata.CopySliceArgs{
-			SliceArgs: coldata.SliceArgs{
-				ColType:     c.typ,
-				Src:         inputCol,
-				Sel:         batch.Selection(),
-				SrcStartIdx: 0,
-				SrcEndIdx:   uint64(batch.Length()),
-			},
-			SelOnDest: true,
-		})
+	c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+		outputCol.Copy(
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:     c.typ,
+					Src:         inputCol,
+					Sel:         batch.Selection(),
+					SrcStartIdx: 0,
+					SrcEndIdx:   uint64(batch.Length()),
+				},
+				SelOnDest: true,
+			})
+	})
 	batch.SetLength(origLen)
 	batch.SetSelection(origHasSel)
 	if origHasSel {

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -115,40 +115,41 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	}
 
 	outputCol := c.buffer.batch.Batch.ColVec(c.outputIdx)
-	for i := range c.caseOps {
-		// Run the next case operator chain. It will project its THEN expression
-		// for all tuples that matched its WHEN expression and that were not
-		// already matched.
-		batch := c.caseOps[i].Next(ctx)
-		// The batch's projection column now additionally contains results for all
-		// of the tuples that passed the ith WHEN clause. The batch's selection
-		// vector is set to the same selection of tuples.
-		// Now, we must subtract this selection vector from the last buffered
-		// selection vector, so that the next operator gets to operate on the
-		// remaining set of tuples in the input that haven't matched an arm of the
-		// case statement.
-		// As an example, imagine the first WHEN op matched tuple 3. The following
-		// diagram shows the selection vector before running WHEN, after running
-		// WHEN, and then the desired selection vector after subtraction:
-		// - origSel
-		// | - selection vector after running WHEN
-		// | | - desired selection vector after subtraction
-		// | | |
-		// 1   1
-		// 2   2
-		// 3 3
-		// 4   4
-		toSubtract := batch.Selection()
-		toSubtract = toSubtract[:batch.Length()]
-		// toSubtract is now a selection vector containing all matched tuples of the
-		// current case arm.
-		var subtractIdx int
-		var curIdx uint16
-		inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[i])
-		// Copy the results into the output vector, using the toSubtract selection
-		// vector to copy only the elements that we actually wrote according to the
-		// current case arm.
-		c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+	var batch coldata.Batch
+	c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+		for i := range c.caseOps {
+			// Run the next case operator chain. It will project its THEN expression
+			// for all tuples that matched its WHEN expression and that were not
+			// already matched.
+			batch = c.caseOps[i].Next(ctx)
+			// The batch's projection column now additionally contains results for all
+			// of the tuples that passed the ith WHEN clause. The batch's selection
+			// vector is set to the same selection of tuples.
+			// Now, we must subtract this selection vector from the last buffered
+			// selection vector, so that the next operator gets to operate on the
+			// remaining set of tuples in the input that haven't matched an arm of the
+			// case statement.
+			// As an example, imagine the first WHEN op matched tuple 3. The following
+			// diagram shows the selection vector before running WHEN, after running
+			// WHEN, and then the desired selection vector after subtraction:
+			// - origSel
+			// | - selection vector after running WHEN
+			// | | - desired selection vector after subtraction
+			// | | |
+			// 1   1
+			// 2   2
+			// 3 3
+			// 4   4
+			toSubtract := batch.Selection()
+			toSubtract = toSubtract[:batch.Length()]
+			// toSubtract is now a selection vector containing all matched tuples of the
+			// current case arm.
+			var subtractIdx int
+			var curIdx uint16
+			inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[i])
+			// Copy the results into the output vector, using the toSubtract selection
+			// vector to copy only the elements that we actually wrote according to the
+			// current case arm.
 			outputCol.Copy(
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
@@ -160,49 +161,47 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 					},
 					SelOnDest: true,
 				})
-		})
-		if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
-			// We have an old selection vector, which represents the tuples that
-			// haven't yet been matched. Remove the ones that just matched from the
-			// old selection vector.
-			for i := range oldSel[:c.buffer.batch.Batch.Length()] {
-				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == oldSel[i] {
-					// The ith element of the old selection vector matched the current one
-					// in toSubtract. Skip writing this element, removing it from the old
-					// selection vector.
-					subtractIdx++
-					continue
+			if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
+				// We have an old selection vector, which represents the tuples that
+				// haven't yet been matched. Remove the ones that just matched from the
+				// old selection vector.
+				for i := range oldSel[:c.buffer.batch.Batch.Length()] {
+					if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == oldSel[i] {
+						// The ith element of the old selection vector matched the current one
+						// in toSubtract. Skip writing this element, removing it from the old
+						// selection vector.
+						subtractIdx++
+						continue
+					}
+					oldSel[curIdx] = oldSel[i]
+					curIdx++
 				}
-				oldSel[curIdx] = oldSel[i]
-				curIdx++
-			}
-		} else {
-			// No selection vector means there have been no matches yet, and we were
-			// considering the entire batch of tuples for this case arm. Make a new
-			// selection vector with all of the tuples but the ones that just matched.
-			c.buffer.batch.Batch.SetSelection(true)
-			oldSel = c.buffer.batch.Batch.Selection()
-			for i := uint16(0); i < c.buffer.batch.Batch.Length(); i++ {
-				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == i {
-					subtractIdx++
-					continue
+			} else {
+				// No selection vector means there have been no matches yet, and we were
+				// considering the entire batch of tuples for this case arm. Make a new
+				// selection vector with all of the tuples but the ones that just matched.
+				c.buffer.batch.Batch.SetSelection(true)
+				oldSel = c.buffer.batch.Batch.Selection()
+				for i := uint16(0); i < c.buffer.batch.Batch.Length(); i++ {
+					if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == i {
+						subtractIdx++
+						continue
+					}
+					oldSel[curIdx] = i
+					curIdx++
 				}
-				oldSel[curIdx] = i
-				curIdx++
 			}
-		}
-		c.buffer.batch.Batch.SetLength(curIdx)
+			c.buffer.batch.Batch.SetLength(curIdx)
 
-		// Now our selection vector is set to exclude all the things that have
-		// matched so far. Reset the buffer and run the next case arm.
-		c.buffer.rewind()
-	}
-	// Finally, run the else operator, which will project into all tuples that
-	// are remaining in the selection vector (didn't match any case arms). Once
-	// that's done, restore the original selection vector and return the batch.
-	batch := c.elseOp.Next(ctx)
-	inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
-	c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+			// Now our selection vector is set to exclude all the things that have
+			// matched so far. Reset the buffer and run the next case arm.
+			c.buffer.rewind()
+		}
+		// Finally, run the else operator, which will project into all tuples that
+		// are remaining in the selection vector (didn't match any case arms). Once
+		// that's done, restore the original selection vector and return the batch.
+		batch = c.elseOp.Next(ctx)
+		inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
 		outputCol.Copy(
 			coldata.CopySliceArgs{
 				SliceArgs: coldata.SliceArgs{

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -194,7 +194,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 	col := vec._FROMTYPE()
 	projVec := batch.ColVec(c.outputIdx)
 	projCol := projVec._TOTYPE()
-	c.allocator.performOperation(
+	c.allocator.PerformOperation(
 		[]coldata.Vec{projVec},
 		func() {
 			if vec.MaybeHasNulls() {

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -562,7 +562,7 @@ const debugState = false
 // NextBatch is nextBatch with the addition of memory accounting.
 func (rf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 	rf.adapter.ctx = ctx
-	rf.adapter.allocator.performOperation(
+	rf.adapter.allocator.PerformOperation(
 		rf.machine.colvecs,
 		rf.nextAdapter,
 	)

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -101,7 +101,7 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec._TemplateType()
-	c.allocator.performOperation(
+	c.allocator.PerformOperation(
 		[]coldata.Vec{vec},
 		func() {
 			if sel := batch.Selection(); sel != nil {

--- a/pkg/sql/colexec/deselector.go
+++ b/pkg/sql/colexec/deselector.go
@@ -56,20 +56,21 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 	p.output.SetLength(batch.Length())
 	p.output.ResetInternalBatch()
 	sel := batch.Selection()
-	for i, t := range p.inputTypes {
-		toCol := p.output.ColVec(i)
-		fromCol := batch.ColVec(i)
-		p.allocator.Copy(
-			toCol,
-			coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					ColType:   t,
-					Src:       fromCol,
-					Sel:       sel,
-					SrcEndIdx: uint64(batch.Length()),
+	p.allocator.PerformOperation(p.output.ColVecs(), func() {
+		for i, t := range p.inputTypes {
+			toCol := p.output.ColVec(i)
+			fromCol := batch.ColVec(i)
+			toCol.Copy(
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						ColType:   t,
+						Src:       fromCol,
+						Sel:       sel,
+						SrcEndIdx: uint64(batch.Length()),
+					},
 				},
-			},
-		)
-	}
+			)
+		}
+	})
 	return p.output
 }

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -148,7 +148,7 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		if !a.foundNonNullForCurrentGroup {
 			a.nulls.SetNull(uint16(a.curIdx))
 		} else {
-			a.allocator.performOperation(
+			a.allocator.PerformOperation(
 				[]coldata.Vec{a.vec},
 				func() {
 					execgen.SET(a.col, a.curIdx, a.curAgg)
@@ -161,7 +161,7 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec._TYPE(), vec.Nulls()
-	a.allocator.performOperation(
+	a.allocator.PerformOperation(
 		[]coldata.Vec{a.vec},
 		func() {
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/orderedsynchronizer_tmpl.go
+++ b/pkg/sql/colexec/orderedsynchronizer_tmpl.go
@@ -139,7 +139,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	}
 	o.output.ResetInternalBatch()
 	outputIdx := uint16(0)
-	o.allocator.performOperation(o.output.ColVecs(), func() {
+	o.allocator.PerformOperation(o.output.ColVecs(), func() {
 		for outputIdx < coldata.BatchSize() {
 			if o.Len() == 0 {
 				// All inputs exhausted.

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -58,7 +58,7 @@ func _ROWS_TO_COL_VEC(
 		row := rows[i]
 		if row[columnIdx].Datum == nil {
 			if err = row[columnIdx].EnsureDecoded(columnType, alloc); err != nil {
-				break
+				return
 			}
 		}
 		datum := row[columnIdx].Datum
@@ -67,7 +67,7 @@ func _ROWS_TO_COL_VEC(
 		} else {
 			v, err := datumToPhysicalFn(datum)
 			if err != nil {
-				break
+				return
 			}
 
 			castV := v.(_GOTYPE)
@@ -76,7 +76,6 @@ func _ROWS_TO_COL_VEC(
 	}
 	// {{end}}
 	// {{/*
-	return nil
 }
 
 // */}}
@@ -95,36 +94,29 @@ func EncDatumRowsToColVec(
 	alloc *sqlbase.DatumAlloc,
 ) error {
 	var err error
-	switch columnType.Family() {
-	// {{range .}}
-	case _FAMILY:
-		// {{ if .Widths }}
-		switch columnType.Width() {
-		// {{range .Widths}}
-		case _WIDTH:
-			allocator.PerformOperation(
-				[]coldata.Vec{vec},
-				func() {
+	allocator.PerformOperation(
+		[]coldata.Vec{vec},
+		func() {
+			switch columnType.Family() {
+			// {{range .}}
+			case _FAMILY:
+				// {{ if .Widths }}
+				switch columnType.Width() {
+				// {{range .Widths}}
+				case _WIDTH:
 					_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
-				},
-			)
-			return err
-		// {{end}}
-		default:
-			execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width(), columnType.String()))
-		}
-		// {{ else }}
-		allocator.PerformOperation(
-			[]coldata.Vec{vec},
-			func() {
+				// {{end}}
+				default:
+					execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width(), columnType.String()))
+				}
+				// {{ else }}
 				_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
-			},
-		)
-		return err
-		// {{end}}
-	// {{end}}
-	default:
-		execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported column type %s", columnType.String()))
-	}
-	return nil
+				// {{end}}
+			// {{end}}
+			default:
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported column type %s", columnType.String()))
+			}
+		},
+	)
+	return err
 }

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -102,7 +102,7 @@ func EncDatumRowsToColVec(
 		switch columnType.Width() {
 		// {{range .Widths}}
 		case _WIDTH:
-			allocator.performOperation(
+			allocator.PerformOperation(
 				[]coldata.Vec{vec},
 				func() {
 					_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
@@ -114,7 +114,7 @@ func EncDatumRowsToColVec(
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width(), columnType.String()))
 		}
 		// {{ else }}
-		allocator.performOperation(
+		allocator.PerformOperation(
 			[]coldata.Vec{vec},
 			func() {
 				_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -287,16 +287,17 @@ func TestOutboxInbox(t *testing.T) {
 					outputBatches.Add(coldata.ZeroBatch)
 				} else {
 					batchCopy := testAllocator.NewMemBatchWithSize(typs, int(outputBatch.Length()))
-					for i := range typs {
-						testAllocator.Append(
-							batchCopy.ColVec(i),
-							coldata.SliceArgs{
-								ColType:   typs[i],
-								Src:       outputBatch.ColVec(i),
-								SrcEndIdx: uint64(outputBatch.Length()),
-							},
-						)
-					}
+					testAllocator.PerformOperation(batchCopy.ColVecs(), func() {
+						for i := range typs {
+							batchCopy.ColVec(i).Append(
+								coldata.SliceArgs{
+									ColType:   typs[i],
+									Src:       outputBatch.ColVec(i),
+									SrcEndIdx: uint64(outputBatch.Length()),
+								},
+							)
+						}
+					})
 					batchCopy.SetLength(outputBatch.Length())
 					outputBatches.Add(batchCopy)
 				}


### PR DESCRIPTION
**colexec: refactor allocator to reduce the number of function calls**

Previously, allocator had methods to Append or Copy a single
coldata.Vec. Those methods created an anonymous function on every call.
However, calls to these methods often occur in a loop over many columns,
so they become relatively expensive. Now this code has been refactored
to Append or Copy all columns at once. Allocator.Append and
Allocator.Copy have been removed and Allocator.PerformOperation has been
exposed as a single method to use.

Release note: None

**colexec: minor refactor of memory accounting**

We extract out PerformOperation call outside of the loop in Case operator
(which should give minor performance improvement in case of multiple When
arms) and do a tweak to rowstovec template. Also, a bug with memory
accounting in any_not_null template is fixed.

Release note: None