### PR TITLE
colexec: add bool_or/bool_and operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -799,6 +799,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/and_or_projection.eg.go \
   pkg/sql/colexec/any_not_null_agg.eg.go \
   pkg/sql/colexec/avg_agg.eg.go \
+  pkg/sql/colexec/bool_and_or_agg.eg.go \
   pkg/sql/colexec/cast.eg.go \
   pkg/sql/colexec/const.eg.go \
   pkg/sql/colexec/count_agg.eg.go \
@@ -1512,6 +1513,7 @@ pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
 pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
 pkg/sql/colexec/tuples_differ.eg.go: pkg/sql/colexec/tuples_differ_tmpl.go
 pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go
+pkg/sql/colexec/boolean_agg.eg.go: pkg/sql/colexec/boolean_agg_tmpl.go
 
 $(EXECGEN_TARGETS): bin/execgen
 	execgen $@

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -1,6 +1,7 @@
 and_or_projection.eg.go
 any_not_null_agg.eg.go
 avg_agg.eg.go
+bool_and_or_agg.eg.go
 cast.eg.go
 const.eg.go
 count_agg.eg.go

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -32,6 +32,8 @@ var SupportedAggFns = []execinfrapb.AggregatorSpec_Func{
 	execinfrapb.AggregatorSpec_COUNT,
 	execinfrapb.AggregatorSpec_MIN,
 	execinfrapb.AggregatorSpec_MAX,
+	execinfrapb.AggregatorSpec_BOOL_AND,
+	execinfrapb.AggregatorSpec_BOOL_OR,
 }
 
 // aggregateFunc is an aggregate function that performs computation on a batch
@@ -243,6 +245,10 @@ func makeAggregateFuncs(
 			funcs[i], err = newMinAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_MAX:
 			funcs[i], err = newMaxAgg(allocator, aggTyps[i][0])
+		case execinfrapb.AggregatorSpec_BOOL_AND:
+			funcs[i] = newBoolAndAgg()
+		case execinfrapb.AggregatorSpec_BOOL_OR:
+			funcs[i] = newBoolOrAgg()
 		default:
 			return nil, nil, errors.Errorf("unsupported columnar aggregate function %s", aggFns[i].String())
 		}

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -1,0 +1,154 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for bool_and_or_agg.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	// */}}
+	// HACK: crlfmt removes the "*/}}" comment if it's the last line in the import
+	// block. This was picked because it sorts after "pkg/sql/colexec/execerror" and
+	// has no deps.
+	_ "github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+)
+
+// {{/*
+
+// _ASSIGN_BOOL_OP is the template boolean operation function for assigning the
+// first input to the result of a boolean operation of the second and the third
+// inputs.
+func _ASSIGN_BOOL_OP(_, _, _ string) {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// {{range .}}
+
+func newBool_OP_TYPEAgg() aggregateFunc {
+	return &bool_OP_TYPEAgg{}
+}
+
+type bool_OP_TYPEAgg struct {
+	done       bool
+	sawNonNull bool
+
+	groups []bool
+	vec    []bool
+
+	nulls  *coldata.Nulls
+	curIdx int
+	curAgg bool
+}
+
+func (b *bool_OP_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
+	b.groups = groups
+	b.vec = vec.Bool()
+	b.nulls = vec.Nulls()
+	b.Reset()
+}
+
+func (b *bool_OP_TYPEAgg) Reset() {
+	b.curIdx = -1
+	b.nulls.UnsetNulls()
+	b.done = false
+	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR aggregate.
+	// For bool_and the _DEFAULT_VAL is true and for bool_or the _DEFAULT_VAL is false.
+	b.curAgg = _DEFAULT_VAL
+}
+
+func (b *bool_OP_TYPEAgg) CurrentOutputIndex() int {
+	return b.curIdx
+}
+
+func (b *bool_OP_TYPEAgg) SetOutputIndex(idx int) {
+	if b.curIdx != -1 {
+		b.curIdx = idx
+		b.nulls.UnsetNullsAfter(uint16(idx))
+	}
+}
+
+func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
+	if b.done {
+		return
+	}
+	inputLen := batch.Length()
+	if inputLen == 0 {
+		if !b.sawNonNull {
+			b.nulls.SetNull(uint16(b.curIdx))
+		} else {
+			b.vec[b.curIdx] = b.curAgg
+		}
+		b.curIdx++
+		b.done = true
+		return
+	}
+	vec, sel := batch.ColVec(int(inputIdxs[0])), batch.Selection()
+	col, nulls := vec.Bool(), vec.Nulls()
+	if sel != nil {
+		sel = sel[:inputLen]
+		for _, i := range sel {
+			_ACCUMULATE_BOOLEAN(b, nulls, i)
+		}
+	} else {
+		col = col[:inputLen]
+		for i := range col {
+			_ACCUMULATE_BOOLEAN(b, nulls, i)
+		}
+	}
+}
+
+func (b *bool_OP_TYPEAgg) HandleEmptyInputScalar() {
+	b.nulls.SetNull(0)
+}
+
+// {{end}}
+
+// {{/*
+// _ACCUMULATE_BOOLEAN aggregates the boolean value at index i into the boolean aggregate.
+func _ACCUMULATE_BOOLEAN(b *bool_OP_TYPEAgg, nulls *coldata.Nulls, i int) { // */}}
+	// {{define "accumulateBoolean" -}}
+	if b.groups[i] {
+		if b.curIdx >= 0 {
+			if !b.sawNonNull {
+				b.nulls.SetNull(uint16(b.curIdx))
+			} else {
+				b.vec[b.curIdx] = b.curAgg
+			}
+		}
+		b.curIdx++
+		// {{with .Global}}
+		b.curAgg = _DEFAULT_VAL
+		// {{end}}
+		b.sawNonNull = false
+	}
+	isNull := nulls.NullAt(uint16(i))
+	if !isNull {
+		// {{with .Global}}
+		_ASSIGN_BOOL_OP(b.curAgg, b.curAgg, col[i])
+		// {{end}}
+		b.sawNonNull = true
+	}
+
+	// {{end}}
+
+	// {{/*
+} // */}}

--- a/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+)
+
+type booleanAggTmplInfo struct {
+	IsAnd bool
+}
+
+func (b booleanAggTmplInfo) AssignBoolOp(target, l, r string) string {
+	switch b.IsAnd {
+	case true:
+		return fmt.Sprintf("%s = %s && %s", target, l, r)
+	case false:
+		return fmt.Sprintf("%s = %s || %s", target, l, r)
+	default:
+		execerror.VectorizedInternalPanic("unsupported boolean agg type")
+		// This code is unreachable, but the compiler cannot infer that.
+		return ""
+	}
+}
+
+func (b booleanAggTmplInfo) OpType() string {
+	if b.IsAnd {
+		return "And"
+	}
+	return "Or"
+}
+
+func (b booleanAggTmplInfo) DefaultVal() string {
+	if b.IsAnd {
+		return "true"
+	}
+	return "false"
+}
+
+// Avoid unused warnings. These methods are used in the template.
+var (
+	_ = booleanAggTmplInfo{}.AssignBoolOp
+	_ = booleanAggTmplInfo{}.OpType
+	_ = booleanAggTmplInfo{}.DefaultVal
+)
+
+func genBooleanAgg(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/bool_and_or_agg_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+
+	s = strings.Replace(s, "_OP_TYPE", "{{.OpType}}", -1)
+	s = strings.Replace(s, "_DEFAULT_VAL", "{{.DefaultVal}}", -1)
+
+	accumulateBoolean := makeFunctionRegex("_ACCUMULATE_BOOLEAN", 3)
+	s = accumulateBoolean.ReplaceAllString(s, `{{template "accumulateBoolean" buildDict "Global" .}}`)
+
+	assignBoolRe := makeFunctionRegex("_ASSIGN_BOOL_OP", 3)
+	s = assignBoolRe.ReplaceAllString(s, `{{.AssignBoolOp "$1" "$2" "$3"}}`)
+
+	tmpl, err := template.New("boolean_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, []booleanAggTmplInfo{{IsAnd: true}, {IsAnd: false}})
+}
+
+func init() {
+	registerGenerator(genBooleanAgg, "bool_and_or_agg.eg.go")
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_agg
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_agg
@@ -1,0 +1,39 @@
+# LogicTest: local-vec
+
+statement ok
+CREATE TABLE bools (a INT, b BOOL)
+
+# Ensure vectorize engine is used
+statement ok
+SET vectorize=experimental_always
+
+query BB
+SELECT bool_and(b), bool_or(b) FROM bools
+----
+NULL NULL
+
+query BB
+SELECT bool_and(b), bool_or(b) FROM bools GROUP BY a
+----
+
+statement ok
+RESET vectorize
+
+statement OK
+INSERT INTO bools VALUES
+(0, NULL),
+(1, true),  (1, true),
+(2, false), (2, false),
+(3, false), (3, true), (3, true),
+(4, NULL),  (4, true),
+(5, false), (5, NULL)
+
+query BB
+SELECT bool_and(b), bool_or(b) FROM bools GROUP BY a
+----
+NULL NULL
+true true
+false false
+false true
+true true
+false false


### PR DESCRIPTION
This PR adds `bool_and` and `bool_or` builtin functions to vectorized engine.

Closes #43560 

Release note (sql_change): The vectorize engine now supports
bool_and/bool_or builtin aggregation functions.