### PR TITLE
storage/engine: fix re-issued KV writes with most recent seq num

### DIFF
--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -171,7 +171,7 @@ func (meta *MVCCMetadata) GetPrevIntentSeq(seq TxnSeq) (TxnSeq, bool) {
 	index := sort.Search(len(meta.IntentHistory), func(i int) bool {
 		return meta.IntentHistory[i].Sequence >= seq
 	})
-	if index > 0 && index < len(meta.IntentHistory) {
+	if index > 0 {
 		return meta.IntentHistory[index-1].Sequence, true
 	}
 	return 0, false

--- a/pkg/storage/engine/enginepb/mvcc_test.go
+++ b/pkg/storage/engine/enginepb/mvcc_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package enginepb
+
+import (
+	fmt "fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataGetPrevIntentSeq(t *testing.T) {
+	for _, tc := range []struct {
+		history      []TxnSeq
+		search       TxnSeq
+		expPrevSeq   TxnSeq
+		expPrevFound bool
+	}{
+		{[]TxnSeq{}, 0, 0, false},
+		{[]TxnSeq{}, 1, 0, false},
+		{[]TxnSeq{}, 2, 0, false},
+		{[]TxnSeq{}, 3, 0, false},
+		{[]TxnSeq{0}, 0, 0, false},
+		{[]TxnSeq{0}, 1, 0, true},
+		{[]TxnSeq{0}, 2, 0, true},
+		{[]TxnSeq{0}, 3, 0, true},
+		{[]TxnSeq{1}, 0, 0, false},
+		{[]TxnSeq{1}, 1, 0, false},
+		{[]TxnSeq{1}, 2, 1, true},
+		{[]TxnSeq{1}, 3, 1, true},
+		{[]TxnSeq{0, 1}, 0, 0, false},
+		{[]TxnSeq{0, 1}, 1, 0, true},
+		{[]TxnSeq{0, 1}, 2, 1, true},
+		{[]TxnSeq{0, 1}, 3, 1, true},
+		{[]TxnSeq{0, 2}, 0, 0, false},
+		{[]TxnSeq{0, 2}, 1, 0, true},
+		{[]TxnSeq{0, 2}, 2, 0, true},
+		{[]TxnSeq{0, 2}, 3, 2, true},
+		{[]TxnSeq{1, 2}, 0, 0, false},
+		{[]TxnSeq{1, 2}, 1, 0, false},
+		{[]TxnSeq{1, 2}, 2, 1, true},
+		{[]TxnSeq{1, 2}, 3, 2, true},
+		{[]TxnSeq{0, 1, 2}, 0, 0, false},
+		{[]TxnSeq{0, 1, 2}, 1, 0, true},
+		{[]TxnSeq{0, 1, 2}, 2, 1, true},
+		{[]TxnSeq{0, 1, 2}, 3, 2, true},
+	} {
+		name := fmt.Sprintf("%v/%d", tc.history, tc.search)
+		t.Run(name, func(t *testing.T) {
+			var meta MVCCMetadata
+			for _, seq := range tc.history {
+				meta.IntentHistory = append(meta.IntentHistory, MVCCMetadata_SequencedIntent{
+					Sequence: seq,
+				})
+			}
+
+			prevSeq, prevFound := meta.GetPrevIntentSeq(tc.search)
+			require.Equal(t, tc.expPrevSeq, prevSeq)
+			require.Equal(t, tc.expPrevFound, prevFound)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #43928.

This commit fixes a bug in `MVCCMetadata.GetPrevIntentSeq` that was present
since its inception (a147f24). The method was failing to properly look up
the previous intent sequence when the last sequence in the sequence history
should have been returned. This could cause errors for read-write KV ops
like CPut, InitPut, and Increment.

This commit does not need to land on master because it was already fixed
there by f6a4dc5. It will need to end up on release-19.1 as well though.

Release note (bug fix): A SQL row write that is re-issued after
already succeeding will no longer throw a duplicate key error when
the previous write in its transaction deleted the row.