### PR TITLE
jobs: fix semantics of PAUSE JOB

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
@@ -260,7 +262,27 @@ func (f *jobFeed) fetchJobError() error {
 
 func (f *jobFeed) Pause() error {
 	_, err := f.db.Exec(`PAUSE JOB $1`, f.JobID)
-	return err
+	if err != nil {
+		return err
+	}
+	// PAUSE JOB does not actually pause the job but only sends a request for
+	// it. Actually block until the job state changes.
+	opts := retry.Options{
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		Multiplier:     2,
+	}
+	ctx := context.Background()
+	return retry.WithMaxAttempts(ctx, opts, 10, func() error {
+		var status string
+		if err := f.db.QueryRowContext(ctx, `SELECT status FROM system.jobs WHERE id = $1`, f.JobID).Scan(&status); err != nil {
+			return err
+		}
+		if jobs.Status(status) != jobs.StatusPaused {
+			return errors.New("could not pause job")
+		}
+		return nil
+	})
 }
 
 func (f *jobFeed) Resume() error {

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -649,7 +649,7 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 	js := queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool { return js.prog.ResumePos[0] > 0 })
 
 	// Pause the job;
-	if err := registry.Pause(ctx, nil, jobID); err != nil {
+	if err := registry.PauseRequested(ctx, nil, jobID); err != nil {
 		t.Fatal(err)
 	}
 	// Send cancellation and unblock breakpoint.
@@ -750,7 +750,7 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 	proceedImport := controllerBarrier.Enter()
 
 	// Pause the job;
-	if err := registry.Pause(ctx, nil, jobID); err != nil {
+	if err := registry.PauseRequested(ctx, nil, jobID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -529,13 +529,13 @@ func (r *Registry) CancelRequested(ctx context.Context, txn *client.Txn, id int6
 	return job.WithTxn(txn).cancelRequested(ctx, nil)
 }
 
-// Pause marks the job with id as paused using the specified txn (may be nil).
-func (r *Registry) Pause(ctx context.Context, txn *client.Txn, id int64) error {
+// PauseRequested marks the job with id as paused-requested using the specified txn (may be nil).
+func (r *Registry) PauseRequested(ctx context.Context, txn *client.Txn, id int64) error {
 	job, _, err := r.getJobFn(ctx, txn, id)
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).paused(ctx)
+	return job.WithTxn(txn).pauseRequested(ctx, nil)
 }
 
 // Resume resumes the paused job with id using the specified txn (may be nil).
@@ -641,8 +641,8 @@ func (r *Registry) stepThroughStateMachine(
 	switch status {
 	case StatusRunning:
 		if jobErr != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
-				"unexpected error provided for a running job")
+			errorMsg := fmt.Sprintf("job %d: resuming with non-nil error: %v", *job.ID(), jobErr)
+			return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 		}
 		err := resumer.Resume(ctx, phs, resultsCh)
 		if err == nil {
@@ -658,17 +658,20 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.Errorf("job %d: %s: restarting in background", *job.ID(), e)
 		}
 		if err, ok := errors.Cause(err).(*InvalidStatusError); ok {
-			if err.status != StatusPaused && err.status != StatusCancelRequested {
-				return errors.NewAssertionErrorWithWrappedErrf(err,
-					"job %d: unexpected status %s provided for a running job", job.ID(), err.status)
+			if err.status != StatusCancelRequested && err.status != StatusPauseRequested {
+				errorMsg := fmt.Sprintf("job %d: unexpected status %s provided for a running job", *job.ID(), err.status)
+				return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 			}
-			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, err.status, err)
+			return err
 		}
 		return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusReverting, err)
-	case StatusPaused:
+	case StatusPauseRequested:
 		return errors.Errorf("job %s", status)
 	case StatusCancelRequested:
 		return errors.Errorf("job %s", status)
+	case StatusPaused:
+		errorMsg := fmt.Sprintf("job %d: unexpected status %s provided to state machine", *job.ID(), status)
+		return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 	case StatusCanceled:
 		if err := job.canceled(ctx, nil); err != nil {
 			// If we can't transactionally mark the job as canceled then it will be
@@ -679,8 +682,8 @@ func (r *Registry) stepThroughStateMachine(
 		return errors.Errorf("job %s", status)
 	case StatusSucceeded:
 		if jobErr != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
-				"job %d: successful bu unexpected error provided", *job.ID())
+			errorMsg := fmt.Sprintf("job %d: successful bu unexpected error provided", *job.ID())
+			return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 		}
 		if err := job.Succeeded(ctx, resumer.OnSuccess); err != nil {
 			// If it didn't succeed, we consider the job as failed and need to go
@@ -688,7 +691,7 @@ func (r *Registry) stepThroughStateMachine(
 			// TODO(spaskob): this is silly, we should remove the OnSuccess hooks and
 			// execute them in resume so that the client can handle these errors
 			// better.
-			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusReverting, errors.Wrapf(err, "could not mark job %d as succeeded", *job.id))
+			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusReverting, errors.Wrapf(err, "could not mark job %d as succeeded", *job.ID()))
 		}
 		resumer.OnTerminal(ctx, status, resultsCh)
 		return nil
@@ -714,21 +717,18 @@ func (r *Registry) stepThroughStateMachine(
 		if e, ok := err.(retryJobError); ok {
 			return errors.Errorf("job %d: %s: restarting in background", *job.ID(), e)
 		}
-		if ierr, ok := errors.Cause(err).(*InvalidStatusError); ok {
-			// TODO(spaskob): enable pausing of reverting jobs.
-			//if ierr.status != StatusPaused {
-			//	return errors.NewAssertionErrorWithWrappedErrf(err,
-			//		"job %d: unexpected status %s provided for a reverting job", job.ID(), err.status)
-			//}
-			//return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusPaused, err)
-			return errors.NewAssertionErrorWithWrappedErrf(ierr,
-				"unexpected error provided for a reverting job")
+		if err, ok := errors.Cause(err).(*InvalidStatusError); ok {
+			if err.status != StatusPauseRequested {
+				errorMsg := fmt.Sprintf("job %d: unexpected status %s provided for a reverting job", job.ID(), err.status)
+				return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
+			}
+			return err
 		}
 		return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, StatusFailed, errors.Wrapf(err, "job %d: cannot be reverted, manual cleanup may be required", *job.ID()))
 	case StatusFailed:
 		if jobErr == nil {
-			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
-				"job %d: has StatusFailed but no error was provided", *job.ID())
+			errorMsg := fmt.Sprintf("job %d: has StatusFailed but no error was provided", *job.ID())
+			return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 		}
 		if err := job.Failed(ctx, jobErr, nil); err != nil {
 			// If we can't transactionally mark the job as failed then it will be
@@ -767,6 +767,9 @@ func (r *Registry) resume(
 		if err == nil {
 			err = r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, status, nil)
 			if err != nil {
+				if errors.HasAssertionFailure(err) {
+					log.ReportOrPanic(ctx, nil, err.Error())
+				}
 				log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
 			}
 			status, err := job.CurrentStatus(ctx)
@@ -788,9 +791,10 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 	const stmt = `
 SELECT id, payload, progress IS NULL, status
 FROM system.jobs
-WHERE status IN ($1, $2, $3, $4) ORDER BY created DESC`
+WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 	rows, err := r.ex.Query(
-		ctx, "adopt-job", nil /* txn */, stmt, StatusPending, StatusRunning, StatusCancelRequested, StatusReverting,
+		ctx, "adopt-job", nil /* txn */, stmt,
+		StatusPending, StatusRunning, StatusCancelRequested, StatusPauseRequested, StatusReverting,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed querying for jobs")
@@ -839,8 +843,10 @@ WHERE status IN ($1, $2, $3, $4) ORDER BY created DESC`
 			return err
 		}
 
-		if log.V(2) {
-			log.Infof(ctx, "evaluating job %d with lease %#v", *id, payload.Lease)
+		status := Status(tree.MustBeDString(row[3]))
+		if log.V(3) {
+			log.Infof(ctx, "job %d: evaluating for adoption with status `%s` and lease %v",
+				*id, status, payload.Lease)
 		}
 
 		if payload.Lease == nil {
@@ -913,24 +919,47 @@ WHERE status IN ($1, $2, $3, $4) ORDER BY created DESC`
 		// Below we know that this node holds the lease on the job.
 		job := &Job{id: id, registry: r}
 		resumeCtx, cancel := r.makeCtx()
-		if err := r.register(*id, cancel); err != nil {
-			status := Status(tree.MustBeDString(row[3]))
-			if cancelJob := (status == StatusCancelRequested); cancelJob {
-				if log.V(2) {
-					log.Infof(ctx, "job %d: canceling: the job is cancelRequested and running on this node", *id)
-				}
+
+		if pauseRequested := status == StatusPauseRequested; pauseRequested {
+			if err := job.Paused(ctx, func(context.Context, *client.Txn) error {
 				r.unregister(*id)
-			} else {
+				return nil
+			}); err != nil {
+				log.Errorf(ctx, "job %d: could not set to paused: %v", *id, err)
+				continue
+			}
+			log.Infof(ctx, "job %d: paused", *id)
+			continue
+		}
+
+		if err := r.register(*id, cancel); err != nil {
+			if keepRunning := status != StatusCancelRequested; keepRunning {
 				if log.V(3) {
 					log.Infof(ctx, "job %d: skipping: the job is already running/reverting on this node", *id)
 				}
+				continue
 			}
-			// It makes sense to continue even in the case of canceling the job since
-			// the node may be under load and we will give a chance for another node
-			// to adopt it.
+			if err := job.Reverted(ctx, func(context.Context, *client.Txn) error {
+				r.unregister(*id)
+				return nil
+			}); err != nil {
+				log.Errorf(ctx, "job %d: could not set to reverting: %v", *id, err)
+				continue
+			}
+			if log.V(2) {
+				log.Infof(ctx, "job %d: canceled: the job is now reverting", *id)
+			}
+			// Don't continue but adopt job for reverting.
+		}
+		// Check if job status has changed in the meanwhile.
+		currentStatus, err := job.CurrentStatus(ctx)
+		if err != nil {
+			return err
+		}
+		if status != currentStatus {
 			continue
 		}
-		// Adopt job and resume it.
+		// Adopt job and resume/revert it.
 		if err := job.adopt(ctx, payload.Lease); err != nil {
 			r.unregister(*id)
 			return errors.Wrap(err, "unable to acquire lease")
@@ -942,6 +971,7 @@ WHERE status IN ($1, $2, $3, $4) ORDER BY created DESC`
 			r.unregister(*id)
 			return err
 		}
+		log.Infof(ctx, "job %d: resuming execution", *id)
 		errCh, err := r.resume(resumeCtx, resumer, resultsCh, job)
 		if err != nil {
 			r.unregister(*id)

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -58,7 +58,7 @@ func (n *controlJobsNode) startExec(params runParams) error {
 
 		switch n.desiredStatus {
 		case jobs.StatusPaused:
-			err = reg.Pause(params.ctx, params.p.txn, int64(jobID))
+			err = reg.PauseRequested(params.ctx, params.p.txn, int64(jobID))
 		case jobs.StatusRunning:
 			err = reg.Resume(params.ctx, params.p.txn, int64(jobID))
 		case jobs.StatusCanceled:

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
 )
 
@@ -95,7 +96,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 		jobID, err := jobutils.RunJob(
 			t, sqlDB, &allowRequest, []string{"PAUSE"}, query,
 		)
-		if !testutils.IsError(err, "job paused") {
+		if !testutils.IsError(err, "pause") && !testutils.IsError(err, "liveness") {
 			t.Fatalf("unexpected: %v", err)
 		}
 
@@ -103,8 +104,18 @@ func TestCreateStatsControlJob(t *testing.T) {
 		sqlDB.CheckQueryResults(t,
 			`SELECT statistics_name, column_names, row_count FROM [SHOW STATISTICS FOR TABLE d.t]`,
 			[][]string{})
+		opts := retry.Options{
+			InitialBackoff: 1 * time.Millisecond,
+			MaxBackoff:     time.Second,
+			Multiplier:     2,
+		}
+		if err := retry.WithMaxAttempts(context.Background(), opts, 10, func() error {
+			_, err := sqlDB.DB.ExecContext(context.Background(), `RESUME JOB $1`, jobID)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
 
-		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, jobID))
 		jobutils.WaitForJob(t, sqlDB, jobID)
 
 		// Now the job should have succeeded in producing stats.
@@ -356,23 +367,52 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Attempt to start an automatic stats run. It should fail.
-	_, err := conn.Exec(`CREATE STATISTICS __auto__ FROM d.t`)
-	expected := "another CREATE STATISTICS job is already running"
-	if !testutils.IsError(err, expected) {
-		t.Fatalf("expected '%s' error, but got %v", expected, err)
+	autoStatsRunShouldFail := func() {
+		expectErrCh := make(chan error, 1)
+		go func() {
+			_, err := conn.Exec(`CREATE STATISTICS __auto__ FROM d.t`)
+			expectErrCh <- err
+		}()
+		select {
+		case err := <-expectErrCh:
+			expected := "another CREATE STATISTICS job is already running"
+			if !testutils.IsError(err, expected) {
+				t.Fatalf("expected '%s' error, but got %v", expected, err)
+			}
+		case <-time.After(time.Second):
+			panic("CREATE STATISTICS job which was expected to fail, timed out instead")
+		}
 	}
 
-	// Pause the job. Starting another automatic stats run should still fail.
+	// Attempt to start an automatic stats run. It should fail.
+	autoStatsRunShouldFail()
+
+	// PAUSE JOB does not bloack until the job is paused but only requests it.
+	// Wait until the job is set to paused.
 	var jobID int64
 	sqlDB.QueryRow(t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`).Scan(&jobID)
-	sqlDB.Exec(t, fmt.Sprintf("PAUSE JOB %d", jobID))
-
-	_, err = conn.Exec(`CREATE STATISTICS __auto__ FROM d.t`)
-	expected = "another CREATE STATISTICS job is already running"
-	if !testutils.IsError(err, expected) {
-		t.Fatalf("expected '%s' error, but got %v", expected, err)
+	opts := retry.Options{
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		Multiplier:     2,
 	}
+	if err := retry.WithMaxAttempts(context.Background(), opts, 10, func() error {
+		_, err := sqlDB.DB.ExecContext(context.Background(), `PAUSE JOB $1`, jobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var status string
+		sqlDB.QueryRow(t, `SELECT status FROM system.jobs WHERE id = $1 LIMIT 1`, jobID).Scan(&status)
+		if status != "paused" {
+			return errors.New("could not pause job")
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Starting another automatic stats run should still fail.
+	autoStatsRunShouldFail()
 
 	// Attempt to start a regular stats run. It should succeed.
 	errCh2 := make(chan error)


### PR DESCRIPTION
So far PAUSE JOB would mark the job as paused
immediately but without actually pausing it.
Instead it relied on the job trying to write
progress at some point and fail. We introduce
a new job state StatusPauseRequested to fix that.
It is used to designate a job that is still running but
has been requested to be paused.

Additionally:
We also make jobs that are reverting pausable.
A few tests that relied on PAUSE pausing the job
immediately after returning were fixed.

Fixes #30505.
Fixes #45809 

Release note (bug fix): 19.2 `IMPORT INTO` jobs could be
pause while recovering from a failure and subsequently resumed
as if the failure did not occur.