### PR TITLE
zone: fix error caused subzone placeholders not inheriting from parents

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -478,6 +478,14 @@ SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = '
 test.parent_modify  ALTER TABLE test.public.parent_modify CONFIGURE ZONE USING
                     gc.ttlseconds = 700
 
+# Regression test for #44231.
+statement ok
+CREATE TABLE t44231 (x INT, INDEX i (x));
+ALTER INDEX t44231@i CONFIGURE ZONE USING num_replicas=COPY FROM PARENT;
+ALTER INDEX t44231@i CONFIGURE ZONE USING num_replicas=COPY FROM PARENT;
+ALTER INDEX t44231@i CONFIGURE ZONE USING num_replicas=COPY FROM PARENT
+
+
 # ------------------------------------------------------------------------------
 # Regression test for #36348; place this at the bottom of this file.
 # ------------------------------------------------------------------------------

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -504,7 +504,8 @@ func (z *ZoneConfig) Validate() error {
 
 // InheritFromParent hydrates a zones missing fields from its parent.
 func (z *ZoneConfig) InheritFromParent(parent *ZoneConfig) {
-	if z.NumReplicas == nil {
+	// Allow for subzonePlaceholders to inherit fields from parents if needed.
+	if z.NumReplicas == nil || (z.NumReplicas != nil && *z.NumReplicas == 0) {
 		if parent.NumReplicas != nil {
 			z.NumReplicas = proto.Int32(*parent.NumReplicas)
 		}


### PR DESCRIPTION
Fixes #44231.
Fixes #41553.

This PR fixes a bug caused by backports.

In short, the backport of #41506 to 19.1 did not include some code
in #40493 which allowed a subzone placeholder to inherit fields
from its parents. This caused a problem the second time a index's
zone was altered, because its parent (now a subzone placeholder)
would no longer be able to inherit values from its parent.
We couldn't backport #40493 because it contained features that
were only released in 19.2, and since there was not a test checking
this specific behavior, we didn't catch the regression on 19.1.
Therefore, this PR contains a partial backport of #40493.

Release note (bug fix): Fix a bug where repeated use of COPY FROM PARENT
on an index or partition could cause an unexpected validation error.