### PR TITLE
roachtest: fail faster and better

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -768,11 +768,8 @@ func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, l *logg
 	// below has problems. For example, `debug zip` is known to
 	// hang sometimes at the time of writing, see:
 	// https://github.com/cockroachdb/cockroach/issues/39620
-	if err := c.FetchLogs(ctx); err != nil {
-		l.Printf("failed to download logs: %s", err)
-	}
 	l.PrintfCtx(ctx, "collecting cluster logs")
-	if err := c.FetchDebugZip(ctx); err != nil {
+	if err := c.FetchLogs(ctx); err != nil {
 		l.Printf("failed to download logs: %s", err)
 	}
 	if err := c.FetchDmesg(ctx); err != nil {
@@ -786,6 +783,9 @@ func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, l *logg
 	}
 	if err := c.CopyRoachprodState(ctx); err != nil {
 		l.Printf("failed to copy roachprod state: %s", err)
+	}
+	if err := c.FetchDebugZip(ctx); err != nil {
+		l.Printf("failed to collect zip: %s", err)
 	}
 }
 


### PR DESCRIPTION
When collecting th artifacts, collect the zip after everything
else. Only the zip is subject to deadlock. Everything else
can be collected earlier and in a timely fashion.

Release note: None