### PR TITLE
release-19.2: sql: convert locale panic to error

### DIFF
--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -70,10 +70,10 @@ func TestInterner(t *testing.T) {
 	dec4, _ := tree.ParseDDecimal("1e0")
 	dec5, _ := tree.ParseDDecimal("1")
 
-	coll1 := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
-	coll2 := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
-	coll3 := tree.NewDCollatedString("foo", "en_US", &tree.CollationEnvironment{})
-	coll4 := tree.NewDCollatedString("food", "en_US", &tree.CollationEnvironment{})
+	coll1, _ := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
+	coll2, _ := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
+	coll3, _ := tree.NewDCollatedString("foo", "en_US", &tree.CollationEnvironment{})
+	coll4, _ := tree.NewDCollatedString("food", "en_US", &tree.CollationEnvironment{})
 
 	tz1 := tree.MakeDTimestampTZ(time.Date(2018, 10, 6, 11, 49, 30, 123, time.UTC), 0)
 	tz2 := tree.MakeDTimestampTZ(time.Date(2018, 10, 6, 11, 49, 30, 123, time.UTC), 0)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1666,7 +1666,11 @@ func (c *CustomFuncs) CastToCollatedString(str opt.ScalarExpr, locale string) op
 		panic(errors.AssertionFailedf("unexpected type for COLLATE: %T", t))
 	}
 
-	return c.f.ConstructConst(tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv))
+	d, err := tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv)
+	if err != nil {
+		panic(err)
+	}
+	return c.f.ConstructConst(d)
 }
 
 // MakeUnorderedSubquery returns a SubqueryPrivate that specifies no ordering.

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1197,24 +1197,35 @@ type collationEnvironmentCacheEntry struct {
 	collator *collate.Collator
 }
 
-func (env *CollationEnvironment) getCacheEntry(locale string) collationEnvironmentCacheEntry {
+func (env *CollationEnvironment) getCacheEntry(
+	locale string,
+) (collationEnvironmentCacheEntry, error) {
 	entry, ok := env.cache[locale]
 	if !ok {
 		if env.cache == nil {
 			env.cache = make(map[string]collationEnvironmentCacheEntry)
 		}
-		entry = collationEnvironmentCacheEntry{locale, collate.New(language.MustParse(locale))}
+		tag, err := language.Parse(locale)
+		if err != nil {
+			err = errors.NewAssertionErrorWithWrappedErrf(err, "failed to parse locale %q", locale)
+			return collationEnvironmentCacheEntry{}, err
+		}
+
+		entry = collationEnvironmentCacheEntry{locale, collate.New(tag)}
 		env.cache[locale] = entry
 	}
-	return entry
+	return entry, nil
 }
 
 // NewDCollatedString is a helper routine to create a *DCollatedString. Panics
 // if locale is invalid. Not safe for concurrent use.
 func NewDCollatedString(
 	contents string, locale string, env *CollationEnvironment,
-) *DCollatedString {
-	entry := env.getCacheEntry(locale)
+) (*DCollatedString, error) {
+	entry, err := env.getCacheEntry(locale)
+	if err != nil {
+		return nil, err
+	}
 	if env.buffer == nil {
 		env.buffer = &collate.Buffer{}
 	}
@@ -1222,7 +1233,7 @@ func NewDCollatedString(
 	d := DCollatedString{contents, entry.locale, make([]byte, len(key))}
 	copy(d.Key, key)
 	env.buffer.Reset()
-	return &d
+	return &d, nil
 }
 
 // AmbiguousFormat implements the Datum interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3370,7 +3370,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			if t.Width() > 0 && int(t.Width()) < len(s) {
 				s = s[:t.Width()]
 			}
-			return NewDCollatedString(s, t.Locale(), &ctx.CollationEnv), nil
+			return NewDCollatedString(s, t.Locale(), &ctx.CollationEnv)
 		}
 
 	case types.BytesFamily:
@@ -3736,9 +3736,9 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	switch d := unwrapped.(type) {
 	case *DString:
-		return NewDCollatedString(string(*d), expr.Locale, &ctx.CollationEnv), nil
+		return NewDCollatedString(string(*d), expr.Locale, &ctx.CollationEnv)
 	case *DCollatedString:
-		return NewDCollatedString(d.Contents, expr.Locale, &ctx.CollationEnv), nil
+		return NewDCollatedString(d.Contents, expr.Locale, &ctx.CollationEnv)
 	default:
 		return nil, pgerror.Newf(pgcode.DatatypeMismatch, "incompatible type for COLLATE: %s", d)
 	}

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -26,7 +26,7 @@ func ParseStringAs(t *types.T, s string, evalCtx *EvalContext) (Datum, error) {
 	case types.BytesFamily:
 		d = NewDBytes(DBytes(s))
 	case types.CollatedStringFamily:
-		d = NewDCollatedString(s, t.Locale(), &evalCtx.CollationEnv)
+		d, err = NewDCollatedString(s, t.Locale(), &evalCtx.CollationEnv)
 	case types.ArrayFamily:
 		d, err = ParseDArrayFromString(evalCtx, s, t.ArrayContents())
 		if err != nil {

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -306,7 +306,8 @@ func DecodeTableKey(
 		if err != nil {
 			return nil, nil, err
 		}
-		return tree.NewDCollatedString(r, valType.Locale(), &a.env), rkey, err
+		d, err := tree.NewDCollatedString(r, valType.Locale(), &a.env)
+		return d, rkey, err
 	case types.JsonFamily:
 		return tree.DNull, []byte{}, nil
 	case types.BytesFamily:
@@ -505,7 +506,11 @@ func decodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		return a.NewDString(tree.DString(data)), b, nil
 	case types.CollatedStringFamily:
 		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
-		return tree.NewDCollatedString(string(data), t.Locale(), &a.env), b, err
+		if err != nil {
+			return nil, b, err
+		}
+		d, err := tree.NewDCollatedString(string(data), t.Locale(), &a.env)
+		return d, b, err
 	case types.BitFamily:
 		b, data, err := encoding.DecodeUntaggedBitArrayValue(buf)
 		return a.NewDBitArray(tree.DBitArray{BitArray: data}), b, err
@@ -841,7 +846,7 @@ func UnmarshalColumnValue(a *DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if err != nil {
 			return nil, err
 		}
-		return tree.NewDCollatedString(string(v), typ.Locale(), &a.env), nil
+		return tree.NewDCollatedString(string(v), typ.Locale(), &a.env)
 	case types.UuidFamily:
 		v, err := value.GetBytes()
 		if err != nil {

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -223,7 +223,11 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 			}
 			buf.WriteRune(r)
 		}
-		return tree.NewDCollatedString(buf.String(), typ.Locale(), &tree.CollationEnvironment{})
+		d, err := tree.NewDCollatedString(buf.String(), typ.Locale(), &tree.CollationEnvironment{})
+		if err != nil {
+			panic(err)
+		}
+		return d
 	case types.OidFamily:
 		return tree.NewDOid(tree.DInt(rng.Uint32()))
 	case types.UnknownFamily:

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -206,7 +206,11 @@ func truncateDatum(evalCtx *tree.EvalContext, d tree.Datum, maxBytes int) tree.D
 
 		// Note: this will end up being larger than maxBytes due to the key and
 		// locale, so this is just a best-effort attempt to limit the size.
-		return tree.NewDCollatedString(contents, t.Locale, &evalCtx.CollationEnv)
+		res, err := tree.NewDCollatedString(contents, t.Locale, &evalCtx.CollationEnv)
+		if err != nil {
+			return d
+		}
+		return res
 
 	case *tree.DOidWrapper:
 		return &tree.DOidWrapper{
@@ -252,8 +256,11 @@ func deepCopyDatum(evalCtx *tree.EvalContext, d tree.Datum) tree.Datum {
 		return tree.NewDString(deepCopyString(string(*t)))
 
 	case *tree.DCollatedString:
-		contents := deepCopyString(t.Contents)
-		return tree.NewDCollatedString(contents, t.Locale, &evalCtx.CollationEnv)
+		return &tree.DCollatedString{
+			Contents: deepCopyString(t.Contents),
+			Locale:   t.Locale,
+			Key:      t.Key,
+		}
 
 	case *tree.DOidWrapper:
 		return &tree.DOidWrapper{

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -108,9 +108,15 @@ func TestTruncateDatum(t *testing.T) {
 	expected3 := tree.DString("Hello 世")
 	runTest(&original3, &expected3)
 
-	original4 := tree.NewDCollatedString(`IT was lovely summer weather in the country, and the golden
+	original4, err := tree.NewDCollatedString(`IT was lovely summer weather in the country, and the golden
 corn, the green oats, and the haystacks piled up in the meadows looked beautiful`,
 		"en_US", &tree.CollationEnvironment{})
-	expected4 := tree.NewDCollatedString("IT was lov", "en_US", &tree.CollationEnvironment{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected4, err := tree.NewDCollatedString("IT was lov", "en_US", &tree.CollationEnvironment{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	runTest(original4, expected4)
 }


### PR DESCRIPTION
Backport 1/1 commits from #44103.

/cc @cockroachdb/release

---

We have seen cases where the locale fails to parse when we create a
`NewDCollatedString`. We can't reproduce and root cause but we can at
least convert it to an internal error.

Informs #35722.

Release note (bug fix): Converted a panic in
golang.org/x/text/language/tags.go when using collated strings to an
error.
