### PR TITLE
sql: fix bug with DROP CASCADE on interleaved parents

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -141,7 +141,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	}
 
 	for _, toDel := range n.td {
-		cascadedObjects, err := p.dropObject(ctx, toDel.desc, tree.DropCascade)
+		cascadedObjects, err := p.dropObject(ctx, toDel.desc, tree.DropCascade, n.n.String())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -53,3 +53,38 @@ CREATE TABLE a (id INT PRIMARY KEY)
 query I
 SELECT * FROM a
 ----
+
+# Ensure that DROP TABLE cascade on interleaved parents actually deletes dependent objects.
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY);
+CREATE TABLE t2 (x INT, y INT, PRIMARY KEY (x, y)) INTERLEAVE IN PARENT t (x);
+CREATE TABLE t3 (x INT, y INT, z INT, PRIMARY KEY (x, y, z)) INTERLEAVE IN PARENT t2 (x, y);
+CREATE TABLE t4 (x INT, y INT, z INT, w INT, PRIMARY KEY (x, y, z, w)) INTERLEAVE IN PARENT t3 (x, y, z);
+CREATE TABLE t5 (x INT, y INT, z INT, FAMILY (x, y, z));
+CREATE INDEX i ON t5 (x, y, z) INTERLEAVE IN PARENT t2 (x, y)
+
+statement ok
+DROP TABLE t2 CASCADE
+
+statement ok
+SHOW CREATE t
+
+# t2, t3, t4, t5@i should be deleted, while t and t5 should be still there.
+statement error pq: relation "t2" does not exist
+SHOW CREATE t2
+
+statement error pq: relation "t3" does not exist
+SHOW CREATE t3
+
+statement error pq: relation "t4" does not exist
+SHOW CREATE t4
+
+query TT
+SHOW CREATE t5
+----
+t5  CREATE TABLE t5 (
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
+)

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -199,6 +199,24 @@ DROP TABLE p2 CASCADE
 statement error pgcode 42P01 relation "p0" does not exist
 SELECT * FROM p0
 
+# Dropping p2 with cascade dropped all the other tables as well. Recreate the needed ones.
+statement ok
+CREATE TABLE p1_0 (
+  i INT,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL,
+  PRIMARY KEY (i, s1),
+  FAMILY (i, s1, s2),
+  FAMILY (d)
+);
+CREATE TABLE p1_1 (
+  i INT PRIMARY KEY,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL
+)
+
 # Validation and descriptor bookkeeping
 
 # TODO(dan): Interleave these two indexes once we support the syntax.


### PR DESCRIPTION
Fixes #44068.

Release note (sql change): This PR fixes a bug where using
`DROP TABLE ... CASCADE` on an interleaved parent would not
drop interleaved tables and indexes, but instead just delete
all data in the table or index.