### PR TITLE
colexec: fix population of EqColsAreKey for hash join with empty eq cols

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -638,6 +638,12 @@ func NewColOperator(
 				if !useStreamingMemAccountForBuffering {
 					hashJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "hash-joiner")
 				}
+				// It is valid for empty set of equality columns to be considered as
+				// "key" (for example, the input has at most 1 row). However, hash
+				// joiner, in order to handle NULL values correctly, needs to think
+				// that an empty set of equality columns doesn't form a key.
+				leftEqColsAreKey := core.HashJoiner.LeftEqColumnsAreKey && len(core.HashJoiner.LeftEqColumns) > 0
+				rightEqColsAreKey := core.HashJoiner.RightEqColumnsAreKey && len(core.HashJoiner.RightEqColumns) > 0
 				result.Op, err = NewEqHashJoinerOp(
 					NewAllocator(ctx, hashJoinerMemAccount),
 					inputs[0],
@@ -648,8 +654,8 @@ func NewColOperator(
 					rightOutCols,
 					leftTypes,
 					rightTypes,
-					core.HashJoiner.RightEqColumnsAreKey,
-					core.HashJoiner.LeftEqColumnsAreKey || core.HashJoiner.RightEqColumnsAreKey,
+					rightEqColsAreKey,
+					leftEqColsAreKey || rightEqColsAreKey,
 					core.HashJoiner.Type,
 				)
 				return onExpr, onExprPlanning, leftOutCols, rightOutCols, err

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -155,3 +155,17 @@ FROM
       tab_1688._float8 = tab_1690._float8
       AND tab_1688._bool = tab_1689._bool;
 ----
+
+# Regression test for empty equality columns with one of the tables having only
+# UNIQUE columns.
+statement ok
+CREATE TABLE t44207_0(c0 INT UNIQUE); CREATE TABLE t44207_1(c0 INT)
+
+statement ok
+INSERT INTO t44207_0(c0) VALUES (NULL), (NULL); INSERT INTO t44207_1(c0) VALUES (0)
+
+query II
+SELECT * FROM t44207_0, t44207_1 WHERE t44207_0.c0 IS NULL
+----
+NULL 0
+NULL 0


### PR DESCRIPTION
It is valid for empty set of equality columns to be considered as
"key" (for example,  the input has at most 1 row). However, hash
joiner, in order to handle NULL values correctly, needs to think
that an empty set of equality columns doesn't form a key.

In case of hash join, the vectorized engine could incorrectly not return
all of the necessary rows. Merge join is not susceptible to such problem
because we plan it only with non-empty equality columns.

There is no release note because so far hash join with vectorized engine
was used only with `experimental_on` vectorize setting.

Fixes: #44207.

Release note: None