### PR TITLE
builtins: fix to_english(math.MinInt64)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2083,12 +2083,13 @@ SELECT oid(3), oid(0), oid(12023948723)
 3  0  12023948723
 
 query T
-SELECT to_english(i) FROM (VALUES (1), (13), (617), (-2)) AS a(i)
+SELECT to_english(i) FROM (VALUES (1), (13), (617), (-2), (-9223372036854775808)) AS a(i)
 ----
 one
 one-three
 six-one-seven
 minus-two
+minus-nine-two-two-three-three-seven-two-zero-three-six-eight-five-four-seven-seven-five-eight-zero-eight
 
 # Do some basic sanity checking of the variadic hash functions.
 query BBBBBBBBB

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -831,11 +831,17 @@ var builtins = map[string]builtinDefinition{
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				val := int(*args[0].(*tree.DInt))
 				var buf bytes.Buffer
+				var digits []string
 				if val < 0 {
 					buf.WriteString("minus-")
+					if val == math.MinInt64 {
+						// Converting MinInt64 to positive overflows the value.
+						// Take the first digit pre-emptively.
+						digits = append(digits, digitNames[8])
+						val /= 10
+					}
 					val = -val
 				}
-				var digits []string
 				digits = append(digits, digitNames[val%10])
 				for val > 9 {
 					val /= 10


### PR DESCRIPTION
Resolves #44152.

Release note (bug fix): `TO_ENGLISH(math.MinInt64)` previously
errored. This is now fixed to return the correct result.