### PR TITLE
builtins,timeutil: fix AT TIME ZONE and timezone builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -450,9 +450,27 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="timeofday"></a><code>timeofday() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current system time on one of the cluster nodes as a string.</p>
 </span></td></tr>
-<tr><td><a name="timezone"></a><code>timezone(timestamp: <a href="timestamp.html">timestamp</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Treat given time stamp without time zone as located in the specified time zone</p>
+<tr><td><a name="timezone"></a><code>timezone(time: <a href="time.html">time</a>, timezone: <a href="string.html">string</a>) &rarr; timetz</code></td><td><span class="funcdesc"><p>Treat given time without time zone as located in the specified time zone
+This is deprecated in favor of timezone(str, time)</p>
 </span></td></tr>
-<tr><td><a name="timezone"></a><code>timezone(timestamptz: <a href="timestamp.html">timestamptz</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Convert given time stamp with time zone to the new time zone, with no time zone designation</p>
+<tr><td><a name="timezone"></a><code>timezone(timestamp: <a href="timestamp.html">timestamp</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Treat given time stamp without time zone as located in the specified time zone.
+This is deprecated in favor of timezone(str, timestamp)</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timestamptz: <a href="timestamp.html">timestamptz</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Convert given time stamp with time zone to the new time zone, with no time zone designation
+This is deprecated in favor of timezone(str, timestamptz)</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timetz: timetz, timezone: <a href="string.html">string</a>) &rarr; timetz</code></td><td><span class="funcdesc"><p>Convert given time with time zone to the new time zone
+This is deprecated in favor of timezone(str, timetz)</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, time: <a href="time.html">time</a>) &rarr; timetz</code></td><td><span class="funcdesc"><p>Treat given time without time zone as located in the specified time zone.</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, timestamp: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Treat given time stamp without time zone as located in the specified time zone.</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, timestamptz: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Convert given time stamp with time zone to the new time zone, with no time zone designation.</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, timestamptz_string: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Convert given time stamp with time zone to the new time zone, with no time zone designation.</p>
+</span></td></tr>
+<tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, timetz: timetz) &rarr; timetz</code></td><td><span class="funcdesc"><p>Convert given time with time zone to the new time zone.</p>
 </span></td></tr>
 <tr><td><a name="transaction_timestamp"></a><code>transaction_timestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -246,7 +246,10 @@ func (ds *ServerImpl) setupFlow(
 				"EvalContext expected to be populated when IsLocal is set")
 		}
 
-		location, err := timeutil.TimeZoneStringToLocation(req.EvalContext.Location)
+		location, err := timeutil.TimeZoneStringToLocation(
+			req.EvalContext.Location,
+			timeutil.TimeZoneStringToLocationISO8601Standard,
+		)
 		if err != nil {
 			tracing.FinishSpan(sp)
 			return ctx, nil, err

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2470,3 +2470,64 @@ user root
 
 statement ok
 DROP DATABASE root_test CASCADE
+
+# Test for timezone builtin.
+subtest timezone_test
+
+statement ok
+SET TIME ZONE -3
+
+query T
+SELECT timezone('UTC+6', '1970-01-01 01:00')
+----
+1969-12-31 22:00:00 +0000 +0000
+
+query T
+SELECT timezone('UTC+6', '1970-01-01 01:00'::time)
+----
+0000-01-01 22:00:00 -0600 -0600
+
+query T
+SELECT timezone('UTC+6', '1970-01-01 01:00'::timetz)
+----
+0000-01-01 22:00:00 -0600 -0600
+
+query T
+SELECT timezone('UTC+6', '1970-01-01 01:00'::timestamp)
+----
+1970-01-01 04:00:00 -0300 -0300
+
+query T
+SELECT timezone('UTC+6', '1970-01-01 01:00'::timestamptz)
+----
+1969-12-31 22:00:00 +0000 +0000
+
+# These test the reciprocal works the other way around.
+# TODO(otan): delete these after 20.1.
+query T
+SELECT timezone('1970-01-01 01:00', 'UTC+6')
+----
+1969-12-31 22:00:00 +0000 +0000
+
+query T
+SELECT timezone('1970-01-01 01:00'::time, 'UTC+6')
+----
+0000-01-01 22:00:00 -0600 -0600
+
+query T
+SELECT timezone('1970-01-01 01:00'::timetz, 'UTC+6')
+----
+0000-01-01 22:00:00 -0600 -0600
+
+query T
+SELECT timezone('1970-01-01 01:00'::timestamp, 'UTC+6')
+----
+1970-01-01 04:00:00 -0300 -0300
+
+query T
+SELECT timezone('1970-01-01 01:00'::timestamptz, 'UTC+6')
+----
+1969-12-31 22:00:00 +0000 +0000
+
+statement ok
+SET TIME ZONE +0

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -244,33 +244,6 @@ query TT
 select * from current_timestamp_test WHERE a - interval '3h' <> b
 ----
 
-subtest regression_cockroachdb-django_97
-
-query T
-SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE '+3'
-----
-2001-01-01 04:00:00 +0000 +0000
-
-query T
-SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE '-3:00'
-----
-2000-12-31 22:00:00 +0000 +0000
-
-query T
-SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'GMT+3'
-----
-2001-01-01 04:00:00 +0000 +0000
-
-query T
-SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'UTC-3:00'
-----
-2000-12-31 22:00:00 +0000 +0000
-
-query T
-SELECT '2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'Pacific/Honolulu'
-----
-2000-12-31 15:00:00 +0000 +0000
-
 subtest localtimestamp_test
 
 query TTTT

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7670,6 +7670,8 @@ a_expr:
   }
 | a_expr AT TIME ZONE a_expr %prec AT
   {
+    // TODO(otan): After 20.1, switch to {$5.expr(), $1.expr()} to match postgres,
+    // and delete the reciprocal method.
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction("timezone"), Exprs: tree.Exprs{$1.expr(), $5.expr()}}
   }
   // These operators must be called out explicitly in order to make use of

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
+	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -2386,6 +2387,134 @@ may increase either contention or retry errors, or both.`,
 
 	// https://www.postgresql.org/docs/9.6/functions-datetime.html
 	"timezone": makeBuiltin(defProps(),
+		// NOTE(otan): this should be deleted and replaced with the correct
+		// function overload promoting the string to timestamptz.
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timezone", types.String},
+				{"timestamptz_string", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Timestamp),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// Try both ways around.
+				// TODO(otan): after 20.1, only accept (timezone, timestamptz).
+				for _, attempt := range []struct {
+					ts, tz tree.Datum
+				}{
+					{args[0], args[1]},
+					{args[1], args[0]},
+				} {
+					ts, err := tree.ParseDTimestampTZ(
+						ctx, string(tree.MustBeDString(attempt.ts)), time.Microsecond,
+					)
+					if err != nil {
+						continue
+					}
+					loc, err := timeutil.TimeZoneStringToLocation(
+						string(tree.MustBeDString(attempt.tz)),
+						timeutil.TimeZoneStringToLocationPOSIXStandard,
+					)
+					if err != nil {
+						continue
+					}
+					return ts.EvalAtTimeZone(ctx, loc), nil
+				}
+				return nil, errors.Newf("cannot evaluate timezone(%s, %s)", args[0].String(), args[1].String())
+			},
+			Info: "Convert given time stamp with time zone to the new time zone, with no time zone designation.",
+		},
+
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timezone", types.String},
+				{"timestamp", types.Timestamp},
+			},
+			ReturnType: tree.FixedReturnType(types.TimestampTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tzStr := string(tree.MustBeDString(args[0]))
+				ts := tree.MustBeDTimestamp(args[1])
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				_, beforeOffsetSecs := ts.Time.Zone()
+				_, afterOffsetSecs := ts.Time.In(loc).Zone()
+				durationDelta := time.Duration(beforeOffsetSecs-afterOffsetSecs) * time.Second
+				return tree.MakeDTimestampTZ(ts.Time.Add(durationDelta), time.Microsecond), nil
+			},
+			Info: "Treat given time stamp without time zone as located in the specified time zone.",
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timezone", types.String},
+				{"timestamptz", types.TimestampTZ},
+			},
+			ReturnType: tree.FixedReturnType(types.Timestamp),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tzStr := string(tree.MustBeDString(args[0]))
+				ts := tree.MustBeDTimestampTZ(args[1])
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				return ts.EvalAtTimeZone(ctx, loc), nil
+			},
+			Info: "Convert given time stamp with time zone to the new time zone, with no time zone designation.",
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timezone", types.String},
+				{"time", types.Time},
+			},
+			ReturnType: tree.FixedReturnType(types.TimeTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tzStr := string(tree.MustBeDString(args[0]))
+				tArg := args[1].(*tree.DTime)
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				tTime := timeofday.TimeOfDay(*tArg).ToTime()
+				_, beforeOffsetSecs := tTime.In(ctx.GetLocation()).Zone()
+				durationDelta := time.Duration(-beforeOffsetSecs) * time.Second
+				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta))), nil
+			},
+			Info: "Treat given time without time zone as located in the specified time zone.",
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timezone", types.String},
+				{"timetz", types.TimeTZ},
+			},
+			ReturnType: tree.FixedReturnType(types.TimeTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// This one should disappear with implicit casts.
+				tzStr := string(tree.MustBeDString(args[0]))
+				tArg := args[1].(*tree.DTimeTZ)
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				tTime := tArg.TimeTZ.ToTime()
+				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc))), nil
+			},
+			Info: "Convert given time with time zone to the new time zone.",
+		},
+
+		// TODO(otan): the below should be deleted after 20.1 after sql.y is changed
+		// for the arguments to be the correct way around.
 		tree.Overload{
 			Types: tree.ArgTypes{
 				{"timestamp", types.Timestamp},
@@ -2395,15 +2524,20 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestamp(args[0])
 				tzStr := string(tree.MustBeDString(args[1]))
-				loc, err := timeutil.TimeZoneStringToLocation(tzStr)
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
 				if err != nil {
 					return nil, err
 				}
-				_, before := ts.Time.Zone()
-				_, after := ts.Time.In(loc).Zone()
-				return tree.MakeDTimestampTZ(ts.Time.Add(time.Duration(before-after)*time.Second), time.Microsecond), nil
+				_, beforeOffsetSecs := ts.Time.Zone()
+				_, afterOffsetSecs := ts.Time.In(loc).Zone()
+				durationDelta := time.Duration(beforeOffsetSecs-afterOffsetSecs) * time.Second
+				return tree.MakeDTimestampTZ(ts.Time.Add(durationDelta), time.Microsecond), nil
 			},
-			Info: "Treat given time stamp without time zone as located in the specified time zone",
+			Info: "Treat given time stamp without time zone as located in the specified time zone.\n" +
+				"This is deprecated in favor of timezone(str, timestamp)",
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -2414,13 +2548,64 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestampTZ(args[0])
 				tzStr := string(tree.MustBeDString(args[1]))
-				loc, err := timeutil.TimeZoneStringToLocation(tzStr)
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
 				if err != nil {
 					return nil, err
 				}
 				return ts.EvalAtTimeZone(ctx, loc), nil
 			},
-			Info: "Convert given time stamp with time zone to the new time zone, with no time zone designation",
+			Info: "Convert given time stamp with time zone to the new time zone, with no time zone designation\n" +
+				"This is deprecated in favor of timezone(str, timestamptz)",
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"time", types.Time},
+				{"timezone", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.TimeTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tArg := args[0].(*tree.DTime)
+				tzStr := string(tree.MustBeDString(args[1]))
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				tTime := timeofday.TimeOfDay(*tArg).ToTime()
+				_, beforeOffsetSecs := tTime.In(ctx.GetLocation()).Zone()
+				durationDelta := time.Duration(-beforeOffsetSecs) * time.Second
+				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta))), nil
+			},
+			Info: "Treat given time without time zone as located in the specified time zone\n" +
+				"This is deprecated in favor of timezone(str, time)",
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"timetz", types.TimeTZ},
+				{"timezone", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.TimeTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// This one should disappear with implicit casts.
+				tArg := args[0].(*tree.DTimeTZ)
+				tzStr := string(tree.MustBeDString(args[1]))
+				loc, err := timeutil.TimeZoneStringToLocation(
+					tzStr,
+					timeutil.TimeZoneStringToLocationPOSIXStandard,
+				)
+				if err != nil {
+					return nil, err
+				}
+				tTime := tArg.TimeTZ.ToTime()
+				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc))), nil
+			},
+			Info: "Convert given time with time zone to the new time zone\n" +
+				"This is deprecated in favor of timezone(str, timetz)",
 		},
 	),
 

--- a/pkg/sql/sem/tree/testdata/eval/at_time_zone
+++ b/pkg/sql/sem/tree/testdata/eval/at_time_zone
@@ -1,0 +1,57 @@
+# Regression test for cockroachdb-django#97.
+eval
+'2001-01-01 01:00:00'::timestamptz AT TIME ZONE '+3'
+----
+'2000-12-31 22:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamptz AT TIME ZONE '-3:00'
+----
+'2001-01-01 04:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'GMT+3'
+----
+'2000-12-31 22:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'UTC-3:00'
+----
+'2001-01-01 04:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamptz AT TIME ZONE 'Pacific/Honolulu'
+----
+'2000-12-31 15:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamp AT TIME ZONE '+3'
+----
+'2001-01-01 04:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamp AT TIME ZONE '-3:00'
+----
+'2000-12-31 22:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamp AT TIME ZONE 'GMT+3'
+----
+'2001-01-01 04:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamp AT TIME ZONE 'UTC-3:00'
+----
+'2000-12-31 22:00:00+00:00'
+
+eval
+'2001-01-01 01:00:00'::timestamp AT TIME ZONE 'Pacific/Honolulu'
+----
+'2001-01-01 11:00:00+00:00'
+
+# Regression test for #44027.
+# Attempt to convert string to AT TIME ZONE. An implicit cast should also work with this.
+eval
+'2001-01-01 01:00:00' AT TIME ZONE 'GMT+3'
+----
+'2000-12-31 22:00:00+00:00'

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -214,7 +214,10 @@ func timeZoneVarGetStringVal(
 	switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
 	case *tree.DString:
 		location := string(*v)
-		loc, err = timeutil.TimeZoneStringToLocation(location)
+		loc, err = timeutil.TimeZoneStringToLocation(
+			location,
+			timeutil.TimeZoneStringToLocationISO8601Standard,
+		)
 		if err != nil {
 			return "", wrapSetVarError("timezone", values[0].String(),
 				"cannot find time zone %q: %v", location, err)
@@ -255,7 +258,10 @@ func timeZoneVarGetStringVal(
 }
 
 func timeZoneVarSet(_ context.Context, m *sessionDataMutator, s string) error {
-	loc, err := timeutil.TimeZoneStringToLocation(s)
+	loc, err := timeutil.TimeZoneStringToLocation(
+		s,
+		timeutil.TimeZoneStringToLocationISO8601Standard,
+	)
 	if err != nil {
 		return wrapSetVarError("TimeZone", s, "%v", err)
 	}

--- a/pkg/util/timeutil/time_zone_util_test.go
+++ b/pkg/util/timeutil/time_zone_util_test.go
@@ -11,6 +11,7 @@
 package timeutil
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -24,21 +25,30 @@ func TestTimeZoneStringToLocation(t *testing.T) {
 
 	testCases := []struct {
 		tz             string
+		std            TimeZoneStringToLocationStandard
 		loc            *time.Location
 		expectedResult bool
 	}{
-		{"UTC", time.UTC, true},
-		{"Australia/Sydney", aus, true},
-		{"fixed offset:3600 (3600)", FixedOffsetTimeZoneToLocation(3600, "3600"), true},
-		{`GMT-3:00`, FixedOffsetTimeZoneToLocation(-3*60*60, "GMT-3:00"), true},
-		{"+10", FixedOffsetTimeZoneToLocation(10*60*60, "+10"), true},
-		{"-10:30", FixedOffsetTimeZoneToLocation(-(10*60*60 + 30*60), "-10:30"), true},
-		{"asdf", nil, false},
+		{"UTC", TimeZoneStringToLocationISO8601Standard, time.UTC, true},
+		{"Australia/Sydney", TimeZoneStringToLocationISO8601Standard, aus, true},
+		{"fixed offset:3600 (3600)", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(3600, "3600"), true},
+		{`GMT-3:00`, TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(-3*60*60, "GMT-3:00"), true},
+		{"+10", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(10*60*60, "+10"), true},
+		{"-10:30", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(-(10*60*60 + 30*60), "-10:30"), true},
+		{"asdf", TimeZoneStringToLocationISO8601Standard, nil, false},
+
+		{"UTC", TimeZoneStringToLocationPOSIXStandard, time.UTC, true},
+		{"Australia/Sydney", TimeZoneStringToLocationPOSIXStandard, aus, true},
+		{"fixed offset:3600 (3600)", TimeZoneStringToLocationPOSIXStandard, FixedOffsetTimeZoneToLocation(3600, "3600"), true},
+		{`GMT-3:00`, TimeZoneStringToLocationPOSIXStandard, FixedOffsetTimeZoneToLocation(3*60*60, "GMT-3:00"), true},
+		{"+10", TimeZoneStringToLocationPOSIXStandard, FixedOffsetTimeZoneToLocation(-10*60*60, "+10"), true},
+		{"-10:30", TimeZoneStringToLocationPOSIXStandard, FixedOffsetTimeZoneToLocation((10*60*60 + 30*60), "-10:30"), true},
+		{"asdf", TimeZoneStringToLocationPOSIXStandard, nil, false},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.tz, func(t *testing.T) {
-			loc, err := TimeZoneStringToLocation(tc.tz)
+		t.Run(fmt.Sprintf("%s_%d", tc.tz, tc.std), func(t *testing.T) {
+			loc, err := TimeZoneStringToLocation(tc.tz, tc.std)
 			if tc.expectedResult {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.loc, loc)


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44027.

This PR adds and fixes a few things:
* We previously did not support AT TIME ZONE for `time` and `timetz`
data types. We add these in in this PR.
* AT TIME ZONE (which calls into the builtin `timezone`) and
`timezone` assumes the `timezone` arguments are `time, str` instead of
the postgres `str, time`. We now support permutations of both ways
around, with the intent of deprecating `time, str` in 20.2 or later.
* POSIX style offsets (i.e. anything that isn't a location) use the
offset number as *west* of GMT instead of *east* of GMT, but only for
the `timezone` / `AT TIME ZONE` functionality. This was newly added for
20.1, and I mistakenly flipped the correct way this should work. This PR
fixes that behavior.

The release note below only captures net news since 19.2.

Release note (sql change, bug fix):
* We now support `AT TIME ZONE` and the `timezone` builtin for `time` and
`timetz` methods.
* Support for `AT TIME ZONE` now supports the POSIX standard - offsets
such as `UTC+3` and `+3` are interpreted to be timezones *west* of UTC
instead of *east* of UTC, e.g. `America/New_York` is equivalent to
`UTC+5` instead of `UTC-5`.
* We previously supported `timezone(timestamp(tz), str)`, but postgres
supports the inverse `timezone(str, timestamp(tz))`. We now support
both, aiming to deprecate the older version at a later stage.
* We now support `str AT TIME ZONE str`, removing the need for an
explicit cast.