### PR TITLE
sql/opt/memo: avoid bytes.Equal in hasher.IsStringEqual

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -641,11 +641,12 @@ func (h *hasher) IsIntEqual(l, r int) bool {
 }
 
 func (h *hasher) IsFloat64Equal(l, r float64) bool {
+	// Compare bit representations so that NaN == NaN and 0 != -0.
 	return math.Float64bits(l) == math.Float64bits(r)
 }
 
 func (h *hasher) IsStringEqual(l, r string) bool {
-	return bytes.Equal([]byte(l), []byte(r))
+	return l == r
 }
 
 func (h *hasher) IsBytesEqual(l, r []byte) bool {


### PR DESCRIPTION
This commit switches `hasher.IsStringEqual` from using `bytes.Equal` to using
the string equality operator. This avoids the need to allocate a new byte slice
and copy over the string contents for each of the arguments to the hasher's
method, which can take time and add unnecessary pressure on the GC.

The use of `bytes.Equal` seems so deliberate that it makes me think I'm
missing something. Am I?

### Benchmark:

The following benchmark demonstrates the cost of calling `bytes.Equal` on medium
sized string arguments:

```
package main

import (
	"bytes"
	"strings"
	"testing"
)

var str1 = repeat("testing1234567890", 3)
var str2 = repeat("testing0987654321", 4)

func repeat(s string, n int) string {
	var buf strings.Builder
	for i := 0; i < n; i++ {
		buf.WriteString(s)
	}
	return buf.String()
}

func strEq(s1, s2 string) bool {
	return s1 == s2
}

func bytesEq(s1, s2 string) bool {
	return bytes.Equal([]byte(s1), []byte(s2))
}

func BenchmarkStringEq(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strEq(str1, str2)
	}
}

func BenchmarkBytesEq(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = bytesEq(str1, str2)
	}
}

// name         time/op
// StringEq-16  0.57ns ± 4%
// BytesEq-16   64.6ns ± 1%
//
// name         alloc/op
// StringEq-16   0.00B
// BytesEq-16     144B ± 0%
//
// name         allocs/op
// StringEq-16    0.00
// BytesEq-16     2.00 ± 0%
```