### PR TITLE
colexec: fix a bug of short-circuiting column append in cast

### DIFF
--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -183,12 +183,12 @@ func (c *castOp_FROMTYPE_TOTYPE) Init() {
 
 func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
+	if c.outputIdx == batch.Width() {
+		c.allocator.AppendColumn(batch, coltypes._TOTYPE)
+	}
 	n := batch.Length()
 	if n == 0 {
 		return batch
-	}
-	if c.outputIdx == batch.Width() {
-		c.allocator.AppendColumn(batch, coltypes._TOTYPE)
 	}
 	vec := batch.ColVec(c.colIdx)
 	col := vec._FROMTYPE()

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1047,3 +1047,11 @@ query I
 SELECT CASE WHEN a = 0 THEN a ELSE 1:::INT8 END FROM t43550
 ----
 1
+
+# Regression test for #43855.
+statement ok
+CREATE TABLE t43855(o OID, r REGPROCEDURE)
+
+query i
+SELECT CASE WHEN o = 0 THEN 0:::OID ELSE r END FROM t43855
+----


### PR DESCRIPTION
We were short-circuiting the appending of a new column in CAST operator
if its input returned zero-length batch. Unfortunately, it is not
allowed and breaks the indices assumptions elsewhere, so it has been
fixed.

Fixes: #43855.

Release note (bug fix): Previously, CockroachDB could return an internal
error when running a query with a CAST operation (`:::`) in some cases
if vectorized execution engine is used, and now this is fixed.