### PR TITLE
coldata: fix recent terrible inefficiency in Vec.Append

### DIFF
--- a/pkg/col/coldata/random_testutils.go
+++ b/pkg/col/coldata/random_testutils.go
@@ -1,0 +1,121 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coldata
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// maxVarLen specifies a length limit for variable length types (e.g. byte slices).
+const maxVarLen = 64
+
+var locations []*time.Location
+
+func init() {
+	// Load some random time zones.
+	for _, locationName := range []string{
+		"Africa/Addis_Ababa",
+		"America/Anchorage",
+		"Antarctica/Davis",
+		"Asia/Ashkhabad",
+		"Australia/Sydney",
+		"Europe/Minsk",
+		"Pacific/Palau",
+	} {
+		loc, err := timeutil.LoadLocation(locationName)
+		if err == nil {
+			locations = append(locations, loc)
+		}
+	}
+}
+
+// RandomVec populates vec with n random values of typ, setting each value to
+// null with a probability of nullProbability. It is assumed that n is in bounds
+// of the given vec.
+// bytesFixedLength (when greater than zero) specifies the fixed length of the
+// bytes slice to be generated. It is used only if typ == coltypes.Bytes.
+func RandomVec(
+	rng *rand.Rand, typ coltypes.T, bytesFixedLength int, vec Vec, n int, nullProbability float64,
+) {
+	switch typ {
+	case coltypes.Bool:
+		bools := vec.Bool()
+		for i := 0; i < n; i++ {
+			if rng.Float64() < 0.5 {
+				bools[i] = true
+			} else {
+				bools[i] = false
+			}
+		}
+	case coltypes.Bytes:
+		bytes := vec.Bytes()
+		for i := 0; i < n; i++ {
+			bytesLen := bytesFixedLength
+			if bytesLen <= 0 {
+				bytesLen = rng.Intn(maxVarLen)
+			}
+			randBytes := make([]byte, bytesLen)
+			// Read always returns len(bytes[i]) and nil.
+			_, _ = rand.Read(randBytes)
+			bytes.Set(i, randBytes)
+		}
+	case coltypes.Decimal:
+		decs := vec.Decimal()
+		for i := 0; i < n; i++ {
+			// int64(rng.Uint64()) to get negative numbers, too
+			decs[i].SetFinite(int64(rng.Uint64()), int32(rng.Intn(40)-20))
+		}
+	case coltypes.Int16:
+		ints := vec.Int16()
+		for i := 0; i < n; i++ {
+			ints[i] = int16(rng.Uint64())
+		}
+	case coltypes.Int32:
+		ints := vec.Int32()
+		for i := 0; i < n; i++ {
+			ints[i] = int32(rng.Uint64())
+		}
+	case coltypes.Int64:
+		ints := vec.Int64()
+		for i := 0; i < n; i++ {
+			ints[i] = int64(rng.Uint64())
+		}
+	case coltypes.Float64:
+		floats := vec.Float64()
+		for i := 0; i < n; i++ {
+			floats[i] = rng.Float64()
+		}
+	case coltypes.Timestamp:
+		timestamps := vec.Timestamp()
+		for i := 0; i < n; i++ {
+			timestamps[i] = timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000))
+			loc := locations[rng.Intn(len(locations))]
+			timestamps[i] = timestamps[i].In(loc)
+		}
+	default:
+		panic(fmt.Sprintf("unhandled type %s", typ))
+	}
+	vec.Nulls().UnsetNulls()
+	if nullProbability == 0 {
+		return
+	}
+
+	for i := 0; i < n; i++ {
+		if rng.Float64() < nullProbability {
+			vec.Nulls().SetNull(uint16(i))
+		}
+	}
+}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -81,14 +81,6 @@ func (m *memColumn) Append(args SliceArgs) {
 			}
 			fromCol.UpdateOffsetsToBeNonDecreasing(uint64(maxIdx + 1))
 			// {{else}}
-			// Ensure that the slice has the capacity for all non-variable width
-			// types.
-			desiredCap := args.DestIdx + args.SrcEndIdx - args.SrcStartIdx
-			if uint64(cap(toCol)) < desiredCap {
-				newToCol := make([]_GOTYPE, desiredCap)
-				copy(newToCol, toCol[:args.DestIdx])
-				toCol = newToCol
-			}
 			toCol = execgen.SLICE(toCol, 0, int(args.DestIdx))
 			// {{end}}
 			for _, selIdx := range sel {

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -240,8 +240,13 @@ func (t T) AppendSlice(target, src, destIdx, srcStartIdx, srcEndIdx string) stri
   if cap({{.Tgt}}) >= __desiredCap {
   	{{.Tgt}} = {{.Tgt}}[:__desiredCap]
   } else {
-    __new_slice := make([]apd.Decimal, __desiredCap)
-    copy(__new_slice, {{.Tgt}})
+    __prevCap := cap({{.Tgt}})
+    __capToAllocate := __desiredCap
+    if __capToAllocate < 2 * __prevCap {
+      __capToAllocate = 2 * __prevCap
+    }
+    __new_slice := make([]apd.Decimal, __desiredCap, __capToAllocate)
+    copy(__new_slice, {{.Tgt}}[:{{.TgtIdx}}])
     {{.Tgt}} = __new_slice
   }
   __src_slice := {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}]

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -217,8 +217,8 @@ func TestRandomComparisons(t *testing.T) {
 		lVec := b.ColVec(0)
 		rVec := b.ColVec(1)
 		ret := b.ColVec(2)
-		RandomVec(rng, typ, bytesFixedLength, lVec, numTuples, 0)
-		RandomVec(rng, typ, bytesFixedLength, rVec, numTuples, 0)
+		coldata.RandomVec(rng, typ, bytesFixedLength, lVec, numTuples, 0)
+		coldata.RandomVec(rng, typ, bytesFixedLength, rVec, numTuples, 0)
 		for i := range lDatums {
 			lDatums[i] = PhysicalTypeColElemToDatum(lVec, uint16(i), da, ct)
 			rDatums[i] = PhysicalTypeColElemToDatum(rVec, uint16(i), da, ct)


### PR DESCRIPTION
**coldata: move RandomVec into coldata**

Release note: None

**coldata: fix recent terrible inefficiency in Vec.Append**

We recently we merged a change to Vec.Append for non-Bytes types when
selection vector is present to make sure that the destination has enough
capacity to be appended to (preallocating new memory region and copying
over the previous values if necessary). Vec.Append is often called in
a loop when a vector is constantly getting appended to (for example,
when loading batches to create a hash table). With that recent change we
will allocate and copy over memory on *every* call to Append. This is
terrible, but the fix is quite simple - letting Golang itself handle
allocations.

Before:
```
BenchmarkAppend/Int64/AppendSimple/NullProbability=0.0-16                  73368             21306 ns/op         384.50 MB/s
BenchmarkAppend/Int64/AppendWithSel/NullProbability=0.0-16                 10000           4721281 ns/op           1.74 MB/s
BenchmarkAppend/Int64/AppendSimple/NullProbability=0.2-16                 188781             15617 ns/op         524.54 MB/s
BenchmarkAppend/Int64/AppendWithSel/NullProbability=0.2-16                 10000           4761916 ns/op           1.72 MB/s
```

After:
```
BenchmarkAppend/Int64/AppendSimple/NullProbability=0.0-16                  64724             18003 ns/op         455.04 MB/s
BenchmarkAppend/Int64/AppendWithSel/NullProbability=0.0-16                157728             12431 ns/op         659.01 MB/s
BenchmarkAppend/Int64/AppendSimple/NullProbability=0.2-16                 181083             13894 ns/op         589.59 MB/s
BenchmarkAppend/Int64/AppendWithSel/NullProbability=0.2-16                177037              6785 ns/op        1207.33 MB/s
```

A similar problem existed with Decimal type for a long time, and it has
been fixed by allocating at least twice the previous size of the
destination.

Fixes: #44140.

Release note: None
