### PR TITLE
release-19.1: opt: fix internal error caused by inconsistent stats

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -464,6 +464,12 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 				// Make sure the distinct count is at least 1, for the same reason as
 				// the row count above.
 				colStat.DistinctCount = max(colStat.DistinctCount, 1)
+
+				// Make sure the values are consistent in case some of the column stats
+				// were added at different times (and therefore have a different row
+				// count).
+				colStat.DistinctCount = min(colStat.DistinctCount, stats.RowCount)
+				colStat.NullCount = min(colStat.NullCount, stats.RowCount)
 			}
 		}
 	}

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -34,12 +34,12 @@ select
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── row-number
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -55,12 +55,12 @@ select
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── row-number
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -96,12 +96,12 @@ project
       ├── fd: (1)-->(3), (3)-->(1)
       ├── row-number
       │    ├── columns: x:1(int!null) ordinality:3(int!null)
-      │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+      │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3), (3)-->(1)
       │    └── scan a
       │         ├── columns: x:1(int!null)
-      │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+      │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
       │         └── key: (1)
       └── filters
            └── (ordinality > 0) AND (ordinality <= 10) [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
@@ -118,12 +118,12 @@ select
  ├── fd: ()-->(1-3)
  ├── row-number
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -110,7 +110,7 @@ select
  ├── fd: (1)-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -127,7 +127,7 @@ select
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -141,12 +141,12 @@ SELECT * FROM a WHERE x IS NULL
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.8, distinct(1)=0.8, null(1)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -1322,3 +1322,73 @@ project
       │    └── fd: (3)-->(1,2)
       └── filters
            └── y = 3 [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+
+exec-ddl
+CREATE TABLE t0(c0 INT)
+----
+TABLE t0
+ ├── c0 int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE VIEW v0(c0) AS SELECT CASE WHEN t0.c0 > 0 THEN 1 ELSE t0.rowid END FROM t0
+----
+VIEW v0 (c0)
+ └── SELECT CASE WHEN t0.c0 > 0 THEN 1 ELSE t0.rowid END FROM t0
+
+exec-ddl
+ALTER TABLE t0 INJECT STATISTICS '[
+  {
+    "columns": ["c0"],
+    "created_at": "2020-01-28 03:02:57.841772+00:00",
+    "row_count": 3,
+    "distinct_count": 1,
+    "null_count": 3
+  },
+  {
+    "columns": ["rowid"],
+    "created_at": "2020-01-28 03:03:03.012072+00:00",
+    "row_count": 2,
+    "distinct_count": 2,
+    "null_count": 0,
+    "histo_buckets": [
+      {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "3"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "4"
+      }
+    ],
+    "histo_col_type": "INT8"
+  }
+]'
+----
+
+# Regression test for #44418. Make sure inconsistent stats don't cause an
+# error.
+norm
+SELECT * FROM v0 WHERE v0.c0 > 0
+----
+select
+ ├── columns: c0:3(int!null)
+ ├── stats: [rows=0, distinct(3)=0, null(3)=0]
+ ├── project
+ │    ├── columns: rowid:3(int)
+ │    ├── stats: [rows=2, distinct(3)=0, null(3)=2]
+ │    ├── scan t0
+ │    │    ├── columns: c0:1(int) t0.rowid:2(int!null)
+ │    │    ├── stats: [rows=2, distinct(1,2)=0, null(1,2)=2]
+ │    │    ├── key: (2)
+ │    │    └── fd: (2)-->(1)
+ │    └── projections
+ │         └── CASE WHEN c0 > 0 THEN 1 ELSE t0.rowid END [type=int, outer=(1,2)]
+ └── filters
+      └── rowid > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1104,8 +1104,8 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
- ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
- ├── cost: 12.9255846
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0]
+ ├── cost: 13.09
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -2739,8 +2739,8 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
- ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
- ├── cost: 12.9255846
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0]
+ ├── cost: 13.09
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1


### PR DESCRIPTION
Backport 1/1 commits from #44430.

/cc @cockroachdb/release

---

If the statistics for different columns in a table are collected at
different times using manual calls to CREATE STATISTICS, it's possible
that the row count will be different between the stats. Prior to this
commit, if the latest stat had a row count that was smaller than the
null count or distinct count in the stats of another column, that could
cause an internal error. This commit fixes the problem by ensuring that
the distinct and null counts are always smaller than the row count when
stats are initially added for each table in the optimizer.

Fixes #44418

Release note (bug fix): Fixed an internal error that could happen in
the planner when table statistics were collected manually using
CREATE STATISTICS for different columns at different times.
