### PR TITLE
build: add config for using Google Cloud Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+cockroach
+bin
+cockroach-data
+pkg/ui/node_modules

--- a/build/cloudbuild/Dockerfile
+++ b/build/cloudbuild/Dockerfile
@@ -5,10 +5,4 @@ WORKDIR $GOPATH/src/github.com/cockroachdb/cockroach
 
 COPY . .
 
-RUN pwd
-RUN ls
-RUN git init
-RUN git submodule update --init --recursive
-RUN cd vendor && pwd && ls && git status
-
 RUN make

--- a/build/cloudbuild/Dockerfile
+++ b/build/cloudbuild/Dockerfile
@@ -7,6 +7,7 @@ COPY . .
 
 RUN pwd
 RUN ls
+RUN git init
 RUN git submodule update --init --recursive
 RUN cd vendor && pwd && ls && git status
 

--- a/build/cloudbuild/Dockerfile
+++ b/build/cloudbuild/Dockerfile
@@ -1,0 +1,13 @@
+FROM cockroachdb/builder:20191218-092712
+
+RUN mkdir -p $GOPATH/src/github.com/cockroachdb/cockroach
+WORKDIR $GOPATH/src/github.com/cockroachdb/cockroach
+
+COPY . .
+
+RUN pwd
+RUN ls
+RUN git submodule update --init --recursive
+RUN cd vendor && pwd && ls && git status
+
+RUN make

--- a/build/cloudbuild/cloudbuild.yaml
+++ b/build/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,5 @@
+# Configuration for Google Cloud Build
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'build/cloudbuild/Dockerfile', '-t', 'gcr.io/$PROJECT_ID/cockroach:$COMMIT_SHA', '.']
+timeout: 1800s

--- a/build/cloudbuild/cloudbuild.yaml
+++ b/build/cloudbuild/cloudbuild.yaml
@@ -1,5 +1,7 @@
 # Configuration for Google Cloud Build
 steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['submodule', 'update', '--init', '--recursive']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-f', 'build/cloudbuild/Dockerfile', '-t', 'gcr.io/$PROJECT_ID/cockroach:$COMMIT_SHA', '.']
 timeout: 1800s

--- a/build/cloudbuild/cloudbuild.yaml
+++ b/build/cloudbuild/cloudbuild.yaml
@@ -1,7 +1,5 @@
 # Configuration for Google Cloud Build
 steps:
-- name: 'gcr.io/cloud-builders/git'
-  args: ['submodule', 'update', '--init', '--recursive']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-f', 'build/cloudbuild/Dockerfile', '-t', 'gcr.io/$PROJECT_ID/cockroach:$COMMIT_SHA', '.']
 timeout: 1800s


### PR DESCRIPTION
Previously, we have lacked an easy way to build and deploy a Docker
image from a yet-to-be-merged PR, so that changes (especially UI)
changes can be evaluated by PMs and designers without doing a local
build or interacting with TeamCity.

Google Cloud build provides an easy way to build docker images of
Cockroach based on PRs, and save them to a GCP-internal registry,
tagged simply with their SHA.

From there, they can be deployed to internal Kubernetes clusters (or
Cockroach Cloud) for testing.

This is possible with a combination of TeamCity and Docker Hub, but
Cloud Build does it with minimal configuration, and it integrates well
with our existing GCP setup for deployment.

Questions:
- [ ] can this be done without a new Dockerfile? I wasn't able to find an existing dockerfile that would build a cockroach image with simply `docker build -f some/Dockerfile .`

Release note: None