### PR TITLE
release-19.2: colexec: fix multiple starts of the wrapped processors

### DIFF
--- a/pkg/sql/colexec/buffer.go
+++ b/pkg/sql/colexec/buffer.go
@@ -21,6 +21,7 @@ import (
 // and makes it available to be read multiple times by downstream consumers.
 type bufferOp struct {
 	OneInputNode
+	initStatus OperatorInitStatus
 
 	// read is true if someone has read the current batch already.
 	read     bool
@@ -46,7 +47,14 @@ func (b *bufferOp) EstimateStaticMemoryUsage() int {
 }
 
 func (b *bufferOp) Init() {
-	b.input.Init()
+	// bufferOp can be an input to multiple operator chains, so Init on it can be
+	// called multiple times. However, we do not want to call Init many times on
+	// the input to bufferOp, so we do this check whether Init has already been
+	// performed.
+	if b.initStatus == OperatorNotInitialized {
+		b.input.Init()
+		b.initStatus = OperatorInitialized
+	}
 }
 
 // rewind resets this buffer to be readable again.

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -30,8 +30,9 @@ type Columnarizer struct {
 	execinfra.ProcessorBase
 	NonExplainable
 
-	input execinfra.RowSource
-	da    sqlbase.DatumAlloc
+	input      execinfra.RowSource
+	da         sqlbase.DatumAlloc
+	initStatus OperatorInitStatus
 
 	buffered        sqlbase.EncDatumRows
 	batch           coldata.Batch
@@ -76,13 +77,19 @@ func (c *Columnarizer) EstimateStaticMemoryUsage() int {
 
 // Init is part of the Operator interface.
 func (c *Columnarizer) Init() {
-	c.batch = coldata.NewMemBatch(c.typs)
-	c.buffered = make(sqlbase.EncDatumRows, coldata.BatchSize())
-	for i := range c.buffered {
-		c.buffered[i] = make(sqlbase.EncDatumRow, len(c.typs))
+	// We don't want to call Start on the input to columnarizer and allocating
+	// internal objects several times if Init method is called more than once, so
+	// we have this check in place.
+	if c.initStatus == OperatorNotInitialized {
+		c.batch = coldata.NewMemBatch(c.typs)
+		c.buffered = make(sqlbase.EncDatumRows, coldata.BatchSize())
+		for i := range c.buffered {
+			c.buffered[i] = make(sqlbase.EncDatumRow, len(c.typs))
+		}
+		c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
+		c.input.Start(c.ctx)
+		c.initStatus = OperatorInitialized
 	}
-	c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
-	c.input.Start(c.ctx)
 }
 
 // Next is part of the Operator interface.

--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -96,6 +96,7 @@ const (
 	colPackagePrefix          = "github.com/cockroachdb/cockroach/pkg/col"
 	colexecPackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	colflowsetupPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/colflow"
+	execinfraPackagePrefix    = "github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	treePackagePrefix         = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -114,6 +115,7 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 	return strings.HasPrefix(panicEmittedFrom, colPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colexecPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colflowsetupPackagePrefix) ||
+		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, treePackagePrefix)
 }
 

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -39,6 +39,17 @@ type Operator interface {
 	execinfra.OpNode
 }
 
+// OperatorInitStatus indicates whether Init method has already been called on
+// an Operator.
+type OperatorInitStatus int
+
+const (
+	// OperatorNotInitialized indicates that Init has not been called yet.
+	OperatorNotInitialized OperatorInitStatus = iota
+	// OperatorInitialized indicates that Init has already been called.
+	OperatorInitialized
+)
+
 // NonExplainable is a marker interface which identifies an Operator that
 // should be omitted from the output of EXPLAIN (VEC). Note that VERBOSE
 // explain option will override the omitting behavior.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1050,3 +1050,10 @@ query I
 SELECT max(c) FROM a
 ----
 2000
+
+# Regression test for starting wrapped processors multiple times.
+statement ok
+CREATE TABLE t44133_0(c0 STRING); CREATE TABLE t44133_1(c0 STRING UNIQUE NOT NULL)
+
+statement ok
+SELECT * FROM t44133_0, t44133_1 WHERE t44133_0.c0 NOT BETWEEN t44133_1.c0 AND '' AND (t44133_1.c0 IS NULL)


### PR DESCRIPTION
Backport 2/2 commits from #44144.

/cc @cockroachdb/release

---

**colexec: fix multiple starts of the wrapped processors**

Previously, wrapped processors could be started multiple times if they
were in the input chain for the bufferOp (each of the CASE arms will
initialize its input - the bufferOp). Now this is fixed by tracking in
both Columnarizer and bufferOp whether Init has already been called.

Previous behavior could lead to a crash when rowexec.valuesProcessor was
wrapped because it sends a "bogus" metadata header on each call to
Start, and only single header is expected whereas with multiple Inits
they would be multiple headers.

Fixes: #44133.

Release note: None.

**execerror: catch panics coming from sql/execinfra package**

sql/execinfra is definitely a part of the vectorized engine as a whole,
so we should be catching panics coming from it when running vectorized
flows.

Release note: None
