### PR TITLE
cli: modify default memory defaults and flag behavior for demo

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -85,6 +85,7 @@ type TestServerArgs struct {
 	TimeSeriesQueryWorkerMax    int
 	TimeSeriesQueryMemoryBudget int64
 	SQLMemoryPoolSize           int64
+	CacheSize                   int64
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -918,6 +918,25 @@ The line length where sqlfmt will try to wrap.`,
 		Description: `How many in-memory nodes to create for the demo.`,
 	}
 
+	DemoNodeSQLMemSize = FlagInfo{
+		Name: "max-sql-memory",
+		Description: `
+Maximum memory capacity available for each node to store temporary data for SQL clients,
+including prepared queries and intermediate data rows during query execution.
+Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
+percentage of physical memory (e.g. .25).
+If left unspecified, defaults to 128MiB.
+`,
+	}
+	DemoNodeCacheSize = FlagInfo{
+		Name: "cache",
+		Description: `
+Total size in bytes for caches per node, shared evenly if there are multiple
+storage devices. Size suffixes are supported (e.g. 1GB and 1GiB).
+If left unspecified, defaults to 64MiB. A percentage of physical memory
+can also be specified (e.g. .25).`,
+	}
+
 	RunDemoWorkload = FlagInfo{
 		Name:        "with-load",
 		Description: `Run a demo workload against the pre-loaded database.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -150,6 +150,8 @@ func initCLIDefaults() {
 	networkBenchCtx.addresses = []string{"localhost:8081"}
 
 	demoCtx.nodes = 1
+	demoCtx.sqlPoolMemorySize = 128 << 20 // 128MB, chosen to fit 9 nodes on 2GB machine.
+	demoCtx.cacheSize = 64 << 20          // 64MB, chosen to fit 9 nodes on 2GB machine.
 	demoCtx.useEmptyDatabase = false
 	demoCtx.simulateLatency = false
 	demoCtx.runWorkload = false
@@ -364,6 +366,8 @@ var sqlfmtCtx struct {
 // Defaults set by InitCLIDefaults() above.
 var demoCtx struct {
 	nodes                     int
+	sqlPoolMemorySize         int64
+	cacheSize                 int64
 	disableTelemetry          bool
 	disableLicenseAcquisition bool
 	useEmptyDatabase          bool

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestServerArgsForTransientCluster(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		nodeID            roachpb.NodeID
+		joinAddr          string
+		sqlPoolMemorySize int64
+		cacheSize         int64
+
+		expected base.TestServerArgs
+	}{
+		{
+			nodeID:            roachpb.NodeID(1),
+			joinAddr:          "127.0.0.1",
+			sqlPoolMemorySize: 2 << 10,
+			cacheSize:         1 << 10,
+			expected: base.TestServerArgs{
+				PartOfCluster:     true,
+				Insecure:          true,
+				JoinAddr:          "127.0.0.1",
+				SQLMemoryPoolSize: 2 << 10,
+				CacheSize:         1 << 10,
+			},
+		},
+		{
+			nodeID:            roachpb.NodeID(3),
+			joinAddr:          "127.0.0.1",
+			sqlPoolMemorySize: 4 << 10,
+			cacheSize:         4 << 10,
+			expected: base.TestServerArgs{
+				PartOfCluster:     true,
+				Insecure:          true,
+				JoinAddr:          "127.0.0.1",
+				SQLMemoryPoolSize: 4 << 10,
+				CacheSize:         4 << 10,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		demoCtxTemp := demoCtx
+		demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
+		demoCtx.cacheSize = tc.cacheSize
+
+		actual := testServerArgsForTransientCluster(tc.nodeID, tc.joinAddr)
+
+		assert.Len(t, actual.StoreSpecs, 1)
+		assert.Equal(
+			t,
+			fmt.Sprintf("demo-node%d", tc.nodeID),
+			actual.StoreSpecs[0].StickyInMemoryEngineID,
+		)
+
+		// We cannot compare these.
+		actual.Stopper = nil
+		actual.StoreSpecs = nil
+
+		assert.Equal(t, tc.expected, actual)
+
+		// Restore demoCtx state after each test.
+		demoCtx = demoCtxTemp
+	}
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -599,6 +599,8 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.runWorkload, cliflags.RunDemoWorkload, false)
 	VarFlag(demoFlags, &demoCtx.localities, cliflags.DemoNodeLocality)
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
+	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
+	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
 	_ = demoFlags.MarkHidden(cliflags.Global.Name)

--- a/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
@@ -1,0 +1,10 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Check demo alerts when there is a memory warning."
+spawn $argv demo --max-sql-memory=10% --nodes=8
+
+eexpect "WARNING: HIGH MEMORY USAGE"
+
+end_test

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -161,6 +161,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLMemoryPoolSize != 0 {
 		cfg.SQLMemoryPoolSize = params.SQLMemoryPoolSize
 	}
+	if params.CacheSize != 0 {
+		cfg.CacheSize = params.CacheSize
+	}
 
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44333.


cli: modify default memory defaults and flag behavior for demo

Changes are as follows:
* Add `--max-sql-memory` and `--cache` for demo, allowing
configuration of maximum memory sizes per node.
* Defaulted sql memory to 128MB and cache to 64MB to fit 9 nodes (a
geo-distributed cluster) within 2GB. Opted for the "dumb" solution
instead of percentages as it is easier to think about with multiple
nodes hanging around.
* Added a new `CacheSize` to TestServerArgs.
* Added a new warning in demo if the configuration will take up too much
memory. A warning example is as follows:
```
*
* WARNING: HIGH MEMORY USAGE
* The sum of --max-sql-memory (3.2 GiB) and --cache (64 MiB) multiplied by the
* number of nodes (8) results in potentially high memory usage on your
* device.
* This server is running at increased risk of memory-related failures.
*
```
* Thread everything through in demo to reflect these changes.

Release note (cli change): Previously, when requesting multiple demo
nodes, each node will take up to 25%+ of your total memory, possibly
running into OOM problems. In this PR, cockroach demo instead takes up
to 128MB for sql memory and 64MB for cache sizes by default for each
node. This can be modified with `--max-sql-memory` and
`--cache`.