### PR TITLE
colexec: reject aggregates with different input and output types

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -280,11 +280,11 @@ func isSupported(spec *execinfrapb.ProcessorSpec) (bool, error) {
 			if len(agg.Arguments) > 0 {
 				return false, errors.Newf("aggregates with arguments not supported")
 			}
-			var inputType *types.T
-			if len(agg.ColIdx) > 0 {
-				inputType = &spec.Input[0].ColumnTypes[agg.ColIdx[0]]
+			var inputTypes []types.T
+			for _, colIdx := range agg.ColIdx {
+				inputTypes = append(inputTypes, spec.Input[0].ColumnTypes[colIdx])
 			}
-			if supported, err := isAggregateSupported(agg.Func, inputType); !supported {
+			if supported, err := isAggregateSupported(agg.Func, inputTypes); !supported {
 				return false, err
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1055,3 +1055,12 @@ CREATE TABLE t43855(o OID, r REGPROCEDURE)
 query i
 SELECT CASE WHEN o = 0 THEN 0:::OID ELSE r END FROM t43855
 ----
+
+# Regression test for an aggregate that has output type different from its
+# input type (INT4 is input whereas output is INT). Currently such query is not
+# supported through vectorized engine, but we will get a plan with wrapped
+# rowexec.orderedAggregator.
+query I
+SELECT max(c) FROM a
+----
+2000


### PR DESCRIPTION
For MIN and MAX aggregate functions, `execinfrapb.GetAggregateInfo`
returns `INT` (i.e. `INT8`) as the return type for all integer types.
However, columnar operators will output the same physical type as their
input. This would lead to a panic of type mismatch, and it has been
fixed by rejecting such queries to run via the vectorized engine.
I believe only MIN and MAX on integer types were affected.

Fixes: #43936.

Release note (bug fix): Previously, an internal error could occur when
a query with an aggregate function MIN or MAX was executed via the
vectorized engine when the input column was either INT2 or INT4 type.
Now this is fixed.