### PR TITLE
roachprod: Increase stdout buffer size on execCmd errors to 4096

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -328,7 +328,7 @@ func execCmd(ctx context.Context, l *logger, args ...string) error {
 	l.Printf("> %s\n", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
-	debugStdoutBuffer, _ := circbuf.NewBuffer(1024)
+	debugStdoutBuffer, _ := circbuf.NewBuffer(4096)
 	debugStderrBuffer, _ := circbuf.NewBuffer(1024)
 
 	// Do a dance around https://github.com/golang/go/issues/23019.


### PR DESCRIPTION
Currently, if an error is encountered when executing a command
in a roachtest, such as the one called by synctest (see #42778),
it can be really hard to debug the cause of the error due to
stacktraces getting truncated by the low 1024 byte limit of
the stdout buffer.

This change quadruples the size of that buffer.

Release note: None