### PR TITLE
sql/tests: close sqlsmith at test end

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -547,6 +547,9 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		}
 		return err
 	})
+	if smither != nil {
+		smither.Close()
+	}
 
 	fmt.Printf("To reproduce, use schema:\n\n")
 	for _, stmt := range tableStmts {


### PR DESCRIPTION
This prevents a go routine leak due to the new bulkio code, which has
a running HTTP server.

Release note: None