### PR TITLE
backupccl: remove legacy aux-dir check in tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -112,27 +112,8 @@ func backupRestoreTestSetupWithParams(
 	}
 
 	cleanupFn := func() {
-		tempDirs := []string{dir}
-		for _, s := range tc.Servers {
-			for _, e := range s.Engines() {
-				tempDirs = append(tempDirs, e.GetAuxiliaryDir())
-			}
-		}
 		tc.Stopper().Stop(context.TODO()) // cleans up in memory storage's auxiliary dirs
 		dirCleanupFn()                    // cleans up dir, which is the nodelocal:// storage
-
-		for _, temp := range tempDirs {
-			testutils.SucceedsSoon(t, func() error {
-				items, err := ioutil.ReadDir(temp)
-				if err != nil && !os.IsNotExist(err) {
-					t.Fatal(err)
-				}
-				for _, leftover := range items {
-					return errors.Errorf("found %q remaining in %s", leftover.Name(), temp)
-				}
-				return nil
-			})
-		}
 	}
 
 	return ctx, tc, sqlDB, dir, cleanupFn


### PR DESCRIPTION
A long itme ago backup/restore used on-disk tempfiles and added this testing check
to ensure they were cleaned up but that has long since changed to in-memory and
this check is no longer relevant to backup/restore.

Release note: none