### PR TITLE
duration,builtins: fix interval cast involving years to match postgres

### DIFF
--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -660,6 +660,16 @@ eval
 '00:02:00'
 
 eval
+interval '1 year 1 day 02:03:04.567'::int
+----
+31651384
+
+eval
+interval '1 year 1 day 02:03:04.567'::float
+----
+3.1651384567e+07
+
+eval
 '2010-09-28'::date + 3
 ----
 '2010-10-01'
@@ -814,30 +824,6 @@ eval
 '-1mon-2d-3h-4s-5us'::interval::int::interval
 ----
 '-1 mons -2 days -03:00:04'
-
-# MaxInt64
-eval
-9223372036854775807::int::interval::int
-----
-9223372036854775807
-
-# MinInt64
-eval
-(-9223372036854775808)::int::interval::int
-----
--9223372036854775808
-
-# MaxInt64
-eval
-'296533308798y20d15h30m7s'::interval::int::interval
-----
-'296533308798 years 20 days 15:30:07'
-
-# MinInt64
-eval
-'-296533308798y-20d-15h-30m-8s'::interval::int::interval
-----
-'-296533308798 years -20 days -15:30:08'
 
 eval
 '1970-01-01 00:01:00.123456-00:00'::timestamp::decimal

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -42,19 +42,19 @@ var positiveDurationTests = []durationTest{
 	{1, Duration{Months: 0, Days: 1, nanos: 0}, false},
 	{0, Duration{Months: 0, Days: 0, nanos: nanosInDay}, false},
 	{1, Duration{Months: 0, Days: 0, nanos: nanosInDay + 1}, false},
-	{1, Duration{Months: 0, Days: daysInMonth - 1, nanos: 0}, false},
+	{1, Duration{Months: 0, Days: DaysPerMonth - 1, nanos: 0}, false},
 	{1, Duration{Months: 0, Days: 0, nanos: nanosInMonth - 1}, false},
 	{1, Duration{Months: 1, Days: 0, nanos: 0}, false},
-	{0, Duration{Months: 0, Days: daysInMonth, nanos: 0}, false},
+	{0, Duration{Months: 0, Days: DaysPerMonth, nanos: 0}, false},
 	{0, Duration{Months: 0, Days: 0, nanos: nanosInMonth}, false},
 	{1, Duration{Months: 0, Days: 0, nanos: nanosInMonth + 1}, false},
-	{1, Duration{Months: 0, Days: daysInMonth + 1, nanos: 0}, false},
+	{1, Duration{Months: 0, Days: DaysPerMonth + 1, nanos: 0}, false},
 	{1, Duration{Months: 1, Days: 1, nanos: 1}, false},
 	{1, Duration{Months: 1, Days: 10, nanos: 0}, false},
 	{0, Duration{Months: 0, Days: 40, nanos: 0}, false},
 	{1, Duration{Months: 2, Days: 0, nanos: 0}, false},
-	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth - 1, nanos: nanosInDay * 2}, true},
-	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth * 2, nanos: nanosInDay * 2}, true},
+	{1, Duration{Months: math.MaxInt64 - 1, Days: DaysPerMonth - 1, nanos: nanosInDay * 2}, true},
+	{1, Duration{Months: math.MaxInt64 - 1, Days: DaysPerMonth * 2, nanos: nanosInDay * 2}, true},
 	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, nanos: nanosInMonth + nanosInDay}, true},
 	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, nanos: math.MaxInt64}, true},
 }
@@ -114,8 +114,8 @@ func TestNormalize(t *testing.T) {
 		if nanos.Cmp(normalizedNanos) != 0 {
 			t.Errorf("%d effective nanos were changed [%s] [%s]", i, test.duration, normalized)
 		}
-		if normalized.Days > daysInMonth && normalized.Months != math.MaxInt64 ||
-			normalized.Days < -daysInMonth && normalized.Months != math.MinInt64 {
+		if normalized.Days > DaysPerMonth && normalized.Months != math.MaxInt64 ||
+			normalized.Days < -DaysPerMonth && normalized.Months != math.MinInt64 {
 			t.Errorf("%d days were not normalized [%s]", i, normalized)
 		}
 		if normalized.nanos > nanosInDay && normalized.Days != math.MaxInt64 ||


### PR DESCRIPTION
Refs: #43272

Release note (sql change, backward-incompatible change): Previously,
intervals could be cast to integers and floats. However, this relies on
a year being 365 days. To match `extract('epoch' from interval)`
behavior in postgres/cockroach having a year being 365.25 days, we
accordingly the cast to int and floats have years valued at 365.25 days
in seconds instead of 365.