### PR TITLE
mutations: add a temporary table mutator

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1277,7 +1277,9 @@ func (t *logicTest) processTestFile(path string, config testClusterConfig) error
 	if err != nil {
 		return err
 	}
-
+	if _, err := t.db.Exec("SET experimental_enable_temp_tables = true"); err != nil {
+		return err
+	}
 	if *showSQL {
 		t.outf("--- queries start here (file: %s)", path)
 	}
@@ -1903,7 +1905,7 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 	if *showSQL {
 		t.outf("%s;", stmt.sql)
 	}
-	execSQL, changed := mutations.ApplyString(t.rng, stmt.sql, mutations.ColumnFamilyMutator)
+	execSQL, changed := mutations.ApplyString(t.rng, stmt.sql, mutations.ColumnFamilyMutator, mutations.TempTableMutator)
 	if changed {
 		t.outf("rewrote:\n%s\n", execSQL)
 	}

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -34,6 +34,10 @@ var (
 	// ColumnFamilyMutator modifies a CREATE TABLE statement without any FAMILY
 	// definitions to have random FAMILY definitions.
 	ColumnFamilyMutator StatementMutator = sqlbase.ColumnFamilyMutator
+
+	// TempTableMutator modifies a CREATE TABLE statement to maybe be
+	// a CREATE TEMP TABLE statement instead.
+	TempTableMutator StatementMutator = tempTableMutator
 )
 
 // StatementMutator defines a func that can change a statement.
@@ -116,6 +120,19 @@ func randNonNegInt(rng *rand.Rand) int64 {
 		v = rng.Int63()
 	}
 	return v
+}
+
+func tempTableMutator(rng *rand.Rand, stmt tree.Statement) bool {
+	create, ok := stmt.(*tree.CreateTable)
+	if !ok {
+		return false
+	}
+	if create.Temporary {
+		return false
+	}
+	isTemp := rng.Intn(2) == 0
+	create.Temporary = isTemp
+	return isTemp
 }
 
 func statisticsMutator(


### PR DESCRIPTION
Fixes #44047.

This PR adds a logictest mutation that randomly
sets certain tables to temporary.

Release note: None