### PR TITLE
storage: use engine.NewReadOnly in read-only gossip codepaths

### DIFF
--- a/pkg/storage/batcheval/command.go
+++ b/pkg/storage/batcheval/command.go
@@ -22,17 +22,21 @@ import (
 
 // A Command is the implementation of a single request within a BatchRequest.
 type Command struct {
-	// DeclareKeys adds all keys this command touches, and when (if applicable), to the given SpanSet.
+	// DeclareKeys adds all keys this command touches, and when (if applicable),
+	// to the given SpanSet.
+	//
 	// TODO(nvanbenschoten): rationalize this RangeDescriptor. Can it change
 	// between key declaration and cmd evaluation?
 	DeclareKeys func(*roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
 
 	// Eval{RW,RO} evaluates a read-{write,only} command respectively on the
-	// given engine.{ReadWriter,Reader}. It should populate the supplied
-	// response (always a non-nil pointer to the correct type) and return
-	// special side effects (if any) in the Result. If it writes to the engine
-	// it should also update *CommandArgs.Stats. It should treat the provided
-	// request as immutable.
+	// given engine.{ReadWriter,Reader}. This is typically derived from
+	// engine.NewBatch or engine.NewReadOnly (which is more performant than
+	// engine.Batch for read-only commands).
+	// It should populate the supplied response (always a non-nil pointer to the
+	// correct type) and return special side effects (if any) in the Result. If
+	// it writes to the engine it should also update *CommandArgs.Stats. It
+	// should treat the provided request as immutable.
 	//
 	// Only one of these is ever set at a time.
 	EvalRW func(context.Context, engine.ReadWriter, CommandArgs, roachpb.Response) (result.Result, error)

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -133,8 +133,11 @@ func (r *Replica) MaybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(span)})
 	// Call evaluateBatch instead of Send to avoid reacquiring latches.
 	rec := NewReplicaEvalContext(r, todoSpanSet)
+	rw := r.Engine().NewReadOnly()
+	defer rw.Close()
+
 	br, result, pErr :=
-		evaluateBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, &ba, true /* readOnly */)
+		evaluateBatch(ctx, storagebase.CmdIDKey(""), rw, rec, nil, &ba, true /* readOnly */)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}
@@ -173,8 +176,11 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(keys.SystemConfigSpan)})
 	// Call evaluateBatch instead of Send to avoid reacquiring latches.
 	rec := NewReplicaEvalContext(r, todoSpanSet)
+	rw := r.Engine().NewReadOnly()
+	defer rw.Close()
+
 	br, result, pErr := evaluateBatch(
-		ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, &ba, true, /* readOnly */
+		ctx, storagebase.CmdIDKey(""), rw, rec, nil, &ba, true, /* readOnly */
 	)
 	if pErr != nil {
 		return nil, pErr.GoError()


### PR DESCRIPTION
Seems like the right thing to do, and certainly preferable to passing in
the raw engine.

Release note: None