### PR TITLE
sql: add telemetry for column creation types

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachange"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -119,6 +121,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 			d = newDef
 
+			telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
 			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx)
 			if err != nil {
 				return err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -1441,6 +1443,7 @@ func makeTableDesc(
 		if !ok {
 			continue
 		}
+		telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
 		newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, &n.Table)
 		if err != nil {
 			return ret, err

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -10,5 +10,21 @@ statement ok
 DROP TABLE TEST2
 
 # Regression for #43894
+subtest regression_43894
 statement ok
 CREATE TABLE IF NOT EXISTS t43894 (PRIMARY KEY (a), a UUID NOT NULL, b JSONB NOT NULL DEFAULT '5')
+
+subtest telemetry_tests
+
+statement ok
+CREATE TABLE new_table (a timetz(3))
+
+statement ok
+ALTER TABLE new_table ADD COLUMN c timetz(4)
+
+# Cannot really get more exact than this (i.e. looking at usage_count), as it increments on each run.
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name IN ('sql.schema.new_column_type.timetz_3_', 'sql.schema.new_column_type.timetz_4_') AND usage_count > 0 ORDER BY feature_name
+----
+sql.schema.new_column_type.timetz_3_
+sql.schema.new_column_type.timetz_4_

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -23,3 +23,9 @@ import (
 func SerialColumnNormalizationCounter(inputType, normType string) telemetry.Counter {
 	return telemetry.GetCounter(fmt.Sprintf("sql.schema.serial.%s.%s", normType, inputType))
 }
+
+// SchemaNewTypeCounter is to be implemented every time a new data type
+// is used in a schema, i.e. by CREATE TABLE or ALTER TABLE ADD COLUMN.
+func SchemaNewTypeCounter(t string) telemetry.Counter {
+	return telemetry.GetCounter("sql.schema.new_column_type." + t)
+}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -13,6 +13,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -1086,6 +1087,13 @@ func (t *T) PGName() string {
 //
 func (t *T) SQLStandardName() string {
 	return t.SQLStandardNameWithTypmod(false, 0)
+}
+
+var telemetryNameReplaceRegex = regexp.MustCompile("[^a-zA-Z0-9]")
+
+// TelemetryName returns a name that is friendly for telemetry.
+func (t *T) TelemetryName() string {
+	return strings.ToLower(telemetryNameReplaceRegex.ReplaceAllString(t.SQLString(), "_"))
 }
 
 // SQLStandardNameWithTypmod is like SQLStandardName but it also accepts a


### PR DESCRIPTION
Resolves #43778, resolves #43880. 

This PR adds tracking for types created with `CREATE TABLE / ALTER
TABLE ADD COLUMN`.

Release note: None