### PR TITLE
opt: don't push negative limits into left join

### DIFF
--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -129,7 +129,7 @@ $input
         $on:*
         $private:*
     )
-    (Const $limit:*) & ^(LimitGeMaxRows $limit $left)
+    (Const $limit:*) & (IsPositiveLimit $limit) & ^(LimitGeMaxRows $limit $left)
     $ordering:* & (HasColsInOrdering $left $ordering)
 )
 =>

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1047,3 +1047,30 @@ limit
  │    └── filters
  │         └── a = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── const: 10 [type=int]
+
+# Don't push negative limits (or we would enter an infinite loop).
+norm expect-not=PushLimitIntoLeftJoin
+SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT -1
+----
+limit
+ ├── columns: a:1(int!null) b:2(int) u:3(int) v:4(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(1-4)
+ ├── left-join (hash)
+ │    ├── columns: a:1(int!null) b:2(int) u:3(int) v:4(int)
+ │    ├── key: (1,3)
+ │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── limit hint: -1.00
+ │    ├── scan ab
+ │    │    ├── columns: a:1(int!null) b:2(int)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:3(int!null) v:4(int)
+ │    │    ├── key: (3)
+ │    │    └── fd: (3)-->(4)
+ │    └── filters
+ │         └── a = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ └── const: -1 [type=int]


### PR DESCRIPTION
Pushing down a negative limit results in an infinite loop in this
rule. I considered treating negative limits as zero limits in
`EliminateLimit` but that would change the semantics of queries
(negative limit causes an error).

Fixes #44565.

Release note (bug fix): fixed server crash caused by some queries with
outer joins and negative limits.

Thanks to @mrigger for finding this bug.