### PR TITLE
build: make all of the logictest binaries depend on OPTGEN_TARGETS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1641,8 +1641,7 @@ logictest-bins := bin/logictest bin/logictestopt bin/logictestccl
 # TODO(benesch): Derive this automatically. This is getting out of hand.
 bin/workload bin/docgen bin/execgen bin/roachtest $(logictest-bins): $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
 bin/workload bin/roachtest $(logictest-bins): $(EXECGEN_TARGETS)
-bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES)
-bin/roachtest bin/logictestopt: $(OPTGEN_TARGETS)
+bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(OPTGEN_TARGETS)
 
 $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized
 	@echo go install -v $*


### PR DESCRIPTION
Fingers crossed this fixes the spurious failures for `make
testlogic`. The theory of that failure is that `bin/logictest` did not
have a dependency on `OPTGEN_TARGETS`. When `make testlogic` is run, the
testlogic rule is expanded to
`bin/logictest{,opt,ccl}`. `OPTGEN_TARGETS` could this be built in
parallel with `bin/logictest` being built.

Release note: None