### PR TITLE
exec: fix flaky test with column families

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1240,7 +1240,7 @@ statement ok
 CREATE TABLE a (a INT PRIMARY KEY, item STRING, price FLOAT, UNIQUE INDEX item (item), UNIQUE INDEX p (price))
 
 statement ok
-CREATE TABLE b (a INT, b INT, c INT NULL, d INT NULL, PRIMARY KEY (a, b))
+CREATE TABLE b (a INT, b INT, c INT NULL, d INT NULL, PRIMARY KEY (a, b), FAMILY (a, b, c, d))
 
 # No parallel line printed out for single-span selects.
 query TTT


### PR DESCRIPTION
PR #43742 extended the ways that the column family randomizer
in the logic tests could randomize column families, and
PR #43567 added the ability for secondary indexes that store
columns to receive the benefit of family specific span generation.

Combined, these two uncovered a flake in a logic test that is fixed
by fixing the families on a table, since the table with families
resulted in a different plan.

Fixes #43866.

Release note: None