### PR TITLE
sql: stop-gap workaround for invalid concurrent uses of client.Txn

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -445,7 +445,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// well as in-between very stage of cascading actions.
 	// This TODO can be removed when the cascading code is reorganized
 	// accordingly and the missing call to Step() is introduced.
-	if err := ex.state.mu.txn.Step(ctx); err != nil {
+	if err := ex.state.stepLocked(ctx); err != nil {
 		return makeErrEvent(err)
 	}
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -991,7 +991,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 		// We place a sequence point before every postquery, so
 		// that each subsequent postquery can observe the writes
 		// by the previous step.
-		if err := planner.Txn().Step(ctx); err != nil {
+		if err := planner.step(ctx); err != nil {
 			recv.SetError(err)
 			return false
 		}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -400,6 +400,15 @@ func (p *planner) Txn() *client.Txn {
 	return p.txn
 }
 
+func (p *planner) step(ctx context.Context) error {
+	if p.extendedEvalCtx.TxnReadOnly {
+		// A read-only txn does not contain writes and thus cannot step.
+		// See the comment over (txnState).stepLocked for a rationale.
+		return nil
+	}
+	return p.txn.Step(ctx)
+}
+
 func (p *planner) User() string {
 	return p.SessionData().User
 }

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -446,3 +446,26 @@ func (ts *txnState) consumeAdvanceInfo() advanceInfo {
 	ts.adv = advanceInfo{}
 	return adv
 }
+
+// stepLocked advances the sequencing step. This is a no-op if the txn
+// is read-only.
+//
+// This no-op behavior is needed because concurrent clients using the
+// same client.Txn are racing with each other to (re)configure the
+// stepping mode. This is a bug/misdesign, see this issue:
+// https://github.com/cockroachdb/cockroach/issues/44201
+//
+// Until that issue is fixed, we simply say "calling step() is
+// possible even with misconfigured stepping modes, as long as the txn
+// is read-only". This is valid because read-only txns do not emit
+// mutations and thus all Step() calls would be no-ops anyway.
+//
+// TODO(andrei,knz): Remove this method and (*planner).step() when
+// remaining invalid concurrent uses of client.Txns have been
+// eliminated.
+func (ts *txnState) stepLocked(ctx context.Context) error {
+	if ts.readOnly {
+		return nil
+	}
+	return ts.mu.txn.Step(ctx)
+}


### PR DESCRIPTION
Informs #44201 
Informs these test flakes: https://github.com/cockroachdb/cockroach/issues/44188#issuecomment-576974114 and #44321

At least the backfiller is violating the client.Txn API contracts by
using the same root txn in concurrent executors. The Step() API is
most definitely not able to handle that (and neither should it).

The proper fix is to change the backfiller.  Until then this patch
provides a workaround by disabling the Step() calls in the particular
case where the txn is read-only, which happens to be the case for the
historical queries used by the backfiller.

A discussion could be had if the client.Txn API could be extended to
authorize concurrent use as long as the txn is read-only.  That would
make sense but then the client.Txn must "own" its read-only
status (i.e. it should not be known only by the conn executor)
and Step() must be taught to use it.

Release note: None