### PR TITLE
backupccl,importccl: fix privilege checks for BACKUP/RESTORE and IMPORT

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -405,8 +405,7 @@ func allocateTableRewrites(
 					return err
 				}
 
-				// Check privileges. These will be checked again in the transaction
-				// that actually writes the new table descriptors.
+				// Check privileges.
 				{
 					parentDB, err := sqlbase.GetDatabaseDescFromID(ctx, txn, parentID)
 					if err != nil {
@@ -1042,10 +1041,8 @@ func WriteTableDescs(
 					return errors.Wrapf(err,
 						"failed to lookup parent DB %d", errors.Safe(tables[i].ParentID))
 				}
-				// TODO(mberhault): CheckPrivilege wants a planner.
-				if err := sql.CheckPrivilegeForUser(ctx, user, parentDB, privilege.CREATE); err != nil {
-					return err
-				}
+				// We don't check priv's here since we checked them during job planning.
+
 				// Default is to copy privs from restoring parent db, like CREATE TABLE.
 				// TODO(dt): Make this more configurable.
 				tables[i].Privileges = parentDB.GetPrivileges()

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -62,19 +62,6 @@ type AuthorizationAccessor interface {
 
 var _ AuthorizationAccessor = &planner{}
 
-// CheckPrivilegeForUser verifies that `user`` has `privilege` on `descriptor`.
-// This is not part of the planner as the only caller (ccl/sqlccl/restore.go) does not have one.
-func CheckPrivilegeForUser(
-	_ context.Context, user string, descriptor sqlbase.DescriptorProto, privilege privilege.Kind,
-) error {
-	if descriptor.GetPrivileges().CheckPrivilege(user, privilege) {
-		return nil
-	}
-	return pgerror.Newf(pgcode.InsufficientPrivilege,
-		"user %s does not have %s privilege on %s %s",
-		user, privilege, descriptor.TypeName(), descriptor.GetName())
-}
-
 // CheckPrivilege implements the AuthorizationAccessor interface.
 func (p *planner) CheckPrivilege(
 	ctx context.Context, descriptor sqlbase.DescriptorProto, privilege privilege.Kind,


### PR DESCRIPTION
This changes the privilege checks in IMPORT, IMPORT INTO and RESTORE to
run during the *planning* of the job, in the SQL plan hook execution,
rather than during the execution of the job. This is done because
privilege checks are implemented on planner, and close over the
planner's txn in some branches/cases, so invoking them later, on a
txn-less planner in a resumed jobs execution, can cause problems.

Before this, the planStateHook's txn was assumed to be set and caused a
panic on checking RBAC privileges. Additionally, permission checks in these
operations did not properly give access to all admin users.

Fixes #44252.

Release note (bug fix): Allow all admin users to use BACKUP/RESTORE and
IMPORT.