### PR TITLE
storage: fix reason in "initiating a merge" message

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1224,6 +1224,9 @@ func (s *adminServer) Cluster(
 }
 
 // Health returns liveness for the node target of the request.
+//
+// NB: this is deprecated. If you're looking for the code serving /health,
+// you want (*statusServer).Details.
 func (s *adminServer) Health(
 	ctx context.Context, req *serverpb.HealthRequest,
 ) (*serverpb.HealthResponse, error) {


### PR DESCRIPTION
It was alluding to a "threshold" but wasn't actually printing it. Now it
does. This will be helpful to understand why merges happened.

Release note: None