### PR TITLE
opt, tree: window functions fixes in some edge cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3619,3 +3619,67 @@ ORDER BY
 2  1  2  2  2
 3  2  4  4  3
 4  2  4  4  4
+
+query IIIRRTBTTTTTTTTT
+SELECT
+  *,
+  array_agg(v) OVER (wv RANGE BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING),
+  array_agg(v) OVER (wv RANGE BETWEEN 0 PRECEDING AND 1 PRECEDING),
+  array_agg(f) OVER (wf RANGE BETWEEN UNBOUNDED PRECEDING AND -0.0 PRECEDING),
+  array_agg(f) OVER (wf RANGE BETWEEN 0.0 PRECEDING AND 1.0 PRECEDING),
+  array_agg(d) OVER (wd RANGE BETWEEN 0.0 FOLLOWING AND 0.0 FOLLOWING),
+  array_agg(d) OVER (wd RANGE BETWEEN 1.0 FOLLOWING AND UNBOUNDED FOLLOWING),
+  array_agg(i) OVER (wi RANGE BETWEEN '1s'::INTERVAL PRECEDING AND '0s'::INTERVAL PRECEDING),
+  array_agg(i) OVER (wi RANGE BETWEEN '1s'::INTERVAL FOLLOWING AND '1s'::INTERVAL FOLLOWING)
+FROM
+  kv
+WINDOW
+  wv AS (ORDER BY v DESC),
+  wf AS (ORDER BY f),
+  wd AS (ORDER BY d DESC),
+  wi AS (ORDER BY i)
+ORDER BY
+  k
+----
+1   2     3  1    1     a     true   00:01:00      {4,4,4,2,2,2,2}            NULL         {0.1,0.2,0.3,1.0}                      NULL  {1}               {-321,NULL,NULL,NULL}          {00:01:00}             NULL
+3   4     5  2    8     a     true   00:00:02      {4,4,4}                    NULL         {0.1,0.2,0.3,1.0,2.0}                  NULL  {8}               {4.4,3,1,-321,NULL,NULL,NULL}  {00:00:02}             NULL
+5   NULL  5  9.9  -321  NULL  false  NULL          {4,4,4,2,2,2,2,NULL,NULL}  {NULL,NULL}  {0.1,0.2,0.3,1.0,2.0,3.0,4.4,6.0,9.9}  NULL  {-321}            {NULL,NULL,NULL}               {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+6   2     3  4.4  4.4   b     true   00:00:00.001  {4,4,4,2,2,2,2}            NULL         {0.1,0.2,0.3,1.0,2.0,3.0,4.4}          NULL  {4.4}             {3,1,-321,NULL,NULL,NULL}      {00:00:00.001}         NULL
+7   2     2  6    7.9   b     true   4 days        {4,4,4,2,2,2,2}            NULL         {0.1,0.2,0.3,1.0,2.0,3.0,4.4,6.0}      NULL  {7.9}             {4.4,3,1,-321,NULL,NULL,NULL}  {"4 days"}             NULL
+8   4     2  3    3     A     false  3 years       {4,4,4}                    NULL         {0.1,0.2,0.3,1.0,2.0,3.0}              NULL  {3}               {1,-321,NULL,NULL,NULL}        {"3 years"}            NULL
+9   2     9  0.1  NULL  NULL  NULL   NULL          {4,4,4,2,2,2,2}            NULL         {0.1}                                  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}               {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+10  4     9  0.2  NULL  NULL  NULL   NULL          {4,4,4}                    NULL         {0.1,0.2}                              NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}               {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+11  NULL  9  0.3  NULL  NULL  NULL   NULL          {4,4,4,2,2,2,2,NULL,NULL}  {NULL,NULL}  {0.1,0.2,0.3}                          NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}               {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+
+# Regression test for #43083 (CBO optimizing out the single column from ORDER
+# BY clause which led to a crash in the execution engine).
+query IIIRRTBTTTTTTTTT
+SELECT
+  *,
+  array_agg(v) OVER (wv RANGE BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING),
+  array_agg(v) OVER (wv RANGE BETWEEN 0 PRECEDING AND 1 PRECEDING),
+  array_agg(f) OVER (wf RANGE BETWEEN UNBOUNDED PRECEDING AND -0.0 PRECEDING),
+  array_agg(f) OVER (wf RANGE BETWEEN 0.0 PRECEDING AND 1.0 PRECEDING),
+  array_agg(d) OVER (wd RANGE BETWEEN 0.0 FOLLOWING AND 0.0 FOLLOWING),
+  array_agg(d) OVER (wd RANGE BETWEEN 1.0 FOLLOWING AND UNBOUNDED FOLLOWING),
+  array_agg(i) OVER (wi RANGE BETWEEN '1s'::INTERVAL PRECEDING AND '0s'::INTERVAL PRECEDING),
+  array_agg(i) OVER (wi RANGE BETWEEN '1s'::INTERVAL FOLLOWING AND '1s'::INTERVAL FOLLOWING)
+FROM
+  kv
+WINDOW
+  wv AS (PARTITION BY v ORDER BY v),
+  wf AS (PARTITION BY f ORDER BY f DESC),
+  wd AS (PARTITION BY d ORDER BY d),
+  wi AS (PARTITION BY i ORDER BY i DESC)
+ORDER BY
+  k
+----
+1   2     3  1    1     a     true   00:01:00      {2,2,2,2}    NULL         {1.0}  NULL  {1}               NULL              {00:01:00}             NULL
+3   4     5  2    8     a     true   00:00:02      {4,4,4}      NULL         {2.0}  NULL  {8}               NULL              {00:00:02}             NULL
+5   NULL  5  9.9  -321  NULL  false  NULL          {NULL,NULL}  {NULL,NULL}  {9.9}  NULL  {-321}            NULL              {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+6   2     3  4.4  4.4   b     true   00:00:00.001  {2,2,2,2}    NULL         {4.4}  NULL  {4.4}             NULL              {00:00:00.001}         NULL
+7   2     2  6    7.9   b     true   4 days        {2,2,2,2}    NULL         {6.0}  NULL  {7.9}             NULL              {"4 days"}             NULL
+8   4     2  3    3     A     false  3 years       {4,4,4}      NULL         {3.0}  NULL  {3}               NULL              {"3 years"}            NULL
+9   2     9  0.1  NULL  NULL  NULL   NULL          {2,2,2,2}    NULL         {0.1}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+10  4     9  0.2  NULL  NULL  NULL   NULL          {4,4,4}      NULL         {0.2}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+11  NULL  9  0.3  NULL  NULL  NULL   NULL          {NULL,NULL}  {NULL,NULL}  {0.3}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1708,6 +1708,9 @@ func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowF
 		if err != nil {
 			return nil, err
 		}
+		if offset == tree.DNull {
+			return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "frame starting offset must not be null")
+		}
 		newDef.Bounds.StartBound.OffsetExpr = offset
 	}
 
@@ -1718,6 +1721,9 @@ func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowF
 		offset, err := b.buildScalar(&scalarCtx, boundExpr)
 		if err != nil {
 			return nil, err
+		}
+		if offset == tree.DNull {
+			return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "frame ending offset must not be null")
 		}
 		newDef.Bounds.EndBound.OffsetExpr = offset
 	}
@@ -1859,14 +1865,20 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		outputIdxs[i] = windowStart + i
 	}
 
+	var rangeOffsetColumn exec.ColumnOrdinal
+	if ord.Empty() {
+		idx, _ := input.outputCols.Get(int(w.RangeOffsetColumn))
+		rangeOffsetColumn = exec.ColumnOrdinal(idx)
+	}
 	node, err := b.factory.ConstructWindow(input.root, exec.WindowInfo{
-		Cols:       resultCols,
-		Exprs:      exprs,
-		OutputIdxs: outputIdxs,
-		ArgIdxs:    argIdxs,
-		FilterIdxs: filterIdxs,
-		Partition:  partitionIdxs,
-		Ordering:   input.sqlOrdering(ord),
+		Cols:              resultCols,
+		Exprs:             exprs,
+		OutputIdxs:        outputIdxs,
+		ArgIdxs:           argIdxs,
+		FilterIdxs:        filterIdxs,
+		Partition:         partitionIdxs,
+		Ordering:          input.sqlOrdering(ord),
+		RangeOffsetColumn: rangeOffsetColumn,
 	})
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -663,6 +663,13 @@ type WindowInfo struct {
 
 	// Ordering is the set of input columns to order on.
 	Ordering sqlbase.ColumnOrdering
+
+	// RangeOffsetColumn is the column ID of a single column from ORDER BY clause
+	// when window frame has RANGE mode of framing and at least one 'offset'
+	// boundary. We store it separately because the ordering might be simplified
+	// (when that single column is in Partition), but the execution still needs
+	// to know the original ordering.
+	RangeOffsetColumn ColumnOrdinal
 }
 
 // ExplainEnvData represents the data that's going to be displayed in EXPLAIN (env).

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -866,6 +866,14 @@ define WindowPrivate {
     # Ordering is the ordering that the window function is computed relative to
     # within each partition.
     Ordering OrderingChoice
+
+    # RangeOffsetColumn is the column ID of a single column from ORDER BY
+    # clause (when there is only one column). We store it separately because
+    # Ordering might be simplified (when that single column is in Partition),
+    # but the execution still needs to know the original ordering with RANGE
+    # mode of framing when at least one of the bounds has "offset". This column
+    # ID is used to reconstruct the Ordering during exec build phase.
+    RangeOffsetColumn ColumnID
 }
 
 # With executes Binding, making its results available to Main. Within Main, the

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -455,12 +455,17 @@ func (b *Builder) findMatchingFrameIndex(
 		}
 	}
 
+	var rangeOffsetColumn opt.ColumnID
+	if len(ordering.Columns) == 1 {
+		rangeOffsetColumn = ordering.Columns[0].AnyID()
+	}
 	// If we can't reuse an existing frame, make a new one.
 	if frameIdx == -1 {
 		*frames = append(*frames, memo.WindowExpr{
 			WindowPrivate: memo.WindowPrivate{
-				Partition: partition,
-				Ordering:  ordering,
+				Partition:         partition,
+				Ordering:          ordering,
+				RangeOffsetColumn: rangeOffsetColumn,
 			},
 			Windows: memo.WindowsExpr{},
 		})

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -99,6 +99,9 @@ func (wfr *WindowFrameRun) getValueByOffset(
 	if err != nil {
 		return nil, err
 	}
+	if value == DNull {
+		return DNull, nil
+	}
 	return binOp.Fn(evalCtx, value, offset)
 }
 
@@ -156,13 +159,13 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 				return 0, err
 			}
 			if wfr.OrdDirection == encoding.Descending {
-				// We use binary search on [wfr.RowIdx, wfr.PartitionSize()) interval
-				// to find the first row whose value is smaller or equal to 'value'.
-				return wfr.RowIdx + sort.Search(wfr.PartitionSize()-wfr.RowIdx, func(i int) bool {
+				// We use binary search on [0, wfr.PartitionSize()) interval to find
+				// the first row whose value is smaller or equal to 'value'.
+				return sort.Search(wfr.PartitionSize(), func(i int) bool {
 					if wfr.err != nil {
 						return false
 					}
-					valueAt, err := wfr.valueAt(ctx, i+wfr.RowIdx)
+					valueAt, err := wfr.valueAt(ctx, i)
 					if err != nil {
 						wfr.err = err
 						return false
@@ -170,13 +173,13 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 					return valueAt.Compare(evalCtx, value) <= 0
 				}), wfr.err
 			}
-			// We use binary search on [wfr.RowIdx, wfr.PartitionSize()) interval
-			// to find the first row whose value is greater or equal to 'value'.
-			return wfr.RowIdx + sort.Search(wfr.PartitionSize()-wfr.RowIdx, func(i int) bool {
+			// We use binary search on [0, wfr.PartitionSize()) interval to find the
+			// first row whose value is greater or equal to 'value'.
+			return sort.Search(wfr.PartitionSize(), func(i int) bool {
 				if wfr.err != nil {
 					return false
 				}
-				valueAt, err := wfr.valueAt(ctx, i+wfr.RowIdx)
+				valueAt, err := wfr.valueAt(ctx, i)
 				if err != nil {
 					wfr.err = err
 					return false
@@ -280,10 +283,12 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 				return 0, err
 			}
 			if wfr.OrdDirection == encoding.Descending {
-				// We use binary search on [0, wfr.RowIdx] interval to find the first row
-				// whose value is smaller than 'value'. If such row is not found,
-				// then Search will correctly return wfr.RowIdx+1.
-				return sort.Search(wfr.RowIdx+1, func(i int) bool {
+				// We use binary search on [0, wfr.PartitionSize()) interval to find
+				// the first row whose value is smaller than 'value'. If such row is
+				// not found, then Search will correctly return wfr.PartitionSize().
+				// Note that searching up to wfr.RowIdx is not correct in case of a
+				// zero offset (we need to include all peers of the current row).
+				return sort.Search(wfr.PartitionSize(), func(i int) bool {
 					if wfr.err != nil {
 						return false
 					}
@@ -295,10 +300,12 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 					return valueAt.Compare(evalCtx, value) < 0
 				}), wfr.err
 			}
-			// We use binary search on [0, wfr.RowIdx] interval to find the first row
-			// whose value is greater than 'value'. If such row is not found,
-			// then Search will correctly return wfr.RowIdx+1.
-			return sort.Search(wfr.RowIdx+1, func(i int) bool {
+			// We use binary search on [0, wfr.PartitionSize()) interval to find
+			// the first row whose value is smaller than 'value'. If such row is
+			// not found, then Search will correctly return wfr.PartitionSize().
+			// Note that searching up to wfr.RowIdx is not correct in case of a
+			// zero offset (we need to include all peers of the current row).
+			return sort.Search(wfr.PartitionSize(), func(i int) bool {
 				if wfr.err != nil {
 					return false
 				}
@@ -318,13 +325,13 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 				return 0, err
 			}
 			if wfr.OrdDirection == encoding.Descending {
-				// We use binary search on [wfr.RowIdx, wfr.PartitionSize()) interval
-				// to find the first row whose value is smaller than 'value'.
-				return wfr.RowIdx + sort.Search(wfr.PartitionSize()-wfr.RowIdx, func(i int) bool {
+				// We use binary search on [0, wfr.PartitionSize()) interval to find
+				// the first row whose value is smaller than 'value'.
+				return sort.Search(wfr.PartitionSize(), func(i int) bool {
 					if wfr.err != nil {
 						return false
 					}
-					valueAt, err := wfr.valueAt(ctx, i+wfr.RowIdx)
+					valueAt, err := wfr.valueAt(ctx, i)
 					if err != nil {
 						wfr.err = err
 						return false
@@ -332,13 +339,13 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 					return valueAt.Compare(evalCtx, value) < 0
 				}), wfr.err
 			}
-			// We use binary search on [wfr.RowIdx, wfr.PartitionSize()) interval
-			// to find the first row whose value is greater than 'value'.
-			return wfr.RowIdx + sort.Search(wfr.PartitionSize()-wfr.RowIdx, func(i int) bool {
+			// We use binary search on [0, wfr.PartitionSize()) interval to find
+			// the first row whose value is smaller than 'value'.
+			return sort.Search(wfr.PartitionSize(), func(i int) bool {
 				if wfr.err != nil {
 					return false
 				}
-				valueAt, err := wfr.valueAt(ctx, i+wfr.RowIdx)
+				valueAt, err := wfr.valueAt(ctx, i)
 				if err != nil {
 					wfr.err = err
 					return false

--- a/pkg/sql/sem/tree/window_funcs_test.go
+++ b/pkg/sql/sem/tree/window_funcs_test.go
@@ -138,7 +138,7 @@ func testStartFollowing(
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			for idx := wfr.RowIdx; idx <= wfr.PartitionSize(); idx++ {
+			for idx := 0; idx <= wfr.PartitionSize(); idx++ {
 				if idx == wfr.PartitionSize() {
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Following: expected %+v, found %+v", idx, frameStartIdx)
@@ -197,7 +197,7 @@ func testEndPreceding(
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			for idx := wfr.RowIdx; idx >= 0; idx-- {
+			for idx := wfr.PartitionSize() - 1; idx >= 0; idx-- {
 				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
@@ -378,4 +378,8 @@ func (ir indexedRow) GetDatum(colIdx int) (Datum, error) {
 // GetDatums implements IndexedRow interface.
 func (ir indexedRow) GetDatums(firstColIdx, lastColIdx int) (Datums, error) {
 	return ir.row[firstColIdx:lastColIdx], nil
+}
+
+func (ir indexedRow) String() string {
+	return fmt.Sprintf("%d: %s", ir.idx, ir.row.String())
 }


### PR DESCRIPTION
**opt: reconstruct simplified ordering in window functions in some cases**

Execution engine needs to know the index of the column from ORDER BY
clause in RANGE mode of framing when at least one of the bounds is
'offset PRECEDING' or 'offset FOLLOWING'. Previously, the ordering could
be simplified such that it no longer contained any columns (in case when
PARTITION BY clause also contained the same column). Now we store
additional information and reconstruct the ordering to keep the
execution engine happy.

Fixes: #43083.

Release note (bug fix): Previously, CockroachDB would crash when using
a window function with RANGE mode of framing with 'offset PRECEDING' or
'offset FOLLOWING' boundary such that the single column in ORDER BY
clause is also mentioned in PARTITION BY clause, and now this has been
fixed.

**sem/tree: fix window function utilities**

Previously, we would crash when trying to calculate the "physical"
boundary of the frame when the current value in the single column from
ORDER BY with RANGE mode of framing was NULL because we would attempt to
do something like 'NULL + 1` where `plus` binary operator assumed that
both sides were integers. This is fixed by returning NULL right away,
without performing binary operation.

Additionally, the boundaries of the window frame were not computed
correctly in case of `0 PRECEDING` or `0 FOLLOWING` due to incorrect
assumption that "preceding" cannot go past the current row and
"following" cannot go prior to the current row (both scenarios are
possible with zero offsets).

Release note (bug fix): Previously, CockroachDB could crash when
computing window functions with RANGE mode of framing when one of the
bounds was either of 'offset PRECEDING' or 'offset FOLLOWING' type when
there were NULL values in the single column from ORDER BY clause.
Additionally, also in RANGE mode bounds '0 PRECEDING' and '0 FOLLOWING'
could be handled incorrectly. Now this has been fixed.