### PR TITLE
kv: relax an assertion

### DIFF
--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -146,8 +146,9 @@ func (sr *txnSpanRefresher) SendLocked(
 		// Sanity check: we're supposed to control the read timestamp. What we're
 		// tracking in sr.refreshedTimestamp is not supposed to get out of sync
 		// with what batches use (which comes from tc.mu.txn).
-		log.Fatalf(ctx, "unexpected batch read timestamp: %s. Expected refreshed timestamp: %s. ba: %s",
-			batchReadTimestamp, sr.refreshedTimestamp, ba)
+		return nil, roachpb.NewError(errors.AssertionFailedf(
+			"unexpected batch read timestamp: %s. Expected refreshed timestamp: %s. ba: %s",
+			batchReadTimestamp, sr.refreshedTimestamp, ba))
 	}
 
 	if rArgs, hasET := ba.GetArg(roachpb.EndTxn); hasET {


### PR DESCRIPTION
The span refresher has an assertion that a batch's read timestamp is the
same as the timestamp tracked by the refresher. This assertion seems to
sometimes fire in the case of rollbacks sent from txn.CleanupOnError().
This patch makes the assertion not fatal; this is how it used to be
until recently, when I changed it from returning an error to a fatal.
Not sure why I did that; might have been by accident.

In any case, I'm separately going to try to figure out what's going on
with those rollbacks.

Release note: None

Fixes #44076