### PR TITLE
storage: deflake TestSplitSnapshotRace_SnapshotWins

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1405,6 +1405,7 @@ func runSetupSplitSnapshotRace(
 	sc.TestingKnobs.IntentResolverKnobs.DisableAsyncIntentResolution = true
 	// Avoid fighting with the merge queue while trying to reproduce this race.
 	sc.TestingKnobs.DisableMergeQueue = true
+	sc.TestingKnobs.DisableGCQueue = true
 	// Disable the split delay mechanism, or it'll spend 10s going in circles.
 	// (We can't set it to zero as otherwise the default overrides us).
 	sc.RaftDelaySplitToSuppressSnapshotTicks = -1


### PR DESCRIPTION
GC somehow seems to pick up timestamps that are not taken from the
manual clock the multiTestContext is supposedly using. This isn't
good but also manual clocks are a bad idea, and it's not worth
making it work better. Just disable the GC queue.

My best guess is that this was introduced near ee2178bde41a5ed5f95c8c9c2b8f6bf8a4195d9e, which changed
the source for the `now` value passed to `RunGC` (it used to come
from the Store's clock, now it comes from some db.Clock).

Closes https://github.com/cockroachdb/cockroach/issues/43897.

Release note: None