### PR TITLE
sem/tree: mark CastExpr as operatorExpr

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local, fakedist
 
 statement ok
 CREATE TABLE f (x FLOAT)
@@ -198,3 +198,9 @@ query TT
 SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL '1 day'
 ----
 2018-01-01 00:00:00 +0000 +0000  2018-01-01 00:00:00 +0000 UTC
+
+statement ok
+CREATE TABLE t44137(c0 INT)
+
+statement ok
+SELECT * FROM t44137 WHERE 1 > -(('1a' COLLATE en)::INT)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -95,6 +95,7 @@ var _ operatorExpr = &UnaryExpr{}
 var _ operatorExpr = &ComparisonExpr{}
 var _ operatorExpr = &RangeCond{}
 var _ operatorExpr = &IsOfTypeExpr{}
+var _ operatorExpr = &CastExpr{}
 
 // Operator is used to identify Operators; used in sql.y.
 type Operator interface {
@@ -1430,6 +1431,8 @@ type CastExpr struct {
 	typeAnnotation
 	SyntaxMode castSyntaxMode
 }
+
+func (*CastExpr) operatorExpr() {}
 
 // Format implements the NodeFormatter interface.
 func (node *CastExpr) Format(ctx *FmtCtx) {


### PR DESCRIPTION
CastExpr now implements operatorExpr interface which is a marker
interface to know whether we should be surrounding the expression with
parenthesis when formatting it.

Fixes: #44137.

Release note: None