### PR TITLE
pgwire/hba: parse connection type as bit field, not string

### DIFF
--- a/pkg/sql/pgwire/hba/hba_test.go
+++ b/pkg/sql/pgwire/hba/hba_test.go
@@ -72,6 +72,32 @@ func TestParseAndNormalizeAuthConfig(t *testing.T) {
 		})
 }
 
+func TestMatchConnType(t *testing.T) {
+	testCases := []struct {
+		conf, conn ConnType
+		match      bool
+	}{
+		{ConnLocal, ConnHostSSL, false},
+		{ConnLocal, ConnHostNoSSL, false},
+		{ConnLocal, ConnLocal, true},
+		{ConnHostAny, ConnLocal, false},
+		{ConnHostAny, ConnHostSSL, true},
+		{ConnHostAny, ConnHostNoSSL, true},
+		{ConnHostSSL, ConnLocal, false},
+		{ConnHostSSL, ConnHostSSL, true},
+		{ConnHostSSL, ConnHostNoSSL, false},
+		{ConnHostNoSSL, ConnLocal, false},
+		{ConnHostNoSSL, ConnHostSSL, false},
+		{ConnHostNoSSL, ConnHostNoSSL, true},
+	}
+	for _, tc := range testCases {
+		entry := Entry{ConnType: tc.conf}
+		if m := entry.ConnTypeMatches(tc.conn); m != tc.match {
+			t.Errorf("%s vs %s: expected %v, got %v", tc.conf, tc.conn, tc.match, m)
+		}
+	}
+}
+
 // TODO(mjibson): these are untested outside ccl +gss builds.
 var _ = Entry.GetOption
 var _ = Entry.GetOptions

--- a/pkg/sql/pgwire/hba/testdata/parse
+++ b/pkg/sql/pgwire/hba/testdata/parse
@@ -35,6 +35,11 @@ subtest end
 subtest unknown_formats
 
 line
+unknown a b c
+----
+error: unknown connection type: "unknown"
+
+line
 local a b c d
 ----
 error: authentication option not in name=value format: d
@@ -46,8 +51,8 @@ subtest quoted_columns
 line
 "local" a b c
 ----
-# TYPE  DATABASE USER ADDRESS METHOD OPTIONS
-"local" a        b            c
+# TYPE DATABASE USER ADDRESS METHOD OPTIONS
+local  a        b            c
 
 line
 local a b "method"
@@ -226,7 +231,7 @@ host   all      testuser,"all" 0.0.0.0/0 cert
 &hba.Conf{
     Entries: {
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"a", Quoted:false},
                 {Value:"b", Quoted:false},
@@ -242,7 +247,7 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             OptionQuotes: nil,
         },
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -258,7 +263,7 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             OptionQuotes: nil,
         },
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"a", Quoted:false},
                 {Value:"b", Quoted:false},
@@ -276,7 +281,7 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             OptionQuotes: nil,
         },
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -307,7 +312,7 @@ host   "all","test space",something some,"us ers" all     cert
 &hba.Conf{
     Entries: {
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:true},
                 {Value:"test space", Quoted:true},
@@ -333,7 +338,7 @@ subtest empty_strings
 multiline
 "" all all all trust
 ----
-error: line 1: cannot use empty string as connection type
+error: line 1: unknown connection type: ""
 
 multiline
 host all all all ""
@@ -359,7 +364,7 @@ host   all      all  all     gss    k=v " someopt = withspaces "
 &hba.Conf{
     Entries: {
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -427,7 +432,7 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
 &hba.Conf{
     Entries: {
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -443,7 +448,7 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
             OptionQuotes: {false},
         },
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:false},
             },
@@ -479,7 +484,7 @@ host   "all"    "all" 0.0.0.0/0 cert
 &hba.Conf{
     Entries: {
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"db", Quoted:false},
             },
@@ -496,7 +501,7 @@ host   "all"    "all" 0.0.0.0/0 cert
             OptionQuotes: nil,
         },
         {
-            Type:     hba.String{Value:"host", Quoted:false},
+            ConnType: 6,
             Database: {
                 {Value:"all", Quoted:true},
             },

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -140,9 +140,9 @@ func checkHBASyntaxBeforeUpdatingSetting(values *settings.Values, s string) erro
 	}
 
 	for _, entry := range conf.Entries {
-		switch entry.Type.Value {
-		case "host":
-		case "local":
+		switch entry.ConnType {
+		case hba.ConnHostAny:
+		case hba.ConnLocal:
 			if st != nil &&
 				!cluster.Version.IsActive(context.TODO(), st, cluster.VersionAuthLocalAndTrustRejectMethods) {
 				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
@@ -153,8 +153,8 @@ func checkHBASyntaxBeforeUpdatingSetting(values *settings.Values, s string) erro
 			// The syntax 'local' is not yet supported.
 			fallthrough
 		default:
-			return unimplemented.Newf("hba-type-"+entry.Type.Value,
-				"unsupported connection type: %s", entry.Type.Value)
+			return unimplemented.Newf("hba-type-"+entry.ConnType.String(),
+				"unsupported connection type: %s", entry.ConnType)
 		}
 		for _, db := range entry.Database {
 			if !db.IsKeyword("all") {
@@ -242,10 +242,10 @@ func ParseAndNormalize(val string) (*hba.Conf, error) {
 }
 
 var rootEntry = hba.Entry{
-	Type:    hba.String{Value: "host"},
-	User:    []hba.String{{Value: security.RootUser, Quoted: false}},
-	Address: hba.AnyAddr{},
-	Method:  hba.String{Value: "cert"},
+	ConnType: hba.ConnHostAny,
+	User:     []hba.String{{Value: security.RootUser, Quoted: false}},
+	Address:  hba.AnyAddr{},
+	Method:   hba.String{Value: "cert"},
 }
 
 // DefaultHBAConfig is used when the stored HBA configuration string

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -1,5 +1,5 @@
 set_hba
-bad
+local
 ----
 ERROR: line 1: end-of-line before database specification (SQLSTATE F0000)
 


### PR DESCRIPTION
Ahead of #31113.

This makes the in-memory data more compact and introduces proper conn
type matching code.

Release note: None