### PR TITLE
cli/zip: make `cockroach zip` more resilient

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -26,7 +26,9 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -217,15 +219,15 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	admin := serverpb.NewAdminClient(conn)
 
 	fmt.Println("retrieving the node status to get the SQL address...")
-	nodeS, err := status.Node(baseCtx, &serverpb.NodeRequest{NodeId: "local"})
+	nodeD, err := status.Details(baseCtx, &serverpb.DetailsRequest{NodeId: "local"})
 	if err != nil {
 		return err
 	}
-	sqlAddr := nodeS.Desc.SQLAddress
+	sqlAddr := nodeD.SQLAddress
 	if sqlAddr.IsEmpty() {
 		// No SQL address: either a pre-19.2 node, or same address for both
 		// SQL and RPC.
-		sqlAddr = nodeS.Desc.Address
+		sqlAddr = nodeD.Address
 	}
 	fmt.Printf("using SQL address: %s\n", sqlAddr.AddressField)
 	cliCtx.clientConnHost, cliCtx.clientConnPort, err = net.SplitHostPort(sqlAddr.AddressField)
@@ -320,193 +322,207 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 			if err := z.createError(nodesPrefix, err); err != nil {
 				return err
 			}
-		} else {
-			for _, node := range nodes.Nodes {
-				id := fmt.Sprintf("%d", node.Desc.NodeID)
-				prefix := fmt.Sprintf("%s/%s", nodesPrefix, id)
-				// Don't use sqlConn because that's only for is the node `debug
-				// zip` was pointed at, but here we want to connect to nodes
-				// individually to grab node- local SQL tables. Try to guess by
-				// replacing the host in the connection string; this may or may
-				// not work and if it doesn't, we let the invalid curSQLConn get
-				// used anyway so that anything that does *not* need it will
-				// still happen.
-				sqlAddr := node.Desc.SQLAddress
-				if sqlAddr.IsEmpty() {
-					// No SQL address: either a pre-19.2 node, or same address for both
-					// SQL and RPC.
-					sqlAddr = node.Desc.Address
+		}
+
+		// In case nodes came up back empty (the Nodes() RPC failed), we
+		// still want to inspect the per-node endpoints on the head
+		// node. As per the above, we were able to connect at least to
+		// that.
+		nodeList := []statuspb.NodeStatus{{Desc: roachpb.NodeDescriptor{
+			NodeID:     nodeD.NodeID,
+			Address:    nodeD.Address,
+			SQLAddress: nodeD.SQLAddress,
+		}}}
+		if nodes != nil {
+			// If the nodes were found, use that instead.
+			nodeList = nodes.Nodes
+		}
+
+		for _, node := range nodeList {
+			id := fmt.Sprintf("%d", node.Desc.NodeID)
+			prefix := fmt.Sprintf("%s/%s", nodesPrefix, id)
+			// Don't use sqlConn because that's only for is the node `debug
+			// zip` was pointed at, but here we want to connect to nodes
+			// individually to grab node- local SQL tables. Try to guess by
+			// replacing the host in the connection string; this may or may
+			// not work and if it doesn't, we let the invalid curSQLConn get
+			// used anyway so that anything that does *not* need it will
+			// still happen.
+			sqlAddr := node.Desc.SQLAddress
+			if sqlAddr.IsEmpty() {
+				// No SQL address: either a pre-19.2 node, or same address for both
+				// SQL and RPC.
+				sqlAddr = node.Desc.Address
+			}
+			curSQLConn := guessNodeURL(sqlConn.url, sqlAddr.AddressField)
+			if err := z.createJSON(prefix+"/status.json", node); err != nil {
+				return err
+			}
+			fmt.Printf("using SQL connection URL for node %s: %s\n", id, curSQLConn.url)
+
+			for _, table := range debugZipTablesPerNode {
+				if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table); err != nil {
+					return errors.Wrap(err, table)
 				}
-				curSQLConn := guessNodeURL(sqlConn.url, sqlAddr.AddressField)
-				if err := z.createJSON(prefix+"/status.json", node); err != nil {
+			}
+
+			for _, r := range []zipRequest{
+				{
+					fn: func(ctx context.Context) (interface{}, error) {
+						return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Ready: false})
+					},
+					pathName: prefix + "/details",
+				},
+				{
+					fn: func(ctx context.Context) (interface{}, error) {
+						return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id})
+					},
+					pathName: prefix + "/gossip",
+				},
+				{
+					fn: func(ctx context.Context) (interface{}, error) {
+						return status.EngineStats(ctx, &serverpb.EngineStatsRequest{NodeId: id})
+					},
+					pathName: prefix + "/enginestats",
+				},
+			} {
+				if err := runZipRequest(r); err != nil {
 					return err
 				}
-				fmt.Printf("using SQL connection URL for node %s: %s\n", id, curSQLConn.url)
+			}
 
-				for _, table := range debugZipTablesPerNode {
-					if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table); err != nil {
-						return errors.Wrap(err, table)
+			var stacksData []byte
+			err = runZipRequestWithTimeout(baseCtx, "requesting stacks for node "+id, timeout,
+				func(ctx context.Context) error {
+					stacks, err := status.Stacks(ctx, &serverpb.StacksRequest{NodeId: id})
+					if err == nil {
+						stacksData = stacks.Data
 					}
-				}
+					return err
+				})
+			if err := z.createRawOrError(prefix+"/stacks.txt", stacksData, err); err != nil {
+				return err
+			}
 
-				for _, r := range []zipRequest{
-					{
-						fn: func(ctx context.Context) (interface{}, error) {
-							return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Ready: false})
-						},
-						pathName: prefix + "/details",
-					},
-					{
-						fn: func(ctx context.Context) (interface{}, error) {
-							return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id})
-						},
-						pathName: prefix + "/gossip",
-					},
-					{
-						fn: func(ctx context.Context) (interface{}, error) {
-							return status.EngineStats(ctx, &serverpb.EngineStatsRequest{NodeId: id})
-						},
-						pathName: prefix + "/enginestats",
-					},
-				} {
-					if err := runZipRequest(r); err != nil {
-						return err
-					}
-				}
-
-				var stacksData []byte
-				err = runZipRequestWithTimeout(baseCtx, "requesting stacks for node "+id, timeout,
-					func(ctx context.Context) error {
-						stacks, err := status.Stacks(ctx, &serverpb.StacksRequest{NodeId: id})
-						if err == nil {
-							stacksData = stacks.Data
-						}
-						return err
+			var heapData []byte
+			err = runZipRequestWithTimeout(baseCtx, "requesting heap profile for node "+id, timeout,
+				func(ctx context.Context) error {
+					heap, err := status.Profile(ctx, &serverpb.ProfileRequest{
+						NodeId: id,
+						Type:   serverpb.ProfileRequest_HEAP,
 					})
-				if err := z.createRawOrError(prefix+"/stacks.txt", stacksData, err); err != nil {
+					if err == nil {
+						heapData = heap.Data
+					}
 					return err
-				}
+				})
+			if err := z.createRawOrError(prefix+"/heap.pprof", heapData, err); err != nil {
+				return err
+			}
 
-				var heapData []byte
-				err = runZipRequestWithTimeout(baseCtx, "requesting heap profile for node "+id, timeout,
-					func(ctx context.Context) error {
-						heap, err := status.Profile(ctx, &serverpb.ProfileRequest{
-							NodeId: id,
-							Type:   serverpb.ProfileRequest_HEAP,
-						})
-						if err == nil {
-							heapData = heap.Data
-						}
-						return err
+			var profiles *serverpb.GetFilesResponse
+			if err := runZipRequestWithTimeout(baseCtx, "requesting heap files for node "+id, timeout,
+				func(ctx context.Context) error {
+					profiles, err = status.GetFiles(ctx, &serverpb.GetFilesRequest{
+						NodeId:   id,
+						Type:     serverpb.FileType_HEAP,
+						Patterns: []string{"*"},
 					})
-				if err := z.createRawOrError(prefix+"/heap.pprof", heapData, err); err != nil {
-					return err
-				}
-
-				var profiles *serverpb.GetFilesResponse
-				if err := runZipRequestWithTimeout(baseCtx, "requesting heap files for node "+id, timeout,
-					func(ctx context.Context) error {
-						profiles, err = status.GetFiles(ctx, &serverpb.GetFilesRequest{
-							NodeId:   id,
-							Type:     serverpb.FileType_HEAP,
-							Patterns: []string{"*"},
-						})
-						return err
-					}); err != nil {
-					if err := z.createError(prefix+"/heapprof", err); err != nil {
-						return err
-					}
-				} else {
-					fmt.Printf("%d found\n", len(profiles.Files))
-					for _, file := range profiles.Files {
-						name := prefix + "/heapprof/" + file.Name + ".pprof"
-						if err := z.createRaw(name, file.Contents); err != nil {
-							return err
-						}
-					}
-				}
-
-				var goroutinesResp *serverpb.GetFilesResponse
-				if err := runZipRequestWithTimeout(baseCtx, "requesting goroutine files for node "+id, timeout,
-					func(ctx context.Context) error {
-						goroutinesResp, err = status.GetFiles(ctx, &serverpb.GetFilesRequest{
-							NodeId:   id,
-							Type:     serverpb.FileType_GOROUTINES,
-							Patterns: []string{"*"},
-						})
-						return err
-					}); err != nil {
-					if err := z.createError(prefix+"/goroutines", err); err != nil {
-						return err
-					}
-				} else {
-					fmt.Printf("%d found\n", len(goroutinesResp.Files))
-					for _, file := range goroutinesResp.Files {
-						// NB: the files have a .txt.gz suffix already.
-						name := prefix + "/goroutines/" + file.Name
-						if err := z.createRawOrError(name, file.Contents, err); err != nil {
-							return err
-						}
-					}
-				}
-
-				var logs *serverpb.LogFilesListResponse
-				if err := runZipRequestWithTimeout(baseCtx, "requesting log files list", timeout,
-					func(ctx context.Context) error {
-						logs, err = status.LogFilesList(
-							ctx, &serverpb.LogFilesListRequest{NodeId: id})
-						return err
-					}); err != nil {
-					if err := z.createError(prefix+"/logs", err); err != nil {
-						return err
-					}
-				} else {
-					fmt.Printf("%d found\n", len(logs.Files))
-					for _, file := range logs.Files {
-						name := prefix + "/logs/" + file.Name
-						var entries *serverpb.LogEntriesResponse
-						if err := runZipRequestWithTimeout(baseCtx, fmt.Sprintf("requesting log file %s", file.Name), timeout,
-							func(ctx context.Context) error {
-								entries, err = status.LogFile(
-									ctx, &serverpb.LogFileRequest{NodeId: id, File: file.Name})
-								return err
-							}); err != nil {
-							if err := z.createError(name, err); err != nil {
-								return err
-							}
-							continue
-						}
-						logOut, err := z.create(name, timeutil.Unix(0, file.ModTimeNanos))
-						if err != nil {
-							return err
-						}
-						for _, e := range entries.Entries {
-							if err := e.Format(logOut); err != nil {
-								return err
-							}
-						}
-					}
-				}
-
-				var ranges *serverpb.RangesResponse
-				if err := runZipRequestWithTimeout(baseCtx, "requesting ranges", timeout, func(ctx context.Context) error {
-					ranges, err = status.Ranges(ctx, &serverpb.RangesRequest{NodeId: id})
 					return err
 				}); err != nil {
-					if err := z.createError(prefix+"/ranges", err); err != nil {
+				if err := z.createError(prefix+"/heapprof", err); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("%d found\n", len(profiles.Files))
+				for _, file := range profiles.Files {
+					name := prefix + "/heapprof/" + file.Name + ".pprof"
+					if err := z.createRaw(name, file.Contents); err != nil {
 						return err
 					}
-				} else {
-					fmt.Printf("%d found\n", len(ranges.Ranges))
-					sort.Slice(ranges.Ranges, func(i, j int) bool {
-						return ranges.Ranges[i].State.Desc.RangeID <
-							ranges.Ranges[j].State.Desc.RangeID
+				}
+			}
+
+			var goroutinesResp *serverpb.GetFilesResponse
+			if err := runZipRequestWithTimeout(baseCtx, "requesting goroutine files for node "+id, timeout,
+				func(ctx context.Context) error {
+					goroutinesResp, err = status.GetFiles(ctx, &serverpb.GetFilesRequest{
+						NodeId:   id,
+						Type:     serverpb.FileType_GOROUTINES,
+						Patterns: []string{"*"},
 					})
-					for _, r := range ranges.Ranges {
-						name := fmt.Sprintf("%s/ranges/%s", prefix, r.State.Desc.RangeID)
-						if err := z.createJSON(name+".json", r); err != nil {
+					return err
+				}); err != nil {
+				if err := z.createError(prefix+"/goroutines", err); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("%d found\n", len(goroutinesResp.Files))
+				for _, file := range goroutinesResp.Files {
+					// NB: the files have a .txt.gz suffix already.
+					name := prefix + "/goroutines/" + file.Name
+					if err := z.createRawOrError(name, file.Contents, err); err != nil {
+						return err
+					}
+				}
+			}
+
+			var logs *serverpb.LogFilesListResponse
+			if err := runZipRequestWithTimeout(baseCtx, "requesting log files list", timeout,
+				func(ctx context.Context) error {
+					logs, err = status.LogFilesList(
+						ctx, &serverpb.LogFilesListRequest{NodeId: id})
+					return err
+				}); err != nil {
+				if err := z.createError(prefix+"/logs", err); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("%d found\n", len(logs.Files))
+				for _, file := range logs.Files {
+					name := prefix + "/logs/" + file.Name
+					var entries *serverpb.LogEntriesResponse
+					if err := runZipRequestWithTimeout(baseCtx, fmt.Sprintf("requesting log file %s", file.Name), timeout,
+						func(ctx context.Context) error {
+							entries, err = status.LogFile(
+								ctx, &serverpb.LogFileRequest{NodeId: id, File: file.Name})
+							return err
+						}); err != nil {
+						if err := z.createError(name, err); err != nil {
 							return err
 						}
+						continue
+					}
+					logOut, err := z.create(name, timeutil.Unix(0, file.ModTimeNanos))
+					if err != nil {
+						return err
+					}
+					for _, e := range entries.Entries {
+						if err := e.Format(logOut); err != nil {
+							return err
+						}
+					}
+				}
+			}
+
+			var ranges *serverpb.RangesResponse
+			if err := runZipRequestWithTimeout(baseCtx, "requesting ranges", timeout, func(ctx context.Context) error {
+				ranges, err = status.Ranges(ctx, &serverpb.RangesRequest{NodeId: id})
+				return err
+			}); err != nil {
+				if err := z.createError(prefix+"/ranges", err); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("%d found\n", len(ranges.Ranges))
+				sort.Slice(ranges.Ranges, func(i, j int) bool {
+					return ranges.Ranges[i].State.Desc.RangeID <
+						ranges.Ranges[j].State.Desc.RangeID
+				})
+				for _, r := range ranges.Ranges {
+					name := fmt.Sprintf("%s/ranges/%s", prefix, r.State.Desc.RangeID)
+					if err := z.createJSON(name+".json", r); err != nil {
+						return err
 					}
 				}
 			}

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -306,7 +306,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, table := range debugZipTablesPerCluster {
-		if err := dumpTableDataForZip(z, sqlConn, base, table); err != nil {
+		if err := dumpTableDataForZip(z, sqlConn, timeout, base, table); err != nil {
 			return errors.Wrap(err, table)
 		}
 	}
@@ -344,7 +344,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 				fmt.Printf("using SQL connection URL for node %s: %s\n", id, curSQLConn.url)
 
 				for _, table := range debugZipTablesPerNode {
-					if err := dumpTableDataForZip(z, curSQLConn, prefix, table); err != nil {
+					if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table); err != nil {
 						return errors.Wrap(err, table)
 					}
 				}
@@ -593,8 +593,10 @@ func (fne *fileNameEscaper) escape(f string) string {
 	return result
 }
 
-func dumpTableDataForZip(z *zipper, conn *sqlConn, base, table string) error {
-	query := fmt.Sprintf(`SELECT * FROM %s`, table)
+func dumpTableDataForZip(
+	z *zipper, conn *sqlConn, timeout time.Duration, base, table string,
+) error {
+	query := fmt.Sprintf(`SET statement_timeout = '%s'; SELECT * FROM %s`, timeout, table)
 	name := base + "/" + table + ".txt"
 
 	fmt.Printf("retrieving SQL data for %s... ", table)

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -102,98 +102,121 @@ func TestZip(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Strip any non-deterministic messages:
+	re := regexp.MustCompile(`(?m)postgresql://.*$`)
+	out = re.ReplaceAllString(out, `postgresql://...`)
+	re = regexp.MustCompile(`(?m)SQL address: .*$`)
+	out = re.ReplaceAllString(out, `SQL address: ...`)
+	re = regexp.MustCompile(`(?m)log file.*$`)
+	out = re.ReplaceAllString(out, `log file ...`)
+	re = regexp.MustCompile(`(?m)RPC connection to .*$`)
+	out = re.ReplaceAllString(out, `RPC connection to ...`)
+
 	const expected = `debug zip ` + os.DevNull + `
+establishing RPC connection to ...
+retrieving the node status to get the SQL address...
+using SQL address: ...
+using SQL connection URL: postgresql://...
 writing ` + os.DevNull + `
-  debug/events.json
-  debug/rangelog.json
-  debug/liveness.json
-  debug/settings.json
-  debug/reports/problemranges.json
-  debug/crdb_internal.cluster_queries.txt
-  debug/crdb_internal.cluster_sessions.txt
-  debug/crdb_internal.cluster_settings.txt
-  debug/crdb_internal.jobs.txt
-  debug/system.jobs.txt
-  debug/system.descriptor.txt
-  debug/system.namespace.txt
-  debug/system.namespace_deprecated.txt
-  debug/crdb_internal.kv_node_status.txt
-  debug/crdb_internal.kv_store_status.txt
-  debug/crdb_internal.schema_changes.txt
-  debug/crdb_internal.partitions.txt
-  debug/crdb_internal.zones.txt
-  debug/nodes/1/status.json
-  debug/nodes/1/crdb_internal.feature_usage.txt
-  debug/nodes/1/crdb_internal.gossip_alerts.txt
-  debug/nodes/1/crdb_internal.gossip_liveness.txt
-  debug/nodes/1/crdb_internal.gossip_network.txt
-  debug/nodes/1/crdb_internal.gossip_nodes.txt
-  debug/nodes/1/crdb_internal.leases.txt
-  debug/nodes/1/crdb_internal.node_build_info.txt
-  debug/nodes/1/crdb_internal.node_metrics.txt
-  debug/nodes/1/crdb_internal.node_queries.txt
-  debug/nodes/1/crdb_internal.node_runtime_info.txt
-  debug/nodes/1/crdb_internal.node_sessions.txt
-  debug/nodes/1/crdb_internal.node_statement_statistics.txt
-  debug/nodes/1/crdb_internal.node_txn_stats.txt
-  debug/nodes/1/details.json
-  debug/nodes/1/gossip.json
-  debug/nodes/1/enginestats.json
-  debug/nodes/1/stacks.txt
-  debug/nodes/1/heap.pprof
-  debug/nodes/1/ranges/1.json
-  debug/nodes/1/ranges/2.json
-  debug/nodes/1/ranges/3.json
-  debug/nodes/1/ranges/4.json
-  debug/nodes/1/ranges/5.json
-  debug/nodes/1/ranges/6.json
-  debug/nodes/1/ranges/7.json
-  debug/nodes/1/ranges/8.json
-  debug/nodes/1/ranges/9.json
-  debug/nodes/1/ranges/10.json
-  debug/nodes/1/ranges/11.json
-  debug/nodes/1/ranges/12.json
-  debug/nodes/1/ranges/13.json
-  debug/nodes/1/ranges/14.json
-  debug/nodes/1/ranges/15.json
-  debug/nodes/1/ranges/16.json
-  debug/nodes/1/ranges/17.json
-  debug/nodes/1/ranges/18.json
-  debug/nodes/1/ranges/19.json
-  debug/nodes/1/ranges/20.json
-  debug/nodes/1/ranges/21.json
-  debug/nodes/1/ranges/22.json
-  debug/nodes/1/ranges/23.json
-  debug/nodes/1/ranges/24.json
-  debug/nodes/1/ranges/25.json
-  debug/nodes/1/ranges/26.json
-  debug/nodes/1/ranges/27.json
-  debug/nodes/1/ranges/28.json
-  debug/schema/defaultdb@details.json
-  debug/schema/postgres@details.json
-  debug/schema/system@details.json
-  debug/schema/system/comments.json
-  debug/schema/system/descriptor.json
-  debug/schema/system/eventlog.json
-  debug/schema/system/jobs.json
-  debug/schema/system/lease.json
-  debug/schema/system/locations.json
-  debug/schema/system/namespace.json
-  debug/schema/system/namespace_deprecated.json
-  debug/schema/system/protected_ts_meta.json
-  debug/schema/system/protected_ts_records.json
-  debug/schema/system/rangelog.json
-  debug/schema/system/replication_constraint_stats.json
-  debug/schema/system/replication_critical_localities.json
-  debug/schema/system/replication_stats.json
-  debug/schema/system/reports_meta.json
-  debug/schema/system/role_members.json
-  debug/schema/system/settings.json
-  debug/schema/system/table_statistics.json
-  debug/schema/system/ui.json
-  debug/schema/system/users.json
-  debug/schema/system/web_sessions.json
-  debug/schema/system/zones.json
+requesting data for debug/events... writing: debug/events.json
+requesting data for debug/rangelog... writing: debug/rangelog.json
+requesting data for debug/liveness... writing: debug/liveness.json
+requesting data for debug/settings... writing: debug/settings.json
+requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
+retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
+retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt
+retrieving SQL data for crdb_internal.jobs... writing: debug/crdb_internal.jobs.txt
+retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
+retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
+retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
+retrieving SQL data for system.namespace_deprecated... writing: debug/system.namespace_deprecated.txt
+retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
+retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
+retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
+retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
+retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+requesting nodes... writing: debug/nodes/1/status.json
+using SQL connection URL for node 1: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/1/crdb_internal.feature_usage.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/1/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/1/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
+requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
+requesting data for debug/nodes/1/gossip... writing: debug/nodes/1/gossip.json
+requesting data for debug/nodes/1/enginestats... writing: debug/nodes/1/enginestats.json
+requesting stacks for node 1... writing: debug/nodes/1/stacks.txt
+requesting heap profile for node 1... writing: debug/nodes/1/heap.pprof
+requesting heap files for node 1... 0 found
+requesting goroutine files for node 1... 0 found
+requesting log file ...
+requesting ranges... 28 found
+writing: debug/nodes/1/ranges/1.json
+writing: debug/nodes/1/ranges/2.json
+writing: debug/nodes/1/ranges/3.json
+writing: debug/nodes/1/ranges/4.json
+writing: debug/nodes/1/ranges/5.json
+writing: debug/nodes/1/ranges/6.json
+writing: debug/nodes/1/ranges/7.json
+writing: debug/nodes/1/ranges/8.json
+writing: debug/nodes/1/ranges/9.json
+writing: debug/nodes/1/ranges/10.json
+writing: debug/nodes/1/ranges/11.json
+writing: debug/nodes/1/ranges/12.json
+writing: debug/nodes/1/ranges/13.json
+writing: debug/nodes/1/ranges/14.json
+writing: debug/nodes/1/ranges/15.json
+writing: debug/nodes/1/ranges/16.json
+writing: debug/nodes/1/ranges/17.json
+writing: debug/nodes/1/ranges/18.json
+writing: debug/nodes/1/ranges/19.json
+writing: debug/nodes/1/ranges/20.json
+writing: debug/nodes/1/ranges/21.json
+writing: debug/nodes/1/ranges/22.json
+writing: debug/nodes/1/ranges/23.json
+writing: debug/nodes/1/ranges/24.json
+writing: debug/nodes/1/ranges/25.json
+writing: debug/nodes/1/ranges/26.json
+writing: debug/nodes/1/ranges/27.json
+writing: debug/nodes/1/ranges/28.json
+requesting list of SQL databases... 3 found
+requesting database details for defaultdb... writing: debug/schema/defaultdb@details.json
+0 tables found
+requesting database details for postgres... writing: debug/schema/postgres@details.json
+0 tables found
+requesting database details for system... writing: debug/schema/system@details.json
+22 tables found
+requesting table details for system.comments... writing: debug/schema/system/comments.json
+requesting table details for system.descriptor... writing: debug/schema/system/descriptor.json
+requesting table details for system.eventlog... writing: debug/schema/system/eventlog.json
+requesting table details for system.jobs... writing: debug/schema/system/jobs.json
+requesting table details for system.lease... writing: debug/schema/system/lease.json
+requesting table details for system.locations... writing: debug/schema/system/locations.json
+requesting table details for system.namespace... writing: debug/schema/system/namespace.json
+requesting table details for system.namespace_deprecated... writing: debug/schema/system/namespace_deprecated.json
+requesting table details for system.protected_ts_meta... writing: debug/schema/system/protected_ts_meta.json
+requesting table details for system.protected_ts_records... writing: debug/schema/system/protected_ts_records.json
+requesting table details for system.rangelog... writing: debug/schema/system/rangelog.json
+requesting table details for system.replication_constraint_stats... writing: debug/schema/system/replication_constraint_stats.json
+requesting table details for system.replication_critical_localities... writing: debug/schema/system/replication_critical_localities.json
+requesting table details for system.replication_stats... writing: debug/schema/system/replication_stats.json
+requesting table details for system.reports_meta... writing: debug/schema/system/reports_meta.json
+requesting table details for system.role_members... writing: debug/schema/system/role_members.json
+requesting table details for system.settings... writing: debug/schema/system/settings.json
+requesting table details for system.table_statistics... writing: debug/schema/system/table_statistics.json
+requesting table details for system.ui... writing: debug/schema/system/ui.json
+requesting table details for system.users... writing: debug/schema/system/users.json
+requesting table details for system.web_sessions... writing: debug/schema/system/web_sessions.json
+requesting table details for system.zones... writing: debug/schema/system/zones.json
 `
 
 	assert.Equal(t, expected, out)
@@ -232,193 +255,220 @@ func TestPartialZip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Strip any non-deterministic error messages:
-	re := regexp.MustCompile(`(?m)\^- resulted in.*$`)
+	// Strip any non-deterministic messages:
+	re := regexp.MustCompile(`(?m)postgresql://.*$`)
+	out = re.ReplaceAllString(out, `postgresql://...`)
+	re = regexp.MustCompile(`(?m)SQL address: .*$`)
+	out = re.ReplaceAllString(out, `SQL address: ...`)
+	re = regexp.MustCompile(`(?m)log file.*$`)
+	out = re.ReplaceAllString(out, `log file ...`)
+	re = regexp.MustCompile(`(?m)RPC connection to .*$`)
+	out = re.ReplaceAllString(out, `RPC connection to ...`)
+	re = regexp.MustCompile(`(?m)\^- resulted in.*$`)
 	out = re.ReplaceAllString(out, `^- resulted in ...`)
 
 	const expected = `debug zip ` + os.DevNull + `
-writing /dev/null
-  debug/events.json
-  debug/rangelog.json
-  debug/liveness.json
-  debug/settings.json
-  debug/reports/problemranges.json
-  debug/crdb_internal.cluster_queries.txt
-  debug/crdb_internal.cluster_sessions.txt
-  debug/crdb_internal.cluster_settings.txt
-  debug/crdb_internal.jobs.txt
-  debug/system.jobs.txt
-  debug/system.descriptor.txt
-  debug/system.namespace.txt
-  debug/crdb_internal.kv_node_status.txt
-  debug/crdb_internal.kv_store_status.txt
-  debug/crdb_internal.schema_changes.txt
-  debug/crdb_internal.partitions.txt
-  debug/crdb_internal.zones.txt
-  debug/nodes/1/status.json
-  debug/nodes/1/crdb_internal.feature_usage.txt
-  debug/nodes/1/crdb_internal.gossip_alerts.txt
-  debug/nodes/1/crdb_internal.gossip_liveness.txt
-  debug/nodes/1/crdb_internal.gossip_network.txt
-  debug/nodes/1/crdb_internal.gossip_nodes.txt
-  debug/nodes/1/crdb_internal.leases.txt
-  debug/nodes/1/crdb_internal.node_build_info.txt
-  debug/nodes/1/crdb_internal.node_metrics.txt
-  debug/nodes/1/crdb_internal.node_queries.txt
-  debug/nodes/1/crdb_internal.node_runtime_info.txt
-  debug/nodes/1/crdb_internal.node_sessions.txt
-  debug/nodes/1/crdb_internal.node_statement_statistics.txt
-  debug/nodes/1/crdb_internal.node_txn_stats.txt
-  debug/nodes/1/details.json
-  debug/nodes/1/gossip.json
-  debug/nodes/1/enginestats.json
-  debug/nodes/1/stacks.txt
-  debug/nodes/1/heap.pprof
-  debug/nodes/1/ranges/1.json
-  debug/nodes/1/ranges/2.json
-  debug/nodes/1/ranges/3.json
-  debug/nodes/1/ranges/4.json
-  debug/nodes/1/ranges/5.json
-  debug/nodes/1/ranges/6.json
-  debug/nodes/1/ranges/7.json
-  debug/nodes/1/ranges/8.json
-  debug/nodes/1/ranges/9.json
-  debug/nodes/1/ranges/10.json
-  debug/nodes/1/ranges/11.json
-  debug/nodes/1/ranges/12.json
-  debug/nodes/1/ranges/13.json
-  debug/nodes/1/ranges/14.json
-  debug/nodes/1/ranges/15.json
-  debug/nodes/1/ranges/16.json
-  debug/nodes/1/ranges/17.json
-  debug/nodes/1/ranges/18.json
-  debug/nodes/1/ranges/19.json
-  debug/nodes/1/ranges/20.json
-  debug/nodes/1/ranges/21.json
-  debug/nodes/1/ranges/22.json
-  debug/nodes/1/ranges/23.json
-  debug/nodes/1/ranges/24.json
-  debug/nodes/1/ranges/25.json
-  debug/nodes/1/ranges/26.json
-  debug/nodes/1/ranges/27.json
-  debug/nodes/1/ranges/28.json
-  debug/nodes/2/status.json
-  debug/nodes/2/crdb_internal.feature_usage.txt
+establishing RPC connection to ...
+retrieving the node status to get the SQL address...
+using SQL address: ...
+using SQL connection URL: postgresql://...
+writing ` + os.DevNull + `
+requesting data for debug/events... writing: debug/events.json
+requesting data for debug/rangelog... writing: debug/rangelog.json
+requesting data for debug/liveness... writing: debug/liveness.json
+requesting data for debug/settings... writing: debug/settings.json
+requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
+retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
+retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt
+retrieving SQL data for crdb_internal.jobs... writing: debug/crdb_internal.jobs.txt
+retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
+retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
+retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
+retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
+retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
+retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
+retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
+retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+requesting nodes... writing: debug/nodes/1/status.json
+using SQL connection URL for node 1: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/1/crdb_internal.feature_usage.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/1/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/1/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
+requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
+requesting data for debug/nodes/1/gossip... writing: debug/nodes/1/gossip.json
+requesting data for debug/nodes/1/enginestats... writing: debug/nodes/1/enginestats.json
+requesting stacks for node 1... writing: debug/nodes/1/stacks.txt
+requesting heap profile for node 1... writing: debug/nodes/1/heap.pprof
+requesting heap files for node 1... 0 found
+requesting goroutine files for node 1... 0 found
+requesting log file ...
+requesting ranges... 28 found
+writing: debug/nodes/1/ranges/1.json
+writing: debug/nodes/1/ranges/2.json
+writing: debug/nodes/1/ranges/3.json
+writing: debug/nodes/1/ranges/4.json
+writing: debug/nodes/1/ranges/5.json
+writing: debug/nodes/1/ranges/6.json
+writing: debug/nodes/1/ranges/7.json
+writing: debug/nodes/1/ranges/8.json
+writing: debug/nodes/1/ranges/9.json
+writing: debug/nodes/1/ranges/10.json
+writing: debug/nodes/1/ranges/11.json
+writing: debug/nodes/1/ranges/12.json
+writing: debug/nodes/1/ranges/13.json
+writing: debug/nodes/1/ranges/14.json
+writing: debug/nodes/1/ranges/15.json
+writing: debug/nodes/1/ranges/16.json
+writing: debug/nodes/1/ranges/17.json
+writing: debug/nodes/1/ranges/18.json
+writing: debug/nodes/1/ranges/19.json
+writing: debug/nodes/1/ranges/20.json
+writing: debug/nodes/1/ranges/21.json
+writing: debug/nodes/1/ranges/22.json
+writing: debug/nodes/1/ranges/23.json
+writing: debug/nodes/1/ranges/24.json
+writing: debug/nodes/1/ranges/25.json
+writing: debug/nodes/1/ranges/26.json
+writing: debug/nodes/1/ranges/27.json
+writing: debug/nodes/1/ranges/28.json
+writing: debug/nodes/2/status.json
+using SQL connection URL for node 2: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/2/crdb_internal.feature_usage.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/2/crdb_internal.gossip_alerts.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/2/crdb_internal.gossip_liveness.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/2/crdb_internal.gossip_network.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/2/crdb_internal.gossip_nodes.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/2/crdb_internal.leases.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/2/crdb_internal.node_build_info.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/2/crdb_internal.node_metrics.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/2/crdb_internal.node_queries.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/2/crdb_internal.node_runtime_info.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/2/crdb_internal.node_sessions.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt
   ^- resulted in ...
-  debug/nodes/2/crdb_internal.node_txn_stats.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/2/crdb_internal.node_txn_stats.txt
   ^- resulted in ...
-  debug/nodes/2/details.json
+requesting data for debug/nodes/2/details... writing: debug/nodes/2/details.json
   ^- resulted in ...
-  debug/nodes/2/gossip.json
+requesting data for debug/nodes/2/gossip... writing: debug/nodes/2/gossip.json
   ^- resulted in ...
-  debug/nodes/2/enginestats.json
+requesting data for debug/nodes/2/enginestats... writing: debug/nodes/2/enginestats.json
   ^- resulted in ...
-  debug/nodes/2/stacks.txt
+requesting stacks for node 2... writing: debug/nodes/2/stacks.txt
   ^- resulted in ...
-  debug/nodes/2/heap.pprof
+requesting heap profile for node 2... writing: debug/nodes/2/heap.pprof
   ^- resulted in ...
-  debug/nodes/2/heapprof
+requesting heap files for node 2... writing: debug/nodes/2/heapprof
   ^- resulted in ...
-  debug/nodes/2/goroutines
+requesting goroutine files for node 2... writing: debug/nodes/2/goroutines
   ^- resulted in ...
-  debug/nodes/2/logs
+requesting log file ...
   ^- resulted in ...
-  debug/nodes/2/ranges
+requesting ranges... writing: debug/nodes/2/ranges
   ^- resulted in ...
-  debug/nodes/3/status.json
-  debug/nodes/3/crdb_internal.feature_usage.txt
-  debug/nodes/3/crdb_internal.gossip_alerts.txt
-  debug/nodes/3/crdb_internal.gossip_liveness.txt
-  debug/nodes/3/crdb_internal.gossip_network.txt
-  debug/nodes/3/crdb_internal.gossip_nodes.txt
-  debug/nodes/3/crdb_internal.leases.txt
-  debug/nodes/3/crdb_internal.node_build_info.txt
-  debug/nodes/3/crdb_internal.node_metrics.txt
-  debug/nodes/3/crdb_internal.node_queries.txt
-  debug/nodes/3/crdb_internal.node_runtime_info.txt
-  debug/nodes/3/crdb_internal.node_sessions.txt
-  debug/nodes/3/crdb_internal.node_statement_statistics.txt
-  debug/nodes/3/crdb_internal.node_txn_stats.txt
-  debug/nodes/3/details.json
-  debug/nodes/3/gossip.json
-  debug/nodes/3/enginestats.json
-  debug/nodes/3/stacks.txt
-  debug/nodes/3/heap.pprof
-  debug/nodes/3/ranges/1.json
-  debug/nodes/3/ranges/2.json
-  debug/nodes/3/ranges/3.json
-  debug/nodes/3/ranges/4.json
-  debug/nodes/3/ranges/5.json
-  debug/nodes/3/ranges/6.json
-  debug/nodes/3/ranges/7.json
-  debug/nodes/3/ranges/8.json
-  debug/nodes/3/ranges/9.json
-  debug/nodes/3/ranges/10.json
-  debug/nodes/3/ranges/11.json
-  debug/nodes/3/ranges/12.json
-  debug/nodes/3/ranges/13.json
-  debug/nodes/3/ranges/14.json
-  debug/nodes/3/ranges/15.json
-  debug/nodes/3/ranges/16.json
-  debug/nodes/3/ranges/17.json
-  debug/nodes/3/ranges/18.json
-  debug/nodes/3/ranges/19.json
-  debug/nodes/3/ranges/20.json
-  debug/nodes/3/ranges/21.json
-  debug/nodes/3/ranges/22.json
-  debug/nodes/3/ranges/23.json
-  debug/nodes/3/ranges/24.json
-  debug/nodes/3/ranges/25.json
-  debug/nodes/3/ranges/26.json
-  debug/nodes/3/ranges/27.json
-  debug/nodes/3/ranges/28.json
-  debug/schema/defaultdb@details.json
-  debug/schema/postgres@details.json
-  debug/schema/system@details.json
-  debug/schema/system/comments.json
-  debug/schema/system/descriptor.json
-  debug/schema/system/eventlog.json
-  debug/schema/system/jobs.json
-  debug/schema/system/lease.json
-  debug/schema/system/locations.json
-  debug/schema/system/namespace.json
-  debug/schema/system/namespace_deprecated.json
-  debug/schema/system/protected_ts_meta.json
-  debug/schema/system/protected_ts_records.json
-  debug/schema/system/rangelog.json
-  debug/schema/system/replication_constraint_stats.json
-  debug/schema/system/replication_critical_localities.json
-  debug/schema/system/replication_stats.json
-  debug/schema/system/reports_meta.json
-  debug/schema/system/role_members.json
-  debug/schema/system/settings.json
-  debug/schema/system/table_statistics.json
-  debug/schema/system/ui.json
-  debug/schema/system/users.json
-  debug/schema/system/web_sessions.json
-  debug/schema/system/zones.json
+writing: debug/nodes/3/status.json
+using SQL connection URL for node 3: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/3/crdb_internal.feature_usage.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/3/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/3/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/3/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/3/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/3/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/3/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/3/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/3/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/3/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/3/crdb_internal.node_txn_stats.txt
+requesting data for debug/nodes/3/details... writing: debug/nodes/3/details.json
+requesting data for debug/nodes/3/gossip... writing: debug/nodes/3/gossip.json
+requesting data for debug/nodes/3/enginestats... writing: debug/nodes/3/enginestats.json
+requesting stacks for node 3... writing: debug/nodes/3/stacks.txt
+requesting heap profile for node 3... writing: debug/nodes/3/heap.pprof
+requesting heap files for node 3... 0 found
+requesting goroutine files for node 3... 0 found
+requesting log file ...
+requesting ranges... 28 found
+writing: debug/nodes/3/ranges/1.json
+writing: debug/nodes/3/ranges/2.json
+writing: debug/nodes/3/ranges/3.json
+writing: debug/nodes/3/ranges/4.json
+writing: debug/nodes/3/ranges/5.json
+writing: debug/nodes/3/ranges/6.json
+writing: debug/nodes/3/ranges/7.json
+writing: debug/nodes/3/ranges/8.json
+writing: debug/nodes/3/ranges/9.json
+writing: debug/nodes/3/ranges/10.json
+writing: debug/nodes/3/ranges/11.json
+writing: debug/nodes/3/ranges/12.json
+writing: debug/nodes/3/ranges/13.json
+writing: debug/nodes/3/ranges/14.json
+writing: debug/nodes/3/ranges/15.json
+writing: debug/nodes/3/ranges/16.json
+writing: debug/nodes/3/ranges/17.json
+writing: debug/nodes/3/ranges/18.json
+writing: debug/nodes/3/ranges/19.json
+writing: debug/nodes/3/ranges/20.json
+writing: debug/nodes/3/ranges/21.json
+writing: debug/nodes/3/ranges/22.json
+writing: debug/nodes/3/ranges/23.json
+writing: debug/nodes/3/ranges/24.json
+writing: debug/nodes/3/ranges/25.json
+writing: debug/nodes/3/ranges/26.json
+writing: debug/nodes/3/ranges/27.json
+writing: debug/nodes/3/ranges/28.json
+requesting list of SQL databases... 3 found
+requesting database details for defaultdb... writing: debug/schema/defaultdb@details.json
+0 tables found
+requesting database details for postgres... writing: debug/schema/postgres@details.json
+0 tables found
+requesting database details for system... writing: debug/schema/system@details.json
+22 tables found
+requesting table details for system.comments... writing: debug/schema/system/comments.json
+requesting table details for system.descriptor... writing: debug/schema/system/descriptor.json
+requesting table details for system.eventlog... writing: debug/schema/system/eventlog.json
+requesting table details for system.jobs... writing: debug/schema/system/jobs.json
+requesting table details for system.lease... writing: debug/schema/system/lease.json
+requesting table details for system.locations... writing: debug/schema/system/locations.json
+requesting table details for system.namespace... writing: debug/schema/system/namespace.json
+requesting table details for system.namespace_deprecated... writing: debug/schema/system/namespace_deprecated.json
+requesting table details for system.protected_ts_meta... writing: debug/schema/system/protected_ts_meta.json
+requesting table details for system.protected_ts_records... writing: debug/schema/system/protected_ts_records.json
+requesting table details for system.rangelog... writing: debug/schema/system/rangelog.json
+requesting table details for system.replication_constraint_stats... writing: debug/schema/system/replication_constraint_stats.json
+requesting table details for system.replication_critical_localities... writing: debug/schema/system/replication_critical_localities.json
+requesting table details for system.replication_stats... writing: debug/schema/system/replication_stats.json
+requesting table details for system.reports_meta... writing: debug/schema/system/reports_meta.json
+requesting table details for system.role_members... writing: debug/schema/system/role_members.json
+requesting table details for system.settings... writing: debug/schema/system/settings.json
+requesting table details for system.table_statistics... writing: debug/schema/system/table_statistics.json
+requesting table details for system.ui... writing: debug/schema/system/ui.json
+requesting table details for system.users... writing: debug/schema/system/users.json
+requesting table details for system.web_sessions... writing: debug/schema/system/web_sessions.json
+requesting table details for system.zones... writing: debug/schema/system/zones.json
 `
 	assert.Equal(t, expected, out)
 }

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -218,6 +219,88 @@ requesting table details for system.users... writing: debug/schema/system/users.
 requesting table details for system.web_sessions... writing: debug/schema/system/web_sessions.json
 requesting table details for system.zones... writing: debug/schema/system/zones.json
 `
+
+	assert.Equal(t, expected, out)
+}
+
+func TestZipSpecialNames(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	c := newCLITest(cliTestParams{
+		storeSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+	})
+	defer c.cleanup()
+
+	c.RunWithArgs([]string{"sql", "-e", `
+create database "a:b";
+create database "a-b";
+create database "a-b-1";
+create database "SYSTEM";
+create table "SYSTEM.JOBS"(x int);
+create database "../system";
+create table defaultdb."a:b"(x int);
+create table defaultdb."a-b"(x int);
+create table defaultdb."pg_catalog.pg_class"(x int);
+create table defaultdb."../system"(x int);
+`})
+
+	out, err := c.RunWithCapture("debug zip " + os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	re := regexp.MustCompile(`(?m)^.*(table|database).*$`)
+	out = strings.Join(re.FindAllString(out, -1), "\n")
+
+	const expected = `requesting list of SQL databases... 8 found
+requesting database details for ../system... writing: debug/schema/___system@details.json
+0 tables found
+requesting database details for SYSTEM... writing: debug/schema/system@details.json
+0 tables found
+requesting database details for a-b... writing: debug/schema/a_b@details.json
+0 tables found
+requesting database details for a-b-1... writing: debug/schema/a_b_1@details.json
+0 tables found
+requesting database details for a:b... writing: debug/schema/a_b-1@details.json
+0 tables found
+requesting database details for defaultdb... writing: debug/schema/defaultdb@details.json
+5 tables found
+requesting table details for defaultdb.../system... writing: debug/schema/defaultdb/___system.json
+requesting table details for defaultdb.SYSTEM.JOBS... writing: debug/schema/defaultdb/system_jobs.json
+requesting table details for defaultdb.a-b... writing: debug/schema/defaultdb/a_b.json
+requesting table details for defaultdb.a:b... writing: debug/schema/defaultdb/a_b-1.json
+requesting table details for defaultdb.pg_catalog.pg_class... writing: debug/schema/defaultdb/pg_catalog_pg_class.json
+requesting database details for postgres... writing: debug/schema/postgres@details.json
+0 tables found
+requesting database details for system... writing: debug/schema/system-1@details.json
+22 tables found
+requesting table details for system.comments... writing: debug/schema/system-1/comments.json
+requesting table details for system.descriptor... writing: debug/schema/system-1/descriptor.json
+requesting table details for system.eventlog... writing: debug/schema/system-1/eventlog.json
+requesting table details for system.jobs... writing: debug/schema/system-1/jobs.json
+requesting table details for system.lease... writing: debug/schema/system-1/lease.json
+requesting table details for system.locations... writing: debug/schema/system-1/locations.json
+requesting table details for system.namespace... writing: debug/schema/system-1/namespace.json
+requesting table details for system.namespace_deprecated... writing: debug/schema/system-1/namespace_deprecated.json
+requesting table details for system.protected_ts_meta... writing: debug/schema/system-1/protected_ts_meta.json
+requesting table details for system.protected_ts_records... writing: debug/schema/system-1/protected_ts_records.json
+requesting table details for system.rangelog... writing: debug/schema/system-1/rangelog.json
+requesting table details for system.replication_constraint_stats... writing: debug/schema/system-1/replication_constraint_stats.json
+requesting table details for system.replication_critical_localities... writing: debug/schema/system-1/replication_critical_localities.json
+requesting table details for system.replication_stats... writing: debug/schema/system-1/replication_stats.json
+requesting table details for system.reports_meta... writing: debug/schema/system-1/reports_meta.json
+requesting table details for system.role_members... writing: debug/schema/system-1/role_members.json
+requesting table details for system.settings... writing: debug/schema/system-1/settings.json
+requesting table details for system.table_statistics... writing: debug/schema/system-1/table_statistics.json
+requesting table details for system.ui... writing: debug/schema/system-1/ui.json
+requesting table details for system.users... writing: debug/schema/system-1/users.json
+requesting table details for system.web_sessions... writing: debug/schema/system-1/web_sessions.json
+requesting table details for system.zones... writing: debug/schema/system-1/zones.json`
 
 	assert.Equal(t, expected, out)
 }


### PR DESCRIPTION
Fixes #44337.
Fixes #36584.
Fixes #44215.
Fixes #44215.
Fixes #39620.

This is a collection of patches that enhance the behavior of `cockroach zip` over partially or fully unavailable clusters. In particular it increases the amount of useful data collected.

