### PR TITLE
sql: fix crash when using COCKROACH_DISTSQL_LOG_PLAN

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -324,7 +324,7 @@ func (dsp *DistSQLPlanner) Run(
 	if logPlanDiagram {
 		log.VEvent(ctx, 1, "creating plan diagram")
 		var stmtStr string
-		if planCtx.planner != nil {
+		if planCtx.planner != nil && planCtx.planner.stmt != nil {
 			stmtStr = planCtx.planner.stmt.String()
 		}
 		_, url, err := execinfrapb.GeneratePlanDiagramURL(stmtStr, flows, false /* showInputTypes */)


### PR DESCRIPTION
In some rare cases (auto stats resuming on another node), we don't
have a statement in the planner here.

Fixes #44049.

Release note: None