### PR TITLE
sqlsmith: add temporary tables to sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -131,7 +131,10 @@ func registerSQLSmith(r *testRegistry) {
 		}
 
 		if t.IsBuildVersion("v20.1.0") {
-			stmt := "SET experimental_enable_primary_key_changes = true;"
+			stmt := `
+SET experimental_enable_primary_key_changes = true;
+SET experimental_enable_temp_tables = true;
+`
 			if _, err := conn.Exec(stmt); err != nil {
 				t.Fatal(err)
 			} else {

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -983,6 +983,7 @@ func RandCreateTableWithInterleave(
 		Table:      tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("%s%d", prefix, tableIdx))),
 		Defs:       defs,
 		Interleave: interleaveDef,
+		Temporary:  rng.Intn(2) == 0,
 	}
 
 	// Create some random column families.


### PR DESCRIPTION
This PR adds temporary tables to the random tables created by SQLSmith.

Release note: None