### PR TITLE
vendor: bump pebble to c333ae77fe84eb2a07ff94f954b81475c08f4745

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e81ebd78a5bd8408793997af228ae23e91b888e6d12041c10cabef0b0ec8584c"
+  digest = "1:6fb3525e24df3488fe4eeec5921b571d523bc565e0be9cbb49806c7345607d77"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -484,6 +484,7 @@
     "internal/cache",
     "internal/crc",
     "internal/humanize",
+    "internal/invariants",
     "internal/manifest",
     "internal/private",
     "internal/rangedel",
@@ -495,7 +496,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "bc72b903e1c384711180877c8eaa80e9eeb21ca6"
+  revision = "c333ae77fe84eb2a07ff94f954b81475c08f4745"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -237,6 +237,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		L0StopWritesThreshold:       1000,
 		LBaseMaxBytes:               64 << 20, // 64 MB
 		Levels:                      make([]pebble.LevelOptions, 7),
+		MaxConcurrentCompactions:    2,
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,


### PR DESCRIPTION
Set `MaxConcurrentCompactions=2` as it seems to have a significant
impact on IMPORT performance when running on Pebble.

* db: s/num_concurrent_compactions/max_concurrent_compactions/g in OPTIONS
* db: sync the OPTIONS file
* db: optimize compaction.elideTombstone
* db: fix an incomplete manifest file error when reopening a db
* db: (re-)enable levelIter invariants
* db: disable problematic use of hard links in Ingest
* db: tweak ingestTargetLevel heuristics
* db: change DB.Ingest to delete source files on success
* db: fix Iterator.SeekPrefixGE+tombstone perf problem
* db: remove time.Sleeps from TestManualCompaction
* db: always cache tombstones in mergingIter
* build: add stressmeta target
* *: add internal/invariants package
* db: fix ordering of resource releasing in Iterator.Close()
* db: fix cases where we were removing still open files
* db: add support for concurrent compactions
* tool: change --filter to use prefix semantics
* internal/metamorphic: properly pass --{keep,disk} to subtest

Release note: None