### PR TITLE
release-19.2: sem/tree: fix LIKE ESCAPE when the pattern contains Unicode symbols

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4797,12 +4797,11 @@ func replaceCustomEscape(s string, escape rune) (string, error) {
 				}
 			}
 		} else {
-			// Regular character, so we simply copy it.
-			ret[retIndex] = s[sIndex]
-			retIndex++
-			sIndex++
+			// Regular symbol, so we simply copy it.
+			copy(ret[retIndex:], s[sIndex:sIndex+w])
+			retIndex += w
+			sIndex += w
 		}
-
 	}
 	return string(ret), nil
 }
@@ -4882,9 +4881,9 @@ func calculateLengthAfterReplacingCustomEscape(s string, escape rune) (bool, int
 				}
 			}
 		} else {
-			// Regular character, so we'll simply copy it.
-			retLen++
-			i++
+			// Regular symbol, so we'll simply copy it.
+			retLen += w
+			i += w
 		}
 	}
 	return changed, retLen, nil

--- a/pkg/sql/sem/tree/testdata/eval/like
+++ b/pkg/sql/sem/tree/testdata/eval/like
@@ -417,6 +417,16 @@ like_escape('%日_', '漢%漢日漢_', '漢')
 ----
 true
 
+eval
+like_escape('a', '꧕', '�')
+----
+false
+
+eval
+like_escape('\꧕%', '�\꧕�%', '�')
+----
+true
+
 # ILIKE with ESCAPE clause
 
 eval


### PR DESCRIPTION
Backport 1/1 commits from #44633.

/cc @cockroachdb/release

---

Previously, we were incorrectly updating the pattern when the current
character was Unicode symbol that had the width of more than a single
byte.

Fixes: #44621.

Release note (bug fix): Previously, running a query with LIKE operator
using custom ESCAPE symbol when the pattern contained Unicode characters
could result in an internal error in CockroachDB, and now this has been
fixed.
