### PR TITLE
jobs: separate state machine job logic from scheduling

### DIFF
--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -84,7 +84,9 @@ func TestRegistryCancelation(t *testing.T) {
 	register := func() {
 		didRegister = true
 		jobID++
-		registry.register(jobID, func() { cancelCount++ })
+		if err := registry.register(jobID, func() { cancelCount++ }); err != nil {
+			t.Fatal(err)
+		}
 	}
 	unregister := func() {
 		registry.unregister(jobID)


### PR DESCRIPTION
This is a preparation for making OnFailOrCancel fault tolerant.
Added a new function stepThroughStateMachine that implements the
job state machine transition.
Also some other minor improvements:
 - added a CurrentStatus method to get the job status
 - removed StartJob function as it is hard to enforce not racing
   with adopt jobs.
 - new jobs are registered before they are inserted in the jobs
   table to prevent race b/w CreateAndStartJob and maybeAdoptJobs
 - added V2 logging to resume to be able to debug scheduling problems.
                                 
 Release note: none