### PR TITLE
sql: fix FK schema resolution error display for temp tables

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -428,7 +429,11 @@ func qualifyFKColErrorWithDB(
 	if err != nil {
 		return tree.ErrString(tree.NewUnresolvedName(tbl.Name, col))
 	}
-	return tree.ErrString(tree.NewUnresolvedName(db.Name, tree.PublicSchema, tbl.Name, col))
+	schema, err := schema.ResolveNameByID(ctx, txn, db.ID, tbl.GetParentSchemaID())
+	if err != nil {
+		return tree.ErrString(tree.NewUnresolvedName(tbl.Name, col))
+	}
+	return tree.ErrString(tree.NewUnresolvedName(db.Name, schema, tbl.Name, col))
 }
 
 // FKTableState is the state of the referencing table resolveFK() is called on.

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -322,39 +322,6 @@ func GetAllDatabaseDescriptorIDs(ctx context.Context, txn *client.Txn) ([]sqlbas
 	return descIDs, nil
 }
 
-// GetSchemasForDatabase looks up and returns all available
-// schema ids to names
-func GetSchemasForDatabase(
-	ctx context.Context, txn *client.Txn, dbID sqlbase.ID,
-) (map[sqlbase.ID]string, error) {
-	log.Eventf(ctx, "fetching all schema descriptor IDs for %d", dbID)
-
-	nameKey := sqlbase.NewSchemaKey(dbID, "" /* name */).Key()
-	kvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /* maxRows */)
-	if err != nil {
-		return nil, err
-	}
-
-	// Always add public schema ID.
-	// TODO(solon): This can be removed in 20.2, when this is always written.
-	// In 20.1, in a migrating state, it may be not included yet.
-	ret := make(map[sqlbase.ID]string, len(kvs)+1)
-	ret[sqlbase.ID(keys.PublicSchemaID)] = tree.PublicSchema
-
-	for _, kv := range kvs {
-		id := sqlbase.ID(kv.ValueInt())
-		if _, ok := ret[id]; ok {
-			continue
-		}
-		_, _, name, err := sqlbase.DecodeNameMetadataKey(kv.Key)
-		if err != nil {
-			return nil, err
-		}
-		ret[id] = name
-	}
-	return ret, nil
-}
-
 // writeDescToBatch adds a Put command writing a descriptor proto to the
 // descriptors table. It writes the descriptor desc at the id descID. If kvTrace
 // is enabled, it will log an event explaining the put that was performed.

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -40,3 +40,17 @@ temp_table_test
 
 statement ok
 DROP TABLE temp_table_ref CASCADE; DROP TABLE temp_table_test CASCADE
+
+subtest foreign_key_errors
+
+statement ok
+CREATE TEMP TABLE a (a int)
+
+statement error cannot add a SET NULL cascading action on column "test\.pg_temp.*\.b\.c" which has a NOT NULL constraint
+CREATE TEMP TABLE b (c int NOT NULL PRIMARY KEY, FOREIGN KEY (c) REFERENCES a ON UPDATE SET NULL)
+
+statement error cannot add a SET DEFAULT cascading action on column "test\.pg_temp_.*\.b\.c" which has a NOT NULL constraint and a NULL default expression
+CREATE TEMP TABLE b (c int DEFAULT NULL PRIMARY KEY, FOREIGN KEY (c) REFERENCES a ON UPDATE SET DEFAULT)
+
+statement ok
+DROP TABLE a

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -948,9 +949,18 @@ func (c *cascader) updateRows(
 									if err != nil {
 										return nil, nil, nil, 0, err
 									}
+									schema, err := schema.ResolveNameByID(
+										ctx,
+										c.txn,
+										referencingTable.ParentID,
+										referencingTable.GetParentSchemaID(),
+									)
+									if err != nil {
+										return nil, nil, nil, 0, err
+									}
 									return nil, nil, nil, 0, pgerror.Newf(pgcode.NullValueNotAllowed,
 										"cannot cascade a null value into %q as it violates a NOT NULL constraint",
-										tree.ErrString(tree.NewUnresolvedName(database.Name, tree.PublicSchema, referencingTable.Name, column.Name)))
+										tree.ErrString(tree.NewUnresolvedName(database.Name, schema, referencingTable.Name, column.Name)))
 								}
 							}
 							continue

--- a/pkg/sql/schema/schema.go
+++ b/pkg/sql/schema/schema.go
@@ -1,0 +1,78 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package schema is to avoid a circular dependency on pkg/sql/row and pkg/sql.
+// It can be removed once schemas can be resolved to a protobuf.
+package schema
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// ResolveNameByID resolves a schema's name based on db and schema id.
+// TODO(sqlexec): this should return the descriptor instead if given an ID.
+// Instead, we have to rely on a scan of the kv table.
+// TODO(sqlexec): this should probably be cached.
+func ResolveNameByID(
+	ctx context.Context, txn *client.Txn, dbID sqlbase.ID, schemaID sqlbase.ID,
+) (string, error) {
+	// Fast-path for public schema, to avoid hot lookups.
+	if schemaID == keys.PublicSchemaID {
+		return string(tree.PublicSchemaName), nil
+	}
+	schemas, err := GetForDatabase(ctx, txn, dbID)
+	if err != nil {
+		return "", err
+	}
+	if schema, ok := schemas[schemaID]; ok {
+		return schema, nil
+	}
+	return "", errors.Newf("unable to resolve schema id %d for db %d", schemaID, dbID)
+}
+
+// GetForDatabase looks up and returns all available
+// schema ids to names for a given database.
+func GetForDatabase(
+	ctx context.Context, txn *client.Txn, dbID sqlbase.ID,
+) (map[sqlbase.ID]string, error) {
+	log.Eventf(ctx, "fetching all schema descriptor IDs for %d", dbID)
+
+	nameKey := sqlbase.NewSchemaKey(dbID, "" /* name */).Key()
+	kvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /* maxRows */)
+	if err != nil {
+		return nil, err
+	}
+
+	// Always add public schema ID.
+	// TODO(solon): This can be removed in 20.2, when this is always written.
+	// In 20.1, in a migrating state, it may be not included yet.
+	ret := make(map[sqlbase.ID]string, len(kvs)+1)
+	ret[sqlbase.ID(keys.PublicSchemaID)] = tree.PublicSchema
+
+	for _, kv := range kvs {
+		id := sqlbase.ID(kv.ValueInt())
+		if _, ok := ret[id]; ok {
+			continue
+		}
+		_, _, name, err := sqlbase.DecodeNameMetadataKey(kv.Key)
+		if err != nil {
+			return nil, err
+		}
+		ret[id] = name
+	}
+	return ret, nil
+}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -678,7 +679,7 @@ func (tc *TableCollection) getSchemasForDatabase(
 	}
 	if _, ok := tc.cachedDatabaseToSchemas[dbID]; !ok {
 		var err error
-		tc.cachedDatabaseToSchemas[dbID], err = GetSchemasForDatabase(ctx, txn, dbID)
+		tc.cachedDatabaseToSchemas[dbID], err = schema.GetForDatabase(ctx, txn, dbID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We previously assumed PublicSchema for printing out bad FK
related errors for display, but this invariant no longer holds for
temporary tables. The aim for this PR is to fix that.

To do this, this PR adds a new package `schema` which contains
functionality that allows for resolving schema names by ID
without introducing a cyclic dependency on `sql/row` and `sql`. This can
go away once we use descriptors to store name data, instead of requiring
a KV lookup.

Release note: None