### PR TITLE
util/mon: remove redundant rounding of requested size

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -578,6 +578,7 @@ func (b *BoundAccount) Shrink(ctx context.Context, delta int64) {
 
 // reserveBytes declares an allocation to this monitor. An error is returned if
 // the allocation is denied.
+// x must be a multiple of `poolAllocationSize`.
 func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
@@ -652,6 +653,7 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 }
 
 // increaseBudget requests more bytes from the pool.
+// minExtra must be a multiple of `poolAllocationSize`.
 func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) error {
 	// NB: mm.mu Already locked by reserveBytes().
 	if mm.mu.curBudget.mon == nil {
@@ -659,7 +661,6 @@ func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) erro
 			minExtra, mm.mu.curAllocated, mm.reserved.used), mm.name,
 		)
 	}
-	minExtra = mm.roundSize(minExtra)
 	if log.V(2) {
 		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.name, minExtra)
 	}


### PR DESCRIPTION
Previously, we would effectively call `roundSize` twice when increasing
a memory budget (once in Grow() and once in increaseBudget() which is
called by Grow()). The latter has been removed.

Release note: None