### PR TITLE
release-19.2: sql: fix locality information in show ranges

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1991,31 +1991,31 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				return nil, err
 			}
 
-			var voterReplicas, learnerReplicas []int
-			for _, rd := range desc.Replicas().Voters() {
-				voterReplicas = append(voterReplicas, int(rd.StoreID))
-			}
+			voterReplicas := append([]roachpb.ReplicaDescriptor(nil), desc.Replicas().Voters()...)
+			var learnerReplicaStoreIDs []int
 			for _, rd := range desc.Replicas().Learners() {
-				learnerReplicas = append(learnerReplicas, int(rd.StoreID))
+				learnerReplicaStoreIDs = append(learnerReplicaStoreIDs, int(rd.StoreID))
 			}
-			sort.Ints(voterReplicas)
-			sort.Ints(learnerReplicas)
+			sort.Slice(voterReplicas, func(i, j int) bool {
+				return voterReplicas[i].StoreID < voterReplicas[j].StoreID
+			})
+			sort.Ints(learnerReplicaStoreIDs)
 			votersArr := tree.NewDArray(types.Int)
 			for _, replica := range voterReplicas {
-				if err := votersArr.Append(tree.NewDInt(tree.DInt(replica))); err != nil {
+				if err := votersArr.Append(tree.NewDInt(tree.DInt(replica.StoreID))); err != nil {
 					return nil, err
 				}
 			}
 			learnersArr := tree.NewDArray(types.Int)
-			for _, replica := range learnerReplicas {
+			for _, replica := range learnerReplicaStoreIDs {
 				if err := learnersArr.Append(tree.NewDInt(tree.DInt(replica))); err != nil {
 					return nil, err
 				}
 			}
 
 			replicaLocalityArr := tree.NewDArray(types.String)
-			for _, id := range voterReplicas {
-				replicaLocality := nodeIDToLocality[roachpb.NodeID(id)].String()
+			for _, replica := range voterReplicas {
+				replicaLocality := nodeIDToLocality[replica.NodeID].String()
 				if err := replicaLocalityArr.Append(tree.NewDString(replicaLocality)); err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Backport 1/1 commits from #43807.

/cc @cockroachdb/release

---

Previously the locality information in show ranges was incorrectly assuming
that range descriptors are node id based.
This was causing a mismatch between replicas tuple and the locality.
To address this, this change makes the locality info be based on store ids.

Fixes #43755, #30940

Release note (sql change): Show ranges now shows locality information
consistent with the range descriptor when node id and store id don't match..
