### PR TITLE
libroach: Double DBLogger initial buffer size

### DIFF
--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -83,7 +83,7 @@ class DBLogger : public rocksdb::Logger {
     }
 
     // First try with a small fixed size buffer.
-    char space[1024];
+    char space[2048];
 
     // It's possible for methods that use a va_list to invalidate the data in
     // it upon use. The fix is to make a copy of the structure before using it
@@ -99,7 +99,7 @@ class DBLogger : public rocksdb::Logger {
     }
 
     // Repeatedly increase buffer size until it fits.
-    int length = sizeof(space);
+    size_t length = sizeof(space);
     while (true) {
       if (result < 0) {
         // Older behavior: just try doubling the buffer size.


### PR DESCRIPTION
Turns out, vsnprintf on the version of glibc we use with 19.1 isn't
very good with dealing with the difference between a size_t and an
int. It often steps beyond the specified n when printing a size_t.

Since this branch moved to size_t for the lengths of DBSlices
and DBStrings back in #42732 , a quick fix is to just increase
the initial buffer size we start with. Fixes synctest on
19.1. Impact out in the wild should have been minimal, since
this code only runs with verbose logging enabled.

Fixes #42778.

Release note: None