### PR TITLE
ui: reserve the statements endpoint to admin users

### DIFF
--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -25,6 +25,10 @@ import (
 func (s *statusServer) Statements(
 	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
+	if _, err := s.admin.requireAdminUser(ctx); err != nil {
+		return nil, err
+	}
+
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 


### PR DESCRIPTION
Informs #44348 (not fixing until backports are issued)

The statements stats infrastructure does not handle privileges and
separation of visibility of statements between different users.

Therefore, it is not safe to allow non-admin users to query the data,
as they could incorrectly become able to view operations ran onto
databases and tables over which they have no privilege.

(Not to mention viewing queries ran by other users; even the shape of
a query or its query plan could potentially be sensitive information.)

Release note (security update): Previous versions of CockroachDB were
incorrectly enabling non-admin users to use the statements details in
the Admin UI and the HTTP endpoint `/_status/statements`. This
information is sensitive because the endpoint does not hide data that
the requester does not have privilege over. This has been corrected
by requiring an admin user.