### PR TITLE
release-19.2: sql: fix decoding error in fetcher

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -141,7 +141,7 @@ func DecodeKeyValsToCols(
 		i := indexColIdx[j]
 		if i == -1 {
 			// Don't need the coldata - skip it.
-			key, err = skipTableKey(&types[j], key, enc)
+			key, err = sqlbase.SkipTableKey(&types[j], key, enc)
 		} else {
 			if unseen != nil {
 				unseen.Remove(i)
@@ -239,56 +239,6 @@ func decodeTableKeyToCol(
 		return rkey, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
 	}
 	return rkey, err
-}
-
-// skipTableKey skips a value of type valType in key, returning the remainder
-// of the key.
-// TODO(jordan): each type could be optimized here.
-// TODO(jordan): should use this approach in the normal row fetcher.
-func skipTableKey(
-	valType *types.T, key []byte, dir sqlbase.IndexDescriptor_Direction,
-) ([]byte, error) {
-	if (dir != sqlbase.IndexDescriptor_ASC) && (dir != sqlbase.IndexDescriptor_DESC) {
-		return nil, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
-	}
-	var isNull bool
-	if key, isNull = encoding.DecodeIfNull(key); isNull {
-		return key, nil
-	}
-	var rkey []byte
-	var err error
-	switch valType.Family() {
-	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily:
-		if dir == sqlbase.IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeVarintAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeVarintDescending(key)
-		}
-	case types.FloatFamily:
-		if dir == sqlbase.IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeFloatAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeFloatDescending(key)
-		}
-	case types.BytesFamily, types.StringFamily, types.UuidFamily:
-		if dir == sqlbase.IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
-		}
-	case types.DecimalFamily:
-		if dir == sqlbase.IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
-		}
-	default:
-		return key, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
-	}
-	if err != nil {
-		return key, err
-	}
-	return rkey, nil
 }
 
 // UnmarshalColumnValueToCol decodes the value from a roachpb.Value using the

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -162,6 +163,72 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 		return encoding.EncodeVarintDescending(b, int64(t.DInt)), nil
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)
+}
+
+// SkipTableKey skips a value of type valType in key, returning the remainder
+// of the key.
+// TODO(jordan): each type could be optimized here.
+func SkipTableKey(valType *types.T, key []byte, dir IndexDescriptor_Direction) ([]byte, error) {
+	if (dir != IndexDescriptor_ASC) && (dir != IndexDescriptor_DESC) {
+		return nil, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
+	}
+	var isNull bool
+	if key, isNull = encoding.DecodeIfNull(key); isNull {
+		return key, nil
+	}
+	var rkey []byte
+	var err error
+	switch valType.Family() {
+	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily, types.TimeFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeVarintDescending(key)
+		}
+	case types.FloatFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeFloatAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeFloatDescending(key)
+		}
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.INetFamily, types.CollatedStringFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
+		}
+	case types.DecimalFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
+		}
+	case types.TimestampFamily, types.TimestampTZFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeTimeAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeTimeDescending(key)
+		}
+	case types.IntervalFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeDurationAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeDurationDescending(key)
+		}
+	case types.BitFamily:
+		if dir == IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeBitArrayAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeBitArrayDescending(key)
+		}
+	default:
+		// Tuples and arrays aren't indexable types right now, so we don't have cases for them.
+		return key, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
+	}
+	if err != nil {
+		return key, err
+	}
+	return rkey, nil
 }
 
 // DecodeTableKey decodes a value encoded by EncodeTableKey.


### PR DESCRIPTION
Backport 1/1 commits from #43002.

This fix is being backported even though column families on secondary indexes are
not implemented in 19.2 because it contains logic for the vectorized engine to skip
values in keys that it does not have support for.

/cc @cockroachdb/release

---

Fixes #42992.

PR #42073 introduced column families for secondary indexes, but also introduced
a bug where if the extra columns of a unique index were included because that
row had a null value, then those extra columns needed to be skipped when
decoding keys. If the type of that extra column was not supported by the
vectorized engine, and internal error was thrown.  This PR fixes the bug by
updating the key skipping logic to handle all valid types.

There is no release note because this was not a change visible
through major versions.

Release note: None
