### PR TITLE
jobs: fix nil pointer dereference

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -215,16 +215,17 @@ func (r *Registry) CreateAndStartJob(
 		return nil, nil, err
 	}
 	if err := j.insert(ctx, id, r.newLease()); err != nil {
-		r.unregister(*j.ID())
+		// Use id instead of job.ID because the new id is not recorded in the job.
+		r.unregister(id)
 		return nil, nil, err
 	}
 	if err := j.Started(ctx); err != nil {
-		r.unregister(*j.ID())
+		r.unregister(id)
 		return nil, nil, err
 	}
 	errCh, err := r.resume(resumeCtx, resumer, resultsCh, j)
 	if err != nil {
-		r.unregister(*j.ID())
+		r.unregister(id)
 		return nil, nil, err
 	}
 	return j, errCh, err


### PR DESCRIPTION
Before a job is inserted in system.jobs its id
pointer is nil.

Fixes #39094, #44432, #43428.

Release note (bug fix): Fixed a nil dereference in CreateAndStartJob.