### PR TITLE
sql: fix virtual schema displays for temp tables

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -1317,6 +1317,7 @@ var (
 	tableTypeSystemView = tree.NewDString("SYSTEM VIEW")
 	tableTypeBaseTable  = tree.NewDString("BASE TABLE")
 	tableTypeView       = tree.NewDString("VIEW")
+	tableTypeTemporary  = tree.NewDString("LOCAL TEMPORARY")
 )
 
 var informationSchemaTablesTable = virtualSchemaTable{
@@ -1338,6 +1339,8 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 				} else if table.IsView() {
 					tableType = tableTypeView
 					insertable = noString
+				} else if table.Temporary {
+					tableType = tableTypeTemporary
 				}
 				dbNameStr := tree.NewDString(db.Name)
 				scNameStr := tree.NewDString(scName)
@@ -1407,9 +1410,16 @@ CREATE TABLE information_schema.views (
 func forEachSchemaName(
 	ctx context.Context, p *planner, db *sqlbase.DatabaseDescriptor, fn func(string) error,
 ) error {
-	scNames := []string{string(tree.PublicSchemaName)}
-	// Handle virtual schemas.
-	for _, schema := range p.getVirtualTabler().getEntries() {
+	schemaNames, err := getSchemaNames(ctx, p, db)
+	if err != nil {
+		return err
+	}
+	vtableEntries := p.getVirtualTabler().getEntries()
+	scNames := make([]string, 0, len(schemaNames)+len(vtableEntries))
+	for _, name := range schemaNames {
+		scNames = append(scNames, name)
+	}
+	for _, schema := range vtableEntries {
 		scNames = append(scNames, schema.desc.Name)
 	}
 	sort.Strings(scNames)
@@ -1542,6 +1552,29 @@ func forEachTableDescWithTableLookup(
 	return forEachTableDescWithTableLookupInternal(ctx, p, dbContext, virtualOpts, false /* allowAdding */, fn)
 }
 
+func getSchemaNames(
+	ctx context.Context, p *planner, dbContext *DatabaseDescriptor,
+) (map[sqlbase.ID]string, error) {
+	if dbContext != nil {
+		return p.Tables().getSchemasForDatabase(ctx, p.txn, dbContext.ID)
+	}
+	ret := make(map[sqlbase.ID]string)
+	dbs, err := p.Tables().getAllDatabaseDescriptors(ctx, p.txn)
+	if err != nil {
+		return nil, err
+	}
+	for _, db := range dbs {
+		schemas, err := p.Tables().getSchemasForDatabase(ctx, p.txn, db.ID)
+		if err != nil {
+			return nil, err
+		}
+		for id, name := range schemas {
+			ret[id] = name
+		}
+	}
+	return ret, nil
+}
+
 // forEachTableDescWithTableLookupInternal is the logic that supports
 // forEachTableDescWithTableLookup.
 //
@@ -1594,6 +1627,12 @@ func forEachTableDescWithTableLookupInternal(
 		}
 	}
 
+	// Generate all schema names, and keep a mapping.
+	schemaNames, err := getSchemaNames(ctx, p, dbContext)
+	if err != nil {
+		return err
+	}
+
 	// Physical descriptors next.
 	for _, tbID := range lCtx.tbIDs {
 		table := lCtx.tbDescs[tbID]
@@ -1601,7 +1640,11 @@ func forEachTableDescWithTableLookupInternal(
 		if table.Dropped() || !userCanSeeTable(ctx, p, table, allowAdding) || !parentExists {
 			continue
 		}
-		if err := fn(dbDesc, tree.PublicSchema, table, lCtx); err != nil {
+		scName, ok := schemaNames[table.GetParentSchemaID()]
+		if !ok {
+			return errors.AssertionFailedf("schema id %d not found", table.GetParentSchemaID())
+		}
+		if err := fn(dbDesc, scName, table, lCtx); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,0 +1,42 @@
+statement ok
+SET experimental_enable_temp_tables=true
+
+subtest test_meta_tables
+
+statement ok
+CREATE TEMP TABLE temp_table_test (a timetz PRIMARY KEY)
+
+statement ok
+CREATE TEMP TABLE temp_table_ref (a timetz PRIMARY KEY)
+
+statement ok
+ALTER TABLE temp_table_ref ADD CONSTRAINT fk_temp FOREIGN KEY (a) REFERENCES temp_table_test(a)
+
+query TT
+SHOW CREATE TABLE temp_table_test
+----
+temp_table_test  CREATE TEMP TABLE temp_table_test (
+                 a TIMETZ NOT NULL,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC),
+                 FAMILY "primary" (a)
+)
+
+query TT
+SELECT table_name, table_type FROM information_schema.tables WHERE table_name = 'temp_table_test' AND table_schema LIKE 'pg_temp_%'
+----
+temp_table_test  LOCAL TEMPORARY
+
+# query changes names, so we can only grab a count to be sure.
+query I
+SELECT count(1) FROM pg_namespace WHERE nspname LIKE 'pg_temp_%'
+----
+1
+
+query T
+SELECT * FROM [SHOW TABLES FROM pg_temp] ORDER BY 1
+----
+temp_table_ref
+temp_table_test
+
+statement ok
+DROP TABLE temp_table_ref CASCADE; DROP TABLE temp_table_test CASCADE

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -863,7 +863,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 					condef = tree.NewDString(table.PrimaryKeyString())
 
 				case sqlbase.ConstraintTypeFK:
-					oid = h.ForeignKeyConstraintOid(db, tree.PublicSchema, table, con.FK)
+					oid = h.ForeignKeyConstraintOid(db, scName, table, con.FK)
 					contype = conTypeFK
 					// Foreign keys don't have a single linked index. Pick the first one
 					// that matches on the referenced table.
@@ -1161,7 +1161,7 @@ CREATE TABLE pg_catalog.pg_depend (
 				} else {
 					refObjID = h.IndexOid(con.ReferencedTable.ID, idx.ID)
 				}
-				constraintOid := h.ForeignKeyConstraintOid(db, tree.PublicSchema, table, con.FK)
+				constraintOid := h.ForeignKeyConstraintOid(db, scName, table, con.FK)
 
 				if err := addRow(
 					pgConstraintTableOid, // classid

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -57,7 +57,11 @@ func ShowCreateTable(
 	a := &sqlbase.DatumAlloc{}
 
 	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE TABLE ")
+	f.WriteString("CREATE ")
+	if desc.Temporary {
+		f.WriteString("TEMP ")
+	}
+	f.WriteString("TABLE ")
 	f.FormatNode(tn)
 	f.WriteString(" (")
 	primaryKeyIsOnVisibleColumn := false

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -139,6 +139,11 @@ type TableCollection struct {
 	// These are purged at the same time as allDescriptors.
 	allDatabaseDescriptors []*sqlbase.DatabaseDescriptor
 
+	// cachedDatabaseToSchemas is a mapping between all available schemas
+	// keyed by database.
+	// These are purged at the same time as allDescriptors.
+	cachedDatabaseToSchemas map[sqlbase.ID]map[sqlbase.ID]string
+
 	// settings are required to correctly resolve system.namespace accesses in
 	// mixed version (19.2/20.1) clusters.
 	// TODO(solon): This field could maybe be removed in 20.2.
@@ -669,11 +674,31 @@ func (tc *TableCollection) getAllDatabaseDescriptors(
 	return tc.allDatabaseDescriptors, nil
 }
 
+// getSchemasForDatabase returns the schemas for a given database
+// visible by the transaction. This uses the schema cache locally
+// if possible, or else performs a scan on kv.
+func (tc *TableCollection) getSchemasForDatabase(
+	ctx context.Context, txn *client.Txn, dbID sqlbase.ID,
+) (map[sqlbase.ID]string, error) {
+	if tc.cachedDatabaseToSchemas == nil {
+		tc.cachedDatabaseToSchemas = make(map[sqlbase.ID]map[sqlbase.ID]string)
+	}
+	if _, ok := tc.cachedDatabaseToSchemas[dbID]; !ok {
+		var err error
+		tc.cachedDatabaseToSchemas[dbID], err = GetSchemasForDatabase(ctx, txn, dbID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return tc.cachedDatabaseToSchemas[dbID], nil
+}
+
 // releaseAllDescriptors releases the cached slice of all descriptors
 // held by TableCollection.
 func (tc *TableCollection) releaseAllDescriptors() {
 	tc.allDescriptors = nil
 	tc.allDatabaseDescriptors = nil
+	tc.cachedDatabaseToSchemas = nil
 }
 
 // Copy the modified schema to the table collection. Used when initializing


### PR DESCRIPTION
Resolves #43852 
Resolves #43853

* Introduced `GetSchemasForDatabase`, which looks up KV for schema names
by ID. This should also be mid-migration compatible as it falls back to
only displaying PublicSchemaID.
* Added a cache in `TableCollection` to get all the schemas for a given
database.
* Altered `forEachTableDescWithTableLookupInternal` and
`forEachSchemaName` to use the TableCollection cache.
* Altered other instances where `tree.PublicSchema` is mentioned in
virtual schemas.
* Show "LOCAL TEMPORARY" for temporary tables in `pg_catalog.tables`
* Added "TEMP" to the create_statements metadata.
* For "SHOW TABLES", fix the delegate to alias `pg_temp` to the current
session.
* Added minor regression tests all of the above.

Release note: None