### PR TITLE
stats: fix flaky test TestCreateStatsControlJob

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -41,8 +41,6 @@ import (
 func TestCreateStatsControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/44522")
-
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
 	}(jobs.DefaultAdoptInterval)
@@ -80,8 +78,8 @@ func TestCreateStatsControlJob(t *testing.T) {
 
 		if _, err := jobutils.RunJob(
 			t, sqlDB, &allowRequest, []string{"cancel"}, query,
-		); !testutils.IsError(err, "cancel-requested") {
-			t.Fatalf("expected 'cancel-requested' error, but got %+v", err)
+		); err == nil {
+			t.Fatal("expected an error")
 		}
 
 		// There should be no results here.


### PR DESCRIPTION
Due to the changes in #44163, it is no longer guaranteed that canceling
a job will return a deterministic "cancel-requested" error. This commit
changes TestCreateStatsControlJob to expect any error, not a specific
error.

Fixes #44522

Release note: None