### PR TITLE
compose: add postgres compare test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1044,6 +1044,11 @@ acceptance: export TESTTIMEOUT := $(TESTTIMEOUT)
 acceptance: ## Run acceptance tests.
 	+@pkg/acceptance/run.sh
 
+.PHONY: compose
+compose: export TESTTIMEOUT := $(TESTTIMEOUT)
+compose: ## Run compose tests.
+	+@pkg/compose/run.sh
+
 .PHONY: dupl
 dupl: bin/.bootstrap
 	$(FIND_RELEVANT) \

--- a/build/teamcity-compose.sh
+++ b/build/teamcity-compose.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+tc_start_block "Prepare environment for compose tests"
+type=$(go env GOOS)
+tc_end_block "Prepare environment for compose tests"
+
+tc_start_block "Compile CockroachDB"
+# Buffer noisy output and only print it on failure.
+run pkg/compose/prepare.sh &> artifacts/compose-compile.log || (cat artifacts/compose-compile.log && false)
+rm artifacts/acceptance-compile.log
+tc_end_block "Compile CockroachDB"
+
+tc_start_block "Compile compose tests"
+run build/builder.sh mkrelease "$type" -Otarget testbuild PKG=./pkg/compose
+tc_end_block "Compile compose tests"
+
+tc_start_block "Run compose tests"
+run cd pkg/compose
+# run_text_test needs ./artifacts to be the artifacts folder.
+ln -s ../../artifacts artifacts
+run_text_test github.com/cockroachdb/cockroach/pkg/compose ./compose.test -test.v -test.timeout 30m
+run cd ../..
+tc_end_block "Run compose tests"

--- a/pkg/cmd/smithcmp/cmpconn/compare.go
+++ b/pkg/cmd/smithcmp/cmpconn/compare.go
@@ -1,0 +1,173 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cmpconn
+
+import (
+	"context"
+	"math/big"
+	"runtime"
+	"strings"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jackc/pgx/pgtype"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// CompareVals returns an error if a and b differ, specifying what the
+// difference is. It is designed to compare SQL results from a query
+// executed on two different servers or configurations (i.e., cockroach and
+// postgres). Postgres and Cockroach have subtle differences in their result
+// types and OIDs. This function is aware of those and is able to correctly
+// compare those values.
+func CompareVals(a, b [][]interface{}) error {
+	if len(a) != len(b) {
+		return errors.Errorf("size difference: %d != %d", len(a), len(b))
+	}
+	if len(a) == 0 {
+		return nil
+	}
+	g, _ := errgroup.WithContext(context.Background())
+	// Split up the slices into subslices of equal length and compare those in parallel.
+	n := len(a) / runtime.NumCPU()
+	if n < 1 {
+		n = len(a)
+	}
+	for i := 0; i < len(a); i++ {
+		start, end := i, i+n
+		if end > len(a) {
+			end = len(a)
+		}
+		g.Go(func() error {
+			if diff := cmp.Diff(a[start:end], b[start:end], cmpOptions...); diff != "" {
+				return errors.New(diff)
+			}
+			return nil
+		})
+		i += n
+	}
+	return g.Wait()
+}
+
+var (
+	cmpOptions = []cmp.Option{
+		cmp.Transformer("", func(x []interface{}) []interface{} {
+			out := make([]interface{}, len(x))
+			for i, v := range x {
+				switch t := v.(type) {
+				case *pgtype.TextArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = ""
+					}
+				case *pgtype.BPCharArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = ""
+					}
+				case *pgtype.VarcharArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = ""
+					}
+				case *pgtype.Int8Array:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.Int8Array{}
+					}
+				case *pgtype.Float8Array:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.Float8Array{}
+					}
+				case *pgtype.UUIDArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.UUIDArray{}
+					}
+				case *pgtype.ByteaArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.ByteaArray{}
+					}
+				case *pgtype.InetArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.InetArray{}
+					}
+				case *pgtype.TimestampArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.TimestampArray{}
+					}
+				case *pgtype.BoolArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.BoolArray{}
+					}
+				case *pgtype.DateArray:
+					if t.Status == pgtype.Present && len(t.Elements) == 0 {
+						v = &pgtype.BoolArray{}
+					}
+				case *pgtype.Varbit:
+					if t.Status == pgtype.Present {
+						s, _ := t.EncodeText(nil, nil)
+						v = string(s)
+					}
+				case *pgtype.Bit:
+					vb := pgtype.Varbit(*t)
+					v = &vb
+				case *pgtype.Interval:
+					if t.Status == pgtype.Present {
+						v = duration.DecodeDuration(int64(t.Months), int64(t.Days), t.Microseconds*1000)
+					}
+				case string:
+					// Postgres sometimes adds spaces to the end of a string.
+					t = strings.TrimSpace(t)
+					v = strings.Replace(t, "T00:00:00+00:00", "T00:00:00Z", 1)
+				case *pgtype.Numeric:
+					if t.Status == pgtype.Present {
+						v = apd.NewWithBigInt(t.Int, t.Exp)
+					}
+				case int64:
+					v = apd.New(t, 0)
+				}
+				out[i] = v
+			}
+			return out
+		}),
+
+		cmpopts.EquateEmpty(),
+		cmpopts.EquateNaNs(),
+		cmpopts.EquateApprox(0.00001, 0),
+		cmp.Comparer(func(x, y *big.Int) bool {
+			return x.Cmp(y) == 0
+		}),
+		cmp.Comparer(func(x, y *apd.Decimal) bool {
+			if x.Negative != y.Negative {
+				return false
+			}
+			x.Abs(x)
+			y.Abs(y)
+
+			min := &apd.Decimal{}
+			if x.Cmp(y) > 1 {
+				min.Set(y)
+			} else {
+				min.Set(x)
+			}
+			ctx := tree.DecimalCtx
+			_, _ = ctx.Mul(min, min, decimalCloseness)
+			sub := &apd.Decimal{}
+			_, _ = ctx.Sub(sub, x, y)
+			sub.Abs(sub)
+			return sub.Cmp(min) <= 0
+		}),
+		cmp.Comparer(func(x, y duration.Duration) bool {
+			return x.Compare(y) == 0
+		}),
+	}
+	decimalCloseness = apd.New(1, -6)
+)

--- a/pkg/cmd/smithcmp/cmpconn/conn.go
+++ b/pkg/cmd/smithcmp/cmpconn/conn.go
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package main
+// Package cmpconn assits in comparing results from DB connections.
+package cmpconn
 
 import (
 	"context"
@@ -19,22 +20,31 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgx"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // Conn holds gosql and pgx connections.
 type Conn struct {
-	DB  *gosql.DB
-	PGX *pgx.Conn
+	DB          *gosql.DB
+	PGX         *pgx.Conn
+	rng         *rand.Rand
+	sqlMutators []sqlbase.Mutator
 }
 
-// NewConn returns a new Conn on the given uri and executes initSQL on it.
+// NewConn returns a new Conn on the given uri and executes initSQL on it. The
+// mutators are applied to initSQL.
 func NewConn(
 	uri string, rng *rand.Rand, sqlMutators []sqlbase.Mutator, initSQL ...string,
 ) (*Conn, error) {
-	var c Conn
+	c := Conn{
+		rng:         rng,
+		sqlMutators: sqlMutators,
+	}
 
 	{
 		connector, err := pq.NewConnector(uri)
@@ -62,12 +72,8 @@ func NewConn(
 			continue
 		}
 
-		newString, changed := mutations.ApplyString(rng, s, sqlMutators...)
-		if changed {
-			fmt.Printf("rewrote: %s -> %s", s, newString)
-		}
-
-		if _, err := c.PGX.Exec(newString); err != nil {
+		s, _ = mutations.ApplyString(rng, s, sqlMutators...)
+		if _, err := c.PGX.Exec(s); err != nil {
 			return nil, errors.Wrap(err, "init SQL")
 		}
 	}
@@ -94,7 +100,8 @@ func (c *Conn) Exec(ctx context.Context, s string) error {
 	return errors.Wrap(err, "exec")
 }
 
-// Values executes prep and exec and returns the results of exec.
+// Values executes prep and exec and returns the results of exec. Mutators
+// passed in during NewConn are applied only to exec.
 func (c *Conn) Values(ctx context.Context, prep, exec string) ([][]interface{}, error) {
 	if prep != "" {
 		rows, err := c.PGX.QueryEx(ctx, prep, simpleProtocol)
@@ -103,6 +110,7 @@ func (c *Conn) Values(ctx context.Context, prep, exec string) ([][]interface{}, 
 		}
 		rows.Close()
 	}
+	exec, _ = mutations.ApplyString(c.rng, exec, c.sqlMutators...)
 	rows, err := c.PGX.QueryEx(ctx, exec, simpleProtocol)
 	if err != nil {
 		return nil, err
@@ -120,3 +128,53 @@ func (c *Conn) Values(ctx context.Context, prep, exec string) ([][]interface{}, 
 }
 
 var simpleProtocol = &pgx.QueryExOptions{SimpleProtocol: true}
+
+// CompareConns executes prep and exec on all connections in conns. If any
+// differ, an error is returned.
+func CompareConns(
+	ctx context.Context, timeout time.Duration, conns map[string]*Conn, prep, exec string,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
+	vvs := map[string][][]interface{}{}
+	var lock syncutil.Mutex
+	for name := range conns {
+		name := name
+		g.Go(func() error {
+			conn := conns[name]
+			vals, err := conn.Values(ctx, prep, exec)
+			if err != nil {
+				return errors.Wrap(err, name)
+			}
+			lock.Lock()
+			vvs[name] = vals
+			lock.Unlock()
+			return nil
+		})
+	}
+	err := g.Wait()
+	if err != nil {
+		fmt.Println("ERR:", err)
+		// We don't care about SQL errors because sqlsmith sometimes
+		// produces bogus queries.
+		return nil
+	}
+	var first [][]interface{}
+	var firstName string
+	for name, vals := range vvs {
+		if first == nil {
+			first = vals
+			firstName = name
+			continue
+		}
+		compareStart := timeutil.Now()
+		fmt.Printf("comparing %s to %s...", firstName, name)
+		err := CompareVals(first, vals)
+		fmt.Printf(" %s\n", timeutil.Since(compareStart))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/smithcmp/main.go
+++ b/pkg/cmd/smithcmp/main.go
@@ -168,17 +168,23 @@ func main() {
 			name := fmt.Sprintf("s%d", i)
 			prep = fmt.Sprintf("PREPARE %s AS\n%s;", name, randStatement.stmt)
 			var sb strings.Builder
-			fmt.Fprintf(&sb, "EXECUTE %s (", name)
+			fmt.Fprintf(&sb, "EXECUTE %s", name)
 			for i, typ := range randStatement.placeholders {
 				if i > 0 {
 					sb.WriteString(", ")
+				} else {
+					sb.WriteString(" (")
 				}
 				d := sqlbase.RandDatum(rng, typ, true)
 				fmt.Println(i, typ, d, tree.Serialize(d))
 				sb.WriteString(tree.Serialize(d))
 			}
-			fmt.Fprintf(&sb, ");")
+			if len(randStatement.placeholders) > 0 {
+				fmt.Fprintf(&sb, ")")
+			}
+			fmt.Fprintf(&sb, ";")
 			exec = sb.String()
+			fmt.Println(exec)
 		}
 		if compare {
 			if err := cmpconn.CompareConns(ctx, timeout, conns, prep, exec); err != nil {

--- a/pkg/cmd/smithcmp/main.go
+++ b/pkg/cmd/smithcmp/main.go
@@ -25,29 +25,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/big"
 	"math/rand"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/cmd/smithcmp/cmpconn"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/jackc/pgx/pgtype"
 	"github.com/lib/pq/oid"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 )
 
 func usage() {
@@ -104,11 +95,12 @@ func main() {
 	}
 
 	rng := rand.New(rand.NewSource(opts.Seed))
-	conns := map[string]*Conn{}
+	conns := map[string]*cmpconn.Conn{}
 	for name, db := range opts.Databases {
 		var err error
-		conns[name], err = NewConn(
-			db.Addr, rng, enableMutations(opts.Databases[name].AllowMutations, sqlMutators), db.InitSQL, opts.InitSQL)
+		mutators := enableMutations(opts.Databases[name].AllowMutations, sqlMutators)
+		conns[name], err = cmpconn.NewConn(
+			db.Addr, rng, mutators, db.InitSQL, opts.InitSQL)
 		if err != nil {
 			log.Fatalf("%s (%s): %+v", name, db.Addr, err)
 		}
@@ -200,7 +192,7 @@ func main() {
 			}
 		}
 		if compare {
-			if err := compareConns(ctx, &opts, rng, sqlMutators, prep, exec, opts.Smither, conns, timeout); err != nil {
+			if err := cmpconn.CompareConns(ctx, timeout, conns, prep, exec); err != nil {
 				fmt.Printf("prep:\n%s;\nexec:\n%s;\nERR: %s\n\n", prep, exec, err)
 				os.Exit(1)
 			}
@@ -220,7 +212,7 @@ func main() {
 				fmt.Printf("\n%s: ping failure: %v\nprevious SQL:\n%s;\n%s;\n", name, err, prep, exec)
 				// Try to reconnect.
 				db := opts.Databases[name]
-				newConn, err := NewConn(db.Addr, rng, enableMutations(db.AllowMutations, sqlMutators), db.InitSQL, opts.InitSQL)
+				newConn, err := cmpconn.NewConn(db.Addr, rng, enableMutations(db.AllowMutations, sqlMutators), db.InitSQL, opts.InitSQL)
 				if err != nil {
 					log.Fatalf("tried to reconnect: %v\n", err)
 				}
@@ -235,209 +227,3 @@ type statement struct {
 	stmt         string
 	placeholders []*types.T
 }
-
-func compareConns(
-	ctx context.Context,
-	opts *options,
-	rng *rand.Rand,
-	sqlMutations []sqlbase.Mutator,
-	prep, exec string,
-	smitherName string,
-	conns map[string]*Conn,
-	timeout time.Duration,
-) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
-	vvs := map[string][][]interface{}{}
-	var lock syncutil.Mutex
-	fmt.Println("executing...")
-	for name := range conns {
-		name := name
-		g.Go(func() error {
-			defer func() {
-				if err := recover(); err != nil {
-					fmt.Printf("panic sql on %s:\n%s;\n%s;\n", name, prep, exec)
-					panic(err)
-				}
-			}()
-			conn := conns[name]
-			if opts.Databases[name].AllowMutations {
-				newExec, changed := mutations.ApplyString(rng, exec, sqlMutations...)
-				if changed {
-					fmt.Printf("rewrote %s -> %s\n", exec, newExec)
-				}
-				exec = newExec
-			}
-			executeStart := timeutil.Now()
-			vals, err := conn.Values(ctx, prep, exec)
-			fmt.Printf("executed %s in %s: %v\n", name, timeutil.Since(executeStart), err)
-			if err != nil {
-				return errors.Wrap(err, name)
-			}
-			lock.Lock()
-			vvs[name] = vals
-			lock.Unlock()
-			return nil
-		})
-	}
-	err := g.Wait()
-	if err != nil {
-		fmt.Println("ERR:", err)
-		// We don't care about SQL errors because sqlsmith sometimes
-		// produces bogus queries.
-		return nil
-	}
-	first := vvs[smitherName]
-	fmt.Println(len(first), "rows")
-	for name, vals := range vvs {
-		if name == smitherName {
-			continue
-		}
-		compareStart := timeutil.Now()
-		fmt.Printf("comparing %s to %s...", smitherName, name)
-		err := compareVals(first, vals)
-		fmt.Printf(" %s\n", timeutil.Since(compareStart))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func compareVals(a, b [][]interface{}) error {
-	if len(a) != len(b) {
-		return errors.Errorf("size difference: %d != %d", len(a), len(b))
-	}
-	if len(a) == 0 {
-		return nil
-	}
-	g, _ := errgroup.WithContext(context.Background())
-	// Split up the slices into subslices of equal length and compare those in parallel.
-	n := len(a) / runtime.NumCPU()
-	if n < 1 {
-		n = len(a)
-	}
-	for i := 0; i < len(a); i++ {
-		start, end := i, i+n
-		if end > len(a) {
-			end = len(a)
-		}
-		g.Go(func() error {
-			if diff := cmp.Diff(a[start:end], b[start:end], cmpOptions...); diff != "" {
-				return errors.New(diff)
-			}
-			return nil
-		})
-		i += n
-	}
-	return g.Wait()
-}
-
-var (
-	cmpOptions = []cmp.Option{
-		cmp.Transformer("", func(x []interface{}) []interface{} {
-			out := make([]interface{}, len(x))
-			for i, v := range x {
-				switch t := v.(type) {
-				case *pgtype.TextArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = ""
-					}
-				case *pgtype.BPCharArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = ""
-					}
-				case *pgtype.VarcharArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = ""
-					}
-				case *pgtype.Int8Array:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.Int8Array{}
-					}
-				case *pgtype.Float8Array:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.Float8Array{}
-					}
-				case *pgtype.UUIDArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.UUIDArray{}
-					}
-				case *pgtype.ByteaArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.ByteaArray{}
-					}
-				case *pgtype.InetArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.InetArray{}
-					}
-				case *pgtype.TimestampArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.TimestampArray{}
-					}
-				case *pgtype.BoolArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.BoolArray{}
-					}
-				case *pgtype.DateArray:
-					if t.Status == pgtype.Present && len(t.Elements) == 0 {
-						v = &pgtype.BoolArray{}
-					}
-				case *pgtype.Varbit:
-					if t.Status == pgtype.Present {
-						s, _ := t.EncodeText(nil, nil)
-						v = string(s)
-					}
-				case *pgtype.Bit:
-					vb := pgtype.Varbit(*t)
-					v = &vb
-				case *pgtype.Interval:
-					if t.Status == pgtype.Present {
-						v = duration.DecodeDuration(int64(t.Months), int64(t.Days), t.Microseconds*1000)
-					}
-				case string:
-					// Postgres sometimes adds spaces to the end of a string.
-					t = strings.TrimSpace(t)
-					v = strings.Replace(t, "T00:00:00+00:00", "T00:00:00Z", 1)
-				case *pgtype.Numeric:
-					if t.Status == pgtype.Present {
-						v = apd.NewWithBigInt(t.Int, t.Exp)
-					}
-				case int64:
-					v = apd.New(t, 0)
-				}
-				out[i] = v
-			}
-			return out
-		}),
-
-		cmpopts.EquateEmpty(),
-		cmpopts.EquateNaNs(),
-		cmpopts.EquateApprox(0.00001, 0),
-		cmp.Comparer(func(x, y *big.Int) bool {
-			return x.Cmp(y) == 0
-		}),
-		cmp.Comparer(func(x, y *apd.Decimal) bool {
-			x.Abs(x)
-			y.Abs(y)
-
-			min := &apd.Decimal{}
-			if x.Cmp(y) > 1 {
-				min.Set(y)
-			} else {
-				min.Set(x)
-			}
-			ctx := tree.DecimalCtx
-			_, _ = ctx.Mul(min, min, decimalCloseness)
-			sub := &apd.Decimal{}
-			_, _ = ctx.Sub(sub, x, y)
-			sub.Abs(sub)
-			return sub.Cmp(min) <= 0
-		}),
-		cmp.Comparer(func(x, y duration.Duration) bool {
-			return x.Compare(y) == 0
-		}),
-	}
-	decimalCloseness = apd.New(1, -6)
-)

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -1,0 +1,121 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// "make test" would normally test this file, but it should only be tested
+// within docker compose.
+
+// +build compose
+
+package compare
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/smithcmp/cmpconn"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+var flagEach = flag.Duration("each", 10*time.Minute, "individual test timeout")
+
+func TestCompare(t *testing.T) {
+	uris := map[string]string{
+		"postgres":   "postgresql://postgres@postgres:5432/",
+		"cockroach1": "postgresql://root@cockroach1:26257/?sslmode=disable",
+		"cockroach2": "postgresql://root@cockroach2:26257/?sslmode=disable",
+	}
+	configs := map[string]testConfig{
+		"default": {
+			opts: []sqlsmith.SmitherOption{sqlsmith.PostgresMode()},
+			conns: []testConn{
+				{
+					name:     "cockroach1",
+					mutators: []sqlbase.Mutator{mutations.PostgresMutator},
+				},
+				{
+					name:     "postgres",
+					mutators: []sqlbase.Mutator{mutations.PostgresMutator},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for confName, config := range configs {
+		t.Run(confName, func(t *testing.T) {
+			rng, _ := randutil.NewPseudoRand()
+			conns := map[string]*cmpconn.Conn{}
+			for _, testCn := range config.conns {
+				uri, ok := uris[testCn.name]
+				if !ok {
+					t.Fatalf("bad connection name: %s", testCn.name)
+				}
+				conn, err := cmpconn.NewConn(uri, rng, testCn.mutators)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer conn.Close()
+				conns[testCn.name] = conn
+			}
+			smither, err := sqlsmith.NewSmither(conns[config.conns[0].name].DB, rng, config.opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			until := time.After(*flagEach)
+			for {
+				select {
+				case <-until:
+					return
+				default:
+				}
+				query := smither.Generate()
+				// #44029
+				if strings.Contains(query, "FULL JOIN") {
+					continue
+				}
+				// #44079
+				if strings.Contains(query, "|| NULL::") {
+					continue
+				}
+				query, _ = mutations.ApplyString(rng, query, mutations.PostgresMutator)
+				if err := cmpconn.CompareConns(ctx, time.Second*30, conns, "" /* prep */, query); err != nil {
+					_ = ioutil.WriteFile("/test/query.sql", []byte(query+";"), 0666)
+					t.Log(query)
+					t.Fatal(err)
+				}
+				// Make sure we can still ping on a connection. If we can't we may have
+				// crashed something.
+				for name, conn := range conns {
+					if err := conn.Ping(); err != nil {
+						t.Log(query)
+						t.Fatalf("%s: ping: %v", name, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+type testConfig struct {
+	opts  []sqlsmith.SmitherOption
+	conns []testConn
+}
+
+type testConn struct {
+	name     string
+	mutators []sqlbase.Mutator
+}

--- a/pkg/compose/compare/compare/empty.go
+++ b/pkg/compose/compare/compare/empty.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package compare
+
+// This file is here so go test always finds at least one file.

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:11
+    environment:
+      - POSTGRES_INITDB_ARGS=--locale=C
+  cockroach1:
+    image: ubuntu:xenial-20170214
+    command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach1
+    volumes:
+      - ../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
+  cockroach2:
+    image: ubuntu:xenial-20170214
+    command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach2
+    volumes:
+      - ../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
+  test:
+    image: ubuntu:xenial-20170214
+    # compare.test is a binary built by the pkg/compose/prepare.sh
+    command: /compare/compare.test -each ${EACH}
+    depends_on:
+      - postgres
+      - cockroach1
+      - cockroach2
+    volumes:
+      - ./compare:/compare

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package compose contains nightly tests that need docker-compose.
+package compose
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var flagEach = flag.Duration("each", 10*time.Minute, "individual test timeout")
+
+func TestComposeCompare(t *testing.T) {
+	const file = "docker-compose"
+	if _, err := exec.LookPath(file); err != nil {
+		t.Skip(err)
+	}
+	cmd := exec.Command(
+		file,
+		"-f", filepath.Join("compare", "docker-compose.yml"),
+		"up",
+		"--force-recreate",
+		"--exit-code-from", "test",
+	)
+	cmd.Env = []string{fmt.Sprintf("EACH=%s", *flagEach)}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(out))
+		t.Fatal(err)
+	}
+}

--- a/pkg/compose/prepare.sh
+++ b/pkg/compose/prepare.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Ensure that no stale binary remains.
+rm -f cockroach-linux-2.6.32-gnu-amd64 pkg/compose/compose.test pkg/compose/compare/compare/compare.test
+
+# Build the release and test binaries so they can be used during docker compose execution.
+build/builder.sh mkrelease linux-gnu
+build/builder.sh mkrelease linux-gnu -Otarget testbuild PKG=./pkg/compose/compare/compare TAGS=compose

--- a/pkg/compose/run.sh
+++ b/pkg/compose/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+"$(dirname "${0}")"/prepare.sh
+
+make test PKG=./pkg/compose TESTTIMEOUT="${TESTTIMEOUT-30m}" TESTFLAGS="${TESTFLAGS--v}"

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -351,4 +351,8 @@ var PostgresMode = multiOption(
 	// Some func impls differ from postgres, so skip them here.
 	// #41709
 	IgnoreFNs("^sha"),
+	// We use e'XX' instead of E'XX' for hex strings, so ignore these.
+	IgnoreFNs("^quote"),
+	// We have some differences here with empty string and "default"; skip until fixed.
+	IgnoreFNs("^pg_collation_for"),
 )


### PR DESCRIPTION
Add a docker-compose test that spins up postgres and cockroach servers for
differential testing. Run some sqlsmith on them and verify the output is
identical. Has already found a few incorrectness bugs. The test framework
is written in such a way that, although a single query is generated per
run, each connection can have different mutations (which shouldn't change
the output) applied. In addition, two cockroach servers are started so
that they can be configured differently to ensure output doesn't change
when, say, there's different vectorized settings (there's no tests yet
that do this, but the framework is here for them to be added).

The cmpconn package has been changed to remove its go routines and
test row-by-row instead of fetching all of the rows. This is because
there was a bug that sometimes messed up the order of the rows. It is
possibly slower due to not using multiple goroutines for comparison,
but I have not seen any false positives since this change.

This has been added as a new compose package that is designed to run
nightly teamcity jobs needing docker-compose. The acceptance tests aren't
a good fit for nightlies since these need to run for a while. The makefile
has been taught about `make compose` to run these.

Fixes #33477