### PR TITLE
colexec: refactor CASE operator

### DIFF
--- a/pkg/sql/colexec/buffer_test.go
+++ b/pkg/sql/colexec/buffer_test.go
@@ -43,23 +43,4 @@ func TestBufferOp(t *testing.T) {
 		require.Nil(t, b.Selection())
 		require.Equal(t, uint16(0), b.Length())
 	})
-
-	t.Run("TestBufferRestoresOriginalBatch", func(t *testing.T) {
-		buffer.rewind()
-		b := buffer.Next(ctx)
-		b.SetSelection(true)
-		sel := b.Selection()
-		sel[0] = 1
-		b.SetLength(1)
-
-		// We have modified the selection batch, but rewinding the buffer should
-		// restore the returned batch to the original state.
-		buffer.rewind()
-		b = buffer.Next(ctx)
-		require.Nil(t, b.Selection())
-		require.Equal(t, uint16(len(inputTuples)), b.Length())
-		b = buffer.Next(ctx)
-		require.Nil(t, b.Selection())
-		require.Equal(t, uint16(0), b.Length())
-	})
 }

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1410,7 +1410,6 @@ func planProjectionOperators(
 		}
 
 		buffer := NewBufferOp(input)
-		internalMemUsed += buffer.(InternalMemoryOperator).InternalMemoryUsage()
 		caseOps := make([]Operator, len(t.Whens))
 		caseOutputType := typeconv.FromColumnType(t.ResolvedType())
 		caseOutputIdx := len(columnTypes)


### PR DESCRIPTION
This commit removes selectionBatch which was used by the CASE operator
and, instead, moves the logic that selectionBatch was providing into the
operator itself. I think it is clearer this way.

Release note: None