### PR TITLE
sql: fix the client.Txn API usage by the backfiller

### DIFF
--- a/pkg/kv/txn_lock_gatekeeper.go
+++ b/pkg/kv/txn_lock_gatekeeper.go
@@ -64,11 +64,8 @@ func (gs *txnLockGatekeeper) SendLocked(
 	// in flight whose spans haven't been accounted for.
 	//
 	// As a special case, allow for async rollbacks and heartbeats to be sent
-	// whenever. As another special case, we allow concurrent requests on AS OF
-	// SYSTEM TIME transactions. I think these transactions can't experience
-	// retriable errors, so they're safe. And they're used concurrently by schema
-	// change code.
-	if !gs.allowConcurrentRequests && !ba.Txn.CommitTimestampFixed {
+	// whenever.
+	if !gs.allowConcurrentRequests {
 		asyncRequest := ba.IsSingleAbortTxnRequest() || ba.IsSingleHeartbeatTxnRequest()
 		if !asyncRequest {
 			if gs.requestInFlight {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -105,11 +105,46 @@ func (sc *SchemaChanger) getChunkSize(chunkSize int64) int64 {
 	return chunkSize
 }
 
-// runBackfill runs the backfill for the schema changer.
-func (sc *SchemaChanger) runBackfill(
+// scTxnFn is the type of functions that operates using transactions in the backfiller.
+type scTxnFn func(ctx context.Context, txn *client.Txn, evalCtx *extendedEvalContext) error
+
+// historicalTxnRunner is the type of the callback used by the various
+// helper functions to run checks at a fixed timestamp (logically, at
+// the start of the backfill).
+type historicalTxnRunner func(ctx context.Context, fn scTxnFn) error
+
+// makeFixedTimestampRunner creates a historicalTxnRunner suitable for use by the helpers.
+func (sc *SchemaChanger) makeFixedTimestampRunner(
+	readAsOf hlc.Timestamp, tracing *SessionTracing,
+) historicalTxnRunner {
+	runner := func(ctx context.Context, retryable scTxnFn) error {
+		return sc.fixedTimestampTxn(ctx, readAsOf, func(ctx context.Context, txn *client.Txn) error {
+			// We need to re-create the evalCtx since the txn may retry.
+			evalCtx := createSchemaChangeEvalCtx(ctx, readAsOf, tracing, sc.ieFactory)
+			return retryable(ctx, txn, &evalCtx)
+		})
+	}
+	return runner
+}
+
+func (sc *SchemaChanger) fixedTimestampTxn(
 	ctx context.Context,
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	evalCtx *extendedEvalContext,
+	readAsOf hlc.Timestamp,
+	retryable func(ctx context.Context, txn *client.Txn) error,
+) error {
+	return sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		txn.SetFixedTimestamp(ctx, readAsOf)
+		return retryable(ctx, txn)
+	})
+}
+
+// runBackfill runs the backfill for the schema changer.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely. The various
+// function that it calls make their own txns.
+func (sc *SchemaChanger) runBackfill(
+	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease, tracing *SessionTracing,
 ) error {
 	if sc.testingKnobs.RunBeforeBackfill != nil {
 		if err := sc.testingKnobs.RunBeforeBackfill(); err != nil {
@@ -221,7 +256,7 @@ func (sc *SchemaChanger) runBackfill(
 
 	// Add and drop columns.
 	if needColumnBackfill {
-		if err := sc.truncateAndBackfillColumns(ctx, evalCtx, lease, version); err != nil {
+		if err := sc.truncateAndBackfillColumns(ctx, tracing, lease, version); err != nil {
 			return err
 		}
 	}
@@ -229,7 +264,7 @@ func (sc *SchemaChanger) runBackfill(
 	// Add new indexes.
 	if len(addedIndexSpans) > 0 {
 		// Check if bulk-adding is enabled and supported by indexes (ie non-unique).
-		if err := sc.backfillIndexes(ctx, evalCtx, lease, version, addedIndexSpans); err != nil {
+		if err := sc.backfillIndexes(ctx, tracing, lease, version, addedIndexSpans); err != nil {
 			return err
 		}
 	}
@@ -251,7 +286,7 @@ func (sc *SchemaChanger) runBackfill(
 
 	// Validate check and foreign key constraints.
 	if len(constraintsToValidate) > 0 {
-		if err := sc.validateConstraints(ctx, evalCtx, lease, constraintsToValidate); err != nil {
+		if err := sc.validateConstraints(ctx, tracing, lease, constraintsToValidate); err != nil {
 			return err
 		}
 	}
@@ -445,9 +480,14 @@ func (sc *SchemaChanger) addConstraints(
 	return nil
 }
 
+// validateConstraints checks that the current table data obeys the
+// provided constraints.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely, so it makes its own.
 func (sc *SchemaChanger) validateConstraints(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
+	tracing *SessionTracing,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	constraints []sqlbase.ConstraintToUpdate,
 ) error {
@@ -467,53 +507,56 @@ func (sc *SchemaChanger) validateConstraints(
 	}
 
 	readAsOf := sc.clock.Now()
-	return sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetFixedTimestamp(ctx, readAsOf)
-		tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
-		if err != nil {
-			return err
-		}
+	var tableDesc *sqlbase.TableDescriptor
 
-		if err := sc.ExtendLease(ctx, lease); err != nil {
-			return err
-		}
+	if err := sc.fixedTimestampTxn(ctx, readAsOf, func(ctx context.Context, txn *client.Txn) error {
+		tableDesc, err = sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
+		return err
+	}); err != nil {
+		return err
+	}
 
-		grp := ctxgroup.WithContext(ctx)
+	if err := sc.ExtendLease(ctx, lease); err != nil {
+		return err
+	}
 
-		// Notify when validation is finished (or has returned an error) for a check.
-		countDone := make(chan struct{}, len(constraints))
+	grp := ctxgroup.WithContext(ctx)
 
-		for i := range constraints {
-			c := constraints[i]
-			grp.GoCtx(func(ctx context.Context) error {
-				defer func() { countDone <- struct{}{} }()
+	// Notify when validation is finished (or has returned an error) for a check.
+	countDone := make(chan struct{}, len(constraints))
 
-				// Make the mutations public in a private copy of the descriptor
-				// and add it to the TableCollection, so that we can use SQL below to perform
-				// the validation. We wouldn't have needed to do this if we could have
-				// updated the descriptor and run validation in the same transaction. However,
-				// our current system is incapable of running long running schema changes
-				// (the validation can take many minutes). So we pretend that the schema
-				// has been updated and actually update it in a separate transaction that
-				// follows this one.
-				desc, err := sqlbase.NewImmutableTableDescriptor(*tableDesc).MakeFirstMutationPublic(sqlbase.IgnoreConstraints)
-				if err != nil {
-					return err
-				}
-				// Create a new eval context only because the eval context cannot be shared across many
-				// goroutines.
-				newEvalCtx := createSchemaChangeEvalCtx(ctx, readAsOf, evalCtx.Tracing, sc.ieFactory)
+	// The various checks below operate at a fixed timestamp.
+	runHistoricalTxn := sc.makeFixedTimestampRunner(readAsOf, tracing)
+
+	for i := range constraints {
+		c := constraints[i]
+		grp.GoCtx(func(ctx context.Context) error {
+			defer func() { countDone <- struct{}{} }()
+			// Make the mutations public in a private copy of the descriptor
+			// and add it to the TableCollection, so that we can use SQL below to perform
+			// the validation. We wouldn't have needed to do this if we could have
+			// updated the descriptor and run validation in the same transaction. However,
+			// our current system is incapable of running long running schema changes
+			// (the validation can take many minutes). So we pretend that the schema
+			// has been updated and actually update it in a separate transaction that
+			// follows this one.
+			desc, err := sqlbase.NewImmutableTableDescriptor(*tableDesc).MakeFirstMutationPublic(sqlbase.IgnoreConstraints)
+			if err != nil {
+				return err
+			}
+			// Each check operates at the historical timestamp.
+			return runHistoricalTxn(ctx, func(ctx context.Context, txn *client.Txn, evalCtx *extendedEvalContext) error {
 				switch c.ConstraintType {
 				case sqlbase.ConstraintToUpdate_CHECK:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &newEvalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
 						return err
 					}
 				case sqlbase.ConstraintToUpdate_FOREIGN_KEY:
-					if err := validateFkInTxn(ctx, sc.leaseMgr, &newEvalCtx.EvalContext, desc, txn, c.Name); err != nil {
+					if err := validateFkInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Name); err != nil {
 						return err
 					}
 				case sqlbase.ConstraintToUpdate_NOT_NULL:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &newEvalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
 						// TODO (lucy): This should distinguish between constraint
 						// validation errors and other types of unexpected errors, and
 						// return a different error code in the former case
@@ -524,39 +567,46 @@ func (sc *SchemaChanger) validateConstraints(
 				}
 				return nil
 			})
-		}
-
-		// Periodic schema change lease extension.
-		grp.GoCtx(func(ctx context.Context) error {
-			count := len(constraints)
-			refreshTimer := timeutil.NewTimer()
-			defer refreshTimer.Stop()
-			refreshTimer.Reset(checkpointInterval)
-			for {
-				select {
-				case <-countDone:
-					count--
-					if count == 0 {
-						// Stop.
-						return nil
-					}
-
-				case <-refreshTimer.C:
-					refreshTimer.Read = true
-					refreshTimer.Reset(checkpointInterval)
-					if err := sc.ExtendLease(ctx, lease); err != nil {
-						return err
-					}
-
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			}
 		})
-		return grp.Wait()
+	}
+
+	// Periodic schema change lease extension.
+	grp.GoCtx(func(ctx context.Context) error {
+		count := len(constraints)
+		refreshTimer := timeutil.NewTimer()
+		defer refreshTimer.Stop()
+		refreshTimer.Reset(checkpointInterval)
+		for {
+			select {
+			case <-countDone:
+				count--
+				if count == 0 {
+					// Stop.
+					return nil
+				}
+
+			case <-refreshTimer.C:
+				refreshTimer.Read = true
+				refreshTimer.Reset(checkpointInterval)
+				if err := sc.ExtendLease(ctx, lease); err != nil {
+					return err
+				}
+
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 	})
+	return grp.Wait()
 }
 
+// getTableVersion retrieves the descriptor for the table being
+// targeted by the schema changer using the provided txn, and asserts
+// that the retrieved descriptor is at the given version. An error is
+// returned otherwise.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *client.Txn, tc *TableCollection, version sqlbase.DescriptorVersion,
 ) (*sqlbase.ImmutableTableDescriptor, error) {
@@ -570,6 +620,10 @@ func (sc *SchemaChanger) getTableVersion(
 	return tableDesc, nil
 }
 
+// truncateIndexes truncate the KV ranges corresponding to dropped indexes.
+//
+// The indexes are dropped chunk by chunk, each chunk being deleted in
+// its own txn.
 func (sc *SchemaChanger) truncateIndexes(
 	ctx context.Context,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
@@ -585,6 +639,15 @@ func (sc *SchemaChanger) truncateIndexes(
 		var resume roachpb.Span
 		for rowIdx, done := int64(0), false; !done; rowIdx += chunkSize {
 			// First extend the schema change lease.
+			//
+			// TODO(lucy): verify this extension. What guarantee is there
+			// that the deleteIndex()/clearIndex() calls below won't last
+			// more than the expiration time for the lease?
+			// In fact if it does, the index drop will never complete.
+			//
+			// I notice there is an async periodic schema change lease
+			// extension in validateConstraints(). Maybe the same is needed
+			// here.
 			if err := sc.ExtendLease(ctx, lease); err != nil {
 				return err
 			}
@@ -594,6 +657,8 @@ func (sc *SchemaChanger) truncateIndexes(
 				log.Infof(ctx, "drop index (%d, %d) at row: %d, span: %s",
 					sc.tableID, sc.mutationID, rowIdx, resume)
 			}
+
+			// Make a new txn just to drop this chunk.
 			if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 				if fn := sc.execCfg.DistSQLRunTestingKnobs.RunBeforeBackfillChunk; fn != nil {
 					if err := fn(resume); err != nil {
@@ -604,6 +669,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					defer fn()
 				}
 
+				// Retrieve a lease for this table inside the current txn.
 				tc := &TableCollection{
 					leaseMgr: sc.leaseMgr,
 					settings: sc.settings,
@@ -641,6 +707,9 @@ func (sc *SchemaChanger) truncateIndexes(
 				return err
 			}
 		}
+
+		// All the data chunks have been removed. Now also removed the
+		// zone configs for the dropped indexes, if any.
 		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			return removeIndexZoneConfigs(ctx, txn, sc.execCfg, sc.tableID, dropped)
 		}); err != nil {
@@ -674,6 +743,9 @@ func getJobIDForMutationWithDescriptor(
 }
 
 // nRanges returns the number of ranges that cover a set of spans.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func (sc *SchemaChanger) nRanges(
 	ctx context.Context, txn *client.Txn, spans []roachpb.Span,
 ) (int, error) {
@@ -701,9 +773,12 @@ func (sc *SchemaChanger) nRanges(
 // distBackfill runs (or continues) a backfill for the first mutation
 // enqueued on the SchemaChanger's table descriptor that passes the input
 // MutationFilter.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely, so it makes its own.
 func (sc *SchemaChanger) distBackfill(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
+	tracing *SessionTracing,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	version sqlbase.DescriptorVersion,
 	backfillType backfillType,
@@ -767,8 +842,7 @@ func (sc *SchemaChanger) distBackfill(
 		if backfillType == indexBackfill {
 			const pageSize = 10000
 			noop := func(_ []client.KeyValue) error { return nil }
-			if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-				txn.SetFixedTimestamp(ctx, readAsOf)
+			if err := sc.fixedTimestampTxn(ctx, readAsOf, func(ctx context.Context, txn *client.Txn) error {
 				for _, span := range targetSpans {
 					// TODO(dt): a Count() request would be nice here if the target isn't
 					// empty, since we don't need to drag all the results back just to
@@ -782,6 +856,8 @@ func (sc *SchemaChanger) distBackfill(
 				return err
 			}
 		}
+
+		// Gather the initial resume spans for the table.
 		var todoSpans []roachpb.Span
 		var mutationIdx int
 		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -792,6 +868,7 @@ func (sc *SchemaChanger) distBackfill(
 		}); err != nil {
 			return err
 		}
+
 		for len(todoSpans) > 0 {
 			log.VEventf(ctx, 2, "backfill: process %+v spans", todoSpans)
 			if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -861,6 +938,7 @@ func (sc *SchemaChanger) distBackfill(
 					return nil
 				}
 				cbw := metadataCallbackWriter{rowResultWriter: &errOnlyResultWriter{}, fn: metaFn}
+				evalCtx := createSchemaChangeEvalCtx(ctx, txn.ReadTimestamp(), tracing, sc.ieFactory)
 				recv := MakeDistSQLReceiver(
 					ctx,
 					&cbw,
@@ -875,7 +953,7 @@ func (sc *SchemaChanger) distBackfill(
 				)
 				defer recv.Release()
 
-				planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, evalCtx, txn)
+				planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, txn)
 				plan, err := sc.distSQLPlanner.createBackfiller(
 					planCtx, backfillType, *tableDesc.TableDesc(), duration, chunkSize, todoSpans, otherTableDescs, readAsOf,
 				)
@@ -885,7 +963,7 @@ func (sc *SchemaChanger) distBackfill(
 				sc.distSQLPlanner.Run(
 					planCtx,
 					nil, /* txn - the processors manage their own transactions */
-					&plan, recv, evalCtx,
+					&plan, recv, &evalCtx,
 					nil, /* finishedSetupFn */
 				)()
 				return cbw.Err()
@@ -923,7 +1001,11 @@ func (sc *SchemaChanger) distBackfill(
 	return g.Wait()
 }
 
-// update the job running status.
+// updateJobRunningStatus updates the status field in the job entry
+// with the given value.
+//
+// The update is performed in a separate txn at the current logical
+// timestamp.
 func (sc *SchemaChanger) updateJobRunningStatus(
 	ctx context.Context, status jobs.RunningStatus,
 ) (*sqlbase.TableDescriptor, error) {
@@ -970,11 +1052,12 @@ func (sc *SchemaChanger) updateJobRunningStatus(
 	return tableDesc, err
 }
 
-// validate the new indexes being added
+// validateIndexes checks that the new indexes have entries for all the rows.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely, so it makes its own.
 func (sc *SchemaChanger) validateIndexes(
-	ctx context.Context,
-	evalCtx *extendedEvalContext,
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
+	ctx context.Context, tracing *SessionTracing, lease *sqlbase.TableDescriptor_SchemaChangeLease,
 ) error {
 	if testDisableTableLeases {
 		return nil
@@ -992,102 +1075,110 @@ func (sc *SchemaChanger) validateIndexes(
 	}
 
 	readAsOf := sc.clock.Now()
-	return sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetFixedTimestamp(ctx, readAsOf)
-		tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
-		if err != nil {
-			return err
+	var tableDesc *sqlbase.TableDescriptor
+	if err := sc.fixedTimestampTxn(ctx, readAsOf, func(ctx context.Context, txn *client.Txn) error {
+		tableDesc, err = sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	if err := sc.ExtendLease(ctx, lease); err != nil {
+		return err
+	}
+
+	var forwardIndexes []*sqlbase.IndexDescriptor
+	var invertedIndexes []*sqlbase.IndexDescriptor
+
+	for _, m := range tableDesc.Mutations {
+		if sc.mutationID != m.MutationID {
+			break
 		}
-
-		if err := sc.ExtendLease(ctx, lease); err != nil {
-			return err
+		idx := m.GetIndex()
+		if idx == nil || m.Direction == sqlbase.DescriptorMutation_DROP {
+			continue
 		}
-
-		var forwardIndexes []*sqlbase.IndexDescriptor
-		var invertedIndexes []*sqlbase.IndexDescriptor
-
-		for _, m := range tableDesc.Mutations {
-			if sc.mutationID != m.MutationID {
-				break
-			}
-			idx := m.GetIndex()
-			if idx == nil || m.Direction == sqlbase.DescriptorMutation_DROP {
-				continue
-			}
-			switch idx.Type {
-			case sqlbase.IndexDescriptor_FORWARD:
-				forwardIndexes = append(forwardIndexes, idx)
-			case sqlbase.IndexDescriptor_INVERTED:
-				invertedIndexes = append(invertedIndexes, idx)
-			}
+		switch idx.Type {
+		case sqlbase.IndexDescriptor_FORWARD:
+			forwardIndexes = append(forwardIndexes, idx)
+		case sqlbase.IndexDescriptor_INVERTED:
+			invertedIndexes = append(invertedIndexes, idx)
 		}
-		if len(forwardIndexes) == 0 && len(invertedIndexes) == 0 {
-			return nil
-		}
+	}
+	if len(forwardIndexes) == 0 && len(invertedIndexes) == 0 {
+		return nil
+	}
 
-		grp := ctxgroup.WithContext(ctx)
+	grp := ctxgroup.WithContext(ctx)
 
-		forwardIndexesDone := make(chan struct{})
-		invertedIndexesDone := make(chan struct{})
+	forwardIndexesDone := make(chan struct{})
+	invertedIndexesDone := make(chan struct{})
+	runHistoricalTxn := sc.makeFixedTimestampRunner(readAsOf, tracing)
 
+	if len(forwardIndexes) > 0 {
 		grp.GoCtx(func(ctx context.Context) error {
 			defer close(forwardIndexesDone)
-			if len(forwardIndexes) > 0 {
-				return sc.validateForwardIndexes(ctx, evalCtx, txn, tableDesc, readAsOf, forwardIndexes)
-			}
-			return nil
+			return sc.validateForwardIndexes(ctx, tableDesc, forwardIndexes, runHistoricalTxn)
 		})
+	} else {
+		close(forwardIndexesDone)
+	}
 
+	if len(invertedIndexes) > 0 {
 		grp.GoCtx(func(ctx context.Context) error {
 			defer close(invertedIndexesDone)
-			if len(invertedIndexes) > 0 {
-				return sc.validateInvertedIndexes(ctx, evalCtx, txn, tableDesc, readAsOf, invertedIndexes)
-			}
-			return nil
+			return sc.validateInvertedIndexes(ctx, tableDesc, invertedIndexes, runHistoricalTxn)
 		})
+	} else {
+		close(invertedIndexesDone)
+	}
 
-		// Periodic schema change lease extension.
-		grp.GoCtx(func(ctx context.Context) error {
-			forwardDone := false
-			invertedDone := false
+	// Periodic schema change lease extension.
+	grp.GoCtx(func(ctx context.Context) error {
+		forwardDone := false
+		invertedDone := false
 
-			refreshTimer := timeutil.NewTimer()
-			defer refreshTimer.Stop()
-			refreshTimer.Reset(checkpointInterval)
-			for {
-				if forwardDone && invertedDone {
-					return nil
-				}
-				select {
-				case <-forwardIndexesDone:
-					forwardDone = true
-
-				case <-invertedIndexesDone:
-					invertedDone = true
-
-				case <-refreshTimer.C:
-					refreshTimer.Read = true
-					refreshTimer.Reset(checkpointInterval)
-					if err := sc.ExtendLease(ctx, lease); err != nil {
-						return err
-					}
-
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+		refreshTimer := timeutil.NewTimer()
+		defer refreshTimer.Stop()
+		refreshTimer.Reset(checkpointInterval)
+		for {
+			if forwardDone && invertedDone {
+				return nil
 			}
-		})
-		return grp.Wait()
+			select {
+			case <-forwardIndexesDone:
+				forwardDone = true
+
+			case <-invertedIndexesDone:
+				invertedDone = true
+
+			case <-refreshTimer.C:
+				refreshTimer.Read = true
+				refreshTimer.Reset(checkpointInterval)
+				if err := sc.ExtendLease(ctx, lease); err != nil {
+					return err
+				}
+
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 	})
+	return grp.Wait()
 }
 
+// validateInvertedIndexes checks that the indexes have entries for
+// all the items of data in rows.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely.
+// Instead it uses the provided runHistoricalTxn which can operate
+// at the historical fixed timestamp for checks.
 func (sc *SchemaChanger) validateInvertedIndexes(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
-	txn *client.Txn,
 	tableDesc *TableDescriptor,
-	readAsOf hlc.Timestamp,
 	indexes []*sqlbase.IndexDescriptor,
+	runHistoricalTxn historicalTxnRunner,
 ) error {
 	grp := ctxgroup.WithContext(ctx)
 
@@ -1107,16 +1198,21 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 			var idxLen int64
 			key := tableDesc.IndexSpan(idx.ID).Key
 			endKey := tableDesc.IndexSpan(idx.ID).EndKey
-			for {
-				kvs, err := txn.Scan(ctx, key, endKey, 1000000)
-				if err != nil {
-					return err
+			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *client.Txn, _ *extendedEvalContext) error {
+				for {
+					kvs, err := txn.Scan(ctx, key, endKey, 1000000)
+					if err != nil {
+						return err
+					}
+					if len(kvs) == 0 {
+						break
+					}
+					idxLen += int64(len(kvs))
+					key = kvs[len(kvs)-1].Key.PrefixEnd()
 				}
-				if len(kvs) == 0 {
-					break
-				}
-				idxLen += int64(len(kvs))
-				key = kvs[len(kvs)-1].Key.PrefixEnd()
+				return nil
+			}); err != nil {
+				return err
 			}
 			log.Infof(ctx, "inverted index %s/%s count = %d, took %s",
 				tableDesc.Name, idx.Name, idxLen, timeutil.Since(start))
@@ -1145,18 +1241,24 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 					idx.Name, idx.ColumnNames))
 			}
 			col := idx.ColumnNames[0]
-			ie := evalCtx.InternalExecutor.(*InternalExecutor)
-			row, err := ie.QueryRowEx(ctx, "verify-inverted-idx-count", txn,
-				sqlbase.InternalExecutorSessionDataOverride{},
-				fmt.Sprintf(
-					`SELECT coalesce(sum_int(crdb_internal.json_num_index_entries(%s)), 0) FROM [%d AS t]`,
-					col, tableDesc.ID,
-				),
-			)
-			if err != nil {
+
+			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *client.Txn, evalCtx *extendedEvalContext) error {
+				ie := evalCtx.InternalExecutor.(*InternalExecutor)
+				row, err := ie.QueryRowEx(ctx, "verify-inverted-idx-count", txn,
+					sqlbase.InternalExecutorSessionDataOverride{},
+					fmt.Sprintf(
+						`SELECT coalesce(sum_int(crdb_internal.json_num_index_entries(%s)), 0) FROM [%d AS t]`,
+						col, tableDesc.ID,
+					),
+				)
+				if err != nil {
+					return err
+				}
+				expectedCount[i] = int64(tree.MustBeDInt(row[0]))
+				return nil
+			}); err != nil {
 				return err
 			}
-			expectedCount[i] = int64(tree.MustBeDInt(row[0]))
 			log.Infof(ctx, "JSON column %s/%s expected inverted index count = %d, took %s",
 				tableDesc.Name, col, expectedCount[i], timeutil.Since(start))
 			return nil
@@ -1166,13 +1268,17 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 	return grp.Wait()
 }
 
+// validateForwardIndexes checks that the indexes have entries for all the rows.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely.
+// Instead it uses the provided runHistoricalTxn which can operate
+// at the historical fixed timestamp for checks.
 func (sc *SchemaChanger) validateForwardIndexes(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
-	txn *client.Txn,
 	tableDesc *TableDescriptor,
-	readAsOf hlc.Timestamp,
 	indexes []*sqlbase.IndexDescriptor,
+	runHistoricalTxn historicalTxnRunner,
 ) error {
 	grp := ctxgroup.WithContext(ctx)
 
@@ -1205,28 +1311,32 @@ func (sc *SchemaChanger) validateForwardIndexes(
 				return err
 			}
 
-			// Create a new eval context only because the eval context cannot be shared across many
-			// goroutines.
-			newEvalCtx := createSchemaChangeEvalCtx(ctx, readAsOf, evalCtx.Tracing, sc.ieFactory)
-			// TODO(vivek): This is not a great API. Leaving #34304 open.
-			ie := newEvalCtx.InternalExecutor.(*InternalExecutor)
-			ie.tcModifier = tc
-			defer func() {
-				ie.tcModifier = nil
-			}()
+			// Retrieve the row count in the index.
+			var idxLen int64
+			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *client.Txn, evalCtx *extendedEvalContext) error {
+				// TODO(vivek): This is not a great API. Leaving #34304 open.
+				ie := evalCtx.InternalExecutor.(*InternalExecutor)
+				ie.tcModifier = tc
+				defer func() {
+					ie.tcModifier = nil
+				}()
 
-			row, err := ie.QueryRowEx(ctx, "verify-idx-count", txn,
-				sqlbase.InternalExecutorSessionDataOverride{},
-				fmt.Sprintf(`SELECT count(1) FROM [%d AS t]@[%d] AS OF SYSTEM TIME %s`,
-					tableDesc.ID, idx.ID, readAsOf.AsOfSystemTime()))
-			if err != nil {
+				row, err := ie.QueryRowEx(ctx, "verify-idx-count", txn,
+					sqlbase.InternalExecutorSessionDataOverride{},
+					fmt.Sprintf(`SELECT count(1) FROM [%d AS t]@[%d]`, tableDesc.ID, idx.ID))
+				if err != nil {
+					return err
+				}
+				idxLen = int64(tree.MustBeDInt(row[0]))
+				return nil
+			}); err != nil {
 				return err
 			}
-			idxLen := int64(tree.MustBeDInt(row[0]))
 
-			log.Infof(ctx, "validation: index %s/%s row count = %d, took %s",
+			log.Infof(ctx, "validation: index %s/%s row count = %d, time so far %s",
 				tableDesc.Name, idx.Name, idxLen, timeutil.Since(start))
 
+			// Now compare with the row count in the table.
 			select {
 			case <-tableCountReady:
 				if idxLen != tableRowCount {
@@ -1250,16 +1360,22 @@ func (sc *SchemaChanger) validateForwardIndexes(
 		defer close(tableCountReady)
 		var tableRowCountTime time.Duration
 		start := timeutil.Now()
+
 		// Count the number of rows in the table.
-		ie := evalCtx.InternalExecutor.(*InternalExecutor)
-		cnt, err := ie.QueryRowEx(ctx, "VERIFY INDEX", txn,
-			sqlbase.InternalExecutorSessionDataOverride{},
-			fmt.Sprintf(`SELECT count(1) FROM [%d AS t] AS OF SYSTEM TIME %s`,
-				tableDesc.ID, readAsOf.AsOfSystemTime()))
-		if err != nil {
+		if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *client.Txn, evalCtx *extendedEvalContext) error {
+			ie := evalCtx.InternalExecutor.(*InternalExecutor)
+			cnt, err := ie.QueryRowEx(ctx, "VERIFY INDEX", txn,
+				sqlbase.InternalExecutorSessionDataOverride{},
+				fmt.Sprintf(`SELECT count(1) FROM [%d AS t]`, tableDesc.ID))
+			if err != nil {
+				return err
+			}
+			tableRowCount = int64(tree.MustBeDInt(cnt[0]))
+			return nil
+		}); err != nil {
 			return err
 		}
-		tableRowCount = int64(tree.MustBeDInt(cnt[0]))
+
 		tableRowCountTime = timeutil.Since(start)
 		log.Infof(ctx, "validation: table %s row count = %d, took %s",
 			tableDesc.Name, tableRowCount, tableRowCountTime)
@@ -1269,9 +1385,14 @@ func (sc *SchemaChanger) validateForwardIndexes(
 	return grp.Wait()
 }
 
+// backfillIndexes fills the missing columns in the indexes of the
+// leased tables.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely.
 func (sc *SchemaChanger) backfillIndexes(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
+	tracing *SessionTracing,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	version sqlbase.DescriptorVersion,
 	addingSpans []roachpb.Span,
@@ -1290,21 +1411,26 @@ func (sc *SchemaChanger) backfillIndexes(
 
 	chunkSize := indexBulkBackfillChunkSize.Get(&sc.settings.SV)
 	if err := sc.distBackfill(
-		ctx, evalCtx, lease, version, indexBackfill, chunkSize,
+		ctx, tracing, lease, version, indexBackfill, chunkSize,
 		backfill.IndexMutationFilter, addingSpans); err != nil {
 		return err
 	}
-	return sc.validateIndexes(ctx, evalCtx, lease)
+	return sc.validateIndexes(ctx, tracing, lease)
 }
 
+// truncateAndBackfillColumns performs the backfill operation on the given leased
+// table descriptors.
+//
+// This operates over multiple goroutines concurrently and is thus not
+// able to reuse the original client.Txn safely.
 func (sc *SchemaChanger) truncateAndBackfillColumns(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
+	tracing *SessionTracing,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	version sqlbase.DescriptorVersion,
 ) error {
 	return sc.distBackfill(
-		ctx, evalCtx,
+		ctx, tracing,
 		lease, version, columnBackfill, columnTruncateAndBackfillChunkSize,
 		backfill.ColumnMutationFilter, nil)
 }
@@ -1314,6 +1440,9 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 // schema changes in the same transaction. The CREATE TABLE is
 // invisible to the rest of the cluster, so the schema changes
 // can be executed immediately on the same version of the table.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse the planner's client.Txn safely.
 func runSchemaChangesInTxn(
 	ctx context.Context, planner *planner, tableDesc *sqlbase.MutableTableDescriptor, traceKV bool,
 ) error {
@@ -1494,10 +1623,14 @@ func runSchemaChangesInTxn(
 // transaction. If the provided table descriptor version is newer than the
 // cluster version, it will be used in the InternalExecutor that performs the
 // validation query.
+//
 // TODO (lucy): The special case where the table descriptor version is the same
 // as the cluster version only happens because the query in VALIDATE CONSTRAINT
 // still runs in the user transaction instead of a step in the schema changer.
 // When that's no longer true, this function should be updated.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func validateCheckInTxn(
 	ctx context.Context,
 	leaseMgr *LeaseManager,
@@ -1534,10 +1667,14 @@ func validateCheckInTxn(
 // transaction. If the provided table descriptor version is newer than the
 // cluster version, it will be used in the InternalExecutor that performs the
 // validation query.
+//
 // TODO (lucy): The special case where the table descriptor version is the same
 // as the cluster version only happens because the query in VALIDATE CONSTRAINT
 // still runs in the user transaction instead of a step in the schema changer.
 // When that's no longer true, this function should be updated.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func validateFkInTxn(
 	ctx context.Context,
 	leaseMgr *LeaseManager,
@@ -1580,6 +1717,9 @@ func validateFkInTxn(
 
 // columnBackfillInTxn backfills columns for all mutation columns in
 // the mutation list.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func columnBackfillInTxn(
 	ctx context.Context,
 	txn *client.Txn,
@@ -1634,6 +1774,11 @@ func columnBackfillInTxn(
 	return nil
 }
 
+// indexBackfillInTxn runs one chunk of the index backfill on the
+// primary index.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func indexBackfillInTxn(
 	ctx context.Context, txn *client.Txn, tableDesc *sqlbase.ImmutableTableDescriptor, traceKV bool,
 ) error {
@@ -1653,6 +1798,9 @@ func indexBackfillInTxn(
 	return nil
 }
 
+// indexTruncateInTxn deletes the index in the table's first mutation.
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func indexTruncateInTxn(
 	ctx context.Context,
 	txn *client.Txn,

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -27,6 +27,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// validateCheckExpr verifies that the given CHECK expression returns true
+// for all the rows in the table.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func validateCheckExpr(
 	ctx context.Context,
 	exprStr string,
@@ -221,6 +226,11 @@ func nonMatchingRowQuery(
 	), originColNames, nil
 }
 
+// validateForeignKey verifies that all the rows in the srcTable
+// have a matching row in their referenced table.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func validateForeignKey(
 	ctx context.Context,
 	srcTable *sqlbase.TableDescriptor,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -446,7 +446,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// well as in-between very stage of cascading actions.
 	// This TODO can be removed when the cascading code is reorganized
 	// accordingly and the missing call to Step() is introduced.
-	if err := ex.state.stepLocked(ctx); err != nil {
+	if err := ex.state.mu.txn.Step(ctx); err != nil {
 		return makeErrEvent(err)
 	}
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -993,7 +993,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 		// We place a sequence point before every postquery, so
 		// that each subsequent postquery can observe the writes
 		// by the previous step.
-		if err := planner.step(ctx); err != nil {
+		if err := planner.Txn().Step(ctx); err != nil {
 			recv.SetError(err)
 			return false
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1136,7 +1136,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc.settings = cfg.Settings
 		sc.ieFactory = ieFactory
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-			if err := sc.exec(ctx, true /* inSession */, tracing); err != nil {
+			if err := sc.exec(ctx, true /* inSession */); err != nil {
 				if onError := cfg.SchemaChangerTestingKnobs.OnError; onError != nil {
 					onError(err)
 				}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1136,8 +1136,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc.settings = cfg.Settings
 		sc.ieFactory = ieFactory
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-			evalCtx := createSchemaChangeEvalCtx(ctx, cfg.Clock.Now(), tracing, ieFactory)
-			if err := sc.exec(ctx, true /* inSession */, &evalCtx); err != nil {
+			if err := sc.exec(ctx, true /* inSession */, tracing); err != nil {
 				if onError := cfg.SchemaChangerTestingKnobs.OnError; onError != nil {
 					onError(err)
 				}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -400,15 +400,6 @@ func (p *planner) Txn() *client.Txn {
 	return p.txn
 }
 
-func (p *planner) step(ctx context.Context) error {
-	if p.extendedEvalCtx.TxnReadOnly {
-		// A read-only txn does not contain writes and thus cannot step.
-		// See the comment over (txnState).stepLocked for a rationale.
-		return nil
-	}
-	return p.txn.Step(ctx)
-}
-
 func (p *planner) User() string {
 	return p.SessionData().User
 }

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -581,8 +581,13 @@ func (sc *SchemaChanger) maybeDropTable(
 
 // maybe backfill a created table by executing the AS query. Return nil if
 // successfully backfilled.
+//
+// Note that this does not connect to the tracing settings of the
+// surrounding SQL transaction. This should be OK as (at the time of
+// this writing) this code path is only used for standalone CREATE
+// TABLE AS statements, which cannot be traced.
 func (sc *SchemaChanger) maybeBackfillCreateTableAs(
-	ctx context.Context, table *sqlbase.TableDescriptor, tracing *SessionTracing,
+	ctx context.Context, table *sqlbase.TableDescriptor,
 ) error {
 	if table.Adding() && table.IsAs() {
 		// Acquire lease.
@@ -668,7 +673,10 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 					func(ts hlc.Timestamp) {
 						_ = sc.clock.Update(ts)
 					},
-					tracing,
+					// Make a session tracing object on-the-fly. This is OK
+					// because it sets "enabled: false" and thus none of the
+					// other fields are used.
+					&SessionTracing{},
 				)
 				defer recv.Release()
 
@@ -940,7 +948,7 @@ func (sc *SchemaChanger) drainNames(ctx context.Context) error {
 //
 // If the txn that queued the schema changer did not commit, this will be a
 // no-op, as we'll fail to find the job for our mutation in the jobs registry.
-func (sc *SchemaChanger) exec(ctx context.Context, inSession bool, tracing *SessionTracing) error {
+func (sc *SchemaChanger) exec(ctx context.Context, inSession bool) error {
 	ctx = logtags.AddTag(ctx, "scExec", nil)
 
 	tableDesc, notFirst, err := sc.notFirstInLine(ctx)
@@ -971,7 +979,7 @@ func (sc *SchemaChanger) exec(ctx context.Context, inSession bool, tracing *Sess
 		return err
 	}
 
-	if err := sc.maybeBackfillCreateTableAs(ctx, tableDesc, tracing); err != nil {
+	if err := sc.maybeBackfillCreateTableAs(ctx, tableDesc); err != nil {
 		return err
 	}
 
@@ -1065,7 +1073,7 @@ func (sc *SchemaChanger) exec(ctx context.Context, inSession bool, tracing *Sess
 	}
 
 	// Run through mutation state machine and backfill.
-	err = sc.runStateMachineAndBackfill(ctx, &lease, tracing)
+	err = sc.runStateMachineAndBackfill(ctx, &lease)
 
 	defer func() {
 		if err := waitToUpdateLeases(err == nil /* refreshStats */); err != nil && !errors.Is(err, sqlbase.ErrDescriptorNotFound) {
@@ -1083,7 +1091,7 @@ func (sc *SchemaChanger) exec(ctx context.Context, inSession bool, tracing *Sess
 	// a permanent error. All other errors are transient errors that are
 	// resolved by retrying the backfill.
 	if isPermanentSchemaChangeError(err) {
-		if rollbackErr := sc.rollbackSchemaChange(ctx, err, &lease, tracing); rollbackErr != nil {
+		if rollbackErr := sc.rollbackSchemaChange(ctx, err, &lease); rollbackErr != nil {
 			// Note: the "err" object is captured by rollbackSchemaChange(), so
 			// it does not simply disappear.
 			return errors.Wrap(rollbackErr, "while rolling back schema change")
@@ -1137,10 +1145,7 @@ func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 }
 
 func (sc *SchemaChanger) rollbackSchemaChange(
-	ctx context.Context,
-	err error,
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	tracing *SessionTracing,
+	ctx context.Context, err error, lease *sqlbase.TableDescriptor_SchemaChangeLease,
 ) error {
 	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", *sc.job.ID(), err)
 	if errReverse := sc.reverseMutations(ctx, err); errReverse != nil {
@@ -1162,7 +1167,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(
 
 	// After this point the schema change has been reversed and any retry
 	// of the schema change will act upon the reversed schema change.
-	if errPurge := sc.runStateMachineAndBackfill(ctx, lease, tracing); errPurge != nil {
+	if errPurge := sc.runStateMachineAndBackfill(ctx, lease); errPurge != nil {
 		// Don't return this error because we do want the caller to know
 		// that an integrity constraint was violated with the original
 		// schema change. The reversed schema change will be
@@ -1531,7 +1536,7 @@ func (sc *SchemaChanger) notFirstInLine(
 // runStateMachineAndBackfill runs the schema change state machine followed by
 // the backfill.
 func (sc *SchemaChanger) runStateMachineAndBackfill(
-	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease, tracing *SessionTracing,
+	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease,
 ) error {
 	if fn := sc.testingKnobs.RunBeforePublishWriteAndDelete; fn != nil {
 		fn()
@@ -1542,7 +1547,7 @@ func (sc *SchemaChanger) runStateMachineAndBackfill(
 	}
 
 	// Run backfill(s).
-	if err := sc.runBackfill(ctx, lease, tracing); err != nil {
+	if err := sc.runBackfill(ctx, lease); err != nil {
 		return err
 	}
 
@@ -2108,10 +2113,8 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 		execOneSchemaChange := func(schemaChangers map[sqlbase.ID]SchemaChanger) {
 			for tableID, sc := range schemaChangers {
 				if timeutil.Since(sc.execAfter) > 0 {
-					sessionTracing := &SessionTracing{}
-
 					execCtx, cleanup := tracing.EnsureContext(ctx, s.ambientCtx.Tracer, "schema change [async]")
-					err := sc.exec(execCtx, false /* inSession */, sessionTracing)
+					err := sc.exec(execCtx, false /* inSession */)
 					cleanup()
 
 					// Advance the execAfter time so that this schema
@@ -2391,11 +2394,11 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 //
 // TODO(andrei): This EvalContext() will be broken for backfills trying to use
 // functions marked with distsqlBlacklist.
+// Also, the SessionTracing inside the context is unrelated to the one
+// used in the surrounding SQL session, so session tracing is unable
+// to capture schema change activity.
 func createSchemaChangeEvalCtx(
-	ctx context.Context,
-	ts hlc.Timestamp,
-	tracing *SessionTracing,
-	ieFactory sqlutil.SessionBoundInternalExecutorFactory,
+	ctx context.Context, ts hlc.Timestamp, ieFactory sqlutil.SessionBoundInternalExecutorFactory,
 ) extendedEvalContext {
 	dummyLocation := time.UTC
 
@@ -2418,7 +2421,10 @@ func createSchemaChangeEvalCtx(
 	}
 
 	evalCtx := extendedEvalContext{
-		Tracing: tracing,
+		// Make a session tracing object on-the-fly. This is OK
+		// because it sets "enabled: false" and thus none of the
+		// other fields are used.
+		Tracing: &SessionTracing{},
 		EvalContext: tree.EvalContext{
 			SessionData:      sd,
 			InternalExecutor: ieFactory(ctx, sd),

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -442,7 +442,6 @@ func (sc *SchemaChanger) truncateTable(
 	ctx context.Context,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	table *sqlbase.TableDescriptor,
-	evalCtx *extendedEvalContext,
 ) error {
 	// If DropTime isn't set, assume this drop request is from a version
 	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.
@@ -520,7 +519,7 @@ func (sc *SchemaChanger) truncateTable(
 
 // maybe Drop a table. Return nil if successfully dropped.
 func (sc *SchemaChanger) maybeDropTable(
-	ctx context.Context, inSession bool, table *sqlbase.TableDescriptor, evalCtx *extendedEvalContext,
+	ctx context.Context, inSession bool, table *sqlbase.TableDescriptor,
 ) error {
 	if !table.Dropped() || inSession {
 		return nil
@@ -568,7 +567,7 @@ func (sc *SchemaChanger) maybeDropTable(
 	}()
 
 	// Do all the hard work of deleting the table data and the table ID.
-	if err := sc.truncateTable(ctx, &lease, table, evalCtx); err != nil {
+	if err := sc.truncateTable(ctx, &lease, table); err != nil {
 		return err
 	}
 
@@ -583,7 +582,7 @@ func (sc *SchemaChanger) maybeDropTable(
 // maybe backfill a created table by executing the AS query. Return nil if
 // successfully backfilled.
 func (sc *SchemaChanger) maybeBackfillCreateTableAs(
-	ctx context.Context, table *sqlbase.TableDescriptor, evalCtx *extendedEvalContext,
+	ctx context.Context, table *sqlbase.TableDescriptor, tracing *SessionTracing,
 ) error {
 	if table.Adding() && table.IsAs() {
 		// Acquire lease.
@@ -669,7 +668,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 					func(ts hlc.Timestamp) {
 						_ = sc.clock.Update(ts)
 					},
-					evalCtx.Tracing,
+					tracing,
 				)
 				defer recv.Release()
 
@@ -941,9 +940,7 @@ func (sc *SchemaChanger) drainNames(ctx context.Context) error {
 //
 // If the txn that queued the schema changer did not commit, this will be a
 // no-op, as we'll fail to find the job for our mutation in the jobs registry.
-func (sc *SchemaChanger) exec(
-	ctx context.Context, inSession bool, evalCtx *extendedEvalContext,
-) error {
+func (sc *SchemaChanger) exec(ctx context.Context, inSession bool, tracing *SessionTracing) error {
 	ctx = logtags.AddTag(ctx, "scExec", nil)
 
 	tableDesc, notFirst, err := sc.notFirstInLine(ctx)
@@ -970,11 +967,11 @@ func (sc *SchemaChanger) exec(
 	)
 
 	// Delete dropped table data if possible.
-	if err := sc.maybeDropTable(ctx, inSession, tableDesc, evalCtx); err != nil {
+	if err := sc.maybeDropTable(ctx, inSession, tableDesc); err != nil {
 		return err
 	}
 
-	if err := sc.maybeBackfillCreateTableAs(ctx, tableDesc, evalCtx); err != nil {
+	if err := sc.maybeBackfillCreateTableAs(ctx, tableDesc, tracing); err != nil {
 		return err
 	}
 
@@ -1068,7 +1065,7 @@ func (sc *SchemaChanger) exec(
 	}
 
 	// Run through mutation state machine and backfill.
-	err = sc.runStateMachineAndBackfill(ctx, &lease, evalCtx)
+	err = sc.runStateMachineAndBackfill(ctx, &lease, tracing)
 
 	defer func() {
 		if err := waitToUpdateLeases(err == nil /* refreshStats */); err != nil && !errors.Is(err, sqlbase.ErrDescriptorNotFound) {
@@ -1086,7 +1083,7 @@ func (sc *SchemaChanger) exec(
 	// a permanent error. All other errors are transient errors that are
 	// resolved by retrying the backfill.
 	if isPermanentSchemaChangeError(err) {
-		if rollbackErr := sc.rollbackSchemaChange(ctx, err, &lease, evalCtx); rollbackErr != nil {
+		if rollbackErr := sc.rollbackSchemaChange(ctx, err, &lease, tracing); rollbackErr != nil {
 			// Note: the "err" object is captured by rollbackSchemaChange(), so
 			// it does not simply disappear.
 			return errors.Wrap(rollbackErr, "while rolling back schema change")
@@ -1143,7 +1140,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(
 	ctx context.Context,
 	err error,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	evalCtx *extendedEvalContext,
+	tracing *SessionTracing,
 ) error {
 	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", *sc.job.ID(), err)
 	if errReverse := sc.reverseMutations(ctx, err); errReverse != nil {
@@ -1165,7 +1162,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(
 
 	// After this point the schema change has been reversed and any retry
 	// of the schema change will act upon the reversed schema change.
-	if errPurge := sc.runStateMachineAndBackfill(ctx, lease, evalCtx); errPurge != nil {
+	if errPurge := sc.runStateMachineAndBackfill(ctx, lease, tracing); errPurge != nil {
 		// Don't return this error because we do want the caller to know
 		// that an integrity constraint was violated with the original
 		// schema change. The reversed schema change will be
@@ -1534,9 +1531,7 @@ func (sc *SchemaChanger) notFirstInLine(
 // runStateMachineAndBackfill runs the schema change state machine followed by
 // the backfill.
 func (sc *SchemaChanger) runStateMachineAndBackfill(
-	ctx context.Context,
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	evalCtx *extendedEvalContext,
+	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease, tracing *SessionTracing,
 ) error {
 	if fn := sc.testingKnobs.RunBeforePublishWriteAndDelete; fn != nil {
 		fn()
@@ -1547,7 +1542,7 @@ func (sc *SchemaChanger) runStateMachineAndBackfill(
 	}
 
 	// Run backfill(s).
-	if err := sc.runBackfill(ctx, lease, evalCtx); err != nil {
+	if err := sc.runBackfill(ctx, lease, tracing); err != nil {
 		return err
 	}
 
@@ -2113,10 +2108,10 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 		execOneSchemaChange := func(schemaChangers map[sqlbase.ID]SchemaChanger) {
 			for tableID, sc := range schemaChangers {
 				if timeutil.Since(sc.execAfter) > 0 {
-					evalCtx := createSchemaChangeEvalCtx(ctx, s.execCfg.Clock.Now(), &SessionTracing{}, s.ieFactory)
+					sessionTracing := &SessionTracing{}
 
 					execCtx, cleanup := tracing.EnsureContext(ctx, s.ambientCtx.Tracer, "schema change [async]")
-					err := sc.exec(execCtx, false /* inSession */, &evalCtx)
+					err := sc.exec(execCtx, false /* inSession */, sessionTracing)
 					cleanup()
 
 					// Advance the execAfter time so that this schema

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -867,6 +867,12 @@ func getZoneConfigRaw(
 	return &zone, nil
 }
 
+// removeIndexZoneConfigs removes the zone configurations for some
+// indexs being dropped. It is a no-op if there is no zone
+// configuration.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing client.Txn safely.
 func removeIndexZoneConfigs(
 	ctx context.Context,
 	txn *client.Txn,


### PR DESCRIPTION
Fixes #44201.

Prior to this patch, the backfiller was sharing client.Txn
objects between multiple goroutines, which was problematic.

This patch changes it to ensure the various goroutines use different
objects.

Additionally, this patch acknowledges that the `*extendedEvalContext`
argument was not needed in many of the functions in `backfill.go` as
it was merely used for its `*SessionTracing` field. This was
misleading as it was suggesting that future additions to the code
could exploit the other fields in the evalCtx in a meaningful
manner. The patch changes the interface of the functions to use a
`*SessionTracing` parameter directly.

Release note: None