### PR TITLE
release-19.2: colexec: skip over unneeded columns with unknown types in cfetcher

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -180,7 +180,9 @@ func (m *MemBatch) Reset(types []coltypes.T, length int) {
 func (m *MemBatch) ResetInternalBatch() {
 	m.SetSelection(false)
 	for _, v := range m.b {
-		v.Nulls().UnsetNulls()
+		if v.Type() != coltypes.Unhandled {
+			v.Nulls().UnsetNulls()
+		}
 		if v.Type() == coltypes.Bytes {
 			v.Bytes().Reset()
 		}

--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -64,7 +64,8 @@ func BatchSize() uint16 {
 	return batchSize
 }
 
-// NewMemBatch allocates a new in-memory Batch.
+// NewMemBatch allocates a new in-memory Batch. A coltypes.Unknown type
+// will create a placeholder Vec that may not be accessed.
 // TODO(jordan): pool these allocations.
 func NewMemBatch(types []coltypes.T) Batch {
 	return NewMemBatchWithSize(types, int(BatchSize()))

--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -1,0 +1,97 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coldata
+
+import (
+	"time"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// unknown is a Vec that represents an unhandled type. Used when a batch needs a placeholder Vec.
+type unknown struct{}
+
+func (u unknown) Type() coltypes.T {
+	return coltypes.Unhandled
+}
+
+func (u unknown) Bool() []bool {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Int16() []int16 {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Int32() []int32 {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Int64() []int64 {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Float64() []float64 {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Bytes() *Bytes {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Decimal() []apd.Decimal {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Timestamp() []time.Time {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Col() interface{} {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) SetCol(interface{}) {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) _TemplateType() []interface{} {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Append(SliceArgs) {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Copy(CopySliceArgs) {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Slice(colType coltypes.T, start uint64, end uint64) Vec {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) PrettyValueAt(idx uint16, colType coltypes.T) string {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) MaybeHasNulls() bool {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) Nulls() *Nulls {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
+func (u unknown) SetNulls(*Nulls) {
+	panic("Vec is of unknown type and should not be accessed")
+}

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -156,6 +156,8 @@ func NewMemColumn(t coltypes.T, n int) Vec {
 		return &memColumn{t: t, col: make([]apd.Decimal, n), nulls: nulls}
 	case coltypes.Timestamp:
 		return &memColumn{t: t, col: make([]time.Time, n), nulls: nulls}
+	case coltypes.Unhandled:
+		return unknown{}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", t))
 	}

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -267,7 +267,9 @@ func (rf *cFetcher) Init(
 	typs := make([]coltypes.T, len(colDescriptors))
 	for i := range typs {
 		typs[i] = typeconv.FromColumnType(&colDescriptors[i].Type)
-		if typs[i] == coltypes.Unhandled {
+		if typs[i] == coltypes.Unhandled && tableArgs.ValNeededForCol.Contains(i) {
+			// Only return an error if the type is unhandled and needed. If not needed,
+			// a placeholder Vec will be created.
 			return errors.Errorf("unhandled type %+v", &colDescriptors[i].Type)
 		}
 	}

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -57,9 +57,6 @@ type cTableInfo struct {
 	// schema changes.
 	cols []sqlbase.ColumnDescriptor
 
-	// The exec types corresponding to the table columns in cols.
-	typs []coltypes.T
-
 	// The ordered list of ColumnIDs that are required.
 	neededColsList []int
 
@@ -280,7 +277,6 @@ func (rf *cFetcher) Init(
 		index:            tableArgs.Index,
 		isSecondaryIndex: tableArgs.IsSecondaryIndex,
 		cols:             colDescriptors,
-		typs:             typs,
 
 		// These slice fields might get re-allocated below, so reslice them from
 		// the old table here in case they've got enough capacity already.
@@ -596,8 +592,10 @@ func (rf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
 		case stateResetBatch:
-			for i := range rf.machine.colvecs {
-				rf.machine.colvecs[i].Nulls().UnsetNulls()
+			for _, colvec := range rf.machine.colvecs {
+				if colvec.Type() != coltypes.Unhandled {
+					colvec.Nulls().UnsetNulls()
+				}
 			}
 			rf.machine.batch.ResetInternalBatch()
 			rf.shiftState()

--- a/pkg/sql/colexec/mem_estimation.go
+++ b/pkg/sql/colexec/mem_estimation.go
@@ -66,6 +66,8 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// significantly overestimate.
 			// TODO(yuzefovich): figure out whether the caching does take place.
 			acc += sizeOfTime
+		case coltypes.Unhandled:
+			// Placeholder codlata.Vecs of unknown types are allowed.
 		default:
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", t))
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -59,3 +59,32 @@ false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23
 # (TimestampTZ). We're only interested in not getting an error. See #42871.
 statement ok
 SELECT experimental_strptime(_string, _string) IS NULL FROM all_types
+
+statement ok
+CREATE TABLE skip_unneeded_cols (
+  _id UUID,
+  _id2 INT8,
+  _float FLOAT8,
+  _unsupported1 INT ARRAY,
+  _bool BOOL,
+  _unsupported2 INT ARRAY,
+  _bool2 BOOL,
+  PRIMARY KEY(_id, _id2)
+)
+
+statement ok
+INSERT INTO skip_unneeded_cols VALUES ('63616665-6630-3064-6465-616462656562', 1, '1.2', NULL, true, NULL, false)
+
+statement ok
+SET vectorize=experimental_always
+
+statement error pq: unable to vectorize execution plan: unhandled type int\[\]
+SELECT _unsupported1 FROM skip_unneeded_cols
+
+query IBB
+SELECT _id2, _bool, _bool2 FROM skip_unneeded_cols
+----
+1 true false
+
+statement ok
+RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -55,11 +55,6 @@ SELECT * FROM all_types ORDER BY 1
 NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL
 false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000
 
-# This query uses a builtin that returns currently unsupported type
-# (TimestampTZ). We're only interested in not getting an error. See #42871.
-statement ok
-SELECT experimental_strptime(_string, _string) IS NULL FROM all_types
-
 statement ok
 CREATE TABLE skip_unneeded_cols (
   _id UUID,
@@ -85,6 +80,28 @@ query IBB
 SELECT _id2, _bool, _bool2 FROM skip_unneeded_cols
 ----
 1 true false
+
+statement ok
+RESET vectorize
+
+# This query uses a builtin that returns currently unsupported type
+# (TimestampTZ). We're only interested in not getting an error. See #42871.
+statement ok
+SELECT experimental_strptime(_string, _string) IS NULL FROM all_types
+
+statement ok
+CREATE TABLE unsupported_type (id INT PRIMARY KEY, unsupported INT ARRAY)
+
+statement ok
+INSERT INTO unsupported_type (id) SELECT * FROM generate_series(1, 2000)
+
+statement ok
+SET vectorize=experimental_always
+
+# This query makes sure that CFetcher when reading from a table with an
+# unhandled type (that isn't needed) is reset correctly between batches.
+statement ok
+SELECT id FROM unsupported_type LIMIT 1 OFFSET 1100
 
 statement ok
 RESET vectorize

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -56,7 +56,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r FROM t
 ----
 ·          distributed  false      ·    ·
-·          vectorized   false      ·    ·
+·          vectorized   true       ·    ·
 render     ·            ·          (r)  ·
  │         render 0     3          ·    ·
  └── scan  ·            ·          ()   ·
@@ -67,7 +67,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a + 2 AS r FROM t
 ----
 ·          distributed  false      ·    ·
-·          vectorized   false      ·    ·
+·          vectorized   true       ·    ·
 render     ·            ·          (r)  ·
  │         render 0     a + 2      ·    ·
  └── scan  ·            ·          (a)  ·
@@ -78,7 +78,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 AS r FROM t
 ----
 ·          distributed  false                                 ·          ·
-·          vectorized   false                                 ·          ·
+·          vectorized   true                                  ·          ·
 render     ·            ·                                     (r)        ·
  │         render 0     ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
  └── scan  ·            ·                                     (a, b, c)  ·
@@ -89,7 +89,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4 AS r FROM t
 ----
 ·          distributed  false                               ·          ·
-·          vectorized   false                               ·          ·
+·          vectorized   true                                ·          ·
 render     ·            ·                                   (r)        ·
  │         render 0     ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
  └── scan  ·            ·                                   (a, b, c)  ·
@@ -100,7 +100,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) AS r FROM t
 ----
 ·          distributed  false      ·    ·
-·          vectorized   false      ·    ·
+·          vectorized   true       ·    ·
 render     ·            ·          (r)  ·
  │         render 0     a != 5     ·    ·
  └── scan  ·            ·          (a)  ·
@@ -111,7 +111,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) AS r FROM t
 ----
 ·          distributed  false                 ·       ·
-·          vectorized   false                 ·       ·
+·          vectorized   true                  ·       ·
 render     ·            ·                     (r)     ·
  │         render 0     (a <= 5) OR (b < 10)  ·       ·
  └── scan  ·            ·                     (a, b)  ·
@@ -122,7 +122,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) AS r FROM t
 ----
 ·          distributed  false                                                ·          ·
-·          vectorized   false                                                ·          ·
+·          vectorized   true                                                 ·          ·
 render     ·            ·                                                    (r)        ·
  │         render 0     ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
  └── scan  ·            ·                                                    (a, b, c)  ·
@@ -133,7 +133,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) AS r FROM t
 ----
 ·          distributed  false                                ·          ·
-·          vectorized   false                                ·          ·
+·          vectorized   true                                 ·          ·
 render     ·            ·                                    (r)        ·
  │         render 0     ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
  └── scan  ·            ·                                    (a, b, c)  ·
@@ -144,7 +144,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  AS r FROM t
 ----
 ·          distributed  false                ·       ·
-·          vectorized   false                ·       ·
+·          vectorized   true                 ·       ·
 render     ·            ·                    (r)     ·
  │         render 0     (a = 1) AND (b = 2)  ·       ·
  └── scan  ·            ·                    (a, b)  ·
@@ -155,7 +155,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) AS r FROM t
 ----
 ·          distributed  false        ·    ·
-·          vectorized   false        ·    ·
+·          vectorized   true         ·    ·
 render     ·            ·            (r)  ·
  │         render 0     a IN (1, 2)  ·    ·
  └── scan  ·            ·            (a)  ·
@@ -177,7 +177,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  AS r FROM t
 ----
 ·          distributed  false                                                            ·             ·
-·          vectorized   false                                                            ·             ·
+·          vectorized   true                                                             ·             ·
 render     ·            ·                                                                (r)           ·
  │         render 0     ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
  └── scan  ·            ·                                                                (a, b, c, d)  ·
@@ -188,7 +188,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  AS r FROM t
 ----
 ·          distributed  false                                            ·             ·
-·          vectorized   false                                            ·             ·
+·          vectorized   true                                             ·             ·
 render     ·            ·                                                (r)           ·
  │         render 0     (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
  └── scan  ·            ·                                                (a, b, c, d)  ·
@@ -199,7 +199,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) AS r FROM t
 ----
 ·          distributed  false                                                                                  ·             ·
-·          vectorized   false                                                                                  ·             ·
+·          vectorized   true                                                                                   ·             ·
 render     ·            ·                                                                                      (r)           ·
  │         render 0     (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
  └── scan  ·            ·                                                                                      (a, b, c, s)  ·
@@ -210,7 +210,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NULL AS r FROM t
 ----
 ·          distributed  false      ·    ·
-·          vectorized   false      ·    ·
+·          vectorized   true       ·    ·
 render     ·            ·          (r)  ·
  │         render 0     a IS NULL  ·    ·
  └── scan  ·            ·          (a)  ·
@@ -221,7 +221,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL AS r FROM t
 ----
 ·          distributed  false      ·    ·
-·          vectorized   false      ·    ·
+·          vectorized   true       ·    ·
 render     ·            ·          (r)  ·
  │         render 0     a IS NULL  ·    ·
  └── scan  ·            ·          (a)  ·
@@ -243,7 +243,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL AS r FROM t
 ----
 ·          distributed  false          ·    ·
-·          vectorized   false          ·    ·
+·          vectorized   true           ·    ·
 render     ·            ·              (r)  ·
  │         render 0     a IS NOT NULL  ·    ·
  └── scan  ·            ·              (a)  ·
@@ -254,7 +254,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL AS r FROM t
 ----
 ·          distributed  false          ·    ·
-·          vectorized   false          ·    ·
+·          vectorized   true           ·    ·
 render     ·            ·              (r)  ·
  │         render 0     a IS NOT NULL  ·    ·
  └── scan  ·            ·              (a)  ·
@@ -298,7 +298,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END AS r FROM t
 ----
 ·          distributed  false                              ·    ·
-·          vectorized   false                              ·    ·
+·          vectorized   true                               ·    ·
 render     ·            ·                                  (r)  ·
  │         render 0     CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
  └── scan  ·            ·                                  (a)  ·
@@ -321,7 +321,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END AS r FROM t
 ----
 ·          distributed  false                       ·    ·
-·          vectorized   false                       ·    ·
+·          vectorized   true                        ·    ·
 render     ·            ·                           (r)  ·
  │         render 0     CASE WHEN a = 2 THEN 1 END  ·    ·
  └── scan  ·            ·                           (a)  ·
@@ -353,7 +353,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT length(s) FROM t
 ----
 ·          distributed  false      ·         ·
-·          vectorized   false      ·         ·
+·          vectorized   true       ·         ·
 render     ·            ·          (length)  ·
  │         render 0     length(s)  ·         ·
  └── scan  ·            ·          (s)       ·
@@ -538,7 +538,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
 ·          distributed  false                  ·          ·
-·          vectorized   false                  ·          ·
+·          vectorized   true                   ·          ·
 render     ·            ·                      (a)        ·
  │         render 0     a                      ·          ·
  └── scan  ·            ·                      (a, b, d)  ·
@@ -550,7 +550,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
 ·          distributed  false               ·          ·
-·          vectorized   false               ·          ·
+·          vectorized   true                ·          ·
 render     ·            ·                   (a)        ·
  │         render 0     a                   ·          ·
  └── scan  ·            ·                   (a, b, d)  ·
@@ -562,7 +562,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
 ·          distributed  false                                               ·          ·
-·          vectorized   false                                               ·          ·
+·          vectorized   true                                                ·          ·
 render     ·            ·                                                   (r)        ·
  │         render 0     ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
  └── scan  ·            ·                                                   (a, b, d)  ·
@@ -573,7 +573,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
 ·          distributed  false                                          ·          ·
-·          vectorized   false                                          ·          ·
+·          vectorized   true                                           ·          ·
 render     ·            ·                                              (r)        ·
  │         render 0     ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
  └── scan  ·            ·                                              (a, b, d)  ·
@@ -628,7 +628,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
 ·          distributed  false      ·             ·
-·          vectorized   false      ·             ·
+·          vectorized   true       ·             ·
 render     ·            ·          ("?column?")  ·
  │         render 0     true       ·             ·
  └── scan  ·            ·          ()            ·
@@ -639,7 +639,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
 ·          distributed  false      ·             ·
-·          vectorized   false      ·             ·
+·          vectorized   true       ·             ·
 render     ·            ·          ("?column?")  ·
  │         render 0     false      ·             ·
  └── scan  ·            ·          ()            ·
@@ -704,7 +704,7 @@ EXPLAIN (VERBOSE) SELECT 1::FLOAT + length(upper(concat('a', 'b', 'c')))::FLOAT 
                          1::FLOAT + length(upper(concat('a', 'b', s)))::FLOAT AS r2 FROM t
 ----
 ·          distributed  false                                             ·         ·
-·          vectorized   false                                             ·         ·
+·          vectorized   true                                              ·         ·
 render     ·            ·                                                 (r1, r2)  ·
  │         render 0     4.0                                               ·         ·
  │         render 1     length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -658,7 +658,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
 ----
 ·     distributed  false                    ·           ·
-·     vectorized   false                    ·           ·
+·     vectorized   true                     ·           ·
 scan  ·            ·                        (b string)  +b
 ·     table        computed@computed_b_idx  ·           ·
 ·     spans        ALL                      ·           ·
@@ -899,7 +899,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT i FROM num WHERE i = -1:::INT
 ----
 ·     distributed  false          ·        ·
-·     vectorized   false          ·        ·
+·     vectorized   true           ·        ·
 scan  ·            ·              (i int)  ·
 ·     table        num@num_i_key  ·        ·
 ·     spans        /-1-/0         ·        ·
@@ -908,7 +908,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT f FROM num WHERE f = -1:::FLOAT
 ----
 ·     distributed  false              ·          ·
-·     vectorized   false              ·          ·
+·     vectorized   true               ·          ·
 scan  ·            ·                  (f float)  ·
 ·     table        num@num_f_key      ·          ·
 ·     spans        /-1-/-1/PrefixEnd  ·          ·
@@ -917,7 +917,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT d FROM num WHERE d = -1:::DECIMAL
 ----
 ·     distributed  false              ·            ·
-·     vectorized   false              ·            ·
+·     vectorized   true               ·            ·
 scan  ·            ·                  (d decimal)  ·
 ·     table        num@num_d_key      ·            ·
 ·     spans        /-1-/-1/PrefixEnd  ·            ·


### PR DESCRIPTION
This PR unreverts the revert done in #43072 now that #43932 is in (the original PR is #42616). #43939 should fast follow this backport as well.

Please take a close look.