### PR TITLE
storage: ensure that the quotapool is closed when a replica is destroyed

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -302,6 +302,15 @@ func (r *Replica) QuotaAvailable() uint64 {
 	return r.mu.proposalQuota.ApproximateQuota()
 }
 
+// GetProposalQuota returns the Replica's internal proposal quota.
+// It is not safe to be used concurrently so do ensure that the Replica is
+// no longer active.
+func (r *Replica) GetProposalQuota() *quotapool.IntPool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.proposalQuota
+}
+
 func (r *Replica) QuotaReleaseQueueLen() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/storage/replica_proposal_quota.go
+++ b/pkg/storage/replica_proposal_quota.go
@@ -90,25 +90,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		return
 	}
 
-	// We need to check if the replica is being destroyed and if so, unblock
-	// all ongoing and subsequent quota acquisition goroutines (if any).
-	//
-	// TODO(irfansharif): There is still a potential problem here that leaves
-	// clients hanging if the replica gets destroyed but this code path is
-	// never taken. Moving quota pool draining to every point where a
-	// replica can get destroyed is an option, alternatively we can clear
-	// our leader status and close the proposalQuota whenever the replica is
-	// destroyed.
-	if r.mu.destroyStatus.Removed() {
-		if r.mu.proposalQuota != nil {
-			r.mu.proposalQuota.Close("destroyed")
-		}
-		r.mu.proposalQuota = nil
-		r.mu.lastUpdateTimes = nil
-		r.mu.quotaReleaseQueue = nil
-		return
-	}
-
 	status := r.mu.internalRaftGroup.BasicStatus()
 	if r.mu.leaderID != lastLeaderID {
 		if r.mu.replicaID == r.mu.leaderID {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8794,13 +8794,9 @@ func TestCancelPendingCommands(t *testing.T) {
 		t.Fatalf("command finished earlier than expected with error %v", pErr)
 	default:
 	}
-
 	tc.repl.raftMu.Lock()
-	tc.repl.mu.Lock()
-	tc.repl.cancelPendingCommandsLocked(ctx)
-	tc.repl.mu.Unlock()
+	tc.repl.disconnectReplicationRaftMuLocked(ctx)
 	tc.repl.raftMu.Unlock()
-
 	pErr := <-errChan
 	if _, ok := pErr.GetDetail().(*roachpb.AmbiguousResultError); !ok {
 		t.Errorf("expected AmbiguousResultError, got %v", pErr)


### PR DESCRIPTION
This commit is a drive-by cleanup of a TODO. The Replica had code to close the
proposalQuota when `Replica.updateProposalQuotaRaftMuLocked()` was called and
the Replica had a destroy status indicating that it had been removed. This case
never occurs in 19.2 binaries; we always return prior to calling the update
method in handleRaftReady. The comment near this call indicated that maybe
there was a problem with the `Close()` not being called on all destroy
paths. It turns out it was never called at all. Fortunately it was okay that
the `Close` was never called. All waiters on quota will eventually make it
through in the destroy case as any outstanding proposals will either be
cancelled or subsequently fail and drop their quota. It is still better to
close the pool upon removal so this PR adds the logic in the right place and
cleans up the code around those two removal paths.

Release note: None