### PR TITLE
release-19.2: cli: fix error test missing closing paren

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -293,7 +293,8 @@ func (u urlParser) Set(v string) error {
 				}
 			}
 		default:
-			return fmt.Errorf("unsupported sslmode=%s (supported: disable, require, verify-ca, verify-full", sslMode)
+			return fmt.Errorf(
+				"unsupported sslmode=%s (supported: disable, require, verify-ca, verify-full)", sslMode)
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #44087.

/cc @cockroachdb/release

---

Release note: None
