### PR TITLE
engine: skip constructing empty SST

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -1164,14 +1164,14 @@ func pebbleExportToSst(
 		}
 	}
 
-	if err := sstWriter.Finish(); err != nil {
-		return nil, roachpb.BulkOpSummary{}, err
+	if rows.BulkOpSummary.DataSize == 0 {
+		// If no records were added to the sstable, skip completing it and return a
+		// nil slice – the export code will discard it anyway (based on 0 DataSize).
+		return nil, roachpb.BulkOpSummary{}, nil
 	}
 
-	if rows.BulkOpSummary.DataSize == 0 {
-		// If no records were added to the sstable, return an empty sstable. This
-		// is used by export code to avoid ingestion of empty sstables.
-		return nil, roachpb.BulkOpSummary{}, nil
+	if err := sstWriter.Finish(); err != nil {
+		return nil, roachpb.BulkOpSummary{}, err
 	}
 
 	return sstFile.Data(), rows.BulkOpSummary, nil


### PR DESCRIPTION
Currently we skip returning empty (no key/value pair) SSTables, but when doing so, we can
also skip finishing them (constructing and flushing the trailer) since it is just going
to be discarded anyway.

Release note: none.