### PR TITLE
ccl,sql: fallback system.namespace reads to system.namespace_deprecated

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -2101,29 +2102,71 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 	},
 }
 
-type namespaceKey struct {
-	parentID sqlbase.ID
-	name     string
+// NamespaceKey represents a key from the namespace table.
+type NamespaceKey struct {
+	ParentID sqlbase.ID
+	// ParentSchemaID is not populated for rows under system.deprecated_namespace.
+	// This table will no longer exist on 20.2 or later.
+	ParentSchemaID sqlbase.ID
+	Name           string
 }
 
 // getAllNames returns a map from ID to namespaceKey for every entry in
 // system.namespace.
-func (p *planner) getAllNames(ctx context.Context) (map[sqlbase.ID]namespaceKey, error) {
-	namespace := map[sqlbase.ID]namespaceKey{}
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
-		ctx, "get-all-names", p.txn,
-		`SELECT id, "parentID", name FROM system.namespace`,
+func (p *planner) getAllNames(ctx context.Context) (map[sqlbase.ID]NamespaceKey, error) {
+	return getAllNames(ctx, p.txn, p.ExtendedEvalContext().ExecCfg.InternalExecutor)
+}
+
+// TestingGetAllNames is a wrapper for getAllNames.
+func TestingGetAllNames(
+	ctx context.Context, txn *client.Txn, executor *InternalExecutor,
+) (map[sqlbase.ID]NamespaceKey, error) {
+	return getAllNames(ctx, txn, executor)
+}
+
+// getAllNames is the testable implementation of getAllNames.
+// It is public so that it can be tested outside the sql package.
+func getAllNames(
+	ctx context.Context, txn *client.Txn, executor *InternalExecutor,
+) (map[sqlbase.ID]NamespaceKey, error) {
+	namespace := map[sqlbase.ID]NamespaceKey{}
+	rows, err := executor.Query(
+		ctx, "get-all-names", txn,
+		`SELECT id, "parentID", "parentSchemaID", name FROM system.namespace`,
 	)
 	if err != nil {
 		return nil, err
 	}
 	for _, r := range rows {
-		id, parentID, name := tree.MustBeDInt(r[0]), tree.MustBeDInt(r[1]), tree.MustBeDString(r[2])
-		namespace[sqlbase.ID(id)] = namespaceKey{
-			parentID: sqlbase.ID(parentID),
-			name:     string(name),
+		id, parentID, parentSchemaID, name := tree.MustBeDInt(r[0]), tree.MustBeDInt(r[1]), tree.MustBeDInt(r[2]), tree.MustBeDString(r[3])
+		namespace[sqlbase.ID(id)] = NamespaceKey{
+			ParentID:       sqlbase.ID(parentID),
+			ParentSchemaID: sqlbase.ID(parentSchemaID),
+			Name:           string(name),
 		}
 	}
+
+	// Also get all rows from namespace_deprecated, and add to the namespace map
+	// if it is not already there yet.
+	// If a row exists in both here and namespace, only use the one from namespace.
+	// TODO(sqlexec): In 20.2, this can be removed.
+	deprecatedRows, err := executor.Query(
+		ctx, "get-all-names-deprecated-namespace", txn,
+		`SELECT id, "parentID", name FROM system.namespace_deprecated`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range deprecatedRows {
+		id, parentID, name := tree.MustBeDInt(r[0]), tree.MustBeDInt(r[1]), tree.MustBeDString(r[2])
+		if _, ok := namespace[sqlbase.ID(id)]; !ok {
+			namespace[sqlbase.ID(id)] = NamespaceKey{
+				ParentID: sqlbase.ID(parentID),
+				Name:     string(name),
+			}
+		}
+	}
+
 	return namespace, nil
 }
 
@@ -2158,7 +2201,7 @@ CREATE TABLE crdb_internal.zones (
 		}
 		resolveID := func(id uint32) (parentID uint32, name string, err error) {
 			if entry, ok := namespace[sqlbase.ID(id)]; ok {
-				return uint32(entry.parentID), entry.name, nil
+				return uint32(entry.ParentID), entry.Name, nil
 			}
 			return 0, "", errors.AssertionFailedf(
 				"object with ID %d does not exist", errors.Safe(id))

--- a/pkg/sql/privileged_accessor_test.go
+++ b/pkg/sql/privileged_accessor_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLookupNamespaceID tests the lookup namespace id falls back
+// onto system.namespace_deprecated.
+func TestLookupNamespaceIDFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		return txn.Put(
+			ctx,
+			sqlbase.NewDeprecatedTableKey(999, "bob").Key(),
+			9999,
+		)
+	})
+	require.NoError(t, err)
+
+	// Assert the row exists in the database.
+	var id int64
+	err = sqlDB.QueryRow(
+		`SELECT crdb_internal.get_namespace_id($1, $2)`,
+		999,
+		"bob",
+	).Scan(&id)
+	require.NoError(t, err)
+	assert.Equal(t, int64(9999), id)
+}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/43243.

With the migration of system.namespace to system.namespace_deprecated,
we sometimes have to fallback to reading system.namespace_deprecated for
tables which are in the middle of a migration. This is done for KVs, but
must be done for SQL statements as well, which this PR aims to achieve.

Due to the difficulty of mocking out the planner, some functions have
had to be made public / abstracted out of planner for testing to occur.

Search params: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/cockroachdb/cockroach%24+system.namespace+-file:test+-file:.md%24&patternType=literal#14

Release note: None