### PR TITLE
roachtest: skip acceptance/version-upgrade because flaky

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -46,6 +46,7 @@ func registerAcceptance(r *testRegistry) {
 		{name: "status-server", fn: runStatusServer},
 		{
 			name: "version-upgrade",
+			skip: "#43957",
 			fn:   runVersionUpgrade,
 			// This test doesn't like running on old versions because it upgrades to
 			// the latest released version and then it tries to "head", where head is


### PR DESCRIPTION
Very flaky, apparently because of some problem with a recent migration.
Touches #43957, #44005

Release note: None