### PR TITLE
engine: redefine targetSize and add maxSize to ExportToSst

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -1136,9 +1136,8 @@ DBStatus DBExportToSst(DBKey start, DBKey end, bool export_all_revisions, uint64
     // Check to see if this is the first version of key and adding it would
     // put us over the limit (we might already be over the limit).
     const int64_t cur_size = bulkop_summary.data_size();
-    const int64_t new_size = cur_size + decoded_key.size() + iter.value().size();
-    const bool is_over_target = cur_size > 0 && new_size > target_size;
-    if (paginated && is_new_key && is_over_target) {
+    const bool reached_target_size = cur_size > 0 && cur_size >= target_size;
+    if (paginated && is_new_key && reached_target_size) {
       resume_key.reserve(decoded_key.size());
       resume_key.assign(decoded_key.data(), decoded_key.size());
       break;
@@ -1154,6 +1153,7 @@ DBStatus DBExportToSst(DBKey start, DBKey end, bool export_all_revisions, uint64
     if (!row_counter.Count((iter.key()), &bulkop_summary)) {
       return ToDBString("Error in row counter");
     }
+    const int64_t new_size = cur_size + decoded_key.size() + iter.value().size();
     bulkop_summary.set_data_size(new_size);
   }
   *summary = ToDBString(bulkop_summary.SerializeAsString());

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -555,11 +555,18 @@ DBStatus DBUnlockFile(DBFileLock lock);
 
 // DBExportToSst exports changes over the keyrange and time interval between the
 // start and end DBKeys to an SSTable using an IncrementalIterator.
+//
 // If target_size is positive, it indicates that the export should produce SSTs
 // which are roughly target size. Specifically, it will return an SST such that
 // the last key is responsible for exceeding the targetSize. If the resume_key
 // is non-NULL then the returns sst will exceed the targetSize.
-DBStatus DBExportToSst(DBKey start, DBKey end, bool export_all_revisions, uint64_t target_size,
+//
+// If max_size is positive, it is an absolute maximum on byte size for the
+// returned sst. If it is the case that the versions of the last key will lead
+// to an SST that exceeds maxSize, an error will be returned. This parameter
+// exists to prevent creating SSTs which are too large to be used.
+DBStatus DBExportToSst(DBKey start, DBKey end, bool export_all_revisions, 
+                       uint64_t target_size, uint64_t max_size,
                        DBIterOptions iter_opts, DBEngine* engine, DBString* data,
                        DBString* write_intent, DBString* summary, DBString* resume);
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -556,13 +556,9 @@ DBStatus DBUnlockFile(DBFileLock lock);
 // DBExportToSst exports changes over the keyrange and time interval between the
 // start and end DBKeys to an SSTable using an IncrementalIterator.
 // If target_size is positive, it indicates that the export should produce SSTs
-// which are roughly target size. Specifically, it will produce SSTs which contain
-// all relevant versions of a key and will not add the first version of a new
-// key if it would lead to the SST exceeding the target_size. If export_all_revisions
-// is false, the returned SST will be smaller than target_size so long as the first
-// kv pair is smaller than target_size. If export_all_revisions is true then
-// target_size may be exceeded. If the SST construction stops due to the target_size,
-// then resume will be set to the value of the resume key.
+// which are roughly target size. Specifically, it will return an SST such that
+// the last key is responsible for exceeding the targetSize. If the resume_key
+// is non-NULL then the returns sst will exceed the targetSize.
 DBStatus DBExportToSst(DBKey start, DBKey end, bool export_all_revisions, uint64_t target_size,
                        DBIterOptions iter_opts, DBEngine* engine, DBString* data,
                        DBString* write_intent, DBString* summary, DBString* resume);

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -135,7 +135,9 @@ func evalExport(
 	// target size for files and then paginate the actual export. The external
 	// API may need to be modified to deal with the case where ReturnSST is true.
 	const targetSize = 0 // unlimited
-	data, summary, resume, err := e.ExportToSst(args.Key, args.EndKey, args.StartTime, h.Timestamp, exportAllRevisions, targetSize, io)
+	const maxSize = 0    // unlimited
+	data, summary, resume, err := e.ExportToSst(args.Key, args.EndKey,
+		args.StartTime, h.Timestamp, exportAllRevisions, targetSize, maxSize, io)
 	if resume != nil {
 		return result.Result{}, crdberrors.AssertionFailedf("expected nil resume key with unlimited target size")
 	}

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -333,9 +333,26 @@ func assertEqualKVs(
 		var kvs []engine.MVCCKeyValue
 		for start := startKey; start != nil; {
 			var sst []byte
-			sst, _, start, err = e.ExportToSst(start, endKey, startTime, endTime, exportAllRevisions, targetSize, io)
+			var summary roachpb.BulkOpSummary
+			sst, summary, start, err = e.ExportToSst(start, endKey, startTime, endTime, exportAllRevisions, targetSize, io)
 			require.NoError(t, err)
 			loaded := loadSST(t, sst, startKey, endKey)
+			// Ensure that the pagination worked properly.
+			if start != nil {
+				dataSize := uint64(summary.DataSize)
+				require.Truef(t, targetSize <= dataSize, "%d > %d",
+					targetSize, summary.DataSize)
+				// Now we want to ensure that if we remove the bytes due to the last
+				// key that we are below the target size.
+				firstKVofLastKey := sort.Search(len(loaded), func(i int) bool {
+					return loaded[i].Key.Key.Equal(loaded[len(loaded)-1].Key.Key)
+				})
+				dataSizeWithoutLastKey := dataSize
+				for _, kv := range loaded[firstKVofLastKey:] {
+					dataSizeWithoutLastKey -= uint64(kv.Key.Len() + len(kv.Value))
+				}
+				require.Truef(t, targetSize > dataSizeWithoutLastKey, "%d <= %d", targetSize, dataSizeWithoutLastKey)
+			}
 			kvs = append(kvs, loaded...)
 		}
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -201,14 +201,10 @@ type Reader interface {
 	// requested or if the start.Timestamp is non-zero. Returns the bytes of an
 	// SSTable containing the exported keys, the size of exported data, or an error.
 	// If targetSize is positive, it indicates that the export should produce SSTs
-	// which are roughly target size. Specifically, it will produce SSTs which contain
-	// all relevant versions of a key and will not add the first version of a new
-	// key if it would lead to the SST exceeding the targetSize. If exportAllRevisions
-	// is false, the returned SST will be smaller than target_size so long as the first
-	// kv pair is smaller than targetSize. If exportAllRevisions is true then
-	// targetSize may be exceeded by as much as the size of all of the versions of
-	// the last key. If the SST construction stops due to the targetSize,
-	// then a non-nil resumeKey will be returned.
+	// which are roughly target size. Specifically, it will return an SST such that
+	// the last key is responsible for meeting or exceeding the targetSize. If the
+	// resumeKey is non-nil then the data size of the returned sst will be greater
+	// than or equal to the targetSize.
 	ExportToSst(
 		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
 		exportAllRevisions bool, targetSize uint64, io IterOptions,

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -200,14 +200,21 @@ type Reader interface {
 	// within the interval is exported. Deletions are included if all revisions are
 	// requested or if the start.Timestamp is non-zero. Returns the bytes of an
 	// SSTable containing the exported keys, the size of exported data, or an error.
+	//
 	// If targetSize is positive, it indicates that the export should produce SSTs
 	// which are roughly target size. Specifically, it will return an SST such that
 	// the last key is responsible for meeting or exceeding the targetSize. If the
 	// resumeKey is non-nil then the data size of the returned sst will be greater
 	// than or equal to the targetSize.
+	//
+	// If maxSize is positive, it is an absolute maximum on byte size for the
+	// returned sst. If it is the case that the versions of the last key will lead
+	// to an SST that exceeds maxSize, an error will be returned. This parameter
+	// exists to prevent creating SSTs which are too large to be used.
 	ExportToSst(
 		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
-		exportAllRevisions bool, targetSize uint64, io IterOptions,
+		exportAllRevisions bool, targetSize uint64, maxSize uint64,
+		io IterOptions,
 	) (sst []byte, _ roachpb.BulkOpSummary, resumeKey roachpb.Key, _ error)
 	// Get returns the value for the given key, nil otherwise.
 	//

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -93,7 +93,7 @@ func (p *pebbleBatch) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
-	targetSize uint64,
+	targetSize, maxSize uint64,
 	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
 	panic("unimplemented")

--- a/pkg/storage/engine/tee.go
+++ b/pkg/storage/engine/tee.go
@@ -89,11 +89,11 @@ func (t *TeeEngine) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
-	targetSize uint64,
+	targetSize, maxSize uint64,
 	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
-	eng1Sst, bulkOpSummary, resume1, err := t.eng1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
-	rocksSst, _, resume2, err2 := t.eng2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
+	eng1Sst, bulkOpSummary, resume1, err := t.eng1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
+	rocksSst, _, resume2, err2 := t.eng2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, bulkOpSummary, nil, err
 	}
@@ -672,11 +672,11 @@ func (t *TeeEngineReader) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
-	targetSize uint64,
+	targetSize, maxSize uint64,
 	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
-	sst1, bulkOpSummary, resume1, err := t.reader1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
-	sst2, _, resume2, err2 := t.reader2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
+	sst1, bulkOpSummary, resume1, err := t.reader1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
+	sst2, _, resume2, err2 := t.reader2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, bulkOpSummary, nil, err
 	}
@@ -776,11 +776,11 @@ func (t *TeeEngineBatch) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
-	targetSize uint64,
+	targetSize, maxSize uint64,
 	io IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
-	sst1, bulkOpSummary, resume1, err := t.batch1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
-	sst2, _, resume2, err2 := t.batch2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
+	sst1, bulkOpSummary, resume1, err := t.batch1.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
+	sst2, _, resume2, err2 := t.batch2.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, bulkOpSummary, nil, err
 	}

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -284,10 +284,10 @@ func (s spanSetReader) ExportToSst(
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
-	targetSize uint64,
+	targetSize, maxSize uint64,
 	io engine.IterOptions,
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
-	return s.r.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, io)
+	return s.r.ExportToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, io)
 }
 
 func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {


### PR DESCRIPTION
This PR is a follow-up of work from #44440 motivated by problems unearthed while typing #44482. The PR comes in two commits:

1) Re-define `targetSize` from being a target below which most requests would remain to being the size above which the export stops.
2) Add a `maxSize` parameter above which the `ExportToSst` call will fail.

See the individual commits for more details. 