### PR TITLE
colexec: add short-circuiting logic into projecting operators

### DIFF
--- a/pkg/sql/colexec/buffer.go
+++ b/pkg/sql/colexec/buffer.go
@@ -56,9 +56,7 @@ func (b *bufferOp) advance(ctx context.Context) {
 
 func (b *bufferOp) Next(ctx context.Context) coldata.Batch {
 	if b.read {
-		// TODO(yuzefovich): use coldata.ZeroBatch.
-		b.batch.SetLength(0)
-		return b.batch
+		return coldata.ZeroBatch
 	}
 	b.read = true
 	return b.batch

--- a/pkg/sql/colexec/buffered_batch.go
+++ b/pkg/sql/colexec/buffered_batch.go
@@ -83,6 +83,12 @@ func (b *bufferedBatch) AppendCol(coldata.Vec) {
 	execerror.VectorizedInternalPanic("AppendCol(coldata.Vec) should not be called on bufferedBatch")
 }
 
+// ReplaceCol is not implemented because bufferedBatch is only initialized
+// when the column schema is known.
+func (b *bufferedBatch) ReplaceCol(coldata.Vec, int) {
+	execerror.VectorizedInternalPanic("ReplaceCol(coldata.Vec, int) should not be called on bufferedBatch")
+}
+
 // Reset is not implemented because bufferedBatch is not reused with
 // different column schemas at the moment.
 func (b *bufferedBatch) Reset(types []coltypes.T, length int) {

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -49,12 +49,10 @@ func (b *defaultBuiltinFuncOperator) Init() {
 func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 	batch := b.input.Next(ctx)
 	n := batch.Length()
-	if b.outputIdx == batch.Width() {
-		b.allocator.AppendColumn(batch, b.outputPhysType)
-	}
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	b.allocator.MaybeAddColumn(batch, b.outputPhysType, b.outputIdx)
 
 	sel := batch.Selection()
 	output := batch.ColVec(b.outputIdx)
@@ -123,14 +121,11 @@ func (s *substringFunctionOperator) Init() {
 
 func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
 	batch := s.input.Next(ctx)
-	if s.outputIdx == batch.Width() {
-		s.allocator.AppendColumn(batch, coltypes.Bytes)
-	}
-
 	n := batch.Length()
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	s.allocator.MaybeAddColumn(batch, coltypes.Bytes, s.outputIdx)
 
 	sel := batch.Selection()
 	runeVec := batch.ColVec(s.argumentCols[0]).Bytes()

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -110,38 +110,25 @@ func (c *caseOp) Init() {
 func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	c.buffer.advance(ctx)
 	origLen := c.buffer.batch.Length()
-	if c.buffer.batch.Width() == c.outputIdx {
-		c.allocator.AppendColumn(c.buffer.batch, c.typ)
+	if origLen == 0 {
+		return coldata.ZeroBatch
 	}
-	// NB: we don't short-circuit if the batch is length 0 here, because we have
-	// to make sure to run all of our case arms. This is unfortunate.
-	// TODO(jordan): add this back in once batches are right-sized by planning.
+	c.allocator.MaybeAddColumn(c.buffer.batch, c.typ, c.outputIdx)
 	var origHasSel bool
 	if sel := c.buffer.batch.Selection(); sel != nil {
 		origHasSel = true
 		copy(c.origSel, sel)
 	}
 
-	// It is possible that we have a typeless zero-length batch, and we cannot
-	// get a particular columnar vector from it, so we have special casing here
-	// for non-zero length batches.
-	// TODO(yuzefovich): remove it once we can short-circuit.
-	var (
-		outputCol  coldata.Vec
-		destVecs   []coldata.Vec
-		prevLen    = origLen
-		prevHasSel bool
-	)
-	if origLen > 0 {
-		outputCol = c.buffer.batch.ColVec(c.outputIdx)
-		destVecs = []coldata.Vec{outputCol}
-		if sel := c.buffer.batch.Selection(); sel != nil {
-			prevHasSel = true
-			c.prevSel = c.prevSel[:origLen]
-			copy(c.prevSel[:origLen], sel[:origLen])
-		}
+	prevLen := origLen
+	prevHasSel := false
+	if sel := c.buffer.batch.Selection(); sel != nil {
+		prevHasSel = true
+		c.prevSel = c.prevSel[:origLen]
+		copy(c.prevSel[:origLen], sel[:origLen])
 	}
-	c.allocator.PerformOperation(destVecs, func() {
+	outputCol := c.buffer.batch.ColVec(c.outputIdx)
+	c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
 		for i := range c.caseOps {
 			// Run the next case operator chain. It will project its THEN expression
 			// for all tuples that matched its WHEN expression and that were not

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -130,13 +130,11 @@ func (c *castOpNullAny) Init() {
 
 func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
-	if c.outputIdx == batch.Width() {
-		c.allocator.AppendColumn(batch, c.toType)
-	}
 	n := batch.Length()
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	c.allocator.MaybeAddColumn(batch, c.toType, c.outputIdx)
 	vec := batch.ColVec(c.colIdx)
 	projVec := batch.ColVec(c.outputIdx)
 	vecNulls := vec.Nulls()
@@ -183,13 +181,11 @@ func (c *castOp_FROMTYPE_TOTYPE) Init() {
 
 func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
-	if c.outputIdx == batch.Width() {
-		c.allocator.AppendColumn(batch, coltypes._TOTYPE)
-	}
 	n := batch.Length()
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	c.allocator.MaybeAddColumn(batch, coltypes._TOTYPE, c.outputIdx)
 	vec := batch.ColVec(c.colIdx)
 	col := vec._FROMTYPE()
 	projVec := batch.ColVec(c.outputIdx)

--- a/pkg/sql/colexec/colbatch_scan.go
+++ b/pkg/sql/colexec/colbatch_scan.go
@@ -69,7 +69,9 @@ func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
 	if err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
-	bat.SetSelection(false)
+	if bat.Selection() != nil {
+		execerror.VectorizedInternalPanic("unexpectedly a selection vector is set on the batch coming from CFetcher")
+	}
 	return bat
 }
 

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -93,12 +93,10 @@ func (c const_TYPEOp) Init() {
 func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
-	if batch.Width() == c.outputIdx {
-		c.allocator.AppendColumn(batch, c.typ)
-	}
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	c.allocator.MaybeAddColumn(batch, c.typ, c.outputIdx)
 	vec := batch.ColVec(c.outputIdx)
 	col := vec._TemplateType()
 	c.allocator.PerformOperation(
@@ -148,14 +146,10 @@ func (c constNullOp) Init() {
 func (c constNullOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
-
-	if batch.Width() == c.outputIdx {
-		c.allocator.AppendColumn(batch, c.typ)
-	}
-
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	c.allocator.MaybeAddColumn(batch, c.typ, c.outputIdx)
 
 	col := batch.ColVec(c.outputIdx)
 	nulls := col.Nulls()

--- a/pkg/sql/colexec/is_null_ops.go
+++ b/pkg/sql/colexec/is_null_ops.go
@@ -48,13 +48,11 @@ func (o *isNullProjOp) Init() {
 
 func (o *isNullProjOp) Next(ctx context.Context) coldata.Batch {
 	batch := o.input.Next(ctx)
-	if o.outputIdx == batch.Width() {
-		o.allocator.AppendColumn(batch, coltypes.Bool)
-	}
 	n := batch.Length()
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	o.allocator.MaybeAddColumn(batch, coltypes.Bool, o.outputIdx)
 	vec := batch.ColVec(o.colIdx)
 	nulls := vec.Nulls()
 	projCol := batch.ColVec(o.outputIdx).Bool()

--- a/pkg/sql/colexec/partitioner.go
+++ b/pkg/sql/colexec/partitioner.go
@@ -72,12 +72,10 @@ func (p *windowSortingPartitioner) Init() {
 
 func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
 	b := p.input.Next(ctx)
-	if p.partitionColIdx == b.Width() {
-		p.allocator.AppendColumn(b, coltypes.Bool)
-	}
 	if b.Length() == 0 {
-		return b
+		return coldata.ZeroBatch
 	}
+	p.allocator.MaybeAddColumn(b, coltypes.Bool, p.partitionColIdx)
 	partitionVec := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()
 	if sel != nil {

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -87,12 +87,10 @@ type _OP_CONST_NAME struct {
 func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
-	if p.outputIdx == batch.Width() {
-		p.allocator.AppendColumn(batch, coltypes._RET_TYP)
-	}
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	p.allocator.MaybeAddColumn(batch, coltypes._RET_TYP, p.outputIdx)
 	vec := batch.ColVec(p.colIdx)
 	// {{if _IS_CONST_LEFT}}
 	col := vec._R_TYP()

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -90,12 +90,10 @@ type _OP_NAME struct {
 func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
-	if p.outputIdx == batch.Width() {
-		p.allocator.AppendColumn(batch, coltypes._RET_TYP)
-	}
 	if n == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	p.allocator.MaybeAddColumn(batch, coltypes._RET_TYP, p.outputIdx)
 	projVec := batch.ColVec(p.outputIdx)
 	projCol := projVec._RET_TYP()
 	vec1 := batch.ColVec(p.col1Idx)

--- a/pkg/sql/colexec/rank_tmpl.go
+++ b/pkg/sql/colexec/rank_tmpl.go
@@ -125,17 +125,13 @@ func (r *_RANK_STRINGOp) Init() {
 
 func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	batch := r.Input().Next(ctx)
-	// {{ if .HasPartition }}
-	if r.partitionColIdx == batch.Width() {
-		r.allocator.AppendColumn(batch, coltypes.Bool)
-	}
-	// {{ end }}
-	if r.outputColIdx == batch.Width() {
-		r.allocator.AppendColumn(batch, coltypes.Int64)
-	}
 	if batch.Length() == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	// {{ if .HasPartition }}
+	r.allocator.MaybeAddColumn(batch, coltypes.Bool, r.partitionColIdx)
+	// {{ end }}
+	r.allocator.MaybeAddColumn(batch, coltypes.Int64, r.outputColIdx)
 
 	// {{ if .HasPartition }}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()

--- a/pkg/sql/colexec/row_number_tmpl.go
+++ b/pkg/sql/colexec/row_number_tmpl.go
@@ -72,17 +72,13 @@ var _ Operator = &_ROW_NUMBER_STRINGOp{}
 
 func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	batch := r.Input().Next(ctx)
-	// {{ if .HasPartition }}
-	if r.partitionColIdx == batch.Width() {
-		r.allocator.AppendColumn(batch, coltypes.Bool)
-	}
-	// {{ end }}
-	if r.outputColIdx == batch.Width() {
-		r.allocator.AppendColumn(batch, coltypes.Int64)
-	}
 	if batch.Length() == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	// {{ if .HasPartition }}
+	r.allocator.MaybeAddColumn(batch, coltypes.Bool, r.partitionColIdx)
+	// {{ end }}
+	r.allocator.MaybeAddColumn(batch, coltypes.Int64, r.outputColIdx)
 
 	// {{ if .HasPartition }}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -198,7 +198,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	for {
 		batch := si.input.Next(ctx)
 		if batch.Length() == 0 {
-			return batch
+			return coldata.ZeroBatch
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -267,12 +267,10 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 
 func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	batch := pi.input.Next(ctx)
-	if pi.outputIdx == batch.Width() {
-		pi.allocator.AppendColumn(batch, coltypes.Bool)
-	}
 	if batch.Length() == 0 {
-		return batch
+		return coldata.ZeroBatch
 	}
+	pi.allocator.MaybeAddColumn(batch, coltypes.Bool, pi.outputIdx)
 
 	vec := batch.ColVec(pi.colIdx)
 	col := vec._TemplateType()

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -174,8 +174,7 @@ func (p *allSpooler) getPartitionsCol() []bool {
 func (p *allSpooler) getWindowedBatch(startIdx, endIdx uint64) coldata.Batch {
 	for i, t := range p.inputTypes {
 		window := p.bufferedTuples.colVecs[i].Window(t, startIdx, endIdx)
-		p.windowedBatch.ColVec(i).SetCol(window.Col())
-		p.windowedBatch.ColVec(i).SetNulls(window.Nulls())
+		p.windowedBatch.ReplaceCol(window, i)
 	}
 	p.windowedBatch.SetLength(uint16(endIdx - startIdx))
 	return p.windowedBatch

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -549,8 +549,10 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 	}
 
 	// Reset nulls for all columns in this batch.
-	for i := 0; i < s.batch.Width(); i++ {
-		s.batch.ColVec(i).Nulls().UnsetNulls()
+	for _, colVec := range s.batch.ColVecs() {
+		if colVec.Type() != coltypes.Unhandled {
+			colVec.Nulls().UnsetNulls()
+		}
 	}
 
 	rng := rand.New(rand.NewSource(123))


### PR DESCRIPTION
Previously, all projecting operators (those that append columns) were
not allowed to short-circuit (i.e. to exit from Next() method) when they
receive a zero-length batch. The problem is that the planning code
assigns each operator an "output index" for the columns and operators
would only append a column if the width of the batch they receive equals
to their assigned output index. In case some projecting operator
short-circuits and doesn't append a column, the downstream operator
would also not append its output column which would lead to an internal
error.

The problem is solved by allowing operators to append as many "unknown"
zero-length columns until the batch becomes of the desired width and
then appending their output column. Now all projecting operators have
responsibility to make sure that their projecting column is set up and
of correct type. In a case, when a projecting operator that previously
short-circuited wants to add a column, but the width of the batch is
higher than the operator's output index (meaning that an "unknown" column
was added in that place), that "unknown" zero-length column is replaced
with the full-sized column of the desired type. All this logic is placed
into the Allocator. This behavior allows us to have short-circuiting
logic in-place but also reduces the amount of allocated memory (if a
projecting operator actually never outputs anything).

Additionally, coldata.ZeroBatch is now implemented by a special wrapper
around coldata.MemBatch that prohibits modifications of the zero batch.
This was prompted by a bug with merge joiner in which we relied on the
width of the zero batch to decide whether to unwrap a vector.

Release note: None