### PR TITLE
colexec: speed up ordered sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -813,6 +813,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/mergejoiner_leftsemi.eg.go \
   pkg/sql/colexec/mergejoiner_rightouter.eg.go \
   pkg/sql/colexec/min_max_agg.eg.go \
+  pkg/sql/colexec/orderedsynchronizer.eg.go \
   pkg/sql/colexec/overloads_test_utils.eg.go \
   pkg/sql/colexec/proj_const_left_ops.eg.go \
   pkg/sql/colexec/proj_const_right_ops.eg.go \
@@ -1496,6 +1497,7 @@ pkg/sql/colexec/mergejoiner_leftouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/mergejoiner_leftsemi.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/mergejoiner_rightouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/min_max_agg.eg.go: pkg/sql/colexec/min_max_agg_tmpl.go
+pkg/sql/colexec/orderedsynchronizer.eg.go: pkg/sql/colexec/orderedsynchronizer_tmpl.go
 pkg/sql/colexec/proj_const_left_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
 pkg/sql/colexec/proj_const_right_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
 pkg/sql/colexec/proj_non_const_ops.eg.go: pkg/sql/colexec/proj_non_const_ops_tmpl.go

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -15,6 +15,7 @@ mergejoiner_leftouter.eg.go
 mergejoiner_leftsemi.eg.go
 mergejoiner_rightouter.eg.go
 min_max_agg.eg.go
+orderedsynchronizer.eg.go
 overloads_test_utils.eg.go
 proj_const_left_ops.eg.go
 proj_const_right_ops.eg.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
@@ -28,8 +28,9 @@ func genOrderedSynchronizer(wr io.Writer) error {
 	s := string(d)
 
 	// Replace the template variables.
-	s = strings.Replace(s, "_TYPE", "coltypes.{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
 
 	s = replaceManipulationFuncs(".LTyp", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genOrderedSynchronizer(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/colexec/orderedsynchronizer_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(d)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_TYPE", "coltypes.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+
+	s = replaceManipulationFuncs(".LTyp", s)
+
+	tmpl, err := template.New("orderedsynchronizer").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.EQ])
+}
+
+func init() {
+	registerGenerator(genOrderedSynchronizer, "orderedsynchronizer.eg.go")
+}


### PR DESCRIPTION
**colexec: refactor ordered sync to use assign instead of append**

Ordered synchronizer sets the output one row at a time. Previously, we
were calling Append on the output vectors, but it is faster to use Sets
in such scenario.

Release note: None

**colexec: speed up ordered sync**

This commit speeds up the ordered synchronizer with two modifications:
1. instead of updating the allocator after we copy a single whole row,
we will now update the allocator after we copy a full batch of rows
2. to reduce the number of interface conversions we will "strip" output
vectors to get to the underlying slices and will use those directly when
copying the data.

Release note: None