### PR TITLE
sql/sqlbase: avoid various allocations during column family span splitting

### DIFF
--- a/pkg/sql/rowexec/indexjoiner.go
+++ b/pkg/sql/rowexec/indexjoiner.go
@@ -211,7 +211,9 @@ func (ij *indexJoiner) generateSpans(row sqlbase.EncDatumRow) (roachpb.Spans, er
 	if err != nil {
 		return nil, err
 	}
-	return ij.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(span, numKeyCols, containsNull), nil
+	return ij.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(
+		nil /* appendTo */, span, numKeyCols, containsNull,
+	), nil
 }
 
 // outputStatsToTrace outputs the collected indexJoiner stats to the trace. Will

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -425,8 +425,8 @@ func (jr *joinReader) readInput() (joinReaderState, *execinfrapb.ProducerMetadat
 		}
 		inputRowIndices := jr.keyToInputRowIndices[string(span.Key)]
 		if inputRowIndices == nil {
-			spans = append(
-				spans, jr.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(span, len(jr.lookupCols), containsNull)...)
+			spans = jr.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(
+				spans, span, len(jr.lookupCols), containsNull)
 		}
 		jr.keyToInputRowIndices[string(span.Key)] = append(inputRowIndices, i)
 	}

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -270,13 +270,16 @@ func NeededColumnFamilyIDs(
 	return needed
 }
 
-// SplitSpanIntoSeparateFamilies can only be used to split a span representing
-// a single row point lookup into separate spans that request particular
-// families from neededFamilies instead of requesting all the families.
-// It is up to the client to verify whether the requested span
-// represents a single row lookup, and when the span splitting is appropriate.
-func SplitSpanIntoSeparateFamilies(span roachpb.Span, neededFamilies []FamilyID) roachpb.Spans {
-	var resultSpans roachpb.Spans
+// SplitSpanIntoSeparateFamilies splits a span representing a single row point
+// lookup into separate disjoint spans that request only the particular column
+// families from neededFamilies instead of requesting all the families. It is up
+// to the client to ensure the requested span represents a single row lookup and
+// that the span splitting is appropriate (see CanSplitSpanIntoSeparateFamilies).
+//
+// The function accepts a slice of spans to append to.
+func SplitSpanIntoSeparateFamilies(
+	appendTo roachpb.Spans, span roachpb.Span, neededFamilies []FamilyID,
+) roachpb.Spans {
 	for i, familyID := range neededFamilies {
 		var tempSpan roachpb.Span
 		tempSpan.Key = make(roachpb.Key, len(span.Key))
@@ -286,12 +289,12 @@ func SplitSpanIntoSeparateFamilies(span roachpb.Span, neededFamilies []FamilyID)
 		if i > 0 && familyID == neededFamilies[i-1]+1 {
 			// This column family is adjacent to the previous one. We can merge
 			// the two spans into one.
-			resultSpans[len(resultSpans)-1].EndKey = tempSpan.EndKey
+			appendTo[len(appendTo)-1].EndKey = tempSpan.EndKey
 		} else {
-			resultSpans = append(resultSpans, tempSpan)
+			appendTo = append(appendTo, tempSpan)
 		}
 	}
-	return resultSpans
+	return appendTo
 }
 
 // makeKeyFromEncDatums creates an index key by concatenating keyPrefix with the


### PR DESCRIPTION
This PR contains two improvements to column family splitting that avoid unnecessary memory allocations and copies.

The first commit avoids intermediate slices during column family span splitting. It does so by reworking the `SplitSpanIntoSeparateFamilies` class of functions to accept slices as arguments and append directly to these slices. This avoids the need for intermediate slice allocation when calling these functions, as they now append directly to the destination slice.

The second commit avoids a useless key copy in `SplitSpanIntoSeparateFamilies `. It does so by making a copy of the provided `roachpb.Key` before using it to construct a family key in `SplitSpanIntoSeparateFamilies `. This was unnecessary because `MakeFamilyKey` is already going to re-alloc when it appends. It looks like we were trying to avoid mutations to extra capacity in `span.Key`, but there's an easier way to do that - just limit its capacity before calling `MakeFamilyKey`.

This is a bit of cleanup work before addressing https://github.com/cockroachdb/cockroach/pull/44178#issuecomment-577347011.