### PR TITLE
sql: unify InternalExecutor and SessionBoundInternalExecutor

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1109,8 +1109,12 @@ func (s *adminServer) SetUIData(
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
 		query := `UPSERT INTO system.ui (key, value, "lastUpdated") VALUES ($1, $2, now())`
-		rowsAffected, err := s.server.internalExecutor.ExecWithUser(
-			ctx, "admin-set-ui-data", nil /* txn */, userName, query, key, val)
+		rowsAffected, err := s.server.internalExecutor.ExecEx(
+			ctx, "admin-set-ui-data", nil, /* txn */
+			sqlbase.InternalExecutorSessionDataOverride{
+				User: userName,
+			},
+			query, key, val)
 		if err != nil {
 			return nil, s.serverError(err)
 		}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -187,8 +187,10 @@ func (s *adminServer) Databases(
 		return nil, err
 	}
 
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-show-dbs", nil /* txn */, sessionUser, "SHOW DATABASES",
+	rows, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-show-dbs", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
+		"SHOW DATABASES",
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -225,8 +227,9 @@ func (s *adminServer) DatabaseDetails(
 	// TODO(cdo): Use placeholders when they're supported by SHOW.
 
 	// Marshal grants.
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-show-grants", nil /* txn */, userName,
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-show-grants", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON DATABASE %s", escDBName),
 	)
 	if s.isNotFoundError(err) {
@@ -269,8 +272,9 @@ func (s *adminServer) DatabaseDetails(
 	}
 
 	// Marshal table names.
-	rows, cols, err = s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-show-tables", nil /* txn */, userName,
+	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-show-tables", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW TABLES FROM %s", escDBName),
 	)
 	if s.isNotFoundError(err) {
@@ -345,9 +349,11 @@ func (s *adminServer) TableDetails(
 	var resp serverpb.TableDetailsResponse
 
 	// Marshal SHOW COLUMNS result.
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
 		ctx, "admin-show-columns",
-		nil /* txn */, userName, fmt.Sprintf("SHOW COLUMNS FROM %s", escQualTable),
+		nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		fmt.Sprintf("SHOW COLUMNS FROM %s", escQualTable),
 	)
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
@@ -406,9 +412,10 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW INDEX result.
-	rows, cols, err = s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-showindex",
-		nil /* txn */, userName, fmt.Sprintf("SHOW INDEX FROM %s", escQualTable),
+	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-showindex", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		fmt.Sprintf("SHOW INDEX FROM %s", escQualTable),
 	)
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
@@ -458,9 +465,10 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW GRANTS result.
-	rows, cols, err = s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-show-grants",
-		nil /* txn */, userName, fmt.Sprintf("SHOW GRANTS ON TABLE %s", escQualTable),
+	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-show-grants", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		fmt.Sprintf("SHOW GRANTS ON TABLE %s", escQualTable),
 	)
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
@@ -490,9 +498,10 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW CREATE result.
-	rows, cols, err = s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-show-create",
-		nil /* txn */, userName, fmt.Sprintf("SHOW CREATE %s", escQualTable),
+	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-show-create", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		fmt.Sprintf("SHOW CREATE %s", escQualTable),
 	)
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
@@ -799,8 +808,10 @@ func (s *adminServer) Users(
 		return nil, err
 	}
 	query := `SELECT username FROM system.users WHERE "isRole" = false`
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-users", nil /* txn */, userName, query,
+	rows, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-users", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		query,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -856,8 +867,10 @@ func (s *adminServer) Events(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-events", nil /* txn */, userName, q.String(), q.QueryArguments()...)
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-events", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		q.String(), q.QueryArguments()...)
 	if err != nil {
 		return nil, s.serverError(err)
 	}
@@ -946,9 +959,10 @@ func (s *adminServer) RangeLog(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-range-log",
-		nil /* txn */, userName, q.String(), q.QueryArguments()...,
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-range-log", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		q.String(), q.QueryArguments()...,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1058,8 +1072,10 @@ func (s *adminServer) getUIData(
 	if err := query.Errors(); err != nil {
 		return nil, s.serverErrorf("error constructing query: %v", err)
 	}
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-getUIData", nil /* txn */, userName, query.String(), query.QueryArguments()...,
+	rows, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-getUIData", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		query.String(), query.QueryArguments()...,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1311,8 +1327,10 @@ func (s *adminServer) Jobs(
 	if req.Limit > 0 {
 		q.Append(" LIMIT $", tree.DInt(req.Limit))
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-jobs", nil /* txn */, userName, q.String(), q.QueryArguments()...,
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-jobs", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		q.String(), q.QueryArguments()...,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1379,8 +1397,10 @@ func (s *adminServer) Locations(
 
 	q := makeSQLQuery()
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-locations", nil /* txn */, userName, q.String(),
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-locations", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		q.String(),
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1433,8 +1453,10 @@ func (s *adminServer) QueryPlan(
 	explain := fmt.Sprintf(
 		"SELECT json FROM [EXPLAIN (DISTSQL) %s]",
 		strings.Trim(req.Query, ";"))
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-query-plan", nil /* txn */, userName, explain,
+	rows, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-query-plan", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		explain,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1637,8 +1659,10 @@ func (s *adminServer) DataDistribution(
 	// and deleted tables (as opposed to e.g. information_schema) because we are interested
 	// in the data for all ranges, not just ranges for visible tables.
 	tablesQuery := `SELECT name, table_id, database_name, drop_time FROM "".crdb_internal.tables WHERE schema_name = 'public'`
-	rows1, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-replica-matrix", nil /* txn */, userName, tablesQuery,
+	rows1, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-replica-matrix", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		tablesQuery,
 	)
 	if err != nil {
 		return nil, s.serverError(err)
@@ -1677,8 +1701,10 @@ func (s *adminServer) DataDistribution(
 				`SELECT zone_id FROM [SHOW ZONE CONFIGURATION FOR TABLE %s.%s]`,
 				(*tree.Name)(dbName), (*tree.Name)(tableName),
 			)
-			rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-				ctx, "admin-replica-matrix", nil /* txn */, userName, zoneConfigQuery,
+			rows, err := s.server.internalExecutor.QueryEx(
+				ctx, "admin-replica-matrix", nil, /* txn */
+				sqlbase.InternalExecutorSessionDataOverride{User: userName},
+				zoneConfigQuery,
 			)
 			if err != nil {
 				return nil, s.serverError(err)
@@ -1752,9 +1778,10 @@ func (s *adminServer) DataDistribution(
 		FROM crdb_internal.zones
 		WHERE target IS NOT NULL
 	`
-	rows2, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-replica-matrix", nil /* txn */, userName, zoneConfigsQuery,
-	)
+	rows2, err := s.server.internalExecutor.QueryEx(
+		ctx, "admin-replica-matrix", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		zoneConfigsQuery)
 	if err != nil {
 		return nil, s.serverError(err)
 	}
@@ -2164,11 +2191,11 @@ func (s *adminServer) queryZone(
 	ctx context.Context, userName string, id sqlbase.ID,
 ) (zonepb.ZoneConfig, bool, error) {
 	const query = `SELECT crdb_internal.get_zone_config($1)`
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
 		ctx,
 		"admin-query-zone",
 		nil, /* txn */
-		userName,
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		query,
 		id,
 	)
@@ -2221,8 +2248,10 @@ func (s *adminServer) queryNamespaceID(
 	ctx context.Context, userName string, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
 	const query = `SELECT crdb_internal.get_namespace_id($1, $2)`
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-query-namespace-ID", nil /* txn */, userName, query, parentID, name,
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "admin-query-namespace-ID", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		query, parentID, name,
 	)
 	if err != nil {
 		return 0, err
@@ -2308,9 +2337,10 @@ func (s *adminServer) hasAdminRole(ctx context.Context, sessionUser string) (boo
 		// Shortcut.
 		return true, nil
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "check-is-admin",
-		nil /* txn */, sessionUser, "SELECT crdb_internal.is_admin()")
+	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+		ctx, "check-is-admin", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
+		"SELECT crdb_internal.is_admin()")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -786,14 +786,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		func(
 			ctx context.Context, sessionData *sessiondata.SessionData,
 		) sqlutil.InternalExecutor {
-			ie := sql.NewSessionBoundInternalExecutor(
+			ie := sql.MakeInternalExecutor(
 				ctx,
-				sessionData,
 				s.pgServer.SQLServer,
 				s.sqlMemMetrics,
 				s.st,
 			)
-			return ie
+			ie.SetSessionData(sessionData)
+			return &ie
 		}
 
 	for _, m := range s.pgServer.Metrics() {
@@ -1606,6 +1606,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.clock,
 		mmKnobs,
 		s.NodeID().String(),
+		s.ClusterSettings(),
 	)
 
 	var bootstrapVersion roachpb.Version

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -17,8 +17,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -90,10 +92,11 @@ func (s *Server) gcSystemLog(
 		var rowsAffected int64
 		err := s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			var err error
-			row, err := s.internalExecutor.QueryRow(
+			row, err := s.internalExecutor.QueryRowEx(
 				ctx,
 				table+"-gc",
 				txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 				deleteStmt,
 				timestampLowerBound,
 				timestampUpperBound,

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // MembershipCache is a shared cache for role membership information.
@@ -153,6 +154,9 @@ func (p *planner) CheckAnyPrivilege(ctx context.Context, descriptor sqlbase.Desc
 // HasAdminRole implements the AuthorizationAccessor interface.
 func (p *planner) HasAdminRole(ctx context.Context) (bool, error) {
 	user := p.SessionData().User
+	if user == "" {
+		return false, errors.AssertionFailedf("empty user")
+	}
 
 	// Check if user is 'root' or 'node'.
 	if user == security.RootUser || user == security.NodeUser {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1207,10 +1207,10 @@ func (sc *SchemaChanger) validateForwardIndexes(
 			// goroutines.
 			newEvalCtx := createSchemaChangeEvalCtx(ctx, readAsOf, evalCtx.Tracing, sc.ieFactory)
 			// TODO(vivek): This is not a great API. Leaving #34304 open.
-			ie := newEvalCtx.InternalExecutor.(*SessionBoundInternalExecutor)
-			ie.impl.tcModifier = tc
+			ie := newEvalCtx.InternalExecutor.(*InternalExecutor)
+			ie.tcModifier = tc
 			defer func() {
-				ie.impl.tcModifier = nil
+				ie.tcModifier = nil
 			}()
 
 			row, err := newEvalCtx.InternalExecutor.QueryRow(ctx, "verify-idx-count", txn,
@@ -1501,7 +1501,7 @@ func validateCheckInTxn(
 	txn *client.Txn,
 	checkName string,
 ) error {
-	ie := evalCtx.InternalExecutor.(*SessionBoundInternalExecutor)
+	ie := evalCtx.InternalExecutor.(*InternalExecutor)
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
 		newTc := &TableCollection{
 			leaseMgr: leaseMgr,
@@ -1512,9 +1512,9 @@ func validateCheckInTxn(
 			return err
 		}
 
-		ie.impl.tcModifier = newTc
+		ie.tcModifier = newTc
 		defer func() {
-			ie.impl.tcModifier = nil
+			ie.tcModifier = nil
 		}()
 	}
 
@@ -1541,7 +1541,7 @@ func validateFkInTxn(
 	txn *client.Txn,
 	fkName string,
 ) error {
-	ie := evalCtx.InternalExecutor.(*SessionBoundInternalExecutor)
+	ie := evalCtx.InternalExecutor.(*InternalExecutor)
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
 		newTc := &TableCollection{
 			leaseMgr: leaseMgr,
@@ -1552,9 +1552,9 @@ func validateFkInTxn(
 			return err
 		}
 
-		ie.impl.tcModifier = newTc
+		ie.tcModifier = newTc
 		defer func() {
-			ie.impl.tcModifier = nil
+			ie.tcModifier = nil
 		}()
 	}
 

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -31,7 +31,7 @@ func validateCheckExpr(
 	ctx context.Context,
 	exprStr string,
 	tableDesc *sqlbase.TableDescriptor,
-	ie tree.InternalExecutor,
+	ie *InternalExecutor,
 	txn *client.Txn,
 ) error {
 	expr, err := parser.ParseExpr(exprStr)
@@ -50,7 +50,9 @@ func validateCheckExpr(
 	queryStr := tree.AsStringWithFlags(stmt, tree.FmtParsable)
 	log.Infof(ctx, "Validating check constraint %q with query %q", expr.String(), queryStr)
 
-	rows, err := ie.QueryRow(ctx, "validate check constraint", txn, queryStr)
+	rows, err := ie.QueryRowEx(ctx, "validate check constraint", txn,
+		sqlbase.InternalExecutorSessionDataOverride{},
+		queryStr)
 	if err != nil {
 		return err
 	}
@@ -223,7 +225,7 @@ func validateForeignKey(
 	ctx context.Context,
 	srcTable *sqlbase.TableDescriptor,
 	fk *sqlbase.ForeignKeyConstraint,
-	ie tree.InternalExecutor,
+	ie *InternalExecutor,
 	txn *client.Txn,
 ) error {
 	targetTable, err := sqlbase.GetTableDescFromID(ctx, txn, fk.ReferencedTableID)
@@ -256,7 +258,9 @@ func validateForeignKey(
 			query,
 		)
 
-		values, err := ie.QueryRow(ctx, "validate foreign key constraint", txn, query)
+		values, err := ie.QueryRowEx(ctx, "validate foreign key constraint", txn,
+			sqlbase.InternalExecutorSessionDataOverride{},
+			query)
 		if err != nil {
 			return err
 		}
@@ -281,7 +285,9 @@ func validateForeignKey(
 		query,
 	)
 
-	values, err := ie.QueryRow(ctx, "validate fk constraint", txn, query)
+	values, err := ie.QueryRowEx(ctx, "validate fk constraint", txn,
+		sqlbase.InternalExecutorSessionDataOverride{},
+		query)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -31,7 +31,7 @@ func validateCheckExpr(
 	ctx context.Context,
 	exprStr string,
 	tableDesc *sqlbase.TableDescriptor,
-	ie tree.SessionBoundInternalExecutor,
+	ie tree.InternalExecutor,
 	txn *client.Txn,
 ) error {
 	expr, err := parser.ParseExpr(exprStr)
@@ -223,7 +223,7 @@ func validateForeignKey(
 	ctx context.Context,
 	srcTable *sqlbase.TableDescriptor,
 	fk *sqlbase.ForeignKeyConstraint,
-	ie tree.SessionBoundInternalExecutor,
+	ie tree.InternalExecutor,
 	txn *client.Txn,
 ) error {
 	targetTable, err := sqlbase.GetTableDescFromID(ctx, txn, fk.ReferencedTableID)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -383,8 +383,10 @@ func (s *Server) SetupConn(
 	clientComm ClientComm,
 	memMetrics MemoryMetrics,
 ) (ConnectionHandler, error) {
-	sd, sdMut := s.newSessionDataAndMutator(args)
-	ex, err := s.newConnExecutor(ctx, sd, sdMut, stmtBuf, clientComm, memMetrics, &s.Metrics)
+	sd := s.newSessionData(args)
+	sdMut := s.makeSessionDataMutator(sd, args.SessionDefaults)
+	ex, err := s.newConnExecutor(
+		ctx, sd, &sdMut, stmtBuf, clientComm, memMetrics, &s.Metrics, resetSessionDataToDefaults)
 	return ConnectionHandler{ex}, err
 }
 
@@ -451,34 +453,57 @@ func (s *Server) ServeConn(
 	return h.ex.run(ctx, s.pool, reserved, cancel)
 }
 
-// newSessionDataAndMutator creates a SessionData and sessionDataMutator that
-// can be passed to newConnExecutor.
-func (s *Server) newSessionDataAndMutator(
-	args SessionArgs,
-) (*sessiondata.SessionData, *sessionDataMutator) {
+// newSessionData a SessionData that can be passed to newConnExecutor.
+func (s *Server) newSessionData(args SessionArgs) *sessiondata.SessionData {
 	sd := &sessiondata.SessionData{
-		User:          args.User,
-		RemoteAddr:    args.RemoteAddr,
-		SequenceState: sessiondata.NewSequenceState(),
-		DataConversion: sessiondata.DataConversionConfig{
-			Location: time.UTC,
-		},
+		User:              args.User,
+		RemoteAddr:        args.RemoteAddr,
 		ResultsBufferSize: args.ConnResultsBufferSize,
 	}
+	s.populateMinimalSessionData(sd)
+	return sd
+}
 
-	m := &sessionDataMutator{
+func (s *Server) makeSessionDataMutator(
+	sd *sessiondata.SessionData, defaults SessionDefaults,
+) sessionDataMutator {
+	return sessionDataMutator{
 		data:     sd,
-		defaults: args.SessionDefaults,
+		defaults: defaults,
 		settings: s.cfg.Settings,
 	}
-
-	return sd, m
 }
+
+// populateMinimalSessionData populates sd with some minimal values needed for
+// not crashing. Fields of sd that are already set are not overwritten.
+func (s *Server) populateMinimalSessionData(sd *sessiondata.SessionData) {
+	if sd.SequenceState == nil {
+		sd.SequenceState = sessiondata.NewSequenceState()
+	}
+	if sd.DataConversion == (sessiondata.DataConversionConfig{}) {
+		sd.DataConversion = sessiondata.DataConversionConfig{
+			Location: time.UTC,
+		}
+	}
+	if len(sd.SearchPath.GetPathArray()) == 0 {
+		sd.SearchPath = sqlbase.DefaultSearchPath
+	}
+}
+
+type sdResetOption bool
+
+const (
+	resetSessionDataToDefaults     sdResetOption = true
+	dontResetSessionDataToDefaults               = false
+)
 
 // newConnExecutor creates a new connExecutor.
 //
-// sdMutator can be nil if SET statements are not going to be executed; this is
-// appropriate for session-bound internal executors.
+// resetOpt controls whether sd is to be reset to the default values.
+// TODO(andrei): resetOpt is a hack needed by the InternalExecutor, which
+// doesn't want this resetting. Figure out a better API where the responsibility
+// of assigning default values is either entirely inside or outside of this
+// ctor.
 func (s *Server) newConnExecutor(
 	ctx context.Context,
 	sd *sessiondata.SessionData,
@@ -487,6 +512,7 @@ func (s *Server) newConnExecutor(
 	clientComm ClientComm,
 	memMetrics MemoryMetrics,
 	srvMetrics *Metrics,
+	resetOpt sdResetOption,
 ) (*connExecutor, error) {
 	// Create the various monitors.
 	// The session monitors are started in activate().
@@ -547,19 +573,19 @@ func (s *Server) newConnExecutor(
 
 	ex.state.txnAbortCount = ex.metrics.EngineMetrics.TxnAbortCount
 
-	if sdMutator != nil {
-		sdMutator.setCurTxnReadOnly = func(val bool) {
-			ex.state.readOnly = val
-		}
-		sdMutator.onTempSchemaCreation = func() {
-			ex.hasCreatedTemporarySchema = true
-		}
-		sdMutator.RegisterOnSessionDataChange("application_name", func(newName string) {
-			ex.appStats = ex.server.sqlStats.getStatsForApplication(newName)
-			ex.applicationName.Store(newName)
-		})
-		// Initialize the session data from provided defaults. We need to do this early
-		// because other initializations below use the configured values.
+	sdMutator.setCurTxnReadOnly = func(val bool) {
+		ex.state.readOnly = val
+	}
+	sdMutator.onTempSchemaCreation = func() {
+		ex.hasCreatedTemporarySchema = true
+	}
+	sdMutator.RegisterOnSessionDataChange("application_name", func(newName string) {
+		ex.appStats = ex.server.sqlStats.getStatsForApplication(newName)
+		ex.applicationName.Store(newName)
+	})
+	// Initialize the session data from provided defaults. We need to do this early
+	// because other initializations below use the configured values.
+	if resetOpt == resetSessionDataToDefaults {
 		if err := resetSessionVars(ctx, sdMutator); err != nil {
 			log.Errorf(ctx, "error setting up client session: %v", err)
 			return nil, err
@@ -578,7 +604,13 @@ func (s *Server) newConnExecutor(
 		// we can measure their respective "pressure" on internal queries.
 		// Hence the choice here to add the delegate prefix
 		// to the current app name.
-		appStatsBucketName := sqlbase.DelegatedAppNamePrefix + ex.sessionData.ApplicationName
+		var appStatsBucketName string
+		if !strings.HasPrefix(ex.sessionData.ApplicationName, sqlbase.InternalAppNamePrefix) {
+			appStatsBucketName = sqlbase.DelegatedAppNamePrefix + ex.sessionData.ApplicationName
+		} else {
+			// If this is already an "internal app", don't put more prefix.
+			appStatsBucketName = ex.sessionData.ApplicationName
+		}
 		ex.appStats = s.sqlStats.getStatsForApplication(appStatsBucketName)
 	}
 
@@ -630,8 +662,10 @@ func (s *Server) newConnExecutorWithTxn(
 	srvMetrics *Metrics,
 	txn *client.Txn,
 	tcModifier tableCollectionModifier,
+	resetOpt sdResetOption,
 ) (*connExecutor, error) {
-	ex, err := s.newConnExecutor(ctx, sd, sdMutator, stmtBuf, clientComm, memMetrics, srvMetrics)
+	ex, err := s.newConnExecutor(
+		ctx, sd, sdMutator, stmtBuf, clientComm, memMetrics, srvMetrics, resetOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -1869,13 +1903,13 @@ func (ex *connExecutor) readWriteModeWithSessionDefault(
 func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalContext, p *planner) {
 	scInterface := newSchemaInterface(&ex.extraTxnState.tables, ex.server.cfg.VirtualSchemas)
 
-	ie := NewSessionBoundInternalExecutor(
+	ie := MakeInternalExecutor(
 		ctx,
-		ex.sessionData,
 		ex.server,
 		ex.memMetrics,
 		ex.server.cfg.Settings,
 	)
+	ie.SetSessionData(ex.sessionData)
 
 	*evalCtx = extendedEvalContext{
 		EvalContext: tree.EvalContext{
@@ -1891,7 +1925,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			NodeID:             ex.server.cfg.NodeID.Get(),
 			Locality:           ex.server.cfg.Locality,
 			ReCache:            ex.server.reCache,
-			InternalExecutor:   ie,
+			InternalExecutor:   &ie,
 			DB:                 ex.server.cfg.DB,
 		},
 		SessionMutator:    ex.dataMutator,
@@ -2082,14 +2116,14 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		scc := &ex.extraTxnState.schemaChangers
 		if len(scc.schemaChangers) != 0 {
 			ieFactory := func(ctx context.Context, sd *sessiondata.SessionData) sqlutil.InternalExecutor {
-				ie := NewSessionBoundInternalExecutor(
+				ie := MakeInternalExecutor(
 					ctx,
-					sd,
 					ex.server,
 					ex.memMetrics,
 					ex.server.cfg.Settings,
 				)
-				return ie
+				ie.SetSessionData(sd)
+				return &ie
 			}
 			if schemaChangeErr := scc.execSchemaChanges(
 				ex.Ctx(), ex.server.cfg, &ex.sessionTracing, ieFactory,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -454,10 +454,10 @@ CREATE TABLE crdb_internal.jobs (
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		query := `SELECT id, status, created, payload, progress FROM system.jobs`
-		rows, _ /* cols */, err :=
-			p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryWithUser(
-				ctx, "crdb-internal-jobs-table", p.txn,
-				p.SessionData().User, query)
+		rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryEx(
+			ctx, "crdb-internal-jobs-table", p.txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: p.SessionData().User},
+			query)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -108,7 +109,9 @@ func TestGossipAlertsTable(t *testing.T) {
 	}
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
-	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "SELECT * FROM crdb_internal.gossip_alerts WHERE store_id = 123")
+	row, err := ie.QueryRowEx(ctx, "test", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		"SELECT * FROM crdb_internal.gossip_alerts WHERE store_id = 123")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -99,10 +99,11 @@ func (n *CreateUserNode) startExec(params runParams) error {
 	}
 
 	// Check if the user/role exists.
-	row, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRow(
+	row, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRowEx(
 		params.ctx,
 		opName,
 		params.p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		`select "isRole" from system.users where username = $1`,
 		normalizedUsername,
 	)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -283,7 +284,7 @@ func (ds *ServerImpl) setupFlow(
 			sd.DurationAdditionMode = duration.AdditionModeLegacy
 		}
 		ie := &lazyInternalExecutor{
-			newInternalExecutor: func() tree.InternalExecutor {
+			newInternalExecutor: func() sqlutil.InternalExecutor {
 				return ds.SessionBoundInternalExecutorFactory(ctx, sd)
 			},
 		}
@@ -574,17 +575,31 @@ func (ds *ServerImpl) FlowStream(stream execinfrapb.DistSQL_FlowStreamServer) er
 // itself only on the first call to QueryRow.
 type lazyInternalExecutor struct {
 	// Set when an internal executor has been initialized.
-	tree.InternalExecutor
+	sqlutil.InternalExecutor
 
 	// Used for initializing the internal executor exactly once.
 	once sync.Once
 
 	// newInternalExecutor must be set when instantiating a lazyInternalExecutor,
 	// it provides an internal executor to use when necessary.
-	newInternalExecutor func() tree.InternalExecutor
+	newInternalExecutor func() sqlutil.InternalExecutor
 }
 
-var _ tree.InternalExecutor = &lazyInternalExecutor{}
+var _ sqlutil.InternalExecutor = &lazyInternalExecutor{}
+
+func (ie *lazyInternalExecutor) QueryRowEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	opts sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, error) {
+	ie.once.Do(func() {
+		ie.InternalExecutor = ie.newInternalExecutor()
+	})
+	return ie.InternalExecutor.QueryRowEx(ctx, opName, txn, opts, stmt, qargs...)
+}
 
 func (ie *lazyInternalExecutor) QueryRow(
 	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -967,12 +967,6 @@ type SessionArgs struct {
 	ConnResultsBufferSize int64
 }
 
-// isDefined returns true iff the SessionArgs is well-defined.
-// This method exists because SessionArgs is passed by value but it
-// matters to the functions using it whether the value was explicitly
-// specified or left empty.
-func (s SessionArgs) isDefined() bool { return len(s.User) != 0 }
-
 // SessionRegistry stores a set of all sessions on this node.
 // Use register() and deregister() to modify this registry.
 type SessionRegistry struct {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -199,7 +199,7 @@ func (ie *InternalExecutor) QueryEx(
 	return datums, err
 }
 
-// QueryWithCols is like Query, but it also returns the computed ResultColumns
+// QueryWithCols is like QueryEx, but it also returns the computed ResultColumns
 // of the input query.
 func (ie *InternalExecutor) QueryWithCols(
 	ctx context.Context,
@@ -262,24 +262,6 @@ func (ie *InternalExecutor) QueryRowEx(
 	default:
 		return nil, &tree.MultipleResultsError{SQL: stmt}
 	}
-}
-
-// QueryWithUser is like Query, except it changes the username to that
-// specified.
-//
-// QueryWithUser is deprecated. Use QueryEx() instead.
-func (ie *InternalExecutor) QueryWithUser(
-	ctx context.Context,
-	opName string,
-	txn *client.Txn,
-	userName string,
-	stmt string,
-	qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	return ie.queryInternal(ctx,
-		opName, txn,
-		sqlbase.InternalExecutorSessionDataOverride{User: userName},
-		stmt, qargs...)
 }
 
 // Exec executes the supplied SQL statement and returns the number of rows

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -41,21 +40,10 @@ var _ sqlutil.InternalExecutor = &InternalExecutor{}
 // doesn't offer a session interface for maintaining session state or for
 // running explicit SQL transactions. However, it supports running SQL
 // statements inside a higher-lever (KV) txn and inheriting session variables
-// from another session (for the latter see SessionBoundInternalExecutor).
+// from another session.
+//
+// Methods not otherwise specified are safe for concurrent execution.
 type InternalExecutor struct {
-	internalExecutorImpl
-}
-
-// SessionBoundInternalExecutor is like InternalExecutor, except that it is
-// initialized with values for session variables. Conversely, it doesn't offer
-// the *WithUser methods of the InternalExecutor.
-type SessionBoundInternalExecutor struct {
-	impl internalExecutorImpl
-}
-
-// internalExecutorImpl supports the implementation of InternalExecutor and
-// SessionBoundInternalExecutor.
-type internalExecutorImpl struct {
 	s *Server
 
 	// mon is the monitor used by all queries executed through the
@@ -67,9 +55,8 @@ type internalExecutorImpl struct {
 	memMetrics MemoryMetrics
 
 	// sessionData, if not nil, represents the session variables used by
-	// statements executed on this internalExecutor. This field supports the
-	// implementation of SessionBoundInternalExecutor. Note that a session bound
-	// internal executor cannot modify session data.
+	// statements executed on this internalExecutor. Note that queries executed by
+	// the executor will run on copies of this data.
 	sessionData *sessiondata.SessionData
 
 	// The internal executor uses its own TableCollection. A TableCollection
@@ -96,39 +83,19 @@ func MakeInternalExecutor(
 		settings,
 	)
 	return InternalExecutor{
-		internalExecutorImpl: internalExecutorImpl{
-			s:          s,
-			mon:        &monitor,
-			memMetrics: memMetrics,
-		},
+		s:          s,
+		mon:        &monitor,
+		memMetrics: memMetrics,
 	}
 }
 
-// NewSessionBoundInternalExecutor creates a SessionBoundInternalExecutor.
-func NewSessionBoundInternalExecutor(
-	ctx context.Context,
-	sessionData *sessiondata.SessionData,
-	s *Server,
-	memMetrics MemoryMetrics,
-	settings *cluster.Settings,
-) *SessionBoundInternalExecutor {
-	monitor := mon.MakeUnlimitedMonitor(
-		ctx,
-		"internal SQL executor",
-		mon.MemoryResource,
-		memMetrics.CurBytesCount,
-		memMetrics.MaxBytesHist,
-		math.MaxInt64, /* noteworthy */
-		settings,
-	)
-	return &SessionBoundInternalExecutor{
-		impl: internalExecutorImpl{
-			s:           s,
-			mon:         &monitor,
-			memMetrics:  memMetrics,
-			sessionData: sessionData,
-		},
-	}
+// SetSessionData binds the session variables that will be used by queries
+// performed through this executor from now on.
+//
+// SetSessionData cannot be called concurently with query execution.
+func (ie *InternalExecutor) SetSessionData(sessionData *sessiondata.SessionData) {
+	ie.s.populateMinimalSessionData(sessionData)
+	ie.sessionData = sessionData
 }
 
 // initConnEx creates a connExecutor and runs it on a separate goroutine. It
@@ -137,13 +104,12 @@ func NewSessionBoundInternalExecutor(
 //
 // If txn is not nil, the statement will be executed in the respective txn.
 //
-// sargs, if not nil, is used to initialize the executor's session data. If nil,
-// then ie.sessionData must be set and it will be used (i.e. the executor must
-// be "session bound").
-func (ie *internalExecutorImpl) initConnEx(
+// sd will constitute the executor's session state.
+func (ie *InternalExecutor) initConnEx(
 	ctx context.Context,
 	txn *client.Txn,
-	sargs SessionArgs,
+	sd *sessiondata.SessionData,
+	sdMut sessionDataMutator,
 	syncCallback func([]resWithPos),
 	errCallback func(error),
 ) (*StmtBuf, *sync.WaitGroup, error) {
@@ -153,43 +119,32 @@ func (ie *internalExecutorImpl) initConnEx(
 		lastDelivered: -1,
 	}
 
-	var sd *sessiondata.SessionData
-	var sdMut *sessionDataMutator
-	if sargs.isDefined() {
-		if ie.sessionData != nil {
-			log.Fatal(ctx, "sargs used on a session bound executor")
-		}
-		sd, sdMut = ie.s.newSessionDataAndMutator(sargs)
-	} else {
-		if ie.sessionData == nil {
-			log.Fatal(ctx, "initConnEx called with no sargs, and the executor is also not session bound")
-		}
-		sd = ie.sessionData
-		// sdMut stays nil for session bound executors.
-	}
-
 	stmtBuf := NewStmtBuf()
 	var ex *connExecutor
 	var err error
 	if txn == nil {
 		ex, err = ie.s.newConnExecutor(
 			ctx,
-			sd, sdMut,
+			sd, &sdMut,
 			stmtBuf,
 			clientComm,
 			ie.memMetrics,
-			&ie.s.InternalMetrics)
+			&ie.s.InternalMetrics,
+			dontResetSessionDataToDefaults,
+		)
 	} else {
 		ex, err = ie.s.newConnExecutorWithTxn(
 			ctx,
-			sd, sdMut,
+			sd, &sdMut,
 			stmtBuf,
 			clientComm,
 			ie.mon,
 			ie.memMetrics,
 			&ie.s.InternalMetrics,
 			txn,
-			ie.tcModifier)
+			ie.tcModifier,
+			dontResetSessionDataToDefaults,
+		)
 	}
 	if err != nil {
 		return nil, nil, err
@@ -214,50 +169,105 @@ func (ie *internalExecutorImpl) initConnEx(
 }
 
 // Query executes the supplied SQL statement and returns the resulting rows.
-// The statement is executed as the root user.
+// If no user has been previously set through SetSessionData, the statement is
+// executed as the root user.
 //
 // If txn is not nil, the statement will be executed in the respective txn.
+//
+// Query is deprecated because it may transparently execute a query as root. Use
+// QueryEx instead.
 func (ie *InternalExecutor) Query(
 	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
 ) ([]tree.Datums, error) {
-	datums, _, err := ie.queryInternal(
-		ctx, opName, txn,
-		internalExecRootSession,
-		SessionArgs{},
-		stmt, qargs...)
+	return ie.QueryEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
+}
+
+// QueryEx is like Query, but allows the caller to override some session data
+// fields (e.g. the user).
+//
+// The fields set in session that are set override the respective fields if they
+// have previously been set through SetSessionData().
+func (ie *InternalExecutor) QueryEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) ([]tree.Datums, error) {
+	datums, _, err := ie.queryInternal(ctx, opName, txn, session, stmt, qargs...)
 	return datums, err
 }
 
 // QueryWithCols is like Query, but it also returns the computed ResultColumns
 // of the input query.
 func (ie *InternalExecutor) QueryWithCols(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	return ie.queryInternal(
-		ctx, opName, txn,
-		internalExecRootSession,
-		SessionArgs{},
-		stmt, qargs...)
-}
-
-func (ie *internalExecutorImpl) queryInternal(
 	ctx context.Context,
 	opName string,
 	txn *client.Txn,
-	sessionMode internalExecSessionMode,
-	sargs SessionArgs,
+	session sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
 ) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	res, err := ie.execInternal(ctx, opName, txn, sessionMode, sargs, stmt, qargs...)
+	return ie.queryInternal(ctx, opName, txn, session, stmt, qargs...)
+}
+
+func (ie *InternalExecutor) queryInternal(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	sessionDataOverride sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) ([]tree.Datums, sqlbase.ResultColumns, error) {
+	res, err := ie.execInternal(ctx, opName, txn, sessionDataOverride, stmt, qargs...)
 	if err != nil {
 		return nil, nil, err
 	}
 	return res.rows, res.cols, res.err
 }
 
+// QueryRow is like Query, except it returns a single row, or nil if not row is
+// found, or an error if more that one row is returned.
+//
+// QueryRow is deprecated (like Query). Use QueryRowEx() instead.
+func (ie *InternalExecutor) QueryRow(
+	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
+) (tree.Datums, error) {
+	return ie.QueryRowEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
+}
+
+// QueryRowEx is like QueryRow, but allows the caller to override some session data
+// fields (e.g. the user).
+//
+// The fields set in session that are set override the respective fields if they
+// have previously been set through SetSessionData().
+func (ie *InternalExecutor) QueryRowEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, error) {
+	rows, err := ie.QueryEx(ctx, opName, txn, session, stmt, qargs...)
+	if err != nil {
+		return nil, err
+	}
+	switch len(rows) {
+	case 0:
+		return nil, nil
+	case 1:
+		return rows[0], nil
+	default:
+		return nil, &tree.MultipleResultsError{SQL: stmt}
+	}
+}
+
 // QueryWithUser is like Query, except it changes the username to that
 // specified.
+//
+// QueryWithUser is deprecated. Use QueryEx() instead.
 func (ie *InternalExecutor) QueryWithUser(
 	ctx context.Context,
 	opName string,
@@ -267,133 +277,39 @@ func (ie *InternalExecutor) QueryWithUser(
 	qargs ...interface{},
 ) ([]tree.Datums, sqlbase.ResultColumns, error) {
 	return ie.queryInternal(ctx,
-		opName, txn, internalExecFixedUserSession, SessionArgs{User: userName}, stmt, qargs...)
+		opName, txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: userName},
+		stmt, qargs...)
 }
 
-// QueryRow is like Query, except it returns a single row, or nil if not row is
-// found, or an error if more that one row is returned.
-func (ie *InternalExecutor) QueryRow(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) (tree.Datums, error) {
-	rows, err := ie.Query(ctx, opName, txn, stmt, qargs...)
-	if err != nil {
-		return nil, err
-	}
-	switch len(rows) {
-	case 0:
-		return nil, nil
-	case 1:
-		return rows[0], nil
-	default:
-		return nil, &tree.MultipleResultsError{SQL: stmt}
-	}
-}
-
-// Exec executes the supplied SQL statement. Statements are currently executed
-// as the root user with the system database as current database.
+// Exec executes the supplied SQL statement and returns the number of rows
+// affected (not like the results; see Query()). If no user has been previously
+// set through SetSessionData, the statement is executed as the root user.
 //
 // If txn is not nil, the statement will be executed in the respective txn.
 //
-// Returns the number of rows affected.
+// Exec is deprecated because it may transparently execute a query as root. Use
+// ExecEx instead.
 func (ie *InternalExecutor) Exec(
 	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
 ) (int, error) {
-	res, err := ie.execInternal(
-		ctx, opName, txn, internalExecRootSession, SessionArgs{}, stmt, qargs...,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return res.rowsAffected, res.err
+	return ie.ExecEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
 }
 
-// ExecWithUser is like Exec, except it changes the username to that
-// specified.
-func (ie *InternalExecutor) ExecWithUser(
+// ExecEx is like Exec, but allows the caller to override some session data
+// fields (e.g. the user).
+//
+// The fields set in session that are set override the respective fields if they
+// have previously been set through SetSessionData().
+func (ie *InternalExecutor) ExecEx(
 	ctx context.Context,
 	opName string,
 	txn *client.Txn,
-	userName string,
+	session sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
 ) (int, error) {
-	res, err := ie.execInternal(ctx,
-		opName, txn, internalExecFixedUserSession, SessionArgs{User: userName}, stmt, qargs...)
-	if err != nil {
-		return 0, err
-	}
-	return res.rowsAffected, res.err
-}
-
-// Settings returns the cluster settings.
-func (ie *InternalExecutor) Settings() *cluster.Settings {
-	return ie.s.cfg.Settings
-}
-
-// Query executes the supplied SQL statement and returns the resulting rows.
-// The statement is executed as the root user.
-//
-// If txn is not nil, the statement will be executed in the respective txn.
-func (ie *SessionBoundInternalExecutor) Query(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) ([]tree.Datums, error) {
-	rows, _, err := ie.impl.queryInternal(
-		ctx, opName, txn,
-		internalExecInheritSession,
-		SessionArgs{},
-		stmt, qargs...)
-	return rows, err
-}
-
-// QueryWithCols is like Query, but it also returns the computed ResultColumns
-// of the input query.
-func (ie *SessionBoundInternalExecutor) QueryWithCols(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	return ie.impl.queryInternal(
-		ctx, opName, txn,
-		internalExecInheritSession,
-		SessionArgs{},
-		stmt, qargs...)
-}
-
-// QueryRow is like Query, except it returns a single row, or nil if not row is
-// found, or an error if more that one row is returned.
-func (ie *SessionBoundInternalExecutor) QueryRow(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) (tree.Datums, error) {
-	rows, _ /* cols */, err := ie.impl.queryInternal(
-		ctx, opName, txn,
-		internalExecInheritSession,
-		SessionArgs{},
-		stmt, qargs...)
-	if err != nil {
-		return nil, err
-	}
-	switch len(rows) {
-	case 0:
-		return nil, nil
-	case 1:
-		return rows[0], nil
-	default:
-		return nil, &tree.MultipleResultsError{SQL: stmt}
-	}
-}
-
-// Exec executes the supplied SQL statement.
-//
-// If txn is not nil, the statement will be executed in the respective txn.
-//
-// Returns the number of rows affected.
-func (ie *SessionBoundInternalExecutor) Exec(
-	ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
-) (int, error) {
-	res, err := ie.impl.execInternal(
-		ctx, opName, txn,
-		internalExecInheritSession,
-		SessionArgs{},
-		stmt, qargs...,
-	)
+	res, err := ie.execInternal(ctx, opName, txn, session, stmt, qargs...)
 	if err != nil {
 		return 0, err
 	}
@@ -407,64 +323,69 @@ type result struct {
 	err          error
 }
 
-type internalExecSessionMode int
+// applyOverrides overrides the respective fields from sd for all the fields set on o.
+func applyOverrides(o sqlbase.InternalExecutorSessionDataOverride, sd *sessiondata.SessionData) {
+	if o.User != "" {
+		sd.User = o.User
+	}
+	if o.Database != "" {
+		sd.Database = o.Database
+	}
+	if o.ApplicationName != "" {
+		sd.ApplicationName = o.ApplicationName
+	}
+}
 
-const (
-	// internalExecInheritSession will pick up the internalExecutor's
-	// existing sessionData.
-	internalExecInheritSession internalExecSessionMode = iota
-	// internalExecRootSession will create a new session from scratch
-	// with the root user, the system database as current database, an
-	// auto-generated internal application_name and all session defaults
-	// otherwise.
-	// This is equivalent to passing internalExecUseFixedUserSession with
-	// the result of newInternalSessionUserArgs(security.RootUser).
-	internalExecRootSession
-	// internalExecFixedUser will use the provided username in
-	// SessionArgs and reset everything else as per internalExecRootSession.
-	internalExecFixedUserSession
-)
+func (ie *InternalExecutor) maybeRootSessionDataOverride(
+	opName string,
+) sqlbase.InternalExecutorSessionDataOverride {
+	if ie.sessionData == nil {
+		return sqlbase.InternalExecutorSessionDataOverride{
+			User:            security.RootUser,
+			ApplicationName: sqlbase.InternalAppNamePrefix + "-" + opName,
+		}
+	}
+	o := sqlbase.InternalExecutorSessionDataOverride{}
+	if ie.sessionData.User == "" {
+		o.User = security.RootUser
+	}
+	if ie.sessionData.ApplicationName == "" {
+		o.ApplicationName = sqlbase.InternalAppNamePrefix + "-" + opName
+	}
+	return o
+}
 
 // execInternal executes a statement.
 //
-// sargs, if not nil, is used to initialize the executor's session data. If nil,
-// then ie.sessionData must be set and it will be used (i.e. the executor must
-// be "session bound").
-func (ie *internalExecutorImpl) execInternal(
+// sessionDataOverride can be used to control select fields in the executor's
+// session data. It overrides what has been previously set through
+// SetSessionData(), if anything.
+func (ie *InternalExecutor) execInternal(
 	ctx context.Context,
 	opName string,
 	txn *client.Txn,
-	sessionMode internalExecSessionMode,
-	sargs SessionArgs,
+	sessionDataOverride sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
 ) (retRes result, retErr error) {
 	ctx = logtags.AddTag(ctx, "intExec", opName)
 
-	switch sessionMode {
-	case internalExecInheritSession, internalExecRootSession:
-		if sargs.isDefined() {
-			log.Fatalf(ctx, "programming error: session args provided with mode %d", sessionMode)
-		}
-		if sessionMode == internalExecRootSession {
-			sargs = SessionArgs{User: security.RootUser}
-		}
+	var sd *sessiondata.SessionData
+	if ie.sessionData != nil {
+		// TODO(andrei): Properly clone (deep copy) ie.sessionData.
+		sdCopy := *ie.sessionData
+		sd = &sdCopy
+	} else {
+		sd = ie.s.newSessionData(SessionArgs{})
 	}
-
-	switch sessionMode {
-	case internalExecFixedUserSession:
-		if !sargs.isDefined() {
-			log.Fatal(ctx, "programming error: mode fixed user with undefined sargs")
-		}
-		// Clear all fields except user.
-		sargs = SessionArgs{User: sargs.User}
-		fallthrough
-	case internalExecRootSession:
-		sargs.SessionDefaults = map[string]string{
-			"database":         "system",
-			"application_name": sqlbase.InternalAppNamePrefix + "-" + opName,
-		}
+	applyOverrides(sessionDataOverride, sd)
+	if sd.User == "" {
+		return result{}, errors.AssertionFailedf("no user specified for internal query")
 	}
+	if sd.ApplicationName == "" {
+		sd.ApplicationName = sqlbase.InternalAppNamePrefix + "-" + opName
+	}
+	sdMutator := ie.s.makeSessionDataMutator(sd, nil /* defaults */)
 
 	defer func() {
 		// We wrap errors with the opName, but not if they're retriable - in that
@@ -517,7 +438,7 @@ func (ie *internalExecutorImpl) execInternal(
 		}
 		resCh <- result{err: err}
 	}
-	stmtBuf, wg, err := ie.initConnEx(ctx, txn, sargs, syncCallback, errCallback)
+	stmtBuf, wg, err := ie.initConnEx(ctx, txn, sd, sdMutator, syncCallback, errCallback)
 	if err != nil {
 		return result{}, err
 	}

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -124,7 +124,9 @@ func TestQueryIsAdminWithNoTxn(t *testing.T) {
 
 	for _, tc := range testData {
 		t.Run(tc.user, func(t *testing.T) {
-			rows, cols, err := ie.QueryWithUser(ctx, "test", nil /* txn */, tc.user, "SELECT crdb_internal.is_admin()")
+			rows, cols, err := ie.QueryWithCols(ctx, "test", nil, /* txn */
+				sqlbase.InternalExecutorSessionDataOverride{User: tc.user},
+				"SELECT crdb_internal.is_admin()")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -941,10 +941,11 @@ func (e *urlOutputter) finish() (url.URL, error) {
 // environmentQuery is a helper to run a query to build up the output of
 // showEnv. It expects a query that returns a single string column.
 func (ef *execFactory) environmentQuery(query string) (string, error) {
-	r, err := ef.planner.extendedEvalCtx.InternalExecutor.QueryRow(
+	r, err := ef.planner.extendedEvalCtx.InternalExecutor.(*InternalExecutor).QueryRowEx(
 		ef.planner.EvalContext().Context,
 		"EXPLAIN (env)",
 		ef.planner.Txn(),
+		sqlbase.InternalExecutorSessionDataOverride{},
 		query,
 	)
 	if err != nil {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -226,7 +226,9 @@ func execQuery(
 	ctx context.Context, query string, s serverutils.TestServerInterface, c *conn,
 ) error {
 	rows, cols, err := s.InternalExecutor().(sqlutil.InternalExecutor).QueryWithCols(
-		ctx, "test", nil /* txn */, query,
+		ctx, "test", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser, Database: "system"},
+		query,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -24,10 +25,11 @@ func (p *planner) LookupNamespaceID(
 	ctx context.Context, parentID int64, name string,
 ) (tree.DInt, bool, error) {
 	const query = `SELECT id FROM system.namespace WHERE "parentID" = $1 AND name = $2`
-	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
+	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRowEx(
 		ctx,
 		"crdb-internal-get-descriptor-id",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		query,
 		parentID,
 		name,
@@ -54,10 +56,11 @@ func (p *planner) LookupZoneConfigByNamespaceID(
 	}
 
 	const query = `SELECT config FROM system.zones WHERE id = $1`
-	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
+	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRowEx(
 		ctx,
 		"crdb-internal-get-zone",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		query,
 		id,
 	)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2625,8 +2625,18 @@ type EvalSessionAccessor interface {
 	HasAdminRole(ctx context.Context) (bool, error)
 }
 
-// InternalExecutor is a subset of sqlutil.InternalExecutor used by
-// this sem/tree package which can't even import sqlutil.
+// InternalExecutor is a subset of sqlutil.InternalExecutor (which, in turn, is
+// implemented by sql.InternalExecutor) used by this sem/tree package which
+// can't even import sqlutil.
+//
+// Note that the functions offered here should be avoided when possible. They
+// execute the query as root if an user hadn't been previously set on the
+// executor through SetSessionData(). These functions are deprecated in
+// sql.InternalExecutor in favor of a safer interface. Unfortunately, those
+// safer functions cannot be exposed through this interface because they depend
+// on sqlbase, and this package cannot import sqlbase. When possible, downcast
+// this to sqlutil.InternalExecutor or sql.InternalExecutor, and use the
+// alternatives.
 type InternalExecutor interface {
 	// Query is part of the sqlutil.InternalExecutor interface.
 	Query(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2625,14 +2625,13 @@ type EvalSessionAccessor interface {
 	HasAdminRole(ctx context.Context) (bool, error)
 }
 
-// SessionBoundInternalExecutor is a subset of sqlutil.InternalExecutor used by
-// this sem/tree package which can't even import sqlutil. Executor used through
-// this interface are always "session-bound" - they inherit session variables
-// from a parent session.
-type SessionBoundInternalExecutor interface {
+// InternalExecutor is a subset of sqlutil.InternalExecutor used by
+// this sem/tree package which can't even import sqlutil.
+type InternalExecutor interface {
 	// Query is part of the sqlutil.InternalExecutor interface.
 	Query(
-		ctx context.Context, opName string, txn *client.Txn, stmt string, qargs ...interface{},
+		ctx context.Context, opName string, txn *client.Txn,
+		stmt string, qargs ...interface{},
 	) ([]Datums, error)
 
 	// QueryRow is part of the sqlutil.InternalExecutor interface.
@@ -2783,7 +2782,7 @@ type EvalContext struct {
 	// need to run a statement, and yet many builtin functions do it.
 	// Note that the executor will be "session-bound" - it will inherit session
 	// variables from a parent session.
-	InternalExecutor SessionBoundInternalExecutor
+	InternalExecutor InternalExecutor
 
 	Planner EvalPlanner
 

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -140,9 +141,10 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 		sql = sql + " AS OF SYSTEM TIME " + ts.AsOfSystemTime()
 	}
 
-	fingerprintCols, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRow(
+	fingerprintCols, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRowEx(
 		params.ctx, "hash-fingerprint",
 		params.p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		sql,
 	)
 	if err != nil {

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -40,10 +41,11 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 		columns: showHistogramColumns,
 
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			row, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
+			row, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRowEx(
 				ctx,
 				"read-histogram",
 				p.txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 				`SELECT histogram
 				 FROM system.table_statistics
 				 WHERE "statisticID" = $1`,

--- a/pkg/sql/sqlbase/internal.go
+++ b/pkg/sql/sqlbase/internal.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlbase
+
+// InternalExecutorSessionDataOverride is used by the InternalExecutor interface
+// to allow control over some of the session data.
+type InternalExecutorSessionDataOverride struct {
+	// User represents the user that the query will run under.
+	User string
+	// Database represents the default database for the query.
+	Database string
+	// ApplicationName represents the application that the query runs under.
+	ApplicationName string
+}

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -33,16 +33,48 @@ type InternalExecutor interface {
 	// If txn is not nil, the statement will be executed in the respective txn.
 	//
 	// Returns the number of rows affected.
+	//
+	// Exec is deprecated. Use ExecEx() instead.
 	Exec(
 		ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
+	) (int, error)
+
+	// ExecEx is like Exec, but allows the caller to override some session data
+	// fields.
+	//
+	// The fields set in session that are set override the respective fields if they
+	// have previously been set through SetSessionData().
+	ExecEx(
+		ctx context.Context,
+		opName string,
+		txn *client.Txn,
+		o sqlbase.InternalExecutorSessionDataOverride,
+		stmt string,
+		qargs ...interface{},
 	) (int, error)
 
 	// Query executes the supplied SQL statement and returns the resulting rows.
 	// The statement is executed as the root user.
 	//
 	// If txn is not nil, the statement will be executed in the respective txn.
+	//
+	// Query is deprecated. Use QueryEx() instead.
 	Query(
 		ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
+	) ([]tree.Datums, error)
+
+	// QueryEx is like Query, but allows the caller to override some session data
+	// fields.
+	//
+	// The fields set in session that are set override the respective fields if
+	// they have previously been set through SetSessionData().
+	QueryEx(
+		ctx context.Context,
+		opName string,
+		txn *client.Txn,
+		session sqlbase.InternalExecutorSessionDataOverride,
+		stmt string,
+		qargs ...interface{},
 	) ([]tree.Datums, error)
 
 	// QueryWithCols executes the supplied SQL statement and returns the resulting
@@ -51,42 +83,31 @@ type InternalExecutor interface {
 	//
 	// If txn is not nil, the statement will be executed in the respective txn.
 	QueryWithCols(
-		ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
+		ctx context.Context, opName string, txn *client.Txn,
+		o sqlbase.InternalExecutorSessionDataOverride, statement string, qargs ...interface{},
 	) ([]tree.Datums, sqlbase.ResultColumns, error)
 
 	// QueryRow is like Query, except it returns a single row, or nil if not row is
 	// found, or an error if more that one row is returned.
+	//
+	// QueryRow is deprecated. Use QueryRowEx() instead.
 	QueryRow(
 		ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 	) (tree.Datums, error)
-}
 
-// InternalExecutorWithUser is like an InternalExecutor but allows the client to
-// specify the user for use during execution.
-type InternalExecutorWithUser interface {
-	InternalExecutor
-
-	// QueryWithUser is like Query, except it changes the username to that
-	// specified.
-	QueryWithUser(
+	// QueryRowEx is like QueryRow, but allows the caller to override some session data
+	// fields.
+	//
+	// The fields set in session that are set override the respective fields if they
+	// have previously been set through SetSessionData().
+	QueryRowEx(
 		ctx context.Context,
 		opName string,
 		txn *client.Txn,
-		userName string,
+		session sqlbase.InternalExecutorSessionDataOverride,
 		stmt string,
 		qargs ...interface{},
-	) ([]tree.Datums, sqlbase.ResultColumns, error)
-
-	// ExecWithUser is like Exec, except it changes the username to that
-	// specified.
-	ExecWithUser(
-		ctx context.Context,
-		opName string,
-		txn *client.Txn,
-		userName string,
-		stmt string,
-		qargs ...interface{},
-	) (int, error)
+	) (tree.Datums, error)
 }
 
 // SessionBoundInternalExecutorFactory is a function that produces a "session

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -109,9 +109,8 @@ func cleanupSessionTempObjects(ctx context.Context, server *Server, sessionID Cl
 					User:          security.RootUser,
 					SequenceState: &sessiondata.SequenceState{},
 				}
-				ie := NewSessionBoundInternalExecutor(
-					ctx, sd, server, MemoryMetrics{}, server.cfg.Settings,
-				)
+				ie := MakeInternalExecutor(ctx, server, MemoryMetrics{}, server.cfg.Settings)
+				ie.SetSessionData(sd)
 				_, err = ie.Exec(ctx, "delete-temp-tables", txn, query.String())
 				if err != nil {
 					return err

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -124,7 +124,8 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 		indexName = n.index.Name
 	}
 	ranges, err := params.p.ExtendedEvalContext().InternalExecutor.Query(
-		params.ctx, "split points query", params.p.txn, statement,
+		params.ctx, "split points query", params.p.txn,
+		statement,
 		dbDesc.Name,
 		n.tableDesc.Name,
 		indexName,

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -123,8 +123,8 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if n.index.ID != n.tableDesc.PrimaryIndex.ID {
 		indexName = n.index.Name
 	}
-	ranges, err := params.p.ExtendedEvalContext().InternalExecutor.Query(
-		params.ctx, "split points query", params.p.txn,
+	ranges, err := params.p.ExtendedEvalContext().InternalExecutor.(*InternalExecutor).QueryEx(
+		params.ctx, "split points query", params.p.txn, sqlbase.InternalExecutorSessionDataOverride{},
 		statement,
 		dbDesc.Name,
 		n.tableDesc.Name,

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -239,14 +239,18 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		includedInBootstrap: cluster.VersionByKey(cluster.Version19_2),
 		workFn: func(ctx context.Context, r runner) error {
 			// Note that these particular schema changes are idempotent.
-			if _, err := r.sqlExecutor.ExecWithUser(ctx, "update-reports-meta-generated", nil, /* txn */
-				security.NodeUser,
+			if _, err := r.sqlExecutor.ExecEx(ctx, "update-reports-meta-generated", nil, /* txn */
+				sqlbase.InternalExecutorSessionDataOverride{
+					User: security.NodeUser,
+				},
 				`ALTER TABLE system.reports_meta ALTER generated TYPE TIMESTAMP WITH TIME ZONE`,
 			); err != nil {
 				return err
 			}
-			if _, err := r.sqlExecutor.ExecWithUser(ctx, "update-reports-meta-generated", nil, /* txn */
-				security.NodeUser,
+			if _, err := r.sqlExecutor.ExecEx(ctx, "update-reports-meta-generated", nil, /* txn */
+				sqlbase.InternalExecutorSessionDataOverride{
+					User: security.NodeUser,
+				},
 				"ALTER TABLE system.replication_constraint_stats ALTER violation_start "+
 					"TYPE TIMESTAMP WITH TIME ZONE",
 			); err != nil {
@@ -355,6 +359,33 @@ func init() {
 type runner struct {
 	db          db
 	sqlExecutor *sql.InternalExecutor
+	settings    *cluster.Settings
+}
+
+func (r runner) execAsRoot(ctx context.Context, opName, stmt string, qargs ...interface{}) error {
+	_, err := r.sqlExecutor.ExecEx(ctx, opName, nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{
+			User: security.RootUser,
+		},
+		stmt, qargs...)
+	return err
+}
+
+func (r runner) execAsRootWithRetry(
+	ctx context.Context, opName string, stmt string, qargs ...interface{},
+) error {
+	// Retry a limited number of times because returning an error and letting
+	// the node kill itself is better than holding the migration lease for an
+	// arbitrarily long time.
+	var err error
+	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
+		err := r.execAsRoot(ctx, opName, stmt, qargs...)
+		if err == nil {
+			break
+		}
+		log.Warningf(ctx, "failed to run %s: %v", stmt, err)
+	}
+	return err
 }
 
 // leaseManager is defined just to allow us to use a fake client.LeaseManager
@@ -383,6 +414,7 @@ type Manager struct {
 	db           db
 	sqlExecutor  *sql.InternalExecutor
 	testingKnobs MigrationManagerTestingKnobs
+	settings     *cluster.Settings
 }
 
 // NewManager initializes and returns a new Manager object.
@@ -393,6 +425,7 @@ func NewManager(
 	clock *hlc.Clock,
 	testingKnobs MigrationManagerTestingKnobs,
 	clientID string,
+	settings *cluster.Settings,
 ) *Manager {
 	opts := client.LeaseManagerOptions{
 		ClientID:      clientID,
@@ -404,6 +437,7 @@ func NewManager(
 		db:           db,
 		sqlExecutor:  executor,
 		testingKnobs: testingKnobs,
+		settings:     settings,
 	}
 }
 
@@ -547,6 +581,7 @@ func (m *Manager) EnsureMigrations(ctx context.Context, bootstrapVersion roachpb
 	r := runner{
 		db:          m.db,
 		sqlExecutor: m.sqlExecutor,
+		settings:    m.settings,
 	}
 	for _, migration := range backwardCompatibleMigrations {
 		minVersion := migration.includedInBootstrap
@@ -608,7 +643,7 @@ func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescript
 	// the reserved ID space. (The SQL layer doesn't allow this.)
 	err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		b := txn.NewBatch()
-		tKey := sqlbase.MakePublicTableNameKey(ctx, r.sqlExecutor.Settings(), desc.GetParentID(), desc.GetName())
+		tKey := sqlbase.MakePublicTableNameKey(ctx, r.settings, desc.GetParentID(), desc.GetName())
 		b.CPut(tKey.Key(), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
 		if err := txn.SetSystemConfigTrigger(); err != nil {
@@ -632,9 +667,10 @@ func createReplicationConstraintStatsTable(ctx context.Context, r runner) error 
 	if err := createSystemTable(ctx, r, sqlbase.ReplicationConstraintStatsTable); err != nil {
 		return err
 	}
-	_, err := r.sqlExecutor.Exec(ctx, "add-constraints-ttl", nil, /* txn */
-		fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE USING gc.ttlseconds = %d",
-			sqlbase.ReplicationConstraintStatsTable.Name, int(sqlbase.ReplicationConstraintStatsTableTTL.Seconds())))
+	err := r.execAsRoot(ctx, "add-constraints-ttl",
+		fmt.Sprintf(
+			"ALTER TABLE system.replication_constraint_stats CONFIGURE ZONE USING gc.ttlseconds = %d",
+			int(sqlbase.ReplicationConstraintStatsTableTTL.Seconds())))
 	return errors.Wrapf(err, "failed to set TTL on %s", sqlbase.ReplicationConstraintStatsTable.Name)
 }
 
@@ -646,9 +682,9 @@ func createReplicationStatsTable(ctx context.Context, r runner) error {
 	if err := createSystemTable(ctx, r, sqlbase.ReplicationStatsTable); err != nil {
 		return err
 	}
-	_, err := r.sqlExecutor.Exec(ctx, "add-replication-status-ttl", nil, /* txn */
-		fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE USING gc.ttlseconds = %d",
-			sqlbase.ReplicationStatsTable.Name, int(sqlbase.ReplicationStatsTableTTL.Seconds())))
+	err := r.execAsRoot(ctx, "add-replication-status-ttl",
+		fmt.Sprintf("ALTER TABLE system.replication_stats CONFIGURE ZONE USING gc.ttlseconds = %d",
+			int(sqlbase.ReplicationStatsTableTTL.Seconds())))
 	return errors.Wrapf(err, "failed to set TTL on %s", sqlbase.ReplicationStatsTable.Name)
 }
 
@@ -715,8 +751,12 @@ func migrateSystemNamespace(ctx context.Context, r runner) error {
 	q := fmt.Sprintf(
 		`SELECT "parentID", name, id FROM [%d AS namespace_deprecated]`,
 		sqlbase.DeprecatedNamespaceTable.ID)
-	rows, _, err := r.sqlExecutor.QueryWithUser(
-		ctx, "read-deprecated-namespace-table", nil /* txn */, security.NodeUser, q)
+	rows, err := r.sqlExecutor.QueryEx(
+		ctx, "read-deprecated-namespace-table", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{
+			User: security.NodeUser,
+		},
+		q)
 	if err != nil {
 		return err
 	}
@@ -757,23 +797,6 @@ func createReportsMetaTable(ctx context.Context, r runner) error {
 	return createSystemTable(ctx, r, sqlbase.ReportsMetaTable)
 }
 
-func runStmtAsRootWithRetry(
-	ctx context.Context, r runner, opName string, stmt string, qargs ...interface{},
-) error {
-	// Retry a limited number of times because returning an error and letting
-	// the node kill itself is better than holding the migration lease for an
-	// arbitrarily long time.
-	var err error
-	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
-		_, err := r.sqlExecutor.Exec(ctx, opName, nil /* txn */, stmt, qargs...)
-		if err == nil {
-			break
-		}
-		log.Warningf(ctx, "failed to run %s: %v", stmt, err)
-	}
-	return err
-}
-
 // SettingsDefaultOverrides documents the effect of several migrations that add
 // an explicit value for a setting, effectively changing the "default value"
 // from what was defined in code.
@@ -787,13 +810,13 @@ func optInToDiagnosticsStatReporting(ctx context.Context, r runner) error {
 	if cluster.TelemetryOptOut() {
 		return nil
 	}
-	return runStmtAsRootWithRetry(
-		ctx, r, "optInToDiagnosticsStatReporting", `SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
+	return r.execAsRootWithRetry(ctx, "optInToDiagnosticsStatReporting",
+		`SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
 }
 
 func initializeClusterSecret(ctx context.Context, r runner) error {
-	return runStmtAsRootWithRetry(
-		ctx, r, "initializeClusterSecret",
+	return r.execAsRootWithRetry(
+		ctx, "initializeClusterSecret",
 		`SET CLUSTER SETTING cluster.secret = gen_random_uuid()::STRING`,
 	)
 }
@@ -821,17 +844,16 @@ func populateVersionSetting(ctx context.Context, r runner) error {
 	// (overwriting also seems reasonable, but what for).
 	// We don't allow users to perform version changes until we have run
 	// the insert below.
-	if _, err := r.sqlExecutor.Exec(
+	if err := r.execAsRoot(
 		ctx,
 		"insert-setting",
-		nil, /* txn */
 		fmt.Sprintf(`INSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ('version', x'%x', now(), 'm') ON CONFLICT(name) DO NOTHING`, b),
 	); err != nil {
 		return err
 	}
 
-	if _, err := r.sqlExecutor.Exec(
-		ctx, "set-setting", nil /* txn */, "SET CLUSTER SETTING version = $1", v.String(),
+	if err := r.execAsRoot(
+		ctx, "set-setting", "SET CLUSTER SETTING version = $1", v.String(),
 	); err != nil {
 		return err
 	}
@@ -843,7 +865,7 @@ func addRootUser(ctx context.Context, r runner) error {
 	const upsertRootStmt = `
 	        UPSERT INTO system.users (username, "hashedPassword", "isRole") VALUES ($1, '', false)
 	        `
-	return runStmtAsRootWithRetry(ctx, r, "addRootUser", upsertRootStmt, security.RootUser)
+	return r.execAsRootWithRetry(ctx, "addRootUser", upsertRootStmt, security.RootUser)
 }
 
 func addAdminRole(ctx context.Context, r runner) error {
@@ -851,7 +873,7 @@ func addAdminRole(ctx context.Context, r runner) error {
 	const upsertAdminStmt = `
           UPSERT INTO system.users (username, "hashedPassword", "isRole") VALUES ($1, '', true)
           `
-	return runStmtAsRootWithRetry(ctx, r, "addAdminRole", upsertAdminStmt, sqlbase.AdminRole)
+	return r.execAsRootWithRetry(ctx, "addAdminRole", upsertAdminStmt, sqlbase.AdminRole)
 }
 
 func addRootToAdminRole(ctx context.Context, r runner) error {
@@ -859,8 +881,8 @@ func addRootToAdminRole(ctx context.Context, r runner) error {
 	const upsertAdminStmt = `
           UPSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, true)
           `
-	return runStmtAsRootWithRetry(
-		ctx, r, "addRootToAdminRole", upsertAdminStmt, sqlbase.AdminRole, security.RootUser)
+	return r.execAsRootWithRetry(
+		ctx, "addRootToAdminRole", upsertAdminStmt, sqlbase.AdminRole, security.RootUser)
 }
 
 func disallowPublicUserOrRole(ctx context.Context, r runner) error {
@@ -870,8 +892,12 @@ func disallowPublicUserOrRole(ctx context.Context, r runner) error {
           `
 
 	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
-		row, err := r.sqlExecutor.QueryRow(
-			ctx, "disallowPublicUserOrRole", nil /* txn */, selectPublicStmt, sqlbase.PublicRole,
+		row, err := r.sqlExecutor.QueryRowEx(
+			ctx, "disallowPublicUserOrRole", nil, /* txn */
+			sqlbase.InternalExecutorSessionDataOverride{
+				User: security.RootUser,
+			},
+			selectPublicStmt, sqlbase.PublicRole,
 		)
 		if err != nil {
 			continue
@@ -908,7 +934,7 @@ func createDefaultDbs(ctx context.Context, r runner) error {
 	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
 		for _, dbName := range []string{sessiondata.DefaultDatabaseName, sessiondata.PgDatabaseName} {
 			stmt := fmt.Sprintf(createDbStmt, dbName)
-			_, err = r.sqlExecutor.Exec(ctx, "create-default-db", nil /* txn */, stmt)
+			err = r.execAsRoot(ctx, "create-default-db", stmt)
 			if err != nil {
 				log.Warningf(ctx, "failed attempt to add database %q: %s", dbName, err)
 				break
@@ -969,7 +995,7 @@ func retireOldTsPurgeIntervalSettings(ctx context.Context, r runner) error {
 	// We rely on the SELECT returning no row if the original setting
 	// was not defined, and INSERT ON CONFLICT DO NOTHING to ignore the
 	// insert if the new name was already set.
-	if _, err := r.sqlExecutor.Exec(ctx, "copy-setting", nil /* txn */, `
+	if err := r.execAsRoot(ctx, "copy-setting", `
 INSERT INTO system.settings (name, value, "lastUpdated", "valueType")
    SELECT 'timeseries.storage.resolution_10s.ttl', value, "lastUpdated", "valueType"
      FROM system.settings WHERE name = 'timeseries.storage.10s_resolution_ttl'
@@ -979,7 +1005,7 @@ ON CONFLICT (name) DO NOTHING`,
 	}
 
 	// Ditto 30m.
-	if _, err := r.sqlExecutor.Exec(ctx, "copy-setting", nil /* txn */, `
+	if err := r.execAsRoot(ctx, "copy-setting", `
 INSERT INTO system.settings (name, value, "lastUpdated", "valueType")
    SELECT 'timeseries.storage.resolution_30m.ttl', value, "lastUpdated", "valueType"
      FROM system.settings WHERE name = 'timeseries.storage.30m_resolution_ttl'

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -467,6 +467,7 @@ func (mt *migrationTest) runMigration(ctx context.Context, m migrationDescriptor
 		return nil
 	}
 	return m.workFn(ctx, runner{
+		settings:    mt.server.ClusterSettings(),
 		db:          mt.kvDB,
 		sqlExecutor: mt.server.InternalExecutor().(*sql.InternalExecutor),
 	})

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -77,7 +79,9 @@ func (s *Store) insertRangeLogEvent(
 		s.metrics.RangeRemoves.Inc(1)
 	}
 
-	rows, err := s.cfg.SQLExecutor.Exec(ctx, "log-range-event", txn, insertEventTableStmt, args...)
+	rows, err := s.cfg.SQLExecutor.ExecEx(ctx, "log-range-event", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		insertEventTableStmt, args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/protectedts/ptcache/cache_test.go
+++ b/pkg/storage/protectedts/ptcache/cache_test.go
@@ -48,7 +48,7 @@ func TestCacheBasic(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	s := tc.Server(0)
 	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+		s.InternalExecutor().(sqlutil.InternalExecutor)), s.DB())
 
 	// Set the poll interval to be very short.
 	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Microsecond)
@@ -117,7 +117,7 @@ func TestRefresh(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	s := tc.Server(0)
 	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+		s.InternalExecutor().(sqlutil.InternalExecutor)), s.DB())
 
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
@@ -199,7 +199,7 @@ func TestStart(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 		s := tc.Server(0)
 		p := ptstorage.New(s.ClusterSettings(),
-			s.InternalExecutor().(sqlutil.InternalExecutorWithUser))
+			s.InternalExecutor().(sqlutil.InternalExecutor))
 		// Set the poll interval to be very long.
 		protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
 		c := ptcache.New(ptcache.Config{
@@ -232,7 +232,7 @@ func TestQueryRecord(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	s := tc.Server(0)
 	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+		s.InternalExecutor().(sqlutil.InternalExecutor)), s.DB())
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
 	c := ptcache.New(ptcache.Config{
@@ -289,7 +289,7 @@ func TestIterate(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	s := tc.Server(0)
 	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+		s.InternalExecutor().(sqlutil.InternalExecutor)), s.DB())
 
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)
@@ -354,7 +354,7 @@ func TestSettingChangedLeadsToFetch(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	s := tc.Server(0)
 	p := ptstorage.WithDatabase(ptstorage.New(s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutorWithUser)), s.DB())
+		s.InternalExecutor().(sqlutil.InternalExecutor)), s.DB())
 
 	// Set the poll interval to be very long.
 	protectedts.PollInterval.Override(&s.ClusterSettings().SV, 500*time.Hour)

--- a/pkg/storage/protectedts/ptstorage/storage.go
+++ b/pkg/storage/protectedts/ptstorage/storage.go
@@ -102,7 +102,9 @@ func (p *storage) GetRecord(
 	if txn == nil {
 		return nil, errNoTxn
 	}
-	row, err := p.ex.QueryRow(ctx, "protectedts-GetRecord", txn, getRecordQuery, id.GetBytesMut())
+	row, err := p.ex.QueryRowEx(ctx, "protectedts-GetRecord", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
+		getRecordQuery, id.GetBytesMut())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read record %v", id)
 	}
@@ -152,7 +154,9 @@ func (p *storage) GetMetadata(ctx context.Context, txn *client.Txn) (ptpb.Metada
 	if txn == nil {
 		return ptpb.Metadata{}, errNoTxn
 	}
-	row, err := p.ex.QueryRow(ctx, "protectedts-GetMetadata", txn, getMetadataQuery)
+	row, err := p.ex.QueryRowEx(ctx, "protectedts-GetMetadata", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
+		getMetadataQuery)
 	if err != nil {
 		return ptpb.Metadata{}, errors.Wrap(err, "failed to read metadata")
 	}
@@ -183,7 +187,9 @@ func (p *storage) GetState(ctx context.Context, txn *client.Txn) (ptpb.State, er
 }
 
 func (p *storage) getRecords(ctx context.Context, txn *client.Txn) ([]ptpb.Record, error) {
-	rows, err := p.ex.Query(ctx, "protectedts-GetRecords", txn, getRecordsQuery)
+	rows, err := p.ex.QueryEx(ctx, "protectedts-GetRecords", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
+		getRecordsQuery)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read records")
 	}

--- a/pkg/storage/protectedts/ptstorage/storage_test.go
+++ b/pkg/storage/protectedts/ptstorage/storage_test.go
@@ -654,23 +654,13 @@ func (ie *wrappedInternalExecutor) QueryRowEx(
 func (ie *wrappedInternalExecutor) Query(
 	ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
 ) ([]tree.Datums, error) {
-	if f := ie.getErrFunc(); f != nil {
-		if err := f(statement); err != nil {
-			return nil, err
-		}
-	}
-	return ie.wrapped.Query(ctx, opName, txn, statement, params...)
+	panic("not implemented")
 }
 
 func (ie *wrappedInternalExecutor) QueryRow(
-	ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
+	ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 ) (tree.Datums, error) {
-	if f := ie.getErrFunc(); f != nil {
-		if err := f(statement); err != nil {
-			return nil, err
-		}
-	}
-	return ie.wrapped.QueryRow(ctx, opName, txn, statement, params...)
+	panic("not implemented")
 }
 
 func (ie *wrappedInternalExecutor) getErrFunc() func(statement string) error {

--- a/pkg/storage/protectedts/ptstorage/storage_test.go
+++ b/pkg/storage/protectedts/ptstorage/storage_test.go
@@ -439,10 +439,11 @@ func TestCorruptData(t *testing.T) {
 		require.NoError(t, s.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			return pts.Protect(ctx, txn, &rec)
 		}))
-		ie := tc.Server(0).InternalExecutor().(sqlutil.InternalExecutorWithUser)
-		affected, err := ie.ExecWithUser(
+		ie := tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor)
+		affected, err := ie.ExecEx(
 			ctx, "corrupt-data", nil, /* txn */
-			security.NodeUser, "UPDATE system.protected_ts_records SET spans = $1 WHERE id = $2",
+			sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
+			"UPDATE system.protected_ts_records SET spans = $1 WHERE id = $2",
 			[]byte("junk"), rec.ID.String())
 		require.NoError(t, err)
 		require.Equal(t, 1, affected)
@@ -487,10 +488,11 @@ func TestCorruptData(t *testing.T) {
 		// This timestamp has too many logical digits and thus will fail parsing.
 		var d tree.DDecimal
 		d.SetFinite(math.MaxInt32, -12)
-		ie := tc.Server(0).InternalExecutor().(sqlutil.InternalExecutorWithUser)
-		affected, err := ie.ExecWithUser(
+		ie := tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor)
+		affected, err := ie.ExecEx(
 			ctx, "corrupt-data", nil, /* txn */
-			security.NodeUser, "UPDATE system.protected_ts_records SET ts = $1 WHERE id = $2",
+			sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
+			"UPDATE system.protected_ts_records SET ts = $1 WHERE id = $2",
 			d.String(), rec.ID.String())
 		require.NoError(t, err)
 		require.Equal(t, 1, affected)
@@ -531,8 +533,8 @@ func TestErrorsFromSQL(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	s := tc.Server(0)
-	ie := s.InternalExecutor().(sqlutil.InternalExecutorWithUser)
-	wrappedIE := &wrappedInternalExecutor{InternalExecutorWithUser: ie}
+	ie := s.InternalExecutor().(sqlutil.InternalExecutor)
+	wrappedIE := &wrappedInternalExecutor{wrapped: ie}
 	pts := ptstorage.New(s.ClusterSettings(), wrappedIE)
 
 	wrappedIE.setErrFunc(func(string) error {
@@ -577,13 +579,76 @@ func TestErrorsFromSQL(t *testing.T) {
 	}), "failed to read records: boom")
 }
 
+// wrappedInternalExecutor allows errors to be injected in SQL execution.
 type wrappedInternalExecutor struct {
-	sqlutil.InternalExecutorWithUser
+	wrapped sqlutil.InternalExecutor
 
 	mu struct {
 		syncutil.RWMutex
 		errFunc func(statement string) error
 	}
+}
+
+var _ sqlutil.InternalExecutor = &wrappedInternalExecutor{}
+
+func (ie *wrappedInternalExecutor) Exec(
+	ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
+) (int, error) {
+	panic("unimplemented")
+}
+
+func (ie *wrappedInternalExecutor) ExecEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	o sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (int, error) {
+	panic("unimplemented")
+}
+
+func (ie *wrappedInternalExecutor) QueryEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) ([]tree.Datums, error) {
+	if f := ie.getErrFunc(); f != nil {
+		if err := f(stmt); err != nil {
+			return nil, err
+		}
+	}
+	return ie.wrapped.QueryEx(ctx, opName, txn, session, stmt, qargs...)
+}
+
+func (ie *wrappedInternalExecutor) QueryWithCols(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	o sqlbase.InternalExecutorSessionDataOverride,
+	statement string,
+	qargs ...interface{},
+) ([]tree.Datums, sqlbase.ResultColumns, error) {
+	panic("unimplemented")
+}
+
+func (ie *wrappedInternalExecutor) QueryRowEx(
+	ctx context.Context,
+	opName string,
+	txn *client.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, error) {
+	if f := ie.getErrFunc(); f != nil {
+		if err := f(stmt); err != nil {
+			return nil, err
+		}
+	}
+	return ie.wrapped.QueryRowEx(ctx, opName, txn, session, stmt, qargs...)
 }
 
 func (ie *wrappedInternalExecutor) Query(
@@ -594,7 +659,7 @@ func (ie *wrappedInternalExecutor) Query(
 			return nil, err
 		}
 	}
-	return ie.InternalExecutorWithUser.Query(ctx, opName, txn, statement, params...)
+	return ie.wrapped.Query(ctx, opName, txn, statement, params...)
 }
 
 func (ie *wrappedInternalExecutor) QueryRow(
@@ -605,39 +670,7 @@ func (ie *wrappedInternalExecutor) QueryRow(
 			return nil, err
 		}
 	}
-	return ie.InternalExecutorWithUser.QueryRow(ctx, opName, txn, statement, params...)
-}
-
-func (ie *wrappedInternalExecutor) QueryWithUser(
-	ctx context.Context,
-	opName string,
-	txn *client.Txn,
-	user string,
-	statement string,
-	params ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	if f := ie.getErrFunc(); f != nil {
-		if err := f(statement); err != nil {
-			return nil, nil, err
-		}
-	}
-	return ie.InternalExecutorWithUser.QueryWithUser(ctx, opName, txn, user, statement, params...)
-}
-
-func (ie *wrappedInternalExecutor) ExecWithUser(
-	ctx context.Context,
-	opName string,
-	txn *client.Txn,
-	user string,
-	statement string,
-	params ...interface{},
-) (int, error) {
-	if f := ie.getErrFunc(); f != nil {
-		if err := f(statement); err != nil {
-			return 0, err
-		}
-	}
-	return ie.InternalExecutorWithUser.ExecWithUser(ctx, opName, txn, user, statement, params...)
+	return ie.wrapped.QueryRow(ctx, opName, txn, statement, params...)
 }
 
 func (ie *wrappedInternalExecutor) getErrFunc() func(statement string) error {

--- a/pkg/storage/protectedts/ptverifier/verifier_test.go
+++ b/pkg/storage/protectedts/ptverifier/verifier_test.go
@@ -63,7 +63,7 @@ func TestVerifier(t *testing.T) {
 		}),
 	)
 
-	pts := ptstorage.New(s.ClusterSettings(), s.InternalExecutor().(sqlutil.InternalExecutorWithUser))
+	pts := ptstorage.New(s.ClusterSettings(), s.InternalExecutor().(sqlutil.InternalExecutor))
 	withDB := ptstorage.WithDatabase(pts, s.DB())
 	db := client.NewDB(s.DB().AmbientContext, tsf, s.Clock())
 	ptv := ptverifier.New(db, pts)

--- a/pkg/storage/reports/reporter.go
+++ b/pkg/storage/reports/reporter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -844,10 +845,11 @@ type reportID int
 func getReportGenerationTime(
 	ctx context.Context, rid reportID, ex sqlutil.InternalExecutor, txn *client.Txn,
 ) (time.Time, error) {
-	row, err := ex.QueryRow(
+	row, err := ex.QueryRowEx(
 		ctx,
 		"get-previous-timestamp",
 		txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.NodeUser},
 		"select generated from system.reports_meta where id = $1",
 		rid,
 	)


### PR DESCRIPTION
The internal executor is a library that started bad and got worse. It
came in two flavors: InternalExecutor and SessionBoundInternalExecutor.
The interface was confusing, only matched by the implementation. And
besides tomes of code, neither of them could do the basic thing of
allowing a higher layer to bind most of the session data for future
internal queries, but let the user be overriden at the query site.

This patch does away with the SessionBoundInternalExecutor. It's
functionality is absorbed into the InternalExecutor. The ie now gets a
SetSessionData() method, used to bind session data. An extended query
interface is added, allowing some aspects of this session data to be
overriden on a per-query basis.

Release note: None