### PR TITLE
colexec: Aggregation function clean up

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -28,6 +28,7 @@ func genAnyNotNullAgg(wr io.Writer) error {
 	s := string(t)
 
 	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)


### PR DESCRIPTION
Remove the use of output vector for storing intermediate result for agg functions and replace it with `curAgg` field in the aggregation functions. We already do this for most of the aggregation functions.

This is required to implement #41678 

Release note: None