### PR TITLE
release-19.1: opt: remap provided ordering for DistinctOn

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -359,7 +359,7 @@ distinct-on
  ├── ordering: +4,+2
  └── sort
       ├── columns: b:2(int!null) d:4(int!null) x:5(int!null)
-      ├── ordering: +4,+2
+      ├── ordering: +4,+2 opt(5)
       └── project
            ├── columns: x:5(int!null) b:2(int!null) d:4(int!null)
            ├── scan abcd

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -77,7 +77,8 @@ func groupByBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) 
 	provided = remapProvided(provided, inputFDs, groupBy.GroupingCols)
 	// Since the input's provided ordering has to satisfy both <required> and the
 	// GroupBy internal ordering, it may need to be trimmed.
-	return trimProvided(provided, required, &expr.Relational().FuncDeps)
+	provided = trimProvided(provided, required, inputFDs)
+	return remapProvided(provided, inputFDs, groupBy.GroupingCols)
 }
 
 func distinctOnCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
@@ -102,10 +103,13 @@ func distinctOnBuildChildReqOrdering(
 }
 
 func distinctOnBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
-	// The input's provided ordering satisfies both <required> and the DistinctOn
-	// internal ordering; it may need to be trimmed.
-	d := expr.(*memo.DistinctOnExpr)
-	return trimProvided(d.Input.ProvidedPhysical().Ordering, required, &d.Relational().FuncDeps)
+	distinctOn := expr.(*memo.DistinctOnExpr)
+	provided := distinctOn.Input.ProvidedPhysical().Ordering
+	inputFDs := &distinctOn.Input.Relational().FuncDeps
+	// Since the input's provided ordering has to satisfy both <required> and the
+	// DistinctOn internal ordering, it may need to be trimmed.
+	provided = trimProvided(provided, required, inputFDs)
+	return remapProvided(provided, inputFDs, distinctOn.Relational().OutputCols)
 }
 
 // StreamingGroupingColOrdering returns an ordering on grouping columns that is

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -92,7 +92,13 @@ func distinctOnBuildChildReqOrdering(
 	if childIdx != 0 {
 		return physical.OrderingChoice{}
 	}
-	return required.Intersection(&parent.(*memo.DistinctOnExpr).Ordering)
+	// The FD set of the input doesn't "pass through" to the DistinctOn FD set;
+	// check the ordering to see if it can be simplified with respect to the input
+	// FD set.
+	distinctOn := parent.(*memo.DistinctOnExpr)
+	result := required.Intersection(&distinctOn.Ordering)
+	result.Simplify(&distinctOn.Input.Relational().FuncDeps)
+	return result
 }
 
 func distinctOnBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/ordering/group_by_test.go
+++ b/pkg/sql/opt/ordering/group_by_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func TestDistinctOnProvided(t *testing.T) {
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+	var f norm.Factory
+	f.Init(evalCtx)
+	md := f.Metadata()
+	for i := 1; i <= 5; i++ {
+		md.AddColumn(fmt.Sprintf("c%d", i), types.Int)
+	}
+	c := func(cols ...int) opt.ColSet {
+		return util.MakeFastIntSet(cols...)
+	}
+
+	fd1eq5 := props.FuncDepSet{}
+	fd1eq5.AddEquivalency(1, 5)
+
+	// DistinctOn might not project all input columns, so we have three sets of
+	// columns, corresponding to this SQL:
+	//   SELECT <outCols> FROM
+	//     SELECT DISTINCT ON(<groupingCols>) <inputCols>
+	testCases := []struct {
+		inCols       opt.ColSet
+		inFDs        props.FuncDepSet
+		outCols      opt.ColSet
+		groupingCols opt.ColSet
+		required     string
+		internal     string
+		input        string
+		expected     string
+	}{
+		{ // case 1: Internal ordering is stronger; the provided ordering needs
+			//         trimming.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        props.FuncDepSet{},
+			outCols:      c(1, 2, 3, 4, 5),
+			groupingCols: c(1, 2),
+			required:     "+1",
+			internal:     "+1,+5",
+			input:        "+1,+5",
+			expected:     "+1",
+		},
+		{ // case 2: Projecting all input columns; ok to pass through provided.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3, 4, 5),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "",
+			input:        "+5",
+			expected:     "+5",
+		},
+		{ // case 3: Not projecting all input columns; the provided ordering
+			//         needs remapping.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "",
+			input:        "+5",
+			expected:     "+1",
+		},
+		{ // case 4: The provided ordering needs both trimming and remapping.
+			inCols:       c(1, 2, 3, 4, 5),
+			inFDs:        fd1eq5,
+			outCols:      c(1, 2, 3),
+			groupingCols: c(1, 2),
+			required:     "+(1|5)",
+			internal:     "+5,+4",
+			input:        "+5,+4",
+			expected:     "+1",
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			input := &testexpr.Instance{
+				Rel: &props.Relational{
+					OutputCols: tc.outCols,
+					FuncDeps:   fd1eq5,
+				},
+				Provided: &physical.Provided{
+					Ordering: physical.ParseOrdering(tc.input),
+				},
+			}
+			p := memo.GroupingPrivate{
+				GroupingCols: tc.groupingCols,
+				Ordering:     physical.ParseOrderingChoice(tc.internal),
+			}
+			var aggs memo.AggregationsExpr
+			tc.outCols.Difference(tc.groupingCols).ForEach(func(col int) {
+				aggs = append(aggs, memo.AggregationsItem{
+					Agg:        f.ConstructFirstAgg(f.ConstructVariable(opt.ColumnID(col))),
+					ColPrivate: memo.ColPrivate{Col: opt.ColumnID(col)},
+				})
+			})
+			distinctOn := f.Memo().MemoizeDistinctOn(input, aggs, &p)
+			req := physical.ParseOrderingChoice(tc.required)
+			res := distinctOnBuildProvided(distinctOn, &req).String()
+			if res != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, res)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -150,9 +150,7 @@ func TestPhysicalProps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(
 		t, "testdata/physprops/",
-		memo.ExprFmtHideMiscProps|
-			memo.ExprFmtHideConstraints|
-			memo.ExprFmtHideFuncDeps|
+		memo.ExprFmtHideConstraints|
 			memo.ExprFmtHideRuleProps|
 			memo.ExprFmtHideStats|
 			memo.ExprFmtHideCost|

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1383,6 +1383,31 @@ sort
            └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
+# Verify that we simplify the child ordering of DistinctOn.
+opt
+SELECT DISTINCT ON(a) a, b FROM abc WHERE a=c ORDER BY a
+----
+distinct-on
+ ├── columns: a:1(int!null) b:2(int)
+ ├── grouping columns: a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (2,3)
+ │    ├── fd: (1)==(3), (3)==(1)
+ │    ├── ordering: +(1|3) [actual: +1]
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
+ │    │    └── ordering: +1
+ │    └── filters
+ │         └── a = c [type=bool, outer=(1,3), fd=(1)==(3), (3)==(1)]
+ └── aggregations
+      └── first-agg [type=int, outer=(2)]
+           └── variable: b [type=int]
+
 # --------------------------------------------------
 # Insert operator.
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -75,6 +75,8 @@ SELECT * FROM a ORDER BY x, y DESC
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1,-2
 
 # Order by prefix.
@@ -83,6 +85,8 @@ SELECT * FROM a ORDER BY x
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1
 
 # Order by additional column (should be dropped by optimizer).
@@ -91,6 +95,8 @@ SELECT * FROM a ORDER BY x, y DESC, z
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  └── ordering: +1,-2
 
 # Order by suffix (scan shouldn't be able to provide).
@@ -99,9 +105,13 @@ SELECT * FROM a ORDER BY y DESC
 ----
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: -2
  └── scan a
-      └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      └── fd: (1,2)-->(3,4)
 
 # Order by suffix, don't project prefix (scan shouldn't be able to provide).
 opt
@@ -123,12 +133,16 @@ SELECT * FROM a WHERE x>y ORDER BY x, y DESC
 ----
 select
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(3,4)
  │    └── ordering: +1,-2
  └── filters
-      └── x > y [type=bool]
+      └── x > y [type=bool, outer=(1,2)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -136,13 +150,19 @@ SELECT * FROM a WHERE x>y ORDER BY z DESC
 ----
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
  ├── ordering: -3
  └── select
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3,4)
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      │    ├── key: (1,2)
+      │    └── fd: (1,2)-->(3,4)
       └── filters
-           └── x > y [type=bool]
+           └── x > y [type=bool, outer=(1,2)]
 
 # --------------------------------------------------
 # Project operator (pass through).
@@ -154,12 +174,15 @@ SELECT x+1 AS r, y FROM a ORDER BY x, y DESC
 ----
 project
  ├── columns: r:5(int) y:2(float!null)  [hidden: x:1(int!null)]
+ ├── key: (1,2)
+ ├── fd: (1)-->(5)
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    └── ordering: +1,-2
  └── projections
-      └── x + 1 [type=int]
+      └── x + 1 [type=int, outer=(1)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -167,13 +190,19 @@ SELECT y, x, z+1 AS r FROM a ORDER BY x, y
 ----
 sort
  ├── columns: y:2(float!null) x:1(int!null) r:5(decimal)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(5)
  ├── ordering: +1,+2
  └── project
       ├── columns: r:5(decimal) x:1(int!null) y:2(float!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(5)
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+      │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+      │    ├── key: (1,2)
+      │    └── fd: (1,2)-->(3)
       └── projections
-           └── z + 1 [type=decimal]
+           └── z + 1 [type=decimal, outer=(3)]
 
 # Ordering cannot be passed through because it includes computed column.
 opt
@@ -181,13 +210,18 @@ SELECT x, y+1 AS computed, y FROM a ORDER BY x, computed
 ----
 sort
  ├── columns: x:1(int!null) computed:5(float) y:2(float!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(5)
  ├── ordering: +1,+5
  └── project
       ├── columns: computed:5(float) x:1(int!null) y:2(float!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(5)
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null)
+      │    ├── columns: x:1(int!null) y:2(float!null)
+      │    └── key: (1,2)
       └── projections
-           └── y + 1.0 [type=float]
+           └── y + 1.0 [type=float, outer=(2)]
 
 # --------------------------------------------------
 # Select + Project operators (pass through both).
@@ -199,17 +233,21 @@ SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
 project
  ├── columns: y:2(float!null) z:5(int)  [hidden: x:1(int!null)]
+ ├── key: (1,2)
+ ├── fd: (1)-->(5)
  ├── ordering: +1,-2
  ├── select
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    ├── ordering: +1,-2
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(float!null)
+ │    │    ├── key: (1,2)
  │    │    └── ordering: +1,-2
  │    └── filters
- │         └── x > y [type=bool]
+ │         └── x > y [type=bool, outer=(1,2)]
  └── projections
-      └── x - 1 [type=int]
+      └── x - 1 [type=int, outer=(1)]
 
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
@@ -255,10 +293,14 @@ sort
       ├── columns: y:2(float!null) z:3(decimal)
       └── select
            ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           ├── key: (1,2)
+           ├── fd: (1,2)-->(3)
            ├── scan a
-           │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+           │    ├── key: (1,2)
+           │    └── fd: (1,2)-->(3)
            └── filters
-                └── x > y [type=bool]
+                └── x > y [type=bool, outer=(1,2)]
 
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
@@ -302,13 +344,16 @@ SELECT array_agg(z) FROM (SELECT * FROM a ORDER BY y)
 scalar-group-by
  ├── columns: array_agg:5(decimal[])
  ├── internal-ordering: +2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
  ├── sort
  │    ├── columns: y:2(float!null) z:3(decimal)
  │    ├── ordering: +2
  │    └── scan a
  │         └── columns: y:2(float!null) z:3(decimal)
  └── aggregations
-      └── array-agg [type=decimal[]]
+      └── array-agg [type=decimal[], outer=(3)]
            └── variable: z [type=decimal]
 
 opt
@@ -317,11 +362,15 @@ SELECT array_agg(x) FROM (SELECT * FROM a ORDER BY x, y DESC)
 scalar-group-by
  ├── columns: array_agg:5(int[])
  ├── internal-ordering: +1,-2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
+ │    ├── key: (1,2)
  │    └── ordering: +1,-2
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(1)]
            └── variable: x [type=int]
 
 # Pass through ordering on grouping columns.
@@ -331,12 +380,14 @@ SELECT a, min(b) FROM abc GROUP BY a ORDER BY a
 group-by
  ├── columns: a:1(int!null) min:4(int)
  ├── grouping columns: a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(4)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null)
  │    └── ordering: +1
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(2)]
            └── variable: b [type=int]
 
 opt
@@ -346,12 +397,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -360,12 +414,15 @@ SELECT a, b, min(c) FROM abc GROUP BY a, b ORDER BY a, b
 group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -374,12 +431,15 @@ SELECT a, b, min(c) FROM abc GROUP BY b, a ORDER BY a, b
 group-by
  ├── columns: a:1(int!null) b:2(int!null) min:4(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── min [type=int]
+      └── min [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # We can't pass through the ordering if it refers to aggregation results.
@@ -388,16 +448,21 @@ SELECT a, b, min(c) AS m FROM abc GROUP BY a, b ORDER BY a, m
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) m:4(int)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+4
  └── group-by
       ├── columns: a:1(int!null) b:2(int!null) min:4(int)
       ├── grouping columns: a:1(int!null) b:2(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(4)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── aggregations
-           └── min [type=int]
+           └── min [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # Satisfy both the required and the internal orderings by requiring a+,b+,c+.
@@ -408,12 +473,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -423,12 +491,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -438,12 +509,15 @@ group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +3 opt(1,2)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(4)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── aggregations
-      └── array-agg [type=int[]]
+      └── array-agg [type=int[], outer=(3)]
            └── variable: c [type=int]
 
 # Verify that the GroupBy child ordering is simplified according to the child's
@@ -454,13 +528,17 @@ SELECT sum(c) FROM abc WHERE a = 1 GROUP BY b ORDER BY b
 group-by
  ├── columns: sum:4(decimal)  [hidden: b:2(int!null)]
  ├── grouping columns: b:2(int!null)
+ ├── key: (2)
+ ├── fd: (2)-->(4)
  ├── ordering: +2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    ├── constraint: /1/2/3: [/1 - /1]
- │    └── ordering: +2 opt(1)
+ │    ├── key: (2,3)
+ │    ├── fd: ()-->(1)
+ │    └── ordering: +2 opt(1) [actual: +2]
  └── aggregations
-      └── sum [type=decimal]
+      └── sum [type=decimal, outer=(3)]
            └── variable: c [type=int]
 
 # Verify we do a streaming group-by using the a, b ordering.
@@ -473,11 +551,13 @@ project
       ├── columns: a:1(int) b:2(int) c:3(int) sum:6(decimal)
       ├── grouping columns: a:1(int) b:2(int) c:3(int)
       ├── internal-ordering: +1,+2
+      ├── key: (1-3)
+      ├── fd: (1-3)-->(6)
       ├── scan abcd@ab
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
       │    └── ordering: +1,+2
       └── aggregations
-           └── sum [type=decimal]
+           └── sum [type=decimal, outer=(4)]
                 └── variable: d [type=int]
 
 # Verify we do a streaming group-by using the c, d ordering.
@@ -490,11 +570,13 @@ project
       ├── columns: b:2(int) c:3(int) d:4(int) sum:6(decimal)
       ├── grouping columns: b:2(int) c:3(int) d:4(int)
       ├── internal-ordering: +3,+4
+      ├── key: (2-4)
+      ├── fd: (2-4)-->(6)
       ├── scan abcd@cd
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
       │    └── ordering: +3,+4
       └── aggregations
-           └── sum [type=decimal]
+           └── sum [type=decimal, outer=(1)]
                 └── variable: a [type=int]
 
 opt
@@ -506,11 +588,13 @@ project
       ├── columns: a:1(int) b:2(int) array_agg:6(int[])
       ├── grouping columns: a:1(int) b:2(int)
       ├── internal-ordering: +3 opt(1,2)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(6)
       ├── scan abcd@cd
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
-      │    └── ordering: +3 opt(1,2)
+      │    └── ordering: +3 opt(1,2) [actual: +3]
       └── aggregations
-           └── array-agg [type=int[]]
+           └── array-agg [type=int[], outer=(4)]
                 └── variable: d [type=int]
 
 # --------------------------------------------------
@@ -524,9 +608,13 @@ explain
  ├── mode: verbose
  └── sort
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3,4)
       ├── ordering: +2
       └── scan a
-           └── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+           ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+           ├── key: (1,2)
+           └── fd: (1,2)-->(3,4)
 
 memo
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
@@ -668,12 +756,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4)
+ ├── key: (2-6)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -684,12 +776,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4)
+ ├── key: (2-6)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -701,12 +797,15 @@ left-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
  ├── left ordering: +1
  ├── right ordering: +4
+ ├── key: (1-6)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -716,16 +815,20 @@ SELECT * FROM abc LEFT JOIN xyz ON a=x ORDER BY x
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
+ ├── key: (1-6)
  ├── ordering: +4
  └── left-join (merge)
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
       ├── left ordering: +1
       ├── right ordering: +4
+      ├── key: (1-6)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       └── filters (true)
 
@@ -735,16 +838,20 @@ SELECT * FROM abc RIGHT JOIN xyz ON a=x ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── key: (1-6)
  ├── ordering: +1
  └── right-join (merge)
       ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
       ├── left ordering: +1
       ├── right ordering: +4
+      ├── key: (1-6)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       └── filters (true)
 
@@ -755,12 +862,15 @@ right-join (merge)
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
+ ├── key: (1-6)
  ├── ordering: +4
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters (true)
 
@@ -769,16 +879,20 @@ SELECT * FROM abc FULL OUTER JOIN xyz ON a=x ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
+ ├── key: (1-6)
  ├── ordering: +1
  └── full-join (merge)
       ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
       ├── left ordering: +1
       ├── right ordering: +4
+      ├── key: (1-6)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1
       ├── scan xyz
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    └── ordering: +4
       └── filters (true)
 
@@ -789,12 +903,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -805,12 +923,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4),+(2|5)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4),+(2|5) [actual: +1,+2]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -821,12 +943,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1,+2
  ├── right ordering: +4,+5
- ├── ordering: +(1|4),+(2|5)
+ ├── key: (3-6)
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── ordering: +(1|4),+(2|5) [actual: +1,+2]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4,+5
  └── filters (true)
 
@@ -842,6 +968,7 @@ SELECT * FROM abc ORDER BY a, b LIMIT 10
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1,+2
 
 # The filter prevents pushing of the limit into the scan.
@@ -851,15 +978,19 @@ SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1,+2
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    └── ordering: +1,+2
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -868,9 +999,11 @@ SELECT * FROM abc ORDER BY a, b OFFSET 10
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── const: 10 [type=int]
 
@@ -883,28 +1016,37 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +2
  └── scan abc
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      └── limit: 10
+      ├── limit: 10
+      └── key: (1-3)
 
 opt
 SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +2
  └── limit
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── internal-ordering: +1,+2
+      ├── cardinality: [0 - 10]
+      ├── key: (1-3)
       ├── select
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    ├── ordering: +1,+2
       │    ├── scan abc
       │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    ├── key: (1-3)
       │    │    └── ordering: +1,+2
       │    └── filters
-      │         └── c < (a + b) [type=bool]
+      │         └── c < (a + b) [type=bool, outer=(1-3)]
       └── const: 10 [type=int]
 
 opt
@@ -912,12 +1054,15 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── key: (1-3)
  ├── ordering: +2
  └── offset
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1-3)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── const: 10 [type=int]
 
@@ -931,6 +1076,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1
 
 opt
@@ -939,15 +1085,19 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    └── ordering: +1,+2
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -956,9 +1106,11 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── const: 10 [type=int]
 
@@ -971,6 +1123,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a, b, c
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── limit: 10
+ ├── key: (1-3)
  └── ordering: +1,+2,+3
 
 opt
@@ -979,15 +1132,19 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a,
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── cardinality: [0 - 10]
+ ├── key: (1-3)
  ├── ordering: +1,+2,+3
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,+2,+3
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    ├── key: (1-3)
  │    │    └── ordering: +1,+2,+3
  │    └── filters
- │         └── c < (a + b) [type=bool]
+ │         └── c < (a + b) [type=bool, outer=(1-3)]
  └── const: 10 [type=int]
 
 opt
@@ -996,9 +1153,11 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a, b, c
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1-3)
  ├── ordering: +1,+2,+3
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2,+3
  └── const: 10 [type=int]
 
@@ -1015,6 +1174,7 @@ SELECT DISTINCT b, c FROM abc ORDER BY b
 distinct-on
  ├── columns: b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── key: (2,3)
  ├── ordering: +2
  └── sort
       ├── columns: b:2(int!null) c:3(int!null)
@@ -1028,6 +1188,7 @@ SELECT DISTINCT a, b, c FROM abc ORDER BY a, b
 ----
 scan abc
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── key: (1-3)
  └── ordering: +1,+2
 
 # DISTINCT ON requires the ordering of its input, as it affects the results
@@ -1038,14 +1199,18 @@ SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY b
 distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +2
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +2
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── key: (1-3)
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 opt
@@ -1055,14 +1220,18 @@ distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1 opt(2,3)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +2,+3
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +2,+3,+1
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── key: (1-3)
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 opt
@@ -1072,14 +1241,18 @@ distinct-on
  ├── columns: a:1(int!null) c:3(int)
  ├── grouping columns: a:1(int!null)
  ├── internal-ordering: -3,+2 opt(1)
+ ├── key: (1)
+ ├── fd: (1)-->(3)
  ├── ordering: +1
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    ├── ordering: +1,-3,+2
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── key: (1-3)
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # Pass through the ordering from above.
@@ -1090,12 +1263,15 @@ distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # Internal orderings that refer just to ON columns can be ignored.
@@ -1105,12 +1281,15 @@ SELECT * FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc ORDER BY a) ORDER BY a
 distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 opt
@@ -1120,12 +1299,15 @@ distinct-on
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── grouping columns: a:1(int!null) b:2(int!null)
  ├── internal-ordering: +1,+2
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1,+2
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(3)]
            └── variable: c [type=int]
 
 # The c,b part of the inner ordering can be ignored.
@@ -1136,12 +1318,15 @@ distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── internal-ordering: +1 opt(2,3)
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(1)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  └── aggregations
-      └── first-agg [type=int]
+      └── first-agg [type=int, outer=(1)]
            └── variable: a [type=int]
 
 # There is no ordering that satisfies both the intra-group ordering of c+ and the
@@ -1151,20 +1336,26 @@ SELECT * FROM (SELECT DISTINCT ON (b) a, b, c FROM abc ORDER BY b, c) ORDER BY a
 ----
 sort
  ├── columns: a:1(int) b:2(int!null) c:3(int)
+ ├── key: (2)
+ ├── fd: (2)-->(1,3)
  ├── ordering: +1
  └── distinct-on
       ├── columns: a:1(int) b:2(int!null) c:3(int)
       ├── grouping columns: b:2(int!null)
       ├── internal-ordering: +3 opt(2)
+      ├── key: (2)
+      ├── fd: (2)-->(1,3)
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: +3 opt(2)
+      │    ├── key: (1-3)
+      │    ├── ordering: +3 opt(2) [actual: +3]
       │    └── scan abc
-      │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │         └── key: (1-3)
       └── aggregations
-           ├── first-agg [type=int]
+           ├── first-agg [type=int, outer=(1)]
            │    └── variable: a [type=int]
-           └── first-agg [type=int]
+           └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # Same as above, except we can use the index ordering for the distinct input.
@@ -1173,18 +1364,23 @@ SELECT * FROM (SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b) ORDER BY c
 ----
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
  ├── ordering: +3
  └── distinct-on
       ├── columns: a:1(int!null) b:2(int) c:3(int)
       ├── grouping columns: a:1(int!null)
       ├── internal-ordering: +1,+2
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
       │    └── ordering: +1,+2
       └── aggregations
-           ├── first-agg [type=int]
+           ├── first-agg [type=int, outer=(2)]
            │    └── variable: b [type=int]
-           └── first-agg [type=int]
+           └── first-agg [type=int, outer=(3)]
                 └── variable: c [type=int]
 
 # --------------------------------------------------
@@ -1201,20 +1397,27 @@ insert abc
  │    ├──  x:4 => a:1
  │    ├──  y:5 => b:2
  │    └──  z:6 => c:3
+ ├── cardinality: [0 - 2]
+ ├── side-effects, mutations
+ ├── key: (1-3)
  ├── ordering: +2
  └── limit
       ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
       ├── internal-ordering: +5,+6
+      ├── cardinality: [0 - 2]
+      ├── key: (4-6)
       ├── ordering: +5
       ├── sort
       │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    ├── key: (4-6)
       │    ├── ordering: +5,+6
       │    └── scan xyz
-      │         └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │         └── key: (4-6)
       └── const: 2 [type=int]
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [INSERT INTO xyz SELECT b, c, d FROM abcd ORDER BY c, d LIMIT 2 RETURNING *]
 ORDER BY y
@@ -1231,13 +1434,11 @@ insert xyz
  └── scan abcd@cd
       ├── columns: b:5(int) c:6(int) d:7(int)
       ├── limit: 2
-      ├── ordering: +6
-      ├── prune: (5)
-      └── interesting orderings: (+6,+7)
+      └── ordering: +6
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [INSERT INTO xyz SELECT b, c, d FROM abcd ORDER BY c, d LIMIT 2 RETURNING *]
 WHERE x=y
@@ -1264,9 +1465,7 @@ sort
       │    ├── side-effects, mutations
       │    └── scan abcd@cd
       │         ├── columns: b:5(int) c:6(int) d:7(int)
-      │         ├── limit: 2
-      │         ├── prune: (5)
-      │         └── interesting orderings: (+6,+7)
+      │         └── limit: 2
       └── filters
            └── x = y [type=bool, outer=(1,2), fd=(1)==(2), (2)==(1)]
 
@@ -1280,8 +1479,11 @@ insert abc
  │    ├──  x:4 => a:1
  │    ├──  y:5 => b:2
  │    └──  z:6 => c:3
+ ├── side-effects, mutations
+ ├── key: (1-3)
  └── scan xyz
-      └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      └── key: (4-6)
 
 # --------------------------------------------------
 # Update operator.
@@ -1293,26 +1495,35 @@ SELECT * FROM [UPDATE abcd SET (a, b)=(1, 2) RETURNING *] ORDER BY c
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
- ├── ordering: +3 opt(1,2)
+ ├── side-effects, mutations
+ ├── fd: ()-->(1,2)
+ ├── ordering: +3 opt(1,2) [actual: +3]
  └── update abcd
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int)
       ├── update-mapping:
       │    ├──  column11:11 => a:1
       │    └──  column12:12 => b:2
-      ├── ordering: +3 opt(1,2)
+      ├── side-effects, mutations
+      ├── key: (5)
+      ├── fd: ()-->(1,2), (5)-->(3,4)
+      ├── ordering: +3 opt(1,2) [actual: +3]
       └── project
            ├── columns: column11:11(int!null) column12:12(int!null) a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
-           ├── ordering: +8 opt(11,12)
+           ├── key: (10)
+           ├── fd: ()-->(11,12), (10)-->(6-9)
+           ├── ordering: +8 opt(11,12) [actual: +8]
            ├── scan abcd@cd
            │    ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
+           │    ├── key: (10)
+           │    ├── fd: (10)-->(6-9)
            │    └── ordering: +8
            └── projections
                 ├── const: 1 [type=int]
                 └── const: 2 [type=int]
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [UPDATE abcd SET b=b+1 ORDER BY c LIMIT 10 RETURNING *]
 ORDER BY c, d
@@ -1322,7 +1533,6 @@ project
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── ordering: +3,+4
- ├── prune: (1-4)
  └── update abcd
       ├── columns: a:1(int) b:2(int) c:3(int) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int)
@@ -1339,22 +1549,18 @@ project
            ├── key: (10)
            ├── fd: (10)-->(6-9), (7)-->(11)
            ├── ordering: +8,+9
-           ├── prune: (6-11)
-           ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
            ├── scan abcd@cd
            │    ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
            │    ├── limit: 10
            │    ├── key: (10)
            │    ├── fd: (10)-->(6-9)
-           │    ├── ordering: +8,+9
-           │    ├── prune: (6-10)
-           │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │    └── ordering: +8,+9
            └── projections
                 └── b + 1 [type=int, outer=(7)]
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [UPDATE abcd SET b=b+1 ORDER BY c, d LIMIT 10 RETURNING *]
 WHERE b=c
@@ -1366,13 +1572,11 @@ sort
  ├── side-effects, mutations
  ├── fd: (2)==(3), (3)==(2)
  ├── ordering: +(2|3),+4 [actual: +2,+4]
- ├── prune: (1-4)
  └── project
       ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── fd: (2)==(3), (3)==(2)
-      ├── prune: (1-4)
       └── select
            ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
            ├── cardinality: [0 - 10]
@@ -1393,15 +1597,11 @@ sort
            │         ├── cardinality: [0 - 10]
            │         ├── key: (10)
            │         ├── fd: (10)-->(6-9), (7)-->(11)
-           │         ├── prune: (6-11)
-           │         ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
            │         ├── scan abcd@cd
            │         │    ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
            │         │    ├── limit: 10
            │         │    ├── key: (10)
-           │         │    ├── fd: (10)-->(6-9)
-           │         │    ├── prune: (6-10)
-           │         │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │         │    └── fd: (10)-->(6-9)
            │         └── projections
            │              └── b + 1 [type=int, outer=(7)]
            └── filters
@@ -1426,6 +1626,7 @@ ORDER BY b
 ----
 sort
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── side-effects, mutations
  ├── ordering: +2
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -1441,25 +1642,33 @@ sort
       │    ├──  upsert_a:11 => a:1
       │    ├──  upsert_b:12 => b:2
       │    └──  upsert_c:13 => c:3
+      ├── side-effects, mutations
       └── project
            ├── columns: upsert_a:11(int) upsert_b:12(int) upsert_c:13(int) x:4(int!null) y:5(int!null) z:6(int!null) a:7(int) b:8(int) c:9(int)
+           ├── key: (4-9)
+           ├── fd: (4,7)-->(11), (5,7,8)-->(12), (6,7,9)-->(13)
            ├── left-join (lookup abc)
            │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null) a:7(int) b:8(int) c:9(int)
            │    ├── key columns: [4 5 6] = [7 8 9]
+           │    ├── key: (4-9)
            │    ├── limit
            │    │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
            │    │    ├── internal-ordering: +5,+6
+           │    │    ├── cardinality: [0 - 2]
+           │    │    ├── key: (4-6)
            │    │    ├── sort
            │    │    │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+           │    │    │    ├── key: (4-6)
            │    │    │    ├── ordering: +5,+6
            │    │    │    └── scan xyz
-           │    │    │         └── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+           │    │    │         ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+           │    │    │         └── key: (4-6)
            │    │    └── const: 2 [type=int]
            │    └── filters (true)
            └── projections
-                ├── CASE WHEN a IS NULL THEN x ELSE 10 END [type=int]
-                ├── CASE WHEN a IS NULL THEN y ELSE b END [type=int]
-                └── CASE WHEN a IS NULL THEN z ELSE c END [type=int]
+                ├── CASE WHEN a IS NULL THEN x ELSE 10 END [type=int, outer=(4,7)]
+                ├── CASE WHEN a IS NULL THEN y ELSE b END [type=int, outer=(5,7,8)]
+                └── CASE WHEN a IS NULL THEN z ELSE c END [type=int, outer=(6,7,9)]
 
 # --------------------------------------------------
 # Delete operator.
@@ -1471,17 +1680,23 @@ SELECT * FROM [DELETE FROM abcd RETURNING *] ORDER BY c
 ----
 project
  ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
+ ├── side-effects, mutations
  ├── ordering: +3
  └── delete abcd
       ├── columns: a:1(int) b:2(int) c:3(int) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int)
+      ├── side-effects, mutations
+      ├── key: (5)
+      ├── fd: (5)-->(1-4)
       ├── ordering: +3
       └── scan abcd@cd
            ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
+           ├── key: (10)
+           ├── fd: (10)-->(6-9)
            └── ordering: +8
 
 # Verify that provided orderings are derived correctly.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [DELETE FROM abcd ORDER BY c LIMIT 10 RETURNING *]
 ORDER BY c, d
@@ -1491,7 +1706,6 @@ project
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── ordering: +3,+4
- ├── prune: (1-4)
  └── delete abcd
       ├── columns: a:1(int) b:2(int) c:3(int) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int)
@@ -1505,13 +1719,11 @@ project
            ├── limit: 10
            ├── key: (10)
            ├── fd: (10)-->(6-9)
-           ├── ordering: +8,+9
-           ├── prune: (6,7,9,10)
-           └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           └── ordering: +8,+9
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
-opt format=(hide-qual,hide-cost,hide-stats,hide-constraints,hide-scalars)
+opt
 SELECT *
 FROM [DELETE FROM abcd ORDER BY c, d LIMIT 10 RETURNING *]
 WHERE b=c
@@ -1523,13 +1735,11 @@ sort
  ├── side-effects, mutations
  ├── fd: (2)==(3), (3)==(2)
  ├── ordering: +(2|3),+4 [actual: +2,+4]
- ├── prune: (1-4)
  └── project
       ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int)
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── fd: (2)==(3), (3)==(2)
-      ├── prune: (1-4)
       └── select
            ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
            ├── cardinality: [0 - 10]
@@ -1547,9 +1757,7 @@ sort
            │         ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
            │         ├── limit: 10
            │         ├── key: (10)
-           │         ├── fd: (10)-->(6-9)
-           │         ├── prune: (6,7,10)
-           │         └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │         └── fd: (10)-->(6-9)
            └── filters
                 └── b = c [type=bool, outer=(2,3), fd=(2)==(3), (3)==(2)]
 
@@ -1563,12 +1771,16 @@ inner-join (merge)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── left ordering: +1
  ├── right ordering: +4
- ├── ordering: +(1|4|6)
+ ├── key: (2,3,5,6)
+ ├── fd: (1)==(4,6), (4)==(1,6), (6)==(1,4)
+ ├── ordering: +(1|4|6) [actual: +1]
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── key: (1-3)
  │    └── ordering: +1
  ├── scan xyz
  │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    ├── key: (4-6)
  │    └── ordering: +4
  └── filters
-      └── x = z [type=bool]
+      └── x = z [type=bool, outer=(4,6), fd=(4)==(6), (6)==(4)]

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -22,7 +22,9 @@ opt
 SELECT a.y, a.x, a.y y2 FROM a
 ----
 scan a
- └── columns: y:2(int) x:1(int!null) y2:2(int)
+ ├── columns: y:2(int) x:1(int!null) y2:2(int)
+ ├── key: (1)
+ └── fd: (1)-->(2)
 
 # Select operator.
 opt
@@ -30,10 +32,14 @@ SELECT a.y, a.x, a.y y2 FROM a WHERE y=1
 ----
 select
  ├── columns: y:2(int!null) x:1(int!null) y2:2(int!null)
+ ├── key: (1)
+ ├── fd: ()-->(2)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── filters
-      └── y = 1 [type=bool]
+      └── y = 1 [type=bool, outer=(2), fd=()-->(2)]
 
 # Project operator.
 opt
@@ -41,10 +47,14 @@ SELECT 1+a.y AS plus, a.x FROM a
 ----
 project
  ├── columns: plus:3(int) x:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(3)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  └── projections
-      └── y + 1 [type=int]
+      └── y + 1 [type=int, outer=(2)]
 
 # Join operator.
 opt
@@ -52,10 +62,16 @@ SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
 ----
 inner-join
  ├── columns: x:3(int) rowid:5(int!null) y:2(int) x:1(int!null) y2:2(int) y:4(float)
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(3,4)
  ├── scan a
- │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
  ├── scan b
- │    └── columns: b.x:3(int) b.y:4(float) rowid:5(int!null)
+ │    ├── columns: b.x:3(int) b.y:4(float) rowid:5(int!null)
+ │    ├── key: (5)
+ │    └── fd: (5)-->(3,4)
  └── filters (true)
 
 # Groupby operator.
@@ -66,11 +82,15 @@ group-by
  ├── columns: max:3(int) y:2(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null)
  ├── internal-ordering: +1
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
  │    └── ordering: +1
  └── aggregations
-      ├── max [type=int]
+      ├── max [type=int, outer=(2)]
       │    └── variable: y [type=int]
-      └── const-agg [type=int]
+      └── const-agg [type=int, outer=(2)]
            └── variable: y [type=int]


### PR DESCRIPTION
Backport 3/3 commits from #44543.

/cc @cockroachdb/release

---

#### opt: don't hide misc props in physicalprops tests

TestPhysicalProps hides FDs and provided orderings, forcing some tests
to override the formatting. This change cleans this up by showing more
stuff by default.

Release note: None

#### opt: simplify child ordering for DistinctOn

Adding a bit of missing code for determining the required ordering for
the DistinctOn input: we weren't simplifying the ordering w.r.t the
FDs. This is not a correctness issue, but simplifying opens up more
opportunities for optimization. The code is also more consistent with
the one for GroupBy which should only differ in projecting the
grouping columns.

Release note: None

#### opt: remap provided ordering for DistinctOn

The code for determining the provided ordering for DistinctOn didn't
take into account that the operator can effectively be projecting out
input columns, in which case the provided ordering might need
remapping.

The corresponding GroupBy code is simplified so the two cases are
handled similarly, with the only difference being the allowed columns
(grouping cols for GroupBy, output cols for DistinctOn).

Fixes #44509.

Release note (bug fix): fixed "no output column equivalent to.." and
"column not in input" errors in some cases involving DISTINCT ON and
ORDER BY.

