### PR TITLE
colexec: add support for Interval-related projections

### DIFF
--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -58,6 +58,10 @@ var AllTypes []T
 // type in a binary expression.
 var CompatibleTypes map[T][]T
 
+// ComparableTypes maps a type to a slice of types that can be used with that
+// type in a comparison expression.
+var ComparableTypes map[T][]T
+
 // NumberTypes is a slice containing all numeric types.
 var NumberTypes = []T{Int16, Int32, Int64, Float64, Decimal}
 
@@ -67,6 +71,9 @@ var IntTypes = []T{Int16, Int32, Int64}
 // FloatTypes is a slice containing all float types.
 var FloatTypes = []T{Float64}
 
+// TimeTypes is a slice containing all time-related types.
+var TimeTypes = []T{Timestamp, Interval}
+
 func init() {
 	for i := Bool; i < Unhandled; i++ {
 		AllTypes = append(AllTypes, i)
@@ -75,13 +82,24 @@ func init() {
 	CompatibleTypes = make(map[T][]T)
 	CompatibleTypes[Bool] = append(CompatibleTypes[Bool], Bool)
 	CompatibleTypes[Bytes] = append(CompatibleTypes[Bytes], Bytes)
-	CompatibleTypes[Decimal] = append(CompatibleTypes[Decimal], NumberTypes...)
-	CompatibleTypes[Int16] = append(CompatibleTypes[Int16], NumberTypes...)
-	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], NumberTypes...)
-	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], NumberTypes...)
-	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], NumberTypes...)
-	CompatibleTypes[Timestamp] = append(CompatibleTypes[Timestamp], Timestamp)
-	CompatibleTypes[Interval] = append(CompatibleTypes[Interval], Interval)
+	CompatibleTypes[Decimal] = append(CompatibleTypes[Decimal], append(NumberTypes, Interval)...)
+	CompatibleTypes[Int16] = append(CompatibleTypes[Int16], append(NumberTypes, Interval)...)
+	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], append(NumberTypes, Interval)...)
+	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], append(NumberTypes, Interval)...)
+	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], append(NumberTypes, Interval)...)
+	CompatibleTypes[Timestamp] = append(CompatibleTypes[Timestamp], TimeTypes...)
+	CompatibleTypes[Interval] = append(CompatibleTypes[Interval], append(NumberTypes, TimeTypes...)...)
+
+	ComparableTypes = make(map[T][]T)
+	ComparableTypes[Bool] = append(ComparableTypes[Bool], Bool)
+	ComparableTypes[Bytes] = append(ComparableTypes[Bytes], Bytes)
+	ComparableTypes[Decimal] = append(ComparableTypes[Decimal], NumberTypes...)
+	ComparableTypes[Int16] = append(ComparableTypes[Int16], NumberTypes...)
+	ComparableTypes[Int32] = append(ComparableTypes[Int32], NumberTypes...)
+	ComparableTypes[Int64] = append(ComparableTypes[Int64], NumberTypes...)
+	ComparableTypes[Float64] = append(ComparableTypes[Float64], NumberTypes...)
+	ComparableTypes[Timestamp] = append(ComparableTypes[Timestamp], Timestamp)
+	ComparableTypes[Interval] = append(ComparableTypes[Interval], Interval)
 }
 
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -99,7 +99,7 @@ func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 
 func (a *avg_TYPEAgg) Reset() {
 	a.scratch.curIdx = -1
-	a.scratch.curSum = zero_TYPEColumn[0]
+	a.scratch.curSum = zero_TYPEValue
 	a.scratch.curCount = 0
 	a.scratch.foundNonNullForCurrentGroup = false
 	a.scratch.nulls.UnsetNulls()
@@ -193,7 +193,7 @@ func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bo
 		}
 		a.scratch.curIdx++
 		// {{with .Global}}
-		a.scratch.curSum = zero_TYPEColumn[0]
+		a.scratch.curSum = zero_TYPEValue
 		// {{end}}
 		a.scratch.curCount = 0
 

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -54,6 +55,9 @@ var _ = math.MaxInt64
 
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/pkg/errors"
 )
 
@@ -36,6 +37,9 @@ var _ apd.Decimal
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum
+
+// Dummy import to pull in "duration" package.
+var _ duration.Duration
 
 // _ASSIGN_ADD is the template addition function for assigning the first input
 // to the result of the second input + the third input.

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -91,7 +91,6 @@ func (a *sum_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *sum_TYPEAgg) Reset() {
-	a.scratch.curAgg = a.scratch.vec[0]
 	a.scratch.curIdx = -1
 	a.scratch.foundNonNullForCurrentGroup = false
 	a.scratch.nulls.UnsetNulls()
@@ -183,7 +182,7 @@ func _ACCUMULATE_SUM(a *sum_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS boo
 		}
 		a.scratch.curIdx++
 		// {{with .Global}}
-		a.scratch.curAgg = zero_TYPEColumn[0]
+		a.scratch.curAgg = zero_TYPEValue
 		// {{end}}
 
 		// {{/*

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -17,22 +17,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
-// TODO(yuzefovich): in most cases only need a single zero value.
-var zeroBoolColumn = make([]bool, coldata.MaxBatchSize)
+var (
+	zeroBoolColumn   = make([]bool, coldata.MaxBatchSize)
+	zeroUint64Column = make([]uint64, coldata.MaxBatchSize)
 
-var zeroDecimalColumn = make([]apd.Decimal, coldata.MaxBatchSize)
-
-var zeroInt16Column = make([]int16, coldata.MaxBatchSize)
-
-var zeroInt32Column = make([]int32, coldata.MaxBatchSize)
-
-var zeroInt64Column = make([]int64, coldata.MaxBatchSize)
-
-var zeroIntervalColumn = make([]duration.Duration, coldata.MaxBatchSize)
-
-var zeroFloat64Column = make([]float64, coldata.MaxBatchSize)
-
-var zeroUint64Column = make([]uint64, coldata.MaxBatchSize)
+	zeroDecimalValue  apd.Decimal
+	zeroFloat64Value  float64
+	zeroInt16Value    int16
+	zeroInt32Value    int32
+	zeroInt64Value    int64
+	zeroIntervalValue duration.Duration
+)
 
 // CopyBatch copies the original batch and returns that copy. However, note that
 // the underlying capacity might be different (a new batch is created only with

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -14,8 +14,10 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
+// TODO(yuzefovich): in most cases only need a single zero value.
 var zeroBoolColumn = make([]bool, coldata.MaxBatchSize)
 
 var zeroDecimalColumn = make([]apd.Decimal, coldata.MaxBatchSize)
@@ -25,6 +27,8 @@ var zeroInt16Column = make([]int16, coldata.MaxBatchSize)
 var zeroInt32Column = make([]int32, coldata.MaxBatchSize)
 
 var zeroInt64Column = make([]int64, coldata.MaxBatchSize)
+
+var zeroIntervalColumn = make([]duration.Duration, coldata.MaxBatchSize)
 
 var zeroFloat64Column = make([]float64, coldata.MaxBatchSize)
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -304,8 +304,7 @@ func (ex *connExecutor) execBind(
 					"expected %d arguments, got %d", numQArgs, len(bindCmd.Args)))
 		}
 
-		ptCtx := tree.NewParseTimeContext(ex.sessionData.DurationAdditionMode,
-			ex.state.sqlTimestamp.In(ex.sessionData.DataConversion.Location))
+		ptCtx := tree.NewParseTimeContext(ex.state.sqlTimestamp.In(ex.sessionData.DataConversion.Location))
 
 		for i, arg := range bindCmd.Args {
 			k := tree.PlaceholderIdx(i)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -279,12 +278,6 @@ func (ds *ServerImpl) setupFlow(
 				BytesEncodeFormat: be,
 				ExtraFloatDigits:  int(req.EvalContext.ExtraFloatDigits),
 			},
-		}
-		// Enable better compatibility with PostgreSQL date math.
-		if req.Version >= 22 {
-			sd.DurationAdditionMode = duration.AdditionModeCompatible
-		} else {
-			sd.DurationAdditionMode = duration.AdditionModeLegacy
 		}
 		ie := &lazyInternalExecutor{
 			newInternalExecutor: func() sqlutil.InternalExecutor {

--- a/pkg/sql/pgwire/pgwirebase/fuzz.go
+++ b/pkg/sql/pgwire/pgwirebase/fuzz.go
@@ -15,13 +15,12 @@ package pgwirebase
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/lib/pq/oid"
 )
 
 var (
-	timeCtx = tree.NewParseTimeContext(duration.AdditionModeCompatible, timeutil.Now())
+	timeCtx = tree.NewParseTimeContext(timeutil.Now())
 	// Compile a slice of all oids.
 	oids = func() []oid.Oid {
 		var ret []oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -348,7 +348,6 @@ var keywordCategoryDescriptions = map[string]string{
 // seriesValueGenerator supports the execution of generate_series()
 // with integer bounds.
 type seriesValueGenerator struct {
-	ctx                                 *tree.EvalContext
 	origStart, value, start, stop, step interface{}
 	nextOK                              bool
 	genType                             *types.T
@@ -404,7 +403,7 @@ func seriesTSNext(s *seriesValueGenerator) (bool, error) {
 	}
 
 	s.value = start
-	s.start = duration.Add(s.ctx, start, step)
+	s.start = duration.Add(start, step)
 	return true, nil
 }
 
@@ -412,7 +411,7 @@ func seriesGenTSValue(s *seriesValueGenerator) tree.Datums {
 	return tree.Datums{tree.MakeDTimestamp(s.value.(time.Time), time.Microsecond)}
 }
 
-func makeSeriesGenerator(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
+func makeSeriesGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
 	start := int64(tree.MustBeDInt(args[0]))
 	stop := int64(tree.MustBeDInt(args[1]))
 	step := int64(1)
@@ -423,7 +422,6 @@ func makeSeriesGenerator(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGen
 		return nil, errStepCannotBeZero
 	}
 	return &seriesValueGenerator{
-		ctx:       ctx,
 		origStart: start,
 		stop:      stop,
 		step:      step,
@@ -433,7 +431,7 @@ func makeSeriesGenerator(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGen
 	}, nil
 }
 
-func makeTSSeriesGenerator(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
+func makeTSSeriesGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
 	start := args[0].(*tree.DTimestamp).Time
 	stop := args[1].(*tree.DTimestamp).Time
 	step := args[2].(*tree.DInterval).Duration
@@ -443,7 +441,6 @@ func makeTSSeriesGenerator(ctx *tree.EvalContext, args tree.Datums) (tree.ValueG
 	}
 
 	return &seriesValueGenerator{
-		ctx:       ctx,
 		origStart: start,
 		stop:      stop,
 		step:      step,

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -103,7 +103,7 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 			if (iv.Duration == duration.Duration{}) {
 				convErr = errors.Errorf("interval value %v too small, absolute value must be >= %v", d, time.Microsecond)
 			}
-			ts.WallTime = duration.Add(evalCtx, stmtTimestamp, iv.Duration).UnixNano()
+			ts.WallTime = duration.Add(stmtTimestamp, iv.Duration).UnixNano()
 			break
 		}
 		convErr = errors.Errorf("value is neither timestamp, decimal, nor interval")
@@ -116,7 +116,7 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 	case *DDecimal:
 		ts, convErr = DecimalToHLC(&d.Decimal)
 	case *DInterval:
-		ts.WallTime = duration.Add(evalCtx, stmtTimestamp, d.Duration).UnixNano()
+		ts.WallTime = duration.Add(stmtTimestamp, d.Duration).UnixNano()
 	default:
 		convErr = errors.Errorf("expected timestamp, decimal, or interval, got %s (%T)", d.ResolvedType(), d)
 	}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1709,7 +1709,6 @@ func NewDDateFromTime(t time.Time) (*DDate, error) {
 // parsing dates, times, and timestamps. A nil value is generally
 // acceptable and will result in reasonable defaults being applied.
 type ParseTimeContext interface {
-	duration.Context
 	// GetRelativeParseTime returns the transaction time in the session's
 	// timezone (i.e. now()). This is used to calculate relative dates,
 	// like "tomorrow", and also provides a default time.Location for
@@ -1723,21 +1722,14 @@ var _ ParseTimeContext = &simpleParseTimeContext{}
 
 // NewParseTimeContext constructs a ParseTimeContext that returns
 // the given values.
-func NewParseTimeContext(mode duration.AdditionMode, relativeParseTime time.Time) ParseTimeContext {
+func NewParseTimeContext(relativeParseTime time.Time) ParseTimeContext {
 	return &simpleParseTimeContext{
-		AdditionMode:      mode,
 		RelativeParseTime: relativeParseTime,
 	}
 }
 
 type simpleParseTimeContext struct {
-	AdditionMode      duration.AdditionMode
 	RelativeParseTime time.Time
-}
-
-// GetAdditionMode implements ParseTimeContext.
-func (ctx simpleParseTimeContext) GetAdditionMode() duration.AdditionMode {
-	return ctx.AdditionMode
 }
 
 // GetRelativeParseTime implements ParseTimeContext.
@@ -2117,7 +2109,7 @@ func ParseDTimestamp(ctx ParseTimeContext, s string, precision time.Duration) (*
 	}
 	// Truncate the timezone. DTimestamp doesn't carry its timezone around.
 	_, offset := t.Zone()
-	t = duration.Add(ctx, t, duration.FromInt64(int64(offset))).UTC()
+	t = duration.Add(t, duration.FromInt64(int64(offset))).UTC()
 	return MakeDTimestamp(t, precision), nil
 }
 
@@ -2446,7 +2438,7 @@ func (d *DTimestampTZ) stripTimeZone(ctx *EvalContext) *DTimestamp {
 // location, returning a timestamp without a timezone.
 func (d *DTimestampTZ) EvalAtTimeZone(ctx *EvalContext, loc *time.Location) *DTimestamp {
 	_, locOffset := d.Time.In(loc).Zone()
-	newTime := duration.Add(ctx, d.Time.UTC(), duration.FromInt64(int64(locOffset)))
+	newTime := duration.Add(d.Time.UTC(), duration.FromInt64(int64(locOffset)))
 	return MakeDTimestamp(newTime, time.Microsecond)
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -667,8 +667,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Timestamp,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				return MakeDTimestamp(duration.Add(ctx,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return MakeDTimestamp(duration.Add(
 					left.(*DTimestamp).Time, right.(*DInterval).Duration), time.Microsecond), nil
 			},
 		},
@@ -676,8 +676,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Interval,
 			RightType:  types.Timestamp,
 			ReturnType: types.Timestamp,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				return MakeDTimestamp(duration.Add(ctx,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return MakeDTimestamp(duration.Add(
 					right.(*DTimestamp).Time, left.(*DInterval).Duration), time.Microsecond), nil
 			},
 		},
@@ -685,8 +685,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimestampTZ,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				t := duration.Add(ctx, left.(*DTimestampTZ).Time, right.(*DInterval).Duration)
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				t := duration.Add(left.(*DTimestampTZ).Time, right.(*DInterval).Duration)
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
 		},
@@ -694,8 +694,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Interval,
 			RightType:  types.TimestampTZ,
 			ReturnType: types.TimestampTZ,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				t := duration.Add(ctx, right.(*DTimestampTZ).Time, left.(*DInterval).Duration)
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				t := duration.Add(right.(*DTimestampTZ).Time, left.(*DInterval).Duration)
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
 		},
@@ -716,7 +716,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx, leftTime, right.(*DInterval).Duration)
+				t := duration.Add(leftTime, right.(*DInterval).Duration)
 				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
@@ -724,12 +724,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Interval,
 			RightType:  types.Date,
 			ReturnType: types.Timestamp,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				rightTime, err := right.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx, rightTime, left.(*DInterval).Duration)
+				t := duration.Add(rightTime, left.(*DInterval).Duration)
 				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
@@ -931,8 +931,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Timestamp,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				return MakeDTimestamp(duration.Add(ctx,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				return MakeDTimestamp(duration.Add(
 					left.(*DTimestamp).Time, right.(*DInterval).Duration.Mul(-1)), time.Microsecond), nil
 			},
 		},
@@ -940,8 +940,8 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimestampTZ,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
-				t := duration.Add(ctx,
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				t := duration.Add(
 					left.(*DTimestampTZ).Time, right.(*DInterval).Duration.Mul(-1))
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
@@ -950,12 +950,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   types.Date,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
-			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				leftTime, err := left.(*DDate).ToTime()
 				if err != nil {
 					return nil, err
 				}
-				t := duration.Add(ctx, leftTime, right.(*DInterval).Duration.Mul(-1))
+				t := duration.Add(leftTime, right.(*DInterval).Duration.Mul(-1))
 				return MakeDTimestamp(t, time.Microsecond), nil
 			},
 		},
@@ -3010,14 +3010,6 @@ func (ctx *EvalContext) SetTxnTimestamp(ts time.Time) {
 // SetStmtTimestamp sets the corresponding timestamp in the EvalContext.
 func (ctx *EvalContext) SetStmtTimestamp(ts time.Time) {
 	ctx.StmtTimestamp = ts
-}
-
-// GetAdditionMode implements duration.Context.
-func (ctx *EvalContext) GetAdditionMode() duration.AdditionMode {
-	if ctx == nil {
-		return duration.AdditionModeCompatible
-	}
-	return ctx.SessionData.DurationAdditionMode
 }
 
 // GetLocation returns the session timezone.

--- a/pkg/sql/sem/tree/fuzz.go
+++ b/pkg/sql/sem/tree/fuzz.go
@@ -12,13 +12,10 @@
 
 package tree
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-)
+import "github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
 var (
-	timeCtx = NewParseTimeContext(duration.AdditionModeCompatible, timeutil.Now())
+	timeCtx = NewParseTimeContext(timeutil.Now())
 )
 
 func FuzzParseDDecimal(data []byte) int {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -142,7 +141,7 @@ const (
 	RejectSubqueries
 
 	// RejectSpecial is used in common places like the LIMIT clause.
-	RejectSpecial SemaRejectFlags = RejectAggregates | RejectGenerators | RejectWindowApplications
+	RejectSpecial = RejectAggregates | RejectGenerators | RejectWindowApplications
 )
 
 // ScalarProperties contains the properties of the current scalar
@@ -206,11 +205,6 @@ func (sc *SemaContext) GetLocation() *time.Location {
 		return time.UTC
 	}
 	return *sc.Location
-}
-
-// GetAdditionMode implements ParseTimeContext.
-func (sc *SemaContext) GetAdditionMode() duration.AdditionMode {
-	return duration.AdditionModeCompatible
 }
 
 // GetRelativeParseTime implements ParseTimeContext.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -15,8 +15,6 @@ import (
 	"net"
 	"strings"
 	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // SessionData contains session parameters. They are all user-configurable.
@@ -65,9 +63,6 @@ type SessionData struct {
 	SequenceState *SequenceState
 	// DataConversion gives access to the data conversion configuration.
 	DataConversion DataConversionConfig
-	// DurationAdditionMode enables math compatibility options to be enabled.
-	// TODO(bob): Remove this once the 2.2 release branch is cut.
-	DurationAdditionMode duration.AdditionMode
 	// VectorizeMode indicates which kinds of queries to use vectorized execution
 	// engine for.
 	VectorizeMode VectorizeExecMode

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -272,7 +272,7 @@ func TestAdd(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		if res := Add(nil, test.t, test.d); !test.exp.Equal(res) {
+		if res := Add(test.t, test.d); !test.exp.Equal(res) {
 			t.Errorf("%d: expected Add(%v, %d) = %v, found %v",
 				i, test.t, test.d, test.exp, res)
 		}
@@ -467,28 +467,28 @@ func BenchmarkAdd(b *testing.B) {
 		s := time.Date(2018, 01, 01, 0, 0, 0, 0, time.UTC)
 		d := Duration{Days: 1}
 		for i := 0; i < b.N; i++ {
-			Add(AdditionModeCompatible, s, d)
+			Add(s, d)
 		}
 	})
 	b.Run("fast-path-by-day-number", func(b *testing.B) {
 		s := time.Date(2018, 01, 01, 0, 0, 0, 0, time.UTC)
 		d := Duration{Months: 1}
 		for i := 0; i < b.N; i++ {
-			Add(AdditionModeCompatible, s, d)
+			Add(s, d)
 		}
 	})
 	b.Run("no-adjustment", func(b *testing.B) {
 		s := time.Date(2018, 01, 31, 0, 0, 0, 0, time.UTC)
 		d := Duration{Months: 2}
 		for i := 0; i < b.N; i++ {
-			Add(AdditionModeCompatible, s, d)
+			Add(s, d)
 		}
 	})
 	b.Run("with-adjustment", func(b *testing.B) {
 		s := time.Date(2018, 01, 31, 0, 0, 0, 0, time.UTC)
 		d := Duration{Months: 1}
 		for i := 0; i < b.N; i++ {
-			Add(AdditionModeCompatible, s, d)
+			Add(s, d)
 		}
 	})
 }


### PR DESCRIPTION
**util/duration: remove AdditionMode**

Over a year ago we made a backwards-incompatible change to fix the
normalization of dates during addition. To allow for mixed-version
clusters to work correctly, `AdditionMode` was introduced to enable old
"legacy" behavior. This tool is no longer needed because since 19.1
release all nodes "speak" the compatible addition mode.

Release note: None

**colexec: add support for Interval-related projections**

Almost all binary projections that have types.Interval as one of its
arguments are now supported. The only exception is with types.Date since
that would overlap with types.Int in "physical type" space.

Fixes: #42044.

Release note: None

**colexec: minor clean up of zeroing out in aggregates**

Previously we had "zero vectors" of which only a single zero value was
used when reset the current state of the SUM and AVG aggregates. This is
now refactored to store only the zero value.

Release note: None