### PR TITLE
roachtest: fix sqlsmith roachtest to check build version

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -130,11 +130,13 @@ func registerSQLSmith(r *testRegistry) {
 			logStmt(setup)
 		}
 
-		stmt := "SET experimental_enable_primary_key_changes = true;"
-		if _, err := conn.Exec(stmt); err != nil {
-			t.Fatal(err)
-		} else {
-			logStmt(stmt)
+		if t.IsBuildVersion("v20.1.0") {
+			stmt := "SET experimental_enable_primary_key_changes = true;"
+			if _, err := conn.Exec(stmt); err != nil {
+				t.Fatal(err)
+			} else {
+				logStmt(stmt)
+			}
 		}
 
 		const timeout = time.Minute


### PR DESCRIPTION
This PR fixes a bug where the sqlsmith roachtest was not
checking the version before trying to set the variable
`experimental_enable_primary_key_changes`, which does not
exist in versions prior to v20.1.0.

Release note: None