### PR TITLE
workload/tpch: unskip query 12

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -46,12 +46,9 @@ func registerTPCHVec(r *testRegistry) {
 		7:  "can cause OOM",
 		8:  "can cause OOM",
 		9:  "can cause OOM",
-		12: "the query is skipped by tpch workload",
 		19: "can cause OOM",
 	}
-	queriesToSkipByVersionPrefix["v20.1"] = map[int]string{
-		12: "the query is skipped by tpch workload",
-	}
+	queriesToSkipByVersionPrefix["v20.1"] = map[int]string{}
 
 	runTPCHVec := func(ctx context.Context, t *test, c *cluster) {
 		TPCHTables := []string{

--- a/pkg/workload/tpch/expected_rows.go
+++ b/pkg/workload/tpch/expected_rows.go
@@ -21,14 +21,6 @@ var (
 		`11`: true,
 		`16`: true,
 	}
-	// Note: if you modify queriesToSkip here, please adjust roachtest/tpchvec.go
-	// accordingly.
-	queriesToSkip = map[string]bool{
-		// TODO(yuzefovich): for some reason, second and third columns returned by
-		// query 12 are ASCII codes of the digits, i.e. we expect 6202 but get
-		// [54 50 48 50] instead.
-		`12`: true,
-	}
 )
 
 func init() {


### PR DESCRIPTION
Previously, query 12 was skipped because the results returned by lib/pq
didn't match the expected output. The issue is that the driver returned
[]byte for decimals whereas we expected a string value and `fmt.Sprint`
was giving us the ASCII codes of the digits instead of printing out the
number. This is fixed by checking whether the returned value is []byte,
and if so, converting it to string directly.

Release note: None