### PR TITLE
lint/passes/nocopy: detect and fix invalid uses of util.NoCopy

### DIFF
--- a/pkg/cmd/roachvet/main.go
+++ b/pkg/cmd/roachvet/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nocopy"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
@@ -48,11 +49,12 @@ import (
 func main() {
 	unitchecker.Main(
 		// First-party analyzers:
+		descriptormarshal.Analyzer,
 		hash.Analyzer,
+		nocopy.Analyzer,
+		returnerrcheck.Analyzer,
 		timer.Analyzer,
 		unconvert.Analyzer,
-		descriptormarshal.Analyzer,
-		returnerrcheck.Analyzer,
 
 		// Standard go vet analyzers:
 		asmdecl.Analyzer,

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -19,6 +19,13 @@ import (
 
 // joinPredicate implements the predicate logic for joins.
 type joinPredicate struct {
+	// This struct must be allocated on the heap and its location stay
+	// stable after construction because it implements
+	// IndexedVarContainer and the IndexedVar objects in sub-expressions
+	// will link to it by reference after checkRenderStar / analyzeExpr.
+	// Enforce this using NoCopy.
+	_ util.NoCopy
+
 	joinType sqlbase.JoinType
 
 	// numLeft/RightCols are the number of columns in the left and right
@@ -58,13 +65,6 @@ type joinPredicate struct {
 	// If set, the right equality columns form a key in the right input. Used as a
 	// hint for optimizing execution.
 	rightEqKey bool
-
-	// This struct must be allocated on the heap and its location stay
-	// stable after construction because it implements
-	// IndexedVarContainer and the IndexedVar objects in sub-expressions
-	// will link to it by reference after checkRenderStar / analyzeExpr.
-	// Enforce this using NoCopy.
-	_ util.NoCopy
 }
 
 // makePredicate constructs a joinPredicate object for joins. The join condition

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -122,7 +122,6 @@ func (ef *execFactory) ConstructScan(
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
 	scan.estimatedRowCount = uint64(rowCount)
-	scan.createdByOpt = true
 	return scan, nil
 }
 

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -26,6 +26,13 @@ import (
 // renderNode encapsulates the render logic of a select statement:
 // expressing new values using expressions over source values.
 type renderNode struct {
+	// This struct must be allocated on the heap and its location stay
+	// stable after construction because it implements
+	// IndexedVarContainer and the IndexedVar objects in sub-expressions
+	// will link to it by reference after checkRenderStar / analyzeExpr.
+	// Enforce this using NoCopy.
+	_ util.NoCopy
+
 	// source describes where the data is coming from.
 	// populated initially by initFrom().
 	// potentially modified by index selection.
@@ -50,13 +57,6 @@ type renderNode struct {
 	columns sqlbase.ResultColumns
 
 	reqOrdering ReqOrdering
-
-	// This struct must be allocated on the heap and its location stay
-	// stable after construction because it implements
-	// IndexedVarContainer and the IndexedVar objects in sub-expressions
-	// will link to it by reference after checkRenderStar / analyzeExpr.
-	// Enforce this using NoCopy.
-	_ util.NoCopy
 }
 
 // IndexedVarEval implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -36,6 +36,10 @@ const (
 // TODO(knz): this does not currently track the amount of memory used
 // for the outer array of Datums references.
 type RowContainer struct {
+	// We should not copy this structure around; each copy would have a
+	// different memAcc (among other things like aliasing chunks).
+	_ util.NoCopy
+
 	numCols int
 
 	// rowsPerChunk is the number of rows in a chunk; we pack multiple rows in a
@@ -67,10 +71,6 @@ type RowContainer struct {
 	// memAcc tracks the current memory consumption of this
 	// RowContainer.
 	memAcc mon.BoundAccount
-
-	// We should not copy this structure around; each copy would have a different
-	// memAcc (among other things like aliasing chunks).
-	_ util.NoCopy
 }
 
 // NewRowContainer allocates a new row container.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -105,9 +105,6 @@ type scanNode struct {
 	// Enforce this using NoCopy.
 	_ util.NoCopy
 
-	// Set when the scanNode is created via the exec factory.
-	createdByOpt bool
-
 	// maxResults, if greater than 0, is the maximum number of results that a
 	// scan is guaranteed to return.
 	maxResults uint64

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -35,6 +35,13 @@ var scanNodePool = sync.Pool{
 // A scanNode handles scanning over the key/value pairs for a table and
 // reconstructing them into rows.
 type scanNode struct {
+	// This struct must be allocated on the heap and its location stay
+	// stable after construction because it implements
+	// IndexedVarContainer and the IndexedVar objects in sub-expressions
+	// will link to it by reference after checkRenderStar / analyzeExpr.
+	// Enforce this using NoCopy.
+	_ util.NoCopy
+
 	desc  *sqlbase.ImmutableTableDescriptor
 	index *sqlbase.IndexDescriptor
 
@@ -97,13 +104,6 @@ type scanNode struct {
 	// Indicates if this scanNode will do a physical data check. This is
 	// only true when running SCRUB commands.
 	isCheck bool
-
-	// This struct must be allocated on the heap and its location stay
-	// stable after construction because it implements
-	// IndexedVarContainer and the IndexedVar objects in sub-expressions
-	// will link to it by reference after checkRenderStar / analyzeExpr.
-	// Enforce this using NoCopy.
-	_ util.NoCopy
 
 	// maxResults, if greater than 0, is the maximum number of results that a
 	// scan is guaranteed to return.

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -183,6 +183,8 @@ const flagsRequiringAnnotations FmtFlags = FmtAlwaysQualifyTableNames
 //
 // FmtCtx cannot be copied by value.
 type FmtCtx struct {
+	_ util.NoCopy
+
 	bytes.Buffer
 
 	// NOTE: if you add more flags to this structure, make sure to add
@@ -202,8 +204,6 @@ type FmtCtx struct {
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
 	// it can be used to format placeholders differently than normal.
 	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
-
-	_ util.NoCopy
 }
 
 // NewFmtCtx creates a FmtCtx; only flags that don't require Annotations

--- a/pkg/testutils/lint/passes/nocopy/nocopy.go
+++ b/pkg/testutils/lint/passes/nocopy/nocopy.go
@@ -1,0 +1,82 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package nocopy defines an Analyzer that detects invalid uses of util.NoCopy.
+package nocopy
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Doc documents this pass.
+const Doc = `check for invalid uses of util.NoCopy`
+
+// Analyzer defines this pass.
+var Analyzer = &analysis.Analyzer{
+	Name:     "nocopy",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+const noCopyType = "github.com/cockroachdb/cockroach/pkg/util.NoCopy"
+
+// nocopy ensures that the util.NoCopy type is not misused. Specifically, it
+// ensures that the type is always embedded without a name as the first field in
+// a parent struct like:
+//
+//     type s struct {
+//         _ util.NoCopy
+//         ...
+//     }
+//
+// We lint against including the type in other positions in structs both for
+// uniformity and because it can have runtime performance effects. Specifically,
+// if util.NoCopy is included as the last field in a parent struct then it will
+// increase the size of the parent struct even though util.NoCopy is zero-sized.
+// This is explained in detail in https://github.com/golang/go/issues/9401 and
+// is demonstrated in https://play.golang.org/p/jwB2Az5owcm.
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	inspect.Preorder([]ast.Node{
+		(*ast.StructType)(nil),
+	}, func(n ast.Node) {
+		str := n.(*ast.StructType)
+		if str.Fields == nil {
+			return
+		}
+		for i, f := range str.Fields.List {
+			tv, ok := pass.TypesInfo.Types[f.Type]
+			if !ok {
+				continue
+			}
+			if tv.Type.String() != noCopyType {
+				continue
+			}
+			switch {
+			case i != 0:
+				pass.Reportf(f.Pos(), "Illegal use of util.NoCopy - must be first field in struct")
+			case len(f.Names) == 0:
+				pass.Reportf(f.Pos(), "Illegal use of util.NoCopy - should not be embedded")
+			case len(f.Names) > 1:
+				pass.Reportf(f.Pos(), "Illegal use of util.NoCopy - should be included only once")
+			case f.Names[0].Name != "_":
+				pass.Reportf(f.Pos(), "Illegal use of util.NoCopy - should be unnamed")
+			default:
+				// Valid use.
+			}
+		}
+	})
+	return nil, nil
+}

--- a/pkg/testutils/lint/passes/nocopy/nocopy_test.go
+++ b/pkg/testutils/lint/passes/nocopy/nocopy_test.go
@@ -1,0 +1,28 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package nocopy defines an Analyzer that detects invalid uses of util.NoCopy.
+package nocopy_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nocopy"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, nocopy.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/nocopy/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/nocopy/testdata/src/a/a.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+import "github.com/cockroachdb/cockroach/pkg/util"
+
+type onlyField struct {
+	_ util.NoCopy
+}
+
+type firstField struct {
+	_ util.NoCopy
+	a int64
+}
+
+type middleField struct {
+	a int64
+	_ util.NoCopy // want `Illegal use of util.NoCopy - must be first field in struct`
+	b int64
+}
+
+type lastField struct {
+	a int64
+	_ util.NoCopy  // want `Illegal use of util.NoCopy - must be first field in struct`
+}
+
+
+type embeddedField struct {
+	util.NoCopy // want `Illegal use of util.NoCopy - should not be embedded`
+}
+
+type multiField struct {
+	_, _ util.NoCopy// want `Illegal use of util.NoCopy - should be included only once`
+}
+
+type namedField struct {
+	noCopy util.NoCopy // want `Illegal use of util.NoCopy - should be unnamed`
+}

--- a/pkg/testutils/lint/passes/nocopy/testdata/src/github.com/cockroachdb/cockroach/pkg/util/nocopy.go
+++ b/pkg/testutils/lint/passes/nocopy/testdata/src/github.com/cockroachdb/cockroach/pkg/util/nocopy.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package util
+
+// NoCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://github.com/golang/go/issues/8005#issuecomment-190753527
+// for details.
+type NoCopy struct{}


### PR DESCRIPTION
This change adds a new lint check that ensures that `util.NoCopy` is not misused. Specifically, it ensures that the type is always embedded without a name as the first field in a parent struct like:

```
type s struct {
    _ util.NoCopy
    ...
}
```

We lint against including the type in other positions in structs both for uniformity and because it can have runtime performance effects. Specifically, if `util.NoCopy` is included as the last field in a parent struct then it will increase the size of the parent struct even though `util.NoCopy` is zero-sized. This is explained in detail in https://github.com/golang/go/issues/9401 and is demonstrated in https://play.golang.org/p/jwB2Az5owcm.

The change then fixes the uses of `util.NoCopy` that violate this contract, most of which are in the `sql` package.