### PR TITLE
Makefile: stop passing --progress to webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1281,7 +1281,7 @@ STYLINT            := ./node_modules/.bin/stylint
 TSLINT             := ./node_modules/.bin/tslint
 TSC                := ./node_modules/.bin/tsc
 KARMA              := ./node_modules/.bin/karma
-WEBPACK            := ./node_modules/.bin/webpack $(if $(MAKE_TERMERR),--progress)
+WEBPACK            := ./node_modules/.bin/webpack
 WEBPACK_DEV_SERVER := ./node_modules/.bin/webpack-dev-server
 WEBPACK_DASHBOARD  := ./opt/node_modules/.bin/webpack-dashboard
 


### PR DESCRIPTION
webpack's progress updates write 1.9 megabytes of output any time a
proto is changed, and due to how we run it in parallel with other tasks
outputting to the same terminal, it cannot use a line-replacing mode but
rather emits about 7100 individual lines. The progress information is
completely useless.

Release note: None.