### PR TITLE
importccl: Support bool and boolean

### DIFF
--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -126,7 +126,7 @@ func nativeToDatum(
 // type names that can be used to construct our target type.
 var familyToAvroT = map[types.Family][]string{
 	// Primitive avro types.
-	types.BoolFamily:   {"bool", "string"},
+	types.BoolFamily:   {"bool", "boolean", "string"},
 	types.IntFamily:    {"int", "long", "string"},
 	types.FloatFamily:  {"float", "double", "string"},
 	types.StringFamily: {"string"},


### PR DESCRIPTION
boolean is an alias for bool -- treat it as such when importing avro.

Release note: better handle booleans when importing avro data.