### PR TITLE
ui: Display SQL Connections metrics per node basis

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -26,7 +26,17 @@ export default function (props: GraphDashboardProps) {
       tooltip={`The total number of active SQL connections ${tooltipSelection}.`}
     >
       <Axis label="connections">
-        <Metric name="cr.node.sql.conns" title="Client Connections" />
+        {
+          _.map(nodeIDs, (node) => (
+            <Metric
+              key={node}
+              name="cr.node.sql.conns"
+              title={nodeDisplayName(nodesSummary, node)}
+              sources={[node]}
+              downsampleMax
+            />
+          ))
+        }
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Previously, SQL Connections graph displayed aggregated information for
all nodes. It is changed to display number of connections per node.