### PR TITLE
cluster: remove a series of 19.1+ cluster versions

### DIFF
--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -293,8 +293,8 @@ func (s *bankState) startSplitMonkey(ctx context.Context, d time.Duration, c *cl
 				zipF := accountDistribution(r)
 				key := zipF.Uint64()
 				c.l.Printf("round %d: splitting key %v\n", curRound, key)
-				_, err := client.db.ExecContext(ctx, fmt.Sprintf(
-					`SET experimental_force_split_at = true; ALTER TABLE bank.accounts SPLIT AT VALUES (%d)`, key))
+				_, err := client.db.ExecContext(ctx,
+					fmt.Sprintf(`ALTER TABLE bank.accounts SPLIT AT VALUES (%d)`, key))
 				if err != nil && !(pgerror.IsSQLRetryableError(err) || isExpectedRelocateError(err)) {
 					s.errChan <- err
 				}

--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -278,9 +278,6 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 func (tc *txnCommitter) canCommitInParallelWithWrites(
 	ctx context.Context, ba roachpb.BatchRequest, et *roachpb.EndTxnRequest,
 ) bool {
-	if !cluster.Version.IsActive(ctx, tc.st, cluster.VersionParallelCommits) {
-		return false
-	}
 	if !parallelCommitsEnabled.Get(&tc.st.SV) {
 		return false
 	}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1230,8 +1230,7 @@ func TestRemoteDebugModeSetting(t *testing.T) {
 	// Create a split so that there's some records in the system.rangelog table.
 	// The test needs them.
 	if _, err := db.Exec(
-		`set experimental_force_split_at = true;
-		create table t(x int primary key);
+		`create table t(x int primary key);
 		alter table t split at values(1);`,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -34,7 +34,6 @@ const (
 	_ VersionKey = iota - 1 // want first named one to start at zero
 	Version19_1
 	VersionStart19_2
-	VersionQueryTxnTimestamp
 	VersionStickyBit
 	VersionParallelCommits
 	VersionGenerationComparable
@@ -182,11 +181,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Key:     VersionStart19_2,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 1},
 	},
-	{
-		// VersionQueryTxnTimestamp is https://github.com/cockroachdb/cockroach/pull/36307.
-		Key:     VersionQueryTxnTimestamp,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 2},
-	},
+	// Removed.
+	// {
+	// 	// VersionQueryTxnTimestamp is https://github.com/cockroachdb/cockroach/pull/36307.
+	// 	Key:     VersionQueryTxnTimestamp,
+	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 2},
+	// },
 	{
 		// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506.
 		Key:     VersionStickyBit,

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -34,7 +34,6 @@ const (
 	_ VersionKey = iota - 1 // want first named one to start at zero
 	Version19_1
 	VersionStart19_2
-	VersionParallelCommits
 	VersionGenerationComparable
 	VersionLearnerReplicas
 	VersionTopLevelForeignKeys
@@ -192,11 +191,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	// 	Key:     VersionStickyBit,
 	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 3},
 	// },
-	{
-		// VersionParallelCommits is https://github.com/cockroachdb/cockroach/pull/37777.
-		Key:     VersionParallelCommits,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 4},
-	},
+	// Removed.
+	// {
+	// 	// VersionParallelCommits is https://github.com/cockroachdb/cockroach/pull/37777.
+	// 	Key:     VersionParallelCommits,
+	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 4},
+	// },
 	{
 		// VersionGenerationComparable is https://github.com/cockroachdb/cockroach/pull/38334.
 		Key:     VersionGenerationComparable,

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -34,7 +34,6 @@ const (
 	_ VersionKey = iota - 1 // want first named one to start at zero
 	Version19_1
 	VersionStart19_2
-	VersionGenerationComparable
 	VersionLearnerReplicas
 	VersionTopLevelForeignKeys
 	VersionAtomicChangeReplicasTrigger
@@ -197,11 +196,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	// 	Key:     VersionParallelCommits,
 	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 4},
 	// },
-	{
-		// VersionGenerationComparable is https://github.com/cockroachdb/cockroach/pull/38334.
-		Key:     VersionGenerationComparable,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 5},
-	},
+	// Removed.
+	// {
+	// 	// VersionGenerationComparable is https://github.com/cockroachdb/cockroach/pull/38334.
+	// 	Key:     VersionGenerationComparable,
+	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 5},
+	// },
 	{
 		// VersionLearnerReplicas is https://github.com/cockroachdb/cockroach/pull/38149.
 		Key:     VersionLearnerReplicas,

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -34,7 +34,6 @@ const (
 	_ VersionKey = iota - 1 // want first named one to start at zero
 	Version19_1
 	VersionStart19_2
-	VersionStickyBit
 	VersionParallelCommits
 	VersionGenerationComparable
 	VersionLearnerReplicas
@@ -187,11 +186,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	// 	Key:     VersionQueryTxnTimestamp,
 	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 2},
 	// },
-	{
-		// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506.
-		Key:     VersionStickyBit,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 3},
-	},
+	// Removed.
+	// {
+	// 	// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506.
+	// 	Key:     VersionStickyBit,
+	// 	Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 3},
+	// },
 	{
 		// VersionParallelCommits is https://github.com/cockroachdb/cockroach/pull/37777.
 		Key:     VersionParallelCommits,

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -10,33 +10,32 @@ func _() {
 	var x [1]struct{}
 	_ = x[Version19_1-0]
 	_ = x[VersionStart19_2-1]
-	_ = x[VersionQueryTxnTimestamp-2]
-	_ = x[VersionStickyBit-3]
-	_ = x[VersionParallelCommits-4]
-	_ = x[VersionGenerationComparable-5]
-	_ = x[VersionLearnerReplicas-6]
-	_ = x[VersionTopLevelForeignKeys-7]
-	_ = x[VersionAtomicChangeReplicasTrigger-8]
-	_ = x[VersionAtomicChangeReplicas-9]
-	_ = x[VersionTableDescModificationTimeFromMVCC-10]
-	_ = x[VersionPartitionedBackup-11]
-	_ = x[Version19_2-12]
-	_ = x[VersionStart20_1-13]
-	_ = x[VersionContainsEstimatesCounter-14]
-	_ = x[VersionChangeReplicasDemotion-15]
-	_ = x[VersionSecondaryIndexColumnFamilies-16]
-	_ = x[VersionNamespaceTableWithSchemas-17]
-	_ = x[VersionProtectedTimestamps-18]
-	_ = x[VersionPrimaryKeyChanges-19]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-20]
-	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-21]
-	_ = x[VersionRootPassword-22]
-	_ = x[VersionNoExplicitForeignKeyIndexIDs-23]
+	_ = x[VersionStickyBit-2]
+	_ = x[VersionParallelCommits-3]
+	_ = x[VersionGenerationComparable-4]
+	_ = x[VersionLearnerReplicas-5]
+	_ = x[VersionTopLevelForeignKeys-6]
+	_ = x[VersionAtomicChangeReplicasTrigger-7]
+	_ = x[VersionAtomicChangeReplicas-8]
+	_ = x[VersionTableDescModificationTimeFromMVCC-9]
+	_ = x[VersionPartitionedBackup-10]
+	_ = x[Version19_2-11]
+	_ = x[VersionStart20_1-12]
+	_ = x[VersionContainsEstimatesCounter-13]
+	_ = x[VersionChangeReplicasDemotion-14]
+	_ = x[VersionSecondaryIndexColumnFamilies-15]
+	_ = x[VersionNamespaceTableWithSchemas-16]
+	_ = x[VersionProtectedTimestamps-17]
+	_ = x[VersionPrimaryKeyChanges-18]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-19]
+	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-20]
+	_ = x[VersionRootPassword-21]
+	_ = x[VersionNoExplicitForeignKeyIndexIDs-22]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 51, 67, 89, 116, 138, 164, 198, 225, 265, 289, 300, 316, 347, 376, 411, 443, 469, 493, 530, 569, 588, 623}
+var _VersionKey_index = [...]uint16{0, 11, 27, 43, 65, 92, 114, 140, 174, 201, 241, 265, 276, 292, 323, 352, 387, 419, 445, 469, 506, 545, 564, 599}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -10,31 +10,30 @@ func _() {
 	var x [1]struct{}
 	_ = x[Version19_1-0]
 	_ = x[VersionStart19_2-1]
-	_ = x[VersionParallelCommits-2]
-	_ = x[VersionGenerationComparable-3]
-	_ = x[VersionLearnerReplicas-4]
-	_ = x[VersionTopLevelForeignKeys-5]
-	_ = x[VersionAtomicChangeReplicasTrigger-6]
-	_ = x[VersionAtomicChangeReplicas-7]
-	_ = x[VersionTableDescModificationTimeFromMVCC-8]
-	_ = x[VersionPartitionedBackup-9]
-	_ = x[Version19_2-10]
-	_ = x[VersionStart20_1-11]
-	_ = x[VersionContainsEstimatesCounter-12]
-	_ = x[VersionChangeReplicasDemotion-13]
-	_ = x[VersionSecondaryIndexColumnFamilies-14]
-	_ = x[VersionNamespaceTableWithSchemas-15]
-	_ = x[VersionProtectedTimestamps-16]
-	_ = x[VersionPrimaryKeyChanges-17]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-18]
-	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-19]
-	_ = x[VersionRootPassword-20]
-	_ = x[VersionNoExplicitForeignKeyIndexIDs-21]
+	_ = x[VersionGenerationComparable-2]
+	_ = x[VersionLearnerReplicas-3]
+	_ = x[VersionTopLevelForeignKeys-4]
+	_ = x[VersionAtomicChangeReplicasTrigger-5]
+	_ = x[VersionAtomicChangeReplicas-6]
+	_ = x[VersionTableDescModificationTimeFromMVCC-7]
+	_ = x[VersionPartitionedBackup-8]
+	_ = x[Version19_2-9]
+	_ = x[VersionStart20_1-10]
+	_ = x[VersionContainsEstimatesCounter-11]
+	_ = x[VersionChangeReplicasDemotion-12]
+	_ = x[VersionSecondaryIndexColumnFamilies-13]
+	_ = x[VersionNamespaceTableWithSchemas-14]
+	_ = x[VersionProtectedTimestamps-15]
+	_ = x[VersionPrimaryKeyChanges-16]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-17]
+	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-18]
+	_ = x[VersionRootPassword-19]
+	_ = x[VersionNoExplicitForeignKeyIndexIDs-20]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 76, 98, 124, 158, 185, 225, 249, 260, 276, 307, 336, 371, 403, 429, 453, 490, 529, 548, 583}
+var _VersionKey_index = [...]uint16{0, 11, 27, 54, 76, 102, 136, 163, 203, 227, 238, 254, 285, 314, 349, 381, 407, 431, 468, 507, 526, 561}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -10,30 +10,29 @@ func _() {
 	var x [1]struct{}
 	_ = x[Version19_1-0]
 	_ = x[VersionStart19_2-1]
-	_ = x[VersionGenerationComparable-2]
-	_ = x[VersionLearnerReplicas-3]
-	_ = x[VersionTopLevelForeignKeys-4]
-	_ = x[VersionAtomicChangeReplicasTrigger-5]
-	_ = x[VersionAtomicChangeReplicas-6]
-	_ = x[VersionTableDescModificationTimeFromMVCC-7]
-	_ = x[VersionPartitionedBackup-8]
-	_ = x[Version19_2-9]
-	_ = x[VersionStart20_1-10]
-	_ = x[VersionContainsEstimatesCounter-11]
-	_ = x[VersionChangeReplicasDemotion-12]
-	_ = x[VersionSecondaryIndexColumnFamilies-13]
-	_ = x[VersionNamespaceTableWithSchemas-14]
-	_ = x[VersionProtectedTimestamps-15]
-	_ = x[VersionPrimaryKeyChanges-16]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-17]
-	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-18]
-	_ = x[VersionRootPassword-19]
-	_ = x[VersionNoExplicitForeignKeyIndexIDs-20]
+	_ = x[VersionLearnerReplicas-2]
+	_ = x[VersionTopLevelForeignKeys-3]
+	_ = x[VersionAtomicChangeReplicasTrigger-4]
+	_ = x[VersionAtomicChangeReplicas-5]
+	_ = x[VersionTableDescModificationTimeFromMVCC-6]
+	_ = x[VersionPartitionedBackup-7]
+	_ = x[Version19_2-8]
+	_ = x[VersionStart20_1-9]
+	_ = x[VersionContainsEstimatesCounter-10]
+	_ = x[VersionChangeReplicasDemotion-11]
+	_ = x[VersionSecondaryIndexColumnFamilies-12]
+	_ = x[VersionNamespaceTableWithSchemas-13]
+	_ = x[VersionProtectedTimestamps-14]
+	_ = x[VersionPrimaryKeyChanges-15]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-16]
+	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-17]
+	_ = x[VersionRootPassword-18]
+	_ = x[VersionNoExplicitForeignKeyIndexIDs-19]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 54, 76, 102, 136, 163, 203, 227, 238, 254, 285, 314, 349, 381, 407, 431, 468, 507, 526, 561}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -10,32 +10,31 @@ func _() {
 	var x [1]struct{}
 	_ = x[Version19_1-0]
 	_ = x[VersionStart19_2-1]
-	_ = x[VersionStickyBit-2]
-	_ = x[VersionParallelCommits-3]
-	_ = x[VersionGenerationComparable-4]
-	_ = x[VersionLearnerReplicas-5]
-	_ = x[VersionTopLevelForeignKeys-6]
-	_ = x[VersionAtomicChangeReplicasTrigger-7]
-	_ = x[VersionAtomicChangeReplicas-8]
-	_ = x[VersionTableDescModificationTimeFromMVCC-9]
-	_ = x[VersionPartitionedBackup-10]
-	_ = x[Version19_2-11]
-	_ = x[VersionStart20_1-12]
-	_ = x[VersionContainsEstimatesCounter-13]
-	_ = x[VersionChangeReplicasDemotion-14]
-	_ = x[VersionSecondaryIndexColumnFamilies-15]
-	_ = x[VersionNamespaceTableWithSchemas-16]
-	_ = x[VersionProtectedTimestamps-17]
-	_ = x[VersionPrimaryKeyChanges-18]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-19]
-	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-20]
-	_ = x[VersionRootPassword-21]
-	_ = x[VersionNoExplicitForeignKeyIndexIDs-22]
+	_ = x[VersionParallelCommits-2]
+	_ = x[VersionGenerationComparable-3]
+	_ = x[VersionLearnerReplicas-4]
+	_ = x[VersionTopLevelForeignKeys-5]
+	_ = x[VersionAtomicChangeReplicasTrigger-6]
+	_ = x[VersionAtomicChangeReplicas-7]
+	_ = x[VersionTableDescModificationTimeFromMVCC-8]
+	_ = x[VersionPartitionedBackup-9]
+	_ = x[Version19_2-10]
+	_ = x[VersionStart20_1-11]
+	_ = x[VersionContainsEstimatesCounter-12]
+	_ = x[VersionChangeReplicasDemotion-13]
+	_ = x[VersionSecondaryIndexColumnFamilies-14]
+	_ = x[VersionNamespaceTableWithSchemas-15]
+	_ = x[VersionProtectedTimestamps-16]
+	_ = x[VersionPrimaryKeyChanges-17]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-18]
+	_ = x[VersionPrimaryKeyColumnsOutOfFamilyZero-19]
+	_ = x[VersionRootPassword-20]
+	_ = x[VersionNoExplicitForeignKeyIndexIDs-21]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDs"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 43, 65, 92, 114, 140, 174, 201, 241, 265, 276, 292, 323, 352, 387, 419, 445, 469, 506, 545, 564, 599}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 76, 98, 124, 158, 185, 225, 249, 260, 276, 307, 336, 371, 403, 429, 453, 490, 529, 548, 583}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1845,10 +1845,6 @@ func (m *sessionDataMutator) SetForceSavepointRestart(val bool) {
 	m.data.ForceSavepointRestart = val
 }
 
-func (m *sessionDataMutator) SetForceSplitAt(val bool) {
-	m.data.ForceSplitAt = val
-}
-
 func (m *sessionDataMutator) SetPrimaryKeyChangesEnabled(val bool) {
 	m.data.PrimaryKeyChangesEnabled = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1570,7 +1570,6 @@ enable_insert_fast_path                  on                  NULL      NULL     
 enable_zigzag_join                       on                  NULL      NULL        NULL        string
 experimental_enable_primary_key_changes  off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables          off                 NULL      NULL        NULL        string
-experimental_force_split_at              off                 NULL      NULL        NULL        string
 experimental_optimizer_foreign_keys      on                  NULL      NULL        NULL        string
 experimental_serial_normalization        rowid               NULL      NULL        NULL        string
 extra_float_digits                       0                   NULL      NULL        NULL        string
@@ -1628,7 +1627,6 @@ enable_insert_fast_path                  on                  NULL  user     NULL
 enable_zigzag_join                       on                  NULL  user     NULL      on                  on
 experimental_enable_primary_key_changes  off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables          off                 NULL  user     NULL      off                 off
-experimental_force_split_at              off                 NULL  user     NULL      off                 off
 experimental_optimizer_foreign_keys      on                  NULL  user     NULL      on                  on
 experimental_serial_normalization        rowid               NULL  user     NULL      rowid               rowid
 extra_float_digits                       0                   NULL  user     NULL      0                   2
@@ -1682,7 +1680,6 @@ enable_insert_fast_path                  NULL    NULL     NULL     NULL        N
 enable_zigzag_join                       NULL    NULL     NULL     NULL        NULL
 experimental_enable_primary_key_changes  NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables          NULL    NULL     NULL     NULL        NULL
-experimental_force_split_at              NULL    NULL     NULL     NULL        NULL
 experimental_optimizer_foreign_keys      NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization        NULL    NULL     NULL     NULL        NULL
 extra_float_digits                       NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -41,7 +41,6 @@ enable_insert_fast_path                  on
 enable_zigzag_join                       on
 experimental_enable_primary_key_changes  off
 experimental_enable_temp_tables          off
-experimental_force_split_at              off
 experimental_optimizer_foreign_keys      on
 experimental_serial_normalization        rowid
 extra_float_digits                       0

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1854,7 +1854,6 @@ func (ef *execFactory) ConstructAlterTableSplit(
 	}
 
 	return &splitNode{
-		force:          ef.planner.SessionData().ForceSplitAt,
 		tableDesc:      &index.Table().(*optTable).desc.TableDescriptor,
 		index:          index.(*optIndex).desc,
 		rows:           input.(planNode),

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -35,9 +35,6 @@ type SessionData struct {
 	// DistSQLMode indicates whether to run queries using the distributed
 	// execution engine.
 	DistSQLMode DistSQLExecMode
-	// ForceSplitAt indicates whether checks to prevent incorrect usage of ALTER
-	// TABLE ... SPLIT AT should be skipped.
-	ForceSplitAt bool
 	// OptimizerFKs indicates whether we should use the new paths to plan foreign
 	// key checks in the optimizer.
 	OptimizerFKs bool

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -14,9 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/errors"
@@ -37,15 +34,6 @@ type unsplitRun struct {
 }
 
 func (n *unsplitNode) startExec(params runParams) error {
-	st := params.EvalContext().Settings
-	stickyBitEnabled := cluster.Version.IsActive(params.ctx, st, cluster.VersionStickyBit)
-	// TODO(jeffreyxiao): Remove this error in v20.1.
-	if !stickyBitEnabled {
-		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-			`UNSPLIT AT requires all nodes to be upgraded to %s`,
-			cluster.VersionByKey(cluster.VersionStickyBit),
-		)
-	}
 	return nil
 }
 
@@ -97,15 +85,6 @@ type unsplitAllRun struct {
 }
 
 func (n *unsplitAllNode) startExec(params runParams) error {
-	st := params.EvalContext().Settings
-	stickyBitEnabled := cluster.Version.IsActive(params.ctx, st, cluster.VersionStickyBit)
-	// TODO(jeffreyxiao): Remove this error in v20.1.
-	if !stickyBitEnabled {
-		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-			`UNSPLIT AT requires all nodes to be upgraded to %s`,
-			cluster.VersionByKey(cluster.VersionStickyBit),
-		)
-	}
 	// Use the internal executor to retrieve the split keys.
 	statement := `
 		SELECT

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -326,23 +326,6 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_force_split_at`: {
-		GetStringVal: makeBoolGetStringValFn(`experimental_force_split_at`),
-		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
-			b, err := parsePostgresBool(s)
-			if err != nil {
-				return err
-			}
-			m.SetForceSplitAt(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ForceSplitAt)
-		},
-		GlobalDefault: globalFalse,
-	},
-
-	// CockroachDB extension.
 	`experimental_enable_primary_key_changes`: {
 		GetStringVal: makeBoolGetStringValFn(`experimental_enable_primary_key_changes`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
@@ -52,12 +51,7 @@ func QueryTxn(
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
 	}
-	// TODO(nvanbenschoten): old clusters didn't attach header timestamps to
-	// QueryTxn requests, so only perform this check for clusters that will
-	// always attach a valid timestamps.
-	checkHeaderTS := cluster.Version.IsActive(
-		ctx, cArgs.EvalCtx.ClusterSettings(), cluster.VersionQueryTxnTimestamp)
-	if h.Timestamp.Less(args.Txn.WriteTimestamp) && checkHeaderTS {
+	if h.Timestamp.Less(args.Txn.WriteTimestamp) {
 		// This condition must hold for the timestamp cache access to be safe.
 		return result.Result{}, errors.Errorf("request timestamp %s less than txn timestamp %s", h.Timestamp, args.Txn.WriteTimestamp)
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -295,16 +295,6 @@ func (r *Replica) adminSplitWithDescriptor(
 	delayable bool,
 	reason string,
 ) (roachpb.AdminSplitResponse, error) {
-	if !cluster.Version.IsActive(ctx, r.store.ClusterSettings(), cluster.VersionStickyBit) {
-		// If sticky bits aren't supported yet but we receive one anyway, ignore
-		// it. The callers are supposed to only pass hlc.Timestamp{} in that
-		// case, but this is violated in at least one case (and there are lots of
-		// callers that aren't easy to audit and maintain audited). Take the
-		// small risk that the cluster version is actually active (but we don't
-		// know it yet) instead of risking broken descriptors.
-		args.ExpirationTime = hlc.Timestamp{}
-	}
-
 	var err error
 	// The split queue doesn't care about the set of replicas, so if we somehow
 	// are being handed one that's in a joint state, finalize that before

--- a/pkg/storage/store_bootstrap.go
+++ b/pkg/storage/store_bootstrap.go
@@ -145,13 +145,11 @@ func WriteInitialClusterData(
 		}
 
 		desc := &roachpb.RangeDescriptor{
-			RangeID:       rangeID,
-			StartKey:      startKey,
-			EndKey:        endKey,
-			NextReplicaID: 2,
-		}
-		if !bootstrapVersion.Less(cluster.VersionByKey(cluster.VersionGenerationComparable)) {
-			desc.GenerationComparable = proto.Bool(true)
+			RangeID:              rangeID,
+			StartKey:             startKey,
+			EndKey:               endKey,
+			NextReplicaID:        2,
+			GenerationComparable: proto.Bool(true),
 		}
 		replicas := []roachpb.ReplicaDescriptor{
 			{


### PR DESCRIPTION
This PR removes the following four cluster versions:
- `VersionQueryTxnTimestamp`
- `VersionStickyBit`
- `VersionParallelCommits`
- `VersionGenerationComparable`