### PR TITLE
sql: stop observing the commit timestamp in TRUNCATE

### DIFF
--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
@@ -272,7 +273,10 @@ func (p *planner) truncateTable(
 	}
 	newTableDesc.Mutations = nil
 	newTableDesc.GCMutations = nil
-	newTableDesc.ModificationTime = p.txn.CommitTimestamp()
+	// NB: Set the modification time to a zero value so that it is interpreted
+	// as the commit timestamp for the new descriptor. See the comment on
+	// sqlbase.Descriptor.Table().
+	newTableDesc.ModificationTime = hlc.Timestamp{}
 	if err := p.createDescriptorWithID(
 		ctx, key, newID, newTableDesc, p.ExtendedEvalContext().Settings); err != nil {
 		return err


### PR DESCRIPTION
In #42650 I had intended to remove all places where the commit timestamp was
observed in TRUNCATE. I missed this case. Modification times for the first
write to table descriptors as of 19.2 should be the zero value (or the commit
timestamp, so this isn't wrong). This observance of the commit timestamp
prevents transactions which TRUNCATE tables from being pushed. Combined
with #44090 we'll have removed all non-user observation of commit timestamps.

Release note (bug fix): Long running transactions which attempt to TRUNCATE
can now be pushed and will commit in cases where they previously could fail
or retry forever.