### PR TITLE
release-19.1: storage/rangefeed: strip incompatible information from RangeFeedEvents

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1138,3 +1138,22 @@ func (e *RangeFeedEvent) MustSetValue(value interface{}) {
 		panic(fmt.Sprintf("%T excludes %T", e, value))
 	}
 }
+
+// ShallowCopy returns a shallow copy of the receiver and its variant type.
+func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
+	cpy := *e
+	switch t := cpy.GetValue().(type) {
+	case *RangeFeedValue:
+		cpyVal := *t
+		cpy.MustSetValue(&cpyVal)
+	case *RangeFeedCheckpoint:
+		cpyChk := *t
+		cpy.MustSetValue(&cpyChk)
+	case *RangeFeedError:
+		cpyErr := *t
+		cpy.MustSetValue(&cpyErr)
+	default:
+		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", t))
+	}
+	return &cpy
+}

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -577,6 +577,9 @@ func (p *Processor) publishCheckpoint(ctx context.Context) {
 }
 
 func (p *Processor) newCheckpointEvent() *roachpb.RangeFeedEvent {
+	// Create a RangeFeedCheckpoint over the Processor's entire span. Each
+	// individual registration will trim this down to just the key span that
+	// it is listening on in registration.maybeStripEvent before publishing.
 	var event roachpb.RangeFeedEvent
 	event.MustSetValue(&roachpb.RangeFeedCheckpoint{
 		Span:       p.Span.AsRawSpanWithNoLocals(),

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -191,7 +191,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, 1, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 1},
 		)},
 		r1Stream.Events(),
@@ -202,7 +202,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 5},
 		)},
 		r1Stream.Events(),
@@ -254,7 +254,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 9},
 		)},
 		r1Stream.Events(),
@@ -264,7 +264,7 @@ func TestProcessorBasic(t *testing.T) {
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 11},
 		)},
 		r1Stream.Events(),
@@ -284,7 +284,7 @@ func TestProcessorBasic(t *testing.T) {
 				},
 			),
 			rangeFeedCheckpoint(
-				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+				roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 				hlc.Timestamp{WallTime: 15},
 			),
 		},
@@ -305,7 +305,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, 2, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
 			hlc.Timestamp{WallTime: 15},
 		)},
 		r2Stream.Events(),
@@ -314,12 +314,16 @@ func TestProcessorBasic(t *testing.T) {
 	// Both registrations should see checkpoint.
 	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
 	p.syncEventAndRegistrations()
-	chEvent := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+	chEventAM := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{WallTime: 20},
 	)}
-	require.Equal(t, chEvent, r1Stream.Events())
-	require.Equal(t, chEvent, r2Stream.Events())
+	require.Equal(t, chEventAM, r1Stream.Events())
+	chEventCZ := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+		roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("z")},
+		hlc.Timestamp{WallTime: 20},
+	)}
+	require.Equal(t, chEventCZ, r2Stream.Events())
 
 	// Test value with two registration that overlaps both.
 	p.ConsumeLogicalOps(
@@ -411,7 +415,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	require.Equal(t, 2, p.Len())
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 			hlc.Timestamp{WallTime: 0},
 		)},
 		r1Stream.Events(),
@@ -532,7 +536,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	// The registration should be provided a checkpoint immediately with an
 	// empty resolved timestamp because it did not perform a catch-up scan.
 	chEvent := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{},
 	)}
 	require.Equal(t, chEvent, r1Stream.Events())
@@ -563,7 +567,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 
 	// The registration should have been informed of the new resolved timestamp.
 	chEvent = []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
-		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
 		hlc.Timestamp{WallTime: 18},
 	)}
 	require.Equal(t, chEvent, r1Stream.Events())

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -378,7 +378,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	// Publish a checkpoint with a timestamp beneath the registration's. Should
 	// be delivered.
 	ev.MustSetValue(&roachpb.RangeFeedCheckpoint{
-		ResolvedTS: hlc.Timestamp{WallTime: 5},
+		Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
 	reg.PublishToOverlapping(spAB, ev)
 	require.NoError(t, reg.waitForCaughtUp(all))

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -137,8 +137,8 @@ func TestRegistrationBasic(t *testing.T) {
 
 	val := roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
-	ev1.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev2.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev1.MustSetValue(&roachpb.RangeFeedValue{Key: keyA, Value: val})
+	ev2.MustSetValue(&roachpb.RangeFeedValue{Key: keyB, Value: val})
 
 	// Registration with no catchup scan specified.
 	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil)
@@ -274,10 +274,10 @@ func TestRegistryBasic(t *testing.T) {
 	val := roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
 	ev3, ev4 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
-	ev1.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev2.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev3.MustSetValue(&roachpb.RangeFeedValue{Value: val})
-	ev4.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev1.MustSetValue(&roachpb.RangeFeedValue{Key: keyA, Value: val})
+	ev2.MustSetValue(&roachpb.RangeFeedValue{Key: keyB, Value: val})
+	ev3.MustSetValue(&roachpb.RangeFeedValue{Key: keyC, Value: val})
+	ev4.MustSetValue(&roachpb.RangeFeedValue{Key: keyD, Value: val})
 	err1 := roachpb.NewErrorf("error1")
 
 	reg := makeRegistry()


### PR DESCRIPTION
Backport 2/2 commits from #44035.

/cc @cockroachdb/release

---

Fixes #43967.

This commit adds a step before publishing RangeFeedEvents to RangeFeed registrations where incompatible information in the events is stripped from the event. There are two cases where this comes up at the moment:

The first is with previous values. If no registrations for the current Range are requesting previous values, then we won't even retrieve them on the Raft goroutine. However, if any are and they overlap with an update then the previous value on the corresponding events will be populated. If we're in this case and any other registrations don't want previous values then we'll need to strip them.

The second is with the key spans in checkpoint events. Checkpoint events are always created spanning the entire Range. However, a registration might not be listening on updates over the entire Range. If this is the case then we need to constrain the checkpoint events published to that registration to just the span that it's listening on. This is more than just a convenience to consumers - it would be incorrect to say that a rangefeed has observed all values up to the checkpoint timestamp over a given key span if any updates to that span have been filtered out.

Release note (bug fix): CDC is no longer susceptible to a bug where a resolved timestamp might be published before all events that precede it have been published in the presence of a Range merge.

