### PR TITLE
colexec: fix randomSel to only return selected indices

### DIFF
--- a/pkg/sql/colexec/random_testutils.go
+++ b/pkg/sql/colexec/random_testutils.go
@@ -65,14 +65,14 @@ func randomSel(rng *rand.Rand, batchSize uint16, probOfOmitting float64) []uint1
 	if probOfOmitting < 0 || probOfOmitting > 1 {
 		execerror.VectorizedInternalPanic(fmt.Sprintf("probability of omitting a row is %f - outside of [0, 1] range", probOfOmitting))
 	}
-	sel := make([]uint16, batchSize)
+	sel := make([]uint16, 0, batchSize)
 	for i := uint16(0); i < batchSize; i++ {
 		if rng.Float64() < probOfOmitting {
 			continue
 		}
-		sel[i] = i
+		sel = append(sel, i)
 	}
-	return sel[:batchSize]
+	return sel
 }
 
 // Suppress unused warnings.


### PR DESCRIPTION
Previously, randomSel claimed it would only return selected indices, but the
code as currently written always returns a selection vector of batchSize, with
0 in the places where an element would not be selected. This is now fixed.

Release note: None (testing-only change)