### PR TITLE
sql: add telemetry for uses of alter primary key

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -324,6 +324,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 					"session variable experimental_enable_primary_key_changes is set to false, cannot perform primary key change")
 			}
 
+			// Increment telemetry about uses of primary key changes.
+			telemetry.Inc(sqltelemetry.AlterPrimaryKeyCounter)
+
 			// Ensure that there is not another primary key change attempted within this transaction.
 			currentMutationID := n.tableDesc.ClusterVersion.NextMutationID
 			for i := range n.tableDesc.Mutations {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -36,6 +36,11 @@ SELECT * from t@primary
 2 6 7 8
 9 10 11 12
 
+query T
+select feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.alter_primary_key' AND usage_count > 0
+----
+sql.schema.alter_primary_key
+
 # Test primary key changes on storing indexes with different column families (the randomizer will do this for us).
 statement ok
 DROP TABLE t;

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -37,3 +37,7 @@ var CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_ta
 // SecondaryIndexColumnFamiliesCounter is a counter that is incremented every time
 // a secondary index that is separated into different column families is created.
 var SecondaryIndexColumnFamiliesCounter = telemetry.GetCounterOnce("sql.schema.secondary_index_column_families")
+
+// AlterPrimaryKeyCounter is a counter that is incremented every time the
+// ALTER PRIMARY KEY command is used.
+var AlterPrimaryKeyCounter = telemetry.GetCounterOnce("sql.schema.alter_primary_key")


### PR DESCRIPTION
Fixes #44716.

This PR adds a telemetry counter for uses
of the alter primary key command.

Release note (sql change): This PR adds collected telemetry
from clusters upon using the alter primary key command.