### PR TITLE
release-2.1: ui: reserve the statements endpoint to admin users

### DIFF
--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -29,6 +29,10 @@ import (
 func (s *statusServer) Statements(
 	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
+	if _, err := s.admin.requireAdminUser(ctx); err != nil {
+		return nil, err
+	}
+
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 


### PR DESCRIPTION
Backport 1/1 commits from #44349.

/cc @cockroachdb/release

---

Informs #44348 (not fixing until backports are issued)
