### PR TITLE
sql: enable txn stepping when running postqueries

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -987,6 +987,8 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 	recv *DistSQLReceiver,
 	maybeDistribute bool,
 ) bool {
+	prevSteppingMode := planner.Txn().ConfigureStepping(ctx, client.SteppingEnabled)
+	defer func() { _ = planner.Txn().ConfigureStepping(ctx, prevSteppingMode) }()
 	for _, postqueryPlan := range postqueryPlans {
 		// We place a sequence point before every postquery, so
 		// that each subsequent postquery can observe the writes

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -3406,3 +3406,27 @@ INSERT INTO nonunique_idx_parent VALUES (1, 10)
 
 statement ok
 INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
+
+# Stepping regression test. There was a bug where having cascades disables txn
+# stepping which caused issues when executing postqueries, so a query which
+# involved a mixed situation would error out.
+
+statement ok
+CREATE TABLE x (
+    k INT PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE y (
+    y INT PRIMARY KEY,
+    b INT NULL REFERENCES x(k),
+    c INT NULL REFERENCES x(k) ON DELETE CASCADE
+)
+
+statement ok
+WITH
+    a AS (INSERT INTO y VALUES (1) RETURNING 1), b AS (DELETE FROM x WHERE true RETURNING 1)
+SELECT
+    *
+FROM
+    a


### PR DESCRIPTION
Previously the postquery code assumed that stepping was always enabled,
however, this was not true if we needed to fall back to old-style FK
execution. Since there are cases where postqueries and old-style FK
checks can coexist, this commit enables stepping before running through
all the postqueries. This still isn't quite right I think, since
conceptually a postquery could itself contain a mutation which causes fallback
again, but I don't believe there are any cases today where we do this. I
think this fix is reasonable in the short-term until we can eliminate
the need for fallback, but I'm unclear on the actual semantics of the
stepping interfaces so this change might be invalid.

Release note (bug fix): fixed an error that could occur in very
specific scenarios involving mutations and foreign keys.