### PR TITLE
release-19.2: cli: new command `auth-session {login,logout,lis…

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -1,0 +1,215 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login [options] <session-username>",
+	Short: "create a HTTP session and token for the given user",
+	Long: `
+Creates a HTTP session for the given user and print out a login cookie for use
+in non-interactive programs.
+
+Example use of the session cookie using 'curl':
+
+   curl -k -b "<cookie>" https://localhost:8080/_admin/v1/settings
+
+The user invoking the 'login' CLI command must be an admin on the cluster.
+The user for which the HTTP session is opened can be arbitrary.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runLogin),
+}
+
+func runLogin(cmd *cobra.Command, args []string) error {
+	username := tree.Name(args[0]).Normalize()
+	id, httpCookie, err := createAuthSessionToken(username)
+	if err != nil {
+		return err
+	}
+	hC := httpCookie.String()
+
+	if authCtx.onlyCookie {
+		// Simple format suitable for automation.
+		fmt.Println(hC)
+	} else {
+		// More complete format, suitable e.g. for appending to a CSV file
+		// with --format=csv.
+		cols := []string{"username", "session ID", "authentication cookie"}
+		rows := [][]string{
+			{username, fmt.Sprintf("%d", id), hC},
+		}
+		if err := printQueryOutput(os.Stdout, cols, newRowSliceIter(rows, "ll")); err != nil {
+			return err
+		}
+
+		checkInteractive()
+		if cliCtx.isInteractive {
+			fmt.Fprintf(stderr, `#
+# Example uses:
+#
+#     curl [-k] --cookie '%s' https://...
+#
+#     wget [--no-check-certificate] --header='Cookie: %s' https://...
+#
+`, hC, hC)
+		}
+	}
+
+	return nil
+}
+
+func createAuthSessionToken(username string) (sessionID int64, httpCookie *http.Cookie, err error) {
+	sqlConn, err := makeSQLClient("cockroach auth-session login", useSystemDb)
+	if err != nil {
+		return -1, nil, err
+	}
+	defer sqlConn.Close()
+
+	// First things first. Does the user exist?
+	_, rows, err := runQuery(sqlConn,
+		makeQuery(`SELECT count(username) FROM system.users WHERE username = $1 AND NOT "isRole"`, username), false)
+	if err != nil {
+		return -1, nil, err
+	}
+	if rows[0][0] != "1" {
+		return -1, nil, fmt.Errorf("user %q does not exist", username)
+	}
+
+	// Make a secret.
+	secret, hashedSecret, err := server.CreateAuthSecret()
+	if err != nil {
+		return -1, nil, err
+	}
+	expiration := timeutil.Now().Add(authCtx.validityPeriod)
+
+	// Create the session on the server to the server.
+	insertSessionStmt := `
+INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt")
+VALUES($1, $2, $3)
+RETURNING id
+`
+	var id int64
+	row, err := sqlConn.QueryRow(
+		insertSessionStmt,
+		[]driver.Value{
+			hashedSecret,
+			username,
+			expiration,
+		},
+	)
+	if err != nil {
+		return -1, nil, err
+	}
+	if len(row) != 1 {
+		return -1, nil, errors.Newf("expected 1 column, got %d", len(row))
+	}
+	id, ok := row[0].(int64)
+	if !ok {
+		return -1, nil, errors.Newf("expected integer, got %T", row[0])
+	}
+
+	// Spell out the cookie.
+	sCookie := &serverpb.SessionCookie{ID: id, Secret: secret}
+	httpCookie, err = server.EncodeSessionCookie(sCookie)
+	return id, httpCookie, err
+}
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout [options] <session-username>",
+	Short: "invalidates all the HTTP session tokens previously created for the given user",
+	Long: `
+Revokes all previously issued HTTP authentication tokens for the given user.
+
+The user invoking the 'login' CLI command must be an admin on the cluster.
+The user for which the HTTP sessions are revoked can be arbitrary.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runLogout),
+}
+
+func runLogout(cmd *cobra.Command, args []string) error {
+	username := tree.Name(args[0]).Normalize()
+
+	sqlConn, err := makeSQLClient("cockroach auth-session logout", useSystemDb)
+	if err != nil {
+		return err
+	}
+	defer sqlConn.Close()
+
+	logoutQuery := makeQuery(
+		`UPDATE system.web_sessions SET "revokedAt" = if("revokedAt"::timestamptz<now(),"revokedAt",now())
+      WHERE username = $1
+  RETURNING username,
+            id AS "session ID",
+            "revokedAt" AS "revoked"`,
+		username)
+	return runQueryAndFormatResults(sqlConn, os.Stdout, logoutQuery)
+}
+
+var authListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "lists the currently active HTTP sessions",
+	Long: `
+Prints out the currently active HTTP sessions.
+
+The user invoking the 'list' CLI command must be an admin on the cluster.
+`,
+	Args: cobra.ExactArgs(0),
+	RunE: MaybeDecorateGRPCError(runAuthList),
+}
+
+func runAuthList(cmd *cobra.Command, args []string) error {
+	sqlConn, err := makeSQLClient("cockroach auth-session list", useSystemDb)
+	if err != nil {
+		return err
+	}
+	defer sqlConn.Close()
+
+	logoutQuery := makeQuery(`
+SELECT username,
+       id AS "session ID",
+       "createdAt" as "created",
+       "expiresAt" as "expires",
+       "revokedAt" as "revoked",
+       "lastUsedAt" as "last used"
+  FROM system.web_sessions`)
+	return runQueryAndFormatResults(sqlConn, os.Stdout, logoutQuery)
+}
+
+var authCmds = []*cobra.Command{
+	loginCmd,
+	logoutCmd,
+	authListCmd,
+}
+
+var authCmd = &cobra.Command{
+	Use:   "auth-session",
+	Short: "log in and out of HTTP sessions",
+	RunE:  usageAndErr,
+}
+
+func init() {
+	authCmd.AddCommand(authCmds...)
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -198,6 +198,7 @@ func init() {
 
 		sqlShellCmd,
 		userCmd,
+		authCmd,
 		nodeCmd,
 		dumpCmd,
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1596,6 +1596,7 @@ Available Commands:
 
   sql               open a sql shell
   user              get, set, list and remove users (deprecated)
+  auth-session      log in and out of HTTP sessions
   node              list, inspect or remove nodes
   dump              dump sql tables
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -178,6 +178,19 @@ when the first store is in-memory.
 `,
 	}
 
+	AuthTokenValidityPeriod = FlagInfo{
+		Name: "expire-after",
+		Description: `
+Duration after which the newly created session token expires.`,
+	}
+
+	OnlyCookie = FlagInfo{
+		Name: "only-cookie",
+		Description: `
+Display only the newly created cookie on the standard output
+without additional details and decoration.`,
+	}
+
 	Cache = FlagInfo{
 		Name: "cache",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -153,6 +153,8 @@ func initCLIDefaults() {
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
 
+	authCtx.validityPeriod = 1 * time.Hour
+
 	initPreFlagsDefaults()
 
 	// Clear the "Changed" state of all the registered command-line flags.
@@ -252,6 +254,13 @@ var dumpCtx struct {
 
 	// asOf determines the time stamp at which the dump should be taken.
 	asOf string
+}
+
+// authCtx captures the command-line parameters of the `auth-session`
+// command.
+var authCtx struct {
+	onlyCookie     bool
+	validityPeriod time.Duration
 }
 
 // debugCtx captures the command-line parameters of the `debug` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -465,6 +465,7 @@ func init() {
 		/* StartCmds are covered above */
 	}
 	clientCmds = append(clientCmds, userCmds...)
+	clientCmds = append(clientCmds, authCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, systemBenchCmds...)
 	clientCmds = append(clientCmds, initCmd)
@@ -478,6 +479,13 @@ func init() {
 
 		// Certificate flags.
 		StringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, baseCfg.SSLCertsDir)
+	}
+
+	// Auth commands.
+	{
+		f := loginCmd.Flags()
+		DurationFlag(f, &authCtx.validityPeriod, cliflags.AuthTokenValidityPeriod, authCtx.validityPeriod)
+		BoolFlag(f, &authCtx.onlyCookie, cliflags.OnlyCookie, authCtx.onlyCookie)
 	}
 
 	timeoutCmds := []*cobra.Command{
@@ -549,6 +557,7 @@ func init() {
 	// Commands that establish a SQL connection.
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}
 	sqlCmds = append(sqlCmds, userCmds...)
+	sqlCmds = append(sqlCmds, authCmds...)
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	for _, cmd := range sqlCmds {
 		f := cmd.Flags()
@@ -580,6 +589,7 @@ func init() {
 		demoCmd.Commands()...)
 	tableOutputCommands = append(tableOutputCommands, userCmds...)
 	tableOutputCommands = append(tableOutputCommands, nodeCmds...)
+	tableOutputCommands = append(tableOutputCommands, authCmds...)
 
 	// By default, these commands print their output as pretty-formatted
 	// tables on terminals, and TSV when redirected to a file. The user

--- a/pkg/cli/interactive_tests/test_auth_cookie.py
+++ b/pkg/cli/interactive_tests/test_auth_cookie.py
@@ -1,0 +1,18 @@
+import urllib2
+import ssl
+import sys
+
+cookiefile = sys.argv[1]
+url = sys.argv[2]
+
+# Disable SSL cert validation for simplicity.
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+# Load the cookie.
+cookie = file('cookie.txt').read().strip()
+
+# Perform the HTTP request.
+httpReq = urllib2.Request(url, "", {"Cookie": cookie})
+print urllib2.urlopen(httpReq, context=ctx).read()

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -2,6 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+set python "python2.7"
 set certs_dir "/certs"
 set ::env(COCKROACH_INSECURE) "false"
 set ::env(COCKROACH_HOST) "localhost"
@@ -13,7 +14,7 @@ set prompt ":/# "
 eexpect $prompt
 
 start_test "Check that --insecure reports that the server is really insecure"
-send "$argv start-single-node --insecure\r"
+send "$argv start-single-node --host=localhost --insecure\r"
 eexpect "WARNING: RUNNING IN INSECURE MODE"
 eexpect "node starting"
 interrupt
@@ -23,7 +24,7 @@ end_test
 
 proc start_secure_server {argv certs_dir} {
     report "BEGIN START SECURE SERVER"
-    system "$argv start-single-node --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background >>expect-cmd.log 2>&1;
+    system "$argv start-single-node --host=localhost --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background >>expect-cmd.log 2>&1;
             $argv sql --certs-dir=$certs_dir -e 'select 1'"
     report "END START SECURE SERVER"
 }
@@ -127,10 +128,71 @@ eexpect "root@"
 interrupt
 end_test
 
-# Terminate with Ctrl+C.
+# Terminate the shell with Ctrl+C.
 interrupt
-
 eexpect $prompt
+
+start_test "Check that an auth cookie cannot be created for a user that does not exist."
+send "$argv auth-session login nonexistent --certs-dir=$certs_dir\r"
+eexpect "user \"nonexistent\" does not exist"
+eexpect $prompt
+end_test
+
+start_test "Check that the auth cookie creation works and reports useful output."
+send "$argv auth-session login eisen --certs-dir=$certs_dir\r"
+eexpect "authentication cookie"
+eexpect "session="
+eexpect "HttpOnly"
+eexpect "Example uses:"
+eexpect "curl"
+eexpect "wget"
+eexpect $prompt
+end_test
+
+start_test "Check that the auth cookie can be emitted standalone."
+send "$argv auth-session login eisen --certs-dir=$certs_dir --only-cookie >cookie.txt\r"
+eexpect $prompt
+system "grep HttpOnly cookie.txt"
+end_test
+
+start_test "Check that the session is visible in the output of list."
+send "$argv auth-session list --certs-dir=$certs_dir\r"
+eexpect username
+eexpect eisen
+eexpect eisen
+eexpect "2 rows"
+eexpect $prompt
+end_test
+
+set pyfile [file join [file dirname $argv0] test_auth_cookie.py]
+
+start_test "Check that the auth cookie works."
+send "$python $pyfile cookie.txt 'https://localhost:8080/_admin/v1/settings'\r"
+eexpect "cluster.organization"
+eexpect $prompt
+end_test
+
+
+start_test "Check that the cookie can be revoked."
+send "$argv auth-session logout eisen --certs-dir=$certs_dir\r"
+eexpect username
+eexpect eisen
+eexpect eisen
+eexpect "2 rows"
+eexpect "$prompt"
+
+send "$python $pyfile cookie.txt 'https://localhost:8080/_admin/v1/settings'\r"
+eexpect "HTTP Error 401"
+eexpect $prompt
+end_test
+
+start_test "Check that a root cookie works."
+send "$argv auth-session login root --certs-dir=$certs_dir --only-cookie >cookie.txt\r"
+eexpect $prompt
+send "$python $pyfile cookie.txt 'https://localhost:8080/_admin/v1/settings'\r"
+eexpect "cluster.organization"
+eexpect $prompt
+end_test
 
 send "exit 0\r"
 eexpect eof

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -43,8 +43,9 @@ const (
 	loginPath  = "/login"
 	logoutPath = "/logout"
 	// secretLength is the number of random bytes generated for session secrets.
-	secretLength      = 16
-	sessionCookieName = "session"
+	secretLength = 16
+	// SessionCookieName is the name of the cookie used for HTTP auth.
+	SessionCookieName = "session"
 )
 
 var webSessionTimeout = settings.RegisterNonNegativeDurationSetting(
@@ -271,19 +272,29 @@ func (s *authenticationServer) verifyPassword(
 	return (security.CompareHashAndPassword(hashedPassword, password) == nil), nil
 }
 
+// CreateAuthSecret creates a secret, hash pair to populate a session auth token.
+func CreateAuthSecret() (secret, hashedSecret []byte, err error) {
+	secret = make([]byte, secretLength)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, nil, err
+	}
+
+	hasher := sha256.New()
+	_, _ = hasher.Write(secret)
+	hashedSecret = hasher.Sum(nil)
+	return secret, hashedSecret, nil
+}
+
 // newAuthSession attempts to create a new authentication session for the given
 // user. If successful, returns the ID and secret value for the new session.
 func (s *authenticationServer) newAuthSession(
 	ctx context.Context, username string,
 ) (int64, []byte, error) {
-	secret := make([]byte, secretLength)
-	if _, err := rand.Read(secret); err != nil {
+	secret, hashedSecret, err := CreateAuthSecret()
+	if err != nil {
 		return 0, nil, err
 	}
 
-	hasher := sha256.New()
-	_, _ = hasher.Write(secret)
-	hashedSecret := hasher.Sum(nil)
 	expiration := s.server.clock.PhysicalTime().Add(webSessionTimeout.Get(&s.server.st.SV))
 
 	insertSessionStmt := `
@@ -385,7 +396,7 @@ func EncodeSessionCookie(sessionCookie *serverpb.SessionCookie) (*http.Cookie, e
 
 func makeCookieWithValue(value string) *http.Cookie {
 	return &http.Cookie{
-		Name:     sessionCookieName,
+		Name:     SessionCookieName,
 		Value:    value,
 		Path:     "/",
 		HttpOnly: true,
@@ -400,7 +411,7 @@ func (am *authenticationMux) getSession(
 	w http.ResponseWriter, req *http.Request,
 ) (string, *serverpb.SessionCookie, error) {
 	// Validate the returned cookie.
-	rawCookie, err := req.Cookie(sessionCookieName)
+	rawCookie, err := req.Cookie(SessionCookieName)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #43872.

/cc @cockroachdb/release

---

Fixes #43870.

tldr: this adds new CLI commands to log users in and out of the
HTTP interface and produce a HTTP cookie for use in monitoring
scripts. This is suitable for use by the `root` user without an
Enterprise license.

Also the new feature is client-side only, so the client binary with
this feature can be used with a CockroachDB server/cluster running at
an older version (including 2.1.x and 19.1.x).
