### PR TITLE
colexec: reduce test runtime

### DIFF
--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -665,7 +665,7 @@ func TestHashRouterRandom(t *testing.T) {
 
 	var (
 		maxValues        = int(coldata.BatchSize()) * 4
-		maxOutputs       = int(coldata.BatchSize())
+		maxOutputs       = 128
 		blockedThreshold = 1 + rng.Intn(maxValues-1)
 		outputSize       = 1 + rng.Intn(maxValues-1)
 		numOutputs       = 1 + rng.Intn(maxOutputs-1)

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -338,12 +338,17 @@ func runTestsWithFn(
 ) {
 	rng, _ := randutil.NewPseudoRand()
 
-	for _, batchSize := range []uint16{1, uint16(math.Trunc(.002 * float64(coldata.BatchSize()))), uint16(math.Trunc(.003 * float64(coldata.BatchSize()))), uint16(math.Trunc(.016 * float64(coldata.BatchSize()))), coldata.BatchSize()} {
-		if batchSize == 0 {
-			// It is possible for batchSize to be 0 here when varying
-			// coldata.BatchSize(), so we want to skip such configuration.
-			continue
-		}
+	// Run tests over batchSizes of 1, (sometimes) a batch size that is small but
+	// greater than 1, and a full coldata.BatchSize().
+	batchSizes := make([]uint16, 0, 3)
+	batchSizes = append(batchSizes, 1)
+	smallButGreaterThanOne := uint16(math.Trunc(.002 * float64(coldata.BatchSize())))
+	if smallButGreaterThanOne > 1 {
+		batchSizes = append(batchSizes, smallButGreaterThanOne)
+	}
+	batchSizes = append(batchSizes, coldata.BatchSize())
+
+	for _, batchSize := range batchSizes {
 		for _, useSel := range []bool{false, true} {
 			t.Run(fmt.Sprintf("batchSize=%d/sel=%t", batchSize, useSel), func(t *testing.T) {
 				inputSources := make([]Operator, len(tups))


### PR DESCRIPTION
**colexec: reduce maximum number of outputs in TestHashRouterRandom**

    We would previously create up to coldata.BatchSize() possible outputs for
    a HashRouter. This ends up creating one goroutine per output, which would
    slow down the runtime of this test dramatically. Since in a production
    deployment, this is the number of nodes, the number of outputs has been limited
    to 128.

    Release note: None (testing change)

**colexec: iterate over less possible batch sizes during tests**

    For any call to runTests, the test itself would be run under a couple varying
    input batch sizes from 1 up to coldata.BatchSize(). Since we added
    randomization of the batch size to tests, this loop results in tests taking
    longer than necessary since the cases with differing input batch sizes would
    be equivalent to running the tests with a different coldata.BatchSize(). The
    exception to this is testing with a smaller input batch size than
    coldata.BatchSize() which is tested by keeping the test of using batchSize=1.
    runTests therefore now runs with two input batch sizes only: 1 and
    coldata.BatchSize(). It is difficult to compare the runtime of different
    `make test` invocations due to the amount of randomization in the package, but
    this should provide a nice improvement in the time taken to run tests.

    Release note: None (testing change)