### PR TITLE
roachtest: set MinVersion on tpccbench/nodes=9/cpu=4/chaos/partition

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -376,6 +376,8 @@ func registerTPCC(r *testRegistry) {
 
 		LoadWarehouses: 2000,
 		EstimatedMax:   900,
+
+		MinVersion: "v19.1.0",
 	})
 }
 


### PR DESCRIPTION
Closes #44293.
Closes #44259.

`COPY FROM PARENT` wasn't supported until v19.1.