### PR TITLE
sql: fix virtual schema treatment of temp tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,0 +1,36 @@
+statement ok
+SET experimental_enable_temp_tables=true
+
+subtest test_meta_tables
+
+statement ok
+CREATE TEMP TABLE temp_table_test (a timetz PRIMARY KEY)
+
+statement ok
+CREATE TEMP TABLE temp_table_ref (a timetz PRIMARY KEY)
+
+statement ok
+ALTER TABLE temp_table_ref ADD CONSTRAINT fk_temp FOREIGN KEY (a) REFERENCES temp_table_test(a)
+
+query TT
+SHOW CREATE TABLE temp_table_test
+----
+temp_table_test  CREATE TEMP TABLE temp_table_test (
+                 a TIMETZ NOT NULL,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC),
+                 FAMILY "primary" (a)
+)
+
+query TT
+SELECT table_name, table_type FROM information_schema.tables WHERE table_name = 'temp_table_test' AND table_schema LIKE 'pg_temp_%'
+----
+temp_table_test  LOCAL TEMPORARY
+
+# query changes names, so we can only grab a count to be sure.
+query I
+SELECT count(1) FROM pg_namespace WHERE nspname LIKE 'pg_temp_%'
+----
+1
+
+statement ok
+DROP TABLE temp_table_ref CASCADE; DROP TABLE temp_table_test CASCADE

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -863,7 +863,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 					condef = tree.NewDString(table.PrimaryKeyString())
 
 				case sqlbase.ConstraintTypeFK:
-					oid = h.ForeignKeyConstraintOid(db, tree.PublicSchema, table, con.FK)
+					oid = h.ForeignKeyConstraintOid(db, scName, table, con.FK)
 					contype = conTypeFK
 					// Foreign keys don't have a single linked index. Pick the first one
 					// that matches on the referenced table.
@@ -1161,7 +1161,7 @@ CREATE TABLE pg_catalog.pg_depend (
 				} else {
 					refObjID = h.IndexOid(con.ReferencedTable.ID, idx.ID)
 				}
-				constraintOid := h.ForeignKeyConstraintOid(db, tree.PublicSchema, table, con.FK)
+				constraintOid := h.ForeignKeyConstraintOid(db, scName, table, con.FK)
 
 				if err := addRow(
 					pgConstraintTableOid, // classid

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -57,7 +57,11 @@ func ShowCreateTable(
 	a := &sqlbase.DatumAlloc{}
 
 	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE TABLE ")
+	f.WriteString("CREATE ")
+	if desc.Temporary {
+		f.WriteString("TEMP ")
+	}
+	f.WriteString("TABLE ")
 	f.FormatNode(tn)
 	f.WriteString(" (")
 	primaryKeyIsOnVisibleColumn := false


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/43852.
Refs https://github.com/cockroachdb/cockroach/issues/43853 - solves it being evaluated from `public`, but does not alias `pg_temp` to `pg_temp_{sessionid}` yet.

* Introduced `GetSchemaNames{ForDatabase}` functionality, which queries
the system.namespace table to retrieve relevant schema names.
* Altered `forEachTableDescWithTableLookupInternal` and
`forEachSchemaName` to use these.
* Altered other instances where `tree.PublicSchema` is mentioned in
virtual schemas.
* Added minor regression tests for this.

Release note: None