### PR TITLE
engine: Standardize NextKey() behaviour in pebble iters with rocks

### DIFF
--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1340,6 +1340,71 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 	}
 }
 
+func TestMVCCPutAfterBatchIterCreate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+
+			err := engine.Put(MVCCKey{testKey1, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = engine.Put(MVCCKey{testKey2, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = engine.Put(MVCCKey{testKey2, hlc.Timestamp{WallTime: 3}}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = engine.Put(MVCCKey{testKey3, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = engine.Put(MVCCKey{testKey4, hlc.Timestamp{WallTime: 5}}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			batch := engine.NewBatch()
+			defer batch.Close()
+			txn := &roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					WriteTimestamp: hlc.Timestamp{WallTime: 10},
+				},
+				Name:                    "test",
+				Status:                  roachpb.PENDING,
+				DeprecatedOrigTimestamp: hlc.Timestamp{WallTime: 10},
+				ReadTimestamp:           hlc.Timestamp{WallTime: 10},
+				MaxTimestamp:            hlc.Timestamp{WallTime: 10},
+			}
+			iter := batch.NewIterator(IterOptions{
+				LowerBound: testKey1,
+				UpperBound: testKey5,
+			})
+			defer iter.Close()
+			iter.SeekGE(MVCCKey{testKey1, hlc.Timestamp{WallTime: 5}})
+			iter.Next() // key2/5
+
+			// Lay down an intent on key3, which will go at key3/0 and sort before key3/5.
+			err = MVCCDelete(context.TODO(), batch, nil, testKey3, txn.WriteTimestamp, txn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Should Next() from key2/5 to key2/3 first, then Seek to key3, and see
+			// the intent.
+			iter.NextKey()
+
+			if iter.UnsafeKey().IsValue() {
+				t.Fatalf("expected iterator to land on an intent, got a value: %v", iter.UnsafeKey())
+			}
+		})
+	}
+}
+
 func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -201,11 +201,13 @@ func (p *pebbleIterator) NextKey() {
 		return
 	}
 	p.keyBuf = append(p.keyBuf[:0], p.UnsafeKey().Key...)
-
-	for p.iter.Next() {
-		if !bytes.Equal(p.keyBuf, p.UnsafeKey().Key) {
-			break
-		}
+	if !p.iter.Next() {
+		return
+	}
+	if bytes.Equal(p.keyBuf, p.UnsafeKey().Key) {
+		// This is equivalent to:
+		// p.iter.SeekGE(EncodeKey(MVCCKey{p.UnsafeKey().Key.Next(), hlc.Timestamp{}}))
+		p.iter.SeekGE(append(p.keyBuf, 0, 0))
 	}
 }
 


### PR DESCRIPTION
RocksDB iterators do a SeekGE if a regular Next() does not advance
MVCC keys. Replicate this behaviour in the pebble iterator NextKey;
which would previously do Next()s indefinitely until it advanced keys
or went invalid. The subtle difference between seeks and nexts makes
a difference in batch iterators where a Seek can see keys that were
added after the creation of the iterator, while a Next may not see
them.

Found via the MVCC metamorphic tests.

Release note: None.