### PR TITLE
wip: example test to exercise unavailable clusters

### DIFF
--- a/pkg/cli/simple_test.go
+++ b/pkg/cli/simple_test.go
@@ -1,0 +1,102 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	gosql "database/sql"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// First test: establish a SQL connection while cluster is available,
+// then switch down some nodes, then verify that some queries indeed
+// fail with the configured timeout.
+func TestUnavailableClusterAfterConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	sqlConn := tc.ServerConn(0)
+
+	// Establish conn.
+	if _, err := sqlConn.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop the server. This should make the system unavailable.
+	tc.StopServer(1)
+	tc.StopServer(2)
+
+	err := contextutil.RunWithTimeout(ctx, t.Name(), 3*time.Second, func(ctx context.Context) error {
+		_, err := sqlConn.ExecContext(ctx, `SELECT * FROM system.users WHERE username = 'notexistent'`)
+		return err
+	})
+	if _, ok := err.(*contextutil.TimeoutError); !ok {
+		t.Fatalf("expected dimeout error, got (%T) %v", err, err)
+	}
+}
+
+// Second test: make cluster unavailable, then establish non-admin
+// user connection with password. As this requires a query to
+// system.users, we're expecting that query to fail.
+func TestUnavailableClusterBeforeConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Call GetAuthenticatedHTTPClient to create a new user in system.user
+	// with password "abc"
+	if _, err := tc.Server(0).GetAuthenticatedHTTPClient(false /*isAdmin*/); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the cluster unavailable.
+	tc.StopServer(1)
+	tc.StopServer(2)
+
+	userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+		tc.Server(0).ServingSQLAddr(),
+		t.Name(),
+		url.UserPassword("authentic_user_noadmin", "abc"),
+		false /* withClientCerts */)
+	defer cleanupFn()
+
+	// Override the timeout built into the SQL driver so we are only
+	// subject to what the server thinks.
+	userURL.RawQuery += "&connect_timeout=0"
+
+	sqlConn, err := gosql.Open("postgres", userURL.String())
+	if err != nil {
+		t.Fatal(err) // No error expected yet - pq does late binding.
+	}
+
+	// Run something to establish the connection. We're expecting
+	// a timeout because a non-root conn is hitting system.users, which
+	// should now be unavailable.
+	err = contextutil.RunWithTimeout(ctx, t.Name(), 3*time.Second, func(ctx context.Context) error {
+		_, err := sqlConn.ExecContext(ctx, `SELECT 1`)
+		return err
+	})
+	if _, ok := err.(*contextutil.TimeoutError); !ok {
+		t.Fatalf("expected dimeout error, got (%T) %v", err, err)
+	}
+
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -548,11 +548,13 @@ func (ts *TestServer) getAuthenticatedHTTPClientAndCookie(
 	return authClient.httpClient, authClient.cookie, authClient.err
 }
 
+const testServerUserPassword = "abc"
+
 func (ts *TestServer) createAuthUser(userName string, isAdmin bool) error {
 	if _, err := ts.Server.internalExecutor.ExecEx(context.TODO(),
 		"create-auth-user", nil,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-		"CREATE USER $1", userName,
+		"CREATE USER $1 WITH PASSWORD $2", userName, testServerUserPassword,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
@tbg this is what we discussed yesterday, from #44342. My "unavailable" clusters are not, actually, unavailable.

The problem I think is that the `system` ranges remain available for a short while because node 1 is the leaseholder on them.

I could potentially change the test to connect from node 2 instead of 1, which will increase the likelihood that the node I'm connecting is not leaseholder. However that's not a idiot-proof solution because leases do move "underneath" a test for various reasons.

I think these various tests do need a way to "wait until unavailability is detected". Pinning the ranges to a node and switching it off seemed like the clearest solution (what I implemented originally) but maybe you have a better idea ?