### PR TITLE
release-19.2: backupccl,importccl: fix privilege checks for BACKUP/RESTORE and IMPORT

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2546,6 +2546,35 @@ func TestBackupRestorePermissions(t *testing.T) {
 			`RESTORE data.bank FROM $1 WITH OPTIONS ('into_db'='system')`, localFoo,
 		)
 	})
+
+	// Ensure that non-root users with the admin role can backup and restore.
+	t.Run("non-root-admin", func(t *testing.T) {
+		sqlDB.Exec(t, "GRANT admin TO testuser")
+
+		t.Run("backup-table", func(t *testing.T) {
+			testLocalFoo := fmt.Sprintf("nodelocal:///%s", t.Name())
+			testLocalBackupStmt := fmt.Sprintf(`BACKUP data.bank TO '%s'`, testLocalFoo)
+			if _, err := testuser.Exec(testLocalBackupStmt); err != nil {
+				t.Fatal(err)
+			}
+			sqlDB.Exec(t, `CREATE DATABASE data2`)
+			if _, err := testuser.Exec(`RESTORE data.bank FROM $1 WITH OPTIONS ('into_db'='data2')`, testLocalFoo); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("backup-database", func(t *testing.T) {
+			testLocalFoo := fmt.Sprintf("nodelocal:///%s", t.Name())
+			testLocalBackupStmt := fmt.Sprintf(`BACKUP DATABASE data TO '%s'`, testLocalFoo)
+			if _, err := testuser.Exec(testLocalBackupStmt); err != nil {
+				t.Fatal(err)
+			}
+			sqlDB.Exec(t, "DROP DATABASE data")
+			if _, err := testuser.Exec(`RESTORE DATABASE data FROM $1`, testLocalFoo); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
 }
 
 func TestRestoreDatabaseVersusTable(t *testing.T) {

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -408,8 +408,7 @@ func allocateTableRewrites(
 					return err
 				}
 
-				// Check privileges. These will be checked again in the transaction
-				// that actually writes the new table descriptors.
+				// Check privileges.
 				{
 					parentDB, err := sqlbase.GetDatabaseDescFromID(ctx, txn, parentID)
 					if err != nil {
@@ -1065,10 +1064,8 @@ func WriteTableDescs(
 					return errors.Wrapf(err,
 						"failed to lookup parent DB %d", errors.Safe(tables[i].ParentID))
 				}
-				// TODO(mberhault): CheckPrivilege wants a planner.
-				if err := sql.CheckPrivilegeForUser(ctx, user, parentDB, privilege.CREATE); err != nil {
-					return err
-				}
+				// We don't check priv's here since we checked them during job planning.
+
 				// Default is to copy privs from restoring parent db, like CREATE TABLE.
 				// TODO(dt): Make this more configurable.
 				tables[i].Privileges = parentDB.GetPrivileges()

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -202,7 +202,15 @@ func importPlanHook(
 				return pgerror.Newf(pgcode.UndefinedObject,
 					"database does not exist: %q", table)
 			}
-			parentID = descI.(*sqlbase.DatabaseDescriptor).ID
+			dbDesc := descI.(*sqlbase.DatabaseDescriptor)
+			// If this is a non-INTO import that will thus be making a new table, we
+			// need the CREATE priv in the target DB.
+			if !importStmt.Into {
+				if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
+					return err
+				}
+			}
+			parentID = dbDesc.ID
 		} else {
 			// No target table means we're importing whatever we find into the session
 			// database, so it must exist.
@@ -210,6 +218,13 @@ func importPlanHook(
 			if err != nil {
 				return pgerror.Wrap(err, pgcode.UndefinedObject,
 					"could not resolve current database")
+			}
+			// If this is a non-INTO import that will thus be making a new table, we
+			// need the CREATE priv in the target DB.
+			if !importStmt.Into {
+				if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
+					return err
+				}
 			}
 			parentID = dbDesc.ID
 		}
@@ -428,6 +443,11 @@ func importPlanHook(
 			// - Write _a lot_ of tests.
 			found, err := p.ResolveMutableTableDescriptor(ctx, table, true, sql.ResolveRequireTableDesc)
 			if err != nil {
+				return err
+			}
+
+			// TODO(dt): checking *CREATE* on an *existing table* is weird.
+			if err := p.CheckPrivilege(ctx, found, privilege.CREATE); err != nil {
 				return err
 			}
 
@@ -750,10 +770,6 @@ func prepareExistingTableDescForIngestion(
 		return nil, errors.Errorf("cannot IMPORT INTO a table with schema changes in progress -- try again later (pending mutation %s)", desc.Mutations[0].String())
 	}
 
-	if err := p.CheckPrivilege(ctx, desc, privilege.CREATE); err != nil {
-		return nil, err
-	}
-
 	// TODO(dt): Ensure no other schema changes can start during ingest.
 	importing := *desc
 	importing.Version++
@@ -799,6 +815,7 @@ func (r *importResumer) prepareTableDescsForIngestion(
 	ctx context.Context, p sql.PlanHookState, details jobspb.ImportDetails,
 ) error {
 	err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+
 		importDetails := details
 		importDetails.Tables = make([]jobspb.ImportDetails_Table, len(details.Tables))
 

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -11,10 +11,12 @@ package importccl
 import (
 	"bytes"
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -23,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -1343,6 +1346,37 @@ func TestImportCSVStmt(t *testing.T) {
 			t, `relation "t" already exists`,
 			fmt.Sprintf(`IMPORT TABLE t (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`, testFiles.files[0]),
 		)
+	})
+
+	// Test basic role based access control. Users who have the admin role should
+	// be able to IMPORT.
+	t.Run("RBAC", func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE USER testuser`)
+		sqlDB.Exec(t, `GRANT admin TO testuser`)
+		pgURL, cleanupFunc := sqlutils.PGUrl(
+			t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser", url.User("testuser"),
+		)
+		defer cleanupFunc()
+		testuser, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testuser.Close()
+
+		t.Run("IMPORT TABLE", func(t *testing.T) {
+			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT TABLE rbac_table_t (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`, testFiles.files[0])); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("IMPORT INTO", func(t *testing.T) {
+			if _, err := testuser.Exec("CREATE TABLE rbac_into_t (a INT8 PRIMARY KEY, b STRING)"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT INTO rbac_into_t (a, b) CSV DATA (%s)`, testFiles.files[0])); err != nil {
+				t.Fatal(err)
+			}
+		})
 	})
 
 	// Verify DEFAULT columns and SERIAL are allowed but not evaluated.

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -62,19 +62,6 @@ type AuthorizationAccessor interface {
 
 var _ AuthorizationAccessor = &planner{}
 
-// CheckPrivilegeForUser verifies that `user`` has `privilege` on `descriptor`.
-// This is not part of the planner as the only caller (ccl/sqlccl/restore.go) does not have one.
-func CheckPrivilegeForUser(
-	_ context.Context, user string, descriptor sqlbase.DescriptorProto, privilege privilege.Kind,
-) error {
-	if descriptor.GetPrivileges().CheckPrivilege(user, privilege) {
-		return nil
-	}
-	return pgerror.Newf(pgcode.InsufficientPrivilege,
-		"user %s does not have %s privilege on %s %s",
-		user, privilege, descriptor.TypeName(), descriptor.GetName())
-}
-
 // CheckPrivilege implements the AuthorizationAccessor interface.
 func (p *planner) CheckPrivilege(
 	ctx context.Context, descriptor sqlbase.DescriptorProto, privilege privilege.Kind,


### PR DESCRIPTION
Backport 2/2 commits from #44250.

/cc @cockroachdb/release

---

This changes the privilege checks in IMPORT, IMPORT INTO and RESTORE to
run during the *planning* of the job, in the SQL plan hook execution,
rather than during the execution of the job. This is done because
privilege checks are implemented on planner, and close over the
planner's txn in some branches/cases, so invoking them later, on a
txn-less planner in a resumed jobs execution, can cause problems.

Before this, the planStateHook's txn was assumed to be set and caused a
panic on checking RBAC privileges. Additionally, permission checks in these
operations did not properly give access to all admin users.

Fixes #44252.

Release note (bug fix): Allow all admin users to use BACKUP/RESTORE and
IMPORT.
