### PR TITLE
release-19.2: colexec: fix negative substring length error propagation

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -149,7 +148,7 @@ func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
 		start := int(startVec[rowIdx]) - 1
 		length := int(lengthVec[rowIdx])
 		if length < 0 {
-			execerror.VectorizedInternalPanic(fmt.Sprintf("negative substring length %d not allowed", length))
+			execerror.NonVectorizedPanic(errors.Errorf("negative substring length %d not allowed", length))
 		}
 
 		end := start + length

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -627,6 +627,10 @@ SELECT substring(x, 1, abs(y)) FROM builtin_test
 Hel
 Th
 
+# Regression test for #44625.
+statement error negative substring length -1 not allowed
+SELECT substring(x, 0, -1) FROM builtin_test
+
 query I
 SELECT abs(y) FROM builtin_test
 ----


### PR DESCRIPTION
Backport 1/1 commits from #44627.

/cc @cockroachdb/release

---

We were incorrectly using `VectorizedInternalPanic` to propagate the
negative substring length error.

Fixes: #44625.

Release note (bug fix): Previously, CockroachDB would return an internal
error when `substring` function with a negative length was executed via
the vectorized engine, and this has been fixed (now it returns a regular
query error).
