### PR TITLE
storageccl: helpers for encrypting and decrypting blobs

### DIFF
--- a/pkg/ccl/storageccl/encryption.go
+++ b/pkg/ccl/storageccl/encryption.go
@@ -1,0 +1,129 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package storageccl
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	crypto_rand "crypto/rand"
+	"crypto/sha256"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// The following helpers are intended for use in creating and reading encrypted
+// files in BACKUPs. Encryption is done using AES-GCM with a key derived from
+// the provided passphrase. Individual files are always written with a random IV
+// which is prefixed to the ciphertext for retrieval and use by decrypt. Helpers
+// are included for deriving a key from a salt and passphrase though the caller
+// is responsible for remembering the salt to rederive that key later.
+
+// encryptionPreamble is a constant string prepended in cleartext to ciphertexts
+// allowing them to be easily recognized by sight and allowing some basic sanity
+// checks when trying to open them (e.g. error if incorrectly using encryption
+// on an unencrypted file of vice-versa).
+var encryptionPreamble = []byte("encrypt")
+
+const encryptionSaltSize = 16
+const encryptionVersionIVPrefix = 1
+
+// GenerateSalt generates a 16 byte random salt.
+func GenerateSalt() ([]byte, error) {
+	// Pick a unique salt for this file.
+	salt := make([]byte, encryptionSaltSize)
+	if _, err := crypto_rand.Read(salt); err != nil {
+		return nil, err
+	}
+	return salt, nil
+}
+
+// GenerateKey generates a key for the supplied passphrase and salt.
+func GenerateKey(passphrase, salt []byte) []byte {
+	return pbkdf2.Key(passphrase, salt, 64000, 32, sha256.New)
+}
+
+// AppearsEncrypted checks if passed bytes begin with an encryption preamble.
+func AppearsEncrypted(text []byte) bool {
+	return bytes.HasPrefix(text, encryptionPreamble)
+}
+
+// EncryptFile encrypts a file with the supplied key and a randomly chosen IV
+// which is prepended in a header on the returned ciphertext. It is intended for
+// use on collections of separate data files that are all encrypted/decrypted
+// with the same key, such as BACKUP data files, and notably does _not_ include
+// information for key derivation as that is _not_ done for individual files in
+// such cases. See EncryptFileStoringSalt for a function that produces a
+// ciphertext that also includes the salt and thus supports decrypting with only
+// the passphrase (at the cost in including key derivation).
+func EncryptFile(plaintext, key []byte) ([]byte, error) {
+	gcm, err := aesgcm(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Allocate our output buffer: preamble + 1B version + iv, plus additional
+	// pre-allocated capacity for the ciphertext.
+	headerSize := len(encryptionPreamble) + 1 + gcm.NonceSize()
+	ciphertext := make([]byte, headerSize, headerSize+len(plaintext)+gcm.Overhead())
+
+	// Write our header (preamble+version+IV) to the ciphertext buffer.
+	copy(ciphertext, encryptionPreamble)
+	ciphertext[len(encryptionPreamble)] = encryptionVersionIVPrefix
+	// Pick a unique IV for this file and write it in the header.
+	iv := ciphertext[len(encryptionPreamble)+1:]
+	if _, err := crypto_rand.Read(iv); err != nil {
+		return nil, err
+	}
+
+	// Generate and write the actual ciphertext.
+	return gcm.Seal(ciphertext, iv, plaintext, nil), nil
+}
+
+// DecryptFile decrypts a file encrypted by EncryptFile, using the supplied key
+// and reading the IV from a prefix of the file. See comments on EncryptFile
+// for intended usage, and see DecryptFile
+func DecryptFile(ciphertext, key []byte) ([]byte, error) {
+	if !AppearsEncrypted(ciphertext) {
+		return nil, errors.New("file does not appear to be encrypted")
+	}
+	ciphertext = ciphertext[len(encryptionPreamble):]
+
+	if len(ciphertext) < 1 {
+		return nil, errors.New("invalid encryption header")
+	}
+	version := ciphertext[0]
+	ciphertext = ciphertext[1:]
+
+	if version != encryptionVersionIVPrefix {
+		return nil, errors.Errorf("unexpected encryption scheme/config version %d", version)
+	}
+	gcm, err := aesgcm(key)
+	if err != nil {
+		return nil, err
+	}
+
+	ivSize := gcm.NonceSize()
+	if len(ciphertext) < ivSize {
+		return nil, errors.New("invalid encryption header: missing IV")
+	}
+	iv := ciphertext[:ivSize]
+	ciphertext = ciphertext[ivSize:]
+	plaintext, err := gcm.Open(ciphertext[:0], iv, ciphertext, nil)
+	return plaintext, err
+}
+
+func aesgcm(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -1,0 +1,132 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package storageccl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	plaintext := bytes.Repeat([]byte("hello world\n"), 3)
+	passphrase := []byte("this is a a key")
+	salt, err := GenerateSalt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := GenerateKey(passphrase, salt)
+
+	t.Run("EncryptFile+DecryptFile", func(t *testing.T) {
+		ciphertext, err := EncryptFile(plaintext, key)
+		require.NoError(t, err)
+		require.True(t, AppearsEncrypted(ciphertext), "cipher text should appear encrypted")
+
+		decrypted, err := DecryptFile(ciphertext, key)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, decrypted)
+	})
+
+	t.Run("helpful error on bad input", func(t *testing.T) {
+
+		_, err := DecryptFile([]byte("a"), key)
+		require.EqualError(t, err, "file does not appear to be encrypted")
+	})
+}
+
+func BenchmarkEncryption(b *testing.B) {
+	plaintext1KB := bytes.Repeat([]byte("0123456789abcdef"), 64)
+	plaintext100KB := bytes.Repeat(plaintext1KB, 100)
+	plaintext1MB := bytes.Repeat(plaintext1KB, 1024)
+
+	passphrase := []byte("this is a a key")
+	salt, err := GenerateSalt()
+	require.NoError(b, err)
+	key := GenerateKey(passphrase, salt)
+
+	ciphertext1KB, err := EncryptFile(plaintext1KB, key)
+	require.NoError(b, err)
+	ciphertext100KB, err := EncryptFile(plaintext100KB, key)
+	require.NoError(b, err)
+	ciphertext1MB, err := EncryptFile(plaintext1MB, key)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	b.Run("EncryptFile", func(b *testing.B) {
+		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB} {
+			b.Run(humanizeutil.IBytes(int64(len(plaintext))), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, err := EncryptFile(plaintext, key)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.SetBytes(int64(len(plaintext)))
+			})
+		}
+	})
+
+	b.Run("DecryptFile", func(b *testing.B) {
+		for _, ciphertextOriginal := range [][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB} {
+			// Decrypt reuses/clobbers the original ciphertext slice.
+			ciphertext := make([]byte, len(ciphertextOriginal))
+			b.Run(humanizeutil.IBytes(int64(len(ciphertext))), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					copy(ciphertext, ciphertextOriginal)
+					_, err := DecryptFile(ciphertext, key)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.SetBytes(int64(len(ciphertext)))
+			})
+		}
+	})
+
+	// If each file written or read also requires key derivation it is much more
+	// expensive.
+	b.Run("DeriveAndEncrypt", func(b *testing.B) {
+		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB} {
+			b.Run(humanizeutil.IBytes(int64(len(plaintext))), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					derived := GenerateKey(passphrase, salt)
+					_, err := EncryptFile(plaintext, derived)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.SetBytes(int64(len(plaintext)))
+			})
+		}
+	})
+
+	b.Run("DeriveAndDecrypt", func(b *testing.B) {
+		for _, ciphertextOriginal := range [][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB} {
+			// Decrypt reuses/clobbers the original ciphertext slice.
+			ciphertext := make([]byte, len(ciphertextOriginal))
+			b.Run(humanizeutil.IBytes(int64(len(ciphertext))), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					copy(ciphertext, ciphertextOriginal)
+					derived := GenerateKey(passphrase, salt)
+					_, err := DecryptFile(ciphertext, derived)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.SetBytes(int64(len(ciphertext)))
+			})
+		}
+	})
+}


### PR DESCRIPTION
These helpers handle encrypting and decrypting files, for use in BACKUP/RESTORE.

The following helpers are intended for use in creating and reading encrypted
BACKUPs that support being created and restored using a simple passphrase.
Encryption is done using ASE-GCM with a key derived from the provided
passphrase. There are helpers here for two types of files:
 a) unique-IV-prefixed files that are encrypted/decrypted with a known key
    using EncryptFile and DecryptFile.
 b) unique-salt-and-IV prefixed files that can be encrypted/decrypted with
    just a passphrase by (re-)deriving the key from the salt, using various
    combinations of GenerateKey, EncryptSaltedFile, DecryptSaltedFile and
    DecryptSaltedFileUsingKey.

The former are relatively cheap to read and write on most modern hardware
thanks to native support for AES, but require that you manage the key used.
The advantages of the later type of files is that, with only a passphrase, you
can pick a salt, derive a key and then create a file that can also be read
with just that passphrase: you can open the file, read the salt to re-derive the
key and then decrypt the file. However, the key derivation step there is
(necessarily!) very expensive - using per-file salts and derived keys for
each individual file in a BACKUP could, assuming we used a nice and secure
expensive derivation function, add considerable cost to running such a job.
By offering helpers for both flavors however, a caller can generate a salt
and key once and use it for the salt-prefixed scheme on a chosen metadata or
manifest file, then just use that key for writing all accompanying files using
the cheaper IV-ony headers that rely on the common key.

A following change will actually integrate this into BACKUP/RESTORE.

Release note: none.