### PR TITLE
sql: fix incorrect distsql plan caused by nil filter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -640,3 +640,18 @@ query IITITTITTTTIFFI
 SELECT * FROM wide
 ----
 0  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  10
+
+# Regression test for #44203 (filter that is not folded inside the optimizer,
+# but is statically evaluated to true when building the filterNode).
+statement ok
+CREATE TABLE t44203(c0 BOOL)
+
+statement ok
+INSERT INTO t44203(c0) VALUES (false)
+
+statement ok
+CREATE VIEW v44203(c0) AS SELECT c0 FROM t44203 WHERE t44203.c0 OFFSET NULL
+
+query B
+SELECT * FROM v44203 WHERE current_user() != ''
+----

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -159,6 +159,7 @@ func (ef *execFactory) ConstructFilter(
 	// limit (it would make the limit apply AFTER the filter).
 	if s, ok := n.(*scanNode); ok && s.filter == nil && s.hardLimit == 0 {
 		s.filter = s.filterVars.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
+		// Note: if the filter statically evaluates to true, s.filter stays nil.
 		s.reqOrdering = ReqOrdering(reqOrdering)
 		return s, nil
 	}
@@ -169,6 +170,10 @@ func (ef *execFactory) ConstructFilter(
 	}
 	f.ivarHelper = tree.MakeIndexedVarHelper(f, len(src.columns))
 	f.filter = f.ivarHelper.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
+	if f.filter == nil {
+		// Filter statically evaluates to true. Just return the input plan.
+		return n, nil
+	}
 	f.reqOrdering = ReqOrdering(reqOrdering)
 
 	// If there's a spool, pull it up.

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -602,6 +602,9 @@ func reverseProjection(outputColumns []uint32, indexVarMap []int) []int {
 func (p *PhysicalPlan) AddFilter(
 	expr tree.TypedExpr, exprCtx ExprContext, indexVarMap []int,
 ) error {
+	if expr == nil {
+		return errors.Errorf("nil filter")
+	}
 	post := p.GetLastStagePost()
 	if len(post.RenderExprs) > 0 || post.Offset != 0 || post.Limit != 0 {
 		// The last stage contains render expressions or a limit. The filter refers
@@ -629,6 +632,7 @@ func (p *PhysicalPlan) AddFilter(
 		return err
 	}
 	if !post.Filter.Empty() {
+		// Either Expr or LocalExpr will be set (not both).
 		if filter.Expr != "" {
 			filter.Expr = fmt.Sprintf("(%s) AND (%s)", post.Filter.Expr, filter.Expr)
 		} else if filter.LocalExpr != nil {


### PR DESCRIPTION
In some cases, filters that are not constant-folded by the optimizer
can be evaluated statically to true when building the filterNode. In
this case we create a filterNode with a nil filter, which is ill
handled by the distsql planner.

This change elides the filterNode in this case, and fixes up the
distsl code to error out in this case.

Release note (bug fix): fixed incorrect plans in very rare cases
involving filters that aren't constant folded in the optimizer but
that can be evaluated statically when running a given query.