### PR TITLE
hlc: further simplify (Timestamp).String()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1094,14 +1094,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:82479a39eed008373e82850057152a72265db974a1f091b991bb792b90f43cce"
-  name = "github.com/knz/go-ilog10"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "0a8343dc930a01c7a31dd1a1c4e74d1ecdeb09ce"
-
-[[projects]]
   digest = "1:71425d83ffb201ca42fd0046860b2cae872c85e4c087c40271c04dea8c755434"
   name = "github.com/knz/go-libedit"
   packages = [
@@ -2092,7 +2084,6 @@
     "github.com/kevinburke/go-bindata/go-bindata",
     "github.com/kisielk/errcheck",
     "github.com/kisielk/gotool",
-    "github.com/knz/go-ilog10",
     "github.com/knz/go-libedit",
     "github.com/knz/strtime",
     "github.com/kr/pretty",

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -134,3 +134,11 @@ func TestTimestampString(t *testing.T) {
 		assert.Equal(t, c.exp, c.ts.String())
 	}
 }
+
+func BenchmarkTimestampString(b *testing.B) {
+	ts := makeTS(-6661234567890, 0)
+
+	for i := 0; i < b.N; i++ {
+		_ = ts.String()
+	}
+}


### PR DESCRIPTION
In my previous iteration of this code I got rid of a dynamic
allocation by observing that the number of decimal digits was
fixed (9) so we just had to know how many digits to print (base-10
logarithm) to know where to start:

```go
buf = append(buf, '.')
const zeroes = "000000000"
buf = append(buf, zeroes[:9-ilog10.NumUint32DecimalDigits(uint32(ns))]...)
buf = strconv.AppendUint(buf, ns, 10)
```

However I was being too smart for my own good. This is really
"algorithm 101": AppendUint can be rewritten to do the job over 9
digits directly instead of stopping when it encounters the head digit:

```go
buf = append(buf, '.', '0', '0', '0', '0', '0', '0', '0', '0', '0')
for i := 0; i < 9; i++ {
  buf[len(buf)-1-i] = byte('0' + ns%10)
  ns = ns / 10
}
```

This is not just readable; it is actually faster.

```
name                old time/op    new time/op    delta
TimestampString-32     104ns ±10%      84ns ± 9%  -18.60%  (p=0.000 n=10+9)
```

Finally by unrolling the loop, we shave 14% on top of that:
```
name                old time/op    new time/op    delta
TimestampString-32     104ns ±10%      72ns ± 5%  -30.09%  (p=0.000 n=10+8)
```

A minor advantage of this patch is that it drops the external
dependency on `go-ilog10` which we were not using otherwise.

Release note: None