### PR TITLE
sql/parser: parse FOR UPDATE lock wait policies

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1173,7 +1173,7 @@ simple_select ::=
 	| set_operation
 
 locking_clause ::=
-	for_locking_strength opt_locked_rels
+	for_locking_strength opt_locked_rels opt_nowait_or_skip
 
 select_clause ::=
 	simple_select
@@ -1582,6 +1582,10 @@ for_locking_strength ::=
 
 opt_locked_rels ::=
 	'OF' table_name_list
+
+opt_nowait_or_skip ::=
+	'SKIP' 'LOCKED'
+	| 'NOWAIT'
 
 offset_clause ::=
 	'OFFSET' a_expr

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -38,5 +38,32 @@ SELECT 1 FOR SHARE OF a, b
 # differently - NOWAIT returns an error to the client instead of blocking,
 # and SKIP LOCKED returns an inconsistent view.
 
-query error at or near "locked": syntax error: unimplemented: this syntax
+query error unimplemented: SKIP LOCKED lock wait policy is not supported
 SELECT 1 FOR UPDATE SKIP LOCKED
+
+query error unimplemented: SKIP LOCKED lock wait policy is not supported
+SELECT 1 FOR NO KEY UPDATE SKIP LOCKED
+
+query error unimplemented: SKIP LOCKED lock wait policy is not supported
+SELECT 1 FOR SHARE SKIP LOCKED
+
+query error unimplemented: SKIP LOCKED lock wait policy is not supported
+SELECT 1 FOR KEY SHARE SKIP LOCKED
+
+query error unimplemented: SKIP LOCKED lock wait policy is not supported
+SELECT 1 FOR UPDATE OF a SKIP LOCKED
+
+query error unimplemented: NOWAIT lock wait policy is not supported
+SELECT 1 FOR UPDATE NOWAIT
+
+query error unimplemented: NOWAIT lock wait policy is not supported
+SELECT 1 FOR NO KEY UPDATE NOWAIT
+
+query error unimplemented: NOWAIT lock wait policy is not supported
+SELECT 1 FOR SHARE NOWAIT
+
+query error unimplemented: NOWAIT lock wait policy is not supported
+SELECT 1 FOR KEY SHARE NOWAIT
+
+query error unimplemented: NOWAIT lock wait policy is not supported
+SELECT 1 FOR UPDATE OF a NOWAIT

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -754,9 +754,9 @@ func (b *Builder) buildSelect(
 	wrapped := stmt.Select
 	orderBy := stmt.OrderBy
 	limit := stmt.Limit
-	forLocked := stmt.ForLocked.Strength
+	forLocked := stmt.ForLocked
 
-	switch forLocked {
+	switch forLocked.Strength {
 	case tree.ForNone:
 	case tree.ForUpdate:
 	case tree.ForNoKeyUpdate:
@@ -767,6 +767,16 @@ func (b *Builder) buildSelect(
 		// whether or not FOR UPDATE (or any of the other weaker modes) actually
 		// created a lock. This behavior may improve as the transaction model gains
 		// more capabilities.
+	}
+
+	switch forLocked.WaitPolicy {
+	case tree.LockWaitBlock:
+	case tree.LockWaitSkip:
+		panic(unimplementedWithIssueDetailf(40476, "",
+			"SKIP LOCKED lock wait policy is not supported"))
+	case tree.LockWaitError:
+		panic(unimplementedWithIssueDetailf(40476, "",
+			"NOWAIT lock wait policy is not supported"))
 	}
 
 	for s, ok := wrapped.(*tree.ParenSelect); ok; s, ok = wrapped.(*tree.ParenSelect) {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1069,6 +1069,8 @@ func TestParse(t *testing.T) {
 		{`SELECT 1 FOR KEY SHARE`},
 		{`SELECT 1 FOR UPDATE OF a`},
 		{`SELECT 1 FOR NO KEY UPDATE OF a, b`},
+		{`SELECT 1 FOR UPDATE SKIP LOCKED`},
+		{`SELECT 1 FOR NO KEY UPDATE OF a, b NOWAIT`},
 
 		{`TABLE a`}, // Shorthand for: SELECT * FROM a; used e.g. in CREATE VIEW v AS TABLE t
 		{`EXPLAIN TABLE a`},

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -556,11 +556,12 @@ func (node ForLocked) docTable(p *PrettyCfg) []pretty.TableRow {
 	if node.Strength == ForNone {
 		return nil
 	}
-	items := make([]pretty.TableRow, 0, 2)
+	items := make([]pretty.TableRow, 0, 3)
 	items = append(items, node.Strength.docTable(p)...)
 	if len(node.Targets) > 0 {
 		items = append(items, p.row("OF", p.Doc(&node.Targets)))
 	}
+	items = append(items, node.WaitPolicy.docTable(p)...)
 	return items
 }
 
@@ -581,6 +582,23 @@ func (node LockingStrength) docTable(p *PrettyCfg) []pretty.TableRow {
 		keyword = "FOR SHARE"
 	case ForKeyShare:
 		keyword = "FOR KEY SHARE"
+	}
+	return []pretty.TableRow{p.row("", pretty.Keyword(keyword))}
+}
+
+func (node LockingWaitPolicy) doc(p *PrettyCfg) pretty.Doc {
+	return p.rlTable(node.docTable(p)...)
+}
+
+func (node LockingWaitPolicy) docTable(p *PrettyCfg) []pretty.TableRow {
+	var keyword string
+	switch node {
+	case LockWaitBlock:
+		return nil
+	case LockWaitSkip:
+		keyword = "SKIP LOCKED"
+	case LockWaitError:
+		keyword = "NOWAIT"
 	}
 	return []pretty.TableRow{p.row("", pretty.Keyword(keyword))}
 }


### PR DESCRIPTION
This commit adds parsing-only support for the SKIP LOCKED and NOWAIT
lock wait policies that accompany the FOR UPDATE locking strength
specifiers. These are still rejected with unimplemented errors, but
they now at least make it to the optimizer, where we can make a
better decision about what to do with them.

Release note: None