### PR TITLE
sql/opt/xform: ensure row-level locking mode propagation through Optimizer

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -461,6 +461,14 @@ func (s *ScanPrivate) IsCanonical() bool {
 		s.HardLimit == 0
 }
 
+// IsLocking returns true if the ScanPrivate is configured to use a row-level
+// locking mode. This can be the case either because the Scan is in the scope of
+// a SELECT .. FOR [KEY] UPDATE/SHARE clause or because the Scan was configured
+// as part of the row retrieval of a DELETE or UPDATE statement.
+func (s *ScanPrivate) IsLocking() bool {
+	return s.Locking != nil
+}
+
 // NeedResults returns true if the mutation operator can return the rows that
 // were mutated.
 func (m *MutationPrivate) NeedResults() bool {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -58,6 +58,14 @@ func (c *CustomFuncs) IsCanonicalScan(scan *memo.ScanPrivate) bool {
 	return scan.IsCanonical()
 }
 
+// IsLocking returns true if the ScanPrivate is configured to use a row-level
+// locking mode. This can be the case either because the Scan is in the scope of
+// a SELECT .. FOR [KEY] UPDATE/SHARE clause or because the Scan was configured
+// as part of the row retrieval of a DELETE or UPDATE statement.
+func (c *CustomFuncs) IsLocking(scan *memo.ScanPrivate) bool {
+	return scan.IsLocking()
+}
+
 // GenerateIndexScans enumerates all secondary indexes on the given Scan
 // operator's table and generates an alternate Scan operator for each index that
 // includes the set of needed columns specified in the ScanOpDef.

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -115,9 +115,15 @@
 # constant values in the filters. See comments in GenerateZigzagJoin and
 # distsqlrun/zigzagjoiner.go for more details on when a zigzag join can be
 # planned.
+#
+# Zigzag joins are prohibited when the source Scan operator has been configured
+# with a row-level locking mode. This is mostly out of convenience so that these
+# row-level locking modes don't need to added to the ZigzagJoin operator. There
+# doesn't seem to be a strong reason to support this, but if one comes up, it
+# should be possible to lift this restriction.
 [GenerateZigzagJoins, Explore]
 (Select
-    (Scan $scan:*) & (IsCanonicalScan $scan)
+    (Scan $scan:*) & (IsCanonicalScan $scan) & ^(IsLocking $scan)
     $filters:*
 )
 =>
@@ -129,9 +135,15 @@
 # row in the primary index could generate multiple inverted index keys. This
 # property can be exploited by zigzag joining on the same inverted index, fixed
 # at any two of the JSON paths we are querying for.
+#
+# Zigzag joins are prohibited when the source Scan operator has been configured
+# with a row-level locking mode. This is mostly out of convenience so that these
+# row-level locking modes don't need to added to the ZigzagJoin operator. There
+# doesn't seem to be a strong reason to support this, but if one comes up, it
+# should be possible to lift this restriction.
 [GenerateInvertedIndexZigzagJoins, Explore]
 (Select
-    (Scan $scan:*) & (IsCanonicalScan $scan) & (HasInvertedIndexes $scan)
+    (Scan $scan:*) & (IsCanonicalScan $scan) & ^(IsLocking $scan) & (HasInvertedIndexes $scan)
     $filters:*
 )
 =>

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1980,9 +1980,28 @@ memo (optimized, ~6KB, required=[presentation: c:3])
  ├── G7: (variable b)
  └── G8: (const 1)
 
-# --------------------------
+# GenerateZigzagJoins is disabled in the presence of a row-level locking clause.
+opt
+SELECT q,r FROM pqr WHERE q = 1 AND r = 2 FOR UPDATE
+----
+select
+ ├── columns: q:2(int!null) r:3(int!null)
+ ├── fd: ()-->(2,3)
+ ├── index-join pqr
+ │    ├── columns: q:2(int) r:3(int)
+ │    ├── fd: ()-->(2)
+ │    └── scan pqr@q
+ │         ├── columns: p:1(int!null) q:2(int!null)
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── locking: for-update
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── r = 2 [type=bool, outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
+
+# --------------------------------------------------
 # GenerateInvertedIndexZigzagJoins
-# --------------------------
+# --------------------------------------------------
 
 exec-ddl
 CREATE TABLE t5 (
@@ -2573,6 +2592,27 @@ project
       │         ├── constraint: /5/3: [/'2019-01-01' - /'2019-01-01']
       │         └── fd: ()-->(5)
       └── filters (true)
+
+# GenerateInvertedIndexZigzagJoins is disabled in the presence of a row-level
+# locking clause.
+opt
+SELECT b,a FROM t5 WHERE b @> '{"a":1, "c":2}' FOR UPDATE
+----
+select
+ ├── columns: b:2(jsonb) a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t5
+ │    ├── columns: a:1(int!null) b:2(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── scan t5@b_idx
+ │         ├── columns: a:1(int!null)
+ │         ├── constraint: /2/1: [/'{"a": 1}' - /'{"a": 1}']
+ │         ├── locking: for-update
+ │         └── key: (1)
+ └── filters
+      └── b @> '{"a": 1, "c": 2}' [type=bool, outer=(2)]
 
 # --------------------------------------------------
 # AssociateJoin

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -11,9 +11,9 @@ CREATE TABLE a
 )
 ----
 
-# --------------------------------------------------
-# PushLimitIntoScan
-# --------------------------------------------------
+# ---------------------------------------------------
+# GenerateLimitedScans / PushLimitIntoConstrainedScan
+# ---------------------------------------------------
 
 opt
 SELECT * FROM a LIMIT 1
@@ -122,8 +122,31 @@ memo (optimized, ~6KB, required=[presentation: s:4])
  ├── G7: (variable s)
  └── G8: (const 'foo')
 
+# GenerateLimitedScans propagates row-level locking information.
+opt
+SELECT * FROM a LIMIT 1 FOR UPDATE
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── limit: 1
+ ├── locking: for-update
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# PushLimitIntoConstrainedScan propagates row-level locking information.
+opt
+SELECT s FROM a WHERE s='foo' LIMIT 1 FOR UPDATE
+----
+scan a@s_idx
+ ├── columns: s:4(string!null)
+ ├── constraint: /4/1: [/'foo' - /'foo']
+ ├── limit: 1
+ ├── locking: for-update
+ ├── key: ()
+ └── fd: ()-->(4)
+
 # --------------------------------------------------
-# PushLimitIntoLookupJoin
+# PushLimitIntoIndexJoin
 # --------------------------------------------------
 
 exec-ddl
@@ -510,3 +533,21 @@ offset
  │         ├── fd: (1)-->(2,4,5)
  │         └── ordering: -4
  └── const: 10 [type=int]
+
+# PushLimitIntoIndexJoin propagates row-level locking information.
+opt
+SELECT * FROM kuv ORDER BY u LIMIT 5 FOR UPDATE
+----
+index-join kuv
+ ├── columns: k:1(int!null) u:2(int) v:3(int)
+ ├── cardinality: [0 - 5]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── ordering: +2
+ └── scan kuv@secondary
+      ├── columns: k:1(int!null) u:2(int)
+      ├── limit: 5
+      ├── locking: for-update
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      └── ordering: +2

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -485,6 +485,15 @@ memo (optimized, ~6KB, required=[presentation: i:2,k:1])
  ├── G7: (variable s)
  └── G8: (const 'foo')
 
+# GenerateIndexScans propagates row-level locking information.
+opt
+SELECT s, i, f FROM a ORDER BY s FOR UPDATE
+----
+scan a@s_idx
+ ├── columns: s:4(string) i:2(int) f:3(float)
+ ├── locking: for-update
+ └── ordering: +4
+
 # Collated strings are treated properly.
 exec-ddl
 CREATE TABLE x (s STRING COLLATE en_u_ks_level1 PRIMARY KEY)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -620,6 +620,57 @@ memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G21: (const 9)
  └── G22: (const 10)
 
+# GenerateConstrainedScans propagates row-level locking information.
+opt
+SELECT k FROM a WHERE k = 1 FOR UPDATE
+----
+scan a
+ ├── columns: k:1(int!null)
+ ├── constraint: /1: [/1 - /1]
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt
+SELECT * FROM b WHERE v >= 1 AND v <= 10 FOR UPDATE
+----
+index-join b
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
+ └── scan b@v
+      ├── columns: k:1(int!null) v:3(int!null)
+      ├── constraint: /3: [/1 - /10]
+      ├── locking: for-update
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      └── fd: (1)-->(3), (3)-->(1)
+
+opt
+SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 FOR UPDATE
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
+ │    └── scan b@v
+ │         ├── columns: k:1(int!null) v:3(int!null)
+ │         ├── constraint: /3: [/1 - /10]
+ │         ├── locking: for-update
+ │         ├── cardinality: [0 - 10]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3), (3)-->(1)
+ └── filters
+      └── (k + u) = 1 [type=bool, outer=(1,2)]
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------
@@ -849,3 +900,20 @@ select
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
       └── j @> '{"a": []}' [type=bool, outer=(4)]
+
+# GenerateInvertedIndexScans propagates row-level locking information.
+opt
+SELECT k FROM b WHERE j @> '{"a": "b"}' FOR UPDATE
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── index-join b
+      ├── columns: k:1(int!null) j:4(jsonb)
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      └── scan b@inv_idx
+           ├── columns: k:1(int!null)
+           ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+           ├── locking: for-update
+           └── key: (1)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -35,7 +35,7 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 // the following stmt.Prepared fields:
 //  - Columns
 //  - Types
-//  - AnonymizedStmt
+//  - AnonymizedStr
 //  - Memo (for reuse during exec, if appropriate).
 //
 // On success, the returned flags always have planFlagOptUsed set.


### PR DESCRIPTION
This PR contains two commits that ensure that row-level locking modes properly propagate through Optimizer transformation rules.

The first commit simply tests that row-level locking modes always propagate through limit, scan, and select transformation rules. This was already the case, so the commit is restricted to adding new tests.

The second commit ensures that row-level locking modes propagate through join transformation rules. In order to ensure this, the commit needed to prohibit zigzag joins in conjunction with row-level locking modes, as these were not working together already. This is mostly out of convenience so that these row-level locking modes don't need to added to the ZigzagJoin operator. There doesn't seem to be a strong reason to support this, but if one comes up, it should be possible to lift this restriction.

After this PR, row-level locking modes will be plumbed all the way to the `execbuilder`. The next step will be to hook them up to `scanNode` and use them to access different (to be exposed) locking modes in the KV API.