### PR TITLE
storage: change low-level liveness methods to regular time 

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1268,7 +1268,7 @@ func (s *adminServer) Liveness(
 ) (*serverpb.LivenessResponse, error) {
 	clock := s.server.clock
 	statusMap := getLivenessStatusMap(
-		s.server.nodeLiveness, clock.PhysicalTime(), s.server.st)
+		s.server.nodeLiveness, clock.Now().GoTime(), s.server.st)
 	livenesses := s.server.nodeLiveness.GetLivenesses()
 	return &serverpb.LivenessResponse{
 		Livenesses: livenesses,
@@ -1575,7 +1575,7 @@ func (s *adminServer) DecommissionStatus(
 			Decommissioning: l.Decommissioning,
 			Draining:        l.Draining,
 		}
-		if l.IsLive(s.server.clock.Now()) {
+		if l.IsLive(s.server.clock.Now().GoTime()) {
 			nodeResp.IsLive = true
 		}
 

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -853,6 +853,7 @@ func (a *Allocator) TransferLeaseTarget(
 
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseStoreID) {
+		log.VEventf(ctx, 2, "no lease transfer target found")
 		return roachpb.ReplicaDescriptor{}
 	}
 

--- a/pkg/storage/storagepb/liveness.pb.go
+++ b/pkg/storage/storagepb/liveness.pb.go
@@ -67,7 +67,7 @@ func (x NodeLivenessStatus) String() string {
 	return proto.EnumName(NodeLivenessStatus_name, int32(x))
 }
 func (NodeLivenessStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_8b452156800a71b7, []int{0}
+	return fileDescriptor_liveness_61dc59fe6795f558, []int{0}
 }
 
 // Liveness holds information about a node's latest heartbeat and epoch.
@@ -80,7 +80,8 @@ type Liveness struct {
 	// may be incremented if the liveness record expires (current time
 	// is later than the expiration timestamp).
 	Epoch int64 `protobuf:"varint,2,opt,name=epoch,proto3" json:"epoch,omitempty"`
-	// The timestamp at which this liveness record expires.
+	// The timestamp at which this liveness record expires. The logical part of
+	// this timestamp is zero.
 	//
 	// Note that the clock max offset is not accounted for in any way when this
 	// expiration is set. If a checker wants to be extra-optimistic about another
@@ -98,7 +99,7 @@ func (m *Liveness) Reset()         { *m = Liveness{} }
 func (m *Liveness) String() string { return proto.CompactTextString(m) }
 func (*Liveness) ProtoMessage()    {}
 func (*Liveness) Descriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_8b452156800a71b7, []int{0}
+	return fileDescriptor_liveness_61dc59fe6795f558, []int{0}
 }
 func (m *Liveness) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -583,10 +584,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/storagepb/liveness.proto", fileDescriptor_liveness_8b452156800a71b7)
+	proto.RegisterFile("storage/storagepb/liveness.proto", fileDescriptor_liveness_61dc59fe6795f558)
 }
 
-var fileDescriptor_liveness_8b452156800a71b7 = []byte{
+var fileDescriptor_liveness_61dc59fe6795f558 = []byte{
 	// 426 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x52, 0xc1, 0x6e, 0x9b, 0x30,
 	0x18, 0xc6, 0x09, 0x49, 0x33, 0x47, 0x5a, 0x98, 0xd7, 0x43, 0x94, 0x03, 0xa0, 0xed, 0x82, 0x36,

--- a/pkg/storage/storagepb/liveness.proto
+++ b/pkg/storage/storagepb/liveness.proto
@@ -28,7 +28,8 @@ message Liveness {
   // may be incremented if the liveness record expires (current time
   // is later than the expiration timestamp).
   int64 epoch = 2;
-  // The timestamp at which this liveness record expires.
+  // The timestamp at which this liveness record expires. The logical part of
+  // this timestamp is zero.
   //
   // Note that the clock max offset is not accounted for in any way when this
   // expiration is set. If a checker wants to be extra-optimistic about another

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -288,6 +288,10 @@ func (c *Clock) enforceWallTimeWithinBoundLocked() {
 }
 
 // PhysicalNow returns the local wall time.
+//
+// Note that, contrary to Now(), PhysicalNow does not take into consideration
+// higher clock signals received through Update(). If you want to take them into
+// consideration, use c.Now().GoTime().
 func (c *Clock) PhysicalNow() int64 {
 	return c.physicalClock()
 }


### PR DESCRIPTION
liveness.IsLive/IsDead were taking an HLC, although liveness is
fundamentally a physical-clock-related concept.

Release note: None