### PR TITLE
cli/interactive_tests: deflake test_multiple_nodes

### DIFF
--- a/pkg/cli/interactive_tests/test_multiple_nodes.tcl
+++ b/pkg/cli/interactive_tests/test_multiple_nodes.tcl
@@ -22,10 +22,10 @@ end_test
 
 
 start_test "Check that a double decommission prints out a warning"
-spawn $argv node decommission 2
+spawn $argv node decommission 2 --wait none
 eexpect eof
 
-spawn $argv node decommission 2
+spawn $argv node decommission 2 --wait none
 eexpect "warning: node 2 is already decommissioning or decommissioned"
 eexpect eof
 end_test


### PR DESCRIPTION
Fixes #44397.

The test was unnecessarily waiting (and then timing out) for the
decommission to complete, which is not needed to just check the
warning.

Release note: None