### PR TITLE
opt: fix internal error when aggregating on a virtual table

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -817,6 +817,10 @@ func (b *Builder) allowImplicitGroupingColumn(colID opt.ColumnID, g *groupby) bo
 	// Get all the PK columns.
 	tab := md.Table(colMeta.Table)
 	var pkCols opt.ColSet
+	if tab.IndexCount() == 0 {
+		// Virtual tables have no indexes.
+		return false
+	}
 	primaryIndex := tab.Index(cat.PrimaryIndex)
 	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
 		pkCols.Add(colMeta.Table.ColumnID(primaryIndex.Column(i).Ordinal))

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3734,6 +3734,12 @@ project
                           ├── variable: k [type=int]
                           └── variable: a [type=int]
 
+# Verify that we handle tables with no primary index (#44659).
+build
+SELECT table_schema FROM information_schema.columns GROUP BY table_name
+----
+error (42803): column "table_schema" must appear in the GROUP BY clause or be used in an aggregate function
+
 # Tests with aliases (see #28059).
 build
 SELECT x + 1 AS z FROM abxy GROUP BY z


### PR DESCRIPTION
Recently introduced logic allows projecting any columns if we are
grouping by the PK of the table. This code generates an internal error
for virtual tables, which have no primary index. Note that in this
case we expect an error.

Fixes #44659.

Release note (bug fix): fixed "no indexes" internal error in some
cases when we GROUP BY on a virtual table.