### PR TITLE
opt: FD libary fixes and test infrastructure

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -152,3 +152,18 @@ SELECT DISTINCT v FROM kv@idx WHERE v > 0
 1
 2
 5
+
+# Regression test for #44296.
+statement ok
+CREATE TABLE t0(c0 INT UNIQUE);
+
+statement ok
+CREATE VIEW v0(c0) AS SELECT DISTINCT t0.c0 FROM t0;
+
+statement ok
+INSERT INTO t0 (c0) VALUES (NULL), (NULL);
+
+query I
+SELECT * FROM v0 WHERE v0.c0 IS NULL
+----
+NULL

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1041,8 +1041,12 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	switch t := private.(type) {
 	case *opt.ColumnID:
 		fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-		label := f.Memo.metadata.QualifiedAlias(*t, fullyQualify, f.Catalog)
-		fmt.Fprintf(f.Buffer, " %s", label)
+		if f.Memo != nil {
+			label := f.Memo.metadata.QualifiedAlias(*t, fullyQualify, f.Catalog)
+			fmt.Fprintf(f.Buffer, " %s", label)
+		} else {
+			fmt.Fprintf(f.Buffer, " unknown%d", *t)
+		}
 
 	case *TupleOrdinal:
 		fmt.Fprintf(f.Buffer, " %d", *t)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1488,3 +1488,77 @@ full-join (cross)
  │    └── tuple [type=tuple]
  └── filters
       └── false [type=bool]
+
+exec-ddl
+CREATE TABLE t1 (x INT, y INT)
+----
+
+exec-ddl
+CREATE TABLE t2 (x INT, y INT)
+----
+
+# Outer join when both sides have a key. Because x can still have NULL values,
+# we cannot say that the outer join has a strict key. For example, this is a
+# possible valid result for this query:
+#   t1.x | t1.y | t2.x | t2.y
+#   -----+------+------+------
+#      1 |    1 |    1 |    2
+#   NULL |    1 | NULL | NULL
+#   NULL | NULL | NULL |    2
+# Here (t1.x, t2.x) is a lax key but not a strict key.
+opt
+SELECT * FROM
+  (SELECT * FROM (SELECT DISTINCT ON (x) x, y FROM t1) WHERE y IS NOT NULL) AS t1
+FULL JOIN
+  (SELECT * FROM (SELECT DISTINCT ON (x) x, y FROM t2) WHERE y IS NOT NULL) AS t2
+ON t1.x = t2.x
+----
+full-join (hash)
+ ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
+ ├── lax-key: (1,4)
+ ├── fd: (1)~~>(2), (4)~~>(5), (1,4)~~>(2,5)
+ ├── reject-nulls: (1,2,4,5)
+ ├── select
+ │    ├── columns: t1.x:1(int) t1.y:2(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── distinct-on
+ │    │    ├── columns: t1.x:1(int) t1.y:2(int)
+ │    │    ├── grouping columns: t1.x:1(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── prune: (2)
+ │    │    ├── scan t1
+ │    │    │    ├── columns: t1.x:1(int) t1.y:2(int)
+ │    │    │    └── prune: (1,2)
+ │    │    └── aggregations
+ │    │         └── first-agg [type=int, outer=(2)]
+ │    │              └── variable: t1.y [type=int]
+ │    └── filters
+ │         └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │              ├── variable: t1.y [type=int]
+ │              └── null [type=unknown]
+ ├── select
+ │    ├── columns: t2.x:4(int) t2.y:5(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(5)
+ │    ├── distinct-on
+ │    │    ├── columns: t2.x:4(int) t2.y:5(int)
+ │    │    ├── grouping columns: t2.x:4(int)
+ │    │    ├── key: (4)
+ │    │    ├── fd: (4)-->(5)
+ │    │    ├── prune: (5)
+ │    │    ├── scan t2
+ │    │    │    ├── columns: t2.x:4(int) t2.y:5(int)
+ │    │    │    └── prune: (4,5)
+ │    │    └── aggregations
+ │    │         └── first-agg [type=int, outer=(5)]
+ │    │              └── variable: t2.y [type=int]
+ │    └── filters
+ │         └── is-not [type=bool, outer=(5), constraints=(/5: (/NULL - ]; tight)]
+ │              ├── variable: t2.y [type=int]
+ │              └── null [type=unknown]
+ └── filters
+      └── eq [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+           ├── variable: t1.x [type=int]
+           └── variable: t2.x [type=int]

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -103,10 +103,11 @@ func TestLookupJoinProvided(t *testing.T) {
 				input,
 				nil, /* FiltersExpr */
 				&memo.LookupJoinPrivate{
-					Table:   tab,
-					Index:   cat.PrimaryIndex,
-					KeyCols: tc.keyCols,
-					Cols:    tc.outCols,
+					JoinType: opt.InnerJoinOp,
+					Table:    tab,
+					Index:    cat.PrimaryIndex,
+					KeyCols:  tc.keyCols,
+					Cols:     tc.outCols,
 				},
 			)
 			req := physical.ParseOrderingChoice(tc.required)

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -469,25 +468,17 @@ func (f *FuncDepSet) ColSet() opt.ColSet {
 		cols.UnionWith(fd.from)
 		cols.UnionWith(fd.to)
 	}
+	if f.hasKey != noKey {
+		// There are cases where key columns don't show up in FDs. For example:
+		//   lax-key(2,3); ()-->(1)
+		cols.UnionWith(f.key)
+	}
 	return cols
 }
 
 // HasMax1Row returns true if the relation has zero or one rows.
 func (f *FuncDepSet) HasMax1Row() bool {
 	return f.hasKey == strictKey && f.key.Empty()
-}
-
-// DowngradeKey marks the FD set as having no strict key. If there was a strict
-// key, it becomes a lax key.
-func (f *FuncDepSet) DowngradeKey() {
-	if f.hasKey == strictKey {
-		if f.key.Empty() {
-			// There is no such thing as an empty lax key.
-			f.hasKey = noKey
-		} else {
-			f.hasKey = laxKey
-		}
-	}
 }
 
 // CopyFrom copies the given FD into this FD, replacing any existing data.
@@ -650,6 +641,9 @@ func (f *FuncDepSet) AddStrictKey(keyCols, allCols opt.ColSet) {
 	keyCols = f.ReduceCols(keyCols)
 	f.addDependency(keyCols, allCols, true /* strict */, false /* equiv */)
 
+	// Try to use the new FD to reduce any existing key first.
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
+
 	if f.hasKey != strictKey || keyCols.Len() < f.key.Len() {
 		f.setKey(keyCols, strictKey)
 	}
@@ -672,8 +666,12 @@ func (f *FuncDepSet) AddLaxKey(keyCols, allCols opt.ColSet) {
 
 	// Ensure we have candidate key (i.e. has no columns that are functionally
 	// determined by other columns).
-	keyCols = f.ReduceCols(keyCols)
 	f.addDependency(keyCols, allCols, false /* strict */, false /* equiv */)
+
+	// TODO(radu): without null column information, we cannot reduce lax keys (see
+	// tryToReduceKey). Consider passing that information (or storing it with the
+	// FDs to begin with). In that case we would need to reduce both the given key
+	// and the existing key, similar to AddStrictKey.
 
 	if f.hasKey == noKey || (f.hasKey == laxKey && keyCols.Len() < f.key.Len()) {
 		f.setKey(keyCols, laxKey)
@@ -705,7 +703,10 @@ func (f *FuncDepSet) MakeMax1Row(cols opt.ColSet) {
 // Note: this function should be called with all known null columns; it won't do
 // as good of a job if it's called multiple times with different subsets.
 func (f *FuncDepSet) MakeNotNull(notNullCols opt.ColSet) {
-	var laxFDs util.FastIntSet
+	// We have to collect all the FDs that can be made strict. We avoid allocation
+	// for the case where there is at most one such FD.
+	var firstLaxFD *funcDep
+	var otherLaxFDs []funcDep
 	for i := range f.deps {
 		fd := &f.deps[i]
 		if fd.strict {
@@ -714,22 +715,22 @@ func (f *FuncDepSet) MakeNotNull(notNullCols opt.ColSet) {
 
 		// FD can be made strict if all determinant columns are not null.
 		if fd.from.SubsetOf(notNullCols) {
-			laxFDs.Add(i)
+			if firstLaxFD == nil {
+				firstLaxFD = fd
+			} else {
+				otherLaxFDs = append(otherLaxFDs, *fd)
+			}
 		}
 	}
 
-	for i, ok := laxFDs.Next(0); ok; i, ok = laxFDs.Next(i + 1) {
-		fd := &f.deps[i]
-		f.addDependency(fd.from, fd.to, true /* strict */, false /* equiv */)
-	}
-
-	// Try to reduce the key based on any new strict FDs.
-	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
-		if f.hasKey == laxKey && f.key.SubsetOf(notNullCols) {
-			f.hasKey = strictKey
+	if firstLaxFD != nil {
+		f.addDependency(firstLaxFD.from, firstLaxFD.to, true /* strict */, false /* equiv */)
+		for i := range otherLaxFDs {
+			f.addDependency(otherLaxFDs[i].from, otherLaxFDs[i].to, true /* strict */, false /* equiv */)
 		}
 	}
+
+	f.tryToReduceKey(notNullCols)
 }
 
 // AddEquivalency adds two FDs to the set that establish a strict equivalence
@@ -811,10 +812,7 @@ func (f *FuncDepSet) AddConstants(cols opt.ColSet) {
 	}
 	f.deps = f.deps[:n]
 
-	// Try to reduce the key based on the new constants.
-	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
-	}
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }
 
 // AddSynthesizedCol adds an FD to the set that is derived from a synthesized
@@ -835,6 +833,8 @@ func (f *FuncDepSet) AddSynthesizedCol(from opt.ColSet, col opt.ColumnID) {
 	var colSet opt.ColSet
 	colSet.Add(col)
 	f.addDependency(from, colSet, true /* strict */, false /* equiv */)
+
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }
 
 // ProjectCols removes all columns that are not in the given set. It does this
@@ -849,9 +849,11 @@ func (f *FuncDepSet) ProjectCols(cols opt.ColSet) {
 	if f.hasKey != noKey && !f.key.SubsetOf(cols) {
 		// Derive new candidate key (or key is no longer possible).
 		if f.hasKey == strictKey && f.ColsAreStrictKey(cols) {
-			f.setKey(f.ReduceCols(cols), strictKey)
+			f.setKey(cols, strictKey)
+			f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 		} else if f.ColsAreLaxKey(cols) {
-			f.setKey(f.ReduceCols(cols), laxKey)
+			f.setKey(cols, laxKey)
+			f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 		} else {
 			f.clearKey()
 		}
@@ -1081,17 +1083,19 @@ func (f *FuncDepSet) MakeApply(inner *FuncDepSet) {
 	}
 }
 
-// MakeOuter modifies the FD set to reflect the impact of adding NULL-extended
-// rows to the results of an inner join. An inner join can be modeled as a
-// cartesian product + ON filtering, and an outer join is modeled as an inner
-// join + union of NULL-extended rows. MakeOuter performs the final step, given
-// the set of columns that will be null-extended (i.e. columns from the
-// null-providing side(s) of the join), as well as the set of input columns from
-// both sides of the join that are not null.
+// MakeLeftOuter modifies the cartesian product FD set to reflect the impact of
+// adding NULL-extended rows to the results of an inner join. An inner join can
+// be modeled as a cartesian product + ON filtering, and an outer join is
+// modeled as an inner join + union of NULL-extended rows. MakeLeftOuter
+// performs the final step, given the set of columns that will be null-extended
+// (i.e. columns from the null-providing side(s) of the join), as well as the
+// set of input columns from both sides of the join that are not null.
 //
-// See the "Left outer join" section on page 84 of the Master's Thesis for
-// the impact of outer joins on FDs.
-func (f *FuncDepSet) MakeOuter(nullExtendedCols, notNullCols opt.ColSet) {
+// This same logic applies for right joins as well (by reversing sides).
+//
+// See the "Left outer join" section on page 84 of the Master's Thesis for the
+// impact of outer joins on FDs.
+func (f *FuncDepSet) MakeLeftOuter(rightCols, notNullInputCols opt.ColSet) {
 	var newFDs []funcDep
 	allCols := f.ColSet()
 
@@ -1102,8 +1106,8 @@ func (f *FuncDepSet) MakeOuter(nullExtendedCols, notNullCols opt.ColSet) {
 		if fd.isConstant() {
 			// Null-extended constant columns are no longer constant, because they
 			// now may contain NULL values.
-			if fd.to.Intersects(nullExtendedCols) {
-				constCols := fd.to.Intersection(nullExtendedCols)
+			if fd.to.Intersects(rightCols) {
+				constCols := fd.to.Intersection(rightCols)
 				if !fd.removeToCols(constCols) {
 					continue
 				}
@@ -1148,17 +1152,17 @@ func (f *FuncDepSet) MakeOuter(nullExtendedCols, notNullCols opt.ColSet) {
 			//    relation. Null-extending one side of the join does not disturb
 			//    the relation's keys, and keys always determine all other columns.
 			//
-			if fd.from.Intersects(nullExtendedCols) {
-				if !fd.from.SubsetOf(nullExtendedCols) {
+			if fd.from.Intersects(rightCols) {
+				if !fd.from.SubsetOf(rightCols) {
 					// Rule #3, described above.
 					if !f.ColsAreStrictKey(fd.from) {
 						continue
 					}
 				} else {
 					// Rule #1, described above (determinant is on null-supplying side).
-					if !fd.to.SubsetOf(nullExtendedCols) {
+					if !fd.to.SubsetOf(rightCols) {
 						// Split the dependants by which side of the join they're on.
-						laxCols := fd.to.Difference(nullExtendedCols)
+						laxCols := fd.to.Difference(rightCols)
 						newFDs = append(newFDs, funcDep{from: fd.from, to: laxCols})
 						if !fd.removeToCols(laxCols) {
 							continue
@@ -1167,14 +1171,14 @@ func (f *FuncDepSet) MakeOuter(nullExtendedCols, notNullCols opt.ColSet) {
 
 					// Rule #2, described above. Note that this rule does not apply to
 					// equivalence FDs, which remain valid.
-					if fd.strict && !fd.equiv && !fd.from.Intersects(notNullCols) {
+					if fd.strict && !fd.equiv && !fd.from.Intersects(notNullInputCols) {
 						newFDs = append(newFDs, funcDep{from: fd.from, to: fd.to})
 						continue
 					}
 				}
 			} else {
 				// Rule #1, described above (determinant is on row-supplying side).
-				if !fd.removeToCols(nullExtendedCols) {
+				if !fd.removeToCols(rightCols) {
 					continue
 				}
 			}
@@ -1199,6 +1203,40 @@ func (f *FuncDepSet) MakeOuter(nullExtendedCols, notNullCols opt.ColSet) {
 	// relation, due to removing FDs and/or making them lax, so if necessary,
 	// add a new strict FD that ensures the key's closure is maintained.
 	f.ensureKeyClosure(allCols)
+}
+
+// MakeFullOuter modifies the cartesian product FD set to reflect the impact of
+// adding NULL-extended rows to the results of an inner join. An inner join can
+// be modeled as a cartesian product + ON filtering, and an outer join is
+// modeled as an inner join + union of NULL-extended rows. MakeFullOuter
+// performs the final step for a full join, given the set of columns on each
+// side, as well as the set of input columns from both sides of the join that
+// are not null.
+func (f *FuncDepSet) MakeFullOuter(leftCols, rightCols, notNullInputCols opt.ColSet) {
+	if f.hasKey == strictKey {
+		if f.key.Empty() {
+			// The cartesian product has an empty key when both sides have an empty key;
+			// but the outer join can have two rows so the empty key doesn't hold.
+			f.hasKey = noKey
+			f.key = opt.ColSet{}
+		} else if !f.key.Intersects(notNullInputCols) {
+			// If the cartesian product has a strict key, the key holds on the full
+			// outer result only if one of the key columns is known to be not-null in
+			// the input. Otherwise, a row where all the key columns are NULL can
+			// "conflict" with a row where these columns are NULL because of
+			// null-extension. For example:
+			//   -- t1 and t2 each have one row containing NULL for column x.
+			//   SELECT * FROM t1 FULL JOIN t2 ON t1.x=t2.x
+			//
+			//   t1.x  t2.x
+			//   ----------
+			//   NULL  NULL
+			//   NULL  NULL
+			f.hasKey = laxKey
+		}
+	}
+	f.MakeLeftOuter(leftCols, notNullInputCols)
+	f.MakeLeftOuter(rightCols, notNullInputCols)
 }
 
 // EquivReps returns one "representative" column from each equivalency group in
@@ -1286,11 +1324,11 @@ func (f *FuncDepSet) Verify() {
 	}
 
 	if f.hasKey != noKey {
-		if reduced := f.ReduceCols(f.key); !reduced.Equals(f.key) {
-			panic(errors.AssertionFailedf("expected FD to have candidate key: %s", f))
-		}
-
 		if f.hasKey == strictKey {
+			if reduced := f.ReduceCols(f.key); !reduced.Equals(f.key) {
+				panic(errors.AssertionFailedf("expected FD to have candidate key %s: %s", reduced, f))
+			}
+
 			allCols := f.ColSet()
 			allCols.UnionWith(f.key)
 			if !f.ComputeClosure(f.key).Equals(allCols) {
@@ -1336,43 +1374,51 @@ func (f FuncDepSet) String() string {
 
 func (f FuncDepSet) formatFDs(b *strings.Builder) {
 	for i := range f.deps {
-		fd := &f.deps[i]
 		if i != 0 {
 			b.WriteString(", ")
 		}
-		if fd.equiv {
-			if !fd.strict {
-				panic(errors.AssertionFailedf("lax equivalent columns are not supported"))
-			}
-			fmt.Fprintf(b, "%s==%s", fd.from, fd.to)
-		} else {
-			if fd.strict {
-				fmt.Fprintf(b, "%s-->%s", fd.from, fd.to)
-			} else {
-				fmt.Fprintf(b, "%s~~>%s", fd.from, fd.to)
-			}
-		}
+		f.deps[i].format(b)
 	}
 }
 
 // colsAreKey returns true if the given columns contain a strict or lax key for
 // the relation.
 func (f *FuncDepSet) colsAreKey(cols opt.ColSet, typ keyType) bool {
-	if f.hasKey == noKey || (typ == strictKey && f.hasKey == laxKey) {
-		// No key exists for the relation, or there exists a lax key and we
-		// need a strict key.
+	switch f.hasKey {
+	case strictKey:
+		// Determine whether the key is in the closure of the given columns. The
+		// closure is necessary in the general case since it's possible that the
+		// columns form a different key. For example:
+		//
+		//   f.key = (a)
+		//   cols  = (b,c)
+		//
+		// and yet both column sets form keys for the relation.
+		return f.inClosureOf(f.key, cols, typ == strictKey)
+
+	case laxKey:
+		if typ == strictKey {
+			// We have a lax key but we need a strict key.
+			return false
+		}
+
+		// For a lax key, we cannot use the strict closure, because the columns we
+		// bring in from the closure might be null. For example, say that
+		//   - column a is constant but (always) null: ()-->(a)
+		//   - (a,b) is the known lax key.
+		// The strict closure of (b) is the lax key (a,b), but (b) is not a lax
+		// key.
+		//
+		// We can however use the equivalent closure, because those columns are null
+		// only if one of the initial cols is null.
+		//
+		// Note: if we had information, we could use just the not-null columns from
+		// the strict closure.
+		return f.key.SubsetOf(f.ComputeEquivClosure(cols))
+
+	default:
 		return false
 	}
-
-	// Determine whether the key is in the closure of the given columns. The
-	// closure is necessary in the general case since it's possible that the
-	// columns form a different key. For example:
-	//
-	//   f.key = (a)
-	//   cols  = (b,c)
-	//
-	// and yet both column sets form keys for the relation.
-	return f.inClosureOf(f.key, cols, typ == strictKey)
 }
 
 // inClosureOf computes the strict or lax closure of the "in" column set, and
@@ -1574,21 +1620,46 @@ func (f *FuncDepSet) addEquivalency(equiv opt.ColSet) {
 		f.deps = deps
 	}
 
-	// Try to reduce the key based on the new equivalency.
-	if f.hasKey != noKey {
-		f.key = f.ReduceCols(f.key)
-	}
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }
 
 // setKey updates the key that the set is currently maintaining.
 func (f *FuncDepSet) setKey(key opt.ColSet, typ keyType) {
 	f.hasKey = typ
 	f.key = key
+	if f.hasKey == laxKey && f.key.Empty() {
+		// An empty lax key is by definition equivalent to an empty strict key; we
+		// normalize it to be strict.
+		f.hasKey = strictKey
+	}
 }
 
 // clearKey removes any strict or lax key.
 func (f *FuncDepSet) clearKey() {
 	f.setKey(opt.ColSet{}, noKey)
+}
+
+// tryToReduceKey tries to reduce any set key, used after new FDs are added.
+func (f *FuncDepSet) tryToReduceKey(notNullCols opt.ColSet) {
+	switch f.hasKey {
+	case laxKey:
+		if !notNullCols.Empty() {
+			// We can only remove columns from a lax key if we know they are
+			// not null; other columns must be retained.
+			nullableKeyCols := f.key.Difference(notNullCols)
+			if nullableKeyCols.Empty() {
+				// All key columns are not-null; we can upgrade the key to strict.
+				f.AddStrictKey(f.key, f.ColSet())
+			} else {
+				reduced := f.ReduceCols(f.key)
+				reduced.UnionWith(nullableKeyCols)
+				f.key = reduced
+			}
+		}
+
+	case strictKey:
+		f.key = f.ReduceCols(f.key)
+	}
 }
 
 // makeEquivMap constructs a map with an entry for each column in the "from" set
@@ -1653,4 +1724,25 @@ func (f *funcDep) removeToCols(remove opt.ColSet) bool {
 		f.to = f.to.Difference(remove)
 	}
 	return !f.to.Empty()
+}
+
+func (f *funcDep) format(b *strings.Builder) {
+	if f.equiv {
+		if !f.strict {
+			panic(errors.AssertionFailedf("lax equivalent columns are not supported"))
+		}
+		fmt.Fprintf(b, "%s==%s", f.from, f.to)
+	} else {
+		if f.strict {
+			fmt.Fprintf(b, "%s-->%s", f.from, f.to)
+		} else {
+			fmt.Fprintf(b, "%s~~>%s", f.from, f.to)
+		}
+	}
+}
+
+func (f *funcDep) String() string {
+	var b strings.Builder
+	f.format(&b)
+	return b.String()
 }

--- a/pkg/sql/opt/props/func_dep_rand_test.go
+++ b/pkg/sql/opt/props/func_dep_rand_test.go
@@ -1,0 +1,957 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+// This file is the home of TestFuncDepOpsRandom, a randomized FD tester.
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"text/tabwriter"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
+)
+
+const debug = false
+
+// testVal is a value in a row in a test relation.
+// Value of 0 is special and is treated as NULL.
+type testVal uint8
+
+const null testVal = 0
+
+func (v testVal) String() string {
+	if v == null {
+		return "NULL"
+	}
+	return fmt.Sprintf("%d", v)
+}
+
+// A testRow in a test relation. Value of 0 is special and is treated as NULL.
+// The first value corresponds to ColumnID 1, and so on.
+// A testRow is immutable after initial construction.
+type testRow []testVal
+
+func (tr testRow) value(col opt.ColumnID) testVal {
+	return tr[col-1]
+}
+
+func (tr testRow) String() string {
+	var b strings.Builder
+	for i, v := range tr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(v.String())
+	}
+	return b.String()
+}
+
+// rowKey encodes the values of at most 16 columns.
+type rowKey uint64
+
+// key generates a rowKey from the values on the given columns. Also returns
+// whether there were any null values.
+func (tr testRow) key(cols opt.ColSet) (_ rowKey, hasNulls bool) {
+	if cols.Len() > 16 {
+		panic(errors.AssertionFailedf("max 16 columns supported"))
+	}
+	var key rowKey
+	cols.ForEach(func(c opt.ColumnID) {
+		val := tr.value(c)
+		if val == null {
+			hasNulls = true
+		}
+		if val > 15 {
+			panic(errors.AssertionFailedf("testVal must be <= 15"))
+		}
+		key = (key << 4) | rowKey(val)
+	})
+	return key, hasNulls
+}
+
+// hasNulls returns true if the row has a null value on any of the given
+// columns.
+func (tr testRow) hasNulls(cols opt.ColSet) bool {
+	var res bool
+	cols.ForEach(func(c opt.ColumnID) {
+		res = res || tr.value(c) == null
+	})
+	return res
+}
+
+// equalOn returns true if the two rows are equal on the given columns.
+func (tr testRow) equalOn(other testRow, cols opt.ColSet) bool {
+	eq := true
+	cols.ForEach(func(c opt.ColumnID) {
+		if tr.value(c) != other.value(c) {
+			eq = false
+		}
+	})
+	return eq
+}
+
+type testRelation []testRow
+
+// String prints out the test relation in the following format:
+//
+//   1     2     3
+//   -------------
+//   NULL  1     2
+//   3     NULL  4
+//
+func (tr testRelation) String() string {
+	if len(tr) == 0 {
+		return "  <empty>\n"
+	}
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+	for i := range tr[0] {
+		fmt.Fprintf(tw, "%d\t", i+1)
+	}
+	fmt.Fprint(tw, "\n")
+	for _, r := range tr {
+		for _, v := range r {
+			fmt.Fprintf(tw, "%s\t", v)
+		}
+		fmt.Fprint(tw, "\n")
+	}
+	_ = tw.Flush()
+
+	rows := strings.Split(buf.String(), "\n")
+	buf.Reset()
+	fmt.Fprintf(&buf, "  %s\n  ", strings.TrimRight(rows[0], " "))
+	for range rows[0] {
+		buf.WriteByte('-')
+	}
+	buf.WriteString("\n")
+	for _, r := range rows[1:] {
+		fmt.Fprintf(&buf, "  %s\n", strings.TrimRight(r, " "))
+	}
+	return buf.String()
+}
+
+// checkKey verifies that a certain key (strict or lax) is valid for the test
+// relation.
+func (tr testRelation) checkKey(key opt.ColSet, typ keyType) error {
+	m := make(map[rowKey]testRow)
+	for _, r := range tr {
+		k, hasNulls := r.key(key)
+		// If it is a lax key, we can ignore any rows that contain a NULL on the
+		// key columns.
+		if typ == laxKey && hasNulls {
+			continue
+		}
+		if existingRow, ok := m[k]; ok {
+			keyStr := ""
+			if typ == laxKey {
+				keyStr = "lax-"
+			}
+			return fmt.Errorf(
+				"%skey%s doesn't hold on rows:\n%s", keyStr, key, testRelation{r, existingRow},
+			)
+		}
+		m[k] = r
+	}
+	return nil
+}
+
+// checkFD verifies that a certain FD holds for the test relation.
+func (tr testRelation) checkFD(dep funcDep) error {
+	if dep.equiv {
+		// An equivalence FD is easy to check row-by-row.
+		for _, r := range tr {
+			c, _ := dep.from.Next(0)
+			val := r.value(c)
+			fail := false
+			dep.to.ForEach(func(col opt.ColumnID) {
+				if r.value(col) != val {
+					fail = true
+				}
+			})
+			if fail {
+				return fmt.Errorf("FD %s doesn't hold on row %s", &dep, r)
+			}
+		}
+		return nil
+	}
+
+	// We split the rows into groups (keyed on the `from` columns), picking the
+	// first row in each group as the "representative" of that group. All other
+	// rows in the group are checked against the representative row.
+	m := make(map[rowKey]testRow)
+	for _, r := range tr {
+		k, hasNulls := r.key(dep.from)
+		// If it is not a strict FD, we can ignore any rows that contain a NULL on
+		// the 'from' columns.
+		if !dep.strict && hasNulls {
+			continue
+		}
+
+		if first, ok := m[k]; ok {
+			if !first.equalOn(r, dep.to) {
+				return fmt.Errorf("FD %s doesn't hold on rows:\n%s", &dep, testRelation{first, r})
+			}
+		} else {
+			m[k] = r
+		}
+	}
+	return nil
+}
+
+// checkFDs verifies that the given FDs hold against the test relation.
+func (tr testRelation) checkFDs(fd *FuncDepSet) error {
+	// Check deps.
+	for _, dep := range fd.deps {
+		if err := tr.checkFD(dep); err != nil {
+			return err
+		}
+	}
+
+	// Check keys.
+	if fd.hasKey != noKey {
+		if err := tr.checkKey(fd.key, fd.hasKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// notNullCols returns the set columns that have no nulls in the test relation.
+func (tr testRelation) notNullCols(numCols int) opt.ColSet {
+	var res opt.ColSet
+	for c := opt.ColumnID(1); c <= opt.ColumnID(numCols); c++ {
+		res.Add(c)
+		for _, r := range tr {
+			if r.value(c) == null {
+				res.Remove(c)
+				break
+			}
+		}
+	}
+	return res
+}
+
+// joinTestRelations creates a possible result of joining two testRelations,
+// specifically:
+//  - an inner join if both leftOuter and rightOuter are false;
+//  - a left/right outer join if one of them is true;
+//  - a full outer join if both are true.
+func joinTestRelations(
+	numLeftCols int,
+	left testRelation,
+	numRightCols int,
+	right testRelation,
+	leftOuter bool,
+	rightOuter bool,
+) testRelation {
+	var res testRelation
+
+	add := func(l, r testRow) {
+		newRow := make(testRow, numLeftCols+numRightCols)
+		for i := range newRow {
+			newRow[i] = null
+		}
+		if l != nil {
+			copy(newRow, l)
+		}
+		if r != nil {
+			copy(newRow[numLeftCols:], r)
+		}
+		res = append(res, newRow)
+	}
+
+	// If this is a right or full join, select the right-hand-side rows that won't
+	// "match" any other rows and will be null-extended.
+	var nullExtRight util.FastIntSet
+	if rightOuter {
+		for i, rightRow := range right {
+			if rand.Intn(2) == 0 || len(left) == 0 {
+				add(nil, rightRow)
+				nullExtRight.Add(i)
+			}
+		}
+	}
+	for _, leftRow := range left {
+		// If this is a left / full join, this row has to be null-extended if there
+		// are no rows left on the other side; otherwise randomly decide.
+		if leftOuter && (len(right) == nullExtRight.Len() || rand.Intn(2) == 0) {
+			add(leftRow, nil)
+			continue
+		}
+		for j, rightRow := range right {
+			if !nullExtRight.Contains(j) {
+				add(leftRow, rightRow)
+			}
+		}
+	}
+	if debug {
+		fmt.Printf("left:\n%s", left)
+		fmt.Printf("right:\n%s", right)
+		fmt.Printf("join(leftOuter=%t, rightOuter=%t):\n%s", leftOuter, rightOuter, res)
+	}
+	return res
+}
+
+// testOp is an interface implemented by test operations. Each test operation
+// makes a call to an FD API and filters out some of the rows in the current
+// test relation in order for that API call to be correct. The resulting FDs are
+// checked to hold on the updated test relations (and various FD APIs are
+// checked as well).
+type testOp interface {
+	fmt.Stringer
+
+	// FilterRelation returns a new subset testRelation that is consistent with
+	// the FD operation.
+	FilterRelation(tr testRelation) testRelation
+
+	// ApplyToFDs returns a new FuncDepSet after the operation.
+	ApplyToFDs(fd FuncDepSet) FuncDepSet
+}
+
+var _ testOp = &addKeyOp{}
+
+type testConfig struct {
+	// numCols is the number of columns in the relation.
+	// Can be at most 8 (see rowKey).
+	numCols int
+	// valRange is the range of values in the test relation.
+	valRange testVal
+}
+
+func (tc *testConfig) randCol() opt.ColumnID {
+	return opt.ColumnID(rand.Intn(tc.numCols) + 1)
+}
+
+func (tc *testConfig) randColSet(minLen, maxLen int) opt.ColSet {
+	if maxLen > tc.numCols {
+		panic(errors.AssertionFailedf("maxLen > numCols"))
+	}
+	length := rand.Intn(maxLen-minLen+1) + minLen
+	// Use Robert Floyd's algorithm to generate <length> distinct integers between
+	// 0 and numCols-1, just because it's so cool!
+	var res opt.ColSet
+	for j := tc.numCols - length; j < tc.numCols; j++ {
+		if t := rand.Intn(j + 1); !res.Contains(opt.ColumnID(t + 1)) {
+			res.Add(opt.ColumnID(t + 1))
+		} else {
+			res.Add(opt.ColumnID(j + 1))
+		}
+	}
+	return res
+}
+
+func (tc *testConfig) allCols() opt.ColSet {
+	var allCols opt.ColSet
+	for i := opt.ColumnID(1); i <= opt.ColumnID(tc.numCols); i++ {
+		allCols.Add(i)
+	}
+	return allCols
+}
+
+// initTestRelation creates a testRelation with all possible combinations of
+// values in the set {0 (null), 1, 2, ... valRange}.
+func (tc *testConfig) initTestRelation() testRelation {
+	var tr testRelation
+
+	// genRows takes a row prefix and recursively generates all rows with that
+	// prefix, appending them to tr.
+	var genRows func(vals []testVal)
+	genRows = func(vals []testVal) {
+		n := len(vals)
+		if n == tc.numCols {
+			// Add each row twice to have duplicates.
+			tr = append(tr, vals, vals)
+			return
+		}
+		for i := null; i <= tc.valRange; i++ {
+			genRows(append(vals[:n:n], i))
+		}
+	}
+	genRows(nil)
+	return tr
+}
+
+func (tc *testConfig) checkAPIs(fd *FuncDepSet, tr testRelation) error {
+	if fd.HasMax1Row() && len(tr) > 1 {
+		return fmt.Errorf("HasMax1Row() incorrectly returns true")
+	}
+
+	for t := 0; t < 5; t++ {
+		cols := tc.randColSet(1, tc.numCols)
+
+		if fd.ColsAreLaxKey(cols) {
+			if err := tr.checkKey(cols, laxKey); err != nil {
+				return fmt.Errorf("ColsAreLaxKey%s incorrectly returns true", cols)
+			}
+		}
+
+		if fd.ColsAreStrictKey(cols) {
+			if err := tr.checkKey(cols, strictKey); err != nil {
+				return fmt.Errorf("ColsAreStrictKey%s incorrectly returns true", cols)
+			}
+		}
+
+		closure := fd.ComputeClosure(cols)
+		if err := tr.checkFD(funcDep{
+			from:   cols,
+			to:     closure,
+			strict: true,
+		}); err != nil {
+			return fmt.Errorf("ComputeClosure%s incorrectly returns %s: %s", cols, closure, err)
+		}
+
+		reduced := fd.ReduceCols(cols)
+		if err := tr.checkFD(funcDep{
+			from:   reduced,
+			to:     cols,
+			strict: true,
+		}); err != nil {
+			return fmt.Errorf("ReduceCols%s incorrectly returns %s: %s", cols, reduced, err)
+		}
+
+		var proj FuncDepSet
+		proj.CopyFrom(fd)
+		proj.ProjectCols(cols)
+		// The FDs after projection should still hold on the table.
+		if err := tr.checkFDs(&proj); err != nil {
+			return fmt.Errorf("ProjectCols%s incorrectly returns %s: %s", cols, proj.String(), err)
+		}
+	}
+
+	return nil
+}
+
+// testOpGenerator generates a testOp, given the number of columns in the
+// relation.
+type testOpGenerator = func(tc *testConfig) testOp
+
+// addKeyOp is a test operation corresponding to AddStrictKey / AddLaxKey.
+type addKeyOp struct {
+	allCols opt.ColSet
+	key     opt.ColSet
+	typ     keyType
+}
+
+func genAddKey(minKeyCols, maxKeyCols int) testOpGenerator {
+	return func(tc *testConfig) testOp {
+		cols := tc.randColSet(minKeyCols, maxKeyCols)
+		typ := strictKey
+		if !cols.Empty() && rand.Int()%2 == 0 {
+			typ = laxKey
+		}
+		return &addKeyOp{
+			allCols: tc.allCols(),
+			key:     cols,
+			typ:     typ,
+		}
+	}
+}
+
+func (o *addKeyOp) String() string {
+	if o.typ == strictKey {
+		return fmt.Sprintf("AddStrictKey%s", o.key)
+	}
+	return fmt.Sprintf("AddLaxKey%s", o.key)
+}
+
+func (o *addKeyOp) FilterRelation(tr testRelation) testRelation {
+	var out testRelation
+	// Process the rows in random order and remove any duplicate rows.
+	m := make(map[rowKey]bool)
+	perm := rand.Perm(len(tr))
+	for _, rowIdx := range perm {
+		r := tr[perm[rowIdx]]
+		key, hasNulls := r.key(o.key)
+		// If it is a lax key, we can leave all rows that contain a NULL on the
+		// key columns.
+		if o.typ == laxKey && hasNulls {
+			out = append(out, r)
+			continue
+		}
+		if !m[key] {
+			out = append(out, r)
+			m[key] = true
+		}
+	}
+	return out
+}
+
+func (o *addKeyOp) ApplyToFDs(fd FuncDepSet) FuncDepSet {
+	var out FuncDepSet
+	out.CopyFrom(&fd)
+	if o.typ == strictKey {
+		out.AddStrictKey(o.key, o.allCols)
+	} else {
+		out.AddLaxKey(o.key, o.allCols)
+	}
+	return out
+}
+
+// makeNotNullOp is a test operation corresponding to MakeNotNull.
+type makeNotNullOp struct {
+	cols opt.ColSet
+}
+
+func genMakeNotNull(minCols, maxCols int) testOpGenerator {
+	return func(tc *testConfig) testOp {
+		return &makeNotNullOp{
+			cols: tc.randColSet(minCols, maxCols),
+		}
+	}
+}
+
+func (o *makeNotNullOp) String() string {
+	return fmt.Sprintf("MakeNotNull%s", o.cols)
+}
+
+func (o *makeNotNullOp) FilterRelation(tr testRelation) testRelation {
+	var out testRelation
+	for _, r := range tr {
+		if !r.hasNulls(o.cols) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (o *makeNotNullOp) ApplyToFDs(fd FuncDepSet) FuncDepSet {
+	var out FuncDepSet
+	out.CopyFrom(&fd)
+	out.MakeNotNull(o.cols)
+	return out
+}
+
+// addConstOp is a test operation corresponding to AddConstants.
+type addConstOp struct {
+	cols opt.ColSet
+	vals []testVal
+}
+
+func genAddConst(minCols, maxCols int) testOpGenerator {
+	return func(tc *testConfig) testOp {
+		cols := tc.randColSet(minCols, maxCols)
+		vals := make([]testVal, cols.Len())
+		for i := range vals {
+			vals[i] = testVal(rand.Intn(int(tc.valRange + 1)))
+		}
+		return &addConstOp{
+			cols: cols,
+			vals: vals,
+		}
+	}
+}
+
+func (o *addConstOp) String() string {
+	return fmt.Sprintf("AddConstants%s values {%v}", o.cols, testRow(o.vals).String())
+}
+
+func (o *addConstOp) FilterRelation(tr testRelation) testRelation {
+	var out testRelation
+	for _, r := range tr {
+		idx := 0
+		ok := true
+		o.cols.ForEach(func(c opt.ColumnID) {
+			if r[c-1] != o.vals[idx] {
+				ok = false
+			}
+			idx++
+		})
+		if ok {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (o *addConstOp) ApplyToFDs(fd FuncDepSet) FuncDepSet {
+	var out FuncDepSet
+	out.CopyFrom(&fd)
+	out.AddConstants(o.cols)
+	return out
+}
+
+// addEquivOp is a test operation corresponding to AddEquivalency.
+type addEquivOp struct {
+	a, b opt.ColumnID
+}
+
+func genAddEquiv() testOpGenerator {
+	return func(tc *testConfig) testOp {
+		return &addEquivOp{
+			a: tc.randCol(),
+			b: tc.randCol(),
+		}
+	}
+}
+
+func (o *addEquivOp) String() string {
+	return fmt.Sprintf("AddEquivalency(%d,%d)", o.a, o.b)
+}
+
+func (o *addEquivOp) FilterRelation(tr testRelation) testRelation {
+	// Filter out rows where the equivalency doesn't hold.
+	var out testRelation
+	for _, r := range tr {
+		if r.value(o.a) == r.value(o.b) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (o *addEquivOp) ApplyToFDs(fd FuncDepSet) FuncDepSet {
+	var out FuncDepSet
+	out.CopyFrom(&fd)
+	out.AddEquivalency(o.a, o.b)
+	return out
+}
+
+// addSynthOp is a test operation corresponding to AddSynthesizedCol.
+type addSynthOp struct {
+	from opt.ColSet
+	to   opt.ColumnID
+}
+
+func genAddSynth(minCols, maxCols int) testOpGenerator {
+	return func(tc *testConfig) testOp {
+		from := tc.randColSet(minCols, maxCols)
+		to := tc.randCol()
+		from.Remove(to)
+		return &addSynthOp{
+			from: from,
+			to:   to,
+		}
+	}
+}
+
+func (o *addSynthOp) String() string {
+	return fmt.Sprintf("AddSynthesizedCol(%s, %d)", o.from, o.to)
+}
+
+func (o *addSynthOp) FilterRelation(tr testRelation) testRelation {
+	// Filter out rows where the from->to FD doesn't hold. The code here parallels
+	// that in testRelation.checkKey.
+	//
+	// We split the rows into groups (keyed on the `from` columns), picking the
+	// first row in each group as the "representative" of that group. All other
+	// rows in the group are checked against the representative row.
+	var out testRelation
+	m := make(map[rowKey]testRow)
+	perm := rand.Perm(len(tr))
+	for _, rowIdx := range perm {
+		r := tr[rowIdx]
+		k, _ := r.key(o.from)
+		if first, ok := m[k]; ok {
+			if first.value(o.to) != r.value(o.to) {
+				// Filter out row.
+				continue
+			}
+		} else {
+			m[k] = r
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func (o *addSynthOp) ApplyToFDs(fd FuncDepSet) FuncDepSet {
+	var out FuncDepSet
+	out.CopyFrom(&fd)
+	out.AddSynthesizedCol(o.from, o.to)
+	return out
+}
+
+// testState corresponds to a chain of applied test operations. The head of a
+// testStates chain has no parent and no op and just corresponds to the initial
+// (empty) FDs and test relation.
+type testState struct {
+	parent *testState
+	cfg    *testConfig
+
+	op  testOp
+	fds FuncDepSet
+	rel testRelation
+}
+
+func (ts *testState) format(b *strings.Builder) {
+	if ts.parent == nil {
+		fmt.Fprintf(b, "initial numCols=%d valRange=%d\n", ts.cfg.numCols, ts.cfg.valRange)
+	} else {
+		ts.parent.format(b)
+		fmt.Fprintf(b, " => %s\n", ts.op.String())
+		fmt.Fprintf(b, "    FDs: %s\n", ts.fds.String())
+	}
+}
+
+// String describes the chain of operations and corresponding FDs.
+// For example:
+//   initial numCols=3 valRange=3
+//    => MakeNotNull(2)
+//       FDs:
+//    => AddConstants(1,3) values {NULL,1}
+//       FDs: ()-->(1,3)
+//    => AddLaxKey(3)
+//       FDs: ()-->(1-3)
+//
+func (ts *testState) String() string {
+	var b strings.Builder
+	ts.format(&b)
+	return b.String()
+}
+
+func initialTestState(cfg *testConfig) *testState {
+	return &testState{
+		cfg: cfg,
+		rel: cfg.initTestRelation(),
+	}
+}
+
+func (ts *testState) child(t *testing.T, op testOp) *testState {
+	child := &testState{
+		parent: ts,
+		cfg:    ts.cfg,
+		op:     op,
+		rel:    op.FilterRelation(ts.rel),
+	}
+
+	err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.AssertionFailedf("%v", r)
+			}
+		}()
+		child.fds = op.ApplyToFDs(ts.fds)
+		child.fds.Verify()
+		if err = child.rel.checkFDs(&child.fds); err != nil {
+			return err
+		}
+		if err = ts.cfg.checkAPIs(&child.fds, child.rel); err != nil {
+			return err
+		}
+		return nil
+	}()
+	if err != nil {
+		t.Fatalf("details below\n%s\n%+v", child.String(), err)
+	}
+
+	return child
+}
+
+// TestFuncDepOpsRandom performs random FD operations and maintains a test
+// relation in parallel, making sure that the FDs always hold w.r.t the test
+// table. We start with a "full" table (all possible combinations of values in a
+// certain range) and each operation filters out rows in conformance with the
+// operation (e.g. if we add a key, we remove duplicate rows). We also test
+// various FuncDepSet APIs at each stage.
+//
+// To reuse work, instead of generating one chain of operations at a time, we
+// generate a tree of operations; each path from root to a leaf is a chain that
+// is getting tested.
+//
+func TestFuncDepOpsRandom(t *testing.T) {
+	type testParams struct {
+		testConfig
+
+		// maxDepth is the maximum length of a chain of test operations.
+		maxDepth int
+
+		// branching is the number of test operations, generated at each level.
+		// The number of total operations is branching ^ maxDepth.
+		branching int
+
+		ops []testOpGenerator
+	}
+
+	testConfigs := []testParams{
+		{
+			testConfig: testConfig{
+				numCols:  3,
+				valRange: 3,
+			},
+			maxDepth:  5,
+			branching: 3,
+			ops: []testOpGenerator{
+				genAddKey(0 /* minKeyCols */, 2 /* maxKeyCols */),
+				genMakeNotNull(1 /* minCols */, 3 /* maxCols */),
+				genAddConst(1 /* minCols */, 3 /* maxCols */),
+				genAddEquiv(),
+				genAddSynth(0 /* minCols */, 3 /* maxCols */),
+			},
+		},
+
+		{
+			testConfig: testConfig{
+				numCols:  5,
+				valRange: 2,
+			},
+			maxDepth:  8,
+			branching: 2,
+			ops: []testOpGenerator{
+				genAddKey(1 /* minKeyCols */, 5 /* maxKeyCols */),
+				genMakeNotNull(1 /* minCols */, 4 /* maxCols */),
+				genAddConst(1 /* minCols */, 4 /* maxCols */),
+				genAddEquiv(),
+				genAddSynth(0 /* minCols */, 3 /* maxCols */),
+			},
+		},
+	}
+
+	const repeats = 100
+
+	for _, cfg := range testConfigs {
+		for r := 0; r < repeats; r++ {
+			var run func(state *testState, depth int)
+			run = func(state *testState, depth int) {
+				for i := 0; i < cfg.branching; i++ {
+					opGenIdx := rand.Intn(len(cfg.ops))
+					op := cfg.ops[opGenIdx](&cfg.testConfig)
+
+					child := state.child(t, op)
+
+					if debug {
+						fmt.Printf("%d: %s %s\n", depth, op, child.fds.String())
+						for _, r := range child.rel {
+							fmt.Printf("  %s\n", r)
+						}
+					}
+
+					if depth < cfg.maxDepth {
+						run(child, depth+1)
+					}
+				}
+			}
+			run(initialTestState(&cfg.testConfig), 1 /* depth */)
+		}
+	}
+
+	// Run tests for joins.
+	for r := 0; r < repeats; r++ {
+		genRandChain := func() *testState {
+			cfg := testConfigs[rand.Intn(len(testConfigs))]
+			state := initialTestState(&cfg.testConfig)
+
+			steps := 1 + rand.Intn(cfg.maxDepth)
+			for i := 0; i < steps; i++ {
+				opGenIdx := rand.Intn(len(cfg.ops))
+				op := cfg.ops[opGenIdx](&cfg.testConfig)
+				state = state.child(t, op)
+			}
+			return state
+		}
+
+		left := genRandChain()
+		nLeft := left.cfg.numCols
+		leftCols := left.cfg.allCols()
+		right := genRandChain()
+		nRight := right.cfg.numCols
+		rightCols := shiftSet(right.cfg.allCols(), nLeft)
+		rightFDs := shiftColumns(right.fds, nLeft)
+
+		// Test inner join.
+		join := joinTestRelations(
+			nLeft, left.rel, nRight, right.rel, false /* leftOuter */, false, /* rightOuter */
+		)
+		var fd FuncDepSet
+		fd.CopyFrom(&left.fds)
+		fd.MakeProduct(&rightFDs)
+		if err := join.checkFDs(&fd); err != nil {
+			t.Fatalf(
+				"MakeProduct returned incorrect FDs\n"+
+					"left:   %s\n"+
+					"right:  %s\n"+
+					"result: %s\n"+
+					"error:  %+v\n\n"+
+					"left side: %s\n"+
+					"right side (cols shifted by %d): %s",
+				&left.fds, &rightFDs, &fd, err, left, nLeft, right,
+			)
+		}
+		// Since we already have the cartesian product, use it to determine the
+		// not-null input columns.
+		notNullInputCols := join.notNullCols(nLeft + nRight)
+
+		// Test left join.
+		join = joinTestRelations(
+			nLeft, left.rel, nRight, right.rel, true /* leftOuter */, false, /* rightOuter */
+		)
+		fd.CopyFrom(&left.fds)
+		fd.MakeProduct(&rightFDs)
+		fd.MakeLeftOuter(rightCols, notNullInputCols)
+		if err := join.checkFDs(&fd); err != nil {
+			t.Fatalf(
+				"MakeLeftOuter(%s, %s) returned incorrect FDs\n"+
+					"left:   %s\n"+
+					"right:  %s\n"+
+					"result: %s\n"+
+					"error:  %+v\n\n"+
+					"left side: %s\n"+
+					"right side (cols shifted by %d): %s",
+				rightCols, notNullInputCols,
+				&left.fds, &rightFDs, &fd, err, left, nLeft, right,
+			)
+		}
+
+		// Test outer join.
+		join = joinTestRelations(
+			nLeft, left.rel, nRight, right.rel, true /* leftOuter */, true, /* rightOuter */
+		)
+		fd.CopyFrom(&left.fds)
+		fd.MakeProduct(&rightFDs)
+		fd.MakeFullOuter(leftCols, rightCols, notNullInputCols)
+		if err := join.checkFDs(&fd); err != nil {
+			t.Fatalf(
+				"MakeFullOuter(%s, %s, %s) returned incorrect FDs\n"+
+					"left:   %s\n"+
+					"right:  %s\n"+
+					"result: %s\n"+
+					"error:  %+v\n\n"+
+					"left side: %s\n"+
+					"right side (cols shifted by %d): %s",
+				leftCols, rightCols, notNullInputCols,
+				&left.fds, &rightFDs, &fd, err, left, nLeft, right,
+			)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}
+
+func shiftSet(cols opt.ColSet, delta int) opt.ColSet {
+	var res opt.ColSet
+	cols.ForEach(func(col opt.ColumnID) {
+		res.Add(col + opt.ColumnID(delta))
+	})
+	return res
+}
+
+func shiftColumns(fd FuncDepSet, delta int) FuncDepSet {
+	var res FuncDepSet
+	res.CopyFrom(&fd)
+	for i := range res.deps {
+		d := &res.deps[i]
+		d.from = shiftSet(d.from, delta)
+		d.to = shiftSet(d.to, delta)
+	}
+	res.key = shiftSet(res.key, delta)
+	return res
+}

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1502,12 +1502,11 @@ project
       │         └── col0 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       ├── select
       │    ├── columns: col0:7(int!null) col2:9(int)
-      │    ├── cardinality: [0 - 1]
-      │    ├── key: ()
+      │    ├── lax-key: (9)
       │    ├── fd: ()-->(7,9)
       │    ├── index-join t
       │    │    ├── columns: col0:7(int) col2:9(int)
-      │    │    ├── lax-key: (7)
+      │    │    ├── lax-key: (7,9)
       │    │    ├── fd: ()-->(9), (9)~~>(7)
       │    │    └── scan t@secondary
       │    │         ├── columns: pk:6(int!null) col2:9(int)


### PR DESCRIPTION
This commits adds randomized testing for FuncDeps and fixes a set of
issues that were found.

The testing approach is described by this comment:
```
// TestFuncDepOpsRandom performs random FD operations and maintains a test
// relation in parallel, making sure that the FDs always hold w.r.t the test
// table. We start with a "full" table (all possible combinations of values in a
// certain range) and each operation filters out rows in conformance with the
// operation (e.g. if we add a key, we remove duplicate rows). We also test
// various FuncDepSet APIs at each stage.
```
When an error is found, the test presents the chain of operations
(which helps a lot in root causing the issue):
```
  initial numCols=3 valRange=3
   => MakeNotNull(2)
      FDs:
   => AddConstants(1,3) values {NULL,1}
      FDs: ()-->(1,3)
   => AddLaxKey(3)
      FDs: ()-->(1-3)

   < some error >
```

This approach quickly found a bunch of bugs:

 - MakeNotNull was reading specific positions of the deps slice but it
   was also indirectly changing it at the same time.

 - various `Verify` assertion failures (e.g. due to not reducing a key
   after an operation)

 - it is incorrect to reduce the columns of a lax key: if a column is
   determined by other lax key columns, it could still be NULL and we
   could be removing the last NULL that allows for duplicates for a
   set of values. This was happening in many hard-to-find places,
   including in APIs like `ColsAreLaxKey` or `ProjectCols`. This is
   the root cause of #44296.

Fixes #44296.

Release note (bug fix): fixed possibly incorrect query results in
various cornercases, especially when SELECT DISTINCT is used.