### PR TITLE
roachtest: publish artifacts at "correct" location

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -125,6 +125,10 @@ type test struct {
 	// artifactsDir is the path to the directory holding all the artifacts for
 	// this test. It will contain a test.log file and cluster logs.
 	artifactsDir string
+	// artifactsSpec is a TeamCity artifacts spec used to publish this test's
+	// artifacts. See:
+	// https://www.jetbrains.com/help/teamcity/2019.1/configuring-general-settings.html#Artifact-Paths
+	artifactsSpec string
 
 	mu struct {
 		syncutil.RWMutex


### PR DESCRIPTION
Prior to this change, roachtest would strip out the run_x suffix from
the per-test artifact directory, i.e. it would use a TeamCity directive
such as

```
publishArtifacts 'artifacts/acceptance/cluster-init/run_0/** => acceptance/cluster-init']
```

This commit changes it to publish at a location that is true to the
physical path of the source artifact, i.e.

```
publishArtifacts 'artifacts/acceptance/cluster-init/** => acceptance/cluster-init']
```

The motivation for that is that we want to add a general artifacts
collection step to the TeamCity job. Without matching destinations,
this would be creating duplicates.

Closes #44402.

Release note: None