### PR TITLE
kv: prioritize TransactionAbortedError above all others

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -2737,7 +2737,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 		{
 			err1:   abortErr,
 			err2:   conditionFailedErr,
-			expErr: "unexpected value",
+			expErr: "TransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND)",
 		},
 		{
 			err1:   conditionFailedErr,

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -779,6 +779,11 @@ func (tc *TxnCoordSender) updateStateLocked(
 			PrevError: pErr.String(),
 		})
 		tc.mu.txn.Update(errTxn)
+		if errTxn.Status != roachpb.PENDING {
+			// We only expect TransactionAbortedError to carry an aborted txn.
+			log.Errorf(ctx, "programming error: ABORTED txn in error: %s. txn: %s", pErr, errTxn)
+			tc.cleanupTxnLocked(ctx)
+		}
 	}
 	return pErr
 }

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -63,14 +63,22 @@ const (
 	// ErrorScoreTxnRestart indicates that the transaction should be restarted
 	// with an incremented epoch.
 	ErrorScoreTxnRestart
-	// ErrorScoreTxnAbort indicates that the transaction is aborted. The
-	// operation can only try again under the purview of a new transaction.
-	ErrorScoreTxnAbort
 	// ErrorScoreNonRetriable indicates that the transaction performed an
 	// operation that does not warrant a retry. Often this indicates that the
 	// operation ran into a logic error. The error should be propagated to the
 	// client and the transaction should terminate immediately.
 	ErrorScoreNonRetriable
+	// ErrorScoreTxnAbort indicates that the transaction is aborted. The
+	// operation can only try again under the purview of a new transaction.
+	//
+	// This error has the highest priority because, as far as KV is concerned, a
+	// TransactionAbortedError is impossible to recover from (whereas
+	// non-retriable errors could conceivably be recovered if the client wanted to
+	// ignore them). Also, the TxnCoordSender likes to assume that a
+	// TransactionAbortedError is the only way it finds about an aborted
+	// transaction, and so it benefits from all other errors being merged into a
+	// TransactionAbortedError instead of the other way around.
+	ErrorScoreTxnAbort
 )
 
 // ErrPriority computes the priority of the given error.

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -228,17 +228,6 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 			expErr: "TransactionRetryWithProtoRefreshError: TransactionRetryError",
 		},
 		{
-			// A TransactionAbortedError overwrites another retriable one.
-			err:    abortErr,
-			expErr: "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
-		},
-		{
-			// A non-aborted retriable error does not overried the
-			// TransactionAbortedError.
-			err:    retryErr,
-			expErr: "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
-		},
-		{
 			// A non-retriable error overwrites a retriable one.
 			err:    fmt.Errorf("err1"),
 			expErr: "err1",
@@ -247,6 +236,17 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 			// Another non-retriable error doesn't overwrite the previous one.
 			err:    fmt.Errorf("err2"),
 			expErr: "err1",
+		},
+		{
+			// A TransactionAbortedError overwrites anything.
+			err:    abortErr,
+			expErr: "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
+		},
+		{
+			// A non-aborted retriable error does not overried the
+			// TransactionAbortedError.
+			err:    retryErr,
+			expErr: "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
 		},
 	}
 


### PR DESCRIPTION
The DistSender and the DistSQLReceiver need to choose one error among
possibly multiple to hand out to a client. Before this patch,
non-retriable errors would take priority over a TransactionAbortedError.
This was a problem because the TxnCoordSender assumes that the only way
it'll find out about an aborted transaction is through a
TransactionAbortedError. When that assumption fails, the TxnCoordSender
doesn't stop the heartbeat loop, but the heartbeat loop reasonably
doesn't like to run on an aborted txn.

This patch makes the TransactionAbortedError have the highest priority,
thus hopefully making the TxnCoordSender's assumption valid.
Besides fixing this bug, prioritizing TransactionAbortedError generally
seems like the right thing to do, as it puts us in a better position to
allow upcoming savepoints to rollback past errors: one cannot rollback
past a TransactionAbortedError and so it seems like a good idea to
prefer to return this error. From the perspective of a particular
transaction, a TransactionAbortedError is the most unrecoverable error
of them all (even though it is retriable at a higher level).

Fixes #43879

Release note: None