### PR TITLE
cmd/smithcmp/cmpconn: fix apd.decimal comparison

### DIFF
--- a/pkg/cmd/smithcmp/cmpconn/compare.go
+++ b/pkg/cmd/smithcmp/cmpconn/compare.go
@@ -128,24 +128,19 @@ var (
 			return x.Cmp(y) == 0
 		}),
 		cmp.Comparer(func(x, y *apd.Decimal) bool {
-			if x.Negative != y.Negative {
-				return false
-			}
-			x.Abs(x)
-			y.Abs(y)
-
-			min := &apd.Decimal{}
-			if x.Cmp(y) > 1 {
-				min.Set(y)
+			var a, b, min, sub apd.Decimal
+			a.Abs(x)
+			b.Abs(y)
+			if a.Cmp(&b) > 1 {
+				min.Set(&b)
 			} else {
-				min.Set(x)
+				min.Set(&a)
 			}
 			ctx := tree.DecimalCtx
-			_, _ = ctx.Mul(min, min, decimalCloseness)
-			sub := &apd.Decimal{}
-			_, _ = ctx.Sub(sub, x, y)
-			sub.Abs(sub)
-			return sub.Cmp(min) <= 0
+			_, _ = ctx.Mul(&min, &min, decimalCloseness)
+			_, _ = ctx.Sub(&sub, x, y)
+			sub.Abs(&sub)
+			return sub.Cmp(&min) <= 0
 		}),
 		cmp.Comparer(func(x, y duration.Duration) bool {
 			return x.Compare(y) == 0

--- a/pkg/cmd/smithcmp/cmpconn/compare_test.go
+++ b/pkg/cmd/smithcmp/cmpconn/compare_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cmpconn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/apd"
+)
+
+func TestCompareVals(t *testing.T) {
+	for i, tc := range []struct {
+		equal bool
+		a, b  []interface{}
+	}{
+		{
+			equal: true,
+			a:     []interface{}{apd.New(-2, 0)},
+			b:     []interface{}{apd.New(-2, 0)},
+		},
+		{
+			equal: true,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(2, 0)},
+		},
+		{
+			equal: false,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(-2, 0)},
+		},
+		{
+			equal: true,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(2000001, -6)},
+		},
+		{
+			equal: false,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(200001, -5)},
+		},
+		{
+			equal: false,
+			a:     []interface{}{apd.New(-2, 0)},
+			b:     []interface{}{apd.New(-200001, -5)},
+		},
+		{
+			equal: false,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(-2000001, -6)},
+		},
+	} {
+		err := CompareVals(tc.a, tc.b)
+		equal := err == nil
+		if equal != tc.equal {
+			t.Log("test index", i)
+			if err != nil {
+				t.Fatal(err)
+			} else {
+				t.Fatal("expected unequal")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Previously we would mutate the decimals when looking for a minimum. Fix
that by allocating new decimals and using those to find the minimum. Add
some tests so this doesn't break.

Release note: None