### PR TITLE
execinfra: comment out some verbose logging

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -723,9 +723,15 @@ func (pb *ProcessorBase) ProcessRowHelper(row sqlbase.EncDatumRow) sqlbase.EncDa
 		pb.MoveToDraining(nil /* err */)
 	}
 	// Note that outRow might be nil here.
-	if outRow != nil && log.V(3) {
-		log.InfofDepth(pb.Ctx, 1, "pushing row %s", outRow.String(pb.Out.OutputTypes))
-	}
+	// TODO(yuzefovich): there is a problem with this logging when MetadataTest*
+	// processors are planned - there is a mismatch between the row and the
+	// output types (rendering is added to the stage of test processors and the
+	// actual processors that are inputs to the test ones have an unset post
+	// processing; I think that we need to set the post processing on the stages
+	// of processors below the test ones).
+	//if outRow != nil && log.V(3) && pb.Ctx != nil {
+	//	log.InfofDepth(pb.Ctx, 1, "pushing row %s", outRow.String(pb.Out.OutputTypes))
+	//}
 	return outRow
 }
 


### PR DESCRIPTION
There were two problems with the logging of rows in ProcessRowHelper:
1. it is possible that pb.Ctx is nil (for example, when the processor
has already moved to draining state), so we should check for that before
logging. Previously it could panic.
2. there are issues with setting up of the post processing on 'metadata'
test configuration. Those are hairy to fix, and for now it is easier to
comment out the logging altogether.

Release note: None