### PR TITLE
build: Allow node versions above 12

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -128,7 +128,7 @@
     "**/url-parse": "^1.4.3"
   },
   "engines": {
-    "node": "^12.13.1",
+    "node": ">=12",
     "yarn": ">=1.7.0"
   },
   "browserslist": [


### PR DESCRIPTION
Most developers who don't work on the Admin UI 
will generally install the latest version of Node
and should not be required to install an older
version just to build the db locally.

Release note: None