### PR TITLE
release-19.1: sql: convert locale panic to error

### DIFF
--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -74,10 +74,10 @@ func TestInterner(t *testing.T) {
 	dec4, _ := tree.ParseDDecimal("1e0")
 	dec5, _ := tree.ParseDDecimal("1")
 
-	coll1 := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
-	coll2 := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
-	coll3 := tree.NewDCollatedString("foo", "en_US", &tree.CollationEnvironment{})
-	coll4 := tree.NewDCollatedString("food", "en_US", &tree.CollationEnvironment{})
+	coll1, _ := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
+	coll2, _ := tree.NewDCollatedString("foo", "sv_SE", &tree.CollationEnvironment{})
+	coll3, _ := tree.NewDCollatedString("foo", "en_US", &tree.CollationEnvironment{})
+	coll4, _ := tree.NewDCollatedString("food", "en_US", &tree.CollationEnvironment{})
 
 	tz1 := tree.MakeDTimestampTZ(time.Date(2018, 10, 6, 11, 49, 30, 123, time.UTC), 0)
 	tz2 := tree.MakeDTimestampTZ(time.Date(2018, 10, 6, 11, 49, 30, 123, time.UTC), 0)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1379,7 +1379,11 @@ func (c *CustomFuncs) CastToCollatedString(str opt.ScalarExpr, locale string) op
 		panic(pgerror.NewAssertionErrorf("unexpected type for COLLATE: %T", log.Safe(str.(*memo.ConstExpr).Value)))
 	}
 
-	return c.f.ConstructConst(tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv))
+	d, err := tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv)
+	if err != nil {
+		panic(err)
+	}
+	return c.f.ConstructConst(d)
 }
 
 // MakeUnorderedSubquery returns a SubqueryPrivate that specifies no ordering.

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1151,24 +1151,35 @@ type collationEnvironmentCacheEntry struct {
 	collator *collate.Collator
 }
 
-func (env *CollationEnvironment) getCacheEntry(locale string) collationEnvironmentCacheEntry {
+func (env *CollationEnvironment) getCacheEntry(
+	locale string,
+) (collationEnvironmentCacheEntry, error) {
 	entry, ok := env.cache[locale]
 	if !ok {
 		if env.cache == nil {
 			env.cache = make(map[string]collationEnvironmentCacheEntry)
 		}
-		entry = collationEnvironmentCacheEntry{locale, collate.New(language.MustParse(locale))}
+		tag, err := language.Parse(locale)
+		if err != nil {
+			err = errors.Errorf("failed to parse locale %q: %v", locale, err)
+			return collationEnvironmentCacheEntry{}, err
+		}
+
+		entry = collationEnvironmentCacheEntry{locale, collate.New(tag)}
 		env.cache[locale] = entry
 	}
-	return entry
+	return entry, nil
 }
 
 // NewDCollatedString is a helper routine to create a *DCollatedString. Panics
 // if locale is invalid. Not safe for concurrent use.
 func NewDCollatedString(
 	contents string, locale string, env *CollationEnvironment,
-) *DCollatedString {
-	entry := env.getCacheEntry(locale)
+) (*DCollatedString, error) {
+	entry, err := env.getCacheEntry(locale)
+	if err != nil {
+		return nil, err
+	}
 	if env.buffer == nil {
 		env.buffer = &collate.Buffer{}
 	}
@@ -1176,7 +1187,7 @@ func NewDCollatedString(
 	d := DCollatedString{contents, entry.locale, make([]byte, len(key))}
 	copy(d.Key, key)
 	env.buffer.Reset()
-	return &d
+	return &d, nil
 }
 
 // AmbiguousFormat implements the Datum interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3219,7 +3219,7 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			if c.N > 0 && c.N < uint(len(s)) {
 				s = s[:c.N]
 			}
-			return NewDCollatedString(s, c.Locale, &ctx.CollationEnv), nil
+			return NewDCollatedString(s, c.Locale, &ctx.CollationEnv)
 		case *coltypes.TName:
 			return NewDName(s), nil
 		}
@@ -3552,9 +3552,9 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	switch d := unwrapped.(type) {
 	case *DString:
-		return NewDCollatedString(string(*d), expr.Locale, &ctx.CollationEnv), nil
+		return NewDCollatedString(string(*d), expr.Locale, &ctx.CollationEnv)
 	case *DCollatedString:
-		return NewDCollatedString(d.Contents, expr.Locale, &ctx.CollationEnv), nil
+		return NewDCollatedString(d.Contents, expr.Locale, &ctx.CollationEnv)
 	default:
 		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "incompatible type for COLLATE: %s", d)
 	}

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -42,7 +42,7 @@ func ParseStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
 				return nil, err
 			}
 		case types.TCollatedString:
-			d = NewDCollatedString(s, t.Locale, &evalCtx.CollationEnv)
+			d, err = NewDCollatedString(s, t.Locale, &evalCtx.CollationEnv)
 		default:
 			d, err = parseStringAs(t, s, evalCtx)
 			if d == nil && err == nil {

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -331,7 +331,8 @@ func DecodeTableKey(
 			if err != nil {
 				return nil, nil, err
 			}
-			return tree.NewDCollatedString(r, t.Locale, &a.env), rkey, err
+			d, err := tree.NewDCollatedString(r, t.Locale, &a.env)
+			return d, rkey, err
 		}
 		return nil, nil, errors.Errorf("TODO(pmattis): decoded index key: %s", valType)
 	}
@@ -533,7 +534,11 @@ func decodeUntaggedDatum(a *DatumAlloc, t types.T, buf []byte) (tree.Datum, []by
 			}, rest, nil
 		case types.TCollatedString:
 			b, data, err := encoding.DecodeUntaggedBytesValue(buf)
-			return tree.NewDCollatedString(string(data), typ.Locale, &a.env), b, err
+			if err != nil {
+				return nil, b, err
+			}
+			d, err := tree.NewDCollatedString(string(data), typ.Locale, &a.env)
+			return d, b, err
 		case types.TArray:
 			return decodeArray(a, typ.Typ, buf)
 		case types.TTuple:
@@ -794,7 +799,7 @@ func UnmarshalColumnValue(a *DatumAlloc, typ ColumnType, value roachpb.Value) (t
 		if err != nil {
 			return nil, err
 		}
-		return tree.NewDCollatedString(string(v), *typ.Locale, &a.env), nil
+		return tree.NewDCollatedString(string(v), *typ.Locale, &a.env)
 	case ColumnType_UUID:
 		v, err := value.GetBytes()
 		if err != nil {

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -182,7 +182,11 @@ func RandDatumWithNullChance(rng *rand.Rand, typ ColumnType, nullChance int) tre
 			}
 			buf.WriteRune(r)
 		}
-		return tree.NewDCollatedString(buf.String(), *typ.Locale, &tree.CollationEnvironment{})
+		d, err := tree.NewDCollatedString(buf.String(), *typ.Locale, &tree.CollationEnvironment{})
+		if err != nil {
+			panic(err)
+		}
+		return d
 	case ColumnType_NAME:
 		// Generate a random ASCII string.
 		p := make([]byte, rng.Intn(10))


### PR DESCRIPTION
Backport 1/1 commits from #44103.  This required a lot of manual merging, would be useful to look over the diff again.

/cc @cockroachdb/release

---

We have seen cases where the locale fails to parse when we create a
`NewDCollatedString`. We can't reproduce and root cause but we can at
least convert it to an internal error.

Informs #35722.

Release note (bug fix): Converted a panic in
golang.org/x/text/language/tags.go when using collated strings to an
error.
