### PR TITLE
keys: outline the crdb keyspace layout

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -33,8 +33,14 @@ const (
 
 // Constants for system-reserved keys in the KV map.
 //
-// Note: preserve group-wise ordering when adding new constants.
+// Note: Preserve group-wise ordering when adding new constants.
+// Note: Update `keymap` in doc.go when adding new constants.
 var (
+	// MinKey is a minimum key value which sorts before all other keys.
+	MinKey = roachpb.KeyMin
+	// MaxKey is the infinity marker which is larger than any other key.
+	MaxKey = roachpb.KeyMax
+
 	// localPrefix is the prefix for all local keys.
 	localPrefix = roachpb.Key{localPrefixByte}
 	// LocalMax is the end of the local key range. It is itself a global
@@ -45,45 +51,11 @@ var (
 	// key suffixes.
 	localSuffixLength = 4
 
-	// There are three types of local key data enumerated below:
-	// store-local, range-local by ID, and range-local by key.
-
-	// localStorePrefix is the prefix identifying per-store data.
-	localStorePrefix = makeKey(localPrefix, roachpb.Key("s"))
-	// localStoreIdentSuffix stores an immutable identifier for this
-	// store, created when the store is first bootstrapped.
-	localStoreIdentSuffix = []byte("iden")
-	// localStoreGossipSuffix stores gossip bootstrap metadata for this
-	// store, updated any time new gossip hosts are encountered.
-	localStoreGossipSuffix = []byte("goss")
-	// localStoreClusterVersionSuffix stores the cluster-wide version
-	// information for this store, updated any time the operator
-	// updates the minimum cluster version.
-	localStoreClusterVersionSuffix = []byte("cver")
-	// localStoreLastUpSuffix stores the last timestamp that a store's node
-	// acknowledged that it was still running. This value will be regularly
-	// refreshed on all stores for a running node; the intention of this value
-	// is to allow a restarting node to discover approximately how long it has
-	// been down without needing to retrieve liveness records from the cluster.
-	localStoreLastUpSuffix = []byte("uptm")
-	// localHLCUpperBoundSuffix stores an upper bound to the wall time used by
-	// the HLC.
-	localHLCUpperBoundSuffix = []byte("hlcu")
-	// localStoreSuggestedCompactionSuffix stores suggested compactions to
-	// be aggregated and processed on the store.
-	localStoreSuggestedCompactionSuffix = []byte("comp")
-
-	// localRemovedLeakedRaftEntriesSuffix is DEPRECATED and remains to prevent reuse.
-	localRemovedLeakedRaftEntriesSuffix = []byte("dlre")
-	_                                   = localRemovedLeakedRaftEntriesSuffix
-
-	// LocalStoreSuggestedCompactionsMin is the start of the span of
-	// possible suggested compaction keys for a store.
-	LocalStoreSuggestedCompactionsMin = MakeStoreKey(localStoreSuggestedCompactionSuffix, nil)
-	// LocalStoreSuggestedCompactionsMax is the end of the span of
-	// possible suggested compaction keys for a store.
-	LocalStoreSuggestedCompactionsMax = LocalStoreSuggestedCompactionsMin.PrefixEnd()
-
+	// There are four types of local key data enumerated below: replicated
+	// range-ID, unreplicated range-ID, range local, and store-local keys.
+	//
+	// 1. Replicated Range-ID keys
+	//
 	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Range ID. The Range ID is appended to this prefix,
 	// encoded using EncodeUvarint. The specific sort of per-range
@@ -94,7 +66,6 @@ var (
 	// NOTE: LocalRangeIDPrefix must be kept in sync with the value
 	// in storage/engine/rocksdb/db.cc.
 	LocalRangeIDPrefix = roachpb.RKey(makeKey(localPrefix, roachpb.Key("i")))
-
 	// LocalRangeIDReplicatedInfix is the post-Range ID specifier for all Raft
 	// replicated per-range data. By appending this after the Range ID, these
 	// keys will be sorted directly before the local unreplicated keys for the
@@ -113,24 +84,29 @@ var (
 	// LocalRangeAppliedStateSuffix is the suffix for the range applied state
 	// key.
 	LocalRangeAppliedStateSuffix = []byte("rask")
+	// LocalRaftTombstoneSuffix is the suffix for the raft tombstone.
+	// Note: This suffix is also used for unreplicated Range-ID keys.
+	LocalRaftTombstoneSuffix = []byte("rftb")
 	// LocalRaftAppliedIndexLegacySuffix is the suffix for the raft applied index.
 	LocalRaftAppliedIndexLegacySuffix = []byte("rfta")
-	// LocalRaftTombstoneSuffix is the suffix for the raft tombstone.
-	LocalRaftTombstoneSuffix = []byte("rftb")
-	// LocalRaftTruncatedStateLegacySuffix is the suffix for the legacy RaftTruncatedState.
-	// See VersionUnreplicatedRaftTruncatedState.
+	// LocalRaftTruncatedStateLegacySuffix is the suffix for the legacy
+	// RaftTruncatedState. See VersionUnreplicatedRaftTruncatedState.
+	// Note: This suffix is also used for unreplicated Range-ID keys.
 	LocalRaftTruncatedStateLegacySuffix = []byte("rftt")
 	// LocalRangeLeaseSuffix is the suffix for a range lease.
 	LocalRangeLeaseSuffix = []byte("rll-")
-	// LocalLeaseAppliedIndexLegacySuffix is the suffix for the applied lease index.
+	// LocalLeaseAppliedIndexLegacySuffix is the suffix for the applied lease
+	// index.
 	LocalLeaseAppliedIndexLegacySuffix = []byte("rlla")
 	// LocalRangeStatsLegacySuffix is the suffix for range statistics.
 	LocalRangeStatsLegacySuffix = []byte("stat")
 	// LocalTxnSpanGCThresholdSuffix is the suffix for the last txn span GC's
-	// threshold.
-	// No longer used; exists only to reserve the key so we don't use it.
+	// threshold. No longer used; exists only to reserve the key so we don't use
+	// it.
 	LocalTxnSpanGCThresholdSuffix = []byte("tst-")
 
+	// 2. Unreplicated Range-ID keys
+	//
 	// localRangeIDUnreplicatedInfix is the post-Range ID specifier for all
 	// per-range data that is not fully Raft replicated. By appending this
 	// after the Range ID, these keys will be sorted directly after the local
@@ -143,13 +119,16 @@ var (
 	LocalRaftLastIndexSuffix = []byte("rfti")
 	// LocalRaftLogSuffix is the suffix for the raft log.
 	LocalRaftLogSuffix = []byte("rftl")
-	// LocalRangeLastReplicaGCTimestampSuffix is the suffix for a range's
-	// last replica GC timestamp (for GC of old replicas).
+	// LocalRangeLastReplicaGCTimestampSuffix is the suffix for a range's last
+	// replica GC timestamp (for GC of old replicas).
 	LocalRangeLastReplicaGCTimestampSuffix = []byte("rlrt")
-	// LocalRangeLastVerificationTimestampSuffixDeprecated is the suffix for a range's
-	// last verification timestamp (for checking integrity of on-disk data).
-	// Note: DEPRECATED.
+	// LocalRangeLastVerificationTimestampSuffixDeprecated is the suffix for a
+	// range's last verification timestamp (for checking integrity of on-disk
+	// data). Note: DEPRECATED.
 	LocalRangeLastVerificationTimestampSuffixDeprecated = []byte("rlvt")
+
+	// 3. Range local keys
+	//
 	// LocalRangePrefix is the prefix identifying per-range data indexed
 	// by range key (either start key, or some key in the range). The
 	// key is appended to this prefix, encoded using EncodeBytes. The
@@ -161,46 +140,87 @@ var (
 	// storage/engine/rocksdb/db.cc.
 	LocalRangePrefix = roachpb.Key(makeKey(localPrefix, roachpb.RKey("k")))
 	LocalRangeMax    = LocalRangePrefix.PrefixEnd()
-	// LocalRangeDescriptorSuffix is the suffix for keys storing
-	// range descriptors. The value is a struct of type RangeDescriptor.
-	LocalRangeDescriptorSuffix = roachpb.RKey("rdsc")
+	// LocalQueueLastProcessedSuffix is the suffix for replica queue state keys.
+	LocalQueueLastProcessedSuffix = roachpb.RKey("qlpt")
 	// LocalRangeDescriptorJointSuffix is the suffix for keys storing
 	// range descriptors. The value is a struct of type RangeDescriptor.
 	//
 	// TODO(tbg): decide what to actually store here. This is still unused.
 	LocalRangeDescriptorJointSuffix = roachpb.RKey("rdjt")
+	// LocalRangeDescriptorSuffix is the suffix for keys storing
+	// range descriptors. The value is a struct of type RangeDescriptor.
+	LocalRangeDescriptorSuffix = roachpb.RKey("rdsc")
 	// LocalTransactionSuffix specifies the key suffix for
 	// transaction records. The additional detail is the transaction id.
 	// NOTE: if this value changes, it must be updated in C++
 	// (storage/engine/rocksdb/db.cc).
 	LocalTransactionSuffix = roachpb.RKey("txn-")
-	// LocalQueueLastProcessedSuffix is the suffix for replica queue state keys.
-	LocalQueueLastProcessedSuffix = roachpb.RKey("qlpt")
 
-	// Meta1Prefix is the first level of key addressing. It is selected such that
-	// all range addressing records sort before any system tables which they
-	// might describe. The value is a RangeDescriptor struct.
-	Meta1Prefix = roachpb.Key{meta1PrefixByte}
-	// Meta2Prefix is the second level of key addressing. The value is a
-	// RangeDescriptor struct.
-	Meta2Prefix = roachpb.Key{meta2PrefixByte}
-	// Meta1KeyMax is the end of the range of the first level of key addressing.
-	// The value is a RangeDescriptor struct.
-	Meta1KeyMax = roachpb.Key(makeKey(Meta1Prefix, roachpb.RKeyMax))
-	// Meta2KeyMax is the end of the range of the second level of key addressing.
-	// The value is a RangeDescriptor struct.
-	Meta2KeyMax = roachpb.Key(makeKey(Meta2Prefix, roachpb.RKeyMax))
+	// 4. Store local keys
+	//
+	// localStorePrefix is the prefix identifying per-store data.
+	localStorePrefix = makeKey(localPrefix, roachpb.Key("s"))
+	// localStoreSuggestedCompactionSuffix stores suggested compactions to
+	// be aggregated and processed on the store.
+	localStoreSuggestedCompactionSuffix = []byte("comp")
+	// localStoreClusterVersionSuffix stores the cluster-wide version
+	// information for this store, updated any time the operator
+	// updates the minimum cluster version.
+	localStoreClusterVersionSuffix = []byte("cver")
+	// localStoreGossipSuffix stores gossip bootstrap metadata for this
+	// store, updated any time new gossip hosts are encountered.
+	localStoreGossipSuffix = []byte("goss")
+	// localStoreHLCUpperBoundSuffix stores an upper bound to the wall time used by
+	// the HLC.
+	localStoreHLCUpperBoundSuffix = []byte("hlcu")
+	// localStoreIdentSuffix stores an immutable identifier for this
+	// store, created when the store is first bootstrapped.
+	localStoreIdentSuffix = []byte("iden")
+	// localStoreLastUpSuffix stores the last timestamp that a store's node
+	// acknowledged that it was still running. This value will be regularly
+	// refreshed on all stores for a running node; the intention of this value
+	// is to allow a restarting node to discover approximately how long it has
+	// been down without needing to retrieve liveness records from the cluster.
+	localStoreLastUpSuffix = []byte("uptm")
+	//
+	// localRemovedLeakedRaftEntriesSuffix is DEPRECATED and remains to prevent reuse.
+	localRemovedLeakedRaftEntriesSuffix = []byte("dlre")
+	_                                   = localRemovedLeakedRaftEntriesSuffix
+	// LocalStoreSuggestedCompactionsMin is the start of the span of
+	// possible suggested compaction keys for a store.
+	LocalStoreSuggestedCompactionsMin = MakeStoreKey(localStoreSuggestedCompactionSuffix, nil)
+	// LocalStoreSuggestedCompactionsMax is the end of the span of
+	// possible suggested compaction keys for a store.
+	LocalStoreSuggestedCompactionsMax = LocalStoreSuggestedCompactionsMin.PrefixEnd()
 
+	// The global keyspace includes the meta{1,2}, system, and SQL keys.
+
+	// 1. Meta keys
+	//
 	// MetaMin is the start of the range of addressing keys.
 	MetaMin = Meta1Prefix
 	// MetaMax is the end of the range of addressing keys.
 	MetaMax = roachpb.Key{metaMaxByte}
+	// Meta1Prefix is the first level of key addressing. It is selected such that
+	// all range addressing records sort before any system tables which they
+	// might describe. The value is a RangeDescriptor struct.
+	Meta1Prefix = roachpb.Key{meta1PrefixByte}
+	// Meta1KeyMax is the end of the range of the first level of key addressing.
+	// The value is a RangeDescriptor struct.
+	Meta1KeyMax = roachpb.Key(makeKey(Meta1Prefix, roachpb.RKeyMax))
+	// Meta2Prefix is the second level of key addressing. The value is a
+	// RangeDescriptor struct.
+	Meta2Prefix = roachpb.Key{meta2PrefixByte}
+	// Meta2KeyMax is the end of the range of the second level of key addressing.
+	// The value is a RangeDescriptor struct.
+	Meta2KeyMax = roachpb.Key(makeKey(Meta2Prefix, roachpb.RKeyMax))
 
+	// 1. System keys
+	//
 	// SystemPrefix indicates the beginning of the key range for
 	// global, system data which are replicated across the cluster.
 	SystemPrefix = roachpb.Key{systemPrefixByte}
 	SystemMax    = roachpb.Key{systemMaxByte}
-
 	// NodeLivenessPrefix specifies the key prefix for the node liveness
 	// table.  Note that this should sort before the rest of the system
 	// keyspace in order to limit the number of ranges which must use
@@ -208,26 +228,15 @@ var (
 	// node-liveness epoch-based range leases (see
 	// https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20160210_range_leases.md)
 	NodeLivenessPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("\x00liveness-")))
-
 	// NodeLivenessKeyMax is the maximum value for any node liveness key.
 	NodeLivenessKeyMax = NodeLivenessPrefix.PrefixEnd()
-
+	//
 	// BootstrapVersion is the key at which clusters bootstrapped with a version
 	// > 1.0 persist the version at which they were bootstrapped.
 	BootstrapVersionKey = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("bootstrap-version")))
-
-	// MigrationPrefix specifies the key prefix to store all migration details.
-	MigrationPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("system-version/")))
-
-	// MigrationLease is the key that nodes must take a lease on in order to run
-	// system migrations on the cluster.
-	MigrationLease = roachpb.Key(makeKey(MigrationPrefix, roachpb.RKey("lease")))
-
-	// MigrationKeyMax is the maximum value for any system migration key.
-	MigrationKeyMax = MigrationPrefix.PrefixEnd()
-
 	// DescIDGenerator is the global descriptor ID generator sequence used for
 	// table and namespace IDs.
+	//
 	DescIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("desc-idgen")))
 	// NodeIDGenerator is the global node ID generator sequence.
 	NodeIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("node-idgen")))
@@ -235,42 +244,47 @@ var (
 	RangeIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("range-idgen")))
 	// StoreIDGenerator is the global store ID generator sequence.
 	StoreIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("store-idgen")))
-
 	// StatusPrefix specifies the key prefix to store all status details.
+	//
 	StatusPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("status-")))
 	// StatusNodePrefix stores all status info for nodes.
 	StatusNodePrefix = roachpb.Key(makeKey(StatusPrefix, roachpb.RKey("node-")))
-
+	//
+	// MigrationPrefix specifies the key prefix to store all migration details.
+	MigrationPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("system-version/")))
+	// MigrationLease is the key that nodes must take a lease on in order to run
+	// system migrations on the cluster.
+	MigrationLease = roachpb.Key(makeKey(MigrationPrefix, roachpb.RKey("lease")))
+	// MigrationKeyMax is the maximum value for any system migration key.
+	MigrationKeyMax = MigrationPrefix.PrefixEnd()
+	//
 	// TimeseriesPrefix is the key prefix for all timeseries data.
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 	// TimeseriesKeyMax is the maximum value for any timeseries data.
 	TimeseriesKeyMax = TimeseriesPrefix.PrefixEnd()
 
+	// 3. SQL keys
+	//
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = roachpb.Key(MakeTablePrefix(0))
 	// TableDataMin is the end of the range of table data keys.
 	TableDataMax = roachpb.Key(MakeTablePrefix(math.MaxUint32))
-
+	//
 	// SystemConfigSplitKey is the key to split at immediately prior to the
 	// system config span. NB: Split keys need to be valid column keys.
 	// TODO(bdarnell): this should be either roachpb.Key or RKey, not []byte.
 	SystemConfigSplitKey = []byte(TableDataMin)
 	// SystemConfigTableDataMax is the end key of system config span.
 	SystemConfigTableDataMax = roachpb.Key(MakeTablePrefix(MaxSystemConfigDescID + 1))
-
-	// UserTableDataMin is the start key of user structured data.
-	UserTableDataMin = roachpb.Key(MakeTablePrefix(MinUserDescID))
-
-	// MaxKey is the infinity marker which is larger than any other key.
-	MaxKey = roachpb.KeyMax
-	// MinKey is a minimum key value which sorts before all other keys.
-	MinKey = roachpb.KeyMin
-
+	//
 	// NamespaceTableMin is the start key of system.namespace, which is a system
 	// table that does not reside in the same range as other system tables.
 	NamespaceTableMin = roachpb.Key(MakeTablePrefix(NamespaceTableID))
 	// NamespaceTableMax is the end key of system.namespace.
 	NamespaceTableMax = roachpb.Key(MakeTablePrefix(NamespaceTableID + 1))
+	//
+	// UserTableDataMin is the start key of user structured data.
+	UserTableDataMin = roachpb.Key(MakeTablePrefix(MinUserDescID))
 )
 
 // Various IDs used by the structured data layer.

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -17,11 +17,17 @@
 // dependency cycles. For example, EnsureSafeSplitKey knows far too much about
 // how to decode SQL keys.
 //
+// 1. Overview
+//
 // This is the ten-thousand foot view of the keyspace:
 //
 //    +----------+
 //    | (empty)  | /Min
-//    | \x01...  | /Local
+//    | \x01...  | /Local    ----+
+//    |          |               |
+//    | ...      |               |	local keys
+//    |          |               |
+//    |          |           ----+
 //    | \x02...  | /Meta1    ----+
 //    | \x03...  | /Meta2        |
 //    | \x04...  | /System       |
@@ -39,66 +45,200 @@
 // When keys are pretty printed, the logical name to the right of the table is
 // shown instead of the raw byte sequence.
 //
-// Non-local key types (i.e., meta1, meta2, system, and SQL keys) are
-// collectively referred to as "global" keys. The empty key (/Min) is a special
-// case. No data is stored there, but it is used as the start key of the first
-// range descriptor and as the starting point for some scans, in which case it
-// acts like a global key.
 //
-// Key addressing
+// 1. Key Ranges
 //
 // The keyspace is divided into contiguous, non-overlapping chunks called
 // "ranges." A range is defined by its start and end keys. For example, a range
 // might span from [/Table/1, /Table/2), where the lower bound is inclusive and
 // the upper bound is exclusive. Any key that begins with /Table/1, like
-// /Table/1/SomePrimaryKeyValue..., would belong to this range. Range boundaries
-// are always global keys.
+// /Table/1/SomePrimaryKeyValue..., would belong to this range. Key ranges
+// exist over the "resolved" keyspace, refer to the "Key Addressing" section
+// below for more details.
 //
-// Local keys are special. They do not belong to the range they would naturally
-// sort into. Instead, they have an "address" that is used to determine which
-// range they sort into. For example, the key /Local/Range/Table/1 would
-// naturally sort into the range [/Min, /System), but its address is /Table/1,
-// so it actually belongs to a range like [/Table1, /Table/2). Note that not
-// every local key has an address.
 //
-// Global keys have an address too, but the address is simply the key itself.
+// 2. Local vs. Global Keys
 //
-// To retrieve a key's address, use the Addr function.
+// There are broadly two types of keys, "local" and "global":
 //
-// Local keys
+//  (i) Local keys, such as store- and range-specific metadata, are keys that
+//  must be physically collocated with the store and/or ranges they refer to but
+//  also logically separated so that they do not pollute the user key space.
+//  This is further elaborated on in the "Key Addressing" section below. Local
+//  data also includes data "local" to a node, such as the store metadata and
+//  the raft log, which is where the name originated.
 //
-// Local keys hold data local to a RocksDB instance, such as store- and
-// range-specific metadata which must not pollute the user key space, but must
-// be collocated with the store and/or ranges which they refer to. Storing this
-// information in the global keyspace would place the data on an arbitrary set
-// of stores, with no guarantee of collocation. Local data includes store
-// metadata, range metadata, abort cache values and transaction records.
+//  (ii) Non-local keys (for e.g. meta1, meta2, system, and SQL keys) are
+//  collectively referred to as "global" keys.
 //
-// The local key prefix was chosen arbitrarily. Local keys would work just as
-// well with a different prefix, like 0xff, or even with a suffix.
+// NB: The empty key (/Min) is a special case. No data is stored there, but it
+// is used as the start key of the first range descriptor and as the starting
+// point for some scans, in which case it acts like a global key.
 //
-// There are four kinds of local keys.
+// (Check `keymap` below for a more precise breakdown of the local and global
+// keyspace.)
 //
-//   - Store local keys contain metadata about an individual store. They are
-//     unreplicated and unaddressable. The typical example is the store 'ident'
-//     record.
 //
-//   - Unreplicated range-ID local keys contain metadata that pertains to just
-//     one replica of a range. They are unreplicated and unaddressable. The
-//     typical example is the Raft log.
+// 2. Key Addressing
 //
-//   - Replicated range-ID local keys store metadata that pertains to a range as
-//     a whole. Though they are replicated, they are unaddressable. Typical
-//     examples are MVCC stats and the abort span.
+// We also have this concept of the "address" for a key. Keys get "resolved"
+// using `keys.Addr`, through which we're able to lookup the range "containing"
+// the key. For global keys, the resolved key is the key itself.
 //
-//   - Range local keys also store metadata that pertains to a range as a whole.
-//     They are replicated and addressable. Typical examples are the local
-//     range descriptor and transaction records.
+// Local keys are special. For certain kinds of local keys (namely, addressable
+// ones), the resolved key is obtained by stripping out the local key prefix,
+// suffix, and optional details (refer to `keymap` below to understand how local
+// keys are constructed). This level of indirection was introduced so that we
+// could logically sort these local keys into a range other than what a
+// strictly physical key based sort would entail. For example, the key
+// /Local/Range/Table/1 would naturally sort into the range [/Min, /System), but
+// its "address" is /Table/1, so it actually belongs to a range like [/Table1,
+// /Table/2).
 //
-// Deciding between replicated range-ID local keys and (replicated) range local
-// keys is not entirely straightforward, as the two key types serve similar
-// purposes. Note that only addressable keys, like range local keys, can be the
-// target of KV operations. Unaddressable keys, like range-ID local keys, can
-// only be written as a side-effect of other KV operations. This often makes the
-// choice between the two clear.
+// Consider the motivating example: we want to store a copy of the range
+// descriptor in a key that's both (a) a part of the range, and (b) does not
+// require us to remove a portion of the keyspace from the user (say by
+// reserving some key suffix). Storing this information in the global keyspace
+// would place the data on an arbitrary set of stores, with no guarantee of
+// collocation. By being able to logically sort the range descriptor key next to
+// the range itself, we're able to collocate the two.
+//
+//
+// 3. (replicated) Range-ID local keys vs. Range local keys
+//
+// Deciding between replicated range-ID local keys and range local keys is not
+// entirely straightforward, as the two key types serve similar purposes.
+// Range-ID keys, as the name suggests, use the range-ID in the key. Range local
+// keys instead use a key within the range bounds. Range-ID keys are not
+// addressable whereas range-local keys are. Note that only addressable keys can
+// be the target of KV operations, unaddressable keys can only be written as a
+// side-effect of other KV operations. This can often makes the choice between
+// the two clear (range descriptor keys needing to be addressable, and therefore
+// being a range local key is one example of this).
+//
+// The "behavioral" difference between range local keys and range-id local keys
+// is that range local keys split and merge along range boundaries while
+// range-id local keys don't. We want to move as little data as possible during
+// splits and merges (in fact, we don't re-write any data during splits), and
+// that generally determines which data sits where. If we want the split point
+// of a range to dictate where certain keys end up, then they're likely meant to
+// be range local keys. If not, they're meant to be range-ID local keys. Any key
+// we need to re-write during splits/merges will needs to go through Raft. We
+// have limits set on the size of Raft proposals so we generally don’t want to
+// be re-writing lots of data.
+//
+// This naturally leads to range-id local keys being used to store metadata
+// about a specific Range and range local keys being used to store metadata
+// about specific "global" keys. Let us consider transaction record keys for
+// example (ignoring for a second we also need them to be addressable). Hot
+// ranges could potentially have lots of transaction keys. Keys destined for the
+// RHS of the split need to be collocated with the RHS range. By categorizing
+// them as as range local keys, we avoid needing to re-write them during splits
+// as they automatically sort into the new range boundaries. If they were
+// range-ID local keys, we'd have to update each transaction key with the new
+// range ID.
 package keys
+
+// NB: The sorting order of the symbols below map to the physical layout.
+// Preserve group-wise ordering when adding new constants.
+var keymap = [...]interface{}{ // lint:ignore U1001
+	MinKey,
+
+	// There are four types of local key data enumerated below: replicated
+	// range-ID, unreplicated range-ID, range local, and store-local keys.
+	// Local keys are constructed using a prefix, an optional infix, and a
+	// suffix. The prefix and infix are used to disambiguate between the four
+	// types of local keys listed above, and determines inter-group ordering.
+	// The string comment next to each symbol below is the suffix pertaining to
+	// the corresponding key (and determines intra-group ordering).
+	// 	  - RangeID replicated keys all share `LocalRangeIDPrefix` and
+	// 		`LocalRangeIDReplicatedInfix`.
+	// 	  - RangeID unreplicated keys all share `LocalRangeIDPrefix` and
+	// 		`localRangeIDUnreplicatedInfix`.
+	// 	  - Range local keys all share `LocalRangePrefix`.
+	//	  - Store keys all share `localStorePrefix`.
+	//
+	// `LocalRangeIDPrefix`, `localRangePrefix` and `localStorePrefix` all in
+	// turn share `localPrefix`. `localPrefix` was chosen arbitrarily. Local
+	// keys would work just as well with a different prefix, like 0xff, or even
+	// with a suffix.
+
+	//   1. Replicated range-ID local keys: These store metadata pertaining to a
+	//   range as a whole. Though they are replicated, they are unaddressable.
+	//   Typical examples are MVCC stats and the abort span. They all share
+	//   `LocalRangeIDPrefix` and `LocalRangeIDReplicatedInfix`.
+	AbortSpanKey,                    // "abc-"
+	RangeFrozenStatusKey,            // "fzn-"
+	RangeLastGCKey,                  // "lgc-"
+	RangeAppliedStateKey,            // "rask"
+	RaftAppliedIndexLegacyKey,       // "rfta"
+	RaftTombstoneIncorrectLegacyKey, // "rftb"
+	RaftTruncatedStateLegacyKey,     // "rftt"
+	RangeLeaseKey,                   // "rll-"
+	LeaseAppliedIndexLegacyKey,      // "rlla"
+	RangeStatsLegacyKey,             // "stat"
+	RangeTxnSpanGCThresholdKey,      // "tst-"
+
+	//   2. Unreplicated range-ID local keys: These contain metadata that
+	//   pertain to just one replica of a range. They are unreplicated and
+	//   unaddressable. The typical example is the Raft log. They all share
+	//   `LocalRangeIDPrefix` and `localRangeIDUnreplicatedInfix`.
+	RaftTombstoneKey,               // "rftb"
+	RaftHardStateKey,               // "rfth"
+	RaftLastIndexKey,               // "rfti"
+	RaftLogKey,                     // "rftl"
+	RaftTruncatedStateKey,          // "rftt"
+	RangeLastReplicaGCTimestampKey, // "rlrt"
+	RangeLastVerificationTimestampKeyDeprecated, // "rlvt"
+
+	//   3. Range local keys: These also store metadata that pertains to a range
+	//   as a whole. They are replicated and addressable. Typical examples are
+	//   the range descriptor and transaction records. They all share
+	//   `LocalRangePrefix`.
+	QueueLastProcessedKey,   // "qlpt"
+	RangeDescriptorJointKey, // "rdjt"
+	RangeDescriptorKey,      // "rdsc"
+	TransactionKey,          // "txn-"
+
+	//   4. Store local keys: These contain metadata about an individual store.
+	//   They are unreplicated and unaddressable. The typical example is the
+	//   store 'ident' record. They all share `localStorePrefix`.
+	StoreSuggestedCompactionKey, // "comp"
+	StoreClusterVersionKey,      // "cver"
+	StoreGossipKey,              // "goss"
+	StoreHLCUpperBoundKey,       // "hlcu"
+	StoreIdentKey,               // "iden"
+	StoreLastUpKey,              // "uptm"
+
+	// The global keyspace includes the meta{1,2}, system, and SQL keys.
+	//
+	// 	1. Meta keys: This is where we store all key addressing data.
+	MetaMin,
+	Meta1Prefix,
+	Meta2Prefix,
+	MetaMax,
+
+	// 	2. System keys: This is where we store global, system data which is
+	// 	replicated across the cluster.
+	SystemPrefix,
+	NodeLivenessPrefix,  // "\x00liveness-"
+	BootstrapVersionKey, // "bootstrap-version"
+	DescIDGenerator,     // "desc-idgen"
+	NodeIDGenerator,     // "node-idgen"
+	RangeIDGenerator,    // "range-idgen"
+	StatusPrefix,        // "status-"
+	StatusNodePrefix,    // "status-node-"
+	StoreIDGenerator,    // "store-idgen"
+	MigrationPrefix,     // "system-version/"
+	MigrationLease,      // "system-version/lease"
+	TimeseriesPrefix,    // "tsd"
+	SystemMax,
+
+	// 	3. SQL keys: This is where we store all table data.
+	TableDataMin,
+	NamespaceTableMin,
+	UserTableDataMin,
+	TableDataMax,
+
+	MaxKey,
+}

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -73,7 +73,7 @@ func StoreLastUpKey() roachpb.Key {
 // StoreHLCUpperBoundKey returns the store-local key for storing an upper bound
 // to the wall time used by HLC.
 func StoreHLCUpperBoundKey() roachpb.Key {
-	return MakeStoreKey(localHLCUpperBoundSuffix, nil)
+	return MakeStoreKey(localStoreHLCUpperBoundSuffix, nil)
 }
 
 // StoreSuggestedCompactionKey returns a store-local key for a

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -33,7 +33,7 @@ func TestStoreKeyEncodeDecode(t *testing.T) {
 		{key: StoreGossipKey(), expSuffix: localStoreGossipSuffix, expDetail: nil},
 		{key: StoreClusterVersionKey(), expSuffix: localStoreClusterVersionSuffix, expDetail: nil},
 		{key: StoreLastUpKey(), expSuffix: localStoreLastUpSuffix, expDetail: nil},
-		{key: StoreHLCUpperBoundKey(), expSuffix: localHLCUpperBoundSuffix, expDetail: nil},
+		{key: StoreHLCUpperBoundKey(), expSuffix: localStoreHLCUpperBoundSuffix, expDetail: nil},
 		{
 			key:       StoreSuggestedCompactionKey(roachpb.Key("a"), roachpb.Key("z")),
 			expSuffix: localStoreSuggestedCompactionSuffix,


### PR DESCRIPTION
I keep finding myself consulting the combination of
pkg/keys/{keys,docs}.go to remind myself what sits where, and under what
key ranges. Having a top-level reference as such made it easier for
me, and might be useful for others. I also added new documentation
around key addressing, and differences between local and global keys.

I've additionally reordered constant declarations in
pkg/keys/constants.go to more closely follow the physical ordering of
keys. I've grouped sets of prefixes/infixes/suffixes to the closest
approximation of the physical grouping. It's not perfect, some
suffixes are reused across categories for e.g.

Release note: None
