### PR TITLE
sql: don't distribute migration queries

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -46,7 +46,6 @@ func registerAcceptance(r *testRegistry) {
 		{name: "status-server", fn: runStatusServer},
 		{
 			name: "version-upgrade",
-			skip: "#43957",
 			fn:   runVersionUpgrade,
 			// This test doesn't like running on old versions because it upgrades to
 			// the latest released version and then it tries to "head", where head is

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -754,7 +754,7 @@ func migrateSystemNamespace(ctx context.Context, r runner) error {
 	rows, err := r.sqlExecutor.QueryEx(
 		ctx, "read-deprecated-namespace-table", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{
-			User: security.NodeUser,
+			User: security.RootUser,
 		},
 		q)
 	if err != nil {


### PR DESCRIPTION
This patch inhibits DistSQL distribution for the queries that the
migrations run. This was prompted by #44101, which is causing a
distributed query done soon after a node startup to sometimes fail.

I've considered more bluntly disabling distribution for any query for a
short period of time after the node starts up, but I went with the more
targeted change to migrations because I think it's a bad idea for
migrations to use query distribution even outside of #44101 -
distributed queries are more fragile than local execution in general
(for example, because of DistSender retries). And migrations can't
tolerate any flakiness.

Fixes #43957
Fixes #44005
Touches #44101