### PR TITLE
sql: minor clean up tableWriter-related structs

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -621,7 +621,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 				td := tableDeleter{rd: rd, alloc: alloc}
-				if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
+				if err := td.init(ctx, txn, nil /* *tree.EvalContext */); err != nil {
 					return err
 				}
 				if !sc.canClearRangeForDrop(&desc) {
@@ -1671,7 +1671,7 @@ func indexTruncateInTxn(
 			return err
 		}
 		td := tableDeleter{rd: rd, alloc: alloc}
-		if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
+		if err := td.init(ctx, txn, nil /* *tree.EvalContext */); err != nil {
 			return err
 		}
 		sp, err = td.deleteIndex(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -306,7 +306,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				*ti = tableInserter{}
 				tableInserterPool.Put(ti)
 			}()
-			if err := tw.init(params.p.txn, params.p.EvalContext()); err != nil {
+			if err := tw.init(params.ctx, params.p.txn, params.p.EvalContext()); err != nil {
 				return err
 			}
 

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -83,7 +83,7 @@ func (d *deleteNode) startExec(params runParams) error {
 			params.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(d.columns), 0)
 	}
-	return d.run.td.init(params.p.txn, params.EvalContext())
+	return d.run.td.init(params.ctx, params.p.txn, params.EvalContext())
 }
 
 // Next is required because batchedPlanNode inherits from planNode, but

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -189,7 +189,7 @@ func (n *insertNode) startExec(params runParams) error {
 
 	n.run.initRowContainer(params, n.columns, 0 /* rowCapacity */)
 
-	return n.run.ti.init(params.p.txn, params.EvalContext())
+	return n.run.ti.init(params.ctx, params.p.txn, params.EvalContext())
 }
 
 // Next is required because batchedPlanNode inherits from planNode, but

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -254,7 +254,7 @@ func (n *insertFastPathNode) startExec(params runParams) error {
 		}
 	}
 
-	return n.run.ti.init(params.p.txn, params.EvalContext())
+	return n.run.ti.init(params.ctx, params.p.txn, params.EvalContext())
 }
 
 // Next is required because batchedPlanNode inherits from planNode, but

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -34,6 +34,8 @@ type tableDeleter struct {
 	alloc *sqlbase.DatumAlloc
 }
 
+var _ tableWriter = &tableDeleter{}
+
 // desc is part of the tableWriter interface.
 func (*tableDeleter) desc() string { return "deleter" }
 
@@ -41,12 +43,12 @@ func (*tableDeleter) desc() string { return "deleter" }
 func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}
 
 // init is part of the tableWriter interface.
-func (td *tableDeleter) init(txn *client.Txn, _ *tree.EvalContext) error {
+func (td *tableDeleter) init(_ context.Context, txn *client.Txn, _ *tree.EvalContext) error {
 	td.tableWriterBase.init(txn)
 	return nil
 }
 
-// flushAndStartNewBatch is part of the extendedTableWriter interface.
+// flushAndStartNewBatch is part of the tableWriter interface.
 func (td *tableDeleter) flushAndStartNewBatch(ctx context.Context) error {
 	return td.tableWriterBase.flushAndStartNewBatch(ctx, td.rd.Helper.TableDesc)
 }
@@ -56,7 +58,7 @@ func (td *tableDeleter) finalize(ctx context.Context, _ bool) (*rowcontainer.Row
 	return nil, td.tableWriterBase.finalize(ctx, td.rd.Helper.TableDesc)
 }
 
-// atBatchEnd is part of the extendedTableWriter interface.
+// atBatchEnd is part of the tableWriter interface.
 func (td *tableDeleter) atBatchEnd(_ context.Context, _ bool) error { return nil }
 
 func (td *tableDeleter) row(ctx context.Context, values tree.Datums, traceKV bool) error {

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -26,11 +26,13 @@ type tableInserter struct {
 	ri row.Inserter
 }
 
+var _ tableWriter = &tableInserter{}
+
 // desc is part of the tableWriter interface.
 func (*tableInserter) desc() string { return "inserter" }
 
 // init is part of the tableWriter interface.
-func (ti *tableInserter) init(txn *client.Txn, _ *tree.EvalContext) error {
+func (ti *tableInserter) init(_ context.Context, txn *client.Txn, _ *tree.EvalContext) error {
 	ti.tableWriterBase.init(txn)
 	return nil
 }
@@ -41,10 +43,10 @@ func (ti *tableInserter) row(ctx context.Context, values tree.Datums, traceKV bo
 	return ti.ri.InsertRow(ctx, ti.b, values, false /* overwrite */, row.CheckFKs, traceKV)
 }
 
-// atBatchEnd is part of the extendedTableWriter interface.
+// atBatchEnd is part of the tableWriter interface.
 func (ti *tableInserter) atBatchEnd(_ context.Context, _ bool) error { return nil }
 
-// flushAndStartNewBatch is part of the extendedTableWriter interface.
+// flushAndStartNewBatch is part of the tableWriter interface.
 func (ti *tableInserter) flushAndStartNewBatch(ctx context.Context) error {
 	return ti.tableWriterBase.flushAndStartNewBatch(ctx, ti.tableDesc())
 }

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -26,11 +26,13 @@ type tableUpdater struct {
 	ru row.Updater
 }
 
+var _ tableWriter = &tableUpdater{}
+
 // desc is part of the tableWriter interface.
 func (*tableUpdater) desc() string { return "updater" }
 
 // init is part of the tableWriter interface.
-func (tu *tableUpdater) init(txn *client.Txn, _ *tree.EvalContext) error {
+func (tu *tableUpdater) init(_ context.Context, txn *client.Txn, _ *tree.EvalContext) error {
 	tu.tableWriterBase.init(txn)
 	return nil
 }
@@ -51,10 +53,10 @@ func (tu *tableUpdater) rowForUpdate(
 	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, row.CheckFKs, traceKV)
 }
 
-// atBatchEnd is part of the extendedTableWriter interface.
+// atBatchEnd is part of the tableWriter interface.
 func (tu *tableUpdater) atBatchEnd(_ context.Context, _ bool) error { return nil }
 
-// flushAndStartNewBatch is part of the extendedTableWriter interface.
+// flushAndStartNewBatch is part of the tableWriter interface.
 func (tu *tableUpdater) flushAndStartNewBatch(ctx context.Context) error {
 	return tu.tableWriterBase.flushAndStartNewBatch(ctx, tu.tableDesc())
 }

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -112,6 +112,8 @@ type optTableUpserter struct {
 	tabColIdxToRetIdx []int
 }
 
+var _ tableWriter = &optTableUpserter{}
+
 // init is part of the tableWriter interface.
 func (tu *optTableUpserter) init(
 	ctx context.Context, txn *client.Txn, evalCtx *tree.EvalContext,
@@ -185,7 +187,7 @@ func (tu *optTableUpserter) init(
 	return err
 }
 
-// flushAndStartNewBatch is part of the extendedTableWriter interface.
+// flushAndStartNewBatch is part of the tableWriter interface.
 func (tu *optTableUpserter) flushAndStartNewBatch(ctx context.Context) error {
 	tu.insertRows.Clear(ctx)
 	if tu.collectRows {
@@ -296,7 +298,7 @@ func (tu *optTableUpserter) row(ctx context.Context, row tree.Datums, traceKV bo
 	)
 }
 
-// atBatchEnd is part of the extendedTableWriter interface.
+// atBatchEnd is part of the tableWriter interface.
 func (tu *optTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error {
 	// Nothing to do, because the row method does everything.
 	return nil

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -562,7 +562,7 @@ func truncateTableInChunks(
 				return err
 			}
 			td := tableDeleter{rd: rd, alloc: alloc}
-			if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
+			if err := td.init(ctx, txn, nil /* *tree.EvalContext */); err != nil {
 				return err
 			}
 			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, traceKV)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -140,7 +140,7 @@ func (u *updateNode) startExec(params runParams) error {
 			params.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(u.columns), 0)
 	}
-	return u.run.tu.init(params.p.txn, params.EvalContext())
+	return u.run.tu.init(params.ctx, params.p.txn, params.EvalContext())
 }
 
 // Next is required because batchedPlanNode inherits from planNode, but


### PR DESCRIPTION
This commit moves the methods of extendedTableWriter into tableWriter
itself (the comment on the former implied that it should be done when
all writers implement both interfaces, and it seems to me that we
reached that point). This also introduces an additional argument to
init() method (a context) to unify the writer with optimizer-driver
upserter.

Release note: None