### PR TITLE
roachtest: fix the deco test + re-implement the warning test

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -90,7 +90,7 @@ proc send_eof {} {
 # in `server_pid`.
 proc start_server {argv} {
     report "BEGIN START SERVER"
-    system "$argv start-single-node --insecure --pid-file=server_pid --listening-url-file=server_url --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
+    system "$argv start-single-node --insecure --max-sql-memory=128MB --pid-file=server_pid --listening-url-file=server_url --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
             $argv sql --insecure -e 'select 1'"
     report "START SERVER DONE"
 }

--- a/pkg/cli/interactive_tests/test_multiple_nodes.tcl
+++ b/pkg/cli/interactive_tests/test_multiple_nodes.tcl
@@ -6,10 +6,10 @@ start_server $argv
 
 start_test "Check that it is possible to add nodes to a server started with start-single-node"
 
-system "$argv start --insecure --port=26258 --http-port=8083 --pid-file=server_pid2 --background -s=path=logs/db2 --join=:26257 >>logs/expect-cmd.log 2>&1;
+system "$argv start --insecure --port=26258 --max-sql-memory=128MB --http-port=8083 --pid-file=server_pid2 --background -s=path=logs/db2 --join=:26257 >>logs/expect-cmd.log 2>&1;
         $argv sql -e 'select 1' --port=26258"
 
-system "$argv start --insecure --port=26259 --http-port=8084 --pid-file=server_pid3 --background -s=path=logs/db3 --join=:26257 >>logs/expect-cmd.log 2>&1;
+system "$argv start --insecure --port=26259 --max-sql-memory=128MB --http-port=8084 --pid-file=server_pid3 --background -s=path=logs/db3 --join=:26257 >>logs/expect-cmd.log 2>&1;
         $argv sql -e 'select 1' --port=26259"
 
 # Check the number of nodes
@@ -19,6 +19,26 @@ eexpect "3 rows"
 eexpect eof
 
 end_test
+
+
+start_test "Check that a double decommission prints out a warning"
+spawn $argv node decommission 2
+eexpect eof
+
+spawn $argv node decommission 2
+eexpect "warning: node 2 is already decommissioning or decommissioned"
+eexpect eof
+end_test
+
+start_test "Check that a double recommission prints out a warning"
+spawn $argv node recommission 2
+eexpect eof
+
+spawn $argv node recommission 2
+eexpect "warning: node 2 is not decommissioned"
+eexpect eof
+end_test
+
 
 # Kill the cluster. We don't care about what happens next in this test,
 # and this makes the test complete faster.

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -439,27 +439,9 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		}
 	}
 
-	t.l.Printf("trying to decommission a second time\n")
-	if buf, err := decommission(ctx, 2, c.Node(1), "decommission"); err != nil {
-		t.Fatalf("decommission failed: %v", err)
-	} else {
-		if !strings.HasPrefix(buf, "warning: node 1 is already decommissioning or decommissioned") {
-			t.Fatalf("expected warning at start of duplicate decommission, got:\n%s", buf)
-		}
-	}
-
 	t.l.Printf("recommissioning first node (from third node)\n")
 	if _, err := decommission(ctx, 3, c.Node(1), "recommission"); err != nil {
 		t.Fatalf("recommission failed: %v", err)
-	}
-
-	t.l.Printf("trying to recommission a second time\n")
-	if buf, err := decommission(ctx, 3, c.Node(1), "recommission"); err != nil {
-		t.Fatalf("recommission failed: %v", err)
-	} else {
-		if !strings.HasPrefix(buf, "warning: node 1 is not decommissioned") {
-			t.Fatalf("expected warning at start of duplicate recommission, got:\n%s", buf)
-		}
 	}
 
 	t.l.Printf("decommissioning second node from third, using --wait=all\n")


### PR DESCRIPTION
Fixes #44276.

The test to check for a warning on double [rd]ecommission was
implemented in roachtest; this was invalid because roachtest
is also used on previous versions and the warning is a new thing.

This patch moves the test to a TCL interactive test instead.

Release note: None