### PR TITLE
cli: fix `--url` with `sslmode` omitted but other options presents

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -171,7 +171,7 @@ func (u urlParser) Set(v string) error {
 		cliCtx.extraConnURLOptions = options
 
 		switch sslMode := options.Get("sslmode"); sslMode {
-		case "disable":
+		case "", "disable":
 			if err := fl.Set(cliflags.ClientInsecure.Name, "true"); err != nil {
 				return errors.Wrapf(err, "setting insecure connection based on --url")
 			}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -265,6 +265,7 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 		{anyNonSQL, []string{"--url=postgresql://b:12345"}, []string{"--host=b", "--port=12345"}, "", ""},
 		{anyNonSQL, []string{"--url=postgresql://b:c"}, nil, `invalid port ":c" after host`, ""},
 
+		{anyCmd, []string{"--url=postgresql://foo?application_name=abc"}, []string{"--host=foo", "--insecure"}, "", ""},
 		{anyCmd, []string{"--url=postgresql://foo?sslmode=disable"}, []string{"--host=foo", "--insecure"}, "", ""},
 		{anySQL, []string{"--url=postgresql://foo?sslmode=require"}, []string{"--host=foo", "--insecure=false"}, "", ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=require"}, nil, "command .* only supports sslmode=disable or sslmode=verify-full", ""},


### PR DESCRIPTION
Fixes #44088.

Release note (bug fix): CockroachDB now properly supports
using `--url` with query options (e.g. `application_name`) but
without specifying `sslmode`. The default of `sslmode=disable` is
assumed in that case.