### PR TITLE
storageccl: fix flakey TestRandomKeyAndTimestampExport

### DIFF
--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -365,6 +365,12 @@ func assertEqualKVs(
 					lessThisKey := dataSizeWhenExceeded - uint64(len(kv.Key.Key)+len(kv.Value))
 					if lessThisKey >= maxSize {
 						dataSizeWhenExceeded = lessThisKey
+						// It might be the case that this key would lead to an SST of exactly
+						// max size, in this case we overwrite max size to be less so that
+						// we still generate an error.
+						if dataSizeWhenExceeded == maxSize {
+							maxSize--
+						}
 					} else {
 						break
 					}


### PR DESCRIPTION
Sometimes the maxSize would line up exactly with the last key. When this
happened the logic to test the maxSize parameter was incorrect. This adds
logic to deal with that case and unflake the test.

Fixes #44589

Release note: None