### PR TITLE
builtins: miscellaneous fixes for the to_hex builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -985,6 +985,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="to_hex"></a><code>to_hex(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> to its hexadecimal representation.</p>
 </span></td></tr>
+<tr><td><a name="to_hex"></a><code>to_hex(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> to its hexadecimal representation.</p>
+</span></td></tr>
 <tr><td><a name="to_ip"></a><code>to_ip(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts the character string representation of an IP to its byte string representation.</p>
 </span></td></tr>
 <tr><td><a name="to_uuid"></a><code>to_uuid(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts the character string representation of a UUID to its byte string representation.</p>

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -351,6 +351,4 @@ var PostgresMode = multiOption(
 	// Some func impls differ from postgres, so skip them here.
 	// #41709
 	IgnoreFNs("^sha"),
-	// #41707
-	IgnoreFNs("^to_hex"),
 )

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2350,3 +2350,22 @@ query B
 SELECT (1, 2) IN ((2, 3), NULL)
 ----
 NULL
+
+# Test for regression in hex functions.
+subtest regression_41707
+
+# The int8 casts make it match postgres behavior - unfortunately, we do not default to int4.
+query TTTTTTT
+select to_hex(-2147483649), to_hex(-2147483648::int8), to_hex(-1::int8), to_hex(0), to_hex(1), to_hex(2147483647), to_hex(2147483648)
+----
+ffffffff7fffffff  ffffffff80000000  ffffffffffffffff  0  1  7fffffff  80000000
+
+query T
+select to_hex(E'\\047\\134'::bytea)
+----
+275c
+
+query T
+select to_hex('abc')
+----
+616263


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/41707.

Release note (sql change, bug fix):
* Added to_hex(string) -> string functionality.
* Previously, `to_hex(-1)` would return `-1` instead of the negative
hex representation (`FFFFFFFFFFFFFFFF`). This has been rectified in
this PR.