### PR TITLE
release-19.2: storage/rangefeed: strip incompatible information from RangeFeedEvents

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1186,6 +1186,25 @@ func (e *RangeFeedEvent) MustSetValue(value interface{}) {
 	}
 }
 
+// ShallowCopy returns a shallow copy of the receiver and its variant type.
+func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
+	cpy := *e
+	switch t := cpy.GetValue().(type) {
+	case *RangeFeedValue:
+		cpyVal := *t
+		cpy.MustSetValue(&cpyVal)
+	case *RangeFeedCheckpoint:
+		cpyChk := *t
+		cpy.MustSetValue(&cpyChk)
+	case *RangeFeedError:
+		cpyErr := *t
+		cpy.MustSetValue(&cpyErr)
+	default:
+		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", t))
+	}
+	return &cpy
+}
+
 // MakeReplicationChanges returns a slice of changes of the given type with an
 // item for each target.
 func MakeReplicationChanges(

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -566,6 +566,9 @@ func (p *Processor) publishCheckpoint(ctx context.Context) {
 }
 
 func (p *Processor) newCheckpointEvent() *roachpb.RangeFeedEvent {
+	// Create a RangeFeedCheckpoint over the Processor's entire span. Each
+	// individual registration will trim this down to just the key span that
+	// it is listening on in registration.maybeStripEvent before publishing.
 	var event roachpb.RangeFeedEvent
 	event.MustSetValue(&roachpb.RangeFeedCheckpoint{
 		Span:       p.Span.AsRawSpanWithNoLocals(),

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -195,7 +195,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, 1, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 1},
 		)},
 		r1Stream.Events(),
@@ -206,7 +206,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 5},
 		)},
 		r1Stream.Events(),
@@ -258,7 +258,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 9},
 		)},
 		r1Stream.Events(),
@@ -268,7 +268,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 11},
 		)},
 		r1Stream.Events(),
@@ -288,7 +288,7 @@ func TestProcessorBasic(t *testing.T) {
 				},
 			),
 			rangeFeedCheckpoint(
-				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 				hlc.Timestamp{WallTime: 15},
 			),
 		},
@@ -310,7 +310,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, 2, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
 			hlc.Timestamp{WallTime: 15},
 		)},
 		r2Stream.Events(),
@@ -319,12 +319,16 @@ func TestProcessorBasic(t *testing.T) {
 	// Both registrations should see checkpoint.
 	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
 	p.syncEventAndRegistrations()
-	chEvent := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+	chEventAM := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{WallTime: 20},
 	)}
-	require.Equal(t, chEvent, r1Stream.Events())
-	require.Equal(t, chEvent, r2Stream.Events())
+	require.Equal(t, chEventAM, r1Stream.Events())
+	chEventCZ := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+		roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
+		hlc.Timestamp{WallTime: 20},
+	)}
+	require.Equal(t, chEventCZ, r2Stream.Events())
 
 	// Test value with two registration that overlaps both.
 	p.ConsumeLogicalOps(
@@ -428,7 +432,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	require.Equal(t, 2, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 0},
 		)},
 		r1Stream.Events(),
@@ -549,7 +553,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	// The registration should be provided a checkpoint immediately with an
 	// empty resolved timestamp because it did not perform a catch-up scan.
 	chEvent := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{},
 	)}
 	require.Equal(t, chEvent, r1Stream.Events())
@@ -580,7 +584,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 
 	// The registration should have been informed of the new resolved timestamp.
 	chEvent = []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{WallTime: 18},
 	)}
 	require.Equal(t, chEvent, r1Stream.Events())

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -111,6 +111,8 @@ func newRegistration(
 // If overflowed is already set, events are ignored and not written to the
 // buffer.
 func (r *registration) publish(event *roachpb.RangeFeedEvent) {
+	event = r.maybeStripEvent(event)
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.mu.overflowed {
@@ -124,6 +126,43 @@ func (r *registration) publish(event *roachpb.RangeFeedEvent) {
 		// a catch-up scan.
 		r.mu.overflowed = true
 	}
+}
+
+// maybeStripEvent determines whether the event contains excess information not
+// applicable to the current registration. If so, it makes a copy of the event
+// and strips the incompatible information to match only what the registration
+// requested.
+func (r *registration) maybeStripEvent(event *roachpb.RangeFeedEvent) *roachpb.RangeFeedEvent {
+	ret := event
+	copyOnWrite := func() interface{} {
+		if ret == event {
+			ret = event.ShallowCopy()
+		}
+		return ret.GetValue()
+	}
+
+	switch t := ret.GetValue().(type) {
+	case *roachpb.RangeFeedValue:
+	case *roachpb.RangeFeedCheckpoint:
+		if !t.Span.EqualValue(r.span) {
+			// Checkpoint events are always created spanning the entire Range.
+			// However, a registration might not be listening on updates over
+			// the entire Range. If this is the case then we need to constrain
+			// the checkpoint events published to that registration to just the
+			// span that it's listening on. This is more than just a convenience
+			// to consumers - it would be incorrect to say that a rangefeed has
+			// observed all values up to the checkpoint timestamp over a given
+			// key span if any updates to that span have been filtered out.
+			if !t.Span.Contains(r.span) {
+				panic(fmt.Sprintf("registration span %v larger than checkpoint span %v", r.span, t.Span))
+			}
+			t = copyOnWrite().(*roachpb.RangeFeedCheckpoint)
+			t.Span = r.span
+		}
+	default:
+		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", t))
+	}
+	return ret
 }
 
 // disconnect cancels the output loop context for the registration and passes an
@@ -368,7 +407,7 @@ func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.Rang
 		// surprising. Revisit this once RangeFeed has more users.
 		minTS = hlc.MaxTimestamp
 	default:
-		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", event))
+		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", t))
 	}
 
 	reg.forOverlappingRegs(span, func(r *registration) (bool, *roachpb.Error) {

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -133,8 +133,8 @@ func TestRegistrationBasic(t *testing.T) {
 
 	val := roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
-	ev1.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev2.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev1.MustSetValue(&roachpb.RangeFeedValue{Key: keyA, Value: val})
+	ev2.MustSetValue(&roachpb.RangeFeedValue{Key: keyB, Value: val})
 
 	// Registration with no catchup scan specified.
 	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil)
@@ -270,10 +270,10 @@ func TestRegistryBasic(t *testing.T) {
 	val := roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
 	ev3, ev4 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
-	ev1.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev2.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev3.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev4.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev1.MustSetValue(&roachpb.RangeFeedValue{Key: keyA, Value: val})
+	ev2.MustSetValue(&roachpb.RangeFeedValue{Key: keyB, Value: val})
+	ev3.MustSetValue(&roachpb.RangeFeedValue{Key: keyC, Value: val})
+	ev4.MustSetValue(&roachpb.RangeFeedValue{Key: keyD, Value: val})
 	err1 := roachpb.NewErrorf("error1")
 
 	reg := makeRegistry()

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -374,7 +374,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	// Publish a checkpoint with a timestamp beneath the registration's. Should
 	// be delivered.
 	ev.MustSetValue(&roachpb.RangeFeedCheckpoint{
-		ResolvedTS: hlc.Timestamp{WallTime: 5},
+		Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
 	reg.PublishToOverlapping(spAB, ev)
 	require.NoError(t, reg.waitForCaughtUp(all))

--- a/pkg/storage/replica_rangefeed_test.go
+++ b/pkg/storage/replica_rangefeed_test.go
@@ -114,6 +114,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	replNum := 3
 	streams := make([]*testStream, replNum)
 	streamErrC := make(chan *roachpb.Error, replNum)
+	rangefeedSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
 	for i := 0; i < replNum; i++ {
 		stream := newTestStream()
 		streams[i] = stream
@@ -123,7 +124,7 @@ func TestReplicaRangefeed(t *testing.T) {
 					Timestamp: initTime,
 					RangeID:   rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				Span: rangefeedSpan,
 			}
 
 			pErr := mtc.Store(i).RangeFeed(&req, stream)
@@ -166,7 +167,7 @@ func TestReplicaRangefeed(t *testing.T) {
 			Key: roachpb.Key("b"), Value: expVal1,
 		}},
 		{Checkpoint: &roachpb.RangeFeedCheckpoint{
-			Span:       roachpb.Span{Key: startKey, EndKey: roachpb.KeyMax},
+			Span:       rangefeedSpan,
 			ResolvedTS: hlc.Timestamp{},
 		}},
 	}
@@ -363,12 +364,6 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 			subT.Fatalf("incorrect events on stream, found %v, want %v", events, expEvents)
 		}
 	}
-	waitForInitialCheckpoint := func(
-		subT *testing.T, stream *testStream, streamErrC <-chan *roachpb.Error,
-	) {
-		span := roachpb.Span{Key: startKey, EndKey: roachpb.KeyMax}
-		waitForInitialCheckpointAcrossSpan(subT, stream, streamErrC, span)
-	}
 
 	assertRangefeedRetryErr := func(
 		subT *testing.T, pErr *roachpb.Error, expReason roachpb.RangeFeedRetryError_Reason,
@@ -396,12 +391,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed on the replica we plan to remove.
 		stream := newTestStream()
 		streamErrC := make(chan *roachpb.Error, 1)
+		rangefeedSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				Span: rangefeedSpan,
 			}
 
 			pErr := mtc.Store(removeStore).RangeFeed(&req, stream)
@@ -409,7 +405,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}()
 
 		// Wait for the first checkpoint event.
-		waitForInitialCheckpoint(t, stream, streamErrC)
+		waitForInitialCheckpointAcrossSpan(t, stream, streamErrC, rangefeedSpan)
 
 		// Remove the replica from the range.
 		mtc.unreplicateRange(rangeID, removeStore)
@@ -425,12 +421,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed on the replica we plan to split.
 		stream := newTestStream()
 		streamErrC := make(chan *roachpb.Error, 1)
+		rangefeedSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				Span: rangefeedSpan,
 			}
 
 			pErr := mtc.Store(0).RangeFeed(&req, stream)
@@ -438,7 +435,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}()
 
 		// Wait for the first checkpoint event.
-		waitForInitialCheckpoint(t, stream, streamErrC)
+		waitForInitialCheckpointAcrossSpan(t, stream, streamErrC, rangefeedSpan)
 
 		// Split the range.
 		args := adminSplitArgs([]byte("m"))
@@ -473,12 +470,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed on the left replica.
 		streamLeft := newTestStream()
 		streamLeftErrC := make(chan *roachpb.Error, 1)
+		rangefeedLeftSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: splitKey}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: splitKey},
+				Span: rangefeedLeftSpan,
 			}
 
 			pErr := mtc.Store(0).RangeFeed(&req, streamLeft)
@@ -488,12 +486,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed on the right replica.
 		streamRight := newTestStream()
 		streamRightErrC := make(chan *roachpb.Error, 1)
+		rangefeedRightSpan := roachpb.Span{Key: splitKey, EndKey: roachpb.Key("z")}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rightRangeID,
 				},
-				Span: roachpb.Span{Key: splitKey, EndKey: roachpb.Key("z")},
+				Span: rangefeedRightSpan,
 			}
 
 			pErr := mtc.Store(0).RangeFeed(&req, streamRight)
@@ -501,12 +500,8 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}()
 
 		// Wait for the first checkpoint event on each stream.
-		waitForInitialCheckpointAcrossSpan(t, streamLeft, streamLeftErrC, roachpb.Span{
-			Key: startKey, EndKey: splitKey,
-		})
-		waitForInitialCheckpointAcrossSpan(t, streamRight, streamRightErrC, roachpb.Span{
-			Key: splitKey, EndKey: roachpb.KeyMax,
-		})
+		waitForInitialCheckpointAcrossSpan(t, streamLeft, streamLeftErrC, rangefeedLeftSpan)
+		waitForInitialCheckpointAcrossSpan(t, streamRight, streamRightErrC, rangefeedRightSpan)
 
 		// Merge the ranges back together
 		mergeArgs := adminMergeArgs(startKey)
@@ -531,12 +526,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed on the replica we plan to partition.
 		stream := newTestStream()
 		streamErrC := make(chan *roachpb.Error, 1)
+		rangefeedSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				Span: rangefeedSpan,
 			}
 
 			timer := time.AfterFunc(10*time.Second, stream.Cancel)
@@ -547,7 +543,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}()
 
 		// Wait for the first checkpoint event.
-		waitForInitialCheckpoint(t, stream, streamErrC)
+		waitForInitialCheckpointAcrossSpan(t, stream, streamErrC, rangefeedSpan)
 
 		// Force the leader off the replica on partitionedStore. If it's the
 		// leader, this test will fall over when it cuts the replica off from
@@ -625,12 +621,13 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		// Establish a rangefeed.
 		stream := newTestStream()
 		streamErrC := make(chan *roachpb.Error, 1)
+		rangefeedSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
 		go func() {
 			req := roachpb.RangeFeedRequest{
 				Header: roachpb.Header{
 					RangeID: rangeID,
 				},
-				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				Span: rangefeedSpan,
 			}
 
 			pErr := mtc.Store(0).RangeFeed(&req, stream)
@@ -638,7 +635,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}()
 
 		// Wait for the first checkpoint event.
-		waitForInitialCheckpoint(t, stream, streamErrC)
+		waitForInitialCheckpointAcrossSpan(t, stream, streamErrC, rangefeedSpan)
 
 		// Disable rangefeeds, which stops logical op logs from being provided
 		// with Raft commands.


### PR DESCRIPTION
Backport 2/2 commits from #44035.

We'll also want to backport this to release-19.1, right Dan?

/cc @cockroachdb/release

---

Fixes #43967.

This commit adds a step before publishing RangeFeedEvents to RangeFeed registrations where incompatible information in the events is stripped from the event. There are two cases where this comes up at the moment:

The first is with previous values. If no registrations for the current Range are requesting previous values, then we won't even retrieve them on the Raft goroutine. However, if any are and they overlap with an update then the previous value on the corresponding events will be populated. If we're in this case and any other registrations don't want previous values then we'll need to strip them.

The second is with the key spans in checkpoint events. Checkpoint events are always created spanning the entire Range. However, a registration might not be listening on updates over the entire Range. If this is the case then we need to constrain the checkpoint events published to that registration to just the span that it's listening on. This is more than just a convenience to consumers - it would be incorrect to say that a rangefeed has observed all values up to the checkpoint timestamp over a given key span if any updates to that span have been filtered out.

Release note (bug fix): CDC is no longer susceptible to a bug where a resolved timestamp might be published before all events that precede it have been published in the presence of a Range merge.
