### PR TITLE
opt: fix insert fast path when using a non-unique index

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -94,20 +94,26 @@ type insertFastPathFKCheck struct {
 }
 
 func (c *insertFastPathFKCheck) init() error {
+	idx := c.ReferencedIndex.(*optIndex)
 	c.tabDesc = c.ReferencedTable.(*optTable).desc
-	c.idxDesc = c.ReferencedIndex.(*optIndex).desc
+	c.idxDesc = idx.desc
 	c.keyPrefix = sqlbase.MakeIndexKeyPrefix(&c.tabDesc.TableDescriptor, c.idxDesc.ID)
 	c.spanBuilder = span.MakeBuilder(c.tabDesc.TableDesc(), c.idxDesc)
 
-	if len(c.InsertCols) > len(c.idxDesc.ColumnIDs) {
+	if len(c.InsertCols) > idx.numLaxKeyCols {
 		return errors.AssertionFailedf(
-			"%d FK cols, only %d cols in index",
-			len(c.InsertCols), len(c.idxDesc.ColumnIDs),
+			"%d FK cols, only %d cols in index", len(c.InsertCols), idx.numLaxKeyCols,
 		)
 	}
 	c.colMap = make(map[sqlbase.ColumnID]int, len(c.InsertCols))
 	for i, ord := range c.InsertCols {
-		colID := c.idxDesc.ColumnIDs[i]
+		var colID sqlbase.ColumnID
+		if i < len(c.idxDesc.ColumnIDs) {
+			colID = c.idxDesc.ColumnIDs[i]
+		} else {
+			colID = c.idxDesc.ExtraColumnIDs[i-len(c.idxDesc.ColumnIDs)]
+		}
+
 		c.colMap[colID] = int(ord)
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -3381,3 +3381,28 @@ ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE
 
 statement ok
 DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE
+
+# Test FK check that is using a non-unique index (#43969). In this case the
+# index on k2 is preferred because it doesn't contain unnecessary column v.
+statement ok
+CREATE TABLE nonunique_idx_parent (
+  k1 INT,
+  k2 INT,
+  v INT,
+  CONSTRAINT "primary" PRIMARY KEY (k1, k2),
+  INDEX (k2)
+)
+
+statement ok
+CREATE TABLE nonunique_idx_child (
+  k INT PRIMARY KEY,
+  ref1 INT,
+  ref2 INT,
+  CONSTRAINT "fk" FOREIGN KEY (ref1, ref2) REFERENCES nonunique_idx_parent (k1, k2)
+)
+
+statement ok
+INSERT INTO nonunique_idx_parent VALUES (1, 10)
+
+statement ok
+INSERT INTO nonunique_idx_child VALUES (0, 1, 10)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -817,3 +817,35 @@ SELECT count(*) > 0 FROM [
 ] WHERE tree LIKE '%insert-fast-path'
 ----
 false
+
+# Test FK check that is using a non-unique index (#43969). In this case the
+# index on k2 is preferred because it doesn't contain unnecessary column v.
+statement ok
+CREATE TABLE nonunique_idx_parent (
+  k1 INT,
+  k2 INT,
+  v INT,
+  CONSTRAINT "primary" PRIMARY KEY (k1, k2),
+  INDEX (k2)
+)
+
+statement ok
+CREATE TABLE nonunique_idx_child (
+  k INT PRIMARY KEY,
+  ref1 INT,
+  ref2 INT,
+  CONSTRAINT "fk" FOREIGN KEY (ref1, ref2) REFERENCES nonunique_idx_parent (k1, k2)
+)
+
+query TTT
+EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
+----
+·                      distributed  false
+·                      vectorized   false
+count                  ·            ·
+ └── insert-fast-path  ·            ·
+·                      into         nonunique_idx_child(k, ref1, ref2)
+·                      strategy     inserter
+·                      auto commit  ·
+·                      FK check     nonunique_idx_parent@nonunique_idx_parent_k2_idx
+·                      size         3 columns, 1 row

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -684,7 +684,8 @@ type InsertFastPathFKCheck struct {
 	ReferencedIndex cat.Index
 
 	// InsertCols contains the FK columns from the origin table, in the order of
-	// the ReferencedIndex columns.
+	// the ReferencedIndex columns. For each, the value in the array indicates the
+	// index of the column in the input table.
 	InsertCols []ColumnOrdinal
 
 	MatchMethod tree.CompositeKeyMatchMethod


### PR DESCRIPTION
The insert fast path doesn't work correctly when the FK checks use a
non-unique index. This is rare, but it can happen when 1) the key is
composite; 2) it is the primary key in the parent table; and 3) there
is a non-unique secondary index on a subset of the primary key
columns. In this case the secondary index is preferred because it
contains fewer columns.

The problem is that the lookup involves implicit columns and neither
the fast path code nor the `EncodePartialIndexKey` code were equipped
to handle this. This change adds logic to handle implicit columns.

Note that the legacy path doesn't have this problem because it is
always hardwired to use the unique index.

Fixes #43969.

Release note (bug fix): fixed internal error of the form "x FK cols, only y cols in
index" in some cases when inserting into a table with foreign key
references.