### PR TITLE
sql: add ClusterID into flowCtx when calling SupportsVectorized

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -217,3 +217,19 @@ func TestExportShow(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expected, got)
 	}
 }
+
+// TestExportVectorized makes sure that SupportsVectorized check doesn't panic
+// on CSVWriter processor.
+func TestExportVectorized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	dir, cleanupDir := testutils.TempDir(t)
+	defer cleanupDir()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir})
+	defer srv.Stopper().Stop(context.Background())
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `CREATE TABLE t(a INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `SET vectorize_row_count_threshold=0`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'http://0.1:37957/exp_1' FROM TABLE t`)
+}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -168,6 +168,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 						Cfg: &execinfra.ServerConfig{
 							DiskMonitor: &mon.BytesMonitor{},
 							Settings:    dsp.st,
+							ClusterID:   &dsp.rpcCtx.ClusterID,
 						},
 						NodeID: -1,
 					}, spec.Processors, fuseOpt,

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -223,6 +223,7 @@ func (p *planner) populateExplain(
 		distSQLPlanner.FinalizePlan(planCtx, &physicalPlan)
 		flows := physicalPlan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
 		flowCtx := makeFlowCtx(planCtx, physicalPlan, params)
+		flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 
 		ctxSessionData := flowCtx.EvalCtx.SessionData
 		vectorizedThresholdMet := physicalPlan.MaxEstimatedRowCount >= ctxSessionData.VectorizeRowCountThreshold

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -72,6 +72,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	distSQLPlanner.FinalizePlan(planCtx, &plan)
 	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
 	flowCtx := makeFlowCtx(planCtx, plan, params)
+	flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 
 	// Temporarily set vectorize to on so that we can get the whole plan back even
 	// if we wouldn't support it due to lack of streaming.


### PR DESCRIPTION
Instantiating a CSVWriter processor requires non-nil ClusterID which
previously was not set in the flowCtx. Now this is fixed, and we can
check whether such a processor can wrapped into the vectorized flow (it
cannot because it is not an execinfra.RowSource).

Fixes: #43885

Release note: None