### PR TITLE
storage: improve the migration away from txn.DeprecatedOrigTimestamp

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -43,9 +43,6 @@ func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 		// Note that writes will be performed at the provisional commit timestamp,
 		// txn.Timestamp, regardless of the batch timestamp.
 		ba.Timestamp = txn.ReadTimestamp
-		// For compatibility with 19.2 nodes which might not have set ReadTimestamp,
-		// fallback to DeprecatedOrigTimestamp.
-		ba.Timestamp.Forward(txn.DeprecatedOrigTimestamp)
 	} else {
 		// When not transactional, allow empty timestamp and use nowFn instead
 		if ba.Timestamp == (hlc.Timestamp{}) {

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -392,9 +392,6 @@ func IsEndTxnTriggeringRetryError(
 		retry, reason = true, roachpb.RETRY_WRITE_TOO_OLD
 	} else {
 		readTimestamp := txn.ReadTimestamp
-		// For compatibility with 19.2 nodes which might not have set
-		// ReadTimestamp, fallback to DeprecatedOrigTimestamp.
-		readTimestamp.Forward(txn.DeprecatedOrigTimestamp)
 		isTxnPushed := txn.WriteTimestamp != readTimestamp
 
 		// Return a transaction retry error if the commit timestamp isn't equal to

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1459,9 +1459,6 @@ func mvccPutInternal(
 	writeTimestamp := timestamp
 	if txn != nil {
 		readTimestamp = txn.ReadTimestamp
-		// For compatibility with 19.2 nodes which might not have set
-		// ReadTimestamp, fallback to DeprecatedOrigTimestamp.
-		readTimestamp.Forward(txn.DeprecatedOrigTimestamp)
 		if readTimestamp != timestamp {
 			return errors.AssertionFailedf(
 				"mvccPutInternal: txn's read timestamp %s does not match timestamp %s",


### PR DESCRIPTION
19.2 doesn't generally set txn.ReadTimestamp. Instead, it sets
txn.DeprecatedOrigTimestamp. Before this patch, all code dealing with
txn.ReadTimestamp had to deal with the possibility of it not being set.
This is fragile; I recently forgot to deal with it in a patch.
This patch sets txn.ReadTimestamp to txn.DeprecatedOrigTimestamp when it
wasn't set, thereby releaving most other code of they worry.

This comes at the cost of an extra txn clone for requests coming from
19.2 nodes.

Release note: None