### PR TITLE
colserde: change DiskQueue constructor

### DIFF
--- a/pkg/col/colserde/diskqueue_test.go
+++ b/pkg/col/colserde/diskqueue_test.go
@@ -56,14 +56,14 @@ func TestQueue(t *testing.T) {
 				// Create queue.
 				directoryName := uuid.FastMakeV4().String()
 				queueCfg := colserde.DiskQueueCfg{
-					Typs:             typs,
+					FS:               fs,
 					Path:             testingFilePath,
 					Dir:              directoryName,
 					BufferSizeBytes:  bufferSizeBytes,
 					MaxFileSizeBytes: maxFileSizeBytes,
 				}
 				queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
-				q, err := colserde.NewDiskQueue(queueCfg, fs)
+				q, err := colserde.NewDiskQueue(typs, queueCfg)
 				require.NoError(t, err)
 
 				// Run verification.
@@ -144,11 +144,12 @@ func BenchmarkQueues(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		op.ResetBatchesToReturn(numBatches)
-		q, err := colserde.NewDiskQueue(colserde.DiskQueueCfg{
+		q, err := colserde.NewDiskQueue(typs, colserde.DiskQueueCfg{
+			FS:               vfs.Default,
 			Path:             testingFilePath,
 			BufferSizeBytes:  bufSize,
 			MaxFileSizeBytes: maxFileSize,
-		}, vfs.Default)
+		})
 		require.NoError(b, err)
 		for {
 			batchToEnqueue := op.Next(ctx)


### PR DESCRIPTION
When integrating the DiskQueue into the HashRouter it makes more sense to
extract the Typs into a separate argument since the disk queue config will live
across instances (passed down from the flow creator) but the types are
instance-specific. FS is also included into the config since that shouldn't
change between instances.

Release note: None (internal code refactoring)