### PR TITLE
sql: Cascading deletes fail when deleting thousands of rows across interleaved tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -404,3 +404,43 @@ query I
 SELECT count(*) FROM users JOIN documents ON users.id=documents.user_id WHERE documents.id=0
 ----
 1
+
+# Regression test for #44158: ensure we can delete many thousands of rows from
+# interleaved child tables.
+
+subtest interleaved_delete_many_rows_child_tables
+statement ok
+CREATE TABLE big_interleave_grandparent (x INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE big_interleave_parent (x INT, y INT, PRIMARY KEY (x, y)) INTERLEAVE IN PARENT big_interleave_grandparent(x);
+
+statement ok
+ALTER TABLE big_interleave_parent ADD CONSTRAINT fk FOREIGN KEY (x) REFERENCES big_interleave_grandparent(x) ON DELETE CASCADE;
+
+statement ok
+CREATE TABLE big_interleave_child (x INT, y INT, z INT, PRIMARY KEY (x, y, z)) INTERLEAVE IN PARENT big_interleave_parent(x, y);
+
+statement ok
+ALTER TABLE big_interleave_child ADD CONSTRAINT fk FOREIGN KEY (x, y) REFERENCES big_interleave_parent(x, y) ON DELETE CASCADE;
+
+statement ok
+INSERT INTO big_interleave_grandparent VALUES (1);
+
+statement ok
+INSERT INTO big_interleave_parent (SELECT 1, id FROM generate_series(1, 20) AS id);
+
+statement ok
+INSERT INTO big_interleave_child (x,y,z) SELECT 1, p.id, q.id FROM (SELECT generate_series(1,17) as id) p, (SELECT generate_series (1,897) as id) q;
+
+statement ok
+DELETE FROM big_interleave_grandparent WHERE x = 1;
+
+query III
+SELECT
+  (SELECT count(*) FROM big_interleave_grandparent)
+ ,(SELECT count(*) FROM big_interleave_parent)
+ ,(SELECT count(*) FROM big_interleave_child)
+;
+----
+0 0 0

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1622,6 +1622,8 @@ func (ef *execFactory) ConstructDelete(
 	fetchColDescs := makeColDescList(table, fetchColOrdSet)
 
 	// Determine the foreign key tables involved in the delete.
+	// This will include all the interleaved child tables as we need them
+	// to see if we can execute the fast path delete.
 	fkTables, err := ef.makeFkMetadata(tabDesc, row.CheckDeletes)
 	if err != nil {
 		return nil, err
@@ -1629,7 +1631,7 @@ func (ef *execFactory) ConstructDelete(
 
 	fastPathInterleaved := canDeleteFastInterleaved(tabDesc, fkTables)
 	if fastPathNode, ok := maybeCreateDeleteFastNode(
-		context.TODO(), input.(planNode), tabDesc, fastPathInterleaved, rowsNeeded); ok {
+		ctx, input.(planNode), tabDesc, fkTables, fastPathInterleaved, rowsNeeded); ok {
 		return fastPathNode, nil
 	}
 


### PR DESCRIPTION
Successive batches delete_range fail to decode index key properly.

Fixes #44158

Release note (bug fix): Fix bug when cascade deleting thousands of rows
across interleaved tables.