### PR TITLE
workload: fix an issue with querylog

### DIFF
--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -745,7 +745,7 @@ func (w *querylog) getColumnsInfo(db *gosql.DB) error {
 		}
 		for rows.Next() {
 			var columnName, dataType string
-			if err = rows.Scan(&columnName, dataType); err != nil {
+			if err = rows.Scan(&columnName, &dataType); err != nil {
 				return err
 			}
 			columnTypeByColumnName[columnName] = dataType


### PR DESCRIPTION
`rows.Scan` expects pointers to the variables into which it'll write the
output. During the epic types refactor an ampersand was removed by
mistake. Now this is fixed.

Release note: None