### PR TITLE
sql: add cluster and session setting for requiring explicit pks

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1321,6 +1321,13 @@ func MakeTableDesc(
 		}
 	}
 
+	// If explicit primary keys are required, error out since a primary key was not supplied.
+	if len(desc.PrimaryIndex.ColumnNames) == 0 && desc.IsPhysicalTable() && evalCtx != nil &&
+		evalCtx.SessionData != nil && evalCtx.SessionData.RequireExplicitPrimaryKeys {
+		return desc, errors.Errorf(
+			"no primary key specified for table %s (require_explicit_primary_keys = true)", desc.Name)
+	}
+
 	if primaryIndexColumnSet != nil {
 		// Primary index columns are not nullable.
 		for i := range desc.Columns {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -147,6 +147,12 @@ var ReorderJoinsLimitClusterValue = settings.RegisterValidatedIntSetting(
 	},
 )
 
+var requireExplicitPrimaryKeysClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.require_explicit_primary_keys.enabled",
+	"default value for requiring explicit primary keys in CREATE TABLE statements",
+	false,
+)
+
 var primaryKeyChangesEnabledClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_primary_key_changes.enabled",
 	"default value for experimental_enable_primary_key_changes session setting; allows use of primary key changes by default",
@@ -1853,6 +1859,10 @@ func (m *sessionDataMutator) SetPrimaryKeyChangesEnabled(val bool) {
 
 func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 	m.data.ZigzagJoinEnabled = val
+}
+
+func (m *sessionDataMutator) SetRequireExplicitPrimaryKeys(val bool) {
+	m.data.RequireExplicitPrimaryKeys = val
 }
 
 func (m *sessionDataMutator) SetReorderJoinsLimit(val int) {

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -38,3 +38,9 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.secondary_index_column_families' AND usage_count >= 2
 ----
 sql.schema.secondary_index_column_families
+
+statement ok
+set require_explicit_primary_keys=true
+
+statement error pq: no primary key specified for table t \(require_explicit_primary_keys = true\)
+CREATE TABLE t (x INT, y INT)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1583,6 +1583,7 @@ max_identifier_length                    128                 NULL      NULL     
 max_index_keys                           32                  NULL      NULL        NULL        string
 node_id                                  1                   NULL      NULL        NULL        string
 reorder_joins_limit                      4                   NULL      NULL        NULL        string
+require_explicit_primary_keys            off                 NULL      NULL        NULL        string
 results_buffer_size                      16384               NULL      NULL        NULL        string
 row_security                             off                 NULL      NULL        NULL        string
 search_path                              public              NULL      NULL        NULL        string
@@ -1640,6 +1641,7 @@ max_identifier_length                    128                 NULL  user     NULL
 max_index_keys                           32                  NULL  user     NULL      32                  32
 node_id                                  1                   NULL  user     NULL      1                   1
 reorder_joins_limit                      4                   NULL  user     NULL      4                   4
+require_explicit_primary_keys            off                 NULL  user     NULL      off                 off
 results_buffer_size                      16384               NULL  user     NULL      16384               16384
 row_security                             off                 NULL  user     NULL      off                 off
 search_path                              public              NULL  user     NULL      public              public
@@ -1694,6 +1696,7 @@ max_index_keys                           NULL    NULL     NULL     NULL        N
 node_id                                  NULL    NULL     NULL     NULL        NULL
 optimizer                                NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                      NULL    NULL     NULL     NULL        NULL
+require_explicit_primary_keys            NULL    NULL     NULL     NULL        NULL
 results_buffer_size                      NULL    NULL     NULL     NULL        NULL
 row_security                             NULL    NULL     NULL     NULL        NULL
 search_path                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -54,6 +54,7 @@ max_identifier_length                    128
 max_index_keys                           32
 node_id                                  1
 reorder_joins_limit                      4
+require_explicit_primary_keys            off
 results_buffer_size                      16384
 row_security                             off
 search_path                              public

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -58,6 +58,9 @@ type SessionData struct {
 	// ReorderJoinsLimit indicates the number of joins at which the optimizer should
 	// stop attempting to reorder.
 	ReorderJoinsLimit int
+	// RequireExplicitPrimaryKeys indicates whether CREATE TABLE statements should
+	// error out if no primary key is provided.
+	RequireExplicitPrimaryKeys bool
 	// SequenceState gives access to the SQL sequences that have been manipulated
 	// by the session.
 	SequenceState *SequenceState

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -387,6 +387,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`require_explicit_primary_keys`: {
+		GetStringVal: makeBoolGetStringValFn(`require_explicit_primary_keys`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetRequireExplicitPrimaryKeys(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.RequireExplicitPrimaryKeys)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(requireExplicitPrimaryKeysClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`vectorize`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.VectorizeExecModeFromString(s)


### PR DESCRIPTION
Fixes #44491.

This PR adds the session setting `require_explicit_primary_keys`
and the cluster setting
`sql.defaults.require_explicit_primary_keys.enabled`
to configure whether the system should error out when tables
are attempted to be created using the default hidden rowid.

Release note (sql change): This PR adds settings (`sql.defaults.require_explicit_primary_keys.enabled`, `require_explicit_primary_keys`) to error out if tables 
are created without explicit primary keys.