### PR TITLE
release-2.1: server,sql: allow admin UI to view table details for non-admins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -917,6 +917,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.get_namespace_id(parent_id: <a href="int.html">int</a>, name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td></td></tr>
+<tr><td><code>crdb_internal.get_zone_config(namespace_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td></td></tr>
 <tr><td><code>crdb_internal.is_admin() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Retrieves the current user’s admin status.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1995,20 +1995,31 @@ func (rs resultScanner) Scan(row tree.Datums, colName string, dst interface{}) e
 func (s *adminServer) queryZone(
 	ctx context.Context, userName string, id sqlbase.ID,
 ) (config.ZoneConfig, bool, error) {
-	const query = `SELECT config FROM system.zones WHERE id = $1`
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
-		ctx, "admin-query-zone", nil /* txn */, userName, query, id,
+	const query = `SELECT crdb_internal.get_zone_config($1)`
+	rows, cols, err := s.server.internalExecutor.QueryWithUser(
+		ctx,
+		"admin-query-zone",
+		nil, /* txn */
+		userName,
+		query,
+		id,
 	)
 	if err != nil {
 		return config.ZoneConfig{}, false, err
 	}
 
-	if len(rows) == 0 {
-		return config.ZoneConfig{}, false, nil
+	if len(rows) != 1 {
+		return config.ZoneConfig{}, false, errors.Errorf("invalid number of rows returned: %s (%d)", query, id)
 	}
 
 	var zoneBytes []byte
-	scanner := resultScanner{}
+	scanner := makeResultScanner(cols)
+	if isNull, err := scanner.IsNull(rows[0], cols[0].Name); err != nil {
+		return config.ZoneConfig{}, false, err
+	} else if isNull {
+		return config.ZoneConfig{}, false, nil
+	}
+
 	err = scanner.ScanIndex(rows[0], 0, &zoneBytes)
 	if err != nil {
 		return config.ZoneConfig{}, false, err
@@ -2041,20 +2052,26 @@ func (s *adminServer) queryZonePath(
 func (s *adminServer) queryNamespaceID(
 	ctx context.Context, userName string, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
-	const query = `SELECT id FROM system.namespace WHERE "parentID" = $1 AND name = $2`
-	rows, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
+	const query = `SELECT crdb_internal.get_namespace_id($1, $2)`
+	rows, cols, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-query-namespace-ID", nil /* txn */, userName, query, parentID, name,
 	)
 	if err != nil {
 		return 0, err
 	}
 
-	if len(rows) == 0 {
-		return 0, errors.Errorf("namespace %s with ParentID %d not found", name, parentID)
+	if len(rows) != 1 {
+		return 0, errors.Errorf("invalid number of rows returned: %s (%d, %s)", query, parentID, name)
 	}
 
 	var id int64
-	scanner := resultScanner{}
+	scanner := makeResultScanner(cols)
+	if isNull, err := scanner.IsNull(rows[0], cols[0].Name); err != nil {
+		return 0, err
+	} else if isNull {
+		return 0, errors.Errorf("namespace %s with ParentID %d not found", name, parentID)
+	}
+
 	err = scanner.ScanIndex(rows[0], 0, &id)
 	if err != nil {
 		return 0, err

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -60,7 +60,13 @@ import (
 func getAdminJSONProto(
 	ts serverutils.TestServerInterface, path string, response protoutil.Message,
 ) error {
-	return serverutils.GetJSONProto(ts, adminPrefix+path, response)
+	return getAdminJSONProtoWithAdminOption(ts, path, response, true)
+}
+
+func getAdminJSONProtoWithAdminOption(
+	ts serverutils.TestServerInterface, path string, response protoutil.Message, isAdmin bool,
+) error {
+	return serverutils.GetJSONProtoWithAdminOption(ts, adminPrefix+path, response, isAdmin)
 }
 
 func postAdminJSONProto(
@@ -237,88 +243,114 @@ func TestAdminAPIDatabases(t *testing.T) {
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
 	defer span.Finish()
 
-	// Test databases endpoint.
 	const testdb = "test"
 	query := "CREATE DATABASE " + testdb
 	if _, err := db.Exec(query); err != nil {
 		t.Fatal(err)
 	}
 
-	var resp serverpb.DatabasesResponse
-	if err := getAdminJSONProto(s, "databases", &resp); err != nil {
+	// We have to create the non-admin user before calling
+	// "GRANT ... TO authenticatedUserNameNoAdmin".
+	// This is done in "GetAuthenticatedHTTPClient".
+	if _, err := ts.GetAuthenticatedHTTPClient(false); err != nil {
 		t.Fatal(err)
 	}
 
-	expectedDBs := []string{"defaultdb", "postgres", "system", testdb}
-	if a, e := len(resp.Databases), len(expectedDBs); a != e {
-		t.Fatalf("length of result %d != expected %d", a, e)
-	}
-
-	sort.Strings(resp.Databases)
-	for i, e := range expectedDBs {
-		if a := resp.Databases[i]; a != e {
-			t.Fatalf("database name %s != expected %s", a, e)
-		}
-	}
-
-	// Test database details endpoint.
+	// Grant permissions to view the tables for the given viewing user.
 	privileges := []string{"SELECT", "UPDATE"}
-	testuser := "testuser"
-	createUserQuery := "CREATE USER " + testuser
-	if _, err := db.Exec(createUserQuery); err != nil {
+	query = fmt.Sprintf(
+		"GRANT %s ON DATABASE %s TO %s",
+		strings.Join(privileges, ", "),
+		testdb,
+		authenticatedUserNameNoAdmin,
+	)
+	if _, err := db.Exec(query); err != nil {
 		t.Fatal(err)
 	}
 
-	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	if _, err := db.Exec(grantQuery); err != nil {
-		t.Fatal(err)
-	}
-
-	var details serverpb.DatabaseDetailsResponse
-	if err := getAdminJSONProto(s, "databases/"+testdb, &details); err != nil {
-		t.Fatal(err)
-	}
-
-	if a, e := len(details.Grants), 4; a != e {
-		t.Fatalf("# of grants %d != expected %d", a, e)
-	}
-
-	userGrants := make(map[string][]string)
-	for _, grant := range details.Grants {
-		switch grant.User {
-		case sqlbase.AdminRole, security.RootUser, testuser:
-			userGrants[grant.User] = append(userGrants[grant.User], grant.Privileges...)
-		default:
-			t.Fatalf("unknown grant to user %s", grant.User)
-		}
-	}
-	for u, p := range userGrants {
-		switch u {
-		case sqlbase.AdminRole:
-			if !reflect.DeepEqual(p, []string{"ALL"}) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
+	for _, tc := range []struct {
+		expectedDBs []string
+		isAdmin     bool
+	}{
+		{[]string{"defaultdb", "postgres", "system", testdb}, true},
+		{[]string{testdb}, false},
+	} {
+		t.Run(fmt.Sprintf("isAdmin:%t", tc.isAdmin), func(t *testing.T) {
+			// Test databases endpoint.
+			var resp serverpb.DatabasesResponse
+			if err := getAdminJSONProtoWithAdminOption(
+				s,
+				"databases",
+				&resp,
+				tc.isAdmin,
+			); err != nil {
+				t.Fatal(err)
 			}
-		case security.RootUser:
-			if !reflect.DeepEqual(p, []string{"ALL"}) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
-			}
-		case testuser:
-			sort.Strings(p)
-			if !reflect.DeepEqual(p, privileges) {
-				t.Fatalf("privileges %v != expected %v", p, privileges)
-			}
-		default:
-			t.Fatalf("unknown grant to user %s", u)
-		}
-	}
 
-	// Verify Descriptor ID.
-	path, err := ts.admin.queryDescriptorIDPath(ctx, security.RootUser, []string{testdb})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if a, e := details.DescriptorID, int64(path[1]); a != e {
-		t.Fatalf("db had descriptorID %d, expected %d", a, e)
+			if a, e := len(resp.Databases), len(tc.expectedDBs); a != e {
+				t.Fatalf("length of result %d != expected %d", a, e)
+			}
+
+			sort.Strings(resp.Databases)
+			for i, e := range tc.expectedDBs {
+				if a := resp.Databases[i]; a != e {
+					t.Fatalf("database name %s != expected %s", a, e)
+				}
+			}
+
+			// Test database details endpoint.
+			var details serverpb.DatabaseDetailsResponse
+			if err := getAdminJSONProtoWithAdminOption(
+				s,
+				"databases/"+testdb,
+				&details,
+				tc.isAdmin,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if a, e := len(details.Grants), 4; a != e {
+				t.Fatalf("# of grants %d != expected %d", a, e)
+			}
+
+			userGrants := make(map[string][]string)
+			for _, grant := range details.Grants {
+				switch grant.User {
+				case sqlbase.AdminRole, security.RootUser, authenticatedUserNameNoAdmin:
+					userGrants[grant.User] = append(userGrants[grant.User], grant.Privileges...)
+				default:
+					t.Fatalf("unknown grant to user %s", grant.User)
+				}
+			}
+			for u, p := range userGrants {
+				switch u {
+				case sqlbase.AdminRole:
+					if !reflect.DeepEqual(p, []string{"ALL"}) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				case security.RootUser:
+					if !reflect.DeepEqual(p, []string{"ALL"}) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				case authenticatedUserNameNoAdmin:
+					sort.Strings(p)
+					if !reflect.DeepEqual(p, privileges) {
+						t.Fatalf("privileges %v != expected %v", p, privileges)
+					}
+				default:
+					t.Fatalf("unknown grant to user %s", u)
+				}
+			}
+
+			// Verify Descriptor ID.
+			path, err := ts.admin.queryDescriptorIDPath(ctx, security.RootUser, []string{testdb})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if a, e := details.DescriptorID, int64(path[1]); a != e {
+				t.Fatalf("db had descriptorID %d, expected %d", a, e)
+			}
+		})
 	}
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1779,10 +1779,11 @@ func (ex *connExecutor) evalCtx(
 
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
-			Planner:         p,
-			Sequence:        p,
-			SessionAccessor: p,
-			StmtTimestamp:   stmtTS,
+			Planner:            p,
+			Sequence:           p,
+			SessionAccessor:    p,
+			PrivilegedAccessor: p,
+			StmtTimestamp:      stmtTS,
 
 			Txn:              txn,
 			SessionData:      &ex.sessionData,

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -166,6 +166,35 @@ func getDescriptor(
 	return true, nil
 }
 
+// lookupDescriptorByID looks up the descriptor for `id` and returns it.
+// It can be a table or database descriptor.
+// Returns the descriptor (if found), a bool representing whether the
+// descriptor was found and an error if any.
+func lookupDescriptorByID(
+	ctx context.Context, txn *client.Txn, id sqlbase.ID,
+) (sqlbase.DescriptorProto, bool, error) {
+	var desc sqlbase.DescriptorProto
+	for _, lookupFn := range []func() (sqlbase.DescriptorProto, error){
+		func() (sqlbase.DescriptorProto, error) {
+			return sqlbase.GetTableDescFromID(ctx, txn, id)
+		},
+		func() (sqlbase.DescriptorProto, error) {
+			return sqlbase.GetDatabaseDescFromID(ctx, txn, id)
+		},
+	} {
+		var err error
+		desc, err = lookupFn()
+		if err != nil {
+			if err == sqlbase.ErrDescriptorNotFound {
+				continue
+			}
+			return nil, false, err
+		}
+		return desc, true, nil
+	}
+	return nil, false, nil
+}
+
 // getDescriptorByID looks up the descriptor for `id`, validates it,
 // and unmarshals it into `descriptor`.
 //

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2053,3 +2053,104 @@ UTF8
 # Ensure that privileged builtins work from DistSQL.
 statement ok
 SELECT crdb_internal.set_vmodule('foo=2') FROM foo
+
+# Test crdb_internal commands which execute as root, but
+# only checks for permissions afterwards.
+subtest crdb_internal_privileged_only
+
+user root
+
+statement ok
+CREATE DATABASE root_test
+
+statement ok
+CREATE TABLE root_test.t(a int)
+
+statement ok
+ALTER DATABASE root_test CONFIGURE ZONE USING num_replicas = 5
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
+----
+NULL
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+----
+59
+
+query I
+SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
+----
+60
+
+query T
+SELECT crdb_internal.get_zone_config(-1)::string
+----
+NULL
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
+----
+\x10808040188080802022040890bf052805
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
+----
+NULL
+
+# switch users -- this one has no permissions so expect errors
+user testuser
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
+----
+NULL
+
+query error insufficient privilege
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+
+query T
+SELECT crdb_internal.get_zone_config(-1)::string
+----
+NULL
+
+query error insufficient privilege
+SELECT crdb_internal.get_zone_config(60)::string -- based on root query. having no permissions blocks us from this test rapidly changing though.
+
+# give testuser permissions on everything and retest
+user root
+
+statement ok
+GRANT ALL ON DATABASE root_test TO testuser
+
+statement ok
+GRANT ALL ON root_test.t TO testuser
+
+user testuser
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+----
+59
+
+query I
+SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
+----
+60
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
+----
+\x10808040188080802022040890bf052805
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
+----
+NULL
+
+# reset state to default
+user root
+
+statement ok
+DROP DATABASE root_test CASCADE

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -256,6 +256,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Planner = p
 	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.SessionAccessor = p
+	p.extendedEvalCtx.PrivilegedAccessor = p
 	p.extendedEvalCtx.ClusterID = execCfg.ClusterID()
 	p.extendedEvalCtx.NodeID = execCfg.NodeID.Get()
 

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -1,0 +1,88 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// LookupNamespaceID implements tree.PrivilegedAccessor.
+func (p *planner) LookupNamespaceID(
+	ctx context.Context, parentID int64, name string,
+) (tree.DInt, bool, error) {
+	const query = `SELECT id FROM system.namespace WHERE "parentID" = $1 AND name = $2`
+	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
+		ctx,
+		"crdb-internal-get-descriptor-id",
+		p.txn,
+		query,
+		parentID,
+		name,
+	)
+	if err != nil {
+		return 0, false, err
+	}
+	if r == nil {
+		return 0, false, nil
+	}
+	id := tree.MustBeDInt(r[0])
+	if err = p.checkDescriptorPermissions(ctx, sqlbase.ID(id)); err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
+// LookupZoneConfigByNamespaceID implements tree.PrivilegedAccessor.
+func (p *planner) LookupZoneConfigByNamespaceID(
+	ctx context.Context, id int64,
+) (tree.DBytes, bool, error) {
+	if err := p.checkDescriptorPermissions(ctx, sqlbase.ID(id)); err != nil {
+		return "", false, err
+	}
+
+	const query = `SELECT config FROM system.zones WHERE id = $1`
+	r, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
+		ctx,
+		"crdb-internal-get-zone",
+		p.txn,
+		query,
+		id,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	if r == nil {
+		return "", false, nil
+	}
+	return tree.MustBeDBytes(r[0]), true, nil
+}
+
+// checkDescriptorPermissions returns nil if the executing user has permissions
+// to check the permissions of a descriptor given its ID, or the id given
+// is not a descriptor of a table or database.
+func (p *planner) checkDescriptorPermissions(ctx context.Context, id sqlbase.ID) error {
+	desc, found, err := lookupDescriptorByID(ctx, p.txn, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
+		return errors.New("insufficient privilege")
+	}
+	return nil
+}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2882,6 +2882,68 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	// Returns a namespace_id based on parentID and a given name.
+	// Allows a non-admin to query the system.namespace table, but performs
+	// the relevant permission checks to ensure secure access.
+	// Returns NULL if none is found.
+	// Errors if there is no permission for the current user to view the descriptor.
+	"crdb_internal.get_namespace_id": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"parent_id", types.Int}, {"name", types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if ctx.PrivilegedAccessor == nil {
+					return nil, errors.New("PrivilegedAccessor not set")
+				}
+
+				parentID := tree.MustBeDInt(args[0])
+				name := tree.MustBeDString(args[1])
+				id, found, err := ctx.PrivilegedAccessor.LookupNamespaceID(
+					ctx.Context,
+					int64(parentID),
+					string(name),
+				)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					return tree.DNull, nil
+				}
+				return tree.NewDInt(id), nil
+			},
+		},
+	),
+
+	// Returns the zone config based on a given namespace id.
+	// Returns NULL if a zone configuration is not found.
+	// Errors if there is no permission for the current user to view the zone config.
+	"crdb_internal.get_zone_config": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"namespace_id", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if ctx.PrivilegedAccessor == nil {
+					return nil, errors.New("PrivilegedAccessor not set")
+				}
+
+				id := tree.MustBeDInt(args[0])
+				bytes, found, err := ctx.PrivilegedAccessor.LookupZoneConfigByNamespaceID(
+					ctx.Context,
+					int64(id),
+				)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					return tree.DNull, nil
+				}
+				return tree.NewDBytes(bytes), nil
+			},
+		},
+	),
+
 	// Returns true iff the current user has admin role.
 	// Note: it would be a privacy leak to extend this to check arbitrary usernames.
 	"crdb_internal.is_admin": makeBuiltin(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2275,6 +2275,25 @@ type SessionBoundInternalExecutor interface {
 	) (Datums, error)
 }
 
+// PrivilegedAccessor gives access to certain queries that would otherwise
+// require someone with RootUser access to query a given data source.
+// It is defined independently to prevent a circular dependency on sql, tree and sqlbase.
+type PrivilegedAccessor interface {
+	// LookupNamespaceID returns the id of the namespace given it's parent id and name.
+	// It is meant as a replacement for looking up the system.namespace directly.
+	// Returns the id, a bool representing whether the namespace exists, and an error
+	// if there is one.
+	LookupNamespaceID(
+		ctx context.Context, parentID int64, name string,
+	) (DInt, bool, error)
+
+	// LookupZoneConfig returns the zone config given a namespace id.
+	// It is meant as a replacement for looking up system.zones directly.
+	// Returns the config byte array, a bool representing whether the namespace exists,
+	// and an error if there is one.
+	LookupZoneConfigByNamespaceID(ctx context.Context, id int64) (DBytes, bool, error)
+}
+
 // SequenceOperators is used for various sql related functions that can
 // be used from EvalContext.
 type SequenceOperators interface {
@@ -2377,6 +2396,8 @@ type EvalContext struct {
 	InternalExecutor SessionBoundInternalExecutor
 
 	Planner EvalPlanner
+
+	PrivilegedAccessor PrivilegedAccessor
 
 	SessionAccessor EvalSessionAccessor
 


### PR DESCRIPTION
Backport 1/1 commits from #44167.

/cc @cockroachdb/release

---

Resolves #44033 

* Added `crdb_internal.get_zone_config` and
`crdb_internal.get_namespace_id`, which executes queries to system
tables and checks permissions afterwards. This is needed for speedy
point lookups for the admin UI.
* Modified the EvalContext with a PrivilegedAccessor, containing
any accessors that requires privileged access to view data.
* Modified the admin UI to use the new crdb_internal queries.

Release note (admin ui change, security update, bug fix): We previously
introduced a fix on the admin UI to prevent non-admin users from
executing queries - however, this accidentally made certain pages
requiring table details not to display. This PR allows the table details
to be displayed in its former glory.
