### PR TITLE
pgwire: properly support unix socket clients with authentication

### DIFF
--- a/pkg/acceptance/testdata/psql/test-psql-unix.sh
+++ b/pkg/acceptance/testdata/psql/test-psql-unix.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+CERTS_DIR=${CERTS_DIR:-/certs}
+crdb=$1
+trap "set -x; killall cockroach cockroachshort || true" EXIT HUP
+
+set -euo pipefail
+
+# Disable automatic network access by psql.
+unset PGHOST
+unset PGPORT
+# Use root access.
+export PGUSER=root
+
+echo "Testing Unix socket connection via insecure server."
+set -x
+
+# Start an insecure CockroachDB server.
+# We use a different port number from standard for an extra guarantee that
+# "psql" is not going to find it.
+"$crdb" start-single-node --background --insecure \
+              --socket=/tmp/.s.PGSQL.1111 \
+              --listen-addr=:12345
+
+# Wait for server ready.
+"$crdb" sql --insecure -e "select 1" -p 12345
+
+# Verify that psql can connect to the server.
+psql -h /tmp -p 1111 -c "select 1" | grep "1 row"
+
+# It worked.
+"$crdb" quit --insecure -p 12345
+sleep 1; killall -9 cockroach cockroachshort || true
+
+set +x
+echo "Testing Unix socket connection via secure server."
+set -x
+
+# Restart the server in secure mode.
+"$crdb" start-single-node --background \
+              --certs-dir="$CERTS_DIR" --socket=/tmp/.s.PGSQL.1111 \
+              --listen-addr=:12345
+
+# Wait for server ready; also create a user that can log in.
+"$crdb" sql --certs-dir="$CERTS_DIR" -e "create user foo with password 'pass'" -p 12345
+
+# Also verify that psql can connect to the server.
+env PGPASSWORD=pass psql -U foo -h /tmp -p 1111 -c "select 1" | grep "1 row"
+
+set +x
+# Done.
+"$crdb" quit --certs-dir="$CERTS_DIR" -p 12345

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -44,7 +44,6 @@ const (
 func authGSS(
 	c pgwire.AuthConn,
 	tlsState tls.ConnectionState,
-	insecure bool,
 	hashedPassword []byte,
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
@@ -189,5 +188,5 @@ func checkEntry(entry hba.Entry) error {
 }
 
 func init() {
-	pgwire.RegisterAuthMethod("gss", authGSS, cluster.Version19_1, checkEntry)
+	pgwire.RegisterAuthMethod("gss", authGSS, cluster.Version19_1, hba.ConnHostSSL, checkEntry)
 }

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -535,9 +535,17 @@ write its process ID to the specified file.`,
 		Name:   "socket",
 		EnvVar: "COCKROACH_SOCKET",
 		Description: `
-Unix socket file, postgresql protocol only.
-Note: when given a path to a unix socket, most postgres clients will
-open "<given path>/.s.PGSQL.<server port>"`,
+Accept client connections using a Unix domain socket with the
+given name.
+
+Note: for compatibility with PostgreSQL clients and drivers,
+ensure that the socket name has the form "/path/to/.s.PGSQL.NNNN",
+where NNNN is a number. PostgreSQL clients only take a port
+number and directory as input and construct the socket name
+programmatically.
+
+To use, for example: psql -h /path/to -p NNNN ...
+`,
 	}
 
 	ClientInsecure = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -350,12 +350,7 @@ func init() {
 		VarFlag(f, &serverCfg.StorageEngine, cliflags.StorageEngine)
 		VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
 
-		// Usage for the unix socket is odd as we use a real file, whereas
-		// postgresql and clients consider it a directory and build a filename
-		// inside it using the port.
-		// Thus, we keep it hidden and use it for testing only.
 		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
-		_ = f.MarkHidden(cliflags.Socket.Name)
 
 		StringFlag(f, &startCtx.listeningURLFile, cliflags.ListeningURLFile, startCtx.listeningURLFile)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1917,8 +1917,8 @@ func (s *Server) startServeSQL(
 			connCtx := logtags.AddTag(pgCtx, "client", conn.RemoteAddr().String())
 			tcpKeepAlive.configure(connCtx, conn)
 
-			if err := s.pgServer.ServeConn(connCtx, conn); err != nil {
-				log.Error(connCtx, err)
+			if err := s.pgServer.ServeConn(connCtx, conn, pgwire.SocketTCP); err != nil {
+				log.Errorf(connCtx, "serving SQL client conn: %v", err)
 			}
 		}))
 	})
@@ -1943,7 +1943,7 @@ func (s *Server) startServeSQL(
 		s.stopper.RunWorker(pgCtx, func(pgCtx context.Context) {
 			netutil.FatalIfUnexpected(connManager.ServeWith(pgCtx, s.stopper, unixLn, func(conn net.Conn) {
 				connCtx := logtags.AddTag(pgCtx, "client", conn.RemoteAddr().String())
-				if err := s.pgServer.ServeConn(connCtx, conn); err != nil {
+				if err := s.pgServer.ServeConn(connCtx, conn, pgwire.SocketUnix); err != nil {
 					log.Error(connCtx, err)
 				}
 			}))

--- a/pkg/sql/pgwire/hba/hba.go
+++ b/pkg/sql/pgwire/hba/hba.go
@@ -65,6 +65,10 @@ const (
 
 	// ConnHostAny matches TCP connections with or without SSL/TLS.
 	ConnHostAny = ConnHostNoSSL | ConnHostSSL
+
+	// ConnAny matches any connection type. Used when registering auth
+	// methods.
+	ConnAny = ConnHostAny | ConnLocal
 )
 
 // String implements the fmt.Formatter interface.
@@ -162,6 +166,18 @@ func (h Entry) ConnTypeMatches(clientConn ConnType) bool {
 	default:
 		panic("unimplemented")
 	}
+}
+
+// ConnMatches returns true iff the provided client connection
+// type and address matches the entry spec.
+func (h Entry) ConnMatches(clientConn ConnType, ip net.IP) (bool, error) {
+	if !h.ConnTypeMatches(clientConn) {
+		return false, nil
+	}
+	if clientConn != ConnLocal {
+		return h.AddressMatches(ip)
+	}
+	return true, nil
 }
 
 // UserMatches returns true iff the provided username matches the an

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -2,8 +2,9 @@
 #
 # An empty config is equivalent to:
 #
-#     host all root 0.0.0.0/0 cert
-#     host all all  0.0.0.0/0 cert-password
+#     host   all root all cert
+#     host   all all  all cert-password
+#     local  all all      password
 #
 # The server is secure, so the test runner sets sslmode=verify-full
 # by default for all test directives below with all other SSL settings loaded.
@@ -22,13 +23,19 @@ set_hba
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      root all     cert
 host   all      all  all     cert-password
+local  all      all          password
 
 subtest root
 
-# Root can always connect regardless.
+# Root can always connect over network regardless.
 connect user=root
 ----
 ok defaultdb
+
+# However root cannot connect over the unix socket by default.
+connect_unix user=root
+----
+ERROR: user root must use certificate authentication instead of password authentication
 
 # When no client cert is presented, the server would otherwise require
 # password auth. However, root password auth is rejected in any case.
@@ -41,10 +48,16 @@ subtest end root
 
 subtest normaluser_cert
 
-# User need no password, and we're presenting a client cert. All good.
+# User has no password, and we're presenting a client cert. All good.
 connect user=testuser
 ----
 ok defaultdb
+
+# Empty/no password means deny password auth. Unix socket does not
+# present a cert so auth fails.
+connect_unix user=testuser
+----
+ERROR: password authentication failed for user testuser
 
 # Make the user need a password.
 sql
@@ -63,6 +76,10 @@ connect user=testuser password=invalid sslmode=verify-ca sslcert=
 ERROR: password authentication failed for user testuser
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
+----
+ok defaultdb
+
+connect_unix user=testuser password=pass
 ----
 ok defaultdb
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -1,7 +1,8 @@
 # This verifies that the behavior with an empty HBA config
 # is equivalent to:
-#     host all root 0.0.0.0/0 cert
-#     host all all  0.0.0.0/0 cert-password
+#     host  all root all cert
+#     host  all all  all cert-password
+#     local all all      password
 # by using that explicit string and reproducing the tests
 # in the test file "empty_hba".
 
@@ -9,13 +10,15 @@ config secure
 ----
 
 set_hba
-host all root all cert
-host all all all cert-password
+host  all root all cert
+host  all all  all cert-password
+local all all      password
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      root all     cert
 host   all      all  all     cert-password
+local  all      all          password
 
 subtest root
 
@@ -24,7 +27,13 @@ connect user=root
 ----
 ok defaultdb
 
-# The rule has method "cert" so a cert is required in any case.
+# However root cannot connect over the unix socket.
+connect_unix user=root
+----
+ERROR: user root must use certificate authentication instead of password authentication
+
+# When no client cert is presented, the server would otherwise require
+# password auth. However, root password auth is rejected in any case.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
 ERROR: no TLS peer certificates, but required for auth
@@ -38,6 +47,12 @@ connect user=testuser
 ----
 ok defaultdb
 
+# Empty/no password means deny password auth. Unix socket does not
+# present a cert so auth fails.
+connect_unix user=testuser
+----
+ERROR: password authentication failed for user testuser
+
 # Make the user need a password.
 sql
 ALTER USER testuser WITH PASSWORD 'pass';
@@ -46,6 +61,10 @@ ok
 
 # Password now needed, but as long as we're presenting a cert it's good.
 connect user=testuser
+----
+ok defaultdb
+
+connect_unix user=testuser password=pass
 ----
 ok defaultdb
 

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -52,11 +52,3 @@ HINT: You have attempted to use a feature that is not yet implemented.<STANDARD 
 --
 List the numeric CIDR notation instead, for example: 127.0.0.1/8.
 Alternatively, use 'all' (without quotes) for any IPv4/IPv6 address.
-
-
-# CockroachDB does not yet support local rules.
-set_hba
-local all all cert
-----
-ERROR: unimplemented: unsupported connection type: local (SQLSTATE 0A000)
-HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>


### PR DESCRIPTION
Fixes #31113. cc @rolandcrosby 
(All commits except for the last from #43837 and #43843)

tldr: this patch makes unix sockets more production-ready,
by enabling clients to use unix sockets in secure mode
and enabling authentication over unix sockets.

**Motivation:**

[Unix domain
sockets](https://en.wikipedia.org/wiki/Unix_domain_socket) are a way
for a server process to accept direct in-memory connections from
processes running on the same machine as the server. They are simpler
and faster as they avoid the TCP/IP stack entirely.

Unix sockets are used both to provide a local client interface
for administrator users operating the system; as well as
setting up more complex authentication systems using the following
topology:

```
         client
           ^
           |
     (non-standard protocol)
           |
.----------|--------------(server machine)--------------------------.
|          v                                                        |
| ,----------------------.                   ,--------------------. |
| |  connection proxy    |                   | server process     | |
| |  and transport-level |<--(unix socket)-->| and authentication | |
| |   security           |                   | (e.g. crdb)        | |
| `----------------------'                   `--------------------' |
`-------------------------------------------------------------------'
```

**Description of this change:**

CockroachDB already supports setting up a unix socket for use by
clients running on the same machine, subject to regular Unix
permission checks.

Prior to this patch, support for unix sockets was incomplete:

- it would work properly for insecure nodes/clusters; however, ...
- ... in secure mode, it would also require a TLS handshake over
  the unix socket, which is neither supported by pg clients
  nor meaningful: unix domain sockets have transport-level
  security already.

This patch extends/fixes support for unix sockets as follows:

- it properly accepts client connections without TLS over
  unix sockets;
- it subjects incoming unix socket connections to the standard HBA
  rule-based authentication selection (via the cluster setting
  `server.host_based_authentication.configuration`);
- it changes the default HBA configuration to contain
  a default `local` rule that requires password
  authentication, in a way compatible with PostgreSQL;
- it un-hides the `--socket` parameter from the output of
  `cockroach start --help`.

Release note (cli change): Connections using Unix sockets are now
accepted even when the server is running in secure more.
(Consult `cockroach start --help` for details about the `--socket`
parameter.)

Release note (security): Connections using unix sockets are now
subject to the HBA rules defined via the setting
`server.host_based_authentication.configuration`, in a way compatible
with PostgreSQL: incoming unix connections match `local` rules,
whereas incoming TCP connections match `host` rules.
The default HBA configuration used when the cluster
setting is empty is now:

    host      all root all cert
    host      all all  all cert-password
    local     all all      password