### PR TITLE
release-19.2: sql: allow booleans in SET tracing and friendlier error message

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1131,13 +1131,22 @@ func (ex *connExecutor) runSetTracing(
 	modes := make([]string, len(n.Values))
 	for i, v := range n.Values {
 		v = unresolvedNameToStrVal(v)
-		strVal, ok := v.(*tree.StrVal)
-		if !ok {
-			res.SetError(errors.AssertionFailedf(
-				"expected string for set tracing argument, not %T", v))
+		var strMode string
+		switch val := v.(type) {
+		case *tree.StrVal:
+			strMode = val.RawString()
+		case *tree.DBool:
+			if *val {
+				strMode = "on"
+			} else {
+				strMode = "off"
+			}
+		default:
+			res.SetError(pgerror.New(pgcode.Syntax,
+				"expected string or boolean for set tracing argument"))
 			return
 		}
-		modes[i] = strVal.RawString()
+		modes[i] = strMode
 	}
 
 	if err := ex.enableTracing(modes); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -302,6 +302,12 @@ SET tracing.blah = 123
 statement error invalid value for parameter "ssl_renegotiation_limit"
 SET ssl_renegotiation_limit = 123
 
+statement ok
+SET SESSION tracing=false
+
+statement error pgcode 42601 expected string or boolean for set tracing argument
+SET SESSION tracing=1
+
 subtest regression_35109_flowable
 
 statement ok


### PR DESCRIPTION
Backport 1/1 commits from #44260.

/cc @cockroachdb/release

---

Previously, we would fail an assertion if a datum of the wrong type is
provided in `SET tracing` query (only strings were allowed). This resulted
in an internal error and printing out of the stack trace which can be
scary to users. This commit removes the assertion and makes it a regular
query error.

Also, booleans are now allowed as argument to `SET tracing`, and `true`
is mapped to `on` mode and `false` to `off`.

Fixes: #44244.

Release note (sql change, bug fix): Previously, CockroachDB would return
an internal error when using `SET tracing` with any type other than
string. Now it will return a regular query error. Additionally, boolean
arguments are now supported in `SET tracing`, and `true` is mapped to
`on` mode of tracing whereas `false` is mapped to `off`.
