### PR TITLE
opt: minor follow-up to #44228

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1910,7 +1910,8 @@ func (h *joinPropsHelper) setFuncDeps(rel *props.Relational) {
 			inputCols := h.leftProps.OutputCols.Union(h.rightProps.OutputCols)
 			if !inputCols.Intersects(notNullInputCols) {
 				rel.FuncDeps.DowngradeKey()
-			} else if key, ok := rel.FuncDeps.LaxKey(); ok && key.Empty() {
+			}
+			if key, ok := rel.FuncDeps.LaxKey(); ok && key.Empty() {
 				// The cross-product has an empty key when both sides have an empty key;
 				// but the outer join can have two rows so the empty key doesn't hold.
 				rel.FuncDeps.RemoveKey()


### PR DESCRIPTION
The `else` means that we might end up with an empty lax key. I had to
make this fix in the 19.1 backport (where I assume we don't do as good
a job with detecting non-null columns and we end up in the first
case).

Release note: None