### PR TITLE
roachtest: don't swallow additional failures

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2361,7 +2361,10 @@ func (m *monitor) Wait() {
 		// If the test has failed, don't try to limp along.
 		return
 	}
-	if err := m.WaitE(); err != nil && !m.t.Failed() {
+	if err := m.WaitE(); err != nil {
+		// Note that we used to avoid fataling again if we had already fatal'ed.
+		// However, this error here might be the one to actually report, see:
+		// https://github.com/cockroachdb/cockroach/issues/44436
 		m.t.Fatal(err)
 	}
 }

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -311,15 +311,17 @@ func (t *test) failWithMsg(msg string) {
 	prefix := ""
 	if t.mu.failed {
 		prefix = "[not the first failure] "
+		// NB: the first failure is not always the relevant one due to:
+		// https://github.com/cockroachdb/cockroach/issues/44436
+		//
+		// So we chain all failures together in the order in which we see
+		// them.
+		msg = "\n" + msg
 	}
 	t.l.Printf("%stest failure: %s", prefix, msg)
 
-	if t.mu.failed {
-		return
-	}
-
 	t.mu.failed = true
-	t.mu.failureMsg = msg
+	t.mu.failureMsg += msg
 	t.mu.output = append(t.mu.output, msg...)
 	if t.mu.cancel != nil {
 		t.mu.cancel()


### PR DESCRIPTION
We were previously careful not to call t.Fatal when it had previously
been called. This was based on the assumption that all but the first
error were "fallout" from the first. However, this assumption does not
generally hold, especially when `t.Fatal` in `(*monitor).Go` is
involved. Report all calls to Fatal instead.

Prior to this patch,

```go
c.Start(ctx, t, c.Node(1))
m := newMonitor(ctx, c)
m.Go(func(ctx context.Context) error {
	c.Run(ctx, c.Node(1), "sleep 100")
	return nil
})
m.Go(func(ctx context.Context) error {
	return errors.New("context is getting canceled by me")
})
m.Wait()
```

would only report the unhelpful `Fatal` error that would result from
within `c.Run` when the context was canceled (as a result of the other
goroutine returning its error). Now it reports both (in the wrong order,
but we'll live with that for now).

I hope that this will shed light on a large number of roachtest failures
which we currently chalk up to "random context cancellation" or "process
got killed for some reason".

I'll note how similar this is in nature to an issue with [errgroup]
and in particular the use of `*testing.T` in its goroutines.

See https://github.com/cockroachdb/cockroach/issues/44436

[errgroup]: https://go-review.googlesource.com/c/sync/+/134395

Release note: None