### PR TITLE
Revert "roachprod: Make multiple set [provider]-zones always geo-distribute nodes"

### DIFF
--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -87,29 +87,6 @@ marc-foo: 23h59m42s remaining
 Syncing...
 ```
 
-#### Choosing a Provider
-
-Use the `--clouds` flag to set which cloud provider(s) to use. Ex:
-
-```
-$ roachprod create foo --clouds gce,aws
-```
-
-#### Node Distribution Options
-
-There are a couple flags that interact to create nodes in one zone or in
-geographically distributed zones:
-
-- `--geo`
-- the `--[provider]-zones` flags (`--gce-zones`, `--aws-zones`, `--azure-locations`)
-
-Here's what to expect when the options are combined:
-
-- _If neither are set_: nodes are all placed within one of the the provider's default zones
-- _`--geo` only_: nodes are spread across the provider's default zones
-- _`--[provider]-zones` or `--geo --[provider]-zones`_: nodes are spread across
-  all the specified zones
-
 ### Interact using crl-prod tools
 
 `roachprod` populates hosts files in `~/.roachprod/hosts`. These are used by

--- a/pkg/cmd/roachprod/vm/azure/azure.go
+++ b/pkg/cmd/roachprod/vm/azure/azure.go
@@ -119,12 +119,8 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 	ctx, cancel := context.WithTimeout(context.Background(), p.opts.operationTimeout)
 	defer cancel()
 
-	if len(p.opts.locations) == 0 {
-		if opts.GeoDistributed {
-			p.opts.locations = defaultLocations
-		} else {
-			p.opts.locations = []string{defaultLocations[0]}
-		}
+	if !opts.GeoDistributed {
+		p.opts.locations = []string{p.opts.locations[0]}
 	}
 
 	if _, err := p.createVNets(ctx, p.opts.locations); err != nil {

--- a/pkg/cmd/roachprod/vm/azure/flags.go
+++ b/pkg/cmd/roachprod/vm/azure/flags.go
@@ -11,8 +11,6 @@
 package azure
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
@@ -28,12 +26,6 @@ type providerOpts struct {
 	vnetName         string
 }
 
-var defaultLocations = []string{
-	"eastus2",
-	"westus",
-	"westeurope",
-}
-
 // ConfigureCreateFlags implements vm.ProviderFlags.
 func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.DurationVar(&o.operationTimeout, ProviderName+"-timeout", 10*time.Minute,
@@ -43,9 +35,9 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.machineType, ProviderName+"-machine-type",
 		string(compute.VirtualMachineSizeTypesStandardD4V3),
 		"Machine type (see https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/)")
-	flags.StringSliceVar(&o.locations, ProviderName+"-locations", nil,
-		fmt.Sprintf("Locations for cluster (see `az account list-locations`) (default\n[%s])",
-			strings.Join(defaultLocations, ",")))
+	flags.StringSliceVar(&o.locations, ProviderName+"-locations",
+		[]string{"eastus2", "westus", "westeurope"},
+		"Locations for cluster (see `az account list-locations`)")
 	flags.StringVar(&o.vnetName, ProviderName+"-vnet-name", "common",
 		"The name of the VNet to use")
 }

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -194,14 +194,6 @@ type projectsVal struct {
 	opts                   *providerOpts
 }
 
-// defaultZones is the list of  zones used by default for cluster creation.
-// If the geo flag is specified, nodes are distributed between zones.
-var defaultZones = []string{
-	"us-east1-b",
-	"us-west1-b",
-	"europe-west2-b",
-}
-
 // Set is part of the pflag.Value interface.
 func (v projectsVal) Set(projects string) error {
 	if projects == "" {
@@ -260,18 +252,17 @@ func (p *Provider) GetProjects() []string {
 func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.MachineType, "machine-type", "n1-standard-4", "DEPRECATED")
 	_ = flags.MarkDeprecated("machine-type", "use "+ProviderName+"-machine-type instead")
-	flags.StringSliceVar(&o.Zones, "zones", nil, "DEPRECATED")
+	flags.StringSliceVar(&o.Zones, "zones", []string{"us-east1-b", "us-west1-b", "europe-west2-b"}, "DEPRECATED")
 	_ = flags.MarkDeprecated("zones", "use "+ProviderName+"-zones instead")
 
 	flags.StringVar(&o.ServiceAccount, ProviderName+"-service-account",
 		os.Getenv("GCE_SERVICE_ACCOUNT"), "Service account to use")
 	flags.StringVar(&o.MachineType, ProviderName+"-machine-type", "n1-standard-4",
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
-	flags.StringSliceVar(&o.Zones, ProviderName+"-zones", nil,
-		fmt.Sprintf("Zones for cluster. If zones are formatted as AZ:N where N is an integer, the zone\n"+
-			"will be repeated N times. If > 1 zone specified, nodes will be geo-distributed\n"+
-			"regardless of geo (default [%s])",
-			strings.Join(defaultZones, ",")))
+	flags.StringSliceVar(&o.Zones, ProviderName+"-zones",
+		[]string{"us-east1-b", "us-west1-b", "europe-west2-b"},
+		"Zones for cluster; If zones are formatted as "+
+			"AZ:N where N is an integer, the zone will be repeated N times")
 	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-1604-xenial-v20190122a",
 		"Image to use to create the vm, ubuntu-1904-disco-v20191008 is a more modern image")
 	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 1,
@@ -356,12 +347,8 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 	if err != nil {
 		return err
 	}
-	if len(zones) == 0 {
-		if opts.GeoDistributed {
-			zones = defaultZones
-		} else {
-			zones = []string{defaultZones[0]}
-		}
+	if !opts.GeoDistributed {
+		zones = []string{zones[0]}
 	}
 
 	// Fixed args.


### PR DESCRIPTION
This reverts commit d24e40ec40f777366d7f9a6d123fcafd8c8f75c2.

Reverting back to the prior roachprod functionality for how --geo and
--zones worked because nightly roachtest running from teamcity is failing
numerous tests and this will allow fixing roachtest without the time pressure.

Release note: None