### PR TITLE
cli: warn if trying to [rd]ecommision when already [rd]ecommissioned

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -341,13 +341,13 @@ func TestRemoveDeadReplicas(t *testing.T) {
 				}
 				adminClient := serverpb.NewAdminClient(grpcConn)
 
-				deadNodeStrs := []string{}
+				deadNodes := []roachpb.NodeID{}
 				for i := testCase.survivingNodes; i < testCase.totalNodes; i++ {
-					deadNodeStrs = append(deadNodeStrs, fmt.Sprintf("%d", i+1))
+					deadNodes = append(deadNodes, roachpb.NodeID(i+1))
 				}
 
 				if err := runDecommissionNodeImpl(
-					ctx, adminClient, nodeDecommissionWaitNone, deadNodeStrs,
+					ctx, adminClient, nodeDecommissionWaitNone, deadNodes,
 				); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -1368,7 +1369,7 @@ func runQuit(cmd *cobra.Command, args []string) (err error) {
 	defer finish()
 
 	if quitCtx.serverDecommission {
-		var myself []string // will remain empty, which means target yourself
+		var myself []roachpb.NodeID // will remain empty, which means target yourself
 		if err := runDecommissionNodeImpl(ctx, c, nodeDecommissionWaitAll, myself); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #36624.
First commit from #43908

Release note (cli change): The CLI commands `cockroach node
decommission` and `cockroach node recommission` now produce a warning
on the standard error if one of the node(s) specified is
already (d/r)ecommissioned.