### PR TITLE
sql, server: allow admin UI to view table details for non-admins

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -48,6 +48,7 @@ SELECT concat('crdb_internal.', table_name) as name FROM [ SHOW TABLES FROM crdb
 'create_statements',
 'forward_dependencies',
 'index_columns',
+'namespaces', -- same as system.namespace
 'table_columns',
 'table_indexes',
 'ranges',

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2159,7 +2159,7 @@ func (rs resultScanner) Scan(row tree.Datums, colName string, dst interface{}) e
 func (s *adminServer) queryZone(
 	ctx context.Context, userName string, id sqlbase.ID,
 ) (zonepb.ZoneConfig, bool, error) {
-	const query = `SELECT config FROM system.zones WHERE id = $1`
+	const query = `SELECT raw_config_protobuf FROM crdb_internal.zones WHERE zone_id = $1`
 	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-query-zone", nil /* txn */, userName, query, id,
 	)
@@ -2205,7 +2205,7 @@ func (s *adminServer) queryZonePath(
 func (s *adminServer) queryNamespaceID(
 	ctx context.Context, userName string, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
-	const query = `SELECT id FROM system.namespace WHERE "parentID" = $1 AND name = $2`
+	const query = `SELECT id FROM crdb_internal.namespaces WHERE parent_id = $1 AND name = $2`
 	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-query-namespace-ID", nil /* txn */, userName, query, parentID, name,
 	)

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -59,7 +59,13 @@ import (
 func getAdminJSONProto(
 	ts serverutils.TestServerInterface, path string, response protoutil.Message,
 ) error {
-	return serverutils.GetJSONProto(ts, adminPrefix+path, response)
+	return getAdminJSONProtoWithAdminOption(ts, adminPrefix+path, response, true)
+}
+
+func getAdminJSONProtoWithAdminOption(
+	ts serverutils.TestServerInterface, path string, response protoutil.Message, isAdmin bool,
+) error {
+	return serverutils.GetJSONProtoWithAdminOption(ts, adminPrefix+path, response, isAdmin)
 }
 
 func postAdminJSONProto(
@@ -236,88 +242,114 @@ func TestAdminAPIDatabases(t *testing.T) {
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
 	defer span.Finish()
 
-	// Test databases endpoint.
 	const testdb = "test"
 	query := "CREATE DATABASE " + testdb
 	if _, err := db.Exec(query); err != nil {
 		t.Fatal(err)
 	}
 
-	var resp serverpb.DatabasesResponse
-	if err := getAdminJSONProto(s, "databases", &resp); err != nil {
+	// We have to create the non-admin user before calling
+	// "GRANT ... TO authenticatedUserNameNoAdmin".
+	// This is done in "GetAuthenticatedHTTPClient".
+	if _, err := ts.GetAuthenticatedHTTPClient(false); err != nil {
 		t.Fatal(err)
 	}
 
-	expectedDBs := []string{"defaultdb", "postgres", "system", testdb}
-	if a, e := len(resp.Databases), len(expectedDBs); a != e {
-		t.Fatalf("length of result %d != expected %d", a, e)
-	}
-
-	sort.Strings(resp.Databases)
-	for i, e := range expectedDBs {
-		if a := resp.Databases[i]; a != e {
-			t.Fatalf("database name %s != expected %s", a, e)
-		}
-	}
-
-	// Test database details endpoint.
+	// Grant permissions to view the tables for the given viewing user.
 	privileges := []string{"SELECT", "UPDATE"}
-	testuser := "testuser"
-	createUserQuery := "CREATE USER " + testuser
-	if _, err := db.Exec(createUserQuery); err != nil {
+	query = fmt.Sprintf(
+		"GRANT %s ON DATABASE %s TO %s",
+		strings.Join(privileges, ", "),
+		testdb,
+		authenticatedUserNameNoAdmin,
+	)
+	if _, err := db.Exec(query); err != nil {
 		t.Fatal(err)
 	}
 
-	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	if _, err := db.Exec(grantQuery); err != nil {
-		t.Fatal(err)
-	}
-
-	var details serverpb.DatabaseDetailsResponse
-	if err := getAdminJSONProto(s, "databases/"+testdb, &details); err != nil {
-		t.Fatal(err)
-	}
-
-	if a, e := len(details.Grants), 4; a != e {
-		t.Fatalf("# of grants %d != expected %d", a, e)
-	}
-
-	userGrants := make(map[string][]string)
-	for _, grant := range details.Grants {
-		switch grant.User {
-		case sqlbase.AdminRole, security.RootUser, testuser:
-			userGrants[grant.User] = append(userGrants[grant.User], grant.Privileges...)
-		default:
-			t.Fatalf("unknown grant to user %s", grant.User)
-		}
-	}
-	for u, p := range userGrants {
-		switch u {
-		case sqlbase.AdminRole:
-			if !reflect.DeepEqual(p, []string{"ALL"}) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
+	for _, tc := range []struct {
+		expectedDBs []string
+		isAdmin     bool
+	}{
+		{[]string{"defaultdb", "postgres", "system", testdb}, true},
+		{[]string{testdb}, false},
+	} {
+		t.Run(fmt.Sprintf("isAdmin:%t", tc.isAdmin), func(t *testing.T) {
+			// Test databases endpoint.
+			var resp serverpb.DatabasesResponse
+			if err := getAdminJSONProtoWithAdminOption(
+				s,
+				"databases",
+				&resp,
+				tc.isAdmin,
+			); err != nil {
+				t.Fatal(err)
 			}
-		case security.RootUser:
-			if !reflect.DeepEqual(p, []string{"ALL"}) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
-			}
-		case testuser:
-			sort.Strings(p)
-			if !reflect.DeepEqual(p, privileges) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
-			}
-		default:
-			t.Fatalf("unknown grant to user %s", u)
-		}
-	}
 
-	// Verify Descriptor ID.
-	path, err := ts.admin.queryDescriptorIDPath(ctx, security.RootUser, []string{testdb})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if a, e := details.DescriptorID, int64(path[1]); a != e {
-		t.Fatalf("db had descriptorID %d, expected %d", a, e)
+			if a, e := len(resp.Databases), len(tc.expectedDBs); a != e {
+				t.Fatalf("length of result %d != expected %d", a, e)
+			}
+
+			sort.Strings(resp.Databases)
+			for i, e := range tc.expectedDBs {
+				if a := resp.Databases[i]; a != e {
+					t.Fatalf("database name %s != expected %s", a, e)
+				}
+			}
+
+			// Test database details endpoint.
+			var details serverpb.DatabaseDetailsResponse
+			if err := getAdminJSONProtoWithAdminOption(
+				s,
+				"databases/"+testdb,
+				&details,
+				tc.isAdmin,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if a, e := len(details.Grants), 4; a != e {
+				t.Fatalf("# of grants %d != expected %d", a, e)
+			}
+
+			userGrants := make(map[string][]string)
+			for _, grant := range details.Grants {
+				switch grant.User {
+				case sqlbase.AdminRole, security.RootUser, authenticatedUserNameNoAdmin:
+					userGrants[grant.User] = append(userGrants[grant.User], grant.Privileges...)
+				default:
+					t.Fatalf("unknown grant to user %s", grant.User)
+				}
+			}
+			for u, p := range userGrants {
+				switch u {
+				case sqlbase.AdminRole:
+					if !reflect.DeepEqual(p, []string{"ALL"}) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				case security.RootUser:
+					if !reflect.DeepEqual(p, []string{"ALL"}) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				case authenticatedUserNameNoAdmin:
+					sort.Strings(p)
+					if !reflect.DeepEqual(p, privileges) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				default:
+					t.Fatalf("unknown grant to user %s", u)
+				}
+			}
+
+			// Verify Descriptor ID.
+			path, err := ts.admin.queryDescriptorIDPath(ctx, security.RootUser, []string{testdb})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if a, e := details.DescriptorID, int64(path[1]); a != e {
+				t.Fatalf("db had descriptorID %d, expected %d", a, e)
+			}
+		})
 	}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -27,6 +27,7 @@ jobs
 kv_node_status
 kv_store_status
 leases
+namespaces
 node_build_info
 node_metrics
 node_queries
@@ -606,3 +607,46 @@ query B
 SELECT crdb_internal.is_admin()
 ----
 false
+
+subtest namespaces_test
+
+user root
+
+statement ok
+CREATE DATABASE namespaces_test_db
+
+statement ok
+CREATE TABLE namespaces_test_db.namespaces_test(a int)
+
+query IIT
+SELECT * FROM crdb_internal.namespaces WHERE name = 'namespaces_test' OR name = 'namespaces_test_db' ORDER BY name
+----
+61  62  namespaces_test
+0   61  namespaces_test_db
+
+user testuser
+
+query IIT
+SELECT * FROM crdb_internal.namespaces WHERE name = 'namespaces_test' OR name = 'namespaces_test_db' ORDER BY name
+----
+
+user root
+
+statement ok
+GRANT ALL ON DATABASE namespaces_test_db TO testuser
+
+statement ok
+GRANT ALL ON namespaces_test_db.namespaces_test TO testuser
+
+user testuser
+
+query IIT
+SELECT * FROM crdb_internal.namespaces WHERE name = 'namespaces_test' OR name = 'namespaces_test_db' ORDER BY name
+----
+61  62  namespaces_test
+0   61  namespaces_test_db
+
+user root
+
+statement ok
+DROP DATABASE namespaces_test_db CASCADE

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -70,6 +70,7 @@ const (
 	CrdbInternalLocalQueriesTableID
 	CrdbInternalLocalSessionsTableID
 	CrdbInternalLocalMetricsTableID
+	CrdbInternalNamespacesTableID
 	CrdbInternalPartitionsTableID
 	CrdbInternalPredefinedCommentsTableID
 	CrdbInternalRangesNoLeasesTableID


### PR DESCRIPTION
Resolves #44033

Two changes:
* Introduced a `crdb_internal.namespaces` table that mirrors
system.namespaces but only displays tables if the user has
permissions to view the database or tables involved.
* Changed the admin queries to go through `crdb_internal.namespaces` and
`crdb_internal.zones` instead of `system.namespaces` and `system.zones`
so that the table details URI works for users who are not admin.

Release note (admin ui change, security update, bug fix): We previously
introduced a fix on the admin UI to prevent non-admin users from
executing queries - however, this accidentally made certain pages
requiring table details not to display. This PR allows the table details
to be displayed in its former glory.