### PR TITLE
release-19.2: backupccl: stop including stats in job payload

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1360,7 +1360,33 @@ func (b *backupResumer) Resume(
 		checkpointDesc,
 		resultsCh,
 	)
+	if err != nil {
+		return err
+	}
 	b.res = res
+
+	err = b.clearStats(ctx, p.ExecCfg().DB)
+	if err != nil {
+		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
+	}
+	return nil
+}
+
+func (b *backupResumer) clearStats(ctx context.Context, DB *client.DB) error {
+	details := b.job.Details().(jobspb.BackupDetails)
+	var backupDesc BackupDescriptor
+	if err := protoutil.Unmarshal(details.BackupDescriptor, &backupDesc); err != nil {
+		return err
+	}
+	backupDesc.Statistics = nil
+	descBytes, err := protoutil.Marshal(&backupDesc)
+	if err != nil {
+		return err
+	}
+	details.BackupDescriptor = descBytes
+	err = DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		return b.job.WithTxn(txn).SetDetails(ctx, details)
+	})
 	return err
 }
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -410,6 +410,25 @@ func backupAndRestore(
 			t.Fatalf("expected %d rows for %d accounts, got %d", expected, numAccounts, exported.rows)
 		}
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
+		const stmt = "SELECT payload FROM system.jobs ORDER BY created DESC LIMIT 1"
+		var payloadBytes []byte
+		sqlDB.QueryRow(t, stmt).Scan(&payloadBytes)
+
+		payload := &jobspb.Payload{}
+		if err := protoutil.Unmarshal(payloadBytes, payload); err != nil {
+			t.Fatal("cannot unmarshal job payload from system.jobs")
+		}
+
+		backupDesc := &backupccl.BackupDescriptor{}
+		backupDetails := payload.Details.(*jobspb.Payload_Backup).Backup
+		if err := protoutil.Unmarshal(backupDetails.BackupDescriptor, backupDesc); err != nil {
+			t.Fatal("cannot unmarshal backup descriptor from job payload from system.jobs")
+		}
+		if backupDesc.Statistics != nil {
+			t.Fatal("expected statistics field of backup descriptor payload to be nil")
+		}
+
 		sqlDB.ExpectErr(t, "already contains a BACKUP file", backupQuery, backupURIArgs...)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #44180.

/cc @cockroachdb/release

---

When statistics were added to backups they were added to the
BackupDescriptor which would be written to the backup manifest. However,
this also meant that they were included in the payload of the backup job
itself. Therefore, if sufficient backups were taken each entry, the
system.jobs table was becoming much larger than before. This resulted in
clusters using a lot of memory when issuing commands such as SHOW JOBS.

This PR removes the Statistics field on the BackupDescriptor upon
completion of the job so that the system.jobs table doesn't grow too
large.

Addresses #44166.

Release note (bug fix): Remove statistics information from backup jobs'
payload information to avoid excessive memory utilization when issuing
commands such as SHOW JOBS.
