### PR TITLE
opt: fix computed col filters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -655,3 +655,15 @@ CREATE VIEW v44203(c0) AS SELECT c0 FROM t44203 WHERE t44203.c0 OFFSET NULL
 query B
 SELECT * FROM v44203 WHERE current_user() != ''
 ----
+
+# Regression test for #44132 - generated column causes incorrect scan.
+statement ok
+CREATE TABLE t44132(c0 BOOL UNIQUE, c1 INT AS (NULL) STORED)
+
+statement ok
+INSERT INTO t44132 (c0) VALUES (true)
+
+query BI
+SELECT * FROM t44132 WHERE c0
+----
+true NULL

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -501,7 +501,8 @@ func (c *CustomFuncs) computedColFilters(
 	for colID := range tabMeta.ComputedCols {
 		if c.tryFoldComputedCol(tabMeta, colID, constCols) {
 			constVal := constCols[colID]
-			eqOp := c.e.f.ConstructEq(c.e.f.ConstructVariable(colID), constVal)
+			// Note: Eq is not correct here because of NULLs.
+			eqOp := c.e.f.ConstructIs(c.e.f.ConstructVariable(colID), constVal)
 			computedColFilters = append(computedColFilters, c.e.f.ConstructFiltersItem(eqOp))
 		}
 	}

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -155,3 +155,20 @@ select
  │              └── k_interval + now() [type=timestamptz]
  └── filters
       └── k_interval = '03:00:00' [type=bool, outer=(1), constraints=(/1: [/'03:00:00' - /'03:00:00']; tight), fd=()-->(1)]
+
+# Verify that a stored NULL value is handled correctly (#44132).
+exec-ddl
+CREATE TABLE null_col (
+    a INT,
+    b INT AS (NULL) STORED,
+    INDEX ab (a, b)
+)
+----
+
+opt
+SELECT a, b FROM null_col WHERE a = 1
+----
+scan null_col@ab
+ ├── columns: a:1(int!null) b:2(int)
+ ├── constraint: /1/2/3: [/1/NULL - /1/NULL]
+ └── fd: ()-->(1)


### PR DESCRIPTION
Replacing `=` with `IS NOT DISTINCT FROM` in computed col filters. The
former doesn't correctly handle NULLs.

Fixes #44132.

Release note (bug fix): fixed invalid query results in some cases
involving stored columns with NULL values.