### PR TITLE
sql/opt/memo: hash ScanFlags Direction val in hasher

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -478,6 +478,7 @@ func (h *hasher) HashScanLimit(val ScanLimit) {
 func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashBool(val.NoIndexJoin)
 	h.HashBool(val.ForceIndex)
+	h.HashInt(int(val.Direction))
 	h.HashUint64(uint64(val.Index))
 }
 

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -327,9 +327,42 @@ func TestInterner(t *testing.T) {
 
 		{hashFn: in.hasher.HashScanFlags, eqFn: in.hasher.IsScanFlagsEqual, variations: []testVariation{
 			{val1: ScanFlags{}, val2: ScanFlags{}, equal: true},
+			{val1: ScanFlags{NoIndexJoin: false}, val2: ScanFlags{NoIndexJoin: true}, equal: false},
+			{val1: ScanFlags{NoIndexJoin: true}, val2: ScanFlags{NoIndexJoin: true}, equal: true},
+			{val1: ScanFlags{ForceIndex: false}, val2: ScanFlags{ForceIndex: true}, equal: false},
+			{val1: ScanFlags{ForceIndex: true}, val2: ScanFlags{ForceIndex: true}, equal: true},
+			{val1: ScanFlags{Direction: tree.Descending}, val2: ScanFlags{Direction: tree.Ascending}, equal: false},
+			{val1: ScanFlags{Direction: tree.Ascending}, val2: ScanFlags{Direction: tree.Ascending}, equal: true},
+			{val1: ScanFlags{Index: 1}, val2: ScanFlags{Index: 2}, equal: false},
+			{val1: ScanFlags{Index: 2}, val2: ScanFlags{Index: 2}, equal: true},
 			{val1: ScanFlags{NoIndexJoin: true, Index: 1}, val2: ScanFlags{NoIndexJoin: true, Index: 1}, equal: true},
 			{val1: ScanFlags{NoIndexJoin: true, Index: 1}, val2: ScanFlags{NoIndexJoin: true, Index: 2}, equal: false},
 			{val1: ScanFlags{NoIndexJoin: true, Index: 1}, val2: ScanFlags{NoIndexJoin: false, Index: 1}, equal: false},
+			{
+				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				val2:  ScanFlags{NoIndexJoin: false, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				equal: false,
+			},
+			{
+				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				val2:  ScanFlags{NoIndexJoin: true, ForceIndex: false, Direction: tree.Ascending, Index: 1},
+				equal: false,
+			},
+			{
+				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				val2:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Descending, Index: 1},
+				equal: false,
+			},
+			{
+				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				val2:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 2},
+				equal: false,
+			},
+			{
+				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				val2:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
+				equal: true,
+			},
 		}},
 
 		{hashFn: in.hasher.HashPointer, eqFn: in.hasher.IsPointerEqual, variations: []testVariation{


### PR DESCRIPTION
This commit fixes what appears to be a bug where the Direction field in ScanFlags
was not being hashed in `hasher.HashScanFlags`. I believe this omission meant that
two ScanExprs that differed only in their scan forced scan direction could be
considered equivalent by the interner and the scan direction on the second ScanExpr
would be accidentally reversed.

The only reason I can think of for why this may have been missed deliberately
is that we may have been trying to define `Direction: None` and `Direction: Ascending`
as equivalent. I don't think that's the case though.

Release note: None