### PR TITLE
storage/engine: increase the default index-block size

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -247,13 +247,14 @@ func DefaultPebbleOptions() *pebble.Options {
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
-		l.EnsureDefaults()
-		l.BlockSize = 32 << 10 // 32 KB
+		l.BlockSize = 32 << 10       // 32 KB
+		l.IndexBlockSize = 256 << 10 // 256 KB
 		l.FilterPolicy = bloom.FilterPolicy(10)
 		l.FilterType = pebble.TableFilter
 		if i > 0 {
 			l.TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
 		}
+		l.EnsureDefaults()
 	}
 
 	// Do not create bloom filters for the last level (i.e. the largest level


### PR DESCRIPTION
Pebble allows control of whether to use use two-level indexes in
sstables via an `IndexBlockSize` option. This was unintentionally being
set to 4KB (the default block size), causing two-level indexes to be
used much more frequently in Pebble at some cost in performance. Bump
this option up to 256KB to more closely reflect RocksDB behavior (which
never uses two-level indexes with our current settings). We can lower
this value down at some point in the future once we're past the current
performance comparisons.

Release note: None