### PR TITLE
opt: remap provided ordering for DistinctOn

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2034,3 +2034,18 @@ SELECT max(z) FROM xyz WHERE y = 100 GROUP BY y
 
 statement ok
 DROP TABLE xyz
+
+# Regression test for #44469 (DistinctOn needs to remap the provided ordering).
+statement ok
+CREATE TABLE t44469_a (a INT, INDEX (a))
+
+statement ok
+CREATE TABLE t44469_b (b INT, INDEX (b))
+
+statement ok
+CREATE TABLE t44469_cd (c INT, d INT, INDEX (c, d));
+
+statement ok
+SELECT DISTINCT ON (b) b
+FROM t44469_a INNER LOOKUP JOIN t44469_b ON a = b INNER LOOKUP JOIN t44469_cd ON c = 1 AND d = a
+ORDER BY b

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -329,7 +329,7 @@ distinct-on
  ├── ordering: +4,+2
  └── sort
       ├── columns: b:2(int!null) d:4(int!null) x:5(int!null)
-      ├── ordering: +4,+2
+      ├── ordering: +4,+2 opt(5)
       └── project
            ├── columns: x:5(int!null) b:2(int!null) d:4(int!null)
            ├── scan abcd

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -88,7 +88,13 @@ func distinctOnBuildChildReqOrdering(
 	if childIdx != 0 {
 		return physical.OrderingChoice{}
 	}
-	return required.Intersection(&parent.(*memo.DistinctOnExpr).Ordering)
+	// The FD set of the input doesn't "pass through" to the DistinctOn FD set;
+	// check the ordering to see if it can be simplified with respect to the input
+	// FD set.
+	distinctOn := parent.(*memo.DistinctOnExpr)
+	result := required.Intersection(&distinctOn.Ordering)
+	result.Simplify(&distinctOn.Input.Relational().FuncDeps)
+	return result
 }
 
 func distinctOnBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -61,19 +61,10 @@ func groupByBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) 
 	provided := groupBy.Input.ProvidedPhysical().Ordering
 	inputFDs := &groupBy.Input.Relational().FuncDeps
 
-	// GroupBy can only provide orderings on grouping columns. We retain the
-	// longest prefix of grouping columns (or columns equivalent to any of them).
-	groupingCols := inputFDs.ComputeEquivClosure(groupBy.GroupingCols)
-	for i := range provided {
-		if !groupingCols.Contains(provided[i].ID()) {
-			provided = provided[:i]
-			break
-		}
-	}
-	provided = remapProvided(provided, inputFDs, groupBy.GroupingCols)
 	// Since the input's provided ordering has to satisfy both <required> and the
 	// GroupBy internal ordering, it may need to be trimmed.
-	return trimProvided(provided, required, &expr.Relational().FuncDeps)
+	provided = trimProvided(provided, required, inputFDs)
+	return remapProvided(provided, inputFDs, groupBy.GroupingCols)
 }
 
 func distinctOnCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
@@ -98,10 +89,13 @@ func distinctOnBuildChildReqOrdering(
 }
 
 func distinctOnBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
-	// The input's provided ordering satisfies both <required> and the DistinctOn
-	// internal ordering; it may need to be trimmed.
-	d := expr.(*memo.DistinctOnExpr)
-	return trimProvided(d.Input.ProvidedPhysical().Ordering, required, &d.Relational().FuncDeps)
+	distinctOn := expr.(*memo.DistinctOnExpr)
+	provided := distinctOn.Input.ProvidedPhysical().Ordering
+	inputFDs := &distinctOn.Input.Relational().FuncDeps
+	// Since the input's provided ordering has to satisfy both <required> and the
+	// DistinctOn internal ordering, it may need to be trimmed.
+	provided = trimProvided(provided, required, inputFDs)
+	return remapProvided(provided, inputFDs, distinctOn.Relational().OutputCols)
 }
 
 // StreamingGroupingColOrdering returns an ordering on grouping columns that is

--- a/pkg/sql/opt/ordering/group_by_test.go
+++ b/pkg/sql/opt/ordering/group_by_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+func TestDistinctOnProvided(t *testing.T) {
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+	var f norm.Factory
+	f.Init(evalCtx, testcat.New())
+	md := f.Metadata()
+	for i := 1; i <= 5; i++ {
+		md.AddColumn(fmt.Sprintf("c%d", i), types.Int)
+	}
+	c := func(cols ...opt.ColumnID) opt.ColSet {
+		return opt.MakeColSet(cols...)
+	}
+
+	fd1eq5 := props.FuncDepSet{}
+	fd1eq5.AddEquivalency(1, 5)
+
+	// DistinctOn might not project all input columns, so we have three sets of
+	// columns, corresponding to this SQL:
+	//   SELECT <outCols> FROM
+	//     SELECT DISTINCT ON(<groupingCols>) <inputCols>
+	testCases := []struct {
+		inCols       opt.ColSet
+		inFDs        props.FuncDepSet
+		outCols      opt.ColSet
+		groupingCols opt.ColSet
+		required     string
+		internal     string
+		input        string
+		expected     string
+	}{
+		{ // case 1: Internal ordering is stronger; the provided ordering needs
+			//         trimming.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        props.FuncDepSet{},
+			outCols:      c(1, 2, 3, 4, 5),
+			groupingCols: c(1, 2),
+			required:     "+1",
+			internal:     "+1,+5",
+			input:        "+1,+5",
+			expected:     "+1",
+		},
+		{ // case 2: Projecting all input columns; ok to pass through provided.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3, 4, 5),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "",
+			input:        "+5",
+			expected:     "+5",
+		},
+		{ // case 3: Not projecting all input columns; the provided ordering
+			//         needs remapping.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "",
+			input:        "+5",
+			expected:     "+1",
+		},
+		{ // case 4: The provided ordering needs both trimming and remapping.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "+5,+4",
+			input:        "+5,+4",
+			expected:     "+1",
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			input := &testexpr.Instance{
+				Rel: &props.Relational{
+					OutputCols: tc.outCols,
+					FuncDeps:   fd1eq5,
+				},
+				Provided: &physical.Provided{
+					Ordering: physical.ParseOrdering(tc.input),
+				},
+			}
+			p := memo.GroupingPrivate{
+				GroupingCols: tc.groupingCols,
+				Ordering:     physical.ParseOrderingChoice(tc.internal),
+			}
+			var aggs memo.AggregationsExpr
+			tc.outCols.Difference(tc.groupingCols).ForEach(func(col opt.ColumnID) {
+				aggs = append(aggs, f.ConstructAggregationsItem(
+					f.ConstructFirstAgg(f.ConstructVariable(col)),
+					col,
+				))
+			})
+			distinctOn := f.Memo().MemoizeDistinctOn(input, aggs, &p)
+			req := physical.ParseOrderingChoice(tc.required)
+			res := distinctOnBuildProvided(distinctOn, &req).String()
+			if res != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, res)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -146,9 +146,7 @@ func TestPhysicalProps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(
 		t, "testdata/physprops/",
-		memo.ExprFmtHideMiscProps|
-			memo.ExprFmtHideConstraints|
-			memo.ExprFmtHideFuncDeps|
+		memo.ExprFmtHideConstraints|
 			memo.ExprFmtHideRuleProps|
 			memo.ExprFmtHideStats|
 			memo.ExprFmtHideCost|

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -57,16 +57,25 @@ SELECT * FROM (SELECT * FROM t OFFSET 5) WITH ORDINALITY ORDER BY ordinality LIM
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) ordinality:4(int!null)
  ├── internal-ordering: +4
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (4)-->(1-3)
  ├── ordering: +4
  ├── ordinality
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) ordinality:4(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (4)-->(1-3)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
  │    └── offset
  │         ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,3)
  │         ├── limit hint: 10.00
  │         ├── scan t
  │         │    ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2,3)
  │         │    └── limit hint: 15.00
  │         └── const: 5 [type=int]
  └── const: 10 [type=int]
@@ -81,16 +90,23 @@ SELECT * FROM (SELECT * FROM t UNION SELECT * from t) LIMIT 10
 ----
 limit
  ├── columns: x:7(int!null) y:8(int) z:9(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (7-9)
  ├── union
  │    ├── columns: x:7(int!null) y:8(int) z:9(int)
  │    ├── left columns: t.x:1(int) t.y:2(int) t.z:3(int)
  │    ├── right columns: t.x:4(int) t.y:5(int) t.z:6(int)
+ │    ├── key: (7-9)
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: t.x:1(int!null) t.y:2(int) t.z:3(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
  │    │    └── limit hint: 10.00
  │    └── scan t
  │         ├── columns: t.x:4(int!null) t.y:5(int) t.z:6(int)
+ │         ├── key: (4)
+ │         ├── fd: (4)-->(5,6)
  │         └── limit hint: 10.00
  └── const: 10 [type=int]
 
@@ -99,6 +115,7 @@ SELECT * FROM (SELECT * FROM t UNION ALL SELECT * from t) LIMIT 10
 ----
 limit
  ├── columns: x:7(int!null) y:8(int) z:9(int)
+ ├── cardinality: [0 - 10]
  ├── union-all
  │    ├── columns: x:7(int!null) y:8(int) z:9(int)
  │    ├── left columns: t.x:1(int) t.y:2(int) t.z:3(int)
@@ -106,9 +123,13 @@ limit
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: t.x:1(int!null) t.y:2(int) t.z:3(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
  │    │    └── limit hint: 10.00
  │    └── scan t
  │         ├── columns: t.x:4(int!null) t.y:5(int) t.z:6(int)
+ │         ├── key: (4)
+ │         ├── fd: (4)-->(5,6)
  │         └── limit hint: 10.00
  └── const: 10 [type=int]
 
@@ -117,10 +138,13 @@ SELECT * FROM (SELECT z FROM t INTERSECT SELECT y from t) LIMIT 10
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (3)
  ├── intersect
  │    ├── columns: z:3(int)
  │    ├── left columns: z:3(int)
  │    ├── right columns: y:5(int)
+ │    ├── key: (3)
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: z:3(int)
@@ -135,6 +159,7 @@ SELECT * FROM (SELECT z FROM t INTERSECT ALL SELECT y from t) LIMIT 10
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 10]
  ├── intersect-all
  │    ├── columns: z:3(int)
  │    ├── left columns: z:3(int)
@@ -153,10 +178,13 @@ SELECT * FROM (SELECT z FROM t EXCEPT SELECT y from t) LIMIT 10
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (3)
  ├── except
  │    ├── columns: z:3(int)
  │    ├── left columns: z:3(int)
  │    ├── right columns: y:5(int)
+ │    ├── key: (3)
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: z:3(int)
@@ -171,6 +199,7 @@ SELECT * FROM (SELECT z FROM t EXCEPT ALL SELECT y from t) LIMIT 10
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 10]
  ├── except-all
  │    ├── columns: z:3(int)
  │    ├── left columns: z:3(int)
@@ -194,14 +223,21 @@ SELECT * FROM t WHERE z=1 LIMIT 10
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
  ├── select
  │    ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
  │    │    └── limit hint: 50.00
  │    └── filters
- │         └── z = 1 [type=bool]
+ │         └── z = 1 [type=bool, outer=(3), fd=()-->(3)]
  └── const: 10 [type=int]
 
 # DistinctOn operator.
@@ -210,9 +246,12 @@ SELECT DISTINCT z FROM t LIMIT 2
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (3)
  ├── distinct-on
  │    ├── columns: z:3(int)
  │    ├── grouping columns: z:3(int)
+ │    ├── key: (3)
  │    ├── limit hint: 2.00
  │    └── scan t
  │         ├── columns: z:3(int)
@@ -225,9 +264,12 @@ SELECT DISTINCT z FROM t LIMIT 10
 ----
 limit
  ├── columns: z:3(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (3)
  ├── distinct-on
  │    ├── columns: z:3(int)
  │    ├── grouping columns: z:3(int)
+ │    ├── key: (3)
  │    ├── limit hint: 10.00
  │    └── scan t
  │         └── columns: z:3(int)
@@ -238,13 +280,20 @@ SELECT * FROM t WHERE z=4 LIMIT 10
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
  ├── select
  │    ├── columns: x:1(int!null) y:2(int) z:3(int!null)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
  │    ├── limit hint: 10.00
  │    ├── scan t
- │    │    └── columns: x:1(int!null) y:2(int) z:3(int)
+ │    │    ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
  │    └── filters
- │         └── z = 4 [type=bool]
+ │         └── z = 4 [type=bool, outer=(3), fd=()-->(3)]
  └── const: 10 [type=int]
 
 
@@ -259,9 +308,14 @@ SELECT z FROM t@y_idx WITH ORDINALITY ORDER BY ordinality LIMIT 10
 limit
  ├── columns: z:3(int)  [hidden: ordinality:4(int!null)]
  ├── internal-ordering: +4
+ ├── cardinality: [0 - 10]
+ ├── key: (4)
+ ├── fd: (4)-->(3)
  ├── ordering: +4
  ├── ordinality
  │    ├── columns: z:3(int) ordinality:4(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(3)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
  │    └── index-join t
@@ -270,6 +324,7 @@ limit
  │         └── scan t@y_idx
  │              ├── columns: x:1(int!null)
  │              ├── flags: force-index=y_idx
+ │              ├── key: (1)
  │              └── limit hint: 10.00
  └── const: 10 [type=int]
 
@@ -280,13 +335,20 @@ SELECT * FROM t WITH ORDINALITY ORDER BY ordinality LIMIT 10
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) ordinality:4(int!null)
  ├── internal-ordering: +4
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (4)-->(1-3)
  ├── ordering: +4
  ├── ordinality
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) ordinality:4(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (4)-->(1-3)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
  │    └── scan t
  │         ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,3)
  │         └── limit hint: 10.00
  └── const: 10 [type=int]
 
@@ -297,13 +359,19 @@ SELECT * FROM (SELECT 1 FROM t) WITH ORDINALITY ORDER BY ordinality LIMIT 10
 limit
  ├── columns: "?column?":4(int!null) ordinality:5(int!null)
  ├── internal-ordering: +5 opt(4)
- ├── ordering: +5 opt(4)
+ ├── cardinality: [0 - 10]
+ ├── key: (5)
+ ├── fd: ()-->(4)
+ ├── ordering: +5 opt(4) [actual: +5]
  ├── ordinality
  │    ├── columns: "?column?":4(int!null) ordinality:5(int!null)
- │    ├── ordering: +5 opt(4)
+ │    ├── key: (5)
+ │    ├── fd: ()-->(4)
+ │    ├── ordering: +5 opt(4) [actual: +5]
  │    ├── limit hint: 10.00
  │    └── project
  │         ├── columns: "?column?":4(int!null)
+ │         ├── fd: ()-->(4)
  │         ├── limit hint: 10.00
  │         ├── scan t@y_idx
  │         │    └── limit hint: 10.00
@@ -317,14 +385,21 @@ SELECT *, generate_series(1, t.x) FROM t LIMIT 10
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) generate_series:4(int)
+ ├── cardinality: [0 - 10]
+ ├── side-effects
+ ├── fd: (1)-->(2,3)
  ├── project-set
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) generate_series:4(int)
+ │    ├── side-effects
+ │    ├── fd: (1)-->(2,3)
  │    ├── limit hint: 10.00
  │    ├── scan t
  │    │    ├── columns: x:1(int!null) y:2(int) z:3(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
  │    │    └── limit hint: 10.00
  │    └── zip
- │         └── function: generate_series [type=int]
+ │         └── function: generate_series [type=int, outer=(1), side-effects]
  │              ├── const: 1 [type=int]
  │              └── variable: x [type=int]
  └── const: 10 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -31,6 +31,8 @@ SELECT * FROM a ORDER BY x, y DESC
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1,-2
 
 # Order by prefix.
@@ -39,6 +41,8 @@ SELECT * FROM a ORDER BY x
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1
 
 # Order by additional column (should be dropped by optimizer).
@@ -47,6 +51,8 @@ SELECT * FROM a ORDER BY x, y DESC, z
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1,-2
 
 # Order by suffix (scan shouldn't be able to provide).
@@ -55,9 +61,13 @@ SELECT * FROM a ORDER BY y DESC
 ----
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: -2
  └── scan a
-      └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      └── fd: (1,2)-->(3,4)
 
 # Order by suffix, don't project prefix (scan shouldn't be able to provide).
 opt
@@ -79,12 +89,16 @@ SELECT * FROM a WHERE x>y ORDER BY x, y DESC
 ----
 select
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(3,4)
  │    └── ordering: +1,-2
  └── filters
-      └── x > y [type=bool]
+      └── x > y [type=bool, outer=(1,2)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -92,13 +106,19 @@ SELECT * FROM a WHERE x>y ORDER BY z DESC
 ----
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: -3
  └── select
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3,4)
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      │    ├── key: (1,2)
+      │    └── fd: (1,2)-->(3,4)
       └── filters
-           └── x > y [type=bool]
+           └── x > y [type=bool, outer=(1,2)]
 
 # --------------------------------------------------
 # Project operator (pass through).
@@ -110,12 +130,15 @@ SELECT x+1 AS r, y FROM a ORDER BY x, y DESC
 ----
 project
  ├── columns: r:5(int!null) y:2(float!null)  [hidden: x:1(int!null)]
+ ├── key: (1,2)
+ ├── fd: (1)-->(5)
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    └── ordering: +1,-2
  └── projections
-      └── x + 1 [type=int]
+      └── x + 1 [type=int, outer=(1)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -123,15 +146,21 @@ SELECT y, x, z+1 AS r FROM a ORDER BY x, y
 ----
 sort (segmented)
  ├── columns: y:2(float!null) x:1(int!null) r:5(decimal)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(5)
  ├── ordering: +1,+2
  └── project
       ├── columns: r:5(decimal) x:1(int!null) y:2(float!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(5)
       ├── ordering: +1
       ├── scan a
       │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+      │    ├── key: (1,2)
+      │    ├── fd: (1,2)-->(3)
       │    └── ordering: +1
       └── projections
-           └── z + 1 [type=decimal]
+           └── z + 1 [type=decimal, outer=(3)]
 
 # Ordering cannot be passed through because it includes computed column.
 opt
@@ -139,15 +168,20 @@ SELECT x, y+1 AS computed, y FROM a ORDER BY x, computed
 ----
 sort (segmented)
  ├── columns: x:1(int!null) computed:5(float!null) y:2(float!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(5)
  ├── ordering: +1,+5
  └── project
       ├── columns: computed:5(float!null) x:1(int!null) y:2(float!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(5)
       ├── ordering: +1
       ├── scan a
       │    ├── columns: x:1(int!null) y:2(float!null)
+      │    ├── key: (1,2)
       │    └── ordering: +1
       └── projections
-           └── y + 1.0 [type=float]
+           └── y + 1.0 [type=float, outer=(2)]
 
 # Ordering on an expression that gets constant-folded to a simple variable.
 # Example from #43360: a boolean (possibly a placeholder) indicates the sort
@@ -157,24 +191,32 @@ SELECT * FROM a ORDER BY CASE WHEN false THEN x END ASC, CASE WHEN NOT false THE
 ----
 project
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)  [hidden: column6:6(int!null)]
- ├── ordering: -(1|6)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4), (1)==(6), (6)==(1)
+ ├── ordering: -(1|6) [actual: -1]
  ├── scan a,rev
  │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(3,4)
  │    └── ordering: -1
  └── projections
-      └── variable: x [type=int]
+      └── variable: x [type=int, outer=(1)]
 
 opt
 SELECT * FROM a ORDER BY CASE WHEN true THEN x END ASC, CASE WHEN NOT true THEN x END DESC
 ----
 project
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)  [hidden: column5:5(int!null)]
- ├── ordering: +(1|5)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4), (1)==(5), (5)==(1)
+ ├── ordering: +(1|5) [actual: +1]
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(3,4)
  │    └── ordering: +1
  └── projections
-      └── variable: x [type=int]
+      └── variable: x [type=int, outer=(1)]
 
 # Similar case, except the equivalent input column is not being projected.
 opt
@@ -182,13 +224,14 @@ SELECT 1 FROM a ORDER BY CASE WHEN false THEN x END ASC, CASE WHEN NOT false THE
 ----
 project
  ├── columns: "?column?":5(int!null)  [hidden: column7:7(int!null)]
- ├── ordering: -7 opt(5)
+ ├── fd: ()-->(5)
+ ├── ordering: -7 opt(5) [actual: -7]
  ├── scan a,rev
  │    ├── columns: x:1(int!null)
  │    └── ordering: -1
  └── projections
       ├── const: 1 [type=int]
-      └── variable: x [type=int]
+      └── variable: x [type=int, outer=(1)]
 
 # --------------------------------------------------
 # Select + Project operators (pass through both).
@@ -200,17 +243,21 @@ SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
 project
  ├── columns: y:2(float!null) z:5(int!null)  [hidden: x:1(int!null)]
+ ├── key: (1,2)
+ ├── fd: (1)-->(5)
  ├── ordering: +1,-2
  ├── select
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    ├── ordering: +1,-2
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(float!null)
+ │    │    ├── key: (1,2)
  │    │    └── ordering: +1,-2
  │    └── filters
- │         └── x > y [type=bool]
+ │         └── x > y [type=bool, outer=(1,2)]
  └── projections
-      └── x - 1 [type=int]
+      └── x - 1 [type=int, outer=(1)]
 
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
@@ -256,10 +303,14 @@ sort
       ├── columns: y:2(float!null) z:3(decimal)
       └── select
            ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           ├── key: (1,2)
+           ├── fd: (1,2)-->(3)
            ├── scan a
-           │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           │    ├── key: (1,2)
+           │    └── fd: (1,2)-->(3)
            └── filters
-                └── x > y [type=bool]
+                └── x > y [type=bool, outer=(1,2)]
 
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
@@ -303,13 +354,16 @@ SELECT array_agg(z) FROM (SELECT * FROM a ORDER BY y)
 scalar-group-by
  ├── columns: array_agg:5(decimal[])
  ├── internal-ordering: +2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
  ├── sort
  │    ├── columns: y:2(float!null) z:3(decimal)
  │    ├── ordering: +2
  │    └── scan a
  │         └── columns: y:2(float!null) z:3(decimal)
  └── aggregations
-      └── array-agg [type=decimal[]]
+      └── array-agg [type=decimal[], outer=(3)]
            └── variable: z [type=decimal]
 
 opt
@@ -318,11 +372,15 @@ SELECT array_agg(x) FROM (SELECT * FROM a ORDER BY x, y DESC)
 scalar-group-by
  ├── columns: array_agg:5(int[])
  ├── internal-ordering: +1,-2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    └── ordering: +1,-2
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(1)]
            └── variable: x [type=int]
 
 # Pass through ordering on grouping columns.
@@ -332,12 +390,14 @@ SELECT a, min(b) FROM abc GROUP BY a ORDER BY a
 group-by
  ├── columns: a:1(int!null) min:4(int)
  ├── grouping columns: a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(4)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null)
  │    └── ordering: +1
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(2)]
            └── variable: b [type=int]
 
 opt
@@ -347,12 +407,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -361,12 +424,15 @@ SELECT a, b, min(c) FROM abc GROUP BY a, b ORDER BY a, b
 group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -375,12 +441,15 @@ SELECT a, b, min(c) FROM abc GROUP BY b, a ORDER BY a, b
 group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # We can't pass through the ordering if it refers to aggregation results.
@@ -389,17 +458,22 @@ SELECT a, b, min(c) AS m FROM abc GROUP BY a, b ORDER BY a, m
 ----
 sort (segmented)
  ├── columns: a:1(int!null) b:2(int!null) m:4(int)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+4
  └── group-by
       ├── columns: a:1(int!null) b:2(int!null) min:4(int)
       ├── grouping columns: a:1(int!null) b:2(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(4)
       ├── ordering: +1
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── aggregations
-           └── min [type=int]
+           └── min [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # Satisfy both the required and the internal orderings by requiring a+,b+,c+.
@@ -410,12 +484,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -425,12 +502,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -440,12 +520,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 # Verify that the GroupBy child ordering is simplified according to the child's
@@ -456,13 +539,17 @@ SELECT sum(c) FROM abc WHERE a = 1 GROUP BY b ORDER BY b
 group-by
  ├── columns: sum:4(decimal)  [hidden: b:2(int!null)]
  ├── grouping columns: b:2(int!null)
+ ├── key: (2)
+ ├── fd: (2)-->(4)
  ├── ordering: +2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    ├── constraint: /1/2/3: [/1 - /1]
- │    └── ordering: +2 opt(1)
+ │    ├── key: (2,3)
+ │    ├── fd: ()-->(1)
+ │    └── ordering: +2 opt(1) [actual: +2]
  └── aggregations
-      └── sum [type=decimal]
+      └── sum [type=decimal, outer=(3)]
            └── variable: c [type=int]
 
 # Verify we do a streaming group-by using the a, b ordering.
@@ -475,11 +562,13 @@ project
       ├── columns: a:1(int) b:2(int) c:3(int) sum:6(decimal)
       ├── grouping columns: a:1(int) b:2(int) c:3(int)
       ├── internal-ordering: +1,+2
+      ├── key: (1-3)
+      ├── fd: (1-3)-->(6)
       ├── scan abcd@ab
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
       │    └── ordering: +1,+2
       └── aggregations
-           └── sum [type=decimal]
+           └── sum [type=decimal, outer=(4)]
                 └── variable: d [type=int]
 
 # Verify we do a streaming group-by using the c, d ordering.
@@ -492,11 +581,13 @@ project
       ├── columns: b:2(int) c:3(int) d:4(int) sum:6(decimal)
       ├── grouping columns: b:2(int) c:3(int) d:4(int)
       ├── internal-ordering: +3,+4
+      ├── key: (2-4)
+      ├── fd: (2-4)-->(6)
       ├── scan abcd@cd
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
       │    └── ordering: +3,+4
       └── aggregations
-           └── sum [type=decimal]
+           └── sum [type=decimal, outer=(1)]
                 └── variable: a [type=int]
 
 opt
@@ -508,11 +599,13 @@ project
       ├── columns: a:1(int) b:2(int) array_agg:6(int[])
       ├── grouping columns: a:1(int) b:2(int)
       ├── internal-ordering: +3 opt(1,2)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(6)
       ├── scan abcd@cd
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
-      │    └── ordering: +3 opt(1,2)
+      │    └── ordering: +3 opt(1,2) [actual: +3]
       └── aggregations
-           └── array-agg [type=int[]]
+           └── array-agg [type=int[], outer=(4)]
                 └── variable: d [type=int]
 
 # --------------------------------------------------
@@ -526,9 +619,13 @@ explain
  ├── mode: verbose
  └── sort
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3,4)
       ├── ordering: +2
       └── scan a
-           └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+           ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+           ├── key: (1,2)
+           └── fd: (1,2)-->(3,4)
 
 memo
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
@@ -670,12 +767,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4)
+ ├── key: (2-6)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -686,12 +787,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4)
+ ├── key: (2-6)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -703,12 +808,15 @@ left-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
  ├── left ordering: +1
  ├── right ordering: +4
+ ├── key: (1-6)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -718,16 +826,20 @@ SELECT * FROM abc LEFT JOIN xyz ON a=x ORDER BY x
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
+ ├── key: (1-6)
  ├── ordering: +4
  └── left-join (merge)
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
       ├── left ordering: +1
       ├── right ordering: +4
+      ├── key: (1-6)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       └── filters (true)
 
@@ -737,16 +849,20 @@ SELECT * FROM abc RIGHT JOIN xyz ON a=x ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── key: (1-6)
  ├── ordering: +1
  └── left-join (merge)
       ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
       ├── left ordering: +4
       ├── right ordering: +1
+      ├── key: (1-6)
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       └── filters (true)
 
@@ -757,12 +873,15 @@ left-join (merge)
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +4
  ├── right ordering: +1
+ ├── key: (1-6)
  ├── ordering: +4
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  └── filters (true)
 
@@ -771,16 +890,20 @@ SELECT * FROM abc FULL OUTER JOIN xyz ON a=x ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
+ ├── key: (1-6)
  ├── ordering: +1
  └── full-join (merge)
       ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
       ├── left ordering: +1
       ├── right ordering: +4
+      ├── key: (1-6)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       └── filters (true)
 
@@ -791,12 +914,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -807,12 +934,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4),+(2|5)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4),+(2|5) [actual: +1,+2]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -823,12 +954,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4),+(2|5)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4),+(2|5) [actual: +1,+2]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -844,6 +979,7 @@ SELECT * FROM abc ORDER BY a, b LIMIT 10
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1,+2
 
 # The filter prevents pushing of the limit into the scan.
@@ -853,17 +989,21 @@ SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1,+2
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── limit hint: 10.00
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    ├── ordering: +1,+2
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -872,9 +1012,11 @@ SELECT * FROM abc ORDER BY a, b OFFSET 10
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── const: 10 [type=int]
 
@@ -887,30 +1029,39 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +2
  └── scan abc
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      └── limit: 10
+      ├── limit: 10
+      └── key: (1-3)
 
 opt
 SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +2
  └── limit
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── internal-ordering: +1,+2
+      ├── cardinality: [0 - 10]
+      ├── key: (1-3)
       ├── select
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    ├── ordering: +1,+2
       │    ├── limit hint: 10.00
       │    ├── scan abc
       │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    ├── key: (1-3)
       │    │    ├── ordering: +1,+2
       │    │    └── limit hint: 30.00
       │    └── filters
-      │         └── c < (a + b) [type=bool]
+      │         └── c < (a + b) [type=bool, outer=(1-3)]
       └── const: 10 [type=int]
 
 opt
@@ -918,12 +1069,15 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── key: (1-3)
  ├── ordering: +2
  └── offset
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1-3)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── const: 10 [type=int]
 
@@ -937,6 +1091,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1
 
 opt
@@ -945,17 +1100,21 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── limit hint: 10.00
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    ├── ordering: +1,+2
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -964,9 +1123,11 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── const: 10 [type=int]
 
@@ -979,6 +1140,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a, b, c
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1,+2,+3
 
 opt
@@ -987,17 +1149,21 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a,
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1,+2,+3
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2,+3
  │    ├── limit hint: 10.00
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    ├── ordering: +1,+2,+3
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -1006,9 +1172,11 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a, b, c
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1,+2,+3
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── const: 10 [type=int]
 
@@ -1025,6 +1193,7 @@ SELECT DISTINCT b, c FROM abc ORDER BY b
 distinct-on
  ├── columns: b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── key: (2,3)
  ├── ordering: +2
  └── sort
       ├── columns: b:2(int!null) c:3(int!null)
@@ -1038,6 +1207,7 @@ SELECT DISTINCT a, b, c FROM abc ORDER BY a, b
 ----
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── key: (1-3)
  └── ordering: +1,+2
 
 # DISTINCT ON requires the ordering of its input, as it affects the results
@@ -1048,14 +1218,18 @@ SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY b
 distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +2
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +2
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── key: (1-3)
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 opt
@@ -1065,14 +1239,18 @@ distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1 opt(2,3)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +2,+3
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +2,+3,+1
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── key: (1-3)
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 opt
@@ -1082,15 +1260,19 @@ distinct-on
  ├── columns: a:1(int!null) c:3(int)
  ├── grouping columns: a:1(int!null)
  ├── internal-ordering: -3,+2 opt(1)
+ ├── key: (1)
+ ├── fd: (1)-->(3)
  ├── ordering: +1
  ├── sort (segmented)
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,-3,+2
  │    └── scan abc
  │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── key: (1-3)
  │         └── ordering: +1
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # Pass through the ordering from above.
@@ -1101,12 +1283,15 @@ distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # Internal orderings that refer just to ON columns can be ignored.
@@ -1116,12 +1301,15 @@ SELECT * FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc ORDER BY a) ORDER BY a
 distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -1131,12 +1319,15 @@ distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # The c,b part of the inner ordering can be ignored.
@@ -1147,12 +1338,15 @@ distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1 opt(2,3)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 # There is no ordering that satisfies both the intra-group ordering of c+ and the
@@ -1162,20 +1356,26 @@ SELECT * FROM (SELECT DISTINCT ON (b) a, b, c FROM abc ORDER BY b, c) ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int!null) c:3(int)
+ ├── key: (2)
+ ├── fd: (2)-->(1,3)
  ├── ordering: +1
  └── distinct-on
       ├── columns: a:1(int) b:2(int!null) c:3(int)
       ├── grouping columns: b:2(int!null)
       ├── internal-ordering: +3 opt(2)
+      ├── key: (2)
+      ├── fd: (2)-->(1,3)
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: +3 opt(2)
+      │    ├── key: (1-3)
+      │    ├── ordering: +3 opt(2) [actual: +3]
       │    └── scan abc
-      │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │         └── key: (1-3)
       └── aggregations
-           ├── first-agg [type=int]
+           ├── first-agg [type=int, outer=(1)]
            │    └── variable: a [type=int]
-           └── first-agg [type=int]
+           └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # Same as above, except we can use the index ordering for the distinct input.
@@ -1184,18 +1384,23 @@ SELECT * FROM (SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b) ORDER BY c
 ----
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
  ├── ordering: +3
  └── distinct-on
       ├── columns: a:1(int!null) b:2(int) c:3(int)
       ├── grouping columns: a:1(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── aggregations
-           ├── first-agg [type=int]
+           ├── first-agg [type=int, outer=(2)]
            │    └── variable: b [type=int]
-           └── first-agg [type=int]
+           └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # --------------------------------------------------
@@ -1208,34 +1413,49 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz ORDER BY y, z LIMIT 2 RETURNING
 ----
 sort
  ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
+ ├── cardinality: [0 - 2]
+ ├── side-effects, mutations
+ ├── key: (7-9)
  ├── ordering: +8
  └── with &1
       ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
+      ├── cardinality: [0 - 2]
+      ├── side-effects, mutations
+      ├── key: (7-9)
       ├── insert abc
       │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null)
       │    ├── insert-mapping:
       │    │    ├──  x:4 => abc.a:1
       │    │    ├──  y:5 => abc.b:2
       │    │    └──  z:6 => abc.c:3
+      │    ├── cardinality: [0 - 2]
+      │    ├── side-effects, mutations
+      │    ├── key: (1-3)
       │    └── limit
       │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
       │         ├── internal-ordering: +5,+6
+      │         ├── cardinality: [0 - 2]
+      │         ├── key: (4-6)
       │         ├── sort
       │         │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │    ├── key: (4-6)
       │         │    ├── ordering: +5,+6
       │         │    ├── limit hint: 2.00
       │         │    └── scan xyz
-      │         │         └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │         └── key: (4-6)
       │         └── const: 2 [type=int]
       └── with-scan &1
            ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
-           └── mapping:
-                ├──  abc.a:1(int) => a:7(int)
-                ├──  abc.b:2(int) => b:8(int)
-                └──  abc.c:3(int) => c:9(int)
+           ├── mapping:
+           │    ├──  abc.a:1(int) => a:7(int)
+           │    ├──  abc.b:2(int) => b:8(int)
+           │    └──  abc.c:3(int) => c:9(int)
+           ├── cardinality: [0 - 2]
+           └── key: (7-9)
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [INSERT INTO xyz SELECT b, c, d FROM abcd ORDER BY c, d LIMIT 2 RETURNING *]
 ORDER BY y
@@ -1245,12 +1465,10 @@ sort
  ├── cardinality: [0 - 2]
  ├── side-effects, mutations
  ├── ordering: +10
- ├── prune: (9-11)
  └── with &1
       ├── columns: x:9(int!null) y:10(int!null) z:11(int!null)
       ├── cardinality: [0 - 2]
       ├── side-effects, mutations
-      ├── prune: (9-11)
       ├── insert xyz
       │    ├── columns: xyz.x:1(int!null) xyz.y:2(int!null) xyz.z:3(int!null)
       │    ├── insert-mapping:
@@ -1261,21 +1479,18 @@ sort
       │    ├── side-effects, mutations
       │    └── scan abcd@cd
       │         ├── columns: b:5(int) c:6(int) d:7(int)
-      │         ├── limit: 2
-      │         ├── prune: (5)
-      │         └── interesting orderings: (+6,+7)
+      │         └── limit: 2
       └── with-scan &1
            ├── columns: x:9(int!null) y:10(int!null) z:11(int!null)
            ├── mapping:
            │    ├──  xyz.x:1(int) => x:9(int)
            │    ├──  xyz.y:2(int) => y:10(int)
            │    └──  xyz.z:3(int) => z:11(int)
-           ├── cardinality: [0 - 2]
-           └── prune: (9-11)
+           └── cardinality: [0 - 2]
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [INSERT INTO xyz SELECT b, c, d FROM abcd ORDER BY c, d LIMIT 2 RETURNING *]
 WHERE x=y
@@ -1287,13 +1502,11 @@ sort
  ├── side-effects, mutations
  ├── fd: (9)==(10), (10)==(9)
  ├── ordering: +(9|10) [actual: +9]
- ├── prune: (11)
  └── with &1
       ├── columns: x:9(int!null) y:10(int!null) z:11(int!null)
       ├── cardinality: [0 - 2]
       ├── side-effects, mutations
       ├── fd: (9)==(10), (10)==(9)
-      ├── prune: (11)
       ├── insert xyz
       │    ├── columns: xyz.x:1(int!null) xyz.y:2(int!null) xyz.z:3(int!null)
       │    ├── insert-mapping:
@@ -1304,22 +1517,18 @@ sort
       │    ├── side-effects, mutations
       │    └── scan abcd@cd
       │         ├── columns: b:5(int) c:6(int) d:7(int)
-      │         ├── limit: 2
-      │         ├── prune: (5)
-      │         └── interesting orderings: (+6,+7)
+      │         └── limit: 2
       └── select
            ├── columns: x:9(int!null) y:10(int!null) z:11(int!null)
            ├── cardinality: [0 - 2]
            ├── fd: (9)==(10), (10)==(9)
-           ├── prune: (11)
            ├── with-scan &1
            │    ├── columns: x:9(int!null) y:10(int!null) z:11(int!null)
            │    ├── mapping:
            │    │    ├──  xyz.x:1(int) => x:9(int)
            │    │    ├──  xyz.y:2(int) => y:10(int)
            │    │    └──  xyz.z:3(int) => z:11(int)
-           │    ├── cardinality: [0 - 2]
-           │    └── prune: (9-11)
+           │    └── cardinality: [0 - 2]
            └── filters
                 └── x = y [type=bool, outer=(9,10), fd=(9)==(10), (10)==(9)]
 
@@ -1329,20 +1538,26 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz ORDER BY y, z RETURNING *]
 ----
 with &1
  ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
+ ├── side-effects, mutations
+ ├── key: (7-9)
  ├── insert abc
  │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null)
  │    ├── insert-mapping:
  │    │    ├──  x:4 => abc.a:1
  │    │    ├──  y:5 => abc.b:2
  │    │    └──  z:6 => abc.c:3
+ │    ├── side-effects, mutations
+ │    ├── key: (1-3)
  │    └── scan xyz
- │         └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │         └── key: (4-6)
  └── with-scan &1
       ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
-      └── mapping:
-           ├──  abc.a:1(int) => a:7(int)
-           ├──  abc.b:2(int) => b:8(int)
-           └──  abc.c:3(int) => c:9(int)
+      ├── mapping:
+      │    ├──  abc.a:1(int) => a:7(int)
+      │    ├──  abc.b:2(int) => b:8(int)
+      │    └──  abc.c:3(int) => c:9(int)
+      └── key: (7-9)
 
 # --------------------------------------------------
 # Update operator.
@@ -1354,34 +1569,48 @@ SELECT * FROM [UPDATE abcd SET (a, b)=(1, 2) RETURNING *] ORDER BY c
 ----
 sort
  ├── columns: a:13(int!null) b:14(int!null) c:15(int) d:16(int)
- ├── ordering: +15 opt(13,14)
+ ├── side-effects, mutations
+ ├── fd: ()-->(13,14)
+ ├── ordering: +15 opt(13,14) [actual: +15]
  └── with &1
       ├── columns: a:13(int!null) b:14(int!null) c:15(int) d:16(int)
+      ├── side-effects, mutations
+      ├── fd: ()-->(13,14)
       ├── project
       │    ├── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int) abcd.d:4(int)
+      │    ├── side-effects, mutations
+      │    ├── fd: ()-->(1,2)
       │    └── update abcd
       │         ├── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
       │         ├── update-mapping:
       │         │    ├──  column11:11 => abcd.a:1
       │         │    └──  column12:12 => abcd.b:2
+      │         ├── side-effects, mutations
+      │         ├── key: (5)
+      │         ├── fd: ()-->(1,2), (5)-->(3,4)
       │         └── project
       │              ├── columns: column11:11(int!null) column12:12(int!null) abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
+      │              ├── key: (10)
+      │              ├── fd: ()-->(11,12), (10)-->(6-9)
       │              ├── scan abcd
-      │              │    └── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
+      │              │    ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
+      │              │    ├── key: (10)
+      │              │    └── fd: (10)-->(6-9)
       │              └── projections
       │                   ├── const: 1 [type=int]
       │                   └── const: 2 [type=int]
       └── with-scan &1
            ├── columns: a:13(int!null) b:14(int!null) c:15(int) d:16(int)
-           └── mapping:
-                ├──  abcd.a:1(int) => a:13(int)
-                ├──  abcd.b:2(int) => b:14(int)
-                ├──  abcd.c:3(int) => c:15(int)
-                └──  abcd.d:4(int) => d:16(int)
+           ├── mapping:
+           │    ├──  abcd.a:1(int) => a:13(int)
+           │    ├──  abcd.b:2(int) => b:14(int)
+           │    ├──  abcd.c:3(int) => c:15(int)
+           │    └──  abcd.d:4(int) => d:16(int)
+           └── fd: ()-->(13,14)
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [UPDATE abcd SET b=b+1 ORDER BY c LIMIT 10 RETURNING *]
 ORDER BY c, d
@@ -1391,17 +1620,14 @@ sort
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── ordering: +14,+15
- ├── prune: (12-15)
  └── with &1
       ├── columns: a:12(int) b:13(int) c:14(int) d:15(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
-      ├── prune: (12-15)
       ├── project
       │    ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
       │    ├── cardinality: [0 - 10]
       │    ├── side-effects, mutations
-      │    ├── prune: (1-4)
       │    └── update abcd
       │         ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
@@ -1416,15 +1642,11 @@ sort
       │              ├── cardinality: [0 - 10]
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
-      │              ├── prune: (6-11)
-      │              ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
       │              ├── scan abcd@cd
       │              │    ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
       │              │    ├── limit: 10
       │              │    ├── key: (10)
-      │              │    ├── fd: (10)-->(6-9)
-      │              │    ├── prune: (6-10)
-      │              │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+      │              │    └── fd: (10)-->(6-9)
       │              └── projections
       │                   └── abcd.b + 1 [type=int, outer=(7)]
       └── with-scan &1
@@ -1434,12 +1656,11 @@ sort
            │    ├──  abcd.b:2(int) => b:13(int)
            │    ├──  abcd.c:3(int) => c:14(int)
            │    └──  abcd.d:4(int) => d:15(int)
-           ├── cardinality: [0 - 10]
-           └── prune: (12-15)
+           └── cardinality: [0 - 10]
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [UPDATE abcd SET b=b+1 ORDER BY c, d LIMIT 10 RETURNING *]
 WHERE b=c
@@ -1451,18 +1672,15 @@ sort
  ├── side-effects, mutations
  ├── fd: (13)==(14), (14)==(13)
  ├── ordering: +(13|14),+15 [actual: +13,+15]
- ├── prune: (12,15)
  └── with &1
       ├── columns: a:12(int) b:13(int!null) c:14(int!null) d:15(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── fd: (13)==(14), (14)==(13)
-      ├── prune: (12,15)
       ├── project
       │    ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
       │    ├── cardinality: [0 - 10]
       │    ├── side-effects, mutations
-      │    ├── prune: (1-4)
       │    └── update abcd
       │         ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
@@ -1477,22 +1695,17 @@ sort
       │              ├── cardinality: [0 - 10]
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
-      │              ├── prune: (6-11)
-      │              ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
       │              ├── scan abcd@cd
       │              │    ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
       │              │    ├── limit: 10
       │              │    ├── key: (10)
-      │              │    ├── fd: (10)-->(6-9)
-      │              │    ├── prune: (6-10)
-      │              │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+      │              │    └── fd: (10)-->(6-9)
       │              └── projections
       │                   └── abcd.b + 1 [type=int, outer=(7)]
       └── select
            ├── columns: a:12(int) b:13(int!null) c:14(int!null) d:15(int)
            ├── cardinality: [0 - 10]
            ├── fd: (13)==(14), (14)==(13)
-           ├── prune: (12,15)
            ├── with-scan &1
            │    ├── columns: a:12(int) b:13(int) c:14(int) d:15(int)
            │    ├── mapping:
@@ -1500,8 +1713,7 @@ sort
            │    │    ├──  abcd.b:2(int) => b:13(int)
            │    │    ├──  abcd.c:3(int) => c:14(int)
            │    │    └──  abcd.d:4(int) => d:15(int)
-           │    ├── cardinality: [0 - 10]
-           │    └── prune: (12-15)
+           │    └── cardinality: [0 - 10]
            └── filters
                 └── b = c [type=bool, outer=(13,14), fd=(13)==(14), (14)==(13)]
 
@@ -1524,9 +1736,11 @@ ORDER BY b
 ----
 sort
  ├── columns: a:14(int!null) b:15(int!null) c:16(int!null)
+ ├── side-effects, mutations
  ├── ordering: +15
  └── with &1
       ├── columns: a:14(int!null) b:15(int!null) c:16(int!null)
+      ├── side-effects, mutations
       ├── upsert abc
       │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null)
       │    ├── canary column: 7
@@ -1541,27 +1755,35 @@ sort
       │    │    ├──  upsert_a:11 => abc.a:1
       │    │    ├──  upsert_b:12 => abc.b:2
       │    │    └──  upsert_c:13 => abc.c:3
+      │    ├── side-effects, mutations
       │    └── project
       │         ├── columns: upsert_a:11(int!null) upsert_b:12(int) upsert_c:13(int) x:4(int!null) y:5(int!null) z:6(int!null) abc.a:7(int) abc.b:8(int) abc.c:9(int)
+      │         ├── key: (4-9)
+      │         ├── fd: (4,7)-->(11), (5,7,8)-->(12), (6,7,9)-->(13)
       │         ├── left-join (lookup abc)
       │         │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null) abc.a:7(int) abc.b:8(int) abc.c:9(int)
       │         │    ├── key columns: [4 5 6] = [7 8 9]
       │         │    ├── lookup columns are key
+      │         │    ├── key: (4-9)
       │         │    ├── limit
       │         │    │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
       │         │    │    ├── internal-ordering: +5,+6
+      │         │    │    ├── cardinality: [0 - 2]
+      │         │    │    ├── key: (4-6)
       │         │    │    ├── sort
       │         │    │    │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │    │    │    ├── key: (4-6)
       │         │    │    │    ├── ordering: +5,+6
       │         │    │    │    ├── limit hint: 2.00
       │         │    │    │    └── scan xyz
-      │         │    │    │         └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │    │    │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         │    │    │         └── key: (4-6)
       │         │    │    └── const: 2 [type=int]
       │         │    └── filters (true)
       │         └── projections
-      │              ├── CASE WHEN abc.a IS NULL THEN x ELSE 10 END [type=int]
-      │              ├── CASE WHEN abc.a IS NULL THEN y ELSE abc.b END [type=int]
-      │              └── CASE WHEN abc.a IS NULL THEN z ELSE abc.c END [type=int]
+      │              ├── CASE WHEN abc.a IS NULL THEN x ELSE 10 END [type=int, outer=(4,7)]
+      │              ├── CASE WHEN abc.a IS NULL THEN y ELSE abc.b END [type=int, outer=(5,7,8)]
+      │              └── CASE WHEN abc.a IS NULL THEN z ELSE abc.c END [type=int, outer=(6,7,9)]
       └── with-scan &1
            ├── columns: a:14(int!null) b:15(int!null) c:16(int!null)
            └── mapping:
@@ -1579,16 +1801,24 @@ SELECT * FROM [DELETE FROM abcd RETURNING *] ORDER BY c
 ----
 sort
  ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
+ ├── side-effects, mutations
  ├── ordering: +13
  └── with &1
       ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
+      ├── side-effects, mutations
       ├── project
       │    ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+      │    ├── side-effects, mutations
       │    └── delete abcd
       │         ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
+      │         ├── side-effects, mutations
+      │         ├── key: (5)
+      │         ├── fd: (5)-->(1-4)
       │         └── scan abcd
-      │              └── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
+      │              ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
+      │              ├── key: (10)
+      │              └── fd: (10)-->(6-9)
       └── with-scan &1
            ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
            └── mapping:
@@ -1598,7 +1828,7 @@ sort
                 └──  abcd.d:4(int) => d:14(int)
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [DELETE FROM abcd ORDER BY c LIMIT 10 RETURNING *]
 ORDER BY c, d
@@ -1608,17 +1838,14 @@ sort
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── ordering: +13,+14
- ├── prune: (11-14)
  └── with &1
       ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
-      ├── prune: (11-14)
       ├── project
       │    ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
       │    ├── cardinality: [0 - 10]
       │    ├── side-effects, mutations
-      │    ├── prune: (1-4)
       │    └── delete abcd
       │         ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
@@ -1630,9 +1857,7 @@ sort
       │              ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
       │              ├── limit: 10
       │              ├── key: (10)
-      │              ├── fd: (10)-->(6-9)
-      │              ├── prune: (6,7,9,10)
-      │              └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+      │              └── fd: (10)-->(6-9)
       └── with-scan &1
            ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
            ├── mapping:
@@ -1640,12 +1865,11 @@ sort
            │    ├──  abcd.b:2(int) => b:12(int)
            │    ├──  abcd.c:3(int) => c:13(int)
            │    └──  abcd.d:4(int) => d:14(int)
-           ├── cardinality: [0 - 10]
-           └── prune: (11-14)
+           └── cardinality: [0 - 10]
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [DELETE FROM abcd ORDER BY c, d LIMIT 10 RETURNING *]
 WHERE b=c
@@ -1657,18 +1881,15 @@ sort
  ├── side-effects, mutations
  ├── fd: (12)==(13), (13)==(12)
  ├── ordering: +(12|13),+14 [actual: +12,+14]
- ├── prune: (11,14)
  └── with &1
       ├── columns: a:11(int) b:12(int!null) c:13(int!null) d:14(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── fd: (12)==(13), (13)==(12)
-      ├── prune: (11,14)
       ├── project
       │    ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
       │    ├── cardinality: [0 - 10]
       │    ├── side-effects, mutations
-      │    ├── prune: (1-4)
       │    └── delete abcd
       │         ├── columns: abcd.a:1(int) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) rowid:5(int!null)
       │         ├── fetch columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int)
@@ -1680,14 +1901,11 @@ sort
       │              ├── columns: abcd.a:6(int) abcd.b:7(int) abcd.c:8(int) abcd.d:9(int) rowid:10(int!null)
       │              ├── limit: 10
       │              ├── key: (10)
-      │              ├── fd: (10)-->(6-9)
-      │              ├── prune: (6,7,10)
-      │              └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+      │              └── fd: (10)-->(6-9)
       └── select
            ├── columns: a:11(int) b:12(int!null) c:13(int!null) d:14(int)
            ├── cardinality: [0 - 10]
            ├── fd: (12)==(13), (13)==(12)
-           ├── prune: (11,14)
            ├── with-scan &1
            │    ├── columns: a:11(int) b:12(int) c:13(int) d:14(int)
            │    ├── mapping:
@@ -1695,8 +1913,7 @@ sort
            │    │    ├──  abcd.b:2(int) => b:12(int)
            │    │    ├──  abcd.c:3(int) => c:13(int)
            │    │    └──  abcd.d:4(int) => d:14(int)
-           │    ├── cardinality: [0 - 10]
-           │    └── prune: (11-14)
+           │    └── cardinality: [0 - 10]
            └── filters
                 └── b = c [type=bool, outer=(12,13), fd=(12)==(13), (13)==(12)]
 
@@ -1710,15 +1927,19 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4|6)
+ ├── key: (2,3,5,6)
+ ├── fd: (1)==(4,6), (4)==(1,6), (6)==(1,4)
+ ├── ordering: +(1|4|6) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters
-      └── x = z [type=bool]
+      └── x = z [type=bool, outer=(4,6), fd=(4)==(6), (6)==(4)]
 
 # TODO(justin): figure out when it is that window functions can preserve their
 # input ordering.
@@ -1727,10 +1948,13 @@ SELECT *, row_number() OVER() FROM abc ORDER BY a
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) row_number:4(int)
+ ├── key: (1-3)
  ├── ordering: +1
  └── window partition=()
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) row_number:4(int)
+      ├── key: (1-3)
       ├── scan abc
-      │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── key: (1-3)
       └── windows
            └── row-number [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1983,3 +1983,50 @@ sort
       │    └── key: (1-3)
       └── windows
            └── row-number [type=int]
+
+# Regression test for #44469 (DistinctOn needs to remap the provided ordering).
+exec-ddl
+CREATE TABLE t44469_a (a INT, INDEX (a))
+----
+
+exec-ddl
+CREATE TABLE t44469_b (b INT, INDEX (b))
+----
+
+exec-ddl
+CREATE TABLE t44469_cd (c INT, d INT, INDEX (c, d));
+----
+
+opt
+SELECT DISTINCT ON (b) b
+FROM t44469_a INNER LOOKUP JOIN t44469_b ON a = b INNER LOOKUP JOIN t44469_cd ON c = 1 AND d = a
+ORDER BY b
+----
+distinct-on
+ ├── columns: b:3(int!null)
+ ├── grouping columns: b:3(int!null)
+ ├── key: (3)
+ ├── ordering: +3
+ └── inner-join (lookup t44469_cd@secondary)
+      ├── columns: a:1(int!null) b:3(int!null) c:5(int!null) d:6(int!null)
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [8 1] = [5 6]
+      ├── fd: ()-->(5), (1)==(3,6), (3)==(1,6), (6)==(1,3)
+      ├── ordering: +(1|3|6) opt(5) [actual: +1]
+      ├── project
+      │    ├── columns: "project_const_col_@5":8(int!null) a:1(int!null) b:3(int!null)
+      │    ├── fd: ()-->(8), (1)==(3), (3)==(1)
+      │    ├── ordering: +(1|3) [actual: +1]
+      │    ├── inner-join (lookup t44469_b@secondary)
+      │    │    ├── columns: a:1(int!null) b:3(int!null)
+      │    │    ├── flags: force lookup join (into right side)
+      │    │    ├── key columns: [1] = [3]
+      │    │    ├── fd: (1)==(3), (3)==(1)
+      │    │    ├── ordering: +(1|3) [actual: +1]
+      │    │    ├── scan t44469_a@secondary
+      │    │    │    ├── columns: a:1(int)
+      │    │    │    └── ordering: +1
+      │    │    └── filters (true)
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── filters (true)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1403,6 +1403,31 @@ sort
            └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
+# Verify that we simplify the child ordering of DistinctOn.
+opt
+SELECT DISTINCT ON(a) a, b FROM abc WHERE a=c ORDER BY a
+----
+distinct-on
+ ├── columns: a:1(int!null) b:2(int)
+ ├── grouping columns: a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (2,3)
+ │    ├── fd: (1)==(3), (3)==(1)
+ │    ├── ordering: +(1|3) [actual: +1]
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
+ │    │    └── ordering: +1
+ │    └── filters
+ │         └── a = c [type=bool, outer=(1,3), fd=(1)==(3), (3)==(1)]
+ └── aggregations
+      └── first-agg [type=int, outer=(2)]
+           └── variable: b [type=int]
+
 # --------------------------------------------------
 # Insert operator.
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -11,7 +11,9 @@ opt
 SELECT a.y, a.x, a.y y2 FROM a
 ----
 scan a
- └── columns: y:2(int) x:1(int!null) y2:2(int)
+ ├── columns: y:2(int) x:1(int!null) y2:2(int)
+ ├── key: (1)
+ └── fd: (1)-->(2)
 
 # Select operator.
 opt
@@ -19,10 +21,14 @@ SELECT a.y, a.x, a.y y2 FROM a WHERE y=1
 ----
 select
  ├── columns: y:2(int!null) x:1(int!null) y2:2(int!null)
+ ├── key: (1)
+ ├── fd: ()-->(2)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── filters
-      └── y = 1 [type=bool]
+      └── y = 1 [type=bool, outer=(2), fd=()-->(2)]
 
 # Project operator.
 opt
@@ -30,10 +36,14 @@ SELECT 1+a.y AS plus, a.x FROM a
 ----
 project
  ├── columns: plus:3(int) x:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(3)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── projections
-      └── y + 1 [type=int]
+      └── y + 1 [type=int, outer=(2)]
 
 # Join operator.
 opt
@@ -41,10 +51,16 @@ SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
 ----
 inner-join (cross)
  ├── columns: x:3(int) rowid:5(int!null) y:2(int) x:1(int!null) y2:2(int) y:4(float)
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(3,4)
  ├── scan a
- │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  ├── scan b
- │    └── columns: b.x:3(int) b.y:4(float) rowid:5(int!null)
+ │    ├── columns: b.x:3(int) b.y:4(float) rowid:5(int!null)
+ │    ├── key: (5)
+ │    └── fd: (5)-->(3,4)
  └── filters (true)
 
 # Groupby operator.
@@ -55,11 +71,15 @@ group-by
  ├── columns: max:3(int) y:2(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null)
  ├── internal-ordering: +1
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
  │    └── ordering: +1
  └── aggregations
-      ├── max [type=int]
+      ├── max [type=int, outer=(2)]
       │    └── variable: y [type=int]
-      └── const-agg [type=int]
+      └── const-agg [type=int, outer=(2)]
            └── variable: y [type=int]


### PR DESCRIPTION
#### opt: don't hide misc props in physicalprops tests

TestPhysicalProps hides FDs and provided orderings, forcing some tests
to override the formatting. This change cleans this up by showing more
stuff by default.

Release note: None

#### opt: simplify child ordering for DistinctOn

Adding a bit of missing code for determining the required ordering for
the DistinctOn input: we weren't simplifying the ordering w.r.t the
FDs. This is not a correctness issue, but simplifying opens up more
opportunities for optimization. The code is also more consistent with
the one for GroupBy which should only differ in projecting the
grouping columns.

Release note: None

#### opt: remap provided ordering for DistinctOn

The code for determining the provided ordering for DistinctOn didn't
take into account that the operator can effectively be projecting out
input columns, in which case the provided ordering might need
remapping.

The corresponding GroupBy code is simplified so the two cases are
handled similarly, with the only difference being the allowed columns
(grouping cols for GroupBy, output cols for DistinctOn).

Fixes #44509.

Release note (bug fix): fixed "no output column equivalent to.." and
"column not in input" errors in some cases involving DISTINCT ON and
ORDER BY.
