### PR TITLE
sql: show correct temp table type in information_schema

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1317,6 +1317,7 @@ var (
 	tableTypeSystemView = tree.NewDString("SYSTEM VIEW")
 	tableTypeBaseTable  = tree.NewDString("BASE TABLE")
 	tableTypeView       = tree.NewDString("VIEW")
+	tableTypeTemporary  = tree.NewDString("LOCAL TEMPORARY")
 )
 
 var informationSchemaTablesTable = virtualSchemaTable{
@@ -1338,6 +1339,8 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 				} else if table.IsView() {
 					tableType = tableTypeView
 					insertable = noString
+				} else if table.Temporary {
+					tableType = tableTypeTemporary
 				}
 				dbNameStr := tree.NewDString(db.Name)
 				scNameStr := tree.NewDString(scName)

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,0 +1,15 @@
+statement ok
+SET experimental_enable_temp_tables=true
+
+subtest test_information_schema
+
+statement ok
+CREATE TEMP TABLE is_test (a timetz);
+
+query TTTTTI
+SELECT * FROM information_schema.tables WHERE table_name = 'is_test'
+----
+test  public  is_test  LOCAL TEMPORARY  YES  1
+
+statement ok
+DROP TABLE is_test


### PR DESCRIPTION
`information_schema.tables` has a `LOCAL TEMPORARY` value for
temporary tables. This PR updates the result accordingly.

No release note as we have not released temporary tables.

Release note: None