### PR TITLE
release-19.2: colexec: minor cleanup

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -600,11 +600,6 @@ func (rf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
 		case stateResetBatch:
-			for _, colvec := range rf.machine.colvecs {
-				if colvec.Type() != coltypes.Unhandled {
-					colvec.Nulls().UnsetNulls()
-				}
-			}
 			rf.machine.batch.ResetInternalBatch()
 			rf.shiftState()
 		case stateDecodeFirstKVOfRow:

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -435,8 +435,9 @@ func NewColOperator(
 		if err := checkNumIn(inputs, 1); err != nil {
 			return result, err
 		}
+		outputIdx := len(spec.Input[0].ColumnTypes)
+		result.Op, result.IsStreaming = NewOrdinalityOp(inputs[0], outputIdx), true
 		result.ColumnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
-		result.Op, result.IsStreaming = NewOrdinalityOp(inputs[0]), true
 
 	case core.HashJoiner != nil:
 		createHashJoinerWithOnExprPlanning := func(

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -46,7 +46,7 @@ func TestOrdinality(t *testing.T) {
 	for _, tc := range tcs {
 		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
 			func(input []Operator) (Operator, error) {
-				return NewOrdinalityOp(input[0]), nil
+				return NewOrdinalityOp(input[0], len(tc.tuples[0])), nil
 			})
 	}
 }
@@ -57,11 +57,10 @@ func BenchmarkOrdinality(b *testing.B) {
 	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64})
 	batch.SetLength(coldata.BatchSize())
 	source := NewRepeatableBatchSource(batch)
-	source.Init()
+	ordinality := NewOrdinalityOp(source, batch.Width())
+	ordinality.Init()
 
-	ordinality := NewOrdinalityOp(source)
-
-	b.SetBytes(int64(8 * int(coldata.BatchSize()) * batch.Width()))
+	b.SetBytes(int64(8 * int(coldata.BatchSize())))
 	for i := 0; i < b.N; i++ {
 		ordinality.Next(ctx)
 	}


### PR DESCRIPTION
Backport 2/3 commits from #44184.

/cc @cockroachdb/release

---

**colexec: clean up ordinalityOp**

This commit changes the planning of ordinalityOp to specify the output
column index (previously, the column was simply appended on the first
call to Next). This unifies ordinalityOp with all other operators. Also,
in theory it is possible that different batches are returned by the
input to ordinalityOp, and the later batches might not have the appended
column, but I cannot reproduce it in practice (probably because
ordinality processor is only planned in non-distributed fashion, and if
several nodes stream data to it, the streams will have been merged
somehow). Anyway, I think this change is beneficial.

Release note: None

**colexec: remove redundant unset of Nulls in cfetcher**

Nulls are reset as part of ResetInternalBatch call below, so unsetting
them explicitly is redundant and is now removed.

Release note: None

