### PR TITLE
opt: ensure that empty lax keys are never created

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -124,25 +124,36 @@ project
       │    └── project
       │         ├── columns: v:6(int!null)
       │         ├── outer: (1)
-      │         ├── fd: ()-->(6)
       │         ├── prune: (6)
-      │         └── inner-join (hash)
+      │         └── inner-join-apply
       │              ├── columns: v:6(int!null) n:9(int!null)
       │              ├── outer: (1)
-      │              ├── fd: ()-->(6,9)
-      │              ├── interesting orderings: (+9)
+      │              ├── fd: ()-->(9)
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
       │              │    └── prune: (6)
-      │              ├── scan mn
-      │              │    ├── columns: n:9(int)
-      │              │    ├── lax-key: (9)
-      │              │    ├── prune: (9)
-      │              │    └── interesting orderings: (+9)
+      │              ├── max1-row
+      │              │    ├── columns: n:9(int!null)
+      │              │    ├── outer: (6)
+      │              │    ├── cardinality: [0 - 1]
+      │              │    ├── key: ()
+      │              │    ├── fd: ()-->(9)
+      │              │    └── select
+      │              │         ├── columns: n:9(int!null)
+      │              │         ├── outer: (6)
+      │              │         ├── fd: ()-->(9)
+      │              │         ├── interesting orderings: (+9)
+      │              │         ├── scan mn@secondary
+      │              │         │    ├── columns: n:9(int!null)
+      │              │         │    ├── constraint: /9: (/NULL - ]
+      │              │         │    ├── key: (9)
+      │              │         │    ├── prune: (9)
+      │              │         │    └── interesting orderings: (+9)
+      │              │         └── filters
+      │              │              └── eq [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
+      │              │                   ├── variable: n [type=int]
+      │              │                   └── variable: v [type=int]
       │              └── filters
-      │                   ├── eq [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
-      │                   │    ├── variable: n [type=int]
-      │                   │    └── variable: v [type=int]
       │                   └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       │                        ├── variable: x [type=int]
       │                        └── variable: n [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -430,3 +430,38 @@ select
                 └── le [type=bool]
                      ├── variable: y [type=int]
                      └── const: 10 [type=int]
+
+exec-ddl
+CREATE TABLE t0(c0 INT UNIQUE)
+----
+
+exec-ddl
+CREATE VIEW v0(c0) AS SELECT DISTINCT t0.c0 FROM t0
+----
+
+# Regression test for #44296. Ensure that no key is added for the Select.
+norm
+SELECT * FROM v0 WHERE v0.c0 IS NULL
+----
+limit
+ ├── columns: c0:1(int)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── interesting orderings: (+1)
+ ├── select
+ │    ├── columns: c0:1(int)
+ │    ├── fd: ()-->(1)
+ │    ├── limit hint: 1.00
+ │    ├── interesting orderings: (+1)
+ │    ├── scan t0
+ │    │    ├── columns: c0:1(int)
+ │    │    ├── lax-key: (1)
+ │    │    ├── limit hint: 100.00
+ │    │    ├── prune: (1)
+ │    │    └── interesting orderings: (+1)
+ │    └── filters
+ │         └── is [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
+ │              ├── variable: c0 [type=int]
+ │              └── null [type=unknown]
+ └── const: 1 [type=int]

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -725,7 +725,7 @@ func (f *FuncDepSet) MakeNotNull(notNullCols opt.ColSet) {
 
 	// Try to reduce the key based on any new strict FDs.
 	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
+		f.setKey(f.ReduceCols(f.key), f.hasKey)
 		if f.hasKey == laxKey && f.key.SubsetOf(notNullCols) {
 			f.hasKey = strictKey
 		}
@@ -813,7 +813,7 @@ func (f *FuncDepSet) AddConstants(cols opt.ColSet) {
 
 	// Try to reduce the key based on the new constants.
 	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
+		f.setKey(f.ReduceCols(f.key), f.hasKey)
 	}
 }
 
@@ -1576,12 +1576,16 @@ func (f *FuncDepSet) addEquivalency(equiv opt.ColSet) {
 
 	// Try to reduce the key based on the new equivalency.
 	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
+		f.setKey(f.ReduceCols(f.key), f.hasKey)
 	}
 }
 
 // setKey updates the key that the set is currently maintaining.
 func (f *FuncDepSet) setKey(key opt.ColSet, typ keyType) {
+	if key.Empty() && typ == laxKey {
+		// There is no such thing as an empty lax key.
+		typ = noKey
+	}
 	f.hasKey = typ
 	f.key = key
 }

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -518,6 +518,14 @@ func TestFuncDeps_AddConstants(t *testing.T) {
 	eqConst.MakeNotNull(c(10))
 	verifyFD(t, &eqConst, "key(11); ()-->(1-5,10), (11)-->(12,13), (1)==(10), (10)==(1)")
 	testColsAreStrictKey(t, &eqConst, c(1, 2, 3, 10, 12), false)
+
+	// Ensure that converting a lax key to a constant does not create an empty
+	// lax key.
+	laxConst := &props.FuncDepSet{}
+	laxConst.AddLaxKey(c(2, 3), c(1, 2, 3))
+	verifyFD(t, laxConst, "lax-key(2,3); (2,3)~~>(1)")
+	laxConst.AddConstants(c(1, 2, 3))
+	verifyFD(t, laxConst, "()-->(1-3)")
 }
 
 // Figure, page references are from this paper:

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1502,8 +1502,6 @@ project
       │         └── col0 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       ├── select
       │    ├── columns: col0:7(int!null) col2:9(int)
-      │    ├── cardinality: [0 - 1]
-      │    ├── key: ()
       │    ├── fd: ()-->(7,9)
       │    ├── index-join t
       │    │    ├── columns: col0:7(int) col2:9(int)


### PR DESCRIPTION
Prior to this commit, it was possible for empty lax keys to be created in
a `FuncDepSet` under certain conditions. In particular, this could happen if
the key was created with a set of columns that had just previously been
reduced to the empty set due to newly added constant columns.

This commit fixes the issue by ensuring that keys are never set directly.
Instead, functions in `func_dep.go` that need to set the key must call a
helper function `setKey`. `setKey` takes as arguments a set of key columns and
the desired type of key. If the key columns are empty and the desired type
is lax key, `setKey` will remove the key altogether.

Fixes #44296

Release note (bug fix): Fixed a bug that caused the optimizer to infer
incorrect keys for certain relational expressions. This could cause
incorrect results to be returned for some queries.