### PR TITLE
sqlsmith: teach sqlsmith about savepoints

### DIFF
--- a/pkg/internal/sqlsmith/random.go
+++ b/pkg/internal/sqlsmith/random.go
@@ -61,3 +61,15 @@ func (s *Smither) sample(n, mean int, fn func(i int)) {
 		fn(perms[ki])
 	}
 }
+
+const letters = "abcdefghijklmnopqrstuvwxyz"
+
+// randString generates a random string with a target length using characters
+// from the input alphabet string.
+func (s *Smither) randString(length int, alphabet string) string {
+	buf := make([]byte, length)
+	for i := range buf {
+		buf[i] = alphabet[s.rnd.Intn(len(alphabet))]
+	}
+	return string(buf)
+}


### PR DESCRIPTION
Fixes #44686.

This PR teaches SQLSmith about savepoints, and sets it
up to use only in situations where we don't have DDLs.

Release note: None