### PR TITLE
cli: new command `auth-session {login,logout,list}`

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -1,0 +1,215 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login [options] <session-username>",
+	Short: "create a HTTP session and token for the given user",
+	Long: `
+Creates a HTTP session for the given user and print out a login cookie for use
+in non-interactive programs.
+
+Example use of the session cookie using 'curl':
+
+   curl -k -b "<cookie>" https://localhost:8080/_admin/v1/settings
+
+The user invoking the 'login' CLI command must be an admin on the cluster.
+The user for which the HTTP session is opened can be arbitrary.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runLogin),
+}
+
+func runLogin(cmd *cobra.Command, args []string) error {
+	username := tree.Name(args[0]).Normalize()
+	id, httpCookie, err := createAuthSessionToken(username)
+	if err != nil {
+		return err
+	}
+	hC := httpCookie.String()
+
+	if authCtx.onlyCookie {
+		// Simple format suitable for automation.
+		fmt.Println(hC)
+	} else {
+		// More complete format, suitable e.g. for appending to a CSV file
+		// with --format=csv.
+		cols := []string{"username", "session ID", "authentication cookie"}
+		rows := [][]string{
+			{username, fmt.Sprintf("%d", id), hC},
+		}
+		if err := printQueryOutput(os.Stdout, cols, newRowSliceIter(rows, "ll")); err != nil {
+			return err
+		}
+
+		checkInteractive()
+		if cliCtx.isInteractive {
+			fmt.Fprintf(stderr, `#
+# Example uses:
+#
+#     curl [-k] --cookie '%s' https://...
+#
+#     wget [--no-check-certificate] --header='Cookie: %s' https://...
+#
+`, hC, hC)
+		}
+	}
+
+	return nil
+}
+
+func createAuthSessionToken(username string) (sessionID int64, httpCookie *http.Cookie, err error) {
+	sqlConn, err := makeSQLClient("cockroach auth-session login", useSystemDb)
+	if err != nil {
+		return -1, nil, err
+	}
+	defer sqlConn.Close()
+
+	// First things first. Does the user exist?
+	_, rows, err := runQuery(sqlConn,
+		makeQuery(`SELECT count(username) FROM system.users WHERE username = $1 AND NOT "isRole"`, username), false)
+	if err != nil {
+		return -1, nil, err
+	}
+	if rows[0][0] != "1" {
+		return -1, nil, fmt.Errorf("user %q does not exist", username)
+	}
+
+	// Make a secret.
+	secret, hashedSecret, err := server.CreateAuthSecret()
+	if err != nil {
+		return -1, nil, err
+	}
+	expiration := timeutil.Now().Add(authCtx.validityPeriod)
+
+	// Create the session on the server to the server.
+	insertSessionStmt := `
+INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt")
+VALUES($1, $2, $3)
+RETURNING id
+`
+	var id int64
+	row, err := sqlConn.QueryRow(
+		insertSessionStmt,
+		[]driver.Value{
+			hashedSecret,
+			username,
+			expiration,
+		},
+	)
+	if err != nil {
+		return -1, nil, err
+	}
+	if len(row) != 1 {
+		return -1, nil, errors.Newf("expected 1 column, got %d", len(row))
+	}
+	id, ok := row[0].(int64)
+	if !ok {
+		return -1, nil, errors.Newf("expected integer, got %T", row[0])
+	}
+
+	// Spell out the cookie.
+	sCookie := &serverpb.SessionCookie{ID: id, Secret: secret}
+	httpCookie, err = server.EncodeSessionCookie(sCookie)
+	return id, httpCookie, err
+}
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout [options] <session-username>",
+	Short: "invalidates all the HTTP session tokens previously created for the given user",
+	Long: `
+Revokes all previously issued HTTP authentication tokens for the given user.
+
+The user invoking the 'login' CLI command must be an admin on the cluster.
+The user for which the HTTP sessions are revoked can be arbitrary.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runLogout),
+}
+
+func runLogout(cmd *cobra.Command, args []string) error {
+	username := tree.Name(args[0]).Normalize()
+
+	sqlConn, err := makeSQLClient("cockroach auth-session logout", useSystemDb)
+	if err != nil {
+		return err
+	}
+	defer sqlConn.Close()
+
+	logoutQuery := makeQuery(
+		`UPDATE system.web_sessions SET "revokedAt" = if("revokedAt"::timestamptz<now(),"revokedAt",now())
+      WHERE username = $1
+  RETURNING username,
+            id AS "session ID",
+            "revokedAt" AS "revoked"`,
+		username)
+	return runQueryAndFormatResults(sqlConn, os.Stdout, logoutQuery)
+}
+
+var authListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "lists the currently active HTTP sessions",
+	Long: `
+Prints out the currently active HTTP sessions.
+
+The user invoking the 'list' CLI command must be an admin on the cluster.
+`,
+	Args: cobra.ExactArgs(0),
+	RunE: MaybeDecorateGRPCError(runAuthList),
+}
+
+func runAuthList(cmd *cobra.Command, args []string) error {
+	sqlConn, err := makeSQLClient("cockroach auth-session list", useSystemDb)
+	if err != nil {
+		return err
+	}
+	defer sqlConn.Close()
+
+	logoutQuery := makeQuery(`
+SELECT username,
+       id AS "session ID",
+       "createdAt" as "created",
+       "expiresAt" as "expires",
+       "revokedAt" as "revoked",
+       "lastUsedAt" as "last used"
+  FROM system.web_sessions`)
+	return runQueryAndFormatResults(sqlConn, os.Stdout, logoutQuery)
+}
+
+var authCmds = []*cobra.Command{
+	loginCmd,
+	logoutCmd,
+	authListCmd,
+}
+
+var authCmd = &cobra.Command{
+	Use:   "auth-session",
+	Short: "log in and out of HTTP sessions",
+	RunE:  usageAndErr,
+}
+
+func init() {
+	authCmd.AddCommand(authCmds...)
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -196,6 +196,7 @@ func init() {
 		quitCmd,
 
 		sqlShellCmd,
+		authCmd,
 		nodeCmd,
 		dumpCmd,
 		nodeLocalCmd,

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1358,6 +1358,7 @@ Available Commands:
   quit              drain and shutdown node
 
   sql               open a sql shell
+  auth-session      log in and out of HTTP sessions
   node              list, inspect or remove nodes
   dump              dump sql tables
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -178,6 +178,19 @@ when the first store is in-memory.
 `,
 	}
 
+	AuthTokenValidityPeriod = FlagInfo{
+		Name: "expire-after",
+		Description: `
+Duration after which the newly created session token expires.`,
+	}
+
+	OnlyCookie = FlagInfo{
+		Name: "only-cookie",
+		Description: `
+Display only the newly created cookie on the standard output
+without additional details and decoration.`,
+	}
+
 	Cache = FlagInfo{
 		Name: "cache",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -159,6 +159,8 @@ func initCLIDefaults() {
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
 
+	authCtx.validityPeriod = 1 * time.Hour
+
 	initPreFlagsDefaults()
 
 	// Clear the "Changed" state of all the registered command-line flags.
@@ -258,6 +260,13 @@ var dumpCtx struct {
 
 	// asOf determines the time stamp at which the dump should be taken.
 	asOf string
+}
+
+// authCtx captures the command-line parameters of the `auth-session`
+// command.
+var authCtx struct {
+	onlyCookie     bool
+	validityPeriod time.Duration
 }
 
 // debugCtx captures the command-line parameters of the `debug` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -455,6 +455,7 @@ func init() {
 		sqlShellCmd,
 		/* StartCmds are covered above */
 	}
+	clientCmds = append(clientCmds, authCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, systemBenchCmds...)
 	clientCmds = append(clientCmds, initCmd)
@@ -469,6 +470,13 @@ func init() {
 
 		// Certificate flags.
 		StringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, baseCfg.SSLCertsDir)
+	}
+
+	// Auth commands.
+	{
+		f := loginCmd.Flags()
+		DurationFlag(f, &authCtx.validityPeriod, cliflags.AuthTokenValidityPeriod, authCtx.validityPeriod)
+		BoolFlag(f, &authCtx.onlyCookie, cliflags.OnlyCookie, authCtx.onlyCookie)
 	}
 
 	timeoutCmds := []*cobra.Command{
@@ -539,6 +547,7 @@ func init() {
 
 	// Commands that establish a SQL connection.
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}
+	sqlCmds = append(sqlCmds, authCmds...)
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	sqlCmds = append(sqlCmds, nodeLocalCmds...)
 	for _, cmd := range sqlCmds {
@@ -570,6 +579,7 @@ func init() {
 		[]*cobra.Command{sqlShellCmd, genSettingsListCmd, demoCmd},
 		demoCmd.Commands()...)
 	tableOutputCommands = append(tableOutputCommands, nodeCmds...)
+	tableOutputCommands = append(tableOutputCommands, authCmds...)
 
 	// By default, these commands print their output as pretty-formatted
 	// tables on terminals, and TSV when redirected to a file. The user

--- a/pkg/cli/interactive_tests/test_auth_cookie.py
+++ b/pkg/cli/interactive_tests/test_auth_cookie.py
@@ -1,0 +1,18 @@
+import urllib2
+import ssl
+import sys
+
+cookiefile = sys.argv[1]
+url = sys.argv[2]
+
+# Disable SSL cert validation for simplicity.
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+# Load the cookie.
+cookie = file('cookie.txt').read().strip()
+
+# Perform the HTTP request.
+httpReq = urllib2.Request(url, "", {"Cookie": cookie})
+print urllib2.urlopen(httpReq, context=ctx).read()


### PR DESCRIPTION
Fixes #43870.

tldr: this adds new CLI commands to log users in and out of the
HTTP interface and produce a HTTP cookie for use in monitoring
scripts. This is suitable for use by the `root` user without an
Enterprise license.

Also the new feature is client-side only, so the client binary with
this feature can be used with a CockroachDB server/cluster running at
an older version.

**Motivation:** users who wish to use certain HTTP monitoring tools,
in particular those that retrieve privileged information like logs,
need a valid HTTP authentication token for an admin user (#42567). This token
can be constructed by accessing the HTTP endpoint `/login`, however:

- manually crafting the token using `/login` is cumbersome;
- it's not possible to use `/login` for the `root` user (#43847);
- it's not possible to create another admin user than `root` without
  a valid Enterprise license (because that requires role management).

**Solution:**

```
cockroach auth-session login <username> [--expire-after=...] [--only-cookie]
cockroach auth-session logout <username>
cockroach auth-session list
```

- all three commands also support the standard SQL command-line
  arguments, e.g. `--url`, `--certs-dir`, `--echo-sql` and
  `--format`.
- the `--expire-after` argument customizes the expiry period. The
  default is one hour.
- the `--only-cookie` arguments limits the output of the command
  to just the HTTP cookie. By default, the session ID and
  the authentication cookie are printed using regular table formatting.

Also see the two release notes below.

Release note (cli change): Three new CLI commands `cockroach
auth-session login`, `cockroach auth-session list` and `cockroach
auth-session logout` are now provided to facilitate the management of
web sessions. The command `auth-session login` also produces a HTTP
cookie which can be used by non-interactive HTTP-based database
management tools. It also can generate such a cookie for the `root`
user, who would not otherwise be able to do so using a web browser.

Release note (security update): The new command `cockroach
auth-session login` (reserved to administrators) is able to create
authentication tokens with an arbitrary expiration date. Operators
should be careful to monitor `system.web_sessions` and enforce
policy-mandated expirations either using SQL queries or the new
command `cockroach auth-session logout`.
