### PR TITLE
sql: add telemetry for CREATE TEMP TABLE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -126,6 +126,8 @@ func (n *createTableNode) startExec(params runParams) error {
 				"temporary tables are unsupported")
 		}
 
+		telemetry.Inc(sqltelemetry.CreateTempTableCounter)
+
 		tempSchemaName := params.p.TemporarySchemaName()
 		sKey := sqlbase.NewSchemaKey(n.dbDesc.ID, tempSchemaName)
 		var err error

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -24,8 +24,12 @@ func SerialColumnNormalizationCounter(inputType, normType string) telemetry.Coun
 	return telemetry.GetCounter(fmt.Sprintf("sql.schema.serial.%s.%s", normType, inputType))
 }
 
-// SchemaNewTypeCounter is to be implemented every time a new data type
+// SchemaNewTypeCounter is to be incremented every time a new data type
 // is used in a schema, i.e. by CREATE TABLE or ALTER TABLE ADD COLUMN.
 func SchemaNewTypeCounter(t string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.new_column_type." + t)
 }
+
+// CreateTempTableCounter is to be incremented every time a TEMP TABLE
+// has been created.
+var CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44373.

This change increments the telemetry counter every time a
`CREATE TEMP TABLE` is used.

Release note: None