### PR TITLE
storage: rename SSTSnapshotStorage{,Scratch,File} vars

### DIFF
--- a/pkg/storage/replica_sst_snapshot_storage.go
+++ b/pkg/storage/replica_sst_snapshot_storage.go
@@ -42,103 +42,102 @@ func NewSSTSnapshotStorage(engine engine.Engine, limiter *rate.Limiter) SSTSnaps
 	}
 }
 
-// NewSSTSnapshotStorageScratch creates a new SST snapshot storage scratch for
-// a specific snapshot.
-func (sss *SSTSnapshotStorage) NewSSTSnapshotStorageScratch(
+// NewScratchSpace creates a new storage scratch space for SSTs for a specific
+// snapshot.
+func (s *SSTSnapshotStorage) NewScratchSpace(
 	rangeID roachpb.RangeID, snapUUID uuid.UUID,
 ) *SSTSnapshotStorageScratch {
-	snapDir := filepath.Join(sss.dir, strconv.Itoa(int(rangeID)), snapUUID.String())
-	ssss := &SSTSnapshotStorageScratch{
-		sss:     sss,
+	snapDir := filepath.Join(s.dir, strconv.Itoa(int(rangeID)), snapUUID.String())
+	return &SSTSnapshotStorageScratch{
+		storage: s,
 		snapDir: snapDir,
 	}
-	return ssss
 }
 
 // Clear removes all created directories and SSTs.
-func (sss *SSTSnapshotStorage) Clear() error {
-	return os.RemoveAll(sss.dir)
+func (s *SSTSnapshotStorage) Clear() error {
+	return os.RemoveAll(s.dir)
 }
 
 // SSTSnapshotStorageScratch keeps track of the SST files incrementally created
 // when receiving a snapshot. Each scratch is associated with a specific
 // snapshot.
 type SSTSnapshotStorageScratch struct {
-	sss        *SSTSnapshotStorage
+	storage    *SSTSnapshotStorage
 	ssts       []string
 	snapDir    string
 	dirCreated bool
 }
 
-func (ssss *SSTSnapshotStorageScratch) filename(id int) string {
-	return filepath.Join(ssss.snapDir, fmt.Sprintf("%d.sst", id))
+func (s *SSTSnapshotStorageScratch) filename(id int) string {
+	return filepath.Join(s.snapDir, fmt.Sprintf("%d.sst", id))
 }
 
-func (ssss *SSTSnapshotStorageScratch) createDir() error {
+func (s *SSTSnapshotStorageScratch) createDir() error {
 	// TODO(peter): The directory creation needs to be plumbed through the Engine
 	// interface. Right now, this is creating a directory on disk even when the
 	// Engine has an in-memory filesystem. The only reason everything still works
 	// is because RocksDB MemEnvs allow the creation of files when the parent
 	// directory doesn't exist.
-	err := os.MkdirAll(ssss.snapDir, 0755)
-	ssss.dirCreated = ssss.dirCreated || err == nil
+	err := os.MkdirAll(s.snapDir, 0755)
+	s.dirCreated = s.dirCreated || err == nil
 	return err
 }
 
 // NewFile adds another file to SSTSnapshotStorageScratch. This file is lazily
 // created when the file is written to the first time. A nonzero value for
 // chunkSize buffers up writes until the buffer is greater than chunkSize.
-func (ssss *SSTSnapshotStorageScratch) NewFile(
+func (s *SSTSnapshotStorageScratch) NewFile(
 	ctx context.Context, chunkSize int64,
 ) (*SSTSnapshotStorageFile, error) {
-	id := len(ssss.ssts)
-	filename := ssss.filename(id)
-	ssss.ssts = append(ssss.ssts, filename)
-	sssf := &SSTSnapshotStorageFile{
-		ssss:      ssss,
+	id := len(s.ssts)
+	filename := s.filename(id)
+	s.ssts = append(s.ssts, filename)
+	f := &SSTSnapshotStorageFile{
+		scratch:   s,
 		filename:  filename,
 		ctx:       ctx,
 		chunkSize: chunkSize,
 	}
-	return sssf, nil
+	return f, nil
 }
 
 // WriteSST writes SST data to a file. The method closes
 // the provided SST when it is finished using it. If the provided SST is empty,
 // then no file will be created and nothing will be written.
-func (ssss *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, data []byte) error {
+func (s *SSTSnapshotStorageScratch) WriteSST(ctx context.Context, data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	sssf, err := ssss.NewFile(ctx, 0)
+	f, err := s.NewFile(ctx, 0)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		// Closing an SSTSnapshotStorageFile multiple times is idempotent. Nothing
 		// actionable if closing fails.
-		_ = sssf.Close()
+		_ = f.Close()
 	}()
-	if _, err := sssf.Write(data); err != nil {
+	if _, err := f.Write(data); err != nil {
 		return err
 	}
-	return sssf.Close()
+	return f.Close()
 }
 
 // SSTs returns the names of the files created.
-func (ssss *SSTSnapshotStorageScratch) SSTs() []string {
-	return ssss.ssts
+func (s *SSTSnapshotStorageScratch) SSTs() []string {
+	return s.ssts
 }
 
 // Clear removes the directory and SSTs created for a particular snapshot.
-func (ssss *SSTSnapshotStorageScratch) Clear() error {
-	return os.RemoveAll(ssss.snapDir)
+func (s *SSTSnapshotStorageScratch) Clear() error {
+	return os.RemoveAll(s.snapDir)
 }
 
 // SSTSnapshotStorageFile is an SST file managed by a
 // SSTSnapshotStorageScratch.
 type SSTSnapshotStorageFile struct {
-	ssss      *SSTSnapshotStorageScratch
+	scratch   *SSTSnapshotStorageScratch
 	created   bool
 	file      engine.File
 	filename  string
@@ -147,83 +146,83 @@ type SSTSnapshotStorageFile struct {
 	buffer    []byte
 }
 
-func (sssf *SSTSnapshotStorageFile) openFile() error {
-	if sssf.created {
-		if sssf.file == nil {
+func (f *SSTSnapshotStorageFile) openFile() error {
+	if f.created {
+		if f.file == nil {
 			return errors.Errorf("file has already been closed")
 		}
 		return nil
 	}
-	if !sssf.ssss.dirCreated {
-		if err := sssf.ssss.createDir(); err != nil {
+	if !f.scratch.dirCreated {
+		if err := f.scratch.createDir(); err != nil {
 			return err
 		}
 	}
-	file, err := sssf.ssss.sss.engine.CreateFile(sssf.filename)
+	file, err := f.scratch.storage.engine.CreateFile(f.filename)
 	if err != nil {
 		return err
 	}
-	sssf.file = file
-	sssf.created = true
+	f.file = file
+	f.created = true
 	return nil
 }
 
 // Write writes contents to the file while respecting the limiter passed into
 // SSTSnapshotStorageScratch. Writing empty contents is okay and is treated as
 // a noop. The file must have not been closed.
-func (sssf *SSTSnapshotStorageFile) Write(contents []byte) (int, error) {
+func (f *SSTSnapshotStorageFile) Write(contents []byte) (int, error) {
 	if len(contents) == 0 {
 		return 0, nil
 	}
-	if err := sssf.openFile(); err != nil {
+	if err := f.openFile(); err != nil {
 		return 0, err
 	}
-	limitBulkIOWrite(sssf.ctx, sssf.ssss.sss.limiter, len(contents))
-	if sssf.chunkSize > 0 {
-		if int64(len(contents)+len(sssf.buffer)) < sssf.chunkSize {
+	limitBulkIOWrite(f.ctx, f.scratch.storage.limiter, len(contents))
+	if f.chunkSize > 0 {
+		if int64(len(contents)+len(f.buffer)) < f.chunkSize {
 			// Don't write to file yet - buffer write until next time.
-			sssf.buffer = append(sssf.buffer, contents...)
+			f.buffer = append(f.buffer, contents...)
 			return len(contents), nil
-		} else if len(sssf.buffer) > 0 {
+		} else if len(f.buffer) > 0 {
 			// Write buffered writes and then empty the buffer.
-			if _, err := sssf.file.Write(sssf.buffer); err != nil {
+			if _, err := f.file.Write(f.buffer); err != nil {
 				return 0, err
 			}
-			sssf.buffer = sssf.buffer[:0]
+			f.buffer = f.buffer[:0]
 		}
 	}
-	if _, err := sssf.file.Write(contents); err != nil {
+	if _, err := f.file.Write(contents); err != nil {
 		return 0, err
 	}
-	return len(contents), sssf.file.Sync()
+	return len(contents), f.file.Sync()
 }
 
 // Close closes the file. Calling this function multiple times is idempotent.
 // The file must have been written to before being closed.
-func (sssf *SSTSnapshotStorageFile) Close() error {
+func (f *SSTSnapshotStorageFile) Close() error {
 	// We throw an error for empty files because it would be an error to ingest
 	// an empty SST so catch this error earlier.
-	if !sssf.created {
+	if !f.created {
 		return errors.New("file is empty")
 	}
-	if sssf.file == nil {
+	if f.file == nil {
 		return nil
 	}
-	if len(sssf.buffer) > 0 {
+	if len(f.buffer) > 0 {
 		// Write out any buffered data.
-		if _, err := sssf.file.Write(sssf.buffer); err != nil {
+		if _, err := f.file.Write(f.buffer); err != nil {
 			return err
 		}
-		sssf.buffer = sssf.buffer[:0]
+		f.buffer = f.buffer[:0]
 	}
-	if err := sssf.file.Close(); err != nil {
+	if err := f.file.Close(); err != nil {
 		return err
 	}
-	sssf.file = nil
+	f.file = nil
 	return nil
 }
 
 // Sync syncs the file to disk. Implements writeCloseSyncer in engine.
-func (sssf *SSTSnapshotStorageFile) Sync() error {
-	return sssf.file.Sync()
+func (f *SSTSnapshotStorageFile) Sync() error {
+	return f.file.Sync()
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -385,7 +385,7 @@ type Store struct {
 	raftEntryCache     *raftentry.Cache
 	limiters           batcheval.Limiters
 	txnWaitMetrics     *txnwait.Metrics
-	sss                SSTSnapshotStorage
+	sstSnapshotStorage SSTSnapshotStorage
 	protectedtsCache   protectedts.Cache
 
 	// gossipRangeCountdown and leaseRangeCountdown are countdowns of
@@ -854,8 +854,8 @@ func NewStore(
 	// after each snapshot application, except when the node crashed right before
 	// it can clean it up. If this fails it's not a correctness issue since the
 	// storage is also cleared before receiving a snapshot.
-	s.sss = NewSSTSnapshotStorage(s.engine, s.limiters.BulkIOWriteRate)
-	if err := s.sss.Clear(); err != nil {
+	s.sstSnapshotStorage = NewSSTSnapshotStorage(s.engine, s.limiters.BulkIOWriteRate)
+	if err := s.sstSnapshotStorage.Clear(); err != nil {
 		log.Warningf(ctx, "failed to clear snapshot storage: %v", err)
 	}
 	s.protectedtsCache = cfg.ProtectedTimestampCache


### PR DESCRIPTION
Around snapshot receiving code, we have variables for SSTSnapshotStorage, SSTSnapshotStorageScratch, and SSTSnapshotStorageFile types
all abbreviated to some variation of sss{,s,f}. We also have "ssts" to
talk about SSTs. This is all terribly confusing, we could do with some
much needed clarity here.

Release note: None.