### PR TITLE
engine: add byte limit to MVCCScan

### DIFF
--- a/c-deps/libroach/chunked_buffer.cc
+++ b/c-deps/libroach/chunked_buffer.cc
@@ -29,6 +29,7 @@ void chunkedBuffer::Put(const rocksdb::Slice& key, const rocksdb::Slice& value) 
   put(key.data(), key.size(), value.size());
   put(value.data(), value.size(), 0);
   count_++;
+  bytes_ += sizeof(size_buf) + key.size() + value.size(); // see (*pebbleResults).put
 }
 
 void chunkedBuffer::Clear() {
@@ -36,6 +37,7 @@ void chunkedBuffer::Clear() {
     delete[] bufs_[i].data;
   }
   count_ = 0;
+  bytes_ = 0;
   buf_ptr_ = nullptr;
   bufs_.clear();
 }

--- a/c-deps/libroach/chunked_buffer.h
+++ b/c-deps/libroach/chunked_buffer.h
@@ -36,6 +36,8 @@ class chunkedBuffer {
 
   // Get the number of key/value pairs written to this chunkedBuffer.
   int Count() const { return count_; }
+  // Get the number of bytes written to this chunkedBuffer.
+  int NumBytes() const { return bytes_; }
 
  private:
   void put(const char* data, int len, int next_size_hint);
@@ -43,6 +45,7 @@ class chunkedBuffer {
  private:
   std::vector<DBSlice> bufs_;
   int64_t count_;
+  int64_t bytes_;
   char* buf_ptr_;
 };
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -366,8 +366,8 @@ typedef struct {
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
                       bool inconsistent, bool tombstones, bool fail_on_more_recent);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse,
-                       bool tombstones, bool fail_on_more_recent);
+                       int64_t max_keys, int64_t target_bytes, DBTxn txn, bool inconsistent,
+                       bool reverse, bool tombstones, bool fail_on_more_recent);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -275,21 +275,21 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // different than the start key. This is a bit of a hack.
   const DBSlice end = {0, 0};
   ScopedStats scoped_iter(iter);
-  mvccForwardScanner scanner(iter, key, end, timestamp, 1 /* max_keys */, txn, inconsistent,
-                             tombstones, fail_on_more_recent);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 1 /* max_keys */, 0 /* target_bytes */, txn,
+                             inconsistent, tombstones, fail_on_more_recent);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse,
-                       bool tombstones, bool fail_on_more_recent) {
+                       int64_t max_keys, int64_t target_bytes, DBTxn txn, bool inconsistent,
+                       bool reverse, bool tombstones, bool fail_on_more_recent) {
   ScopedStats scoped_iter(iter);
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, inconsistent, tombstones,
-                               fail_on_more_recent);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, target_bytes, txn,
+                               inconsistent, tombstones, fail_on_more_recent);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, inconsistent, tombstones,
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, target_bytes, txn, inconsistent, tombstones,
                                fail_on_more_recent);
     return scanner.scan();
   }

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2329,6 +2329,7 @@ func mvccScanToBytes(
 		end:              endKey,
 		ts:               timestamp,
 		maxKeys:          max,
+		targetBytes:      opts.TargetBytes,
 		inconsistent:     opts.Inconsistent,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
@@ -2430,6 +2431,18 @@ type MVCCScanOptions struct {
 	Reverse          bool
 	FailOnMoreRecent bool
 	Txn              *roachpb.Transaction
+	// TargetBytes is a byte threshold to limit the amount of data pulled into
+	// memory during a Scan operation. Once the target is satisfied (i.e. met or
+	// exceeded) by the emitted emitted KV pairs, iteration stops (with a
+	// ResumeSpan as appropriate). In particular, at least one kv pair is
+	// returned (when one exists).
+	//
+	// The number of bytes a particular kv pair accrues depends on internal data
+	// structures, but it is guaranteed to exceed that of the bytes stored in
+	// the key and value itself.
+	//
+	// The zero value indicates no limit.
+	TargetBytes int64
 }
 
 func (opts *MVCCScanOptions) validate() error {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2485,8 +2485,8 @@ func (r *rocksDBIterator) MVCCScan(
 
 	r.clearState()
 	state := C.MVCCScan(
-		r.iter, goToCSlice(start), goToCSlice(end),
-		goToCTimestamp(timestamp), C.int64_t(max),
+		r.iter, goToCSlice(start), goToCSlice(end), goToCTimestamp(timestamp),
+		C.int64_t(max), C.int64_t(opts.TargetBytes),
 		goToCTxn(opts.Txn), C.bool(opts.Inconsistent),
 		C.bool(opts.Reverse), C.bool(opts.Tombstones),
 		C.bool(opts.FailOnMoreRecent),

--- a/pkg/storage/engine/testdata/mvcc_histories/target_bytes
+++ b/pkg/storage/engine/testdata/mvcc_histories/target_bytes
@@ -1,0 +1,217 @@
+## Test opts.TargetBytes.
+
+# First, put some old data that we'll shadow.
+run ok
+with ts=1,0
+  put      k=a v=nevergoingtobeseen
+  put      k=e v=sameasabove
+  put      k=aa v=willbetombstoned
+del        k=aa ts=250,1
+----
+>> at end:
+data: "a"/0.000000001,0 -> /BYTES/nevergoingtobeseen
+data: "aa"/0.000000250,1 -> /<empty>
+data: "aa"/0.000000001,0 -> /BYTES/willbetombstoned
+data: "e"/0.000000001,0 -> /BYTES/sameasabove
+
+run ok
+with ts=123,45
+  put      k=a v=abcdef
+  put      k=c v=ghijkllkjihg
+  put      k=e v=mnopqr
+----
+>> at end:
+data: "a"/0.000000123,45 -> /BYTES/abcdef
+data: "a"/0.000000001,0 -> /BYTES/nevergoingtobeseen
+data: "aa"/0.000000250,1 -> /<empty>
+data: "aa"/0.000000001,0 -> /BYTES/willbetombstoned
+data: "c"/0.000000123,45 -> /BYTES/ghijkllkjihg
+data: "e"/0.000000123,45 -> /BYTES/mnopqr
+data: "e"/0.000000001,0 -> /BYTES/sameasabove
+
+# Scans without or with a large target size return all results.
+
+run ok
+with ts=300,0 k=a end=z
+  scan
+  scan reverse=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+
+run ok
+with ts=300,0 k=a end=z targetbytes=0
+  scan
+  scan reverse=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+
+run ok
+with ts=300,0 k=a end=z targetbytes=10000000
+  scan
+  scan reverse=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+
+
+run ok
+# Target size one byte returns one result (overshooting instead of returning nothing).
+# Upping the target size accordingly results in more rows.
+# In all cases, we're seeing resume spans iff the byte target had an effect.
+#
+# a@123,45 -> abcdef clocks in at 34 bytes as follows:
+#
+#    8 bytes size buf
+# + 14 key timestamp component
+# +  6 key bytes component
+# +  6 value bytes
+#
+# c@123,45 similarly accounts for 40 bytes.
+
+scan     k=a end=z ts=300,0 targetbytes=1
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: resume span ["aa","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=34
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: resume span ["aa","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=35
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["e","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=74
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["e","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=75
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+
+# Works just the same when not starting on an existing key.
+run ok
+scan     k=b end=z ts=300 targetbytes=1
+----
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["e","z")
+
+# Reverse scans.
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=1 reverse=true
+----
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: resume span ["a","c\x00")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=34 reverse=true
+----
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: resume span ["a","c\x00")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=35 reverse=true
+----
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["a","aa\x00")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=74 reverse=true
+----
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["a","aa\x00")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=75 reverse=true
+----
+scan: "e" -> /BYTES/mnopqr @0.000000123,45
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+
+# Scans that return the tombstone (at aa@250,1). The kv pair at a has 34 bytes,
+# aa has 24 (just a key).
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=34 tombstones=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: resume span ["aa","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=35 tombstones=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: resume span ["c","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=58 tombstones=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: resume span ["c","z")
+
+run ok
+scan     k=a end=z ts=300,0 targetbytes=59 tombstones=true
+----
+scan: "a" -> /BYTES/abcdef @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["e","z")
+
+# ... and similarly in reverse.
+
+run ok
+scan    k=a end=d ts=300,0 targetbytes=40 reverse=true tombstones=true
+----
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: resume span ["a","aa\x00")
+
+run ok
+scan    k=a end=d ts=300,0 targetbytes=41 reverse=true tombstones=true
+----
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: resume span ["a","a\x00")
+
+run ok
+scan    k=a end=d ts=300,0 targetbytes=64 reverse=true tombstones=true
+----
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: resume span ["a","a\x00")
+
+run ok
+scan    k=a end=d ts=300,0 targetbytes=65 reverse=true tombstones=true
+----
+scan: "c" -> /BYTES/ghijkllkjihg @0.000000123,45
+scan: "aa" -> /<empty> @0.000000250,1
+scan: "a" -> /BYTES/abcdef @0.000000123,45


### PR DESCRIPTION
A fledgling step towards #19721 is allowing incoming KV requests to
bound the size of the response in terms of bytes rather than rows.
This commit adds a TargetBytes field to MVCCScanOptions to address
this need: scans stop once the size of the result meets or exceeds the
threshold (at least one key will be added, regardless of its size),
and returns a ResumeSpan as appropriate.

The classic example of the problem this addresses is a table in which
each row is, say, ~1mb in size. A full table scan will currently fetch
data from KV in batches of [10k], causing at least 10GB of data held in
memory at any given moment. This sort of thing does happen in practice;
we have a long-failing roachtest #33660 because of just that, and
anecdotally OOMs in production clusters are with regularity caused by
individual queries consuming excessive amounts of memory at the KV
level.

Plumbing this limit into a header field on BatchRequest and down to the
engine level will allow the batching in [10k] to become byte-sized in
nature, thus avoiding one obvious source OOMs. This doesn't solve #19721
in general (many such requests could work together to consume a lot of
memory after all), but it's a sane baby step that might just avoid a
large portion of OOMs already.

[10k]: https://github.com/cockroachdb/cockroach/blob/0a658c19cd164e7c021eaff7f73db173f0650e8c/pkg/sql/row/kv_batch_fetcher.go#L25-L29

Release note: None