### PR TITLE
cli/start: remove the 1-minute hard shutdown timeout

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -949,7 +949,6 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	// So we also pay attention to any additional signal received beyond
 	// this point (maybe some service monitor was impatient and sends
 	// another signal to hasten the shutdown process).
-	// And we also pay attention to an additional timeout.
 	//
 	// If any such trigger to hasten occurs, we simply return, which
 	// will cause the process to exit and the server goroutines to be
@@ -964,9 +963,6 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint))
 		handleSignalDuringShutdown(sig)
 		panic("unreachable")
-
-	case <-time.After(time.Minute):
-		return errors.Errorf("time limit reached, initiating hard shutdown%s", hardShutdownHint)
 
 	case <-stopper.IsStopped():
 		const msgDone = "server drained and shutdown completed"


### PR DESCRIPTION
Fixes #43902.

Prior to this patch, after CockroachDB receives an instruction to
gracefully shut down (signal, `Drain` request etc), the code for
`cockroach start` would start a 1-minute countdown. If the graceful
shutdown did not complete within that time, a hard shutdown was
triggered instead.

This behavior was neither necessary nor desirable.

It is not necessary because process managers already have "process
shutdown timeout" logic to force-shutdown a process that does not
terminate in a timely manner. It is not the db's responsibility to do
the service manager's job (in fact, the redundancy in behavior can be
confusing to troubleshoot).

It is not desirable either because in large clusters, a graceful
shutdown may truly last longer than a minute. Graceful shutdowns are
also rather important to ensure a smooth transition during e.g. a
rolling upgrade, as they guarantee a transition without latency
blips. Even though this `cockroach start` timeout is not the
only such timeout through the code, it is one obstacle to painless
graceful shutdowns and thus ought to be removed.

This patch achieves just that.

Release note (cli change): The CockroachDB node
command (`start`/`start-single-node`) does not any more initiate a
1-minute hard shutdown countdown after a request to gracefully
terminates. This means that graceful shutdowns are now free to take
longer than one minute. It also means that deployments where a
maximum shutdown time must be enforced must now use a service manager
that is suitably configured to do so.