### PR TITLE
colexec: fix vector unwrapping in merge joiner

### DIFF
--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -752,7 +752,7 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildLeftGroups(
 				outStartIdx := int(destStartIdx)
 				out := o.output.ColVec(outColIdx)
 				var src coldata.Vec
-				if batch.Width() > int(inColIdx) {
+				if batch.Length() > 0 {
 					src = batch.ColVec(int(inColIdx))
 				}
 				colType := input.sourceTypes[inColIdx]
@@ -930,7 +930,7 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildRightGroups(
 				outStartIdx := int(destStartIdx)
 				out := o.output.ColVec(outColIdx + colOffset)
 				var src coldata.Vec
-				if batch.Width() > int(inColIdx) {
+				if batch.Length() > 0 {
 					src = batch.ColVec(int(inColIdx))
 				}
 				colType := input.sourceTypes[inColIdx]

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -535,8 +535,10 @@ var (
 	defaultConfigNames = []string{
 		"local",
 		"local-vec-off",
+		"local-vec",
 		"fakedist",
 		"fakedist-vec-off",
+		"fakedist-vec",
 		"fakedist-metadata",
 		"fakedist-disk",
 	}

--- a/pkg/sql/logictest/testdata/logic_test/exec_merge_join_dist
+++ b/pkg/sql/logictest/testdata/logic_test/exec_merge_join_dist
@@ -1,7 +1,5 @@
 # LogicTest: 5node-dist-vec
 
-skip #43357
-
 # Regression test for #39317.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -1,5 +1,3 @@
-skip #43357
-
 statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t
 -----

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -204,7 +204,7 @@ INSERT INTO t VALUES ('cat')
 statement ok
 INSERT INTO u VALUES ('bird')
 
-query TTII colnames
+query TTII colnames,rowsort
 SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
 a    b     generate_series generate_series

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,5 +1,3 @@
-skip #43357
-
 # NOTE: Keep this table at the beginning of the file to ensure that its numeric
 #       reference is 53 (the numeric reference of the first table). If the
 #       numbering scheme in cockroach changes, this test will break.


### PR DESCRIPTION
**colexec: fix vector unwrapping in merge joiner**

Previously, merge joiner would check the width of the batch to
understand whether we have a source colvec to unwrap into its physical
representation (i.e. from coldata.Vec to []int64). This was added when
we introduced coldata.ZeroBatch. The assumption was that
coldata.ZeroBatch is never modified, so checking the width would have
been sufficient. However, as it turns out in some cases we are appending
columns to the zero batch, so its width is not a good indicator. This
commit switches to looking at the length of the batch to decide whether
there is anything to unwrap. The complication (and why we didn't use it
in the first place) is because merge joiner works with regular batches
and buffered batches, and the latter have length is uint64. Previously,
we would panic if Length() method was called on it. Now it is allowed,
but we have to be careful to use it only in a check whether buffered
batch is of zero length.

Fixes: #43357.

Release note: None

**sql: partial revert "sql: skip over a couple of logic tests"**

This partially reverts commit 912feef.
The ability to easily skip a logic test is kept.

Release note: None

**logictest: add vec on configs to default ones**

`srfs` logic test needed to be modified to become deterministic.

Fixes: #38994.

Release note: None