### PR TITLE
sqlbase: add table generator for edge case datums

### DIFF
--- a/pkg/sql/rand_test.go
+++ b/pkg/sql/rand_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestGenerateRandInterestingTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Ensure that we can create the random table.
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+	if _, err := db.Exec("CREATE DATABASE d"); err != nil {
+		t.Fatal(err)
+	}
+	err := sqlbase.GenerateRandInterestingTable(db, "d", "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Part of work for #44322.

This PR adds a testing utility to generate a table
full of edge case datums to test a variety of things in the future.

Release note: None