### PR TITLE
opt: fix flaky delete_range test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete_range
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete_range
@@ -13,14 +13,12 @@ SET tracing = on,kv; DELETE FROM a; SET tracing = off
 # Ensure that DelRange requests are chunked for DELETE FROM...
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message LIKE '%DelRange%' OR message LIKE '%sending batch%'
+WHERE message LIKE '%DelRange%' OR message LIKE '%DelRng%'
 ----
-dist sender send  r26: sending batch 1 Get to (n1,s1):1
 flow              DelRange /Table/53/1 - /Table/53/2
 dist sender send  r28: sending batch 1 DelRng to (n1,s1):1
 flow              DelRange /Table/53/1/601/0 - /Table/53/2
 dist sender send  r28: sending batch 1 DelRng to (n1,s1):1
-dist sender send  r28: sending batch 1 EndTxn to (n1,s1):1
 
 # Ensure that DelRange requests are autocommitted when DELETE FROM happens on a
 # chunk of fewer than 600 keys.


### PR DESCRIPTION
Noticed a flake in this test. Sometimes the first `Get` doesn't show
up; I think it is for a namespace table so that makes sense. Fixing by
filtering better the relevant stuff.

Release note: None