### PR TITLE
 engine/metamorphic: Add engine restarts, compare across runs

### DIFF
--- a/pkg/storage/engine/metamorphic/meta_test.go
+++ b/pkg/storage/engine/metamorphic/meta_test.go
@@ -18,102 +18,142 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func makeStorageConfig(path string) base.StorageConfig {
-	return base.StorageConfig{
-		Attrs:           roachpb.Attributes{},
-		Dir:             path,
-		MustExist:       false,
-		MaxSize:         0,
-		Settings:        cluster.MakeTestingClusterSettings(),
-		UseFileRegistry: false,
-		ExtraOptions:    nil,
+var (
+	keep    = flag.Bool("keep", false, "keep temp directories after test")
+	check   = flag.String("check", "", "run operations in specified file and check output for equality")
+	seed    = flag.Int64("seed", 456, "specify seed to use for random number generator")
+	opCount = flag.Int("operations", 1000, "number of MVCC operations to generate and run")
+)
+
+type testRun struct {
+	ctx             context.Context
+	t               *testing.T
+	seed            int64
+	checkFile       string
+	restarts        bool
+	engineSequences [][]engineImpl
+}
+
+type testRunForEngines struct {
+	ctx            context.Context
+	t              *testing.T
+	seed           int64
+	restarts       bool
+	checkFile      io.Reader
+	outputFile     io.Writer
+	engineSequence []engineImpl
+}
+
+func runMetaTestForEngines(run testRunForEngines) {
+	tempDir, cleanup := testutils.TempDir(run.t)
+	defer func() {
+		if !*keep {
+			cleanup()
+		}
+	}()
+
+	testRunner := metaTestRunner{
+		ctx:         run.ctx,
+		t:           run.t,
+		w:           run.outputFile,
+		seed:        run.seed,
+		restarts:    run.restarts,
+		engineImpls: run.engineSequence,
+		path:        filepath.Join(tempDir, "store"),
+	}
+	fmt.Printf("store path = %s\n", testRunner.path)
+
+	testRunner.init()
+	defer testRunner.closeAll()
+	if run.checkFile != nil {
+		testRunner.parseFileAndRun(run.checkFile)
+	} else {
+		testRunner.generateAndRun(*opCount)
 	}
 }
 
-// createTestRocksDBEngine returns a new in-memory RocksDB engine with 1MB of
-// storage capacity.
-func createTestRocksDBEngine(path string) (engine.Engine, error) {
-	return engine.NewEngine(enginepb.EngineTypeRocksDB, 1<<20, makeStorageConfig(path))
-}
+func runMetaTest(run testRun) {
+	t := run.t
+	outerTempDir, cleanup := testutils.TempDir(run.t)
+	defer func() {
+		if !*keep {
+			cleanup()
+		}
+	}()
 
-// createTestPebbleEngine returns a new in-memory Pebble storage engine.
-func createTestPebbleEngine(path string) (engine.Engine, error) {
-	return engine.NewEngine(enginepb.EngineTypePebble, 1<<20, makeStorageConfig(path))
-}
+	// The test run with the first engine sequence writes its output to this file.
+	// All subsequent engine sequence runs compare their output against this file.
+	firstRunOutput := filepath.Join(outerTempDir, "output.meta")
+	firstRunExecuted := false
+	fmt.Printf("first run output file: %s\n", firstRunOutput)
 
-var mvccEngineImpls = []struct {
-	name   string
-	create func(path string) (engine.Engine, error)
-}{
-	{"rocksdb", createTestRocksDBEngine},
-	{"pebble", createTestPebbleEngine},
-}
+	for _, engineSequence := range run.engineSequences {
+		var engineNames []string
+		for _, engineImpl := range engineSequence {
+			engineNames = append(engineNames, engineImpl.name)
+		}
 
-var (
-	keep  = flag.Bool("keep", false, "keep temp directories after test")
-	check = flag.String("check", "", "run operations in specified file and check output for equality")
-	seed  = flag.Int64("seed", 456, "specify seed to use for random number generator")
-)
-
-func runMetaTest(ctx context.Context, t *testing.T, seed int64, checkFile io.Reader) {
-	for _, engineImpl := range mvccEngineImpls {
-		t.Run(engineImpl.name, func(t *testing.T) {
-			tempDir, cleanup := testutils.TempDir(t)
+		t.Run(strings.Join(engineNames, ","), func(t *testing.T) {
+			innerTempDir, cleanup := testutils.TempDir(t)
 			defer func() {
 				if !*keep {
 					cleanup()
 				}
 			}()
 
-			eng, err := engineImpl.create(filepath.Join(tempDir, engineImpl.name))
+			// If this is not the first sequence run and a "check" file was not passed
+			// in, use the first run's output file as the check file.
+			var checkFileReader io.ReadCloser
+			if run.checkFile == "" && firstRunExecuted {
+				run.checkFile = firstRunOutput
+			}
+			if run.checkFile != "" {
+				var err error
+				checkFileReader, err = os.Open(run.checkFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer checkFileReader.Close()
+			}
+
+			var outputFileWriter io.WriteCloser
+			outputFile := firstRunOutput
+			if firstRunExecuted {
+				outputFile = filepath.Join(innerTempDir, "output.meta")
+			}
+			var err error
+			outputFileWriter, err = os.Create(outputFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer eng.Close()
-
-			outputFilePath := filepath.Join(tempDir, fmt.Sprintf("%s.meta", engineImpl.name))
-			fmt.Printf("output file path: %s\n", outputFilePath)
-
-			outputFile, err := os.Create(outputFilePath)
-			if err != nil {
-				t.Fatal(err)
+			defer outputFileWriter.Close()
+			fmt.Printf("check file = %s\noutput file = %s\n", run.checkFile, outputFile)
+			engineRun := testRunForEngines{
+				ctx:            run.ctx,
+				t:              t,
+				seed:           run.seed,
+				restarts:       run.restarts,
+				checkFile:      checkFileReader,
+				outputFile:     outputFileWriter,
+				engineSequence: engineSequence,
 			}
-			defer outputFile.Close()
-
-			testRunner := metaTestRunner{
-				ctx:    ctx,
-				t:      t,
-				w:      outputFile,
-				seed:   seed,
-				engine: eng,
-			}
-
-			testRunner.init()
-			defer testRunner.closeAll()
-			if checkFile != nil {
-				testRunner.parseFileAndRun(checkFile)
-			} else {
-				// TODO(itsbilal): Make this configurable.
-				testRunner.generateAndRun(10000)
-			}
+			runMetaTestForEngines(engineRun)
+			firstRunExecuted = true
 		})
 	}
 }
 
-// TestMeta runs the MVCC Metamorphic test suite.
-func TestMeta(t *testing.T) {
+// TestRocksPebbleEquivalence runs the MVCC Metamorphic test suite, and checks
+// for matching outputs by the test suite between RocksDB and Pebble.
+func TestRocksPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	ctx := context.Background()
 	if util.RaceEnabled {
@@ -124,23 +164,77 @@ func TestMeta(t *testing.T) {
 	// Have one fixed seed, one user-specified seed, and one random seed.
 	seeds := []int64{123, *seed, rand.Int63()}
 
-	if *check != "" {
-		t.Run("check", func(t *testing.T) {
-			if _, err := os.Stat(*check); os.IsNotExist(err) {
-				t.Fatal(err)
-			}
-			checkFile, err := os.Open(*check)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer checkFile.Close()
-
-			runMetaTest(ctx, t, 0, checkFile)
-		})
-	}
 	for _, seed := range seeds {
 		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
-			runMetaTest(ctx, t, seed, nil)
+			run := testRun{
+				ctx:      ctx,
+				t:        t,
+				seed:     seed,
+				restarts: false,
+				engineSequences: [][]engineImpl{
+					{engineImplRocksDB},
+					{engineImplPebble},
+				},
+			}
+			runMetaTest(run)
 		})
+	}
+}
+
+// TestRocksPebbleRestarts runs the MVCC Metamorphic test suite with restarts
+// enabled, and ensures that the output remains the same across different
+// engine sequences with restarts in between.
+func TestRocksPebbleRestarts(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	ctx := context.Background()
+	if util.RaceEnabled {
+		// This test times out with the race detector enabled.
+		return
+	}
+
+	// Have one fixed seed, one user-specified seed, and one random seed.
+	seeds := []int64{123, *seed, rand.Int63()}
+
+	for _, seed := range seeds {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			run := testRun{
+				ctx:      ctx,
+				t:        t,
+				seed:     seed,
+				restarts: true,
+				engineSequences: [][]engineImpl{
+					{engineImplRocksDB},
+					{engineImplPebble},
+					{engineImplRocksDB, engineImplPebble},
+				},
+			}
+			runMetaTest(run)
+		})
+	}
+}
+
+// TestRocksPebbleCheck checks whether the output file specified with --check has
+// matching behavior across rocks/pebble.
+func TestRocksPebbleCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	ctx := context.Background()
+
+	if *check != "" {
+		if _, err := os.Stat(*check); os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+
+		run := testRun{
+			ctx:       ctx,
+			t:         t,
+			checkFile: *check,
+			restarts:  true,
+			engineSequences: [][]engineImpl{
+				{engineImplRocksDB},
+				{engineImplPebble},
+				{engineImplRocksDB, engineImplPebble},
+			},
+		}
+		runMetaTest(run)
 	}
 }

--- a/pkg/storage/engine/metamorphic/operands.go
+++ b/pkg/storage/engine/metamorphic/operands.go
@@ -259,10 +259,24 @@ func (t *txnManager) clearBatch(batch engine.Batch) {
 	}
 }
 
+func (t *txnManager) trackWriteOnBatch(w engine.Writer, txn *roachpb.Transaction) {
+	if batch, ok := w.(engine.Batch); ok {
+		openBatches, ok := t.openBatches[txn]
+		if !ok {
+			t.openBatches[txn] = make(map[engine.Batch]struct{})
+			openBatches = t.openBatches[txn]
+		}
+		openBatches[batch] = struct{}{}
+	}
+}
+
 func (t *txnManager) closeAll() {
 	for _, txn := range t.liveTxns {
 		t.close(txn)
 	}
+	t.liveTxns = nil
+	t.txnIDMap = make(map[string]*roachpb.Transaction)
+	t.openBatches = make(map[*roachpb.Transaction]map[engine.Batch]struct{})
 }
 
 func (t *txnManager) toString(op operand) string {
@@ -353,7 +367,7 @@ func (t *testRunnerManager) get() operand {
 
 type readWriterManager struct {
 	rng          *rand.Rand
-	eng          engine.Engine
+	m            *metaTestRunner
 	liveBatches  []engine.Batch
 	batchToIDMap map[engine.Batch]int
 	batchCounter int
@@ -364,14 +378,14 @@ var _ operandManager = &readWriterManager{}
 func (w *readWriterManager) get() operand {
 	// 25% chance of returning the engine, even if there are live batches.
 	if len(w.liveBatches) == 0 || w.rng.Float64() < 0.25 {
-		return w.eng
+		return w.m.engine
 	}
 
 	return w.liveBatches[w.rng.Intn(len(w.liveBatches))]
 }
 
 func (w *readWriterManager) open() engine.ReadWriter {
-	batch := w.eng.NewBatch()
+	batch := w.m.engine.NewBatch()
 	w.batchCounter++
 	w.liveBatches = append(w.liveBatches, batch)
 	w.batchToIDMap[batch] = w.batchCounter
@@ -388,7 +402,7 @@ func (w *readWriterManager) count() int {
 
 func (w *readWriterManager) close(op operand) {
 	// No-op if engine.
-	if op == w.eng {
+	if op == w.m.engine {
 		return
 	}
 
@@ -413,7 +427,7 @@ func (w *readWriterManager) closeAll() {
 }
 
 func (w *readWriterManager) toString(op operand) string {
-	if w.eng == op {
+	if w.m.engine == op {
 		return "engine"
 	}
 	return fmt.Sprintf("batch%d", w.batchToIDMap[op.(engine.Batch)])
@@ -421,7 +435,7 @@ func (w *readWriterManager) toString(op operand) string {
 
 func (w *readWriterManager) parse(input string) operand {
 	if input == "engine" {
-		return w.eng
+		return w.m.engine
 	}
 
 	var id int
@@ -512,6 +526,9 @@ func (i *iteratorManager) closeAll() {
 	for iter := range i.iterToInfo {
 		iter.Close()
 	}
+	i.liveIters = nil
+	i.iterToInfo = make(map[engine.Iterator]iteratorInfo)
+	i.readerToIter = make(map[engine.Reader][]engine.Iterator)
 }
 
 func (i *iteratorManager) toString(op operand) string {


### PR DESCRIPTION
This PR builds on top of #44458 (all commits before the last one
are from that PR). It adds two things: one, it ensures that whenever
successive engine types are tested, it does a comparison for matching
outputs. This will ensure CI will fail if any change down the line
causes an observed difference in behaviour between rocksdb and pebble.

Furthermore, it adds a new kind of operation: restart. Restarts are
special in that they're added after the specified n number of runs
have happened; so a test run with 3 specified engine types
(so 2 restarts), and n = 10000 will have 3 * 10000 = 30000 operations.
A restart closes all open objects, then closes the engine, and starts
up the next engine in the specified engine sequence. This, combined
with the aforementioned checking functionality across different
engine runs, lets us test for bidirectional compatibility across
different engines.

Fixes #43762 .

Release note: None.