### PR TITLE
sql: fix comparisons of timestamps and dates in daylight timezones

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -255,3 +255,43 @@ query B
 select localtimestamp(3) - localtimestamp <= '1ms'::interval
 ----
 true
+
+# When doing daylight savings comparisons, ensure they compare correctly.
+# Test day before and after DST.
+subtest regression_django-cockroachdb_120
+
+statement ok
+SET TIME ZONE 'America/Chicago'
+
+query B
+SELECT '2011-03-13'::date = '2011-03-13'::timestamp
+----
+true
+
+query B
+SELECT '2011-03-13'::date = '2011-03-13'::timestamptz
+----
+true
+
+query B
+SELECT '2011-03-13'::timestamp = '2011-03-13'::timestamptz
+----
+true
+
+query B
+SELECT '2011-03-14'::date = '2011-03-14'::timestamp
+----
+true
+
+query B
+SELECT '2011-03-14'::date = '2011-03-14'::timestamptz
+----
+true
+
+query B
+SELECT '2011-03-14'::timestamp = '2011-03-14'::timestamptz
+----
+true
+
+statement ok
+SET TIME ZONE 0

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2163,12 +2163,13 @@ func timeFromDatumForComparison(ctx *EvalContext, d Datum) (time.Time, bool) {
 		return t.Time, true
 	case *DTimestamp:
 		// Normalize to the timezone of the context.
-		_, zoneOffset := ctx.GetRelativeParseTime().Zone()
-		return t.Time.In(ctx.GetLocation()).Add(-time.Duration(zoneOffset) * time.Second), true
+		_, zoneOffset := t.Time.In(ctx.GetLocation()).Zone()
+		ts := t.Time.In(ctx.GetLocation()).Add(-time.Duration(zoneOffset) * time.Second)
+		return ts, true
 	case *DTime:
 		// Normalize to the timezone of the context.
 		toTime := timeofday.TimeOfDay(*t).ToTime()
-		_, zoneOffsetSecs := ctx.GetRelativeParseTime().Zone()
+		_, zoneOffsetSecs := toTime.In(ctx.GetLocation()).Zone()
 		return toTime.In(ctx.GetLocation()).Add(-time.Duration(zoneOffsetSecs) * time.Second), true
 	case *DTimeTZ:
 		return t.ToTime(), true

--- a/pkg/util/timetz/timetz.go
+++ b/pkg/util/timetz/timetz.go
@@ -62,7 +62,7 @@ func MakeTimeTZ(t timeofday.TimeOfDay, offsetSecs int32) TimeTZ {
 
 // MakeTimeTZFromLocation creates a TimeTZ from a TimeOfDay and time.Location.
 func MakeTimeTZFromLocation(t timeofday.TimeOfDay, loc *time.Location) TimeTZ {
-	_, zoneOffsetSecs := timeutil.Unix(0, 0).In(loc).Zone()
+	_, zoneOffsetSecs := timeutil.Now().In(loc).Zone()
 	return TimeTZ{TimeOfDay: t, OffsetSecs: -int32(zoneOffsetSecs)}
 }
 


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/django-cockroachdb/issues/120.

In one of my earlier refactors, I've changed timestamps to always
convert to the local zone. Whilst this is correct, it relied on changing
to the local zone *at time of evaluation*, rather than after moving the
current time to the zone in that point in time, hence potentially giving
different results when transferring to daylight savings to not or vice
versa.

I've double checked casts and they are fine - it was only comparisons
where it did not work.

This bug was introduced in 20.1 alpha, so not including a release note.

Release note: None