### PR TITLE
colexec: minor cleanup

### DIFF
--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -167,8 +167,8 @@ func (a *anyNotNull_TYPEAgg) HandleEmptyInputScalar() {
 // the first row of a new group, and no non-nulls have been found for the
 // current group, then the output for the current group is set to null.
 func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
+	// {{define "findAnyNotNull" -}}
 
-	// {{define "findAnyNotNull"}}
 	if a.groups[i] {
 		// If this is a new group, check if any non-nulls have been found for the
 		// current group. The `a.curIdx` check is necessary because for the first
@@ -189,11 +189,8 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// If we haven't seen any non-nulls for the current group yet, and the
 		// current value is non-null, then we can pick the current value to be the
 		// output.
-		// Explicit template language is used here because the type receiver differs
-		// from the rest of the template file.
-		// TODO(asubiotto): Figure out a way to alias this.
-		// v := {{ .Global.Get "col" "int(i)" }}
-		// {{ .Global.Set "a.col" "a.curIdx" "v" }}
+		v := execgen.UNSAFEGET(col, int(i))
+		execgen.SET(a.col, a.curIdx, v)
 		a.foundNonNullForCurrentGroup = true
 	}
 	// {{end}}

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -623,11 +623,6 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
 		case stateResetBatch:
-			for _, colvec := range rf.machine.colvecs {
-				if colvec.Type() != coltypes.Unhandled {
-					colvec.Nulls().UnsetNulls()
-				}
-			}
 			rf.machine.batch.ResetInternalBatch()
 			rf.shiftState()
 		case stateDecodeFirstKVOfRow:

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -13,11 +13,10 @@ package main
 import (
 	"io"
 	"io/ioutil"
-	"regexp"
 	"strings"
 	"text/template"
 
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func genAnyNotNullAgg(wr io.Writer) error {
@@ -28,27 +27,22 @@ func genAnyNotNullAgg(wr io.Writer) error {
 
 	s := string(t)
 
-	s = strings.Replace(s, "_GOTYPESLICE", "{{.GoTypeSliceName}}", -1)
-	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.}}", -1)
-	s = strings.Replace(s, "_TYPE", "{{.}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.}}", -1)
+	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
 
 	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 4)
-	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $4}}`)
+	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "LTyp" .LTyp "HasNulls" $4}}`)
 
-	s = replaceManipulationFuncs("", s)
-
-	// We have to use explicit template language for some manipulation functions
-	// but need to comment it out so that formatting checks don't fail. Remove the
-	// comments here.
-	s = regexp.MustCompile("// (v := {{ .Global.Get|{{ .Global.Set)").ReplaceAllString(s, "$1")
+	s = replaceManipulationFuncs(".LTyp", s)
 
 	tmpl, err := template.New("any_not_null_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(wr, coltypes.AllTypes)
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.EQ])
 }
 
 func init() {

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -610,8 +610,9 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 1); err != nil {
 				return result, err
 			}
+			outputIdx := len(spec.Input[0].ColumnTypes)
+			result.Op, result.IsStreaming = NewOrdinalityOp(NewAllocator(ctx, streamingMemAccount), inputs[0], outputIdx), true
 			result.ColumnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
-			result.Op, result.IsStreaming = NewOrdinalityOp(NewAllocator(ctx, streamingMemAccount), inputs[0]), true
 
 		case core.HashJoiner != nil:
 			createHashJoinerWithOnExprPlanning := func(

--- a/pkg/sql/colexec/ordinality.go
+++ b/pkg/sql/colexec/ordinality.go
@@ -23,24 +23,22 @@ type ordinalityOp struct {
 	OneInputNode
 
 	allocator *Allocator
-	// ordinalityCol is the index of the column in which ordinalityOp will write
-	// the ordinal number.
-	ordinalityCol int
+	// outputIdx is the index of the column in which ordinalityOp will write the
+	// ordinal number.
+	outputIdx int
 	// counter is the number of tuples seen so far.
 	counter int64
 }
 
 var _ Operator = &ordinalityOp{}
 
-const ordinalityColIndexUnknown = -1
-
 // NewOrdinalityOp returns a new WITH ORDINALITY operator.
-func NewOrdinalityOp(allocator *Allocator, input Operator) Operator {
+func NewOrdinalityOp(allocator *Allocator, input Operator, outputIdx int) Operator {
 	c := &ordinalityOp{
-		OneInputNode:  NewOneInputNode(input),
-		allocator:     allocator,
-		ordinalityCol: ordinalityColIndexUnknown,
-		counter:       1,
+		OneInputNode: NewOneInputNode(input),
+		allocator:    allocator,
+		outputIdx:    outputIdx,
+		counter:      1,
 	}
 	return c
 }
@@ -54,12 +52,9 @@ func (c *ordinalityOp) Next(ctx context.Context) coldata.Batch {
 	if bat.Length() == 0 {
 		return coldata.ZeroBatch
 	}
-	if c.ordinalityCol == ordinalityColIndexUnknown {
-		c.ordinalityCol = bat.Width()
-	}
-	c.allocator.MaybeAddColumn(bat, coltypes.Int64, c.ordinalityCol)
+	c.allocator.MaybeAddColumn(bat, coltypes.Int64, c.outputIdx)
 
-	vec := bat.ColVec(c.ordinalityCol).Int64()
+	vec := bat.ColVec(c.outputIdx).Int64()
 	sel := bat.Selection()
 
 	if sel != nil {

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -46,7 +46,7 @@ func TestOrdinality(t *testing.T) {
 	for _, tc := range tcs {
 		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
 			func(input []Operator) (Operator, error) {
-				return NewOrdinalityOp(testAllocator, input[0]), nil
+				return NewOrdinalityOp(testAllocator, input[0], len(tc.tuples[0])), nil
 			})
 	}
 }
@@ -57,11 +57,10 @@ func BenchmarkOrdinality(b *testing.B) {
 	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
 	batch.SetLength(coldata.BatchSize())
 	source := NewRepeatableBatchSource(batch)
-	source.Init()
+	ordinality := NewOrdinalityOp(testAllocator, source, batch.Width())
+	ordinality.Init()
 
-	ordinality := NewOrdinalityOp(testAllocator, source)
-
-	b.SetBytes(int64(8 * int(coldata.BatchSize()) * batch.Width()))
+	b.SetBytes(int64(8 * int(coldata.BatchSize())))
 	for i := 0; i < b.N; i++ {
 		ordinality.Next(ctx)
 	}


### PR DESCRIPTION
**colexec: clean up ordinalityOp**

This commit changes the planning of ordinalityOp to specify the output
column index (previously, the column was simply appended on the first
call to Next). This unifies ordinalityOp with all other operators. Also,
in theory it is possible that different batches are returned by the
input to ordinalityOp, and the later batches might not have the appended
column, but I cannot reproduce it in practice (probably because
ordinality processor is only planned in non-distributed fashion, and if
several nodes stream data to it, the streams will have been merged
somehow). Anyway, I think this change is beneficial.

Release note: None

**colexec: remove redundant unset of Nulls in cfetcher**

Nulls are reset as part of ResetInternalBatch call below, so unsetting
them explicitly is redundant and is now removed.

Release note: None

**colexec: clean up any_not_null_agg template**

This commit removes explicit template language to align
any_not_null_tmpl with others.

Release note: None
