### PR TITLE
storage: don't account for MaxOffset in liveness expiration

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -417,7 +417,7 @@ func (r *Registry) maybeCancelJobs(ctx context.Context, nl NodeLiveness) {
 	defer r.mu.Unlock()
 	// If we haven't persisted a liveness record within the leniency
 	// interval, we'll cancel all of our jobs.
-	if !liveness.IsLive(r.lenientNow(), r.clock.MaxOffset()) {
+	if !liveness.IsLive(r.lenientNow()) {
 		r.cancelAll(ctx)
 		r.mu.epoch = liveness.Epoch
 		return
@@ -732,16 +732,16 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 		// only a live node updates its own expiration.  Thus, the
 		// expiration time can be used as a reasonable measure of
 		// when the node was last seen.
-		now, maxOffset := r.lenientNow(), r.clock.MaxOffset()
+		now := r.lenientNow()
 		for _, liveness := range nl.GetLivenesses() {
 			nodeStatusMap[liveness.NodeID] = &nodeStatus{
-				isLive: liveness.IsLive(now, maxOffset),
+				isLive: liveness.IsLive(now),
 			}
 
 			// Don't try to start any more jobs unless we're really live,
 			// otherwise we'd just immediately cancel them.
 			if liveness.NodeID == r.nodeID.Get() {
-				if !liveness.IsLive(r.clock.Now(), maxOffset) {
+				if !liveness.IsLive(r.clock.Now()) {
 					return nil
 				}
 			}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1550,7 +1550,7 @@ func (s *adminServer) DecommissionStatus(
 			Decommissioning: l.Decommissioning,
 			Draining:        l.Draining,
 		}
-		if l.IsLive(s.server.clock.Now(), s.server.clock.MaxOffset()) {
+		if l.IsLive(s.server.clock.Now()) {
 			nodeResp.IsLive = true
 		}
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -666,16 +666,11 @@ func (s *statusServer) Details(
 		return nil, grpcstatus.Error(codes.Unavailable, "node is not ready")
 	}
 
-	clock := s.admin.server.clock
 	l, err := s.nodeLiveness.GetLiveness(nodeID)
 	if err != nil {
 		return nil, grpcstatus.Error(codes.Internal, err.Error())
 	}
-	ls := l.LivenessStatus(
-		clock.PhysicalTime(),
-		0, /* threshold */
-		clock.MaxOffset(),
-	)
+	ls := l.LivenessStatus(s.admin.server.clock.PhysicalTime(), 0 /* threshold */)
 	isHealthy := ls == storagepb.NodeLivenessStatus_LIVE
 	if !isHealthy {
 		return nil, grpcstatus.Error(codes.Unavailable, "node is not ready")

--- a/pkg/storage/storagepb/liveness.go
+++ b/pkg/storage/storagepb/liveness.go
@@ -18,8 +18,8 @@ import (
 
 // IsLive returns whether the node is considered live at the given time with the
 // given clock offset.
-func (l *Liveness) IsLive(now hlc.Timestamp, maxOffset time.Duration) bool {
-	expiration := hlc.Timestamp(l.Expiration).Add(-maxOffset.Nanoseconds(), 0)
+func (l *Liveness) IsLive(now hlc.Timestamp) bool {
+	expiration := hlc.Timestamp(l.Expiration)
 	return now.Less(expiration)
 }
 
@@ -30,10 +30,8 @@ func (l *Liveness) IsDead(now hlc.Timestamp, threshold time.Duration) bool {
 }
 
 // LivenessStatus returns a NodeLivenessStatus enumeration value for this liveness
-// based on the provided timestamp, threshold, and clock max offset.
-func (l *Liveness) LivenessStatus(
-	now time.Time, threshold, maxOffset time.Duration,
-) NodeLivenessStatus {
+// based on the provided timestamp and threshold.
+func (l *Liveness) LivenessStatus(now time.Time, threshold time.Duration) NodeLivenessStatus {
 	nowHlc := hlc.Timestamp{WallTime: now.UnixNano()}
 	if l.IsDead(nowHlc, threshold) {
 		if l.Decommissioning {
@@ -47,7 +45,7 @@ func (l *Liveness) LivenessStatus(
 	if l.Draining {
 		return NodeLivenessStatus_UNAVAILABLE
 	}
-	if l.IsLive(nowHlc, maxOffset) {
+	if l.IsLive(nowHlc) {
 		return NodeLivenessStatus_LIVE
 	}
 	return NodeLivenessStatus_UNAVAILABLE

--- a/pkg/storage/storagepb/liveness.pb.go
+++ b/pkg/storage/storagepb/liveness.pb.go
@@ -65,7 +65,7 @@ func (x NodeLivenessStatus) String() string {
 	return proto.EnumName(NodeLivenessStatus_name, int32(x))
 }
 func (NodeLivenessStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_a742f8206583547b, []int{0}
+	return fileDescriptor_liveness_02a7d82e103a0b92, []int{0}
 }
 
 // Liveness holds information about a node's latest heartbeat and epoch.
@@ -79,6 +79,14 @@ type Liveness struct {
 	// is later than the expiration timestamp).
 	Epoch int64 `protobuf:"varint,2,opt,name=epoch,proto3" json:"epoch,omitempty"`
 	// The timestamp at which this liveness record expires.
+	//
+	// Note that the clock max offset is not accounted for in any way when this
+	// expiration is set. If a checker wants to be extra-optimistic about another
+	// node being alive, it can adjust for the max offset. liveness.IsLive()
+	// doesn't do that, however. The expectation is that the expiration duration
+	// is large in comparison to the max offset, and that nodes heartbeat their
+	// liveness records well in advance of this expiration, so the optimism or
+	// pessimism of a checker does not matter very much.
 	Expiration      hlc.LegacyTimestamp `protobuf:"bytes,3,opt,name=expiration,proto3" json:"expiration"`
 	Draining        bool                `protobuf:"varint,4,opt,name=draining,proto3" json:"draining,omitempty"`
 	Decommissioning bool                `protobuf:"varint,5,opt,name=decommissioning,proto3" json:"decommissioning,omitempty"`
@@ -88,7 +96,7 @@ func (m *Liveness) Reset()         { *m = Liveness{} }
 func (m *Liveness) String() string { return proto.CompactTextString(m) }
 func (*Liveness) ProtoMessage()    {}
 func (*Liveness) Descriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_a742f8206583547b, []int{0}
+	return fileDescriptor_liveness_02a7d82e103a0b92, []int{0}
 }
 func (m *Liveness) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -573,10 +581,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/storagepb/liveness.proto", fileDescriptor_liveness_a742f8206583547b)
+	proto.RegisterFile("storage/storagepb/liveness.proto", fileDescriptor_liveness_02a7d82e103a0b92)
 }
 
-var fileDescriptor_liveness_a742f8206583547b = []byte{
+var fileDescriptor_liveness_02a7d82e103a0b92 = []byte{
 	// 426 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x52, 0xc1, 0x6e, 0x9b, 0x30,
 	0x18, 0xc6, 0x09, 0x49, 0x33, 0x47, 0x5a, 0x98, 0xd7, 0x43, 0x94, 0x03, 0xa0, 0xed, 0x82, 0x36,

--- a/pkg/storage/storagepb/liveness.proto
+++ b/pkg/storage/storagepb/liveness.proto
@@ -29,6 +29,14 @@ message Liveness {
   // is later than the expiration timestamp).
   int64 epoch = 2;
   // The timestamp at which this liveness record expires.
+  //
+  // Note that the clock max offset is not accounted for in any way when this
+  // expiration is set. If a checker wants to be extra-optimistic about another
+  // node being alive, it can adjust for the max offset. liveness.IsLive()
+  // doesn't do that, however. The expectation is that the expiration duration
+  // is large in comparison to the max offset, and that nodes heartbeat their
+  // liveness records well in advance of this expiration, so the optimism or
+  // pessimism of a checker does not matter very much.
   util.hlc.LegacyTimestamp expiration = 3 [(gogoproto.nullable) = false];
   bool draining = 4;
   bool decommissioning = 5;

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -102,7 +102,7 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *NodeLiveness) NodeLivenessFunc 
 		if err != nil {
 			return storagepb.NodeLivenessStatus_UNAVAILABLE
 		}
-		return liveness.LivenessStatus(now, threshold, nodeLiveness.clock.MaxOffset())
+		return liveness.LivenessStatus(now, threshold)
 	}
 }
 


### PR DESCRIPTION
Before this patch, a node writing its expiration record would add an
extra MaxOffset to its Liveness.Expiration, and the Liveness.IsLive()
method would subtract MaxOffset from the expiration before comparing it
to the current time. The adding and subtracting cancel each other.

I think this doesn't make any sense. I've thought about it a bunch, and
I can't find any justification for any of this.
Historically, at first came the subtracting, from the very beginning of
liveness records. I think that's the original sin - the code was very
pessimistic about whether records were expired or not.
Then came #12232, which put in the adding to counteract the subtracting :)
It says
// We need to add the maximum clock offset to the expiration because it's
// used when determining liveness for a node.
And in a review comment:
"
We need to add in max offset or else nodes will be considered not live
sooner than expected for very small heartbeat intervals, assuming the
max offset stays at 250ms.
"
Can't argue with that.

This PR gets rid of the pair of adding and subtracting. It seems to me
that that's the sane thing to do. Besides taking offsets out of where
they don't belong, this PR also hopes to open the door to improving the
liveness api: right now there's a Liveness.IsLive(maxOffset) method and
a Liveness.IsDead(threshold) method. If you want to make IsDead() be the
inverse of IsLive(), you'd have to pass a negative threshold
(-maxOffset).

When thinking what could go wrong and how the max offset fares into the
liveness expiration, one has to take into account that the stasis of an
epoch-based lease starts at (liveness.expiration - maxOffset):
https://github.com/cockroachdb/cockroach/blob/6bf028ced62e7c3970afe7aa7de1afd6fedd945e/pkg/storage/replica_range_lease.go#L567
Symmetry with this code may have been what prompted the original
subtracting. However, I think that symmetry was misguided.

I believe the migration story to be fine: liveness records written by
old nodes will be considered by new nodes to be alive marginally longer,
and liveness records written by new nodes will be considered by old
nodes to be alive marginally less. Liveness records are supposed to
expire in 9s, and they're updated after 4.5s.

Release note: None