### PR TITLE
colexec: fix an issue with builtin operators and a minor cleanup

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -128,6 +128,13 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	o.leftFeedOp.batch = batch
 	batch = o.leftProjOpChain.Next(ctx)
 
+	if origLen == 0 {
+		// Run the right-side projection on the remaining tuples.
+		o.rightFeedOp.batch = batch
+		batch = o.rightProjOpChain.Next(ctx)
+		return batch
+	}
+
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
 	// not get the projection for the right side.
@@ -183,10 +190,6 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetSelection(false)
 	}
 	batch.SetLength(origLen)
-
-	if origLen == 0 {
-		return batch
-	}
 
 	rightCol := batch.ColVec(o.rightIdx)
 	outputCol := batch.ColVec(o.outputIdx)

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -102,6 +102,9 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 			}
 		},
 	)
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
 	return batch
 }
 
@@ -185,6 +188,9 @@ func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
 			}
 		},
 	)
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -857,8 +857,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			return rf.machine.batch, nil
 
 		case stateFinished:
-			rf.machine.batch.SetLength(0)
-			return rf.machine.batch, nil
+			return coldata.ZeroBatch, nil
 		}
 	}
 }

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -42,8 +42,6 @@ func NewCountOp(allocator *Allocator, input Operator) Operator {
 
 func (c *countOp) Init() {
 	c.input.Init()
-	// Our output is always just one row.
-	c.internalBatch.SetLength(1)
 	c.count = 0
 	c.done = false
 }
@@ -51,8 +49,7 @@ func (c *countOp) Init() {
 func (c *countOp) Next(ctx context.Context) coldata.Batch {
 	c.internalBatch.ResetInternalBatch()
 	if c.done {
-		c.internalBatch.SetLength(0)
-		return c.internalBatch
+		return coldata.ZeroBatch
 	}
 	for {
 		bat := c.input.Next(ctx)
@@ -60,6 +57,7 @@ func (c *countOp) Next(ctx context.Context) coldata.Batch {
 		if length == 0 {
 			c.done = true
 			c.internalBatch.ColVec(0).Int64()[0] = c.count
+			c.internalBatch.SetLength(1)
 			return c.internalBatch
 		}
 		c.count += int64(length)

--- a/pkg/sql/colexec/deselector.go
+++ b/pkg/sql/colexec/deselector.go
@@ -53,7 +53,6 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 		return batch
 	}
 
-	p.output.SetLength(batch.Length())
 	p.output.ResetInternalBatch()
 	sel := batch.Selection()
 	p.allocator.PerformOperation(p.output.ColVecs(), func() {
@@ -72,5 +71,6 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 			)
 		}
 	})
+	p.output.SetLength(batch.Length())
 	return p.output
 }

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -195,9 +195,8 @@ func (s *zeroOperator) Init() {
 
 func (s *zeroOperator) Next(ctx context.Context) coldata.Batch {
 	// TODO(solon): Can we avoid calling Next on the input at all?
-	next := s.input.Next(ctx)
-	next.SetLength(0)
-	return next
+	s.input.Next(ctx)
+	return coldata.ZeroBatch
 }
 
 type singleTupleNoInputOperator struct {
@@ -224,8 +223,7 @@ func (s *singleTupleNoInputOperator) Init() {
 func (s *singleTupleNoInputOperator) Next(ctx context.Context) coldata.Batch {
 	s.batch.ResetInternalBatch()
 	if s.nexted {
-		s.batch.SetLength(0)
-		return s.batch
+		return coldata.ZeroBatch
 	}
 	s.nexted = true
 	s.batch.SetLength(1)

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -106,6 +106,9 @@ func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	} else {
 		_SET_PROJECTION(false)
 	}
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -108,6 +108,9 @@ func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 		_SET_PROJECTION(false)
 	}
 
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -365,6 +365,9 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 // buffer appends all tuples in range [start,end) from s.batch to already
 // buffered tuples.
 func (s *chunker) buffer(start uint16, end uint16) {
+	if start == end {
+		return
+	}
 	s.allocator.PerformOperation(s.bufferedTuples.colVecs, func() {
 		for i := 0; i < len(s.bufferedTuples.colVecs); i++ {
 			s.bufferedTuples.colVecs[i].Append(

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -203,8 +203,7 @@ func (t *topKSorter) emit() coldata.Batch {
 	toEmit := t.topK.Length() - t.emitted
 	if toEmit == 0 {
 		// We're done.
-		t.output.SetLength(0)
-		return t.output
+		return coldata.ZeroBatch
 	}
 	if toEmit > coldata.BatchSize() {
 		toEmit = coldata.BatchSize()

--- a/pkg/sql/colexec/testutils.go
+++ b/pkg/sql/colexec/testutils.go
@@ -80,10 +80,9 @@ func (s *RepeatableBatchSource) Next(context.Context) coldata.Batch {
 	s.internalBatch.SetSelection(s.sel != nil)
 	s.batchesReturned++
 	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
-		s.internalBatch.SetLength(0)
-	} else {
-		s.internalBatch.SetLength(s.batchLen)
+		return coldata.ZeroBatch
 	}
+	s.internalBatch.SetLength(s.batchLen)
 	if s.sel != nil {
 		// Since selection vectors are mutable, to make sure that we return the
 		// batch with the given selection vector, we need to reset

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -209,12 +209,11 @@ func TestEval(t *testing.T) {
 				Inputs: []colexec.Operator{
 					&colexec.CallbackOperator{
 						NextCb: func(_ context.Context) coldata.Batch {
+							if batchesReturned > 0 {
+								return coldata.ZeroBatch
+							}
 							// It doesn't matter what types we create the input batch with.
 							batch := coldata.NewMemBatch(inputColTyps)
-							if batchesReturned > 0 {
-								batch.SetLength(0)
-								return batch
-							}
 							batch.SetLength(1)
 							batchesReturned++
 							return batch


### PR DESCRIPTION
Flat bytes relies on coldata.Batch.SetLength call to maintain its
invariant. We assume that it is always called before return the batch in
which Bytes vector might have been modified. This was not the case for
default builtin and substring operators, and the calls were added.
Additionally, to be safe, similar calls have been in added in projection
operators.

In a few places where we were setting the length of an internal batch to
0 and then returning it, those were replaced with returning
coldata.ZeroBatch.

Fixes: #43656.

Release note: None