### PR TITLE
pgwire: audit handling of errors returned from writeErr

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -114,7 +114,7 @@ func (r *commandResult) Close(ctx context.Context, t sql.TransactionStatusIndica
 
 	r.conn.writerState.fi.registerCmd(r.pos)
 	if r.err != nil {
-		r.conn.bufferErr(ctx, r.err)
+		writeErrWithLogging(ctx, r.conn.sv, r.err, &r.conn.msgBuilder, &r.conn.writerState.buf)
 		return
 	}
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -406,7 +406,7 @@ Loop:
 		case pgwirebase.ClientMsgPassword:
 			// This messages are only acceptable during the auth phase, handled above.
 			err = pgwirebase.NewProtocolViolationErrorf("unexpected authentication data")
-			_ /* err */ = writeErr(
+			writeErrWithLogging(
 				ctx, &sqlServer.GetExecutorConfig().Settings.SV, err,
 				&c.msgBuilder, &c.writerState.buf)
 			break Loop
@@ -495,9 +495,9 @@ Loop:
 	if draining() {
 		// TODO(andrei): I think sending this extra error to the client if we also
 		// sent another error for the last query (like a context canceled) is a bad
-		// idead; see #22630. I think we should find a way to return the
+		// idea; see #22630. I think we should find a way to return the
 		// AdminShutdown error as the only result of the query.
-		_ /* err */ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
+		writeErrWithLogging(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
 			newAdminShutdownErr(ErrDrainingExistingConn), &c.msgBuilder, &c.writerState.buf)
 		_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
 	}
@@ -582,9 +582,12 @@ func (c *conn) processCommandsAsync(
 					retErr = pgerror.WithCandidateCode(retErr, pgcode.CrashShutdown)
 					// Add a prefix. This also adds a stack trace.
 					retErr = errors.Wrap(retErr, "caught fatal error")
-					_ = writeErr(
+					if err := writeErr(
 						ctx, &sqlServer.GetExecutorConfig().Settings.SV, retErr,
-						&c.msgBuilder, &c.writerState.buf)
+						&c.msgBuilder, &c.writerState.buf,
+					); err != nil {
+						retErr = errors.CombineErrors(retErr, err)
+					}
 					_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
 					c.stmtBuf.Close()
 					// Send a ready for query to make sure the client can react.
@@ -651,12 +654,15 @@ func (c *conn) bufferNotice(ctx context.Context, noticeErr pgnotice.Notice) erro
 func (c *conn) sendInitialConnData(
 	ctx context.Context, sqlServer *sql.Server,
 ) (sql.ConnectionHandler, error) {
-	connHandler, err := sqlServer.SetupConn(
+	connHandler, retErr := sqlServer.SetupConn(
 		ctx, c.sessionArgs, &c.stmtBuf, c, c.metrics.SQLMemMetrics)
-	if err != nil {
-		_ /* err */ = writeErr(
-			ctx, &sqlServer.GetExecutorConfig().Settings.SV, err, &c.msgBuilder, c.conn)
-		return sql.ConnectionHandler{}, err
+	if retErr != nil {
+		if err := writeErr(
+			ctx, &sqlServer.GetExecutorConfig().Settings.SV, retErr, &c.msgBuilder, c.conn,
+		); err != nil {
+			retErr = errors.CombineErrors(retErr, err)
+		}
+		return sql.ConnectionHandler{}, retErr
 	}
 
 	// Send the initial "status parameters" to the client.  This
@@ -1217,17 +1223,22 @@ func (c *conn) bufferPortalSuspended() {
 	}
 }
 
-func (c *conn) bufferErr(ctx context.Context, err error) {
-	if err := writeErr(ctx, c.sv,
-		err, &c.msgBuilder, &c.writerState.buf); err != nil {
-		panic(errors.AssertionFailedf("unexpected err from buffer: %s", err))
-	}
-}
-
 func (c *conn) bufferEmptyQueryResponse() {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgEmptyQuery)
 	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
 		panic(errors.AssertionFailedf("unexpected err from buffer: %s", err))
+	}
+}
+
+// writeErrWithLogging is the same as writeErr with the addition of logging the
+// error returned by writeErr.
+func writeErrWithLogging(
+	ctx context.Context, sv *settings.Values, err error, msgBuilder *writeBuffer, w io.Writer,
+) {
+	if err := writeErr(
+		ctx, sv, err, msgBuilder, w,
+	); err != nil {
+		log.Warningf(ctx, `error in writeErr(): %s`, err)
 	}
 }
 


### PR DESCRIPTION
Previously, we panicked when encountered an error while writing the
result error into the buffer. However, as knz put it, "it's actually
legitimate for an error to occur here. The client could have
disconnected and dropped its connection just before the error packet
is sent. In fact it's even likely, for example if a user interrupts
a long-running query after they quit the client that issued it. We
don't want to panic in those cases."

Additionally, all calls to writeErr were ignoring the error returned
from the method, and they have been audited to either log the error as
a warning or combine the error with another error to return.

Release note: None