### PR TITLE
WIP: broken attempt of timeofday fix

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -683,9 +683,9 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 						}
 					case types.TimeFamily:
 						// pq awkwardly represents TIME as a time.Time with date 0000-01-01.
-						d = tree.MakeDTime(timeofday.FromTime(t))
+						d = tree.MakeDTime(timeofday.FromTime(t, timeofday.RoundingAllow2400))
 					case types.TimeTZFamily:
-						d = tree.NewDTimeTZFromTime(t)
+						d = tree.NewDTimeTZFromTime(t, timeofday.RoundingAllow2400)
 					case types.TimestampFamily:
 						d = tree.MakeDTimestamp(t, time.Nanosecond)
 					case types.TimestampTZFamily:

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -249,11 +249,12 @@ func TestCopyRandom(t *testing.T) {
 				ds = string(d)
 			case time.Time:
 				var dt tree.NodeFormatter
-				if typs[i].Family() == types.TimeFamily {
-					dt = tree.MakeDTime(timeofday.FromTime(d))
-				} else if typs[i].Family() == types.TimeTZFamily {
-					dt = tree.NewDTimeTZFromTime(d)
-				} else {
+				switch typs[i].Family() {
+				case types.TimeFamily:
+					dt = tree.MakeDTime(timeofday.FromTime(d, timeofday.RoundingAllow2400))
+				case types.TimeTZFamily:
+					dt = tree.NewDTimeTZFromTime(d, timeofday.RoundingAllow2400)
+				default:
 					dt = tree.MakeDTimestamp(d, time.Microsecond)
 				}
 				ds = tree.AsStringWithFlags(dt, tree.FmtBareStrings)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2534,7 +2534,12 @@ may increase either contention or retry errors, or both.`,
 				tTime := timeofday.TimeOfDay(*tArg).ToTime()
 				_, beforeOffsetSecs := tTime.In(ctx.GetLocation()).Zone()
 				durationDelta := time.Duration(-beforeOffsetSecs) * time.Second
-				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta))), nil
+				return tree.NewDTimeTZ(
+					timetz.MakeTimeTZFromTime(
+						tTime.In(loc).Add(durationDelta),
+						timeofday.RoundingDisallow2400,
+					),
+				), nil
 			},
 			Info: "Treat given time without time zone as located in the specified time zone.",
 		},
@@ -2556,7 +2561,9 @@ may increase either contention or retry errors, or both.`,
 					return nil, err
 				}
 				tTime := tArg.TimeTZ.ToTime()
-				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc))), nil
+				return tree.NewDTimeTZ(
+					timetz.MakeTimeTZFromTime(tTime.In(loc), timeofday.RoundingDisallow2400),
+				), nil
 			},
 			Info: "Convert given time with time zone to the new time zone.",
 		},
@@ -2627,7 +2634,9 @@ may increase either contention or retry errors, or both.`,
 				tTime := timeofday.TimeOfDay(*tArg).ToTime()
 				_, beforeOffsetSecs := tTime.In(ctx.GetLocation()).Zone()
 				durationDelta := time.Duration(-beforeOffsetSecs) * time.Second
-				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta))), nil
+				return tree.NewDTimeTZ(
+					timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta), timeofday.RoundingDisallow2400),
+				), nil
 			},
 			Info: "Treat given time without time zone as located in the specified time zone\n" +
 				"This is deprecated in favor of timezone(str, time)",
@@ -2650,7 +2659,9 @@ may increase either contention or retry errors, or both.`,
 					return nil, err
 				}
 				tTime := tArg.TimeTZ.ToTime()
-				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc))), nil
+				return tree.NewDTimeTZ(
+					timetz.MakeTimeTZFromTime(tTime.In(loc), timeofday.RoundingDisallow2400),
+				), nil
 			},
 			Info: "Convert given time with time zone to the new time zone\n" +
 				"This is deprecated in favor of timezone(str, timetz)",

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1889,7 +1889,7 @@ func ParseDTime(ctx ParseTimeContext, s string, precision time.Duration) (*DTime
 		// Build our own error message to avoid exposing the dummy date.
 		return nil, makeParseError(s, types.Time, nil)
 	}
-	return MakeDTime(timeofday.FromTime(t).Round(precision)), nil
+	return MakeDTime(timeofday.FromTime(t, timeofday.RoundingDisallow2400).Round(precision)), nil
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -1973,8 +1973,8 @@ type DTimeTZ struct {
 }
 
 var (
-	dMinTimeTZ = NewDTimeTZFromOffset(timeofday.Min, timetz.MinTimeTZOffsetSecs)
-	dMaxTimeTZ = NewDTimeTZFromOffset(timeofday.Time2400, timetz.MaxTimeTZOffsetSecs)
+	DMinTimeTZ = NewDTimeTZFromOffset(timeofday.Min, timetz.MinTimeTZOffsetSecs)
+	DMaxTimeTZ = NewDTimeTZFromOffset(timeofday.Time2400, timetz.MaxTimeTZOffsetSecs)
 )
 
 // NewDTimeTZ creates a DTimeTZ from a timetz.TimeTZ.
@@ -1983,8 +1983,8 @@ func NewDTimeTZ(t timetz.TimeTZ) *DTimeTZ {
 }
 
 // NewDTimeTZFromTime creates a DTimeTZ from time.Time.
-func NewDTimeTZFromTime(t time.Time) *DTimeTZ {
-	return &DTimeTZ{timetz.MakeTimeTZFromTime(t)}
+func NewDTimeTZFromTime(t time.Time, rounding timeofday.Rounding2400Spec) *DTimeTZ {
+	return &DTimeTZ{timetz.MakeTimeTZFromTime(t, rounding)}
 }
 
 // NewDTimeTZFromOffset creates a DTimeTZ from a TimeOfDay and offset.
@@ -2040,17 +2040,17 @@ func (d *DTimeTZ) Next(ctx *EvalContext) (Datum, bool) {
 
 // IsMax implements the Datum interface.
 func (d *DTimeTZ) IsMax(_ *EvalContext) bool {
-	return d.TimeOfDay == dMaxTimeTZ.TimeOfDay && d.OffsetSecs == timetz.MaxTimeTZOffsetSecs
+	return d.TimeOfDay == DMaxTimeTZ.TimeOfDay && d.OffsetSecs == timetz.MaxTimeTZOffsetSecs
 }
 
 // IsMin implements the Datum interface.
 func (d *DTimeTZ) IsMin(_ *EvalContext) bool {
-	return d.TimeOfDay == dMinTimeTZ.TimeOfDay && d.OffsetSecs == timetz.MinTimeTZOffsetSecs
+	return d.TimeOfDay == DMinTimeTZ.TimeOfDay && d.OffsetSecs == timetz.MinTimeTZOffsetSecs
 }
 
 // Max implements the Datum interface.
 func (d *DTimeTZ) Max(_ *EvalContext) (Datum, bool) {
-	return dMaxTimeTZ, true
+	return DMaxTimeTZ, true
 }
 
 // Round returns a new DTimeTZ to the specified precision.
@@ -2060,7 +2060,7 @@ func (d *DTimeTZ) Round(precision time.Duration) *DTimeTZ {
 
 // Min implements the Datum interface.
 func (d *DTimeTZ) Min(_ *EvalContext) (Datum, bool) {
-	return dMinTimeTZ, true
+	return DMinTimeTZ, true
 }
 
 // AmbiguousFormat implements the Datum interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2988,7 +2988,7 @@ func (ctx *EvalContext) GetTxnTime(precision time.Duration) *DTimeTZ {
 	if !ctx.PrepareOnly && ctx.TxnTimestamp.IsZero() {
 		panic(errors.AssertionFailedf("zero transaction timestamp in EvalContext"))
 	}
-	return NewDTimeTZFromTime(ctx.GetRelativeParseTime().Round(precision))
+	return NewDTimeTZFromTime(ctx.GetRelativeParseTime().Round(precision), timeofday.RoundingDisallow2400)
 }
 
 // GetTxnTimeNoZone retrieves the current transaction time as per
@@ -2999,7 +2999,7 @@ func (ctx *EvalContext) GetTxnTimeNoZone(precision time.Duration) *DTime {
 	if !ctx.PrepareOnly && ctx.TxnTimestamp.IsZero() {
 		panic(errors.AssertionFailedf("zero transaction timestamp in EvalContext"))
 	}
-	return MakeDTime(timeofday.FromTime(ctx.GetRelativeParseTime().Round(precision)))
+	return MakeDTime(timeofday.FromTime(ctx.GetRelativeParseTime().Round(precision), timeofday.RoundingDisallow2400))
 }
 
 // SetTxnTimestamp sets the corresponding timestamp in the EvalContext.
@@ -3569,10 +3569,10 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DTimeTZ:
 			return MakeDTime(d.TimeOfDay.Round(roundTo)), nil
 		case *DTimestamp:
-			return MakeDTime(timeofday.FromTime(d.Time).Round(roundTo)), nil
+			return MakeDTime(timeofday.FromTime(d.Time, timeofday.RoundingDisallow2400).Round(roundTo)), nil
 		case *DTimestampTZ:
 			// Strip time zone. Times don't carry their location.
-			return MakeDTime(timeofday.FromTime(d.stripTimeZone(ctx).Time).Round(roundTo)), nil
+			return MakeDTime(timeofday.FromTime(d.stripTimeZone(ctx).Time, timeofday.RoundingDisallow2400).Round(roundTo)), nil
 		case *DInterval:
 			return MakeDTime(timeofday.Min.Add(d.Duration).Round(roundTo)), nil
 		}
@@ -3589,7 +3589,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DTimeTZ:
 			return d.Round(roundTo), nil
 		case *DTimestampTZ:
-			return NewDTimeTZFromTime(d.Time.Round(roundTo)), nil
+			return NewDTimeTZFromTime(d.Time.Round(roundTo), timeofday.RoundingDisallow2400), nil
 		}
 
 	case types.TimestampFamily:

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -58,9 +58,9 @@ func SampleDatum(t *types.T) Datum {
 	case types.DateFamily:
 		return NewDDate(pgdate.MakeCompatibleDateFromDisk(123123))
 	case types.TimeFamily:
-		return MakeDTime(timeofday.FromInt(789))
+		return MakeDTime(timeofday.FromInt(789, timeofday.RoundingAllow2400))
 	case types.TimeTZFamily:
-		return NewDTimeTZFromOffset(timeofday.FromInt(345), 5*60*60 /* OffsetSecs */)
+		return NewDTimeTZFromOffset(timeofday.FromInt(345, timeofday.RoundingAllow2400), 5*60*60 /* OffsetSecs */)
 	case types.TimestampFamily:
 		return MakeDTimestamp(timeutil.Unix(123, 123), time.Second)
 	case types.TimestampTZFamily:

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
+	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/pkg/errors"
@@ -472,8 +473,22 @@ func TestMarshalColumnValue(t *testing.T) {
 		},
 		{
 			typ:   types.Time,
-			datum: tree.MakeDTime(timeofday.FromInt(314159)),
+			datum: tree.MakeDTime(timeofday.FromInt(314159, timeofday.RoundingAllow2400)),
 			exp:   func() (v roachpb.Value) { v.SetInt(314159); return }(),
+		},
+		{
+			typ: types.TimeTZ,
+			datum: tree.NewDTimeTZFromOffset(
+				timeofday.FromInt(314159, timeofday.RoundingAllow2400),
+				3*60*60,
+			),
+			exp: func() (v roachpb.Value) {
+				v.SetTimeTZ(timetz.MakeTimeTZ(
+					timeofday.FromInt(314159, timeofday.RoundingAllow2400),
+					3*60*60,
+				))
+				return
+			}(),
 		},
 		{
 			typ:   types.Timestamp,

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -417,7 +417,12 @@ var (
 		},
 		types.TimeFamily: {
 			tree.MakeDTime(timeofday.Min),
+			tree.MakeDTime(timeofday.MicrosecondBeforeMax),
 			tree.MakeDTime(timeofday.Max),
+		},
+		types.TimeTZFamily: {
+			tree.DMinTimeTZ,
+			tree.DMaxTimeTZ,
 		},
 		types.TimestampFamily: func() []tree.Datum {
 			res := make([]tree.Datum, len(randTimestampSpecials))

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -980,9 +980,8 @@ func DecodeTimeTZAscending(b []byte) ([]byte, timetz.TimeTZ, error) {
 	if err != nil {
 		return nil, timetz.TimeTZ{}, err
 	}
-	// Do not use timeofday.FromInt, as it loses 24:00:00 encoding.
 	return b, timetz.TimeTZ{
-		TimeOfDay:  timeofday.TimeOfDay(unixMicros - int64(offsetSecs)*offsetSecsToMicros),
+		TimeOfDay:  timeofday.FromInt(unixMicros-int64(offsetSecs)*offsetSecsToMicros, timeofday.RoundingAllow2400),
 		OffsetSecs: offsetSecs,
 	}, nil
 }
@@ -993,9 +992,8 @@ func DecodeTimeTZDescending(b []byte) ([]byte, timetz.TimeTZ, error) {
 	if err != nil {
 		return nil, timetz.TimeTZ{}, err
 	}
-	// Do not use timeofday.FromInt, as it loses 24:00:00 encoding.
 	return b, timetz.TimeTZ{
-		TimeOfDay:  timeofday.TimeOfDay(^unixMicros - int64(^offsetSecs)*offsetSecsToMicros),
+		TimeOfDay:  timeofday.FromInt(^unixMicros-int64(^offsetSecs)*offsetSecsToMicros, timeofday.RoundingAllow2400),
 		OffsetSecs: ^offsetSecs,
 	}, nil
 }
@@ -2174,8 +2172,10 @@ func DecodeUntaggedTimeTZValue(b []byte) (remaining []byte, t timetz.TimeTZ, err
 	if err != nil {
 		return b, timetz.TimeTZ{}, err
 	}
-	// Do not use timeofday.FromInt as it truncates 24:00 into 00:00.
-	return b, timetz.MakeTimeTZ(timeofday.TimeOfDay(timeOfDayMicros), int32(offsetSecs)), nil
+	return b, timetz.MakeTimeTZ(
+		timeofday.FromInt(timeOfDayMicros, timeofday.RoundingAllow2400),
+		int32(offsetSecs),
+	), nil
 }
 
 // DecodeDecimalValue decodes a value encoded by EncodeDecimalValue.

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1284,7 +1284,7 @@ func (rd randData) time() time.Time {
 
 func (rd randData) timetz() timetz.TimeTZ {
 	return timetz.MakeTimeTZ(
-		timeofday.FromInt(rd.Int63n(int64(timeofday.Max))),
+		timeofday.FromInt(rd.Int63n(int64(timeofday.Max)), timeofday.RoundingAllow2400),
 		rd.Int31n(timetz.MaxTimeTZOffsetSecs*2)-timetz.MaxTimeTZOffsetSecs,
 	)
 }

--- a/pkg/util/timeofday/time_of_day_test.go
+++ b/pkg/util/timeofday/time_of_day_test.go
@@ -58,7 +58,7 @@ func TestFromAndToTime(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual := FromTime(fromTime).ToTime().Format(time.RFC3339Nano)
+			actual := FromTime(fromTime, RoundingDisallow2400).ToTime().Format(time.RFC3339Nano)
 			if actual != td.exp {
 				t.Errorf("expected %s, got %s", td.exp, actual)
 			}

--- a/pkg/util/timetz/timetz_test.go
+++ b/pkg/util/timetz/timetz_test.go
@@ -21,6 +21,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMakeTimeTZFromTime(t *testing.T) {
+	testCases := []struct {
+		t        time.Time
+		rounding timeofday.Rounding2400Spec
+
+		exp TimeTZ
+	}{}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s_%s", tc.t.Format(time.RFC3339), tc.rounding), func(t *testing.T) {
+			ret := MakeTimeTZFromTime(tc.t, tc.rounding)
+			assert.Equal(t, tc.exp, ret)
+		})
+	}
+}
+
 func TestParseTimeTZToStringRoundTrip(t *testing.T) {
 	testCases := []string{
 		"24:00:00-1559",


### PR DESCRIPTION
NOT FOR REVIEW!

keeping a record in case I want this back -- tried to add "RoundingAllow2400" and "RoundingDisallow2400" to make clear of the behaviour for timeofday handling 2400. But turns out this was not the correct fix for a different problem (namely, lib/pq handling of time.time is broken).