### PR TITLE
vendor: bump pebble to 89adc50375ffd11c8e62f46f1a5c320012cffafe

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6fb3525e24df3488fe4eeec5921b571d523bc565e0be9cbb49806c7345607d77"
+  digest = "1:508bdcca311e78d0c08933baeed20391b217970b7ad8ba145ae86fdb9b8c460e"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -496,7 +496,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "c333ae77fe84eb2a07ff94f954b81475c08f4745"
+  revision = "89adc50375ffd11c8e62f46f1a5c320012cffafe"
 
 [[projects]]
   branch = "master"
@@ -2148,6 +2148,7 @@
     "go.etcd.io/etcd/raft/raftpb",
     "go.etcd.io/etcd/raft/tracker",
     "golang.org/x/crypto/bcrypt",
+    "golang.org/x/crypto/pbkdf2",
     "golang.org/x/crypto/ssh",
     "golang.org/x/crypto/ssh/agent",
     "golang.org/x/crypto/ssh/knownhosts",


### PR DESCRIPTION
* db: additional tweak to the sstable boundary generation
* db: add memTable.logSeqNum
* db: force flushing of overlapping queued memtables during ingestion
* tool: lsm visualization tool
* db: consistently handle key decoding failure
* cmd/pebble: fix lint for maxOpsPerSec's type inference
* tool: add "find" command
* cmd/pebble: fix --rate flag
* internal/metamorphic: use the strict MemFS and add an operation to reset the DB
* db: make DB.Close() wait for any ongoing deletion of obsolete files
* sstable: encode varints directly into buf in blockWriter.store
* sstable: micro-optimize Writer.addPoint()
* sstable: minor cleanup of Writer/blockWriter
* sstable: micro-optimize blockWriter.store

Fixes #44631 

Release note: None