### PR TITLE
sql: fix TypeCheck for NULLIF

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -205,3 +205,19 @@ query B
 SELECT '' BETWEEN ''::BYTES AND '';
 ----
 true
+
+# Regression test for #44632: NULLIF should have the type of the first argument.
+query I
+SELECT NULLIF(NULL, 0) + NULLIF(NULL, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, 0) + NULLIF(0, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, NULL) + NULLIF(0, NULL)
+----
+0

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1025,13 +1025,15 @@ func (expr *NotExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, e
 
 // TypeCheck implements the Expr interface.
 func (expr *NullIfExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error) {
-	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, desired, expr.Expr1, expr.Expr2)
+	typedSubExprs, _, err := TypeCheckSameTypedExprs(ctx, desired, expr.Expr1, expr.Expr2)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible NULLIF expressions")
 	}
 
 	expr.Expr1, expr.Expr2 = typedSubExprs[0], typedSubExprs[1]
-	expr.typ = retType
+
+	// The return type of NULLIF is the type of the first expression.
+	expr.typ = typedSubExprs[0].ResolvedType()
 	return expr, nil
 }
 

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -68,6 +68,7 @@ func TestTypeCheck(t *testing.T) {
 		{`NULLIF(NULL, 2)`, `NULLIF(NULL, 2:::INT8)`},
 		{`NULLIF(2, NULL)`, `NULLIF(2:::INT8, NULL)`},
 		{`NULLIF((1, 2), (1, 3))`, `NULLIF((1:::INT8, 2:::INT8), (1:::INT8, 3:::INT8))`},
+		{`NULLIF(NULL, 0) + NULLIF(NULL, 0)`, `NULL`},
 		{`COALESCE(1, 2, 3, 4, 5)`, `COALESCE(1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8)`},
 		{`COALESCE(1, 2.0)`, `COALESCE(1:::DECIMAL, 2.0:::DECIMAL)`},
 		{`COALESCE(NULL, 2)`, `COALESCE(NULL, 2:::INT8)`},


### PR DESCRIPTION
Prior to this commit, `TypeCheck` for `NULLIF` would set the type of the
expression `NULLIF(NULL, 0)` to be `int`. However, the correct type is
actually `unknown`, since the type of `NULL` is `unknown`. This commit
fixes the error by using the type of the first expression as the type
of `NULLIF`.

Fixes #44632

Release note (bug fix): Fixed an internal error that could occur when
NULLIF was called with one null argument.