### PR TITLE
storage/storagepb: explain the lease stasis

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -843,23 +843,6 @@ error pointing at the replica's last known lease holder. These requests
 are retried transparently with the updated lease by the gateway node and
 never reach the client.
 
-Since reads bypass Raft, a new lease holder will, among other things, ascertain
-that its timestamp cache does not report timestamps smaller than the previous
-lease holder's (so that it's compatible with reads which may have occurred on
-the former lease holder). This is accomplished by letting leases enter
-a <i>stasis period</i> (which is just the expiration minus the maximum clock
-offset) before the actual expiration of the lease, so that all the next lease
-holder has to do is set the low water mark of the timestamp cache to its
-new lease's start time.
-
-As a lease enters its stasis period, no more reads or writes are served, which
-is undesirable. However, this would only happen in practice if a node became
-unavailable. In almost all practical situations, no unavailability results
-since leases are usually long-lived (and/or eagerly extended, which can avoid
-the stasis period) or proactively transferred away from the lease holder, which
-can also avoid the stasis period by promising not to serve any further reads
-until the next lease goes into effect.
-
 ## Colocation with Raft leadership
 
 The range lease is completely separate from Raft leadership, and so without

--- a/pkg/storage/storagepb/lease_status.pb.go
+++ b/pkg/storage/storagepb/lease_status.pb.go
@@ -37,6 +37,18 @@ const (
 	// leases) or Heartbeat (for epoch-based leases). A lease may not
 	// change hands while it is in stasis; would-be acquirers must wait
 	// for the stasis period to expire.
+	//
+	// The point of the stasis period is to prevent reads on the old leaseholder
+	// (the one whose stasis we're talking about) from missing to see writes
+	// performed under the next lease (held by someone else) when these writes
+	// should fall in the uncertainty window. Even without the stasis, writes
+	// performed by the new leaseholder are guaranteed to have higher timestamps
+	// than any reads served by the old leaseholder. However, a read at timestamp
+	// T needs to observe all writes at timestamps [T, T+maxOffset] and so,
+	// without the stasis, only the new leaseholder might have some of these
+	// writes. In other words, without the stasis, a new leaseholder with a fast
+	// clock could start performing writes ordered in real time before the old
+	// leaseholder considers its lease to have expired.
 	LeaseState_STASIS LeaseState = 2
 	// EXPIRED indicates that the lease can't be used. An expired lease
 	// may become VALID for the same leaseholder on RequestLease or
@@ -72,7 +84,7 @@ func (x LeaseState) String() string {
 	return proto.EnumName(LeaseState_name, int32(x))
 }
 func (LeaseState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lease_status_0ec6592ba7112e22, []int{0}
+	return fileDescriptor_lease_status_5a7f1023205288d6, []int{0}
 }
 
 // LeaseStatus holds the lease state, the timestamp at which the state
@@ -93,7 +105,7 @@ func (m *LeaseStatus) Reset()         { *m = LeaseStatus{} }
 func (m *LeaseStatus) String() string { return proto.CompactTextString(m) }
 func (*LeaseStatus) ProtoMessage()    {}
 func (*LeaseStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lease_status_0ec6592ba7112e22, []int{0}
+	return fileDescriptor_lease_status_5a7f1023205288d6, []int{0}
 }
 func (m *LeaseStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -474,10 +486,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/storagepb/lease_status.proto", fileDescriptor_lease_status_0ec6592ba7112e22)
+	proto.RegisterFile("storage/storagepb/lease_status.proto", fileDescriptor_lease_status_5a7f1023205288d6)
 }
 
-var fileDescriptor_lease_status_0ec6592ba7112e22 = []byte{
+var fileDescriptor_lease_status_5a7f1023205288d6 = []byte{
 	// 354 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xcf, 0x4e, 0xea, 0x40,
 	0x14, 0x87, 0x3b, 0xfc, 0xbb, 0x97, 0x43, 0x42, 0x7a, 0x27, 0x77, 0xd1, 0x60, 0x1c, 0x89, 0x71,

--- a/pkg/storage/storagepb/lease_status.proto
+++ b/pkg/storage/storagepb/lease_status.proto
@@ -31,6 +31,18 @@ enum LeaseState {
   // leases) or Heartbeat (for epoch-based leases). A lease may not
   // change hands while it is in stasis; would-be acquirers must wait
   // for the stasis period to expire.
+  //
+  // The point of the stasis period is to prevent reads on the old leaseholder
+  // (the one whose stasis we're talking about) from missing to see writes
+  // performed under the next lease (held by someone else) when these writes
+  // should fall in the uncertainty window. Even without the stasis, writes
+  // performed by the new leaseholder are guaranteed to have higher timestamps
+  // than any reads served by the old leaseholder. However, a read at timestamp
+  // T needs to observe all writes at timestamps [T, T+maxOffset] and so,
+  // without the stasis, only the new leaseholder might have some of these
+  // writes. In other words, without the stasis, a new leaseholder with a fast
+  // clock could start performing writes ordered in real time before the old
+  // leaseholder considers its lease to have expired.
   STASIS = 2;
   // EXPIRED indicates that the lease can't be used. An expired lease
   // may become VALID for the same leaseholder on RequestLease or


### PR DESCRIPTION
Also remove a section about it from the design doc, which I believe to
be incorrect. The section suggests that without the stasis, an old lease
holder might serve reads at higher timestamps than writes served by the
new leaseholder, which is false.

Release note: None