### PR TITLE
server,cli,sql: enable setting a password for the root user

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -61,6 +61,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-9</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-10</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -15,6 +15,7 @@
 package gssapiccl
 
 import (
+	"context"
 	"crypto/tls"
 	"strings"
 	"unsafe"
@@ -42,9 +43,10 @@ const (
 // authGSS performs GSS authentication. See:
 // https:github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
 func authGSS(
+	ctx context.Context,
 	c pgwire.AuthConn,
 	tlsState tls.ConnectionState,
-	hashedPassword []byte,
+	_ pgwire.PasswordRetrievalFn,
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -58,13 +58,6 @@ send "\\q\r"
 eexpect $prompt
 end_test
 
-start_test "Check that root cannot use password."
-# Run as root but with a non-existent certs directory.
-send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full&sslrootcert=$certs_dir/ca.crt'\r"
-eexpect "ERROR: connections with user root must use a client certificate"
-eexpect "Failed running \"sql\""
-end_test
-
 start_test "Check that CREATE USER WITH PASSWORD can be used from transactions."
 # Create a user from a transaction.
 send "$argv sql --certs-dir=$certs_dir\r"

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -96,10 +96,6 @@ func UserAuthPasswordHook(insecureMode bool, password string, hashedPassword []b
 			return nil
 		}
 
-		if requestedUser == RootUser {
-			return errors.Errorf("user %s must use certificate authentication instead of password authentication", RootUser)
-		}
-
 		// If the requested user has an empty password, disallow authentication.
 		if len(password) == 0 || CompareHashAndPassword(hashedPassword, password) != nil {
 			return errors.Errorf(ErrPasswordUserAuthFailed, requestedUser)

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -54,6 +54,7 @@ const (
 	VersionPrimaryKeyChanges
 	VersionAuthLocalAndTrustRejectMethods
 	VersionPrimaryKeyColumnsOutOfFamilyZero
+	VersionRootPassword
 
 	// Add new versions here (step one of two).
 )
@@ -375,6 +376,17 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// primary key changes that move primary key columns to different families.
 		Key:     VersionPrimaryKeyColumnsOutOfFamilyZero,
 		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 9},
+	},
+	{
+		// VersionRootPassword enables setting a password for the `root`
+		// user from SQL. Even though introducing a password for the root
+		// user in 20.1 does not prevent 19.2 nodes from using the root
+		// account, we need a cluster setting: the 19.2 nodes do not even
+		// *check* the password, so setting a pw in a hybrid 20.1/19.2
+		// cluster would yield different client auth successes in
+		// different nodes (which is poor UX).
+		Key:     VersionRootPassword,
+		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 10},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -30,11 +30,12 @@ func _() {
 	_ = x[VersionPrimaryKeyChanges-19]
 	_ = x[VersionAuthLocalAndTrustRejectMethods-20]
 	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-21]
+	_ = x[VersionRootPassword-22]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZero"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPassword"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530, 569}
+var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530, 569, 588}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -65,15 +66,25 @@ func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 		return err
 	}
 
-	// The root user is not allowed a password.
-	if normalizedUsername == security.RootUser {
-		return pgerror.Newf(pgcode.InvalidPassword,
-			"user %s cannot use password authentication", security.RootUser)
+	// TODO(knz): Remove in 20.2.
+	if normalizedUsername == security.RootUser && len(hashedPassword) > 0 &&
+		!cluster.Version.IsActive(params.ctx, params.EvalContext().Settings, cluster.VersionRootPassword) {
+		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			`setting a root password requires all nodes to be upgraded to %s`,
+			cluster.VersionByKey(cluster.VersionRootPassword),
+		)
 	}
 
 	if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Insecure {
+		// We disallow setting a non-empty password in insecure mode
+		// because insecure means an observer may have MITM'ed the change
+		// and learned the password.
+		//
+		// It's valid to clear the password (WITH PASSWORD NULL) however
+		// since that forces cert auth when moving back to secure mode,
+		// and certs can't be MITM'ed over the insecure SQL connection.
 		return pgerror.New(pgcode.InvalidPassword,
-			"cluster in insecure mode; user cannot use password authentication")
+			"setting or updating a password is not supported in insecure mode")
 	}
 
 	n.run.rowsAffected, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -488,7 +488,7 @@ func TestSetUserPasswordInsecure(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop(context.TODO())
 
-	errFail := "cluster in insecure mode; user cannot use password authentication"
+	errFail := "setting or updating a password is not supported in insecure mode"
 
 	testCases := []struct {
 		sql       string

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -121,9 +121,6 @@ testuser
 
 user root
 
-statement error pq: user root cannot use password authentication
-ALTER USER root WITH PASSWORD 'foo'
-
 statement ok
 SET SESSION AUTHORIZATION DEFAULT
 

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -82,8 +82,8 @@ func (c *conn) handleAuthentication(
 
 	// Check that the requested user exists and retrieve the hashed
 	// password in case password authentication is needed.
-	exists, hashedPassword, err := sql.GetUserHashedPassword(
-		ctx, authOpt.ie, &c.metrics.SQLMemMetrics, c.sessionArgs.User,
+	exists, pwRetrievalFn, err := sql.GetUserHashedPassword(
+		ctx, authOpt.ie, c.sessionArgs.User,
 	)
 	if err != nil {
 		return sendError(err)
@@ -99,7 +99,7 @@ func (c *conn) handleAuthentication(
 	}
 
 	// Ask the method to authenticate.
-	authenticationHook, err := methodFn(ac, tlsState, hashedPassword, execCfg, hbaEntry)
+	authenticationHook, err := methodFn(ctx, ac, tlsState, pwRetrievalFn, execCfg, hbaEntry)
 	if err != nil {
 		return sendError(err)
 	}

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -246,7 +246,7 @@ var rootEntry = hba.Entry{
 	ConnType: hba.ConnHostAny,
 	User:     []hba.String{{Value: security.RootUser, Quoted: false}},
 	Address:  hba.AnyAddr{},
-	Method:   hba.String{Value: "cert"},
+	Method:   hba.String{Value: "cert-password"},
 }
 
 // DefaultHBAConfig is used when the stored HBA configuration string

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -2,7 +2,7 @@
 #
 # An empty config is equivalent to:
 #
-#     host   all root all cert
+#     host   all root all cert-password
 #     host   all all  all cert-password
 #     local  all all      password
 #
@@ -21,7 +21,7 @@ set_hba
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert
+host   all      root all     cert-password
 host   all      all  all     cert-password
 local  all      all          password
 
@@ -32,16 +32,17 @@ connect user=root
 ----
 ok defaultdb
 
-# However root cannot connect over the unix socket by default.
+# However root cannot connect over the unix socket by default
+# because it does not have a password.
 connect_unix user=root
 ----
-ERROR: user root must use certificate authentication instead of password authentication
+ERROR: password authentication failed for user root
 
 # When no client cert is presented, the server would otherwise require
-# password auth. However, root password auth is rejected in any case.
+# password auth. However, root does not have a password.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
-ERROR: no TLS peer certificates, but required for auth
+ERROR: password authentication failed for user root
 
 subtest end root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -1,6 +1,6 @@
 # This verifies that the behavior with an empty HBA config
 # is equivalent to:
-#     host  all root all cert
+#     host  all root all cert-password
 #     host  all all  all cert-password
 #     local all all      password
 # by using that explicit string and reproducing the tests
@@ -10,13 +10,13 @@ config secure
 ----
 
 set_hba
-host  all root all cert
+host  all root all cert-password
 host  all all  all cert-password
 local all all      password
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert
+host   all      root all     cert-password
 host   all      all  all     cert-password
 local  all      all          password
 
@@ -27,16 +27,17 @@ connect user=root
 ----
 ok defaultdb
 
-# However root cannot connect over the unix socket.
+# However root cannot connect over the unix socket because
+# they do not have a password by default.
 connect_unix user=root
 ----
-ERROR: user root must use certificate authentication instead of password authentication
+ERROR: password authentication failed for user root
 
 # When no client cert is presented, the server would otherwise require
-# password auth. However, root password auth is rejected in any case.
+# password auth. However, root does not have a password.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
-ERROR: no TLS peer certificates, but required for auth
+ERROR: password authentication failed for user root
 
 subtest end root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -11,8 +11,8 @@ set_hba
 host all all 0.0.0.0/32 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER ADDRESS    METHOD OPTIONS
-host   all      root all        cert
+# TYPE DATABASE USER ADDRESS    METHOD        OPTIONS
+host   all      root all        cert-password
 host   all      all  0.0.0.0/32 cert
 
 connect user=testuser
@@ -41,8 +41,8 @@ set_hba
 host all all 127.0.0.0/8 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER ADDRESS     METHOD OPTIONS
-host   all      root all         cert
+# TYPE DATABASE USER ADDRESS     METHOD        OPTIONS
+host   all      root all         cert-password
 host   all      all  127.0.0.0/8 cert
 
 connect user=testuser

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -22,8 +22,8 @@ set_hba
 host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
-host   all      root all       cert
+# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
+host   all      root all       cert-password
 host   all      root 0.0.0.0/0 cert
 
 connect user=root
@@ -51,8 +51,8 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER     ADDRESS   METHOD OPTIONS
-host   all      root     all       cert
+# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
+host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 cert
 
 connect user=testuser
@@ -78,8 +78,8 @@ set_hba
 host all "a","b","testuser" 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER       ADDRESS   METHOD OPTIONS
-host   all      root       all       cert
+# TYPE DATABASE USER       ADDRESS   METHOD        OPTIONS
+host   all      root       all       cert-password
 host   all      "a"        0.0.0.0/0 cert
 host   all      "b"        0.0.0.0/0 cert
 host   all      "testuser" 0.0.0.0/0 cert
@@ -98,7 +98,7 @@ host all passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert
+host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert
 host   all      passworduser 0.0.0.0/0 cert-password
 
@@ -126,7 +126,7 @@ host all testuser,passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert
+host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert-password
 host   all      passworduser 0.0.0.0/0 cert-password
 
@@ -161,8 +161,8 @@ host all testuser,all 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER         ADDRESS   METHOD   OPTIONS
-host   all      root         all       cert
+# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
+host   all      root         all       cert-password
 host   all      all          0.0.0.0/0 cert
 host   all      passworduser 0.0.0.0/0 password
 
@@ -183,8 +183,8 @@ host all testuser,"all" 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER         ADDRESS   METHOD   OPTIONS
-host   all      root         all       cert
+# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
+host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert
 host   all      "all"        0.0.0.0/0 cert
 host   all      passworduser 0.0.0.0/0 password

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -19,8 +19,8 @@ set_hba
 host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER ADDRESS   METHOD OPTIONS
-host   all      root all       cert
+# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
+host   all      root all       cert-password
 host   all      root 0.0.0.0/0 cert
 
 connect user=root sslmode=disable

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -4,6 +4,8 @@
 config secure
 ----
 
+subtest regular_user
+
 sql
 CREATE USER userpw WITH PASSWORD 'pass'
 ----
@@ -50,3 +52,34 @@ ERROR: password authentication failed for user userpw
 connect user=userpw
 ----
 ERROR: password authentication failed for user userpw
+
+subtest end
+
+subtest root_pw
+
+# By default root cannot log in with a password.
+connect user=root sslmode=require sslcert= sslkey=
+----
+ERROR: password authentication failed for user root
+
+connect_unix user=root
+----
+ERROR: password authentication failed for user root
+
+
+# However if we give them a password, they can log in with password.
+sql
+ALTER USER root WITH PASSWORD 'secureabc'
+----
+ok
+
+# Then they can log in.
+connect user=root password=secureabc sslmode=require sslcert= sslkey=
+----
+ok defaultdb
+
+connect_unix user=root password=secureabc
+----
+ok defaultdb
+
+subtest end

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -18,13 +18,13 @@ set_hba
 host all root 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER ADDRESS   METHOD   OPTIONS
-host   all      root all       cert
+# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
+host   all      root all       cert-password
 host   all      root 0.0.0.0/0 password
 
 connect user=root password=abc sslmode=verify-ca sslcert=
 ----
-ERROR: no TLS peer certificates, but required for auth
+ERROR: password authentication failed for user root
 
 subtest end root_user_cannot_use_password
 
@@ -45,8 +45,8 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER     ADDRESS   METHOD OPTIONS
-host   all      root     all       cert
+# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
+host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 cert
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
@@ -61,8 +61,8 @@ set_hba
 host all testuser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER     ADDRESS   METHOD   OPTIONS
-host   all      root     all       cert
+# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
+host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 password
 
 connect user=testuser

--- a/pkg/sql/pgwire/testdata/auth/trust_reject
+++ b/pkg/sql/pgwire/testdata/auth/trust_reject
@@ -16,7 +16,7 @@ host all all all cert-password
 ----
 # Active authentication configuration on this node:
 # TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
-host   all      root     all     cert
+host   all      root     all     cert-password
 host   all      testuser all     reject
 host   all      all      all     cert-password
 
@@ -42,8 +42,8 @@ host all nocert all trust
 host all all all cert
 ----
 # Active authentication configuration on this node:
-# TYPE DATABASE USER   ADDRESS METHOD OPTIONS
-host   all      root   all     cert
+# TYPE DATABASE USER   ADDRESS METHOD        OPTIONS
+host   all      root   all     cert-password
 host   all      nocert all     trust
 host   all      all    all     cert
 

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -186,8 +186,8 @@ GRANT ALL ON DATABASE defaultdb TO foo`); err != nil {
 		if err == nil {
 			defer func() { _ = dbSQL.Close() }()
 		}
-		if !testutils.IsError(err, "timeout while retrieving user account") {
-			t.Fatalf("expected timeout error during connection, got %v", err)
+		if !testutils.IsError(err, "internal error while retrieving user account") {
+			t.Fatalf("expected error during connection, got %v", err)
 		}
 		timeoutDur := timeutil.Now().Sub(start)
 		if timeoutDur > 5*time.Second {


### PR DESCRIPTION
tldr: this patch enables the `root` user to have a password like
any user.

Fixes #43847. 

**Background**

Previously, CockroachDB implemented a plethora of special and highly
redundant cases to ensures that the `root` user could never have a
password and could never try to log in with a password, no matter
what. Only `root` was given these special cases, not other admin
users.

The somewhat reasonable first principle underlying the irrational
amount of redundant code is that contrary to most other DBs, it is
extremely difficult to re-add a valid user account into a cluster that
shut itself off by mis-configuring user accounts (short of re-starting
the entire cluster in insecure mode, which is arguably unpalatable in
production systems). It is desirable to guarantee `root` access
somehow. Allowing users to set, then forget, a `root` password
would endanger that.

This principle is not violated by this patch. This is described
further below.

Two additional principles were _originally_ valid but are not valid any
more:

- allowing users to configure passwords and enable password
  authentication provide a false sense of security, *in the particular
  case when the password is provided by a human having to memorize it
  and typing it on a keyboard.* [1] CockroachDB tries to
  promote industry best practices and promoting password
  authentication *with weak passwords* is not a best practice.

- CockroachDB "admin" users, like `root`, have the permission to
  pretty much do anything with a cluster, including viewing and
  modifying any data they want and hiding their traces. Therefore, admin
  users should be subject to a higher standard of scrutiny, and allowing
  them to have weak passwords (or any password at all, since
  CockroachDB has not entered the business of enforcing password
  hygiene) fails to match that higher standard.

This last principle is not valid any more because the `admin` role
can be granted to any user with any password, and it is accepted
to be industry-standard that password hygiene is the responsibility of
a site's operator, not that of the database engine.

[1] the password-on-keyboard case is the thing that's unsafe about
passwords. A sufficiently complex password entered non-interactively
by as password manager is virtually indistinguishable from a TLS client
certificate with regards to authentication.

Finally, CockroachDB does not support unencrypted network connections
in secure mode, so password sniffing on the network is not (currently)
possible. Allowing users to have and use passwords is not inherently
less secure than using and distributing TLS client certs, as transport
security is enforced using TLS in any case.

**Cluster safety consideration**

The previous section established that it is important that an admin
user _always_ be able to log in (currently, `root`) and that users are
not able to "shut themselves out" of operating their cluster.

This is currently implemented as follows in CockroachDB:

- in secure clusters, a valid TLS client for the `root` user is
  always guaranteed to yield a successful SQL authentication.
  This is in turn enforced by ensuring that the HBA configuration
  always start with a rule that allows cert auth for the `root` user.
- should the `root` cert be lost (and the CA key as well, preventing
  issuance of new `root` certs), it is possible to restart all the
  cluster with new CA whose key is known and issue a new `root` cert
  with that.

Remarkably, no mention is made here of passwords. This safety
guarantee is provided exclusively using TLS certs and the
special handling of HBA configurations.

**Description of changes**

This commit changes the following:

- removes the `root` special case in the UI login routine,
- removes the `root` special case in the
  `security.UserAuthPasswordHook` used to validate passwords
  through the various client channels,
- removes the `root` special case in the CLI client code that
  establishes SQL connections,
- removes the `root` special cases for password checks in CREATE USER
  and ALTER USER,
- changes the special HBA first rule to become `host all all root
  cert-password` instead of `host all all root cert`.

The commit in particular does not _remove_ the special HBA first rule
nor remove the ability to use a TLS client cert for `root`.


Additionally, the special case in `sql.GetUserHashedPassword` is
changed/evolved to enable root pw authentication, but still
guarantee that root can log in when some system range(s) are
unavailable. This is achieved as follows:

1) the interface of the function is changed to conceptually separate
   the lookup of whether the user exists from the lookup of their hashed
   password. This makes it possible to skip looking up the password
   when it is not needed.

2) by reporting that the root user exists without accessing
   system.users. This way, authentication methods that do not need a
   password (e.g. cert) do not need system.users to let root log in.

3) in case the root user is accessing via a password (e.g.  via the
   unix socket), by limiting the timeout to 5 seconds, so that large
   values of `system.user_login.timeout` do not impair the ability of
   operators to access the cluster.

Release note (security update): The `root` user is not anymore special
with regards to password management and can have a password like any
other member of the `admin` role. However, as in previous
versions, the HBA configuration cannot be overridden to prevent
`root` from logging in with a valid TLS client certificate. This
special rule remains enforced as a way to ensure that users cannot
"lock themselves out" of administrating their cluster.

Release note (security update): The `root` user remains special with
regards to authentication when some system ranges are unavailable: in
that case, password authentication will fail, subject to a timeout set
to the minimum between 5 seconds and the configured value of
`system.user_login_timeout` because the password cannot be retrieved
from a system table; however, certificate authentication remains
available.