### PR TITLE
roachtest: only pass one zone if geo isn't set

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -628,6 +628,10 @@ func (s clusterSpec) String() string {
 	return str
 }
 
+func firstZone(zones string) string {
+	return strings.SplitN(zones, ",", 2)[0]
+}
+
 func (s *clusterSpec) args() []string {
 	var args []string
 
@@ -654,7 +658,11 @@ func (s *clusterSpec) args() []string {
 		}
 	}
 	if s.Zones != "" {
-		args = append(args, "--gce-zones="+s.Zones)
+		if s.Geo {
+			args = append(args, "--gce-zones="+s.Zones)
+		} else {
+			args = append(args, "--gce-zones="+firstZone(s.Zones))
+		}
 	}
 	if s.Geo {
 		args = append(args, "--geo")
@@ -964,7 +972,11 @@ func (f *clusterFactory) newCluster(
 	sargs := []string{roachprod, "create", c.name, "-n", fmt.Sprint(c.spec.NodeCount)}
 	sargs = append(sargs, cfg.spec.args()...)
 	if !local && zonesF != "" && cfg.spec.Zones == "" {
-		sargs = append(sargs, "--gce-zones="+zonesF)
+		if cfg.spec.Geo {
+			sargs = append(sargs, "--gce-zones="+zonesF)
+		} else {
+			sargs = append(sargs, "--gce-zones="+firstZone(zonesF))
+		}
 	}
 	if !cfg.useIOBarrier {
 		sargs = append(sargs, "--local-ssd-no-ext4-barrier")

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -205,7 +205,9 @@ the test tags.
 			&clusterWipe, "wipe", true,
 			"wipe existing cluster before starting test (for use with --cluster)")
 		cmd.Flags().StringVar(
-			&zonesF, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
+			&zonesF, "zones", "",
+			"Zones for the cluster. (non-geo tests use the first zone, geo tests use all zones) "+
+				"(uses roachprod defaults if empty)")
 		cmd.Flags().IntVar(
 			&cpuQuota, "cpu-quota", 300,
 			"The number of cloud CPUs roachtest is allowed to use at any one time.")


### PR DESCRIPTION
Before: all zones specified either in the clusterSpec or via the --zones flag
were added to the roachprod command without regard to whether --geo was set.

Why change? Because the way roachprod handled --geo and --[provider]-zones
changed. See https://github.com/cockroachdb/cockroach/pull/43748 .

Now:

1. if geo is not set and zones are set (via CLI flag or in the clusterSpec),
   only the first zone will be passed to roachprod.
2. if geo is set and zones are set (via CLI flag or in the clusterSpec), all
   zones will be passed to roachprod.

Fixes #43898

Release note: None