### PR TITLE
roachtest: continue running if test panics

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -731,6 +731,13 @@ func (r *testRunner) runTest(
 		defer close(done) // closed only after we've grabbed the debug info below
 
 		// This is the call to actually run the test.
+		defer func() {
+			if r := recover(); r != nil {
+				// TODO(andreimatei): prevent the cluster from being reused.
+				t.Fatalf("test panicked: %v", r)
+			}
+		}()
+
 		t.spec.Run(runCtx, t, c)
 	}()
 


### PR DESCRIPTION
We didn't run most roachtests tonight because the sqlsmith roachtest
panicked in `.Generate()` (ironic I know).

Obviously a panicking test ought not be able to mess with roachtest
in that way. Translate the panic into a test failure and carry on.

Release note: None