### PR TITLE
release-19.2: sql: fix internal error with mixed types for BETWEEN from/to

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -200,3 +200,10 @@ query TT
 SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL '1 day'
 ----
 2018-01-01 00:00:00 +0000 +0000  2018-01-01 00:00:00 +0000 UTC
+
+# Regression test for #44181: allow left side of BETWEEN to be typed
+# differently in the two comparisons.
+query B
+SELECT '' BETWEEN ''::BYTES AND '';
+----
+true

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -336,10 +336,11 @@ func (b *Builder) buildScalar(
 		}
 
 	case *tree.RangeCond:
-		input := b.buildScalar(t.TypedLeft(), inScope, nil, nil, colRefs)
+		inputFrom := b.buildScalar(t.TypedLeftFrom(), inScope, nil, nil, colRefs)
 		from := b.buildScalar(t.TypedFrom(), inScope, nil, nil, colRefs)
+		inputTo := b.buildScalar(t.TypedLeftTo(), inScope, nil, nil, colRefs)
 		to := b.buildScalar(t.TypedTo(), inScope, nil, nil, colRefs)
-		out = b.buildRangeCond(t.Not, t.Symmetric, input, from, to)
+		out = b.buildRangeCond(t.Not, t.Symmetric, inputFrom, from, inputTo, to)
 
 	case *srf:
 		if len(t.cols) == 1 {
@@ -493,24 +494,28 @@ func (b *Builder) buildFunction(
 // x BETWEEN SYMMETRIC a AND b      ->  (x >= a AND x <= b) OR (x >= b AND x <= a)
 // x NOT BETWEEN SYMMETRIC a AND b  ->  NOT ((x >= a AND x <= b) OR (x >= b AND x <= a))
 //
+// Note that x can be typed differently in the expressions (x >= a) and (x <= b)
+// because a and b can have different types; the function takes both "variants"
+// of x.
+//
 // Note that these expressions are subject to normalization rules (which can
 // push down the negation).
 // TODO(radu): this doesn't work when the expressions have side-effects.
 func (b *Builder) buildRangeCond(
-	not bool, symmetric bool, input, from, to opt.ScalarExpr,
+	not bool, symmetric bool, inputFrom, from, inputTo, to opt.ScalarExpr,
 ) opt.ScalarExpr {
 	// Build "input >= from AND input <= to".
 	out := b.factory.ConstructAnd(
-		b.factory.ConstructGe(input, from),
-		b.factory.ConstructLe(input, to),
+		b.factory.ConstructGe(inputFrom, from),
+		b.factory.ConstructLe(inputTo, to),
 	)
 
 	if symmetric {
 		// Build "(input >= from AND input <= to) OR (input >= to AND input <= from)".
 		lhs := out
 		rhs := b.factory.ConstructAnd(
-			b.factory.ConstructGe(input, to),
-			b.factory.ConstructLe(input, from),
+			b.factory.ConstructGe(inputTo, to),
+			b.factory.ConstructLe(inputFrom, from),
 		)
 		out = b.factory.ConstructOr(lhs, rhs)
 	}

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -599,6 +599,37 @@ not [type=bool]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
 
+# The left side of BETWEEN is typed differently in the two comparisons.
+build-scalar
+'' BETWEEN ''::BYTES AND ''
+----
+and [type=bool]
+ ├── ge [type=bool]
+ │    ├── const: '\x' [type=bytes]
+ │    └── const: '\x' [type=bytes]
+ └── le [type=bool]
+      ├── const: '' [type=string]
+      └── const: '' [type=string]
+
+build-scalar
+'' BETWEEN SYMMETRIC ''::BYTES AND ''
+----
+or [type=bool]
+ ├── and [type=bool]
+ │    ├── ge [type=bool]
+ │    │    ├── const: '\x' [type=bytes]
+ │    │    └── const: '\x' [type=bytes]
+ │    └── le [type=bool]
+ │         ├── const: '' [type=string]
+ │         └── const: '' [type=string]
+ └── and [type=bool]
+      ├── ge [type=bool]
+      │    ├── const: '' [type=string]
+      │    └── const: '' [type=string]
+      └── le [type=bool]
+           ├── const: '\x' [type=bytes]
+           └── const: '\x' [type=bytes]
+
 build-scalar
 NULL
 ----

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -548,6 +548,12 @@ type RangeCond struct {
 	Left      Expr
 	From, To  Expr
 
+	// Typed version of Left for the comparison with To (where it may be
+	// type-checked differently). After type-checking, Left is set to the typed
+	// version for the comparison with From, and leftTo is set to the typed
+	// version for the comparison with To.
+	leftTo TypedExpr
+
 	typeAnnotation
 }
 
@@ -567,14 +573,21 @@ func (node *RangeCond) Format(ctx *FmtCtx) {
 	binExprFmtWithParen(ctx, node.From, "AND", node.To, true)
 }
 
-// TypedLeft returns the RangeCond's left expression as a TypedExpr.
-func (node *RangeCond) TypedLeft() TypedExpr {
+// TypedLeftFrom returns the RangeCond's left expression as a TypedExpr, in the
+// context of a comparison with TypedFrom().
+func (node *RangeCond) TypedLeftFrom() TypedExpr {
 	return node.Left.(TypedExpr)
 }
 
 // TypedFrom returns the RangeCond's from expression as a TypedExpr.
 func (node *RangeCond) TypedFrom() TypedExpr {
 	return node.From.(TypedExpr)
+}
+
+// TypedLeftTo returns the RangeCond's left expression as a TypedExpr, in the
+// context of a comparison with TypedTo().
+func (node *RangeCond) TypedLeftTo() TypedExpr {
+	return node.leftTo
 }
 
 // TypedTo returns the RangeCond's to expression as a TypedExpr.

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -94,6 +94,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`12 BETWEEN 24 AND 36`, `false`},
 		{`12 BETWEEN 10 AND 20`, `true`},
 		{`10 BETWEEN a AND 20`, `a <= 10`},
+		{`(1 + 2) BETWEEN b AND c`, `(b <= 3) AND (c >= 3)`},
 		{`a BETWEEN b AND c`, `(a >= b) AND (a <= c)`},
 		{`a BETWEEN SYMMETRIC b AND c`, `((a >= b) AND (a <= c)) OR ((a >= c) AND (a <= b))`},
 		{`a NOT BETWEEN b AND c`, `(a < b) OR (a > c)`},

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1099,16 +1099,16 @@ func (expr *AllColumnsSelector) TypeCheck(_ *SemaContext, desired *types.T) (Typ
 
 // TypeCheck implements the Expr interface.
 func (expr *RangeCond) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error) {
-	leftTyped, fromTyped, _, _, err := typeCheckComparisonOp(ctx, GT, expr.Left, expr.From)
+	leftFromTyped, fromTyped, _, _, err := typeCheckComparisonOp(ctx, GT, expr.Left, expr.From)
 	if err != nil {
 		return nil, err
 	}
-	_, toTyped, _, _, err := typeCheckComparisonOp(ctx, LT, expr.Left, expr.To)
+	leftToTyped, toTyped, _, _, err := typeCheckComparisonOp(ctx, LT, expr.Left, expr.To)
 	if err != nil {
 		return nil, err
 	}
-
-	expr.Left, expr.From, expr.To = leftTyped, fromTyped, toTyped
+	expr.Left, expr.From = leftFromTyped, fromTyped
+	expr.leftTo, expr.To = leftToTyped, toTyped
 	expr.typ = types.Bool
 	return expr, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #44216.

/cc @cockroachdb/release

---

A `RangeCond` (for `BETWEEN`) is type-checked as two comparisons. The
issue is that the same left side could be type-checked differently in
the two cases. Fortunately, we build it as two comparisons so the fix
is to keep track of both "variants" of the left side.

Fixes #44181.

Release note (bug fix): fixed internal error when mixed types are used
with BETWEEN.
