### PR TITLE
sql: fix DROP DATABASE and RENAME DATABASE behavior with temp tables

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -62,11 +62,20 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, err
 	}
 
-	tbNames, err := GetObjectNames(
-		ctx, p.txn, p, dbDesc, tree.PublicSchema, true, /*explicitPrefix*/
-	)
+	schemas, err := p.Tables().getSchemasForDatabase(ctx, p.txn, dbDesc.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	var tbNames TableNames
+	for _, schema := range schemas {
+		toAppend, err := GetObjectNames(
+			ctx, p.txn, p, dbDesc, schema, true, /*explicitPrefix*/
+		)
+		if err != nil {
+			return nil, err
+		}
+		tbNames = append(tbNames, toAppend...)
 	}
 
 	if len(tbNames) > 0 {

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -78,3 +78,27 @@ SELECT * FROM public.table_a ORDER BY a
 
 statement ok
 DROP TABLE pg_temp.table_a; DROP TABLE public.table_a
+
+# Test operations on a database with temp tables inside them.
+subtest test_database_operations
+
+statement ok
+CREATE DATABASE bob; USE bob; CREATE TEMP TABLE a(a int); USE defaultdb
+
+statement ok
+SET sql_safe_updates = true
+
+statement error DROP DATABASE on non-empty database without explicit CASCADE
+DROP DATABASE bob
+
+statement ok
+CREATE VIEW a_view AS SELECT a FROM bob.pg_temp.a
+
+statement error cannot rename database because view "defaultdb.public.a_view" depends on table "a"
+ALTER DATABASE bob RENAME TO alice
+
+statement ok
+DROP VIEW a_view; ALTER DATABASE bob RENAME TO alice
+
+statement ok
+DROP DATABASE alice CASCADE

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -156,9 +156,19 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 	if err != nil {
 		return err
 	}
-	tbNames, err := GetObjectNames(ctx, p.txn, p, dbDesc, tree.PublicSchema, true /*explicitPrefix*/)
+
+	schemas, err := p.Tables().getSchemasForDatabase(ctx, p.txn, dbDesc.ID)
 	if err != nil {
 		return err
+	}
+
+	var tbNames TableNames
+	for _, schema := range schemas {
+		toAppend, err := GetObjectNames(ctx, p.txn, p, dbDesc, schema, true /*explicitPrefix*/)
+		if err != nil {
+			return err
+		}
+		tbNames = append(tbNames, toAppend...)
 	}
 
 	for i := range tbNames {


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44536
Resolves https://github.com/cockroachdb/cockroach/issues/44535

We previously only looked up the public schema when doing pre-validation
with the DROP DATABASE and RENAME DATABASE operators, resulting in these
operations succeeding with temp tables that should be blocking certain
operations. This PR resolves this but considering all schemas before
performing DROP and RENAME on DATABASE.

Release note: None