### PR TITLE
colexec: use the same struct for buffering tuples

### DIFF
--- a/pkg/sql/colexec/buffered_batch.go
+++ b/pkg/sql/colexec/buffered_batch.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+)
+
+func newBufferedBatch(allocator *Allocator, types []coltypes.T, initialSize int) *bufferedBatch {
+	b := &bufferedBatch{
+		colVecs: make([]coldata.Vec, len(types)),
+	}
+	for i, t := range types {
+		b.colVecs[i] = allocator.NewMemColumn(t, initialSize)
+	}
+	return b
+}
+
+// bufferedBatch is a custom implementation of coldata.Batch interface (only
+// a subset of methods is implemented) which stores the length as uint64. It
+// should be used whenever we're doing possibly unbounded buffering of tuples.
+type bufferedBatch struct {
+	colVecs []coldata.Vec
+	length  uint64
+}
+
+var _ coldata.Batch = &bufferedBatch{}
+
+func (b *bufferedBatch) Length() uint16 {
+	execerror.VectorizedInternalPanic("Length() should not be called on bufferedBatch; instead, " +
+		"length field should be accessed directly")
+	// This code is unreachable, but the compiler cannot infer that.
+	return 0
+}
+
+func (b *bufferedBatch) SetLength(uint16) {
+	execerror.VectorizedInternalPanic("SetLength(uint16) should not be called on bufferedBatch;" +
+		"instead, length field should be accessed directly")
+}
+
+func (b *bufferedBatch) Width() int {
+	return len(b.colVecs)
+}
+
+func (b *bufferedBatch) ColVec(i int) coldata.Vec {
+	return b.colVecs[i]
+}
+
+func (b *bufferedBatch) ColVecs() []coldata.Vec {
+	return b.colVecs
+}
+
+// Selection is not implemented because the tuples should only be appended to
+// bufferedBatch, and Append does the deselection step.
+func (b *bufferedBatch) Selection() []uint16 {
+	return nil
+}
+
+// SetSelection is not implemented because the tuples should only be appended
+// to bufferedBatch, and Append does the deselection step.
+func (b *bufferedBatch) SetSelection(bool) {
+	execerror.VectorizedInternalPanic("SetSelection(bool) should not be called on bufferedBatch")
+}
+
+// AppendCol is not implemented because bufferedBatch is only initialized
+// when the column schema is known.
+func (b *bufferedBatch) AppendCol(coldata.Vec) {
+	execerror.VectorizedInternalPanic("AppendCol(coldata.Vec) should not be called on bufferedBatch")
+}
+
+// Reset is not implemented because bufferedBatch is not reused with
+// different column schemas at the moment.
+func (b *bufferedBatch) Reset(types []coltypes.T, length int) {
+	execerror.VectorizedInternalPanic("Reset([]coltypes.T, int) should not be called on bufferedBatch")
+}
+
+// ResetInternalBatch is not implemented because bufferedBatch is not meant
+// to be used by any operator other than its "owner", and the owner should be
+// using reset() instead.
+func (b *bufferedBatch) ResetInternalBatch() {
+	execerror.VectorizedInternalPanic("ResetInternalBatch() should not be called on bufferedBatch")
+}
+
+// reset resets the state of the buffered group so that we can reuse the
+// underlying memory. Note that the underlying memory is not released, so there
+// is no need to update memory account while performing this operation.
+func (b *bufferedBatch) reset() {
+	b.length = 0
+	for _, colVec := range b.colVecs {
+		// We do not need to reset the column vectors because those will be just
+		// written over, but we do need to reset the nulls.
+		colVec.Nulls().UnsetNulls()
+		if colVec.Type() == coltypes.Bytes {
+			// Bytes type is the only exception to the comment above.
+			colVec.Bytes().Reset()
+		}
+	}
+}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -221,7 +221,7 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 		// size, we can use it for the distinct vector.
 		op.distinct = op.ht.visited
 
-		for i := uint64(0); i < op.ht.size; i++ {
+		for i := uint64(0); i < op.ht.vals.length; i++ {
 			op.distinct[i] = false
 			for !op.ht.head[headID] || curID == 0 {
 				op.distinct[i] = true
@@ -239,8 +239,8 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 	nSelected := uint16(0)
 
 	batchEnd := op.batchStart + uint64(coldata.BatchSize())
-	if batchEnd > op.ht.size {
-		batchEnd = op.ht.size
+	if batchEnd > op.ht.vals.length {
+		batchEnd = op.ht.vals.length
 	}
 	nSelected = uint16(batchEnd - op.batchStart)
 
@@ -249,7 +249,7 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 	op.ht.allocator.PerformOperation(op.batch.ColVecs(), func() {
 		for i, colIdx := range op.ht.outCols {
 			toCol := op.batch.ColVec(i)
-			fromCol := op.ht.vals[colIdx]
+			fromCol := op.ht.vals.colVecs[colIdx]
 			toCol.Copy(
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
@@ -274,7 +274,7 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 // benchmarks.
 func (op *hashGrouper) reset() {
 	op.batchStart = 0
-	op.ht.size = 0
+	op.ht.vals.reset()
 	op.buildFinished = false
 }
 

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -394,7 +394,7 @@ func (ht *hashTable) checkCol(t coltypes.T, keyColIdx int, nToCheck uint16, sel 
 	switch t {
 	// {{range $neType := .NETemplate}}
 	case _TYPES_T:
-		buildVec := ht.vals[ht.keyCols[keyColIdx]]
+		buildVec := ht.vals.colVecs[ht.keyCols[keyColIdx]]
 		probeVec := ht.keys[keyColIdx]
 
 		buildKeys := buildVec._TemplateType()

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1069,8 +1069,8 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) setBuilderSourceToBuff
 	// We cannot yet reset the buffered groups because the builder will be taking
 	// input from them. The actual reset will take place on the next call to
 	// initProberState().
-	o.proberState.lBufferedGroup.needToReset = true
-	o.proberState.rBufferedGroup.needToReset = true
+	o.proberState.lBufferedGroupNeedToReset = true
+	o.proberState.rBufferedGroupNeedToReset = true
 }
 
 // exhaustLeftSource sets up the builder to process any remaining tuples from

--- a/pkg/sql/colexec/mergejoiner_util.go
+++ b/pkg/sql/colexec/mergejoiner_util.go
@@ -10,12 +10,6 @@
 
 package colexec
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
-)
-
 // circularGroupsBuffer is a struct designed to store the groups' slices for a
 // given column. We know that there is a maximum number of possible groups per
 // batch, so we can cap the buffer and make it circular.
@@ -221,98 +215,4 @@ func (b *circularGroupsBuffer) getGroups() ([]group, []group) {
 	}
 
 	return leftGroups[startIdx:endIdx], rightGroups[startIdx:endIdx]
-}
-
-func newMJBufferedGroup(allocator *Allocator, types []coltypes.T) *mjBufferedGroup {
-	bg := &mjBufferedGroup{
-		colVecs: make([]coldata.Vec, len(types)),
-	}
-	for i, t := range types {
-		bg.colVecs[i] = allocator.NewMemColumn(t, int(coldata.BatchSize()))
-	}
-	return bg
-}
-
-// mjBufferedGroup is a custom implementation of coldata.Batch interface (only
-// a subset of methods is implemented) which stores the length as uint64. This
-// allows for plugging it into the builder through the common interface.
-type mjBufferedGroup struct {
-	colVecs []coldata.Vec
-	length  uint64
-	// needToReset indicates whether the buffered group should be reset on the
-	// call to reset().
-	needToReset bool
-}
-
-var _ coldata.Batch = &mjBufferedGroup{}
-
-func (bg *mjBufferedGroup) Length() uint16 {
-	execerror.VectorizedInternalPanic("Length() should not be called on mjBufferedGroup; instead, " +
-		"length field should be accessed directly")
-	// This code is unreachable, but the compiler cannot infer that.
-	return 0
-}
-
-func (bg *mjBufferedGroup) SetLength(uint16) {
-	execerror.VectorizedInternalPanic("SetLength(uint16) should not be called on mjBufferedGroup;" +
-		"instead, length field should be accessed directly")
-}
-
-func (bg *mjBufferedGroup) Width() int {
-	return len(bg.colVecs)
-}
-
-func (bg *mjBufferedGroup) ColVec(i int) coldata.Vec {
-	return bg.colVecs[i]
-}
-
-func (bg *mjBufferedGroup) ColVecs() []coldata.Vec {
-	return bg.colVecs
-}
-
-// Selection is not implemented because the tuples should only be appended to
-// mjBufferedGroup, and Append does the deselection step.
-func (bg *mjBufferedGroup) Selection() []uint16 {
-	return nil
-}
-
-// SetSelection is not implemented because the tuples should only be appended
-// to mjBufferedGroup, and Append does the deselection step.
-func (bg *mjBufferedGroup) SetSelection(bool) {
-	execerror.VectorizedInternalPanic("SetSelection(bool) should not be called on mjBufferedGroup")
-}
-
-// AppendCol is not implemented because mjBufferedGroup is only initialized
-// when the column schema is known.
-func (bg *mjBufferedGroup) AppendCol(coldata.Vec) {
-	execerror.VectorizedInternalPanic("AppendCol(coldata.Vec) should not be called on mjBufferedGroup")
-}
-
-// Reset is not implemented because mjBufferedGroup is not reused with
-// different column schemas at the moment.
-func (bg *mjBufferedGroup) Reset(types []coltypes.T, length int) {
-	execerror.VectorizedInternalPanic("Reset([]coltypes.T, int) should not be called on mjBufferedGroup")
-}
-
-// ResetInternalBatch is not implemented because mjBufferedGroup is not meant
-// to be used by any operator other than the merge joiner, and it should be
-// using reset() instead.
-func (bg *mjBufferedGroup) ResetInternalBatch() {
-	execerror.VectorizedInternalPanic("ResetInternalBatch() should not be called on mjBufferedGroup")
-}
-
-// reset resets the state of the buffered group so that we can reuse the
-// underlying memory.
-func (bg *mjBufferedGroup) reset() {
-	bg.length = 0
-	bg.needToReset = false
-	for _, colVec := range bg.colVecs {
-		// We do not need to reset the column vectors because those will be just
-		// written over, but we do need to reset the nulls.
-		colVec.Nulls().UnsetNulls()
-		if colVec.Type() == coltypes.Bytes {
-			// Bytes type is the only exception to the comment above.
-			colVec.Bytes().Reset()
-		}
-	}
 }


### PR DESCRIPTION
Previously, all buffering components (allSpooler, chunker, merge joiner,
hash table) were using custom ways to store the buffered tuples (as
a slice of coldata.Vec's with uint64 length). However, the intention is
the same, and this commit renames existing mjBufferedGroup to
bufferedBatch. The latter is now used in all buffering components.

Release note: None