### PR TITLE
storage: introduce pkg/raftstorage

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -300,6 +300,24 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 			Value: iter.Value(),
 		})
 	}
+
+	if debugCtx.replicated {
+		return nil
+	}
+
+	raftIter := rditer.NewReplicaRaftDataIterator(&desc, db)
+	defer raftIter.Close()
+	for ; ; raftIter.Next() {
+		if ok, err := raftIter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+		storage.PrintKeyValue(engine.MVCCKeyValue{
+			Key:   raftIter.Key(),
+			Value: raftIter.Value(),
+		})
+	}
 	return nil
 }
 

--- a/pkg/storage/batcheval/cmd_conditional_put.go
+++ b/pkg/storage/batcheval/cmd_conditional_put.go
@@ -42,7 +42,15 @@ func ConditionalPut(
 	}
 	handleMissing := engine.CPutMissingBehavior(args.AllowIfDoesNotExist)
 	if args.Blind {
-		return result.Result{}, engine.MVCCBlindConditionalPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.ExpValue, handleMissing, h.Txn)
+		err := engine.MVCCBlindConditionalPut(
+			ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value,
+			args.ExpValue, handleMissing, h.Txn,
+		)
+		return result.Result{}, err
 	}
-	return result.Result{}, engine.MVCCConditionalPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.ExpValue, handleMissing, h.Txn)
+	err := engine.MVCCConditionalPut(
+		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value,
+		args.ExpValue, handleMissing, h.Txn,
+	)
+	return result.Result{}, err
 }

--- a/pkg/storage/batcheval/cmd_init_put.go
+++ b/pkg/storage/batcheval/cmd_init_put.go
@@ -42,7 +42,15 @@ func InitPut(
 		}
 	}
 	if args.Blind {
-		return result.Result{}, engine.MVCCBlindInitPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
+		err := engine.MVCCBlindInitPut(
+			ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value,
+			args.FailOnTombstones, h.Txn,
+		)
+		return result.Result{}, err
 	}
-	return result.Result{}, engine.MVCCInitPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)
+	err := engine.MVCCInitPut(
+		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value,
+		args.FailOnTombstones, h.Txn,
+	)
+	return result.Result{}, err
 }

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1920,7 +1920,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 		t.Fatalf("expected RHS's GCThreshold is equal to %v, but got %v", specifiedGCThreshold, gcThreshold)
 	}
 
-	repl.AssertState(context.TODO(), store.Engine())
+	repl.AssertState(context.TODO(), store.Engine(), store.RaftEngine())
 }
 
 // TestStoreRangeSplitRaceUninitializedRHS reproduces #7600 (before it was

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -129,12 +129,11 @@ type CleanupIntentsFunc func(context.Context, []roachpb.Intent) error
 // transaction record.
 type CleanupTxnIntentsAsyncFunc func(context.Context, *roachpb.Transaction, []roachpb.Intent) error
 
-// Run runs garbage collection for the specified descriptor on the
-// provided Engine (which is not mutated). It uses the provided gcFn
-// to run garbage collection once on all implicated spans,
-// cleanupIntentsFn to resolve intents synchronously, and
-// cleanupTxnIntentsAsyncFn to asynchronously cleanup intents and
-// associated transaction record on success.
+// Run runs garbage collection for the specified descriptor on the provided
+// Reader. It uses the provided gcFn to run garbage collection once on all
+// implicated spans, cleanupIntentsFn to resolve intents synchronously, and
+// cleanupTxnIntentsAsyncFn to asynchronously cleanup intents and associated
+// transaction record on success.
 func Run(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -410,7 +410,7 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg *config.S
 		log.VEventf(ctx, 1, "not gc'ing replica %v due to pending protection: %v", repl, err)
 		return nil
 	}
-	snap := repl.store.Engine().NewSnapshot()
+	snap := repl.Engine().NewSnapshot()
 	defer snap.Close()
 
 	info, err := gc.Run(ctx, desc, snap, gcTimestamp, *zone.GC, &replicaGCer{repl: repl},

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -837,11 +837,9 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			"but only %d are left", exp, count)
 	}
 
-	batch := tc.engine.NewSnapshot()
-	defer batch.Close()
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
-	tc.repl.assertStateLocked(ctx, batch) // check that in-mem and on-disk state were updated
+	tc.repl.assertStateLocked(ctx, tc.engine, tc.raftEngine) // check that in-mem and on-disk state were updated
 	tc.repl.mu.Unlock()
 	tc.repl.raftMu.Unlock()
 }

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/raftstorage"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -239,12 +240,14 @@ func NewTestStorePool(cfg StoreConfig) *StorePool {
 	)
 }
 
-func (r *Replica) AssertState(ctx context.Context, reader engine.Reader) {
+func (r *Replica) AssertState(
+	ctx context.Context, reader engine.Reader, raftReader raftstorage.Reader,
+) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.assertStateLocked(ctx, reader)
+	r.assertStateLocked(ctx, reader, raftReader)
 }
 
 func (r *Replica) RaftLock() {

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -542,7 +542,7 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ *config.Syst
 		// make sure concurrent Raft activity doesn't foul up our update to the
 		// cached in-memory values.
 		r.raftMu.Lock()
-		n, err := ComputeRaftLogSize(ctx, r.RangeID, r.Engine(), r.raftMu.sideloaded)
+		n, err := ComputeRaftLogSize(ctx, r.RangeID, r.RaftEngine(), r.raftMu.sideloaded)
 		if err == nil {
 			r.mu.Lock()
 			r.mu.raftLogSize = n

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/raftstorage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -848,7 +849,8 @@ func TestTruncateLogRecompute(t *testing.T) {
 	defer eng.Close()
 
 	tc := testContext{
-		engine: eng,
+		engine:     eng,
+		raftEngine: raftstorage.Wrap(eng),
 	}
 	cfg := TestStoreConfig(nil)
 	cfg.TestingKnobs.DisableRaftLogQueue = true

--- a/pkg/storage/raftstorage/raftstorage.go
+++ b/pkg/storage/raftstorage/raftstorage.go
@@ -1,0 +1,160 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package raftstorage defines the API boundaries for a store to interact with
+// the Raft state for the replicas it contains. The exposed interfaces are a
+// subset of those also found in the `engine` package. It itself does not expose
+// the `engine` API.
+//
+// Currently this package serves as glue code to cleanly separate raft storage
+// code in pkg/storage from directly accessing the underlying
+// engine.{Engine,Batch,...}. As a result, its usage closely mimics that of the
+// lower-level engine package. Over time we expect to pull in more code sitting
+// below this glue code and expose Raft state (i.e. log entries, truncated
+// state, etc.) as first class primitives. Long term, think `etcd/raft.Storage`
+// but for multi-raft.
+//
+// We allow implicit conversions between {Writer,Reader,ReadWriter} and
+// engine.{Writer,Reader,ReadWriter} respectively. This in intentional as the
+// engine.MVCC{...} APIs expect engine.{Writer,Reader,ReadWriter}s. We don't,
+// however, allow implicit conversion between {Engine,Batch} and
+// engine.{Engine,Batch} respectively. We expect all usage to derive through
+// Engines constructed through this package.
+//
+// (Use of this package also introduces the nice property that lets us now jump
+// to usage of all code pertaining to "raft storage".)
+package raftstorage
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+)
+
+// Writer is a thin wrapper around engine.Writer, and represents an
+// engine.Writer derived from a raftstorage.{Engine,Batch}.
+type Writer interface {
+	engine.Writer
+}
+
+// Reader is a thin wrapper around engine.Reader, and represents an
+// engine.Reader derived from a raftstorage.{Engine,Batch}.
+type Reader interface {
+	engine.Reader
+}
+
+// ReadWriter is a thin wrapper around engine.Writer, and represents an
+// engine.ReadWriter derived from a raft storage engine.
+type ReadWriter interface {
+	Reader
+	Writer
+}
+
+// TODO(irfansharif): Encapsulate engine specific code in implementation here.
+// Right now everything passes through thin shims that simply forward to the
+// underlying engine interfaces. This was done to make it easier to wean out
+// raft storage addressing code within pkg/storage. This package, however,
+// should should be a "deeper" one, pulling in all raft storage abstractions.
+// Merging in the RaftEntryCache and replica_raftstorage.go would be good
+// places to start. We should create a thin wrapper around the Engine type to
+// act as a "handler" for a given replica, with all the key generation happening
+// internally (instead of constructing raft keys manually at the caller).
+
+// Engine represents a raft storage engine. It's a subset of the interface
+// defined in engine.Engine. Refer to the documentation in pkg/storage/engine
+// for usage.
+type Engine interface {
+	ReadWriter
+	NewBatch() Batch
+	NewWriteOnlyBatch() Batch
+	NewReadOnly() ReadWriter
+	NewSnapshot() Reader
+	UnderlyingEngine() engine.Engine
+
+	IngestExternalFiles(ctx context.Context, paths []string) error
+	CreateCheckpoint(dir string) error
+}
+
+// Batch represents a batch derived from Engine. It's a subset of the interface
+// defined in engine.Batch. Refer to the documentation in pkg/storage/engine for
+// usage.
+type Batch interface {
+	ReadWriter
+	Distinct() ReadWriter
+	Empty() bool
+	Commit(sync bool) error
+}
+
+// raftEngine is a concrete implementation of Engine.
+type raftEngine struct {
+	engine.Engine
+}
+
+var _ Engine = &raftEngine{}
+var _ ReadWriter = &raftEngine{}
+
+// Wrap wraps an existing engine.Engine that is to be used as a raft storage
+// engine.
+//
+// TODO(irfansharif): This exists as a stop gap for the migration story around
+// raft storage. Once that's sorted out, a separate engine will need to be
+// constructed at all call sites. The same applies for WrapBatch below, which
+// needs to be removed entirely.
+func Wrap(eng engine.Engine) Engine {
+	return &raftEngine{Engine: eng}
+}
+
+func (e *raftEngine) NewBatch() Batch {
+	return &raftBatch{
+		Batch: e.UnderlyingEngine().NewBatch(),
+	}
+}
+
+func (e *raftEngine) NewWriteOnlyBatch() Batch {
+	return &raftBatch{
+		Batch: e.UnderlyingEngine().NewWriteOnlyBatch(),
+	}
+}
+
+func (e *raftEngine) NewReadOnly() ReadWriter {
+	return e.UnderlyingEngine().NewReadOnly()
+}
+
+func (e *raftEngine) NewSnapshot() Reader {
+	return e.UnderlyingEngine().NewSnapshot()
+}
+
+func (e *raftEngine) UnderlyingEngine() engine.Engine {
+	return e.Engine
+}
+
+// Close closes the raft engine.
+//
+// TODO(irfansharif): Close is a no-op for now, while the raftstorage engine is
+// backed by and existing engine (so we avoid double closing). This will need be
+// changed when we're using a separate engine.
+func (e *raftEngine) Close() {}
+
+type raftBatch struct {
+	engine.Batch
+}
+
+var _ Batch = &raftBatch{}
+var _ ReadWriter = &raftBatch{}
+
+// WrapBatch wraps an existing engine.Batch that is to be used as a raft storage
+// batch.
+func WrapBatch(batch engine.Batch) Batch {
+	return &raftBatch{Batch: batch}
+}
+
+func (b *raftBatch) Distinct() ReadWriter {
+	return b.Batch.Distinct()
+}

--- a/pkg/storage/rditer/replica_data_iter_test.go
+++ b/pkg/storage/rditer/replica_data_iter_test.go
@@ -124,6 +124,8 @@ func verifyRDIter(
 	replicatedOnly bool,
 	expectedKeys []engine.MVCCKey,
 ) {
+	// XXX(irfansharif): NewReplicaDataIterator only iterates over one
+	// engine. This, and all callers need to be updated.
 	t.Helper()
 	verify := func(t *testing.T, useSpanSet, reverse bool) {
 		if useSpanSet {

--- a/pkg/storage/replica_init.go
+++ b/pkg/storage/replica_init.go
@@ -105,7 +105,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 	r.mu.proposalBuf.Init((*replicaProposer)(r))
 
 	var err error
-	if r.mu.state, err = r.mu.stateLoader.Load(ctx, r.Engine(), desc); err != nil {
+	if r.mu.state, err = r.mu.stateLoader.Load(ctx, r.Engine(), r.RaftEngine(), desc); err != nil {
 		return err
 	}
 
@@ -129,7 +129,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 
 	r.rangeStr.store(0, r.mu.state.Desc)
 
-	r.mu.lastIndex, err = r.mu.stateLoader.LoadLastIndex(ctx, r.Engine())
+	r.mu.lastIndex, err = r.mu.stateLoader.LoadLastIndex(ctx, r.Engine(), r.RaftEngine())
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 		log.Fatalf(ctx, "attempting to initialize a replica which has ID %d with ID %d",
 			r.mu.replicaID, replicaID)
 	}
-	r.assertStateLocked(ctx, r.store.Engine())
+	r.assertStateLocked(ctx, r.Engine(), r.RaftEngine())
 	return nil
 }
 
@@ -196,7 +196,7 @@ func (r *Replica) setReplicaIDRaftMuLockedMuLocked(
 		replicaID,
 		ssBase,
 		r.store.limiters.BulkIOWriteRate,
-		r.store.engine,
+		r.Engine(),
 	); err != nil {
 		return errors.Wrap(err, "while initializing sideloaded storage")
 	}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -748,8 +748,13 @@ func (r *Replica) evaluateProposal(
 		!res.Replicated.Equal(storagepb.ReplicatedEvalResult{})
 
 	if needConsensus {
-		// Set the proposal's WriteBatch, which is the serialized representation of
-		// the proposals effect on RocksDB.
+		// Set the proposal's WriteBatch, which is the serialized representation
+		// of the proposals' effect on the primary storage engine.
+		//
+		// NB: For evaluations of splits, the WriteBatch will also contain
+		// truncated state for the RHS, which is a key to be applied in the raft
+		// storage engine. Downstream of raft we will reconstruct this key in
+		// order to apply to the raft storage engine.
 		res.WriteBatch = &storagepb.WriteBatch{
 			Data: batch.Repr(),
 		}

--- a/pkg/storage/replica_raft_truncation_test.go
+++ b/pkg/storage/replica_raft_truncation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/raftstorage"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -85,7 +86,9 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 					Term:  term,
 				}
 
-				apply, err := handleTruncatedStateBelowRaft(ctx, &prevTruncatedState, newTruncatedState, loader, eng)
+				apply, err := handleTruncatedStateBelowRaft(
+					ctx, &prevTruncatedState, newTruncatedState, loader, eng, raftstorage.Wrap(eng),
+				)
 				if err != nil {
 					return err.Error()
 				}

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -67,7 +67,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// TODO(irfansharif): It's unfortunate that in this read-only code path,
 	// we're stuck with a ReadWriter because of the way evaluateBatch is
 	// designed.
-	rw := r.store.Engine().NewReadOnly()
+	rw := r.Engine().NewReadOnly()
 	if util.RaceEnabled {
 		rw = spanset.NewReadWriterAt(rw, spans, ba.Timestamp)
 	}

--- a/pkg/storage/replica_sst_snapshot_storage.go
+++ b/pkg/storage/replica_sst_snapshot_storage.go
@@ -34,11 +34,13 @@ type SSTSnapshotStorage struct {
 }
 
 // NewSSTSnapshotStorage creates a new SST snapshot storage.
-func NewSSTSnapshotStorage(engine engine.Engine, limiter *rate.Limiter) SSTSnapshotStorage {
+func NewSSTSnapshotStorage(
+	engine engine.Engine, dir string, limiter *rate.Limiter,
+) SSTSnapshotStorage {
 	return SSTSnapshotStorage{
 		engine:  engine,
 		limiter: limiter,
-		dir:     filepath.Join(engine.GetAuxiliaryDir(), "sstsnapshot"),
+		dir:     filepath.Join(engine.GetAuxiliaryDir(), dir),
 	}
 }
 

--- a/pkg/storage/replica_sst_snapshot_storage_test.go
+++ b/pkg/storage/replica_sst_snapshot_storage_test.go
@@ -34,7 +34,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	defer cleanup()
 	defer eng.Close()
 
-	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
+	sstSnapshotStorage := NewSSTSnapshotStorage(eng, "sstsnapshot", testLimiter)
 	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
 
 	// Check that the storage lazily creates the directories on first write.

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -289,7 +289,7 @@ func (r *Replica) evaluateWriteBatch(
 			if !etArg.Commit {
 				clonedTxn.Status = roachpb.ABORTED
 				batch.Close()
-				batch = r.store.Engine().NewBatch()
+				batch = r.Engine().NewBatch()
 				ms = enginepb.MVCCStats{}
 			} else {
 				// Run commit trigger manually.
@@ -353,7 +353,7 @@ func (r *Replica) evaluateWriteBatchWithLocalRetries(
 			*ms = goldenMS
 			batch.Close()
 		}
-		batch = r.store.Engine().NewBatch()
+		batch = r.Engine().NewBatch()
 		var opLogger *engine.OpLoggerBatch
 		if RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 			// TODO(nvanbenschoten): once we get rid of the RangefeedEnabled

--- a/pkg/storage/stateloader/initial.go
+++ b/pkg/storage/stateloader/initial.go
@@ -16,31 +16,85 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/raftstorage"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
 
-// raftInitialLog{Index,Term} are the starting points for the raft log. We
+// RaftInitialLog{Index,Term} are the starting points for the raft log. We
 // bootstrap the raft membership by synthesizing a snapshot as if there were
 // some discarded prefix to the log, so we must begin the log at an arbitrary
 // index greater than 1.
 const (
-	raftInitialLogIndex = 10
-	raftInitialLogTerm  = 5
+	RaftInitialLogIndex = 10
+	RaftInitialLogTerm  = 5
 )
 
-// WriteInitialReplicaState sets up a new Range, but without writing an
-// associated Raft state (which must be written separately via
-// synthesizeRaftState before instantiating a Replica). The main task is to
-// persist a ReplicaState which does not start from zero but presupposes a few
-// entries already having applied. The supplied MVCCStats are used for the Stats
-// field after adjusting for persisting the state itself, and the updated stats
-// are returned.
-func WriteInitialReplicaState(
+// WriteInitialReplicaStateUpstreamOfRaft is like writeInitialReplicaState,
+// except "raft data" is addressed to just the one provided engine.ReadWriter.
+// Since we're upstream of raft, we're only evaluating replica state writes.
+// Because commands are only evaluated on batches derived from the one data
+// engine, we simply collect replica state writes in the one provided
+// engine.Batch.
+func WriteInitialReplicaStateUpstreamOfRaft(
 	ctx context.Context,
 	readWriter engine.ReadWriter,
+	ms enginepb.MVCCStats,
+	desc roachpb.RangeDescriptor,
+	lease roachpb.Lease,
+	gcThreshold hlc.Timestamp,
+	truncStateType TruncatedStateType,
+) (enginepb.MVCCStats, error) {
+	// Upstream of raft, we're only ever evaluating writes to replica state, not
+	// actually persisting them.
+	batch, ok := readWriter.(engine.Batch)
+	if !ok {
+		panic("expected readWriter to be an engine.Batch")
+	}
+
+	return writeInitialReplicaState(
+		ctx, readWriter, raftstorage.WrapBatch(batch), ms, desc, lease, gcThreshold, truncStateType,
+	)
+}
+
+// WriteInitialStateDuringBootstrap writes the initial replica state to the
+// provided engine.ReadWriters (derived from the data engine and the raft engine
+// respectively), and synthesizes the Raft state required before instantiating a
+// replica.
+func WriteInitialStateDuringBootstrap(
+	ctx context.Context,
+	readWriter engine.ReadWriter,
+	raftRW raftstorage.ReadWriter,
+	ms enginepb.MVCCStats,
+	desc roachpb.RangeDescriptor,
+	lease roachpb.Lease,
+	gcThreshold hlc.Timestamp,
+	truncStateType TruncatedStateType,
+) (enginepb.MVCCStats, error) {
+	newMS, err := writeInitialReplicaState(
+		ctx, readWriter, raftRW, ms, desc, lease, gcThreshold, truncStateType,
+	)
+	if err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := Make(desc.RangeID).SynthesizeRaftState(ctx, readWriter, raftRW); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return newMS, nil
+}
+
+// writeInitialReplicaState sets up a new Range, but without writing an
+// associated Raft state (which must be written separately via
+// SynthesizeRaftState). The main task is to persist a ReplicaState which does
+// not start from zero but presupposes a few entries already having applied. The
+// supplied MVCCStats are used for the Stats field after adjusting for
+// persisting the state itself, and the updated stats are returned.
+func writeInitialReplicaState(
+	ctx context.Context,
+	readWriter engine.ReadWriter,
+	raftRW raftstorage.ReadWriter,
 	ms enginepb.MVCCStats,
 	desc roachpb.RangeDescriptor,
 	lease roachpb.Lease,
@@ -50,8 +104,8 @@ func WriteInitialReplicaState(
 	rsl := Make(desc.RangeID)
 	var s storagepb.ReplicaState
 	s.TruncatedState = &roachpb.RaftTruncatedState{
-		Term:  raftInitialLogTerm,
-		Index: raftInitialLogIndex,
+		Term:  RaftInitialLogTerm,
+		Index: RaftInitialLogIndex,
 	}
 	s.RaftAppliedIndex = s.TruncatedState.Index
 	s.Desc = &roachpb.RangeDescriptor{
@@ -74,34 +128,10 @@ func WriteInitialReplicaState(
 		log.Fatalf(ctx, "expected trivial GChreshold, but found %+v", existingGCThreshold)
 	}
 
-	newMS, err := rsl.Save(ctx, readWriter, s, truncStateType)
+	newMS, err := rsl.Save(ctx, readWriter, raftRW, s, truncStateType)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 
-	return newMS, nil
-}
-
-// WriteInitialState calls WriteInitialReplicaState followed by
-// SynthesizeRaftState. It is typically called during bootstrap. The supplied
-// MVCCStats are used for the Stats field after adjusting for persisting the
-// state itself, and the updated stats are returned.
-func WriteInitialState(
-	ctx context.Context,
-	readWriter engine.ReadWriter,
-	ms enginepb.MVCCStats,
-	desc roachpb.RangeDescriptor,
-	lease roachpb.Lease,
-	gcThreshold hlc.Timestamp,
-	truncStateType TruncatedStateType,
-) (enginepb.MVCCStats, error) {
-	newMS, err := WriteInitialReplicaState(
-		ctx, readWriter, ms, desc, lease, gcThreshold, truncStateType)
-	if err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := Make(desc.RangeID).SynthesizeRaftState(ctx, readWriter); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
 	return newMS, nil
 }

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/raftstorage"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -581,7 +582,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	stopper.AddCloser(eng)
 	cfg := TestStoreConfig(clock)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-	store := NewStore(ctx, cfg, eng, &node)
+	store := NewStore(ctx, cfg, eng, raftstorage.Wrap(eng), &node)
 	// Fake an ident because this test doesn't want to start the store
 	// but without an Ident there will be NPEs.
 	store.Ident = &roachpb.StoreIdent{

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -381,6 +381,10 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 	}
 	logEntries := make([][]byte, 0, preallocSize)
 
+	// TODO(irfansharif): Log entries are no longer sent with snapshots as of
+	// v19.2, we can/should delete all code around the sending of log entries in
+	// snapshots before v20.1 is cut.
+
 	var raftLogBytes int64
 	scanFunc := func(kv roachpb.KeyValue) (bool, error) {
 		bytes, err := kv.Value.GetBytes()

--- a/pkg/storage/store_snapshot_preemptive.go
+++ b/pkg/storage/store_snapshot_preemptive.go
@@ -278,7 +278,7 @@ func (s *Store) processPreemptiveSnapshotRequest(
 		needTombstone := r.mu.state.Desc.NextReplicaID != 0
 		r.mu.Unlock()
 
-		appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.store.Engine())
+		appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.Engine())
 		if err != nil {
 			return roachpb.NewError(err)
 		}
@@ -294,7 +294,7 @@ func (s *Store) processPreemptiveSnapshotRequest(
 		preemptiveSnapshotRaftGroupID := uint64(snapHeader.RaftMessageRequest.FromReplica.ReplicaID)
 		raftGroup, err := raft.NewRawNode(
 			newRaftConfig(
-				raft.Storage((*replicaRaftStorage)(r)),
+				raft.Storage(replicaRaftStorage{r}),
 				preemptiveSnapshotRaftGroupID,
 				// We pass the "real" applied index here due to subtleties
 				// arising in the case in which Raft discards the snapshot:

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -221,7 +221,7 @@ type StoreTestingKnobs struct {
 	ReplicationAlwaysUseJointConfig func() bool
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
-	BeforeSnapshotSSTIngestion func(IncomingSnapshot, SnapshotRequest_Type, []string) error
+	BeforeSnapshotSSTIngestion func(IncomingSnapshot, SnapshotRequest_Type, []string, []string) error
 	// BeforeRelocateOne intercepts the return values of s.relocateOne before
 	// they're being put into effect.
 	BeforeRelocateOne func(_ []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget, _ error)


### PR DESCRIPTION
Introduce dedicated raft storage engine for Raft data. See
pkg/storage/raftstorage to start. Most of this PR is plumbing through
the interfaces defined there throughout pkg/storage. There are a few
subtle edges around splits and the construction of RaftTruncatedState
keys for the RHS range. Similarly there's some careful stitching around
replica destruction, writing of initial replica state, and the handling
of snapshots. From the package doc:

```
Package raftstorage defines the API boundaries for a store to
interact with the Raft state for the replicas it contains. The
exposed interfaces are a subset of those also found in the `engine`
package. It itself does not expose the `engine` API.

Currently this package serves as glue code to cleanly separate raft
storage code in pkg/storage from directly accessing the underlying
engine.{Engine,Batch,...}. As a result, its usage closely mimics that
of the lower-level engine package. Over time we expect to pull in
more code sitting below this glue code and expose Raft state (i.e.
log entries, truncated state, etc.) as first class primitives. Long
term, think `etcd/raft.Storage` but for multi-raft.

We allow implicit conversions between {Writer,Reader,ReadWriter} and
engine.{Writer,Reader,ReadWriter} respectively. This in intentional
as the engine.MVCC{...} APIs expect
engine.{Writer,Reader,ReadWriter}s. We don't, however, allow implicit
conversion between {Engine,Batch} and engine.{Engine,Batch}
respectively. We expect all usage to derive through Engines
constructed through this package.

(Use of this package also introduces the nice property that lets us
now jump to usage of all code pertaining to "raft storage".)
```

Note: Merging this PR would not actually introduce a separate engine, it
simply wraps around the existing engine and introduces all the right
hooks we would need to plumb in a separately constructed engine after
the fact. There are a few spots where we would have to make adjustments
when actually using a separate underlying engine (those have been
mapped out accordingly). There is also some overlap with this PR and
long running migrations (#39182) as actual use of a separate engine in
v20.1 would require migration infrastructure to copy over all raft state
from the primary engine to the raft one (there's now work underway
towards that). In the interim however, as plan B, we will introduce a
follow-up PR to use a separate engine for fresh clusters (which doesn't
require any sort of migration story).

Release note: None
