### PR TITLE
opt: add first half of upsert FK checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -133,6 +133,69 @@ DROP TABLE child2
 statement ok
 DROP TABLE parent2
 
+# Upsert
+# ------
+
+statement ok
+CREATE TABLE parent (p INT PRIMARY KEY, other INT)
+
+statement ok
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+
+statement ok
+INSERT INTO parent VALUES (1), (2)
+
+# Insert case.
+statement ok
+INSERT INTO child VALUES (1, 1) ON CONFLICT (c) DO UPDATE SET p = 2
+
+statement error foreign key
+INSERT INTO child VALUES (2, 10) ON CONFLICT (c) DO UPDATE SET p = 2
+
+# Update case.
+statement ok
+INSERT INTO child VALUES (1, 1) ON CONFLICT (c) DO UPDATE SET p = 1
+
+statement ok
+INSERT INTO child VALUES (1, 10) ON CONFLICT (c) DO UPDATE SET p = 1
+
+statement error foreign key
+INSERT INTO child VALUES (1, 10) ON CONFLICT (c) DO UPDATE SET p = 10
+
+statement ok
+TRUNCATE child
+
+statement ok
+INSERT INTO child VALUES (1, 1)
+
+# Both insert and update case.
+
+# Both insert and update are invalid.
+
+statement error foreign key
+INSERT INTO child VALUES (1, 1), (2, 3) ON CONFLICT (c) DO UPDATE SET p = 3
+
+# Insert is invalid, update is valid.
+
+statement error foreign key
+INSERT INTO child VALUES (1, 2), (2, 3) ON CONFLICT (c) DO UPDATE SET p = 1
+
+# Insert is valid, update is invalid.
+
+statement error foreign key
+INSERT INTO child VALUES (1, 2), (2, 1) ON CONFLICT (c) DO UPDATE SET p = 3
+
+# Both insert and update are valid.
+
+statement ok
+INSERT INTO child VALUES (1, 2), (2, 1) ON CONFLICT (c) DO UPDATE SET p = 2
+
+statement ok
+DROP TABLE child
+
+statement ok
+DROP TABLE parent
+
 # --- Tests that follow are copied from the fk tests and adjusted as needed.
 
 statement ok

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -275,6 +275,7 @@ func (f *stubFactory) ConstructUpsert(
 	returnCols exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
+	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -365,6 +365,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	updateColOrds := ordinalSetFromColList(ups.UpdateCols)
 	returnColOrds := ordinalSetFromColList(ups.ReturnCols)
 	checkOrds := ordinalSetFromColList(ups.CheckCols)
+	disableExecFKs := !ups.FKFallback
 	node, err := b.factory.ConstructUpsert(
 		input.root,
 		tab,
@@ -375,8 +376,13 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 		returnColOrds,
 		checkOrds,
 		b.allowAutoCommit && len(ups.Checks) == 0,
+		disableExecFKs,
 	)
 	if err != nil {
+		return execPlan{}, err
+	}
+
+	if err := b.buildFKChecks(ups.Checks); err != nil {
 		return execPlan{}, err
 	}
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -421,6 +421,11 @@ type Factory interface {
 	// transaction (if appropriate, i.e. if it is in an implicit transaction).
 	// This is false if there are multiple mutations in a statement, or the output
 	// of the mutation is processed through side-effecting expressions.
+	//
+	// If skipFKChecks is set, foreign keys are not checked as part of the
+	// execution of the upsert for the insert half. This is used when the FK
+	// checks are planned by the optimizer and are run separately as plan
+	// postqueries.
 	ConstructUpsert(
 		input Node,
 		table cat.Table,
@@ -431,6 +436,7 @@ type Factory interface {
 		returnCols ColumnOrdinalSet,
 		checks CheckOrdinalSet,
 		allowAutoCommit bool,
+		skipFKChecks bool,
 	) (Node, error)
 
 	// ConstructDelete creates a node that implements a DELETE statement. The
@@ -447,8 +453,8 @@ type Factory interface {
 	// of the mutation is processed through side-effecting expressions.
 	//
 	// If skipFKChecks is set, foreign keys are not checked as part of the
-	// execution of the insertion. This is used when the FK checks are planned by
-	// the optimizer and are run separately as plan postqueries.
+	// execution of the delete. This is used when the FK checks are planned
+	// by the optimizer and are run separately as plan postqueries.
 	ConstructDelete(
 		input Node,
 		table cat.Table,

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -26,13 +26,16 @@ insert child
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column2:7(int!null)
-                ├── with-scan &1
-                │    ├── columns: column2:7(int!null)
-                │    └── mapping:
-                │         └──  column2:4(int) => column2:7(int)
+                ├── columns: column2:6(int!null)
+                ├── project
+                │    ├── columns: column2:6(int!null)
+                │    └── with-scan &1
+                │         ├── columns: column1:5(int!null) column2:6(int!null)
+                │         └── mapping:
+                │              ├──  column1:3(int) => column1:5(int)
+                │              └──  column2:4(int) => column2:6(int)
                 ├── scan parent
-                │    └── columns: parent.p:5(int!null)
+                │    └── columns: parent.p:7(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
@@ -49,23 +52,26 @@ INSERT INTO child SELECT x, y FROM xy
 insert child
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  x:3 => c:1
+ │    ├──  xy.x:3 => c:1
  │    └──  xy.y:4 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: x:3(int) xy.y:4(int)
+ │    ├── columns: xy.x:3(int) xy.y:4(int)
  │    └── scan xy
- │         └── columns: x:3(int) xy.y:4(int) rowid:5(int!null)
+ │         └── columns: xy.x:3(int) xy.y:4(int) rowid:5(int!null)
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: y:8(int)
-                ├── with-scan &1
-                │    ├── columns: y:8(int)
-                │    └── mapping:
-                │         └──  xy.y:4(int) => y:8(int)
+                ├── columns: y:7(int)
+                ├── project
+                │    ├── columns: y:7(int)
+                │    └── with-scan &1
+                │         ├── columns: x:6(int) y:7(int)
+                │         └── mapping:
+                │              ├──  xy.x:3(int) => x:6(int)
+                │              └──  xy.y:4(int) => y:7(int)
                 ├── scan parent
-                │    └── columns: parent.p:6(int!null)
+                │    └── columns: parent.p:8(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: y [type=int]
@@ -98,19 +104,22 @@ insert child_nullable
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column2:7(int!null)
+                ├── columns: column2:6(int!null)
                 ├── select
-                │    ├── columns: column2:7(int!null)
-                │    ├── with-scan &1
-                │    │    ├── columns: column2:7(int)
-                │    │    └── mapping:
-                │    │         └──  column2:4(int) => column2:7(int)
+                │    ├── columns: column2:6(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:6(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:5(int!null) column2:6(int)
+                │    │         └── mapping:
+                │    │              ├──  column1:3(int) => column1:5(int)
+                │    │              └──  column2:4(int) => column2:6(int)
                 │    └── filters
                 │         └── is-not [type=bool]
                 │              ├── variable: column2 [type=int]
                 │              └── null [type=unknown]
                 ├── scan parent
-                │    └── columns: parent.p:5(int!null)
+                │    └── columns: parent.p:7(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
@@ -138,13 +147,16 @@ insert child_nullable
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column2:7(int!null)
-                ├── with-scan &1
-                │    ├── columns: column2:7(int!null)
-                │    └── mapping:
-                │         └──  column2:4(int) => column2:7(int)
+                ├── columns: column2:6(int!null)
+                ├── project
+                │    ├── columns: column2:6(int!null)
+                │    └── with-scan &1
+                │         ├── columns: column1:5(int!null) column2:6(int!null)
+                │         └── mapping:
+                │              ├──  column1:3(int) => column1:5(int)
+                │              └──  column2:4(int) => column2:6(int)
                 ├── scan parent
-                │    └── columns: parent.p:5(int!null)
+                │    └── columns: parent.p:7(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
@@ -177,19 +189,22 @@ insert child_nullable_full
  └── f-k-checks
       └── f-k-checks-item: child_nullable_full(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column2:7(int!null)
+                ├── columns: column2:6(int!null)
                 ├── select
-                │    ├── columns: column2:7(int!null)
-                │    ├── with-scan &1
-                │    │    ├── columns: column2:7(int)
-                │    │    └── mapping:
-                │    │         └──  column2:4(int) => column2:7(int)
+                │    ├── columns: column2:6(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:6(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:5(int!null) column2:6(int)
+                │    │         └── mapping:
+                │    │              ├──  column1:3(int) => column1:5(int)
+                │    │              └──  column2:4(int) => column2:6(int)
                 │    └── filters
                 │         └── is-not [type=bool]
                 │              ├── variable: column2 [type=int]
                 │              └── null [type=unknown]
                 ├── scan parent
-                │    └── columns: parent.p:5(int!null)
+                │    └── columns: parent.p:7(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
@@ -233,15 +248,18 @@ insert multi_col_child
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
+                ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
                 ├── select
-                │    ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                │    ├── with-scan &1
-                │    │    ├── columns: column2:13(int) column3:14(int) column4:15(int)
-                │    │    └── mapping:
-                │    │         ├──  column2:6(int) => column2:13(int)
-                │    │         ├──  column3:7(int) => column3:14(int)
-                │    │         └──  column4:8(int) => column4:15(int)
+                │    ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:10(int) column3:11(int) column4:12(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:9(int!null) column2:10(int) column3:11(int) column4:12(int)
+                │    │         └── mapping:
+                │    │              ├──  column1:5(int) => column1:9(int)
+                │    │              ├──  column2:6(int) => column2:10(int)
+                │    │              ├──  column3:7(int) => column3:11(int)
+                │    │              └──  column4:8(int) => column4:12(int)
                 │    └── filters
                 │         ├── is-not [type=bool]
                 │         │    ├── variable: column2 [type=int]
@@ -253,7 +271,7 @@ insert multi_col_child
                 │              ├── variable: column4 [type=int]
                 │              └── null [type=unknown]
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -294,15 +312,18 @@ insert multi_col_child
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
+                ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
                 ├── select
-                │    ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                │    ├── with-scan &1
-                │    │    ├── columns: column2:13(int) column3:14(int) column4:15(int!null)
-                │    │    └── mapping:
-                │    │         ├──  column2:6(int) => column2:13(int)
-                │    │         ├──  column3:7(int) => column3:14(int)
-                │    │         └──  column4:8(int) => column4:15(int)
+                │    ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:10(int) column3:11(int) column4:12(int!null)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:9(int!null) column2:10(int) column3:11(int) column4:12(int!null)
+                │    │         └── mapping:
+                │    │              ├──  column1:5(int) => column1:9(int)
+                │    │              ├──  column2:6(int) => column2:10(int)
+                │    │              ├──  column3:7(int) => column3:11(int)
+                │    │              └──  column4:8(int) => column4:12(int)
                 │    └── filters
                 │         ├── is-not [type=bool]
                 │         │    ├── variable: column2 [type=int]
@@ -311,7 +332,7 @@ insert multi_col_child
                 │              ├── variable: column3 [type=int]
                 │              └── null [type=unknown]
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -345,15 +366,18 @@ insert multi_col_child
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                ├── with-scan &1
-                │    ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                │    └── mapping:
-                │         ├──  column2:6(int) => column2:13(int)
-                │         ├──  column3:7(int) => column3:14(int)
-                │         └──  column4:8(int) => column4:15(int)
+                ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                ├── project
+                │    ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │    └── with-scan &1
+                │         ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │         └── mapping:
+                │              ├──  column1:5(int) => column1:9(int)
+                │              ├──  column2:6(int) => column2:10(int)
+                │              ├──  column3:7(int) => column3:11(int)
+                │              └──  column4:8(int) => column4:12(int)
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -398,15 +422,18 @@ insert multi_col_child_full
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int) column3:14(int) column4:15(int)
+                ├── columns: column2:10(int) column3:11(int) column4:12(int)
                 ├── select
-                │    ├── columns: column2:13(int) column3:14(int) column4:15(int)
-                │    ├── with-scan &1
-                │    │    ├── columns: column2:13(int) column3:14(int) column4:15(int)
-                │    │    └── mapping:
-                │    │         ├──  column2:6(int) => column2:13(int)
-                │    │         ├──  column3:7(int) => column3:14(int)
-                │    │         └──  column4:8(int) => column4:15(int)
+                │    ├── columns: column2:10(int) column3:11(int) column4:12(int)
+                │    ├── project
+                │    │    ├── columns: column2:10(int) column3:11(int) column4:12(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:9(int!null) column2:10(int) column3:11(int) column4:12(int)
+                │    │         └── mapping:
+                │    │              ├──  column1:5(int) => column1:9(int)
+                │    │              ├──  column2:6(int) => column2:10(int)
+                │    │              ├──  column3:7(int) => column3:11(int)
+                │    │              └──  column4:8(int) => column4:12(int)
                 │    └── filters
                 │         └── or [type=bool]
                 │              ├── or [type=bool]
@@ -420,7 +447,7 @@ insert multi_col_child_full
                 │                   ├── variable: column4 [type=int]
                 │                   └── null [type=unknown]
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -461,15 +488,18 @@ insert multi_col_child_full
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int) column3:14(int) column4:15(int!null)
-                ├── with-scan &1
-                │    ├── columns: column2:13(int) column3:14(int) column4:15(int!null)
-                │    └── mapping:
-                │         ├──  column2:6(int) => column2:13(int)
-                │         ├──  column3:7(int) => column3:14(int)
-                │         └──  column4:8(int) => column4:15(int)
+                ├── columns: column2:10(int) column3:11(int) column4:12(int!null)
+                ├── project
+                │    ├── columns: column2:10(int) column3:11(int) column4:12(int!null)
+                │    └── with-scan &1
+                │         ├── columns: column1:9(int!null) column2:10(int) column3:11(int) column4:12(int!null)
+                │         └── mapping:
+                │              ├──  column1:5(int) => column1:9(int)
+                │              ├──  column2:6(int) => column2:10(int)
+                │              ├──  column3:7(int) => column3:11(int)
+                │              └──  column4:8(int) => column4:12(int)
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -503,15 +533,18 @@ insert multi_col_child_full
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
-                ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                ├── with-scan &1
-                │    ├── columns: column2:13(int!null) column3:14(int!null) column4:15(int!null)
-                │    └── mapping:
-                │         ├──  column2:6(int) => column2:13(int)
-                │         ├──  column3:7(int) => column3:14(int)
-                │         └──  column4:8(int) => column4:15(int)
+                ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                ├── project
+                │    ├── columns: column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │    └── with-scan &1
+                │         ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null)
+                │         └── mapping:
+                │              ├──  column1:5(int) => column1:9(int)
+                │              ├──  column2:6(int) => column2:10(int)
+                │              ├──  column3:7(int) => column3:11(int)
+                │              └──  column4:8(int) => column4:12(int)
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
+                │    └── columns: multi_col_parent.p:13(int!null) multi_col_parent.q:14(int!null) multi_col_parent.r:15(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
@@ -566,33 +599,42 @@ insert multi_ref_child
  └── f-k-checks
       ├── f-k-checks-item: multi_ref_child(a) -> multi_ref_parent_a(a)
       │    └── anti-join (hash)
-      │         ├── columns: column2:11(int!null)
+      │         ├── columns: column2:10(int!null)
       │         ├── select
-      │         │    ├── columns: column2:11(int!null)
-      │         │    ├── with-scan &1
-      │         │    │    ├── columns: column2:11(int)
-      │         │    │    └── mapping:
-      │         │    │         └──  column2:6(int) => column2:11(int)
+      │         │    ├── columns: column2:10(int!null)
+      │         │    ├── project
+      │         │    │    ├── columns: column2:10(int)
+      │         │    │    └── with-scan &1
+      │         │    │         ├── columns: column1:9(int!null) column2:10(int) column3:11(int) column4:12(int)
+      │         │    │         └── mapping:
+      │         │    │              ├──  column1:5(int) => column1:9(int)
+      │         │    │              ├──  column2:6(int) => column2:10(int)
+      │         │    │              ├──  column3:7(int) => column3:11(int)
+      │         │    │              └──  column4:8(int) => column4:12(int)
       │         │    └── filters
       │         │         └── is-not [type=bool]
       │         │              ├── variable: column2 [type=int]
       │         │              └── null [type=unknown]
       │         ├── scan multi_ref_parent_a
-      │         │    └── columns: multi_ref_parent_a.a:9(int!null)
+      │         │    └── columns: multi_ref_parent_a.a:13(int!null)
       │         └── filters
       │              └── eq [type=bool]
       │                   ├── variable: column2 [type=int]
       │                   └── variable: multi_ref_parent_a.a [type=int]
       └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
            └── anti-join (hash)
-                ├── columns: column3:15(int!null) column4:16(int!null)
+                ├── columns: column3:17(int!null) column4:18(int!null)
                 ├── select
-                │    ├── columns: column3:15(int!null) column4:16(int!null)
-                │    ├── with-scan &1
-                │    │    ├── columns: column3:15(int) column4:16(int)
-                │    │    └── mapping:
-                │    │         ├──  column3:7(int) => column3:15(int)
-                │    │         └──  column4:8(int) => column4:16(int)
+                │    ├── columns: column3:17(int!null) column4:18(int!null)
+                │    ├── project
+                │    │    ├── columns: column3:17(int) column4:18(int)
+                │    │    └── with-scan &1
+                │    │         ├── columns: column1:15(int!null) column2:16(int) column3:17(int) column4:18(int)
+                │    │         └── mapping:
+                │    │              ├──  column1:5(int) => column1:15(int)
+                │    │              ├──  column2:6(int) => column2:16(int)
+                │    │              ├──  column3:7(int) => column3:17(int)
+                │    │              └──  column4:8(int) => column4:18(int)
                 │    └── filters
                 │         ├── is-not [type=bool]
                 │         │    ├── variable: column3 [type=int]
@@ -601,7 +643,7 @@ insert multi_ref_child
                 │              ├── variable: column4 [type=int]
                 │              └── null [type=unknown]
                 ├── scan multi_ref_parent_bc
-                │    └── columns: multi_ref_parent_bc.b:12(int!null) multi_ref_parent_bc.c:13(int!null)
+                │    └── columns: multi_ref_parent_bc.b:19(int!null) multi_ref_parent_bc.c:20(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -11,26 +11,29 @@ UPDATE child SET p = 4
 ----
 update child
  ├── columns: <none>
- ├── fetch columns: c:3(int) child.p:4(int)
+ ├── fetch columns: child.c:3(int) child.p:4(int)
  ├── update-mapping:
  │    └──  column5:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5(int!null) c:3(int!null) child.p:4(int!null)
+ │    ├── columns: column5:5(int!null) child.c:3(int!null) child.p:4(int!null)
  │    ├── scan child
- │    │    └── columns: c:3(int!null) child.p:4(int!null)
+ │    │    └── columns: child.c:3(int!null) child.p:4(int!null)
  │    └── projections
  │         └── const: 4 [type=int]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:9(int!null)
-                ├── with-scan &1
-                │    ├── columns: column5:9(int!null)
-                │    └── mapping:
-                │         └──  column5:5(int) => column5:9(int)
+                ├── columns: column5:7(int!null)
+                ├── project
+                │    ├── columns: column5:7(int!null)
+                │    └── with-scan &1
+                │         ├── columns: c:6(int!null) column5:7(int!null)
+                │         └── mapping:
+                │              ├──  child.c:3(int) => c:6(int)
+                │              └──  column5:5(int) => column5:7(int)
                 ├── scan parent
-                │    └── columns: parent.p:7(int!null)
+                │    └── columns: parent.p:9(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column5 [type=int]
@@ -132,26 +135,29 @@ UPDATE child SET p = 4
 ----
 update child
  ├── columns: <none>
- ├── fetch columns: c:3(int) child.p:4(int)
+ ├── fetch columns: child.c:3(int) child.p:4(int)
  ├── update-mapping:
  │    └──  column5:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5(int!null) c:3(int!null) child.p:4(int!null)
+ │    ├── columns: column5:5(int!null) child.c:3(int!null) child.p:4(int!null)
  │    ├── scan child
- │    │    └── columns: c:3(int!null) child.p:4(int!null)
+ │    │    └── columns: child.c:3(int!null) child.p:4(int!null)
  │    └── projections
  │         └── const: 4 [type=int]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:9(int!null)
-                ├── with-scan &1
-                │    ├── columns: column5:9(int!null)
-                │    └── mapping:
-                │         └──  column5:5(int) => column5:9(int)
+                ├── columns: column5:7(int!null)
+                ├── project
+                │    ├── columns: column5:7(int!null)
+                │    └── with-scan &1
+                │         ├── columns: c:6(int!null) column5:7(int!null)
+                │         └── mapping:
+                │              ├──  child.c:3(int) => c:6(int)
+                │              └──  column5:5(int) => column5:7(int)
                 ├── scan parent
-                │    └── columns: parent.p:7(int!null)
+                │    └── columns: parent.p:9(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column5 [type=int]
@@ -162,22 +168,25 @@ UPDATE child SET p = p
 ----
 update child
  ├── columns: <none>
- ├── fetch columns: c:3(int) child.p:4(int)
+ ├── fetch columns: child.c:3(int) child.p:4(int)
  ├── update-mapping:
  │    └──  child.p:4 => child.p:2
  ├── input binding: &1
  ├── scan child
- │    └── columns: c:3(int!null) child.p:4(int!null)
+ │    └── columns: child.c:3(int!null) child.p:4(int!null)
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: p:8(int!null)
-                ├── with-scan &1
-                │    ├── columns: p:8(int!null)
-                │    └── mapping:
-                │         └──  child.p:4(int) => p:8(int)
+                ├── columns: p:6(int!null)
+                ├── project
+                │    ├── columns: p:6(int!null)
+                │    └── with-scan &1
+                │         ├── columns: c:5(int!null) p:6(int!null)
+                │         └── mapping:
+                │              ├──  child.c:3(int) => c:5(int)
+                │              └──  child.p:4(int) => p:6(int)
                 ├── scan parent
-                │    └── columns: parent.p:6(int!null)
+                │    └── columns: parent.p:8(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: p [type=int]
@@ -207,38 +216,41 @@ update child
  └── f-k-checks
       ├── f-k-checks-item: child(p) -> parent(p)
       │    └── anti-join (hash)
-      │         ├── columns: column5:10(int!null)
-      │         ├── with-scan &1
-      │         │    ├── columns: column5:10(int!null)
-      │         │    └── mapping:
-      │         │         └──  column5:5(int) => column5:10(int)
+      │         ├── columns: column5:8(int!null)
+      │         ├── project
+      │         │    ├── columns: column5:8(int!null)
+      │         │    └── with-scan &1
+      │         │         ├── columns: column6:7(int!null) column5:8(int!null)
+      │         │         └── mapping:
+      │         │              ├──  column6:6(int) => column6:7(int)
+      │         │              └──  column5:5(int) => column5:8(int)
       │         ├── scan parent
-      │         │    └── columns: parent.p:8(int!null)
+      │         │    └── columns: parent.p:10(int!null)
       │         └── filters
       │              └── eq [type=bool]
       │                   ├── variable: column5 [type=int]
       │                   └── variable: parent.p [type=int]
       └── f-k-checks-item: grandchild(c) -> child(c)
            └── semi-join (hash)
-                ├── columns: c:13(int!null)
+                ├── columns: c:14(int!null)
                 ├── project
-                │    ├── columns: c:13(int!null)
+                │    ├── columns: c:14(int!null)
                 │    ├── except
-                │    │    ├── columns: c:11(int!null)
-                │    │    ├── left columns: c:11(int!null)
-                │    │    ├── right columns: column6:12(int)
+                │    │    ├── columns: c:12(int!null)
+                │    │    ├── left columns: c:12(int!null)
+                │    │    ├── right columns: column6:13(int)
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: c:11(int!null)
+                │    │    │    ├── columns: c:12(int!null)
                 │    │    │    └── mapping:
-                │    │    │         └──  child.c:3(int) => c:11(int)
+                │    │    │         └──  child.c:3(int) => c:12(int)
                 │    │    └── with-scan &1
-                │    │         ├── columns: column6:12(int!null)
+                │    │         ├── columns: column6:13(int!null)
                 │    │         └── mapping:
-                │    │              └──  column6:6(int) => column6:12(int)
+                │    │              └──  column6:6(int) => column6:13(int)
                 │    └── projections
                 │         └── variable: c [type=int]
                 ├── scan grandchild
-                │    └── columns: grandchild.c:15(int!null)
+                │    └── columns: grandchild.c:16(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: c [type=int]
@@ -254,26 +266,29 @@ UPDATE child SET p = 4
 ----
 update child
  ├── columns: <none>
- ├── fetch columns: c:3(int) child.p:4(int)
+ ├── fetch columns: child.c:3(int) child.p:4(int)
  ├── update-mapping:
  │    └──  column5:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5(int!null) c:3(int!null) child.p:4(int!null)
+ │    ├── columns: column5:5(int!null) child.c:3(int!null) child.p:4(int!null)
  │    ├── scan child
- │    │    └── columns: c:3(int!null) child.p:4(int!null)
+ │    │    └── columns: child.c:3(int!null) child.p:4(int!null)
  │    └── projections
  │         └── const: 4 [type=int]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:9(int!null)
-                ├── with-scan &1
-                │    ├── columns: column5:9(int!null)
-                │    └── mapping:
-                │         └──  column5:5(int) => column5:9(int)
+                ├── columns: column5:7(int!null)
+                ├── project
+                │    ├── columns: column5:7(int!null)
+                │    └── with-scan &1
+                │         ├── columns: c:6(int!null) column5:7(int!null)
+                │         └── mapping:
+                │              ├──  child.c:3(int) => c:6(int)
+                │              └──  column5:5(int) => column5:7(int)
                 ├── scan parent
-                │    └── columns: parent.p:7(int!null)
+                │    └── columns: parent.p:9(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column5 [type=int]
@@ -288,30 +303,33 @@ UPDATE self SET y = 3
 ----
 update self
  ├── columns: <none>
- ├── fetch columns: x:3(int) y:4(int)
+ ├── fetch columns: self.x:3(int) y:4(int)
  ├── update-mapping:
  │    └──  column5:5 => y:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5(int!null) x:3(int!null) y:4(int!null)
+ │    ├── columns: column5:5(int!null) self.x:3(int!null) y:4(int!null)
  │    ├── scan self
- │    │    └── columns: x:3(int!null) y:4(int!null)
+ │    │    └── columns: self.x:3(int!null) y:4(int!null)
  │    └── projections
  │         └── const: 3 [type=int]
  └── f-k-checks
       └── f-k-checks-item: self(y) -> self(x)
            └── anti-join (hash)
-                ├── columns: column5:8(int!null)
-                ├── with-scan &1
-                │    ├── columns: column5:8(int!null)
-                │    └── mapping:
-                │         └──  column5:5(int) => column5:8(int)
+                ├── columns: column5:7(int!null)
+                ├── project
+                │    ├── columns: column5:7(int!null)
+                │    └── with-scan &1
+                │         ├── columns: x:6(int!null) column5:7(int!null)
+                │         └── mapping:
+                │              ├──  self.x:3(int) => x:6(int)
+                │              └──  column5:5(int) => column5:7(int)
                 ├── scan self
-                │    └── columns: x:6(int!null)
+                │    └── columns: self.x:8(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column5 [type=int]
-                          └── variable: x [type=int]
+                          └── variable: self.x [type=int]
 
 build
 UPDATE self SET x = 3
@@ -381,14 +399,14 @@ UPDATE fam SET c = 3
 ----
 update fam
  ├── columns: <none>
- ├── fetch columns: fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) rowid:12(int)
+ ├── fetch columns: fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) fam.rowid:12(int)
  ├── update-mapping:
  │    └──  column13:13 => c:3
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13(int!null) fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) rowid:12(int!null)
+ │    ├── columns: column13:13(int!null) fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) fam.rowid:12(int!null)
  │    ├── scan fam
- │    │    └── columns: fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) rowid:12(int!null)
+ │    │    └── columns: fam.a:7(int) fam.b:8(int) c:9(int) fam.d:10(int) fam.rowid:12(int!null)
  │    └── projections
  │         └── const: 3 [type=int]
  └── f-k-checks
@@ -407,7 +425,7 @@ update fam
                 │              ├── variable: d [type=int]
                 │              └── null [type=unknown]
                 ├── scan two
-                │    └── columns: two.a:14(int!null) two.b:15(int!null)
+                │    └── columns: two.a:20(int!null) two.b:21(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column13 [type=int]
@@ -421,14 +439,14 @@ UPDATE fam SET d = 3
 ----
 update fam
  ├── columns: <none>
- ├── fetch columns: fam.c:9(int) d:10(int) e:11(int) rowid:12(int)
+ ├── fetch columns: fam.c:9(int) d:10(int) fam.e:11(int) fam.rowid:12(int)
  ├── update-mapping:
  │    └──  column13:13 => d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13(int!null) fam.c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │    ├── columns: column13:13(int!null) fam.c:9(int) d:10(int) fam.e:11(int) fam.rowid:12(int!null)
  │    ├── scan fam
- │    │    └── columns: fam.c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+ │    │    └── columns: fam.c:9(int) d:10(int) fam.e:11(int) fam.rowid:12(int!null)
  │    └── projections
  │         └── const: 3 [type=int]
  └── f-k-checks
@@ -447,7 +465,7 @@ update fam
                 │              ├── variable: c [type=int]
                 │              └── null [type=unknown]
                 ├── scan two
-                │    └── columns: two.a:14(int!null) two.b:15(int!null)
+                │    └── columns: two.a:20(int!null) two.b:21(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: c [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -1,0 +1,812 @@
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY, other INT)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), i INT)
+----
+
+build
+UPSERT INTO child VALUES (100, 1), (200, 1)
+----
+upsert child
+ ├── columns: <none>
+ ├── canary column: 7
+ ├── fetch columns: child.c:7(int) child.p:8(int) i:9(int)
+ ├── insert-mapping:
+ │    ├──  column1:4 => child.c:1
+ │    ├──  column2:5 => child.p:2
+ │    └──  column6:6 => i:3
+ ├── update-mapping:
+ │    ├──  column2:5 => child.p:2
+ │    └──  column6:6 => i:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:10(int) column1:4(int!null) column2:5(int!null) column6:6(int) child.c:7(int) child.p:8(int) i:9(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:4(int!null) column2:5(int!null) column6:6(int) child.c:7(int) child.p:8(int) i:9(int)
+ │    │    ├── project
+ │    │    │    ├── columns: column6:6(int) column1:4(int!null) column2:5(int!null)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:4(int!null) column2:5(int!null)
+ │    │    │    │    ├── tuple [type=tuple{int, int}]
+ │    │    │    │    │    ├── const: 100 [type=int]
+ │    │    │    │    │    └── const: 1 [type=int]
+ │    │    │    │    └── tuple [type=tuple{int, int}]
+ │    │    │    │         ├── const: 200 [type=int]
+ │    │    │    │         └── const: 1 [type=int]
+ │    │    │    └── projections
+ │    │    │         └── cast: INT8 [type=int]
+ │    │    │              └── null [type=unknown]
+ │    │    ├── scan child
+ │    │    │    └── columns: child.c:7(int!null) child.p:8(int!null) i:9(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: column1 [type=int]
+ │    │              └── variable: child.c [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: child.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: column2:12(int!null)
+                ├── project
+                │    ├── columns: column2:12(int!null)
+                │    └── project
+                │         ├── columns: column1:11(int!null) column2:12(int!null) column6:13(int) c:14(int)
+                │         └── select
+                │              ├── columns: column1:11(int!null) column2:12(int!null) column6:13(int) c:14(int)
+                │              ├── with-scan &1
+                │              │    ├── columns: column1:11(int!null) column2:12(int!null) column6:13(int) c:14(int)
+                │              │    └── mapping:
+                │              │         ├──  column1:4(int) => column1:11(int)
+                │              │         ├──  column2:5(int) => column2:12(int)
+                │              │         ├──  column6:6(int) => column6:13(int)
+                │              │         └──  child.c:7(int) => c:14(int)
+                │              └── filters
+                │                   └── is [type=bool]
+                │                        ├── variable: c [type=int]
+                │                        └── null [type=unknown]
+                ├── scan parent
+                │    └── columns: parent.p:15(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: parent.p [type=int]
+
+# Use a non-constant input.
+exec-ddl
+CREATE TABLE xy (x INT, y INT)
+----
+
+build
+UPSERT INTO child SELECT x, y FROM xy
+----
+upsert child
+ ├── columns: <none>
+ ├── canary column: 8
+ ├── fetch columns: child.c:8(int) child.p:9(int) i:10(int)
+ ├── insert-mapping:
+ │    ├──  xy.x:4 => child.c:1
+ │    ├──  xy.y:5 => child.p:2
+ │    └──  column7:7 => i:3
+ ├── update-mapping:
+ │    ├──  xy.y:5 => child.p:2
+ │    └──  column7:7 => i:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:11(int) xy.x:4(int) xy.y:5(int) column7:7(int) child.c:8(int) child.p:9(int) i:10(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: xy.x:4(int) xy.y:5(int) column7:7(int) child.c:8(int) child.p:9(int) i:10(int)
+ │    │    ├── project
+ │    │    │    ├── columns: column7:7(int) xy.x:4(int) xy.y:5(int)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: xy.x:4(int) xy.y:5(int)
+ │    │    │    │    └── scan xy
+ │    │    │    │         └── columns: xy.x:4(int) xy.y:5(int) rowid:6(int!null)
+ │    │    │    └── projections
+ │    │    │         └── cast: INT8 [type=int]
+ │    │    │              └── null [type=unknown]
+ │    │    ├── scan child
+ │    │    │    └── columns: child.c:8(int!null) child.p:9(int!null) i:10(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xy.x [type=int]
+ │    │              └── variable: child.c [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: xy.x [type=int]
+ │              └── variable: child.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: y:13(int)
+                ├── project
+                │    ├── columns: y:13(int)
+                │    └── project
+                │         ├── columns: x:12(int) y:13(int) column7:14(int) c:15(int)
+                │         └── select
+                │              ├── columns: x:12(int) y:13(int) column7:14(int) c:15(int)
+                │              ├── with-scan &1
+                │              │    ├── columns: x:12(int) y:13(int) column7:14(int) c:15(int)
+                │              │    └── mapping:
+                │              │         ├──  xy.x:4(int) => x:12(int)
+                │              │         ├──  xy.y:5(int) => y:13(int)
+                │              │         ├──  column7:7(int) => column7:14(int)
+                │              │         └──  child.c:8(int) => c:15(int)
+                │              └── filters
+                │                   └── is [type=bool]
+                │                        ├── variable: c [type=int]
+                │                        └── null [type=unknown]
+                ├── scan parent
+                │    └── columns: parent.p:16(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: y [type=int]
+                          └── variable: parent.p [type=int]
+
+# Use a non-constant input.
+exec-ddl
+CREATE TABLE uv (u INT NOT NULL, v INT NOT NULL)
+----
+
+build
+INSERT INTO child SELECT u, v FROM uv ON CONFLICT (c) DO UPDATE SET i = child.c + 1
+----
+upsert child
+ ├── columns: <none>
+ ├── canary column: 8
+ ├── fetch columns: child.c:8(int) child.p:9(int) i:10(int)
+ ├── insert-mapping:
+ │    ├──  uv.u:4 => child.c:1
+ │    ├──  uv.v:5 => child.p:2
+ │    └──  column7:7 => i:3
+ ├── update-mapping:
+ │    └──  upsert_i:14 => i:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:12(int) upsert_p:13(int) upsert_i:14(int) uv.u:4(int!null) uv.v:5(int!null) column7:7(int) child.c:8(int) child.p:9(int) i:10(int) column11:11(int)
+ │    ├── project
+ │    │    ├── columns: column11:11(int) uv.u:4(int!null) uv.v:5(int!null) column7:7(int) child.c:8(int) child.p:9(int) i:10(int)
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: uv.u:4(int!null) uv.v:5(int!null) column7:7(int) child.c:8(int) child.p:9(int) i:10(int)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: column7:7(int) uv.u:4(int!null) uv.v:5(int!null)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: uv.u:4(int!null) uv.v:5(int!null)
+ │    │    │    │    │    └── scan uv
+ │    │    │    │    │         └── columns: uv.u:4(int!null) uv.v:5(int!null) rowid:6(int!null)
+ │    │    │    │    └── projections
+ │    │    │    │         └── cast: INT8 [type=int]
+ │    │    │    │              └── null [type=unknown]
+ │    │    │    ├── scan child
+ │    │    │    │    └── columns: child.c:8(int!null) child.p:9(int!null) i:10(int)
+ │    │    │    └── filters
+ │    │    │         └── eq [type=bool]
+ │    │    │              ├── variable: uv.u [type=int]
+ │    │    │              └── variable: child.c [type=int]
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: child.c [type=int]
+ │    │              └── const: 1 [type=int]
+ │    └── projections
+ │         ├── case [type=int]
+ │         │    ├── true [type=bool]
+ │         │    ├── when [type=int]
+ │         │    │    ├── is [type=bool]
+ │         │    │    │    ├── variable: child.c [type=int]
+ │         │    │    │    └── null [type=unknown]
+ │         │    │    └── variable: uv.u [type=int]
+ │         │    └── variable: child.c [type=int]
+ │         ├── case [type=int]
+ │         │    ├── true [type=bool]
+ │         │    ├── when [type=int]
+ │         │    │    ├── is [type=bool]
+ │         │    │    │    ├── variable: child.c [type=int]
+ │         │    │    │    └── null [type=unknown]
+ │         │    │    └── variable: uv.v [type=int]
+ │         │    └── variable: child.p [type=int]
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column7 [type=int]
+ │              └── variable: column11 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: v:16(int!null)
+                ├── project
+                │    ├── columns: v:16(int!null)
+                │    └── project
+                │         ├── columns: u:15(int!null) v:16(int!null) column7:17(int) c:18(int)
+                │         └── select
+                │              ├── columns: u:15(int!null) v:16(int!null) column7:17(int) c:18(int)
+                │              ├── with-scan &1
+                │              │    ├── columns: u:15(int!null) v:16(int!null) column7:17(int) c:18(int)
+                │              │    └── mapping:
+                │              │         ├──  uv.u:4(int) => u:15(int)
+                │              │         ├──  uv.v:5(int) => v:16(int)
+                │              │         ├──  column7:7(int) => column7:17(int)
+                │              │         └──  child.c:8(int) => c:18(int)
+                │              └── filters
+                │                   └── is [type=bool]
+                │                        ├── variable: c [type=int]
+                │                        └── null [type=unknown]
+                ├── scan parent
+                │    └── columns: parent.p:19(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: v [type=int]
+                          └── variable: parent.p [type=int]
+
+exec-ddl
+CREATE TABLE parent2 (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child2 (c INT PRIMARY KEY, FOREIGN KEY (c) REFERENCES PARENT(p))
+----
+
+build
+INSERT INTO child2 VALUES (1), (2) ON CONFLICT (c) DO UPDATE SET c = 1
+----
+upsert child2
+ ├── columns: <none>
+ ├── canary column: 3
+ ├── fetch columns: child2.c:3(int)
+ ├── insert-mapping:
+ │    └──  column1:2 => child2.c:1
+ ├── update-mapping:
+ │    └──  upsert_c:5 => child2.c:1
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:5(int!null) column1:2(int!null) child2.c:3(int) column4:4(int!null)
+ │    ├── project
+ │    │    ├── columns: column4:4(int!null) column1:2(int!null) child2.c:3(int)
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:2(int!null) child2.c:3(int)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:2(int!null)
+ │    │    │    │    ├── tuple [type=tuple{int}]
+ │    │    │    │    │    └── const: 1 [type=int]
+ │    │    │    │    └── tuple [type=tuple{int}]
+ │    │    │    │         └── const: 2 [type=int]
+ │    │    │    ├── scan child2
+ │    │    │    │    └── columns: child2.c:3(int!null)
+ │    │    │    └── filters
+ │    │    │         └── eq [type=bool]
+ │    │    │              ├── variable: column1 [type=int]
+ │    │    │              └── variable: child2.c [type=int]
+ │    │    └── projections
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: child2.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: column4 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child2(c) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: column1:6(int!null)
+                ├── project
+                │    ├── columns: column1:6(int!null)
+                │    └── project
+                │         ├── columns: column1:6(int!null) c:7(int)
+                │         └── select
+                │              ├── columns: column1:6(int!null) c:7(int)
+                │              ├── with-scan &1
+                │              │    ├── columns: column1:6(int!null) c:7(int)
+                │              │    └── mapping:
+                │              │         ├──  column1:2(int) => column1:6(int)
+                │              │         └──  child2.c:3(int) => c:7(int)
+                │              └── filters
+                │                   └── is [type=bool]
+                │                        ├── variable: c [type=int]
+                │                        └── null [type=unknown]
+                ├── scan parent
+                │    └── columns: p:8(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column1 [type=int]
+                          └── variable: p [type=int]
+
+exec-ddl
+CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
+----
+
+# Because the input column can be NULL (in which case it requires no FK match),
+# we have to add an extra filter.
+norm
+UPSERT INTO child_nullable VALUES (100, 1), (200, NULL)
+----
+upsert child_nullable
+ ├── columns: <none>
+ ├── canary column: 5
+ ├── fetch columns: child_nullable.c:5(int) child_nullable.p:6(int)
+ ├── insert-mapping:
+ │    ├──  column1:3 => child_nullable.c:1
+ │    └──  column2:4 => child_nullable.p:2
+ ├── update-mapping:
+ │    └──  column2:4 => child_nullable.p:2
+ ├── input binding: &1
+ ├── left-join (hash)
+ │    ├── columns: column1:3(int!null) column2:4(int) child_nullable.c:5(int) child_nullable.p:6(int)
+ │    ├── values
+ │    │    ├── columns: column1:3(int!null) column2:4(int)
+ │    │    ├── tuple [type=tuple{int, int}]
+ │    │    │    ├── const: 100 [type=int]
+ │    │    │    └── const: 1 [type=int]
+ │    │    └── tuple [type=tuple{int, int}]
+ │    │         ├── const: 200 [type=int]
+ │    │         └── null [type=int]
+ │    ├── scan child_nullable
+ │    │    └── columns: child_nullable.c:5(int!null) child_nullable.p:6(int)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: column1 [type=int]
+ │              └── variable: child_nullable.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child_nullable(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: column2:9(int!null)
+                ├── project
+                │    ├── columns: column2:9(int!null)
+                │    └── select
+                │         ├── columns: column2:9(int!null) c:10(int)
+                │         ├── with-scan &1
+                │         │    ├── columns: column2:9(int) c:10(int)
+                │         │    └── mapping:
+                │         │         ├──  column2:4(int) => column2:9(int)
+                │         │         └──  child_nullable.c:5(int) => c:10(int)
+                │         └── filters
+                │              ├── is [type=bool]
+                │              │    ├── variable: c [type=int]
+                │              │    └── null [type=unknown]
+                │              └── is-not [type=bool]
+                │                   ├── variable: column2 [type=int]
+                │                   └── null [type=unknown]
+                ├── scan parent
+                │    └── columns: parent.p:11(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: parent.p [type=int]
+
+# Tests with multicolumn FKs.
+exec-ddl
+CREATE TABLE multi_col_parent (p INT, q INT, r INT, other INT, PRIMARY KEY (p, q, r))
+----
+
+exec-ddl
+CREATE TABLE multi_col_child  (
+  c INT PRIMARY KEY,
+  p INT, q INT, r INT,
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES multi_col_parent(p,q,r) MATCH SIMPLE
+)
+----
+
+# All columns are nullable and must be part of the filter.
+build
+UPSERT INTO multi_col_child VALUES (4, NULL, NULL, NULL)
+----
+upsert multi_col_child
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ ├── insert-mapping:
+ │    ├──  column1:5 => multi_col_child.c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── update-mapping:
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:13(int) column1:5(int!null) column2:6(int) column3:7(int) column4:8(int) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+ │    │    │    └── tuple [type=tuple{int, int, int, int}]
+ │    │    │         ├── const: 4 [type=int]
+ │    │    │         ├── cast: INT8 [type=int]
+ │    │    │         │    └── null [type=unknown]
+ │    │    │         ├── cast: INT8 [type=int]
+ │    │    │         │    └── null [type=unknown]
+ │    │    │         └── cast: INT8 [type=int]
+ │    │    │              └── null [type=unknown]
+ │    │    ├── scan multi_col_child
+ │    │    │    └── columns: multi_col_child.c:9(int!null) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: column1 [type=int]
+ │    │              └── variable: multi_col_child.c [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: multi_col_child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: multi_col_child.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
+           └── anti-join (hash)
+                ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                ├── select
+                │    ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:15(int) column3:16(int) column4:17(int)
+                │    │    └── project
+                │    │         ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) c:18(int)
+                │    │         └── select
+                │    │              ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) c:18(int)
+                │    │              ├── with-scan &1
+                │    │              │    ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) c:18(int)
+                │    │              │    └── mapping:
+                │    │              │         ├──  column1:5(int) => column1:14(int)
+                │    │              │         ├──  column2:6(int) => column2:15(int)
+                │    │              │         ├──  column3:7(int) => column3:16(int)
+                │    │              │         ├──  column4:8(int) => column4:17(int)
+                │    │              │         └──  multi_col_child.c:9(int) => c:18(int)
+                │    │              └── filters
+                │    │                   └── is [type=bool]
+                │    │                        ├── variable: c [type=int]
+                │    │                        └── null [type=unknown]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column2 [type=int]
+                │         │    └── null [type=unknown]
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column3 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column4 [type=int]
+                │              └── null [type=unknown]
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:19(int!null) multi_col_parent.q:20(int!null) multi_col_parent.r:21(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: multi_col_parent.r [type=int]
+
+# Only p and q are nullable.
+build
+UPSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
+----
+upsert multi_col_child
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ ├── insert-mapping:
+ │    ├──  column1:5 => multi_col_child.c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── update-mapping:
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:13(int) column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null)
+ │    │    │    ├── tuple [type=tuple{int, int, int, int}]
+ │    │    │    │    ├── const: 2 [type=int]
+ │    │    │    │    ├── cast: INT8 [type=int]
+ │    │    │    │    │    └── null [type=unknown]
+ │    │    │    │    ├── const: 20 [type=int]
+ │    │    │    │    └── const: 20 [type=int]
+ │    │    │    └── tuple [type=tuple{int, int, int, int}]
+ │    │    │         ├── const: 3 [type=int]
+ │    │    │         ├── const: 20 [type=int]
+ │    │    │         ├── cast: INT8 [type=int]
+ │    │    │         │    └── null [type=unknown]
+ │    │    │         └── const: 20 [type=int]
+ │    │    ├── scan multi_col_child
+ │    │    │    └── columns: multi_col_child.c:9(int!null) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: column1 [type=int]
+ │    │              └── variable: multi_col_child.c [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: multi_col_child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: multi_col_child.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
+           └── anti-join (hash)
+                ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                ├── select
+                │    ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:15(int) column3:16(int) column4:17(int!null)
+                │    │    └── project
+                │    │         ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int!null) c:18(int)
+                │    │         └── select
+                │    │              ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int!null) c:18(int)
+                │    │              ├── with-scan &1
+                │    │              │    ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int!null) c:18(int)
+                │    │              │    └── mapping:
+                │    │              │         ├──  column1:5(int) => column1:14(int)
+                │    │              │         ├──  column2:6(int) => column2:15(int)
+                │    │              │         ├──  column3:7(int) => column3:16(int)
+                │    │              │         ├──  column4:8(int) => column4:17(int)
+                │    │              │         └──  multi_col_child.c:9(int) => c:18(int)
+                │    │              └── filters
+                │    │                   └── is [type=bool]
+                │    │                        ├── variable: c [type=int]
+                │    │                        └── null [type=unknown]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column2 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column3 [type=int]
+                │              └── null [type=unknown]
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:19(int!null) multi_col_parent.q:20(int!null) multi_col_parent.r:21(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: multi_col_parent.r [type=int]
+
+# All the FK columns are not-null; no filter necessary.
+build
+UPSERT INTO multi_col_child VALUES (1, 10, 10, 10)
+----
+upsert multi_col_child
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ ├── insert-mapping:
+ │    ├──  column1:5 => multi_col_child.c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── update-mapping:
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_c:13(int) column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null) multi_col_child.c:9(int) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null)
+ │    │    │    └── tuple [type=tuple{int, int, int, int}]
+ │    │    │         ├── const: 1 [type=int]
+ │    │    │         ├── const: 10 [type=int]
+ │    │    │         ├── const: 10 [type=int]
+ │    │    │         └── const: 10 [type=int]
+ │    │    ├── scan multi_col_child
+ │    │    │    └── columns: multi_col_child.c:9(int!null) multi_col_child.p:10(int) multi_col_child.q:11(int) multi_col_child.r:12(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: column1 [type=int]
+ │    │              └── variable: multi_col_child.c [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: multi_col_child.c [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: multi_col_child.c [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
+           └── anti-join (hash)
+                ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                ├── project
+                │    ├── columns: column2:15(int!null) column3:16(int!null) column4:17(int!null)
+                │    └── project
+                │         ├── columns: column1:14(int!null) column2:15(int!null) column3:16(int!null) column4:17(int!null) c:18(int)
+                │         └── select
+                │              ├── columns: column1:14(int!null) column2:15(int!null) column3:16(int!null) column4:17(int!null) c:18(int)
+                │              ├── with-scan &1
+                │              │    ├── columns: column1:14(int!null) column2:15(int!null) column3:16(int!null) column4:17(int!null) c:18(int)
+                │              │    └── mapping:
+                │              │         ├──  column1:5(int) => column1:14(int)
+                │              │         ├──  column2:6(int) => column2:15(int)
+                │              │         ├──  column3:7(int) => column3:16(int)
+                │              │         ├──  column4:8(int) => column4:17(int)
+                │              │         └──  multi_col_child.c:9(int) => c:18(int)
+                │              └── filters
+                │                   └── is [type=bool]
+                │                        ├── variable: c [type=int]
+                │                        └── null [type=unknown]
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:19(int!null) multi_col_parent.q:20(int!null) multi_col_parent.r:21(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: multi_col_parent.r [type=int]
+
+exec-ddl
+CREATE TABLE multi_ref_parent_a (a INT PRIMARY KEY, other INT)
+----
+
+exec-ddl
+CREATE TABLE multi_ref_parent_bc (b INT, c INT, PRIMARY KEY (b,c), other INT)
+----
+
+exec-ddl
+CREATE TABLE multi_ref_child (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  CONSTRAINT fk FOREIGN KEY (a) REFERENCES multi_ref_parent_a(a),
+  CONSTRAINT fk FOREIGN KEY (b,c) REFERENCES multi_ref_parent_bc(b,c)
+)
+----
+
+build
+UPSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
+----
+upsert multi_ref_child
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: multi_ref_child.k:9(int) multi_ref_child.a:10(int) multi_ref_child.b:11(int) multi_ref_child.c:12(int)
+ ├── insert-mapping:
+ │    ├──  column1:5 => multi_ref_child.k:1
+ │    ├──  column2:6 => multi_ref_child.a:2
+ │    ├──  column3:7 => multi_ref_child.b:3
+ │    └──  column4:8 => multi_ref_child.c:4
+ ├── update-mapping:
+ │    ├──  column2:6 => multi_ref_child.a:2
+ │    ├──  column3:7 => multi_ref_child.b:3
+ │    └──  column4:8 => multi_ref_child.c:4
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_k:13(int) column1:5(int!null) column2:6(int) column3:7(int) column4:8(int) multi_ref_child.k:9(int) multi_ref_child.a:10(int) multi_ref_child.b:11(int) multi_ref_child.c:12(int)
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int) multi_ref_child.k:9(int) multi_ref_child.a:10(int) multi_ref_child.b:11(int) multi_ref_child.c:12(int)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+ │    │    │    └── tuple [type=tuple{int, int, int, int}]
+ │    │    │         ├── const: 1 [type=int]
+ │    │    │         ├── cast: INT8 [type=int]
+ │    │    │         │    └── null [type=unknown]
+ │    │    │         ├── cast: INT8 [type=int]
+ │    │    │         │    └── null [type=unknown]
+ │    │    │         └── cast: INT8 [type=int]
+ │    │    │              └── null [type=unknown]
+ │    │    ├── scan multi_ref_child
+ │    │    │    └── columns: multi_ref_child.k:9(int!null) multi_ref_child.a:10(int) multi_ref_child.b:11(int) multi_ref_child.c:12(int)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: column1 [type=int]
+ │    │              └── variable: multi_ref_child.k [type=int]
+ │    └── projections
+ │         └── case [type=int]
+ │              ├── true [type=bool]
+ │              ├── when [type=int]
+ │              │    ├── is [type=bool]
+ │              │    │    ├── variable: multi_ref_child.k [type=int]
+ │              │    │    └── null [type=unknown]
+ │              │    └── variable: column1 [type=int]
+ │              └── variable: multi_ref_child.k [type=int]
+ └── f-k-checks
+      ├── f-k-checks-item: multi_ref_child(a) -> multi_ref_parent_a(a)
+      │    └── anti-join (hash)
+      │         ├── columns: column2:15(int!null)
+      │         ├── select
+      │         │    ├── columns: column2:15(int!null)
+      │         │    ├── project
+      │         │    │    ├── columns: column2:15(int)
+      │         │    │    └── project
+      │         │    │         ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) k:18(int)
+      │         │    │         └── select
+      │         │    │              ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) k:18(int)
+      │         │    │              ├── with-scan &1
+      │         │    │              │    ├── columns: column1:14(int!null) column2:15(int) column3:16(int) column4:17(int) k:18(int)
+      │         │    │              │    └── mapping:
+      │         │    │              │         ├──  column1:5(int) => column1:14(int)
+      │         │    │              │         ├──  column2:6(int) => column2:15(int)
+      │         │    │              │         ├──  column3:7(int) => column3:16(int)
+      │         │    │              │         ├──  column4:8(int) => column4:17(int)
+      │         │    │              │         └──  multi_ref_child.k:9(int) => k:18(int)
+      │         │    │              └── filters
+      │         │    │                   └── is [type=bool]
+      │         │    │                        ├── variable: k [type=int]
+      │         │    │                        └── null [type=unknown]
+      │         │    └── filters
+      │         │         └── is-not [type=bool]
+      │         │              ├── variable: column2 [type=int]
+      │         │              └── null [type=unknown]
+      │         ├── scan multi_ref_parent_a
+      │         │    └── columns: multi_ref_parent_a.a:19(int!null)
+      │         └── filters
+      │              └── eq [type=bool]
+      │                   ├── variable: column2 [type=int]
+      │                   └── variable: multi_ref_parent_a.a [type=int]
+      └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
+           └── anti-join (hash)
+                ├── columns: column3:23(int!null) column4:24(int!null)
+                ├── select
+                │    ├── columns: column3:23(int!null) column4:24(int!null)
+                │    ├── project
+                │    │    ├── columns: column3:23(int) column4:24(int)
+                │    │    └── project
+                │    │         ├── columns: column1:21(int!null) column2:22(int) column3:23(int) column4:24(int) k:25(int)
+                │    │         └── select
+                │    │              ├── columns: column1:21(int!null) column2:22(int) column3:23(int) column4:24(int) k:25(int)
+                │    │              ├── with-scan &1
+                │    │              │    ├── columns: column1:21(int!null) column2:22(int) column3:23(int) column4:24(int) k:25(int)
+                │    │              │    └── mapping:
+                │    │              │         ├──  column1:5(int) => column1:21(int)
+                │    │              │         ├──  column2:6(int) => column2:22(int)
+                │    │              │         ├──  column3:7(int) => column3:23(int)
+                │    │              │         ├──  column4:8(int) => column4:24(int)
+                │    │              │         └──  multi_ref_child.k:9(int) => k:25(int)
+                │    │              └── filters
+                │    │                   └── is [type=bool]
+                │    │                        ├── variable: k [type=int]
+                │    │                        └── null [type=unknown]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column3 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column4 [type=int]
+                │              └── null [type=unknown]
+                ├── scan multi_ref_parent_bc
+                │    └── columns: multi_ref_parent_bc.b:26(int!null) multi_ref_parent_bc.c:27(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: multi_ref_parent_bc.b [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: multi_ref_parent_bc.c [type=int]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -197,26 +197,26 @@ insert "order"
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
            └── anti-join (lookup customer)
-                ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
-                ├── key columns: [38 39 40] = [19 18 17]
+                ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
+                ├── key columns: [19 18 20] = [27 26 25]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.26
                 ├── key: ()
-                ├── fd: ()-->(38-40)
+                ├── fd: ()-->(18-20)
                 ├── with-scan &1
-                │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
+                │    ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:11(int) => column3:38(int)
-                │    │    ├──  column2:10(int) => column2:39(int)
-                │    │    └──  column4:12(int) => column4:40(int)
+                │    │    ├──  column2:10(int) => column2:18(int)
+                │    │    ├──  column3:11(int) => column3:19(int)
+                │    │    └──  column4:12(int) => column4:20(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
+                │    ├── stats: [rows=1, distinct(18)=1, null(18)=0, distinct(19)=1, null(19)=0, distinct(20)=1, null(20)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(38-40)
-                │    └── prune: (38-40)
+                │    ├── fd: ()-->(18-20)
+                │    └── prune: (18-20)
                 └── filters (true)
 
 opt format=hide-qual
@@ -248,26 +248,26 @@ insert new_order
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
            └── anti-join (lookup order)
-                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
-                ├── key columns: [15 16 17] = [9 8 7]
+                ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
+                ├── key columns: [9 8 7] = [12 11 10]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.13
                 ├── key: ()
-                ├── fd: ()-->(15-17)
+                ├── fd: ()-->(7-9)
                 ├── with-scan &1
-                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:6(int) => column3:15(int)
-                │    │    ├──  column2:5(int) => column2:16(int)
-                │    │    └──  column1:4(int) => column1:17(int)
+                │    │    ├──  column1:4(int) => column1:7(int)
+                │    │    ├──  column2:5(int) => column2:8(int)
+                │    │    └──  column3:6(int) => column3:9(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
+                │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(15-17)
-                │    └── prune: (15-17)
+                │    ├── fd: ()-->(7-9)
+                │    └── prune: (7-9)
                 └── filters (true)
 
 opt format=hide-qual
@@ -783,40 +783,40 @@ insert order_line
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
-      │         ├── key columns: [30 31 32] = [24 23 22]
+      │         ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
+      │         ├── key columns: [24 23 22] = [34 33 32]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 36.68
       │         ├── with-scan &1
-      │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
+      │         │    ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:13(int) => column3:30(int)
-      │         │    │    ├──  column2:12(int) => column2:31(int)
-      │         │    │    └──  column1:11(int) => column1:32(int)
+      │         │    │    ├──  column1:11(int) => column1:22(int)
+      │         │    │    ├──  column2:12(int) => column2:23(int)
+      │         │    │    └──  column3:13(int) => column3:24(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    ├── stats: [rows=6, distinct(22)=0.6, null(22)=0, distinct(23)=0.6, null(23)=0, distinct(24)=0.6, null(24)=0]
       │         │    ├── cost: 0.01
-      │         │    └── prune: (30-32)
+      │         │    └── prune: (22-24)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:50(int!null) column5:51(int!null)
-                ├── key columns: [51 50] = [33 34]
+                ├── columns: column5:44(int!null) column6:45(int!null)
+                ├── key columns: [44 45] = [50 51]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 36.1061434
                 ├── with-scan &1
-                │    ├── columns: column6:50(int!null) column5:51(int!null)
+                │    ├── columns: column5:44(int!null) column6:45(int!null)
                 │    ├── mapping:
-                │    │    ├──  column6:16(int) => column6:50(int)
-                │    │    └──  column5:15(int) => column5:51(int)
+                │    │    ├──  column5:15(int) => column5:44(int)
+                │    │    └──  column6:16(int) => column6:45(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    ├── stats: [rows=6, distinct(44)=0.6, null(44)=0, distinct(45)=0.6, null(45)=0]
                 │    ├── cost: 0.01
-                │    └── prune: (50,51)
+                │    └── prune: (44,45)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1130,48 +1130,48 @@ insert history
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
       │    └── anti-join (lookup customer)
-      │         ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
-      │         ├── key columns: [41 42 43] = [22 21 20]
+      │         ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
+      │         ├── key columns: [23 22 21] = [31 30 29]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 6.26
       │         ├── key: ()
-      │         ├── fd: ()-->(41-43)
+      │         ├── fd: ()-->(21-23)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
+      │         │    ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:12(int) => column3:41(int)
-      │         │    │    ├──  column2:11(int) => column2:42(int)
-      │         │    │    └──  column1:10(int) => column1:43(int)
+      │         │    │    ├──  column1:10(int) => column1:21(int)
+      │         │    │    ├──  column2:11(int) => column2:22(int)
+      │         │    │    └──  column3:12(int) => column3:23(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
+      │         │    ├── stats: [rows=1, distinct(21)=1, null(21)=0, distinct(22)=1, null(22)=0, distinct(23)=1, null(23)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    ├── fd: ()-->(41-43)
-      │         │    └── prune: (41-43)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── prune: (21-23)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
-                ├── columns: column5:55(int!null) column4:56(int!null)
-                ├── key columns: [55 56] = [45 44]
+                ├── columns: column4:54(int!null) column5:55(int!null)
+                ├── key columns: [55 54] = [60 59]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.15
                 ├── key: ()
-                ├── fd: ()-->(55,56)
+                ├── fd: ()-->(54,55)
                 ├── with-scan &1
-                │    ├── columns: column5:55(int!null) column4:56(int!null)
+                │    ├── columns: column4:54(int!null) column5:55(int!null)
                 │    ├── mapping:
-                │    │    ├──  column5:14(int) => column5:55(int)
-                │    │    └──  column4:13(int) => column4:56(int)
+                │    │    ├──  column4:13(int) => column4:54(int)
+                │    │    └──  column5:14(int) => column5:55(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
+                │    ├── stats: [rows=1, distinct(54)=1, null(54)=0, distinct(55)=1, null(55)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(55,56)
-                │    └── prune: (55,56)
+                │    ├── fd: ()-->(54,55)
+                │    └── prune: (54,55)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -200,26 +200,26 @@ insert "order"
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
            └── anti-join (lookup customer)
-                ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
-                ├── key columns: [38 39 40] = [19 18 17]
+                ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
+                ├── key columns: [19 18 20] = [27 26 25]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.26
                 ├── key: ()
-                ├── fd: ()-->(38-40)
+                ├── fd: ()-->(18-20)
                 ├── with-scan &1
-                │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
+                │    ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:11(int) => column3:38(int)
-                │    │    ├──  column2:10(int) => column2:39(int)
-                │    │    └──  column4:12(int) => column4:40(int)
+                │    │    ├──  column2:10(int) => column2:18(int)
+                │    │    ├──  column3:11(int) => column3:19(int)
+                │    │    └──  column4:12(int) => column4:20(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
+                │    ├── stats: [rows=1, distinct(18)=1, null(18)=0, distinct(19)=1, null(19)=0, distinct(20)=1, null(20)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(38-40)
-                │    └── prune: (38-40)
+                │    ├── fd: ()-->(18-20)
+                │    └── prune: (18-20)
                 └── filters (true)
 
 opt format=hide-qual
@@ -251,26 +251,26 @@ insert new_order
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
            └── anti-join (lookup order)
-                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
-                ├── key columns: [15 16 17] = [9 8 7]
+                ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
+                ├── key columns: [9 8 7] = [12 11 10]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.11975196
                 ├── key: ()
-                ├── fd: ()-->(15-17)
+                ├── fd: ()-->(7-9)
                 ├── with-scan &1
-                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:6(int) => column3:15(int)
-                │    │    ├──  column2:5(int) => column2:16(int)
-                │    │    └──  column1:4(int) => column1:17(int)
+                │    │    ├──  column1:4(int) => column1:7(int)
+                │    │    ├──  column2:5(int) => column2:8(int)
+                │    │    └──  column3:6(int) => column3:9(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
+                │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(15-17)
-                │    └── prune: (15-17)
+                │    ├── fd: ()-->(7-9)
+                │    └── prune: (7-9)
                 └── filters (true)
 
 opt format=hide-qual
@@ -786,40 +786,40 @@ insert order_line
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
-      │         ├── key columns: [30 31 32] = [24 23 22]
+      │         ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
+      │         ├── key columns: [24 23 22] = [34 33 32]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 36.6185118
       │         ├── with-scan &1
-      │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
+      │         │    ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:13(int) => column3:30(int)
-      │         │    │    ├──  column2:12(int) => column2:31(int)
-      │         │    │    └──  column1:11(int) => column1:32(int)
+      │         │    │    ├──  column1:11(int) => column1:22(int)
+      │         │    │    ├──  column2:12(int) => column2:23(int)
+      │         │    │    └──  column3:13(int) => column3:24(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    ├── stats: [rows=6, distinct(22)=0.6, null(22)=0, distinct(23)=0.6, null(23)=0, distinct(24)=0.6, null(24)=0]
       │         │    ├── cost: 0.01
-      │         │    └── prune: (30-32)
+      │         │    └── prune: (22-24)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:50(int!null) column5:51(int!null)
-                ├── key columns: [51 50] = [33 34]
+                ├── columns: column5:44(int!null) column6:45(int!null)
+                ├── key columns: [44 45] = [50 51]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 36.1061434
                 ├── with-scan &1
-                │    ├── columns: column6:50(int!null) column5:51(int!null)
+                │    ├── columns: column5:44(int!null) column6:45(int!null)
                 │    ├── mapping:
-                │    │    ├──  column6:16(int) => column6:50(int)
-                │    │    └──  column5:15(int) => column5:51(int)
+                │    │    ├──  column5:15(int) => column5:44(int)
+                │    │    └──  column6:16(int) => column6:45(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    ├── stats: [rows=6, distinct(44)=0.6, null(44)=0, distinct(45)=0.6, null(45)=0]
                 │    ├── cost: 0.01
-                │    └── prune: (50,51)
+                │    └── prune: (44,45)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1133,48 +1133,48 @@ insert history
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
       │    └── anti-join (lookup customer)
-      │         ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
-      │         ├── key columns: [41 42 43] = [22 21 20]
+      │         ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
+      │         ├── key columns: [23 22 21] = [31 30 29]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 6.26
       │         ├── key: ()
-      │         ├── fd: ()-->(41-43)
+      │         ├── fd: ()-->(21-23)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
+      │         │    ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:12(int) => column3:41(int)
-      │         │    │    ├──  column2:11(int) => column2:42(int)
-      │         │    │    └──  column1:10(int) => column1:43(int)
+      │         │    │    ├──  column1:10(int) => column1:21(int)
+      │         │    │    ├──  column2:11(int) => column2:22(int)
+      │         │    │    └──  column3:12(int) => column3:23(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
+      │         │    ├── stats: [rows=1, distinct(21)=1, null(21)=0, distinct(22)=1, null(22)=0, distinct(23)=1, null(23)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    ├── fd: ()-->(41-43)
-      │         │    └── prune: (41-43)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── prune: (21-23)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
-                ├── columns: column5:55(int!null) column4:56(int!null)
-                ├── key columns: [55 56] = [45 44]
+                ├── columns: column4:54(int!null) column5:55(int!null)
+                ├── key columns: [55 54] = [60 59]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.15
                 ├── key: ()
-                ├── fd: ()-->(55,56)
+                ├── fd: ()-->(54,55)
                 ├── with-scan &1
-                │    ├── columns: column5:55(int!null) column4:56(int!null)
+                │    ├── columns: column4:54(int!null) column5:55(int!null)
                 │    ├── mapping:
-                │    │    ├──  column5:14(int) => column5:55(int)
-                │    │    └──  column4:13(int) => column4:56(int)
+                │    │    ├──  column4:13(int) => column4:54(int)
+                │    │    └──  column5:14(int) => column5:55(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
+                │    ├── stats: [rows=1, distinct(54)=1, null(54)=0, distinct(55)=1, null(55)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(55,56)
-                │    └── prune: (55,56)
+                │    ├── fd: ()-->(54,55)
+                │    └── prune: (54,55)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -194,26 +194,26 @@ insert "order"
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
            └── anti-join (lookup customer)
-                ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
-                ├── key columns: [38 39 40] = [19 18 17]
+                ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
+                ├── key columns: [19 18 20] = [27 26 25]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.02224
                 ├── key: ()
-                ├── fd: ()-->(38-40)
+                ├── fd: ()-->(18-20)
                 ├── with-scan &1
-                │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
+                │    ├── columns: column2:18(int!null) column3:19(int!null) column4:20(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:11(int) => column3:38(int)
-                │    │    ├──  column2:10(int) => column2:39(int)
-                │    │    └──  column4:12(int) => column4:40(int)
+                │    │    ├──  column2:10(int) => column2:18(int)
+                │    │    ├──  column3:11(int) => column3:19(int)
+                │    │    └──  column4:12(int) => column4:20(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
+                │    ├── stats: [rows=1, distinct(18)=1, null(18)=0, distinct(19)=1, null(19)=0, distinct(20)=1, null(20)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(38-40)
-                │    └── prune: (38-40)
+                │    ├── fd: ()-->(18-20)
+                │    └── prune: (18-20)
                 └── filters (true)
 
 opt format=hide-qual
@@ -245,26 +245,26 @@ insert new_order
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
            └── anti-join (lookup order)
-                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
-                ├── key columns: [15 16 17] = [9 8 7]
+                ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
+                ├── key columns: [9 8 7] = [12 11 10]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.02211
                 ├── key: ()
-                ├── fd: ()-->(15-17)
+                ├── fd: ()-->(7-9)
                 ├── with-scan &1
-                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
                 │    ├── mapping:
-                │    │    ├──  column3:6(int) => column3:15(int)
-                │    │    ├──  column2:5(int) => column2:16(int)
-                │    │    └──  column1:4(int) => column1:17(int)
+                │    │    ├──  column1:4(int) => column1:7(int)
+                │    │    ├──  column2:5(int) => column2:8(int)
+                │    │    └──  column3:6(int) => column3:9(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
+                │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(15-17)
-                │    └── prune: (15-17)
+                │    ├── fd: ()-->(7-9)
+                │    └── prune: (7-9)
                 └── filters (true)
 
 opt format=hide-qual
@@ -780,40 +780,40 @@ insert order_line
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
-      │         ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
-      │         ├── key columns: [30 31 32] = [24 23 22]
+      │         ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
+      │         ├── key columns: [24 23 22] = [34 33 32]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 24.03266
       │         ├── with-scan &1
-      │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
+      │         │    ├── columns: column1:22(int!null) column2:23(int!null) column3:24(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:13(int) => column3:30(int)
-      │         │    │    ├──  column2:12(int) => column2:31(int)
-      │         │    │    └──  column1:11(int) => column1:32(int)
+      │         │    │    ├──  column1:11(int) => column1:22(int)
+      │         │    │    ├──  column2:12(int) => column2:23(int)
+      │         │    │    └──  column3:13(int) => column3:24(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    ├── stats: [rows=6, distinct(22)=0.6, null(22)=0, distinct(23)=0.6, null(23)=0, distinct(24)=0.6, null(24)=0]
       │         │    ├── cost: 0.01
-      │         │    └── prune: (30-32)
+      │         │    └── prune: (22-24)
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
-                ├── columns: column6:50(int!null) column5:51(int!null)
-                ├── key columns: [51 50] = [33 34]
+                ├── columns: column5:44(int!null) column6:45(int!null)
+                ├── key columns: [44 45] = [50 51]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 25.244
                 ├── with-scan &1
-                │    ├── columns: column6:50(int!null) column5:51(int!null)
+                │    ├── columns: column5:44(int!null) column6:45(int!null)
                 │    ├── mapping:
-                │    │    ├──  column6:16(int) => column6:50(int)
-                │    │    └──  column5:15(int) => column5:51(int)
+                │    │    ├──  column5:15(int) => column5:44(int)
+                │    │    └──  column6:16(int) => column6:45(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    ├── stats: [rows=6, distinct(44)=0.6, null(44)=0, distinct(45)=0.6, null(45)=0]
                 │    ├── cost: 0.01
-                │    └── prune: (50,51)
+                │    └── prune: (44,45)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1127,48 +1127,48 @@ insert history
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
       │    └── anti-join (lookup customer)
-      │         ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
-      │         ├── key columns: [41 42 43] = [22 21 20]
+      │         ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
+      │         ├── key columns: [23 22 21] = [31 30 29]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 4.02224
       │         ├── key: ()
-      │         ├── fd: ()-->(41-43)
+      │         ├── fd: ()-->(21-23)
       │         ├── with-scan &1
-      │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
+      │         │    ├── columns: column1:21(int!null) column2:22(int!null) column3:23(int!null)
       │         │    ├── mapping:
-      │         │    │    ├──  column3:12(int) => column3:41(int)
-      │         │    │    ├──  column2:11(int) => column2:42(int)
-      │         │    │    └──  column1:10(int) => column1:43(int)
+      │         │    │    ├──  column1:10(int) => column1:21(int)
+      │         │    │    ├──  column2:11(int) => column2:22(int)
+      │         │    │    └──  column3:12(int) => column3:23(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
+      │         │    ├── stats: [rows=1, distinct(21)=1, null(21)=0, distinct(22)=1, null(22)=0, distinct(23)=1, null(23)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    ├── fd: ()-->(41-43)
-      │         │    └── prune: (41-43)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── prune: (21-23)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
-                ├── columns: column5:55(int!null) column4:56(int!null)
-                ├── key columns: [55 56] = [45 44]
+                ├── columns: column4:54(int!null) column5:55(int!null)
+                ├── key columns: [55 54] = [60 59]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.233
                 ├── key: ()
-                ├── fd: ()-->(55,56)
+                ├── fd: ()-->(54,55)
                 ├── with-scan &1
-                │    ├── columns: column5:55(int!null) column4:56(int!null)
+                │    ├── columns: column4:54(int!null) column5:55(int!null)
                 │    ├── mapping:
-                │    │    ├──  column5:14(int) => column5:55(int)
-                │    │    └──  column4:13(int) => column4:56(int)
+                │    │    ├──  column4:13(int) => column4:54(int)
+                │    │    └──  column5:14(int) => column5:55(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
+                │    ├── stats: [rows=1, distinct(54)=1, null(54)=0, distinct(55)=1, null(55)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    ├── fd: ()-->(55,56)
-                │    └── prune: (55,56)
+                │    ├── fd: ()-->(54,55)
+                │    └── prune: (54,55)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1510,6 +1510,7 @@ func (ef *execFactory) ConstructUpsert(
 	returnColOrdSet exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
+	skipFKChecks bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1520,15 +1521,22 @@ func (ef *execFactory) ConstructUpsert(
 	fetchColDescs := makeColDescList(table, fetchColOrdSet)
 	updateColDescs := makeColDescList(table, updateColOrdSet)
 
+	var fkTables row.FkTableMetadata
+	checkFKs := row.SkipFKs
+	if !skipFKChecks {
+		checkFKs = row.CheckFKs
+	}
 	// Determine the foreign key tables involved in the upsert.
-	fkTables, err := ef.makeFkMetadata(tabDesc, row.CheckUpdates)
+	// TODO(justin): move inside conditional block once we emit update checks.
+	var err error
+	fkTables, err = ef.makeFkMetadata(tabDesc, row.CheckUpdates)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create the table inserter, which does the bulk of the insert-related work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, tabDesc, insertColDescs, row.CheckFKs, fkTables, &ef.planner.alloc,
+		ctx, ef.planner.txn, tabDesc, insertColDescs, checkFKs, fkTables, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1547,6 +1555,7 @@ func (ef *execFactory) ConstructUpsert(
 		updateColDescs,
 		fetchColDescs,
 		row.UpdaterDefault,
+		// TODO(justin): make this conditional on skipFKChecks once we emit the update checks.
 		row.CheckFKs,
 		ef.planner.EvalContext(),
 		&ef.planner.alloc,


### PR DESCRIPTION
An Upsert can be decomposed into an insert half and an update half, so
we must emit the checks for both components. This commit introduces
checks for the insert half.

Release note (sql change): foreign key checks for insertions performed
by upserts are now handled by the optimizer.