### PR TITLE
roachtest: wait for full replication in follower_reads test

### DIFF
--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -89,7 +89,7 @@ func runFollowerReadsTest(ctx context.Context, t *test, c *cluster) {
 	if r, err := db.ExecContext(ctx, "CREATE TABLE test.test ( k INT8, v INT8, PRIMARY KEY (k) )"); err != nil {
 		t.Fatalf("failed to create table: %v %v", err, r)
 	}
-
+	waitForFullReplication(t, db)
 	const rows = 100
 	const concurrency = 32
 	sem := make(chan struct{}, concurrency)


### PR DESCRIPTION
Before this commit it was possible for a follower reads test to commence before
the data had been up-replicated to all of the nodes. This change ensures that
the data is fully replicated before beginning the test.

See https://github.com/cockroachdb/cockroach/issues/43754#issuecomment-579243057.  We saw that [here](https://teamcity.cockroachdb.com/viewLog.html?buildId=1708156&buildTypeId=Cockroach_Nightlies_WorkloadNightly&tab=artifacts#%2Ffollower-reads).

Release note: None.