### PR TITLE
distsql: reduce log severity of inbound stream error

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -561,8 +561,11 @@ func (ds *ServerImpl) flowStreamInt(
 func (ds *ServerImpl) FlowStream(stream execinfrapb.DistSQL_FlowStreamServer) error {
 	ctx := ds.AnnotateCtx(stream.Context())
 	err := ds.flowStreamInt(ctx, stream)
-	if err != nil {
-		log.Error(ctx, err)
+	if err != nil && log.V(2) {
+		// flowStreamInt may return an error during normal operation (e.g. a flow
+		// was canceled as part of a graceful teardown). Log this error at the INFO
+		// level behind a verbose flag for visibility.
+		log.Info(ctx, err)
 	}
 	return err
 }


### PR DESCRIPTION
Inbound streams may error out for normal reasons. One of these is when a
context cancellation happens. Any error was logged at the ERROR level, that
severity has now been reduced to INFO and the required verbosity to log has
been increased to 2.

Release note (bug fix): A benign error previously logged at the ERROR level
is now logged at the INFO level behind a verbosity(2) flag. This error might
have been observed as "context canceled: readerCtx in Inbox stream handler".

Fixes #43953 