### PR TITLE
release-19.2: colexec: reject aggregates with different input and output types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1041,3 +1041,12 @@ query I
 SELECT b FROM t42994_2@i
 ----
 NULL
+
+# Regression test for an aggregate that has output type different from its
+# input type (INT4 is input whereas output is INT). Currently such query is not
+# supported through vectorized engine, but we will get a plan with wrapped
+# rowexec.orderedAggregator.
+query I
+SELECT max(c) FROM a
+----
+2000


### PR DESCRIPTION
Backport 1/1 commits from #43985.

/cc @cockroachdb/release

---

For MIN and MAX aggregate functions, `execinfrapb.GetAggregateInfo`
returns `INT` (i.e. `INT8`) as the return type for all integer types.
However, columnar operators will output the same physical type as their
input. This would lead to a panic of type mismatch, and it has been
fixed by rejecting such queries to run via the vectorized engine.
I believe only MIN and MAX on integer types were affected.

Fixes: #43936.

Release note (bug fix): Previously, an internal error could occur when
a query with an aggregate function MIN or MAX was executed via the
vectorized engine when the input column was either INT2 or INT4 type.
Now this is fixed.
