### PR TITLE
engine: Handle put when all writes are ignored and there are no committed values

### DIFF
--- a/pkg/storage/engine/testdata/mvcc_histories/ignored_seq_nums_cput
+++ b/pkg/storage/engine/testdata/mvcc_histories/ignored_seq_nums_cput
@@ -40,7 +40,7 @@ run ok
 cput t=A k=k cond=first v=b
 ----
 >> at end:
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/first}}
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000011,0 del=false klen=12 vlen=6
 data: "k"/0.000000011,0 -> /BYTES/b
 data: "k"/0.000000001,0 -> /BYTES/first
 
@@ -86,7 +86,7 @@ run ok
 cput t=B k=k cond=a v=c
 ----
 >> at end:
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/a}}
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 data: "k"/0.000000011,0 -> /BYTES/c
 data: "k"/0.000000001,0 -> /BYTES/first
 
@@ -143,7 +143,7 @@ run ok
 cput t=C k=k cond=a v=c
 ----
 >> at end:
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}{30 /BYTES/a}}
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 data: "k"/0.000000011,0 -> /BYTES/c
 data: "k"/0.000000001,0 -> /BYTES/first
 
@@ -199,6 +199,6 @@ run ok
 cput t=D k=k cond=first v=c
 ----
 >> at end:
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/first}}
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 data: "k"/0.000000011,0 -> /BYTES/c
 data: "k"/0.000000001,0 -> /BYTES/first

--- a/pkg/storage/engine/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/engine/testdata/mvcc_histories/put_after_rollback
@@ -1,0 +1,14 @@
+run error
+with t=A k=k2
+  txn_begin ts=1
+  txn_step  seq=10
+  put       v=a
+  txn_ignore_seqs seqs=(5-15)
+  txn_step  seq=20
+  put       v=b
+----
+>> at end:
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=10} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k2"/0.000000001,0 -> /BYTES/a
+error: (*withstack.withStack:) previous intent of the transaction with the same epoch not found for "k2"/0,0 ("A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1)

--- a/pkg/storage/engine/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/engine/testdata/mvcc_histories/put_after_rollback
@@ -1,4 +1,4 @@
-run error
+run ok
 with t=A k=k2
   txn_begin ts=1
   txn_step  seq=10
@@ -6,9 +6,78 @@ with t=A k=k2
   txn_ignore_seqs seqs=(5-15)
   txn_step  seq=20
   put       v=b
+  get
+  txn_ignore_seqs seqs=(5-25)
+  get
 ----
+get: "k2" -> /BYTES/b @0.000000001,0
+get: "k2" -> <no data>
 >> at end:
 txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
-meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=10} ts=0.000000001,0 del=false klen=12 vlen=6
-data: "k2"/0.000000001,0 -> /BYTES/a
-error: (*withstack.withStack:) previous intent of the transaction with the same epoch not found for "k2"/0,0 ("A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1)
+meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k2"/0.000000001,0 -> /BYTES/b
+
+run ok
+with t=A k=k3
+  txn_step  seq=30
+  put       v=a
+  txn_ignore_seqs seqs=(5-35)
+  txn_step  seq=40
+  del
+----
+>> at end:
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k2"/0.000000001,0 -> /BYTES/b
+meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0
+data: "k3"/0.000000001,0 -> /<empty>
+
+run ok
+with t=A k=k4
+  txn_step  seq=50
+  put       v=a
+  txn_step  seq=51
+  cput      v=b cond=a
+  txn_ignore_seqs seqs=(5-55)
+  txn_step  seq=60
+  cput      v=c
+----
+>> at end:
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=60} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k2"/0.000000001,0 -> /BYTES/b
+meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0
+data: "k3"/0.000000001,0 -> /<empty>
+meta: "k4"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=60} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k4"/0.000000001,0 -> /BYTES/c
+
+run ok
+put k=k5 v=foo ts=3
+with t=B k=k5
+  txn_begin ts=5
+  txn_step  seq=10
+  put       v=a
+  txn_step  seq=20
+  put       v=b
+  txn_step  seq=30
+  txn_ignore_seqs seqs=(15-25)
+  put       v=c
+  check_intent
+  txn_step  seq=40
+  txn_ignore_seqs seqs=(5-35)
+  put       v=d
+  check_intent
+  resolve_intent status=COMMITTED
+----
+meta: "k5" -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=30} ts=0.000000005,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
+meta: "k5" -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=40} ts=0.000000005,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
+>> at end:
+txn: "B" meta={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000005,0 wto=false max=0,0 isn=1
+meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k2"/0.000000001,0 -> /BYTES/b
+meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0
+data: "k3"/0.000000001,0 -> /<empty>
+meta: "k4"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=60} ts=0.000000001,0 del=false klen=12 vlen=6
+data: "k4"/0.000000001,0 -> /BYTES/c
+data: "k5"/0.000000005,0 -> /BYTES/d
+data: "k5"/0.000000003,0 -> /BYTES/foo


### PR DESCRIPTION
(This is really an issue, filed as a PR because it contains a test case in the right place)

The following sequence currently triggers an assertion error inside
`mvcc.go`, where it should succeed without error instead:

1. start txn
2. put at seq = 10
3. ignore seqs 5-15
4. put at seq = 20

The error is: `previous intent of the transaction with the same epoch
not found for ...` (mvcc.go:1650)

See the enclosed test case.

Release note: none