### PR TITLE
sql: fix bad "split"s in fakeSpanResolver

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -308,9 +308,8 @@ statement error ambiguous source name: "excluded"
 INSERT INTO excluded VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 
 # Tests for upsert/on conflict returning
-# TODO(mjibson): Remove family definition once #41313 is fixed.
 statement ok
-CREATE TABLE upsert_returning (a INT PRIMARY KEY, b INT, c INT, d INT DEFAULT -1, FAMILY "primary" (a, b, c, d))
+CREATE TABLE upsert_returning (a INT PRIMARY KEY, b INT, c INT, d INT DEFAULT -1)
 
 statement count 1
 INSERT INTO upsert_returning VALUES (1, 1, NULL)


### PR DESCRIPTION
The fakeSpanResolver, which is used for the fakedist* logic test
configs, was causing spurious test failures for tables with multiple
column families. The reason for this is that we sometimes generate
multiple spans for a point lookup if not all the column families are
needed. However, the fakeSpanResolver generates new splits and new
replica assignments on every call to Seek(). This means that spans for a
single row could get "split" across multiple replicas, which the SQL
layer is not equipped to deal with.

My somewhat hacky fix is to enforce that after Seek() is called, the
first range is assigned to the same replica as the last range from the
previous Seek() call. This ensures that if point lookups on the same
row are passed to Seek() in succession, they will not end up on
different replicas.

Fixes #44323

Release note: None