### PR TITLE
sqlsmith: prevent deadlock during multiple go routines

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -65,7 +65,7 @@ func (s *Smither) getRandTable() (*aliasedTableRef, bool) {
 		return nil, false
 	}
 	table := s.tables[s.rnd.Intn(len(s.tables))]
-	indexes := s.getIndexes(*table.TableName)
+	indexes := s.indexes[*table.TableName]
 	var indexFlags tree.IndexFlags
 	if s.coin() {
 		indexNames := make([]tree.Name, 0, len(indexes))
@@ -85,16 +85,12 @@ func (s *Smither) getRandTable() (*aliasedTableRef, bool) {
 	return aliased, true
 }
 
-func (s *Smither) getIndexes(table tree.TableName) map[tree.Name]*tree.CreateIndex {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.indexes[table]
-}
-
 func (s *Smither) getRandTableIndex(
 	table, alias tree.TableName,
 ) (*tree.TableIndexName, *tree.CreateIndex, colRefs, bool) {
-	indexes := s.getIndexes(table)
+	s.lock.RLock()
+	indexes := s.indexes[table]
+	s.lock.RUnlock()
 	if len(indexes) == 0 {
 		return nil, nil, nil, false
 	}


### PR DESCRIPTION
When multiple go routines are attempting to generate a statement it could
previously deadlock. While multiple RLocks can be acquired by the same
go routine (as previously done here), if another go routine is waiting
on a normal write Lock, then the second RLock will block to attempt to
allow the write Lock to proceed. But the write Lock can't since an RLock
is already being held, preventing progress.

Fix this by removing the getIndexes func and lock, and forcing users of
the indexes property to manage locks themselves.

Release note: None