### PR TITLE
kv: fix stopping of the heartbeat loop

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -779,6 +779,9 @@ func (tc *TxnCoordSender) updateStateLocked(
 			PrevError: pErr.String(),
 		})
 		tc.mu.txn.Update(errTxn)
+		if tc.mu.txn.Status != roachpb.PENDING {
+			tc.cleanupTxnLocked(ctx)
+		}
 	}
 	return pErr
 }


### PR DESCRIPTION
Before this patch, when receiving a transaction different from
TransactionAbortedError, the TxnCoordSender would not stop the heartbeat
loop. The heartbeat loop, however, doesn't like to run in an aborted
txn - reasonably enough. It turns out that errors different from
TransactionAbortedError can carry an ABORTED txn status due to the
DistSender merging error; in that merging, TransactionAbortedErrors
don't have the highest priority, and so they can be replaced.

This patch makes the TxnCoordSender close the heartbeat loop in such
cases too.

Fixes #43879

Release note: None