### PR TITLE
release-19.2: stats: fix flaky test TestDefaultColumns

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -416,6 +416,11 @@ func TestDefaultColumns(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
+	st := cluster.MakeTestingClusterSettings()
+	AutomaticStatisticsClusterMode.Override(&st.SV, false)
+	evalCtx := tree.NewTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRun.Exec(t,
 		`CREATE DATABASE t;
@@ -428,17 +433,6 @@ func TestDefaultColumns(t *testing.T) {
 	}
 
 	sqlRun.Exec(t, `CREATE STATISTICS s FROM t.a`)
-
-	// TODO(rytaft): this extra logging was added to help debug issue #38572.
-	// Remove it once that issue is resolved.
-	// === BEGINNING OF EXTRA LOGGING ===
-	res := sqlRun.QueryStr(t, `SHOW CREATE TABLE t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	res = sqlRun.QueryStr(t, `EXPLAIN (DISTSQL) CREATE STATISTICS s FROM t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	res = sqlRun.QueryStr(t, `SHOW STATISTICS FOR TABLE t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	// === END OF EXTRA LOGGING ===
 
 	// There should be 101 stats. One for the primary index, plus 100 other
 	// columns.


### PR DESCRIPTION
Backport 1/1 commits from #44560.

/cc @cockroachdb/release

---

`TestDefaultColumns` creates statistics on a table with 110 columns
using the command `CREATE STATISTICS s FROM t.a`. It then checks
that there are exactly 101 column statistics on table `t.a` with
statistics_name = 's' (one stat for the primary index, plus 100
other column stats). However, this test may be flaky if automatic
statistics are running, since each new automatic stat will cause
other stats to be deleted.

This commit fixes the problem by disabling automatic stats for this
test, ensuring that the 101 column stats are not deleted after they
have been created.

Fixes #44208

Release note: None
