### PR TITLE
roachtest: assign each test an owner

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -66,6 +66,7 @@ func registerAcceptance(r *testRegistry) {
 		// this naming scheme ever change (or issues such as #33519)
 		// will be posted.
 		Name:    "acceptance",
+		Owner:   OwnerKV,
 		Timeout: 10 * time.Minute,
 		Tags:    tags,
 		Cluster: makeClusterSpec(numNodes),

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -73,6 +73,7 @@ func registerAllocator(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    `replicate/up/1to3`,
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
@@ -80,6 +81,7 @@ func registerAllocator(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:    `replicate/rebalance/3to5`,
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
@@ -87,6 +89,7 @@ func registerAllocator(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:    `replicate/wide`,
+		Owner:   OwnerKV,
 		Timeout: 10 * time.Minute,
 		Cluster: makeClusterSpec(9, cpu(1)),
 		Run:     runWideReplication,

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -84,7 +84,8 @@ func registerAlterPK(r *testRegistry) {
 	}
 	r.Add(testSpec{
 		// TODO (rohany): update this setup if we want to add more workloads to this roachtest.
-		Name: "alterpk",
+		Name:  "alterpk",
+		Owner: OwnerSQLExec,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		MinVersion: "v20.1.0",

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -24,6 +24,7 @@ func registerBackup(r *testRegistry) {
 	backup2TBSpec := makeClusterSpec(10)
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("backup2TB/%s", backup2TBSpec),
+		Owner:      OwnerBulkIO,
 		Cluster:    backup2TBSpec,
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -64,6 +65,7 @@ func registerBackup(r *testRegistry) {
 	// verifies them with a fingerprint.
 	r.Add(testSpec{
 		Name:    `backupTPCC`,
+		Owner:   OwnerBulkIO,
 		Cluster: makeClusterSpec(3),
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -113,6 +113,7 @@ func registerCancel(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Owner:   OwnerSQLExec,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
@@ -121,6 +122,7 @@ func registerCancel(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Owner:   OwnerSQLExec,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -514,6 +514,7 @@ func registerCDC(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/tpcc-1000/rangefeed=%t", useRangeFeed),
+		Owner:      `cdc`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -529,6 +530,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/initial-scan/rangefeed=%t", useRangeFeed),
+		Owner:      `cdc`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -544,7 +546,8 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name: "cdc/poller/rangefeed=false",
+		Name:  "cdc/poller/rangefeed=false",
+		Owner: `cdc`,
 		// When testing a 2.1 binary, we use the poller for all the other tests
 		// and this is close enough to cdc/tpcc-1000 test to be redundant, so
 		// skip it.
@@ -562,7 +565,8 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name: fmt.Sprintf("cdc/sink-chaos/rangefeed=%t", useRangeFeed),
+		Name:  fmt.Sprintf("cdc/sink-chaos/rangefeed=%t", useRangeFeed),
+		Owner: `cdc`,
 		// TODO(dan): Re-enable this test on 2.1 if we decide to backport #36852.
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
@@ -579,8 +583,9 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name: fmt.Sprintf("cdc/crdb-chaos/rangefeed=%t", useRangeFeed),
-		Skip: "#37716",
+		Name:  fmt.Sprintf("cdc/crdb-chaos/rangefeed=%t", useRangeFeed),
+		Owner: `cdc`,
+		Skip:  "#37716",
 		// TODO(dan): Re-enable this test on 2.1 if we decide to backport #36852.
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
@@ -602,6 +607,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/ledger/rangefeed=%t", useRangeFeed),
+		Owner:      `cdc`,
 		MinVersion: "v2.1.0",
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
@@ -621,6 +627,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/cloud-sink-gcs/rangefeed=true",
+		Owner:      `cdc`,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -643,6 +650,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/bank",
+		Owner:      `cdc`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -651,6 +659,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/schemareg",
+		Owner:      `cdc`,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(1),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -22,7 +22,8 @@ func registerClearRange(r *testRegistry) {
 	for _, checks := range []bool{true, false} {
 		checks := checks
 		r.Add(testSpec{
-			Name: fmt.Sprintf(`clearrange/checks=%t`, checks),
+			Name:  fmt.Sprintf(`clearrange/checks=%t`, checks),
+			Owner: OwnerStorage,
 			// 5h for import, 90 for the test. The import should take closer
 			// to <3:30h but it varies.
 			Timeout:    5*time.Hour + 90*time.Minute,

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -129,7 +129,8 @@ func registerClockJumpTests(r *testRegistry) {
 	for i := range testCases {
 		tc := testCases[i]
 		spec := testSpec{
-			Name: "clock/jump/" + tc.name,
+			Name:  "clock/jump/" + tc.name,
+			Owner: OwnerKV,
 			// These tests muck with NTP, therefore we don't want the cluster reused
 			// by others.
 			Cluster: makeClusterSpec(1, reuseTagged("offset-injector")),

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -129,7 +129,8 @@ func registerClockMonotonicTests(r *testRegistry) {
 	for i := range testCases {
 		tc := testCases[i]
 		spec := testSpec{
-			Name: "clock/monotonic/" + tc.name,
+			Name:  "clock/monotonic/" + tc.name,
+			Owner: OwnerKV,
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
 			Cluster: makeClusterSpec(1, reuseTagged("offset-injector")),

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -142,6 +142,7 @@ func registerCopy(r *testRegistry) {
 		inTxn := inTxn
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
+			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runCopy(ctx, t, c, rows, inTxn)

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -239,6 +239,7 @@ func registerDecommission(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -22,6 +22,7 @@ import (
 func registerDiskFull(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "disk-full",
+		Owner:      OwnerKV,
 		MinVersion: `v2.1.0`,
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/35328#issuecomment-478540195",
 		Cluster:    makeClusterSpec(5),

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -32,6 +32,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 					"disk-stalled/log=%t,data=%t",
 					affectsLogDir, affectsDataDir,
 				),
+				Owner:      OwnerKV,
 				MinVersion: "v19.1.0",
 				Cluster:    makeClusterSpec(1),
 				Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -127,7 +127,7 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx, c, node, "install cockroach-django", `
-					cd /mnt/data1/django/tests/cockroach-django/ && 
+					cd /mnt/data1/django/tests/cockroach-django/ &&
 					pip3 install psycopg2-binary --user && pip3 install . --user`,
 		); err != nil {
 			t.Fatal(err)
@@ -137,7 +137,7 @@ func registerDjango(r *testRegistry) {
 			ctx, c, node, "install django's dependencies", `
 				cd /mnt/data1/django/tests &&
 				pip3 install -e .. --user &&
-				pip3 install -r requirements/py3.txt --user && 
+				pip3 install -r requirements/py3.txt --user &&
 				pip3 install -r requirements/postgres.txt --user`,
 		); err != nil {
 			t.Fatal(err)
@@ -189,6 +189,7 @@ func registerDjango(r *testRegistry) {
 		Skip:       "django tests are still too flaky to run",
 		MinVersion: "v19.2.0",
 		Name:       "django",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -166,6 +166,7 @@ func registerDrop(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
+		Owner:      OwnerKV,
 		MinVersion: `v2.1.0`,
 		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -20,6 +20,7 @@ import (
 func registerElectionAfterRestart(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "election-after-restart",
+		Owner:   OwnerKV,
 		Skip:    "https://github.com/cockroachdb/cockroach/issues/35047",
 		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -76,6 +76,7 @@ func registerEncryption(r *testRegistry) {
 	for _, n := range []int{1} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("encryption/nodes=%d", n),
+			Owner:      OwnerStorage,
 			MinVersion: "v2.1.0",
 			Cluster:    makeClusterSpec(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -96,6 +96,7 @@ func registerFlowable(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "flowable",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -30,6 +30,7 @@ import (
 func registerFollowerReads(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "follower-reads/nodes=3",
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(3 /* nodeCount */, cpu(2), geo()),
 		MinVersion: "v19.1.0",
 		Run:        runFollowerReadsTest,

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -151,6 +151,7 @@ func registerGopg(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "gopg",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.2.0",
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -115,6 +115,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("gossip/chaos/nodes=9"),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(9),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runGossipChaos(ctx, t, c)

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -178,6 +178,7 @@ func registerHibernate(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "hibernate",
+		Owner:   OwnerAppDev,
 		Cluster: makeClusterSpec(1),
 		Tags:    []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -98,6 +98,7 @@ func registerHotSpotSplits(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -51,6 +51,7 @@ func registerImportTPCC(r *testRegistry) {
 	for _, numNodes := range []int{4, 32} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
+			Owner:   OwnerBulkIO,
 			Cluster: makeClusterSpec(numNodes),
 			Timeout: 5 * time.Hour,
 			Run: func(ctx context.Context, t *test, c *cluster) {
@@ -62,6 +63,7 @@ func registerImportTPCC(r *testRegistry) {
 	const geoZones = "europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b"
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
+		Owner:   OwnerBulkIO,
 		Cluster: makeClusterSpec(8, cpu(16), geo(), zones(geoZones)),
 		Timeout: 5 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -90,6 +92,7 @@ func registerImportTPCH(r *testRegistry) {
 		item := item
 		r.Add(testSpec{
 			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
+			Owner:   OwnerBulkIO,
 			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -21,6 +21,7 @@ import (
 func registerInconsistency(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("inconsistency"),
+		Owner:      OwnerKV,
 		MinVersion: "v19.2.2", // https://github.com/cockroachdb/cockroach/pull/42149 is new in 19.2.2
 		Cluster:    makeClusterSpec(3),
 		Run:        runInconsistency,

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -23,6 +23,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(geoZonesStr)),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		MinVersion: `v19.1.0`,

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -124,6 +124,7 @@ func registerInterleaved(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "interleavedpartitioned",
+		Owner:   OwnerPartitioning,
 		Cluster: makeClusterSpec(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runInterleaved(ctx, t, c,

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -21,6 +21,7 @@ import (
 func registerSchemaChangeInvertedIndex(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    "schemachange/invertedindex",
+		Owner:   OwnerSQLSchema,
 		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -311,7 +311,8 @@ func registerJepsen(r *testRegistry) {
 		for _, nemesis := range jepsenNemeses {
 			nemesis := nemesis // copy for closure
 			spec := testSpec{
-				Name: fmt.Sprintf("jepsen/%s/%s", testName, nemesis.name),
+				Name:  fmt.Sprintf("jepsen/%s/%s", testName, nemesis.name),
+				Owner: OwnerKV,
 				// The Jepsen tests do funky things to machines, like muck with the
 				// system clock; therefore, their clusters cannot be reused other tests
 				// except the Jepsen ones themselves which reset all this state when

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -176,6 +176,7 @@ func registerKV(r *testRegistry) {
 
 		r.Add(testSpec{
 			Name:       strings.Join(nameParts, "/"),
+			Owner:      OwnerKV,
 			MinVersion: minVersion,
 			Cluster:    makeClusterSpec(opts.nodes+1, cpu(opts.cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
@@ -190,6 +191,7 @@ func registerKVContention(r *testRegistry) {
 	const nodes = 4
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("kv/contention/nodes=%d", nodes),
+		Owner:      OwnerKV,
 		MinVersion: "v19.2.0",
 		Cluster:    makeClusterSpec(nodes + 1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -247,6 +249,7 @@ func registerKVContention(r *testRegistry) {
 func registerKVQuiescenceDead(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "kv/quiescence/nodes=3",
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4),
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -329,6 +332,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 	r.Add(testSpec{
 		Skip:    "https://github.com/cockroachdb/cockroach/issues/33501",
 		Name:    "kv/gracefuldraining/nodes=3",
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.spec.NodeCount - 1
@@ -456,6 +460,7 @@ func registerKVSplits(r *testRegistry) {
 		item := item // for use in closure below
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t", item.quiesce),
+			Owner:   OwnerKV,
 			Timeout: item.timeout,
 			Cluster: makeClusterSpec(4),
 			Run: func(ctx context.Context, t *test, c *cluster) {
@@ -527,6 +532,7 @@ func registerKVScalability(r *testRegistry) {
 			p := p
 			r.Add(testSpec{
 				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
+				Owner:   OwnerKV,
 				Cluster: makeClusterSpec(7, cpu(8)),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runScalability(ctx, t, c, p)
@@ -660,6 +666,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		}
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
+			Owner:      OwnerKV,
 			MinVersion: "v19.2.0",
 			Cluster:    makeClusterSpec(nodes+1, cpu(cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -81,6 +81,7 @@ func registerKVBenchSpec(r *testRegistry, b kvBenchSpec) {
 	nodes := makeClusterSpec(b.Nodes+1, opts...)
 	r.Add(testSpec{
 		Name:    name,
+		Owner:   OwnerKV,
 		Cluster: nodes,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runKVBench(ctx, t, c, b)

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -20,6 +20,7 @@ func registerLedger(r *testRegistry) {
 	const azs = "us-central1-a,us-central1-b,us-central1-c"
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(azs)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			roachNodes := c.Range(1, nodes)

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -104,6 +104,7 @@ func registerLibPQ(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "lib/pq",
+		Owner:      OwnerAppDev,
 		MinVersion: "v19.2.0",
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -121,9 +121,13 @@ Examples:
 				registerBenchmarks(&r)
 			}
 
-			names := r.List(context.Background(), args)
-			for _, name := range names {
-				fmt.Println(name)
+			matchedTests := r.List(context.Background(), args)
+			for _, test := range matchedTests {
+				var skip string
+				if test.Skip != "" {
+					skip = " (skipped: " + test.Skip + ")"
+				}
+				fmt.Printf("%s [%s]%s\n", test.Name, test.Owner, skip)
 			}
 			return nil
 		},

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -243,6 +243,7 @@ func registerNetwork(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
@@ -250,6 +251,7 @@ func registerNetwork(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("network/tpcc/nodes=%d", numNodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runNetworkTPCC(ctx, t, c, numNodes)

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -114,6 +114,7 @@ func registerTPCCOverloadSpec(r *testRegistry, s tpccOLAPSpec) {
 		s.Nodes, s.CPUs, s.Warehouses, s.Concurrency)
 	r.Add(testSpec{
 		Name:       name,
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(s.Nodes+1, cpu(s.CPUs)),
 		Run:        s.run,
 		MinVersion: "v19.2.0",

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -177,6 +177,7 @@ func registerPgjdbc(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "pgjdbc",
+		Owner:   OwnerAppDev,
 		Cluster: makeClusterSpec(1),
 		Tags:    []string{`default`, `driver`},
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -115,6 +115,7 @@ func registerPgx(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "pgx",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.2.0",
 		Tags:       []string{`default`, `driver`},

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -126,6 +126,7 @@ func registerPsycopg(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "psycopg",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
 		Tags:       []string{`default`, `driver`},

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -25,6 +25,7 @@ func registerQueue(r *testRegistry) {
 	r.Add(testSpec{
 		Skip:    "https://github.com/cockroachdb/cockroach/issues/17229",
 		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runQueue(ctx, t, c)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -132,6 +132,7 @@ func registerRebalanceLoad(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       `rebalance-leases-by-load`,
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -144,6 +145,7 @@ func registerRebalanceLoad(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       `rebalance-replicas-by-load`,
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -21,6 +21,7 @@ func registerReplicaGC(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "replicagc-changed-peers/withRestart",
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(6),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runReplicaGCChangedPeers(ctx, t, c, true /* withRestart */)
@@ -28,6 +29,7 @@ func registerReplicaGC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:    "replicagc-changed-peers/noRestart",
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(6),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runReplicaGCChangedPeers(ctx, t, c, false /* withRestart */)

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -85,6 +85,7 @@ func runRestart(ctx context.Context, t *test, c *cluster, downDuration time.Dura
 func registerRestart(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("restart/down-for-2m"),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(3),
 		// "cockroach workload is only in 19.1+"
 		MinVersion: "v19.1.0",

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -219,6 +219,7 @@ func registerRestore(r *testRegistry) {
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),
+			Owner:   OwnerBulkIO,
 			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -70,6 +70,7 @@ func registerRoachmart(r *testRegistry) {
 		v := v
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
+			Owner:   OwnerPartitioning,
 			Cluster: makeClusterSpec(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -42,6 +42,7 @@ func registerScaleData(r *testRegistry) {
 		for _, n := range []int{3, 6} {
 			r.Add(testSpec{
 				Name:    fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
+				Owner:   OwnerKV,
 				Timeout: 2 * duration,
 				Cluster: makeClusterSpec(n + 1),
 				Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -23,6 +23,7 @@ import (
 func registerSchemaChangeKV(r *testRegistry) {
 	r.Add(testSpec{
 		Name:    `schemachange/mixed/kv`,
+		Owner:   OwnerSQLSchema,
 		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
@@ -294,6 +295,7 @@ func registerSchemaChangeIndexTPCC100(r *testRegistry) {
 func makeIndexAddTpccTest(spec clusterSpec, warehouses int, length time.Duration) testSpec {
 	return testSpec{
 		Name:    fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
+		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -323,6 +325,7 @@ func registerSchemaChangeBulkIngest(r *testRegistry) {
 func makeSchemaChangeBulkIngestTest(numNodes, numRows int, length time.Duration) testSpec {
 	return testSpec{
 		Name:    "schemachange/bulkingest",
+		Owner:   OwnerSQLSchema,
 		Cluster: makeClusterSpec(numNodes),
 		Timeout: length * 2,
 		// `fixtures import` (with the workload paths) is not supported in 2.1
@@ -406,6 +409,7 @@ func registerMixedSchemaChangesTPCC1000(r *testRegistry) {
 func makeMixedSchemaChanges(spec clusterSpec, warehouses int, length time.Duration) testSpec {
 	return testSpec{
 		Name:    "schemachange/mixed/tpcc",
+		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -48,6 +48,7 @@ func makeScrubTPCCTest(
 
 	return testSpec{
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
+		Owner:   OwnerSQLExec,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{

--- a/pkg/cmd/roachtest/secondary_indexes.go
+++ b/pkg/cmd/roachtest/secondary_indexes.go
@@ -38,8 +38,8 @@ func registerSecondaryIndexesMultiVersionCluster(r *testRegistry) {
 		conn := c.Conn(ctx, 1)
 		if _, err := conn.Exec(`
 CREATE TABLE t (
-	x INT PRIMARY KEY, y INT, z INT, w INT, 
-	INDEX i (y) STORING (z, w), 
+	x INT PRIMARY KEY, y INT, z INT, w INT,
+	INDEX i (y) STORING (z, w),
 	FAMILY (x), FAMILY (y), FAMILY (z), FAMILY (w)
 );
 INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
@@ -103,6 +103,7 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 	}
 	r.Add(testSpec{
 		Name:       "secondary-index-multi-version",
+		Owner:      OwnerSQLExec,
 		Cluster:    makeClusterSpec(3),
 		MinVersion: "v20.1.0",
 		Run:        runTest,

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -41,6 +41,7 @@ func registerLoadSplits(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/uniform/nodes=%d", numNodes),
+		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -84,6 +85,7 @@ func registerLoadSplits(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/sequential/nodes=%d", numNodes),
+		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -104,6 +106,7 @@ func registerLoadSplits(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/spanning/nodes=%d", numNodes),
+		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -217,6 +220,7 @@ func registerLargeRange(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("splits/largerange/size=%s,nodes=%d", bytesStr(size), numNodes),
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Timeout: 5 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -204,6 +204,7 @@ func registerSQLAlchemy(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "sqlalchemy",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v2.1.0",
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -190,7 +190,9 @@ func registerSQLSmith(r *testRegistry) {
 
 	register := func(setup, setting string) {
 		r.Add(testSpec{
-			Name:       fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
+			Name: fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
+			// NB: sqlsmith failures should never block a release.
+			Owner:      OwnerSQLExec,
 			Cluster:    makeClusterSpec(4),
 			MinVersion: "v20.1.0",
 			Timeout:    time.Minute * 20,

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -29,6 +29,7 @@ fi
 
 	r.Add(testSpec{
 		Name:       "synctest",
+		Owner:      OwnerStorage,
 		MinVersion: "v19.1.0",
 		// This test sets up a custom file system; we don't want the cluster reused.
 		Cluster: makeClusterSpec(1, reuseNone()),

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -131,6 +131,7 @@ func registerSysbench(r *testRegistry) {
 
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
+			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(n+1, cpu(cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runSysbench(ctx, t, c, opts)

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -36,6 +36,10 @@ type testSpec struct {
 	SkipDetails string
 
 	Name string
+	// Owner is the name of the team responsible for signing off on failures of
+	// this test that happen in the release process. This must be one of a limited
+	// set of values (the keys in the roachtestTeams map).
+	Owner Owner
 	// The maximum duration the test is allowed to run before it is considered
 	// failed. If not specified, the default timeout is 10m before the test's
 	// associated cluster expires. The timeout is always truncated to 10m before

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/kr/pretty"
 )
 
+const OwnerUnitTest Owner = `unittest`
+
 const defaultParallelism = 10
 
 func TestMatchOrSkip(t *testing.T) {
@@ -50,7 +52,7 @@ func TestMatchOrSkip(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			f := newFilter(c.filter)
-			spec := &testSpec{Name: c.name, Tags: c.tags}
+			spec := &testSpec{Name: c.name, Owner: OwnerUnitTest, Tags: c.tags}
 			if value := spec.matchOrSkip(f); c.expected != value {
 				t.Fatalf("expected %t, but found %t", c.expected, value)
 			} else if value && c.expectedSkip != spec.Skip {
@@ -80,11 +82,13 @@ func TestRunnerRun(t *testing.T) {
 	}
 	r.Add(testSpec{
 		Name:    "pass",
+		Owner:   OwnerUnitTest,
 		Run:     func(ctx context.Context, t *test, c *cluster) {},
 		Cluster: makeClusterSpec(0),
 	})
 	r.Add(testSpec{
-		Name: "fail",
+		Name:  "fail",
+		Owner: OwnerUnitTest,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Fatal("failed")
 		},
@@ -170,6 +174,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 	}
 	test := testSpec{
 		Name:    `timeout`,
+		Owner:   OwnerUnitTest,
 		Timeout: 10 * time.Millisecond,
 		Cluster: makeClusterSpec(0),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -204,6 +209,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 		{
 			testSpec{
 				Name:    "a",
+				Owner:   OwnerUnitTest,
 				Run:     dummyRun,
 				Cluster: makeClusterSpec(0),
 			},
@@ -213,6 +219,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 		{
 			testSpec{
 				Name:       "a",
+				Owner:      OwnerUnitTest,
 				MinVersion: "v2.1.0",
 				Run:        dummyRun,
 				Cluster:    makeClusterSpec(0),
@@ -223,6 +230,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 		{
 			testSpec{
 				Name:       "a",
+				Owner:      OwnerUnitTest,
 				MinVersion: "foo",
 				Run:        dummyRun,
 				Cluster:    makeClusterSpec(0),
@@ -273,6 +281,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			}
 			r.Add(testSpec{
 				Name:       "a",
+				Owner:      OwnerUnitTest,
 				MinVersion: "v2.0.0",
 				Cluster:    makeClusterSpec(0),
 				Run: func(ctx context.Context, t *test, c *cluster) {
@@ -281,6 +290,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			})
 			r.Add(testSpec{
 				Name:       "b",
+				Owner:      OwnerUnitTest,
 				MinVersion: "v2.1.0",
 				Cluster:    makeClusterSpec(0),
 				Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -219,7 +219,8 @@ func registerTPCC(r *testRegistry) {
 		// w=headroom runs tpcc for a semi-extended period with some amount of
 		// headroom, more closely mirroring a real production deployment than
 		// running with the max supported warehouses.
-		Name: "tpcc/headroom/" + headroomSpec.String(),
+		Name:  "tpcc/headroom/" + headroomSpec.String(),
+		Owner: OwnerKV,
 		// TODO(dan): Backfill tpccSupportedWarehouses and remove this "v2.1.0"
 		// minimum on gce.
 		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
@@ -240,7 +241,8 @@ func registerTPCC(r *testRegistry) {
 		// mixed-headroom is similar to w=headroom, but with an additional node
 		// and on a mixed version cluster. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
-		Name: "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
+		Name:  "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
+		Owner: OwnerKV,
 		// TODO(dan): Backfill tpccSupportedWarehouses and remove this "v2.1.0"
 		// minimum on gce.
 		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
@@ -270,6 +272,7 @@ func registerTPCC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "tpcc-nowait/nodes=3/w=1",
+		Owner:      OwnerKV,
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -282,6 +285,7 @@ func registerTPCC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "weekly/tpcc-max",
+		Owner:      OwnerKV,
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Tags:       []string{`weekly`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
@@ -297,6 +301,7 @@ func registerTPCC(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "tpcc/w=100/nodes=3/chaos=true",
+		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4),
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -554,6 +559,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 
 	r.Add(testSpec{
 		Name:       name,
+		Owner:      OwnerKV,
 		Cluster:    nodes,
 		MinVersion: minVersion,
 		Tags:       b.Tags,

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -238,6 +238,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 
 	r.Add(testSpec{
 		Name:       strings.Join(nameParts, "/"),
+		Owner:      OwnerSQLExec,
 		Cluster:    makeClusterSpec(numNodes),
 		MinVersion: minVersion,
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -217,6 +217,7 @@ RESTORE tpch.* FROM 'gs://cockroach-fixtures/workload/tpch/scalefactor=1/backup'
 
 	r.Add(testSpec{
 		Name:       "tpchvec",
+		Owner:      OwnerSQLExec,
 		Cluster:    makeClusterSpec(nodeCount),
 		MinVersion: "v19.2.0",
 		Run:        runTPCHVec,

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -153,6 +153,7 @@ func registerTypeORM(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "typeorm",
+		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -252,6 +252,7 @@ func registerUpgrade(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("upgrade"),
+		Owner:      OwnerKV,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -219,6 +219,7 @@ func registerVersion(r *testRegistry) {
 	for _, n := range []int{3, 5} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("version/mixed/nodes=%d", n),
+			Owner:      OwnerKV,
 			MinVersion: "v2.1.0",
 			Cluster:    makeClusterSpec(n + 1),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -50,6 +50,7 @@ func registerYCSB(r *testRegistry) {
 			wl, cpus := wl, cpus
 			r.Add(testSpec{
 				Name:    name,
+				Owner:   OwnerKV,
 				Cluster: makeClusterSpec(4, cpu(cpus)),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runYCSB(ctx, t, c, wl, cpus)


### PR DESCRIPTION
Previously, roachtest ownership was a combination of individual opinion and git blame. To make it easier on the release team as well as to support future automation, tag each test as it's registered with an owning team (not individual). To prevent new tests from being added without an owner, the roachtest registry will reject any tests that are missing it, which will fail the build.

Release note: None