### PR TITLE
opt: fix typing error for scalar operations with all null operands

### DIFF
--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -47,6 +47,9 @@ func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
 			return o.ReturnType
 		}
 	}
+	if inputType.Family() == types.UnknownFamily {
+		return types.Unknown
+	}
 	panic(errors.AssertionFailedf("could not find type for unary expression %s", log.Safe(op)))
 }
 
@@ -55,6 +58,9 @@ func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
 func InferBinaryType(op opt.Operator, leftType, rightType *types.T) *types.T {
 	o, ok := FindBinaryOverload(op, leftType, rightType)
 	if !ok {
+		if leftType.Family() == types.UnknownFamily && rightType.Family() == types.UnknownFamily {
+			return types.Unknown
+		}
 		panic(errors.AssertionFailedf("could not find type for binary expression %s", log.Safe(op)))
 	}
 	return o.ReturnType

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -12,6 +12,15 @@
 [FoldNullUnary, Normalize]
 (Unary $input:(Null)) => (FoldNullUnary (OpName) $input)
 
+# FoldNullBinary replaces the binary operator with null if both inputs are null.
+[FoldNullBinary, Normalize]
+(Binary
+    $left:(Null)
+    $right:(Null)
+)
+=>
+(FoldNullBinary (OpName) $left $right)
+
 # FoldNullBinaryLeft replaces the binary operator with null if its left input
 # is null and it does not allow null arguments.
 [FoldNullBinaryLeft, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -261,6 +261,15 @@ select
 # --------------------------------------------------
 # FoldNullComparisonLeft, FoldNullComparisonRight
 # --------------------------------------------------
+norm expect=FoldNullComparisonLeft
+SELECT NULLIF(NULL, 0) > NULLIF(NULL, 0);
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{bool}]
 
 # Use null::type to circumvent type checker constant folding.
 norm expect=(FoldNullComparisonLeft,FoldNullComparisonRight)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -30,6 +30,16 @@ values
 # FoldNullUnary
 # --------------------------------------------------
 norm expect=FoldNullUnary
+SELECT -NULLIF(NULL, 0)
+----
+values
+ ├── columns: "?column?":1(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{unknown}]
+
+norm expect=FoldNullUnary
 SELECT +null::int AS r, -null::int AS s, ~null::int AS t FROM a
 ----
 project
@@ -41,9 +51,20 @@ project
       ├── null [type=int]
       └── null [type=int]
 
-# --------------------------------------------------
-# FoldNullBinaryLeft, FoldNullBinaryRight
-# --------------------------------------------------
+# -------------------------------------------------------
+# FoldNullBinary, FoldNullBinaryLeft, FoldNullBinaryRight
+# -------------------------------------------------------
+# Regression test for #44632.
+norm expect=FoldNullBinary
+SELECT NULLIF(NULL, 0) + NULLIF(NULL, 0);
+----
+values
+ ├── columns: "?column?":1(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{unknown}]
+
 norm expect=(FoldNullBinaryLeft,FoldNullBinaryRight)
 SELECT
     null::int & 1 AS ra, 1 & null::int AS rb,


### PR DESCRIPTION
Prior to this commit, the constant folding code in the optimizer threw
an error if it encountered a binary or unary operation with all null
operands. This commit fixes the error by ensuring that these operations
are simply converted to null.

Fixes #44632

Release note (bug fix): Fixed an error in the planner that occurred when
all operands of a unary or binary expression evaluated to null.