### PR TITLE
sql: add telemetry for RANGE FOR ROW

### DIFF
--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -60,6 +61,8 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 
 	idxSpanStart := hex.EncodeToString([]byte(span.Key))
 	idxSpanEnd := hex.EncodeToString([]byte(span.EndKey))
+
+	sqltelemetry.IncrementShowCounter(sqltelemetry.RangeForRow)
 
 	// Format the expressions into a string to be passed into the crdb_internal.encode_key function.
 	// We have to be sneaky here and special case when exprs has length 1 and place a comma after the

--- a/pkg/sql/sqltelemetry/show.go
+++ b/pkg/sql/sqltelemetry/show.go
@@ -30,13 +30,16 @@ const (
 	Locality
 	// Create represents the SHOW CREATE command.
 	Create
+	// RangeForRow represents the SHOW RANGE FOR ROW command.
+	RangeForRow
 )
 
 var showTelemetryNameMap = map[ShowTelemetryType]string{
-	Ranges:     "ranges",
-	Partitions: "partitions",
-	Locality:   "locality",
-	Create:     "create",
+	Ranges:      "ranges",
+	Partitions:  "partitions",
+	Locality:    "locality",
+	Create:      "create",
+	RangeForRow: "rangeforrow",
 }
 
 func (s ShowTelemetryType) String() string {


### PR DESCRIPTION
Fixes #44374.

Release note (sql change): This commit adds telemetry recording
information for uses of the `SHOW RANGE ... FROM ROW` command.