### PR TITLE
cli: add system.namespace_deprecated to debug zip

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -60,6 +60,7 @@ var debugZipTablesPerCluster = []string{
 	"system.jobs",       // get the raw, restorable jobs records too.
 	"system.descriptor", // descriptors also contain job-like mutation state.
 	"system.namespace",
+	"system.namespace_deprecated", // TODO(sqlexec): consider removing in 20.2 or later.
 
 	"crdb_internal.kv_node_status",
 	"crdb_internal.kv_store_status",

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -66,7 +66,13 @@ ORDER BY name ASC`)
 		assert.NoError(t, rows.Scan(&table))
 		tables = append(tables, table)
 	}
-	tables = append(tables, "system.jobs", "system.descriptor", "system.namespace")
+	tables = append(
+		tables,
+		"system.jobs",
+		"system.descriptor",
+		"system.namespace",
+		"system.namespace_deprecated",
+	)
 	sort.Strings(tables)
 
 	var exp []string
@@ -110,6 +116,7 @@ writing ` + os.DevNull + `
   debug/system.jobs.txt
   debug/system.descriptor.txt
   debug/system.namespace.txt
+  debug/system.namespace_deprecated.txt
   debug/crdb_internal.kv_node_status.txt
   debug/crdb_internal.kv_store_status.txt
   debug/crdb_internal.schema_changes.txt


### PR DESCRIPTION
As we are migrating system.namespace from system.namespace_deprecated in
20.2, it may be useful to have a zip of this old table, in case it comes
in handy for debugging in future.

Release note: None