### PR TITLE
release-19.2: storage: fix nil pointer panic in tryGetOrCreateReplica

### DIFF
--- a/pkg/storage/store_create_replica.go
+++ b/pkg/storage/store_create_replica.go
@@ -85,18 +85,18 @@ func (s *Store) tryGetOrCreateReplica(
 		repl.raftMu.Lock() // not unlocked on success
 		repl.mu.Lock()
 
-		// Drop messages from replicas we know to be too old.
-		if fromReplicaIsTooOld(repl, creatingReplica) {
-			repl.mu.Unlock()
-			repl.raftMu.Unlock()
-			return nil, false, roachpb.NewReplicaTooOldError(creatingReplica.ReplicaID)
-		}
-
 		// The current replica is removed, go back around.
 		if repl.mu.destroyStatus.Removed() {
 			repl.mu.Unlock()
 			repl.raftMu.Unlock()
 			return nil, false, errRetry
+		}
+
+		// Drop messages from replicas we know to be too old.
+		if fromReplicaIsTooOld(repl, creatingReplica) {
+			repl.mu.Unlock()
+			repl.raftMu.Unlock()
+			return nil, false, roachpb.NewReplicaTooOldError(creatingReplica.ReplicaID)
 		}
 
 		toTooOld := toReplicaIsTooOld(repl, replicaID)
@@ -187,6 +187,22 @@ func (s *Store) tryGetOrCreateReplica(
 	// Store.mu to maintain lock ordering invariant.
 	repl.mu.Lock()
 	repl.mu.tombstoneMinReplicaID = tombstone.NextReplicaID
+	uninitializedDesc := &roachpb.RangeDescriptor{
+		RangeID: rangeID,
+		// NB: other fields are unknown; need to populate them from
+		// snapshot.
+	}
+	// NB: A Replica should never be in the store's replicas map with a nil
+	// descriptor. Assign it directly here. In the case that the Replica should
+	// exist (which we confirm with another check of the Tombstone below), we'll
+	// re-initialize the replica with the same uninitializedDesc.
+	//
+	// During a short window between here and call to s.unlinkReplicaByRangeIDLocked()
+	// in the failure branch below, the Replica used to have a nil descriptor and
+	// was present in the map. While it was the case that the destroy status had
+	// been set, not every code path which inspects the descriptor checks the
+	// destroy status.
+	repl.mu.state.Desc = uninitializedDesc
 	// Add the range to range map, but not replicasByKey since the range's start
 	// key is unknown. The range will be added to replicasByKey later when a
 	// snapshot is applied. After unlocking Store.mu above, another goroutine
@@ -225,15 +241,10 @@ func (s *Store) tryGetOrCreateReplica(
 			log.Fatalf(ctx, "found non-zero HardState.Commit on uninitialized replica %s. HS=%+v", repl, hs)
 		}
 
-		desc := &roachpb.RangeDescriptor{
-			RangeID: rangeID,
-			// NB: other fields are unknown; need to populate them from
-			// snapshot.
-		}
-		return repl.initRaftMuLockedReplicaMuLocked(desc, s.Clock(), replicaID)
+		return repl.initRaftMuLockedReplicaMuLocked(uninitializedDesc, s.Clock(), replicaID)
 	}(); err != nil {
 		// Mark the replica as destroyed and remove it from the replicas maps to
-		// ensure nobody tries to use it
+		// ensure nobody tries to use it.
 		repl.mu.destroyStatus.Set(errors.Wrapf(err, "%s: failed to initialize", repl), destroyReasonRemoved)
 		repl.mu.Unlock()
 		s.mu.Lock()

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2676,6 +2677,35 @@ func TestStoreGCThreshold(t *testing.T) {
 	}
 
 	assertThreshold(threshold)
+}
+
+// TestRaceOnTryGetOrCreateReplicas exercises a case where a race between
+// different raft messages addressed to different replica IDs could lead to
+// a nil pointer panic.
+func TestRaceOnTryGetOrCreateReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+	tc.Start(t, stopper)
+	s := tc.store
+	var wg sync.WaitGroup
+	for i := 3; i < 100; i++ {
+		wg.Add(1)
+		go func(rid roachpb.ReplicaID) {
+			defer wg.Done()
+			r, _, _ := s.getOrCreateReplica(ctx, 42, rid, &roachpb.ReplicaDescriptor{
+				NodeID:    2,
+				StoreID:   2,
+				ReplicaID: 2,
+			}, false)
+			if r != nil {
+				r.raftMu.Unlock()
+			}
+		}(roachpb.ReplicaID(i))
+	}
+	wg.Wait()
 }
 
 func TestStoreRangePlaceholders(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #44513.

/cc @cockroachdb/release

---

This commit checks the Replica's destroy status in tryGetOrCreateReplica
prior to checking if the fromReplica is too old. The hazard occurs when a
freshly previously created Replica was determined to be older than a tombstone
which was created concurrently (see the second tombstone check in the same
function). In that case it's possible for a destroyed replica to exist in the
store's map with a nil descriptor.

The added test reproduced the panic under stress within 5s.

This PR should be backported to 19.2.

Fixes #44332.

Release note: None
