### PR TITLE
sql: add telemetry for uses of secondary indexes with column families

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1345,6 +1345,14 @@ func MakeTableDesc(
 		}
 	}
 
+	for i := range desc.Indexes {
+		idx := &desc.Indexes[i]
+		// Increment the counter if this index could be storing data across multiple column families.
+		if len(idx.StoreColumnNames) > 1 && len(desc.Families) > 1 {
+			telemetry.Inc(sqltelemetry.SecondaryIndexColumnFamiliesCounter)
+		}
+	}
+
 	if n.Interleave != nil {
 		if err := addInterleave(ctx, txn, vt, &desc, &desc.PrimaryIndex, n.Interleave); err != nil {
 			return desc, err

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -28,3 +28,13 @@ SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name IN ('sql
 ----
 sql.schema.new_column_type.timetz_3_
 sql.schema.new_column_type.timetz_4_
+
+
+statement ok
+CREATE TABLE sec_col_fam(x INT, y INT, z INT, FAMILY (x), FAMILY (y), FAMILY (z), INDEX (x) STORING (y, z));
+CREATE INDEX ON sec_col_fam (x) STORING (y, z)
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.secondary_index_column_families' AND usage_count >= 2
+----
+sql.schema.secondary_index_column_families

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -33,3 +33,7 @@ func SchemaNewTypeCounter(t string) telemetry.Counter {
 // CreateTempTableCounter is to be incremented every time a TEMP TABLE
 // has been created.
 var CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")
+
+// SecondaryIndexColumnFamiliesCounter is a counter that is incremented every time
+// a secondary index that is separated into different column families is created.
+var SecondaryIndexColumnFamiliesCounter = telemetry.GetCounterOnce("sql.schema.secondary_index_column_families")


### PR DESCRIPTION
Fixes #44375.

Release note (sql change): This commit collects telemetry information
for uses of secondary indexes that use column families.