### PR TITLE
storage: fix replay protection for 1PC txns

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -71,7 +71,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -99,7 +99,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{1}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{1}
 }
 
 type ChecksumMode int32
@@ -146,7 +146,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{2}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -177,7 +177,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{3}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{3}
 }
 
 type ExternalStorageProvider int32
@@ -215,7 +215,7 @@ func (x ExternalStorageProvider) String() string {
 	return proto.EnumName(ExternalStorageProvider_name, int32(x))
 }
 func (ExternalStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{4}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{4}
 }
 
 type MVCCFilter int32
@@ -238,7 +238,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{5}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -264,7 +264,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{2, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{2, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -306,7 +306,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{26, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{26, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -320,7 +320,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -363,7 +363,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{1}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -425,7 +425,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{2}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -459,7 +459,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{3}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -497,7 +497,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{4}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -540,7 +540,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{5}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -574,7 +574,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{6}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -628,7 +628,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{7}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -663,7 +663,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{8}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -709,7 +709,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{9}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -743,7 +743,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{10}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -783,7 +783,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{11}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -820,7 +820,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{12}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -854,7 +854,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{13}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -888,7 +888,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{14}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -940,7 +940,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{15}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -977,7 +977,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{16}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1024,7 +1024,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{17}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1058,7 +1058,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{18}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1099,7 +1099,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{19}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{19}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1133,7 +1133,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{20}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{20}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1173,7 +1173,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{21}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{21}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1220,7 +1220,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{22}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{22}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1260,7 +1260,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{23}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{23}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1307,7 +1307,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{24}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{24}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1360,7 +1360,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{25}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{25}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1397,7 +1397,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{26}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{26}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1441,7 +1441,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{26, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{26, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1489,7 +1489,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{27}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{27}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1525,7 +1525,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{28}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{28}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1596,6 +1596,10 @@ type EndTxnRequest struct {
 	// Requires that the transaction completes as a 1 phase commit. This
 	// guarantees that all writes are to the same range and that no
 	// intents are left in the event of an error.
+	//
+	// Note(andrei): Use this flag with care; retriable errors are not generated
+	// reliably for these transactions - a TransactionStatusError might be
+	// returned instead if 1PC execution fails.
 	Require1PC bool `protobuf:"varint,6,opt,name=require_1pc,json=require1pc,proto3" json:"require_1pc,omitempty"`
 	// CanCommitAtHigherTimestamp indicates that the batch this EndTxn is part of
 	// can be evaluated at a higher timestamp than the transaction's read
@@ -1616,7 +1620,7 @@ func (m *EndTxnRequest) Reset()         { *m = EndTxnRequest{} }
 func (m *EndTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTxnRequest) ProtoMessage()    {}
 func (*EndTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{29}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{29}
 }
 func (m *EndTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1662,7 +1666,7 @@ func (m *EndTxnResponse) Reset()         { *m = EndTxnResponse{} }
 func (m *EndTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTxnResponse) ProtoMessage()    {}
 func (*EndTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{30}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{30}
 }
 func (m *EndTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1723,7 +1727,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{31}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{31}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1758,7 +1762,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{32}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{32}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1797,7 +1801,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{33}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{33}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1832,7 +1836,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{34}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{34}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1875,7 +1879,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{35}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{35}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1910,7 +1914,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{36}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{36}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1948,7 +1952,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{37}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{37}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1981,7 +1985,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{38}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{38}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2016,7 +2020,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{39}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{39}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2074,7 +2078,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{40}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{40}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2109,7 +2113,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{41}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{41}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2146,7 +2150,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{42}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{42}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2179,7 +2183,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{43}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{43}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2218,7 +2222,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{44}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{44}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2255,7 +2259,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{45}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{45}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2293,7 +2297,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{46}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{46}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2327,7 +2331,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{46, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{46, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2361,7 +2365,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{47}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{47}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2430,7 +2434,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{48}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{48}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2473,7 +2477,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{49}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{49}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2520,7 +2524,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{50}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{50}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2556,7 +2560,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{51}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{51}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2600,7 +2604,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{52}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{52}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2639,7 +2643,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{53}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{53}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2699,7 +2703,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{54}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{54}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2735,7 +2739,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{55}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{55}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2781,7 +2785,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{56}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{56}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2816,7 +2820,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{57}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{57}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2866,7 +2870,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{58}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{58}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2901,7 +2905,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{59}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{59}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2938,7 +2942,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{60}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{60}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2972,7 +2976,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{61}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{61}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3017,7 +3021,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{62}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{62}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3051,7 +3055,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{63}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{63}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3095,7 +3099,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{64}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{64}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3144,7 +3148,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{65}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{65}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3181,7 +3185,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{66}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{66}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3218,7 +3222,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{67}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{67}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3253,7 +3257,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{68}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{68}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3308,7 +3312,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{69}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{69}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3345,7 +3349,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{70}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{70}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3384,7 +3388,7 @@ func (m *ExternalStorage) Reset()         { *m = ExternalStorage{} }
 func (m *ExternalStorage) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage) ProtoMessage()    {}
 func (*ExternalStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71}
 }
 func (m *ExternalStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3418,7 +3422,7 @@ func (m *ExternalStorage_LocalFilePath) Reset()         { *m = ExternalStorage_L
 func (m *ExternalStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExternalStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 0}
 }
 func (m *ExternalStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3451,7 +3455,7 @@ func (m *ExternalStorage_Http) Reset()         { *m = ExternalStorage_Http{} }
 func (m *ExternalStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Http) ProtoMessage()    {}
 func (*ExternalStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 1}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 1}
 }
 func (m *ExternalStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3491,7 +3495,7 @@ func (m *ExternalStorage_S3) Reset()         { *m = ExternalStorage_S3{} }
 func (m *ExternalStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_S3) ProtoMessage()    {}
 func (*ExternalStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 2}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 2}
 }
 func (m *ExternalStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3530,7 +3534,7 @@ func (m *ExternalStorage_GCS) Reset()         { *m = ExternalStorage_GCS{} }
 func (m *ExternalStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_GCS) ProtoMessage()    {}
 func (*ExternalStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 3}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 3}
 }
 func (m *ExternalStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3566,7 +3570,7 @@ func (m *ExternalStorage_Azure) Reset()         { *m = ExternalStorage_Azure{} }
 func (m *ExternalStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Azure) ProtoMessage()    {}
 func (*ExternalStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 4}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 4}
 }
 func (m *ExternalStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3605,7 +3609,7 @@ func (m *ExternalStorage_Workload) Reset()         { *m = ExternalStorage_Worklo
 func (m *ExternalStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Workload) ProtoMessage()    {}
 func (*ExternalStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{71, 5}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{71, 5}
 }
 func (m *ExternalStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3645,7 +3649,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{72}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{72}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3679,7 +3683,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{73}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{73}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3713,7 +3717,7 @@ func (m *FileEncryptionOptions) Reset()         { *m = FileEncryptionOptions{} }
 func (m *FileEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*FileEncryptionOptions) ProtoMessage()    {}
 func (*FileEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{74}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{74}
 }
 func (m *FileEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3783,7 +3787,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{75}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{75}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3819,7 +3823,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{76}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{76}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3855,7 +3859,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{77}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{77}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3895,7 +3899,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{77, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{77, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3946,7 +3950,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{78}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{78}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3981,7 +3985,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{78, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{78, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4017,7 +4021,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{78, 1}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{78, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4052,7 +4056,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{79}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{79}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4090,7 +4094,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{80}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{80}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4125,7 +4129,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{81}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{81}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4158,7 +4162,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{81, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{81, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4203,7 +4207,7 @@ func (m *AdminVerifyProtectedTimestampRequest) Reset()         { *m = AdminVerif
 func (m *AdminVerifyProtectedTimestampRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampRequest) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{82}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{82}
 }
 func (m *AdminVerifyProtectedTimestampRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4241,7 +4245,7 @@ func (m *AdminVerifyProtectedTimestampResponse) Reset()         { *m = AdminVeri
 func (m *AdminVerifyProtectedTimestampResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampResponse) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{83}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{83}
 }
 func (m *AdminVerifyProtectedTimestampResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4294,7 +4298,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{84}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{84}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4328,7 +4332,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{85}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{85}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4372,7 +4376,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{86}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{86}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4406,7 +4410,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{87}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{87}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4445,7 +4449,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{88}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{88}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4479,7 +4483,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{89}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{89}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4528,7 +4532,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{90}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{90}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4577,7 +4581,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{91}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{91}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4612,7 +4616,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{92}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{92}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4651,7 +4655,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{93}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{93}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4734,7 +4738,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{94}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{94}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6184,7 +6188,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{95}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{95}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7638,7 +7642,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{96}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{96}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7674,7 +7678,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{97}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{97}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7711,7 +7715,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{98}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{98}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7769,7 +7773,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{98, 0}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{98, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7808,7 +7812,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{99}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{99}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7849,7 +7853,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{100}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{100}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7890,7 +7894,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{101}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{101}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7927,7 +7931,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{102}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{102}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7964,7 +7968,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_969d46c00ba9fe48, []int{103}
+	return fileDescriptor_api_51c48dd37e52e81c, []int{103}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -37164,9 +37168,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_969d46c00ba9fe48) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_51c48dd37e52e81c) }
 
-var fileDescriptor_api_969d46c00ba9fe48 = []byte{
+var fileDescriptor_api_51c48dd37e52e81c = []byte{
 	// 7222 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x5d, 0x6b, 0x6c, 0x23, 0xd7,
 	0x75, 0xd6, 0x90, 0x14, 0x45, 0x1e, 0x3e, 0x44, 0x5d, 0xed, 0x83, 0x2b, 0xdb, 0x92, 0x96, 0xfb,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -573,6 +573,10 @@ message EndTxnRequest {
   // Requires that the transaction completes as a 1 phase commit. This
   // guarantees that all writes are to the same range and that no
   // intents are left in the event of an error.
+  //
+  // Note(andrei): Use this flag with care; retriable errors are not generated
+  // reliably for these transactions - a TransactionStatusError might be
+  // returned instead if 1PC execution fails.
   bool require_1pc = 6 [(gogoproto.customname) = "Require1PC"];
   // CanCommitAtHigherTimestamp indicates that the batch this EndTxn is part of
   // can be evaluated at a higher timestamp than the transaction's read

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -174,7 +174,10 @@ func EndTxn(
 		return result.Result{}, err
 	}
 	if args.Require1PC {
-		// If a 1PC txn was required and we're in EndTxn, something went wrong.
+		// If a 1PC txn was required and we're in EndTxn, we've failed to evaluate
+		// the batch as a 1PC. We're returning early instead of preferring a
+		// possible retriable error because we might want to leave intents behind in
+		// case of retriable errors - which Require1PC does not want.
 		return result.Result{}, roachpb.NewTransactionStatusError("could not commit in one phase as requested")
 	}
 	if args.Commit && args.Poison {

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -240,6 +240,37 @@ and the following Raft status: %+v`,
 	}
 }
 
+// canAttempt1PCEvaluation looks at the batch and decides whether it can be
+// executed as 1PC.
+func (r *Replica) canAttempt1PCEvaluation(
+	ctx context.Context, ba *roachpb.BatchRequest,
+) (bool, *roachpb.Error) {
+	if !isOnePhaseCommit(ba) {
+		return false, nil
+	}
+
+	if ba.Timestamp != ba.Txn.WriteTimestamp {
+		log.Fatalf(ctx, "unexpected 1PC execution with diverged timestamp. %s != %s",
+			ba.Timestamp, ba.Txn.WriteTimestamp)
+	}
+
+	// The EndTxn checks whether the txn record can be created, but we're
+	// eliding the EndTxn. So, we'll do the check instead.
+	ok, minCommitTS, reason := r.CanCreateTxnRecord(ba.Txn.ID, ba.Txn.Key, ba.Txn.MinTimestamp)
+	if !ok {
+		newTxn := ba.Txn.Clone()
+		newTxn.Status = roachpb.ABORTED
+		return false, roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(reason), newTxn)
+	}
+	if ba.Timestamp.Less(minCommitTS) {
+		ba.Txn.WriteTimestamp = minCommitTS
+		// We can only evaluate at the new timestamp if we manage to bump the read
+		// timestamp.
+		return maybeBumpReadTimestampToWriteTimestamp(ctx, ba), nil
+	}
+	return true, nil
+}
+
 // evaluateWriteBatch evaluates the supplied batch.
 //
 // If the batch is transactional and has all the hallmarks of a 1PC commit (i.e.
@@ -260,7 +291,11 @@ func (r *Replica) evaluateWriteBatch(
 
 	// Attempt 1PC execution, if applicable. If not transactional or there are
 	// indications that the batch's txn will require retry, execute as normal.
-	if isOnePhaseCommit(ba) {
+	ok, pErr := r.canAttempt1PCEvaluation(ctx, ba)
+	if pErr != nil {
+		return nil, enginepb.MVCCStats{}, nil, result.Result{}, pErr
+	}
+	if ok {
 		res := r.evaluate1PC(ctx, idKey, ba, spans)
 		switch res.success {
 		case onePCSucceeded:
@@ -318,10 +353,6 @@ func (r *Replica) evaluate1PC(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba *roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (onePCRes onePCResult) {
 	log.VEventf(ctx, 2, "attempting 1PC execution")
-	if ba.Timestamp != ba.Txn.WriteTimestamp {
-		log.Fatalf(ctx, "unexpected 1PC execution with diverged timestamp. %s != %s",
-			ba.Timestamp.String(), ba.Txn.WriteTimestamp.String())
-	}
 
 	var batch engine.Batch
 	defer func() {

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -359,17 +359,6 @@ func (r *Replica) evaluate1PC(
 	}
 
 	if pErr != nil || (!canFwdTimestamp && ba.Timestamp != br.Timestamp) {
-		if etArg.Require1PC {
-			if pErr == nil {
-				pErr = roachpb.NewError(roachpb.NewTransactionRetryError(
-					roachpb.RETRY_SERIALIZABLE, "Require1PC batch pushed"))
-			}
-			return onePCResult{
-				success: onePCFailed,
-				pErr:    pErr,
-			}
-		}
-
 		if pErr != nil {
 			log.VEventf(ctx, 2,
 				"1PC execution failed, falling back to transactional execution. pErr: %v", pErr.String())


### PR DESCRIPTION
Before this patch, a "replayed" 1PC txn could succeed in committing.
This is not intended; the timestamp cache is supposed to fail an EndTxn
request if the respective txn has been finalized before. When the
request is evaluated as a 1PC, though, it was failing to perform the
required timestamp cache check. This broke possibly when we got rid of
BeginTxn.

Personally, I'm unconvinced of the importance of "replay protection" (as
opposed to idempotency where possible, and protection against races
between a commit and an abort), but we're supposed to have this
mechanism so I guess we ought to make it work. In the case of these 1PC
txns, there's also a possibility that this protection encounters a push
rather than a finalized txn, which is a good reason for this patch
(although I'm not actually sure a 1PC txn can be pushed).

Release note: None