### PR TITLE
build: record artifact of "Maybe stress{,race}" CI step

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -39,7 +39,7 @@ function run_json_test() {
   go install github.com/cockroachdb/cockroach/pkg/cmd/testfilter
   go install github.com/cockroachdb/cockroach/pkg/cmd/github-post
   mkdir -p artifacts
-  tmpfile="artifacts/debug.${run_counter}.txt"
+  tmpfile="artifacts/raw.${run_counter}.json.txt"
   tc_end_block "prep"
 
   tc_start_block "run"
@@ -80,13 +80,22 @@ function run_json_test() {
   tc_start_block "artifacts"
   # Create (or append to) failures.txt artifact and delete stripped.txt.
   testfilter -mode=omit < artifacts/stripped.txt | testfilter -mode convert >> artifacts/failures.txt
-  rm -f artifacts/stripped.txt
 
-  # Keep the debug file around for failed builds. Compress it to avoid
-  # clogging the agents with stuff we'll hopefully rarely ever need to
-  # look at.
-  tar --strip-components 1 -czf "${tmpfile}.tgz" "${tmpfile}"
-  rm -f "${tmpfile}"
+  if [ $status -ne 0 ]; then
+    # Keep the debug file around for failed builds. Compress it to avoid
+    # clogging the agents with stuff we'll hopefully rarely ever need to
+    # look at.
+    # If the process failed, also save the full human-readable output. This is
+    # helpful in cases in which tests timed out, where it's difficult to blame
+    # the failure on any particular test. It's also a good alternative to poking
+    # around in $tmpfile itself when anything else we don't handle well happens,
+    # whatever that may be.
+    fullfile=artifacts/full_output.txt
+    testfilter -mode convert < "${tmpfile}" >> "${fullfile}"
+    tar --strip-components 1 -czf "${tmpfile}.tgz" "${tmpfile}" "${fullfile}"
+    rm -f "${fullfile}"
+  fi
+  rm -f "${tmpfile}" artifacts/stripped.txt
   tc_end_block "artifacts"
 
   # Make it easier to figure out whether we're exiting because of a test failure

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -123,7 +123,7 @@ function maybe_stress() {
   block="Maybe ${target} pull request"
   tc_start_block "${block}"
   run build/builder.sh go install ./pkg/cmd/github-pull-request-make
-  run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET="${target}" github-pull-request-make
+  run_json_test build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET="${target}" github-pull-request-make
   tc_end_block "${block}"
 }
 

--- a/pkg/cmd/testfilter/testdata/omit.txt
+++ b/pkg/cmd/testfilter/testdata/omit.txt
@@ -1,7 +1,12 @@
-# Does not like empty input (avoids misconfiguration)
+# OK with empty input
 omit
 ----
-not a single test was parsed
+
+# Does not like input without JSON but with plain text output (avoids misconfiguration)
+omit
+PASS
+----
+not a single test was parsed, but detected test output: PASS
 
 # Skips non-test lines. The test line is required to avoid a sanity
 # check in the tool.

--- a/pkg/cmd/testfilter/testdata/strip.txt
+++ b/pkg/cmd/testfilter/testdata/strip.txt
@@ -1,7 +1,12 @@
-# Doesn't like empty input.
-strip
+# OK with empty input
+omit
 ----
-not a single test was parsed
+
+# Does not like input without JSON but with plain text output (avoids misconfiguration)
+omit
+PASS
+----
+not a single test was parsed, but detected test output: PASS
 
 # Strips passing tests but keeps the start/stop events as well as random non-test output.
 strip


### PR DESCRIPTION
This previously wasn't the case, but if stressing ran into the test
timeout, TeamCity doesn't provide easy access to the output.

See #43947.

Release note: None