### PR TITLE
sql: allow creation of temporary views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -92,9 +92,9 @@ statement error DROP DATABASE on non-empty database without explicit CASCADE
 DROP DATABASE bob
 
 statement ok
-CREATE VIEW a_view AS SELECT a FROM bob.pg_temp.a
+CREATE TEMP VIEW a_view AS SELECT a FROM bob.pg_temp.a
 
-statement error cannot rename database because view "defaultdb.public.a_view" depends on table "a"
+statement error cannot rename database because view "defaultdb.pg_temp_.*.a_view" depends on table "a"
 ALTER DATABASE bob RENAME TO alice
 
 statement ok
@@ -102,3 +102,43 @@ DROP VIEW a_view; ALTER DATABASE bob RENAME TO alice
 
 statement ok
 DROP DATABASE alice CASCADE
+
+# Test for temporary views.
+subtest temporary_views
+
+statement ok
+CREATE TABLE permanent_table(a int); CREATE TEMP TABLE temp_table(a int)
+
+statement ok
+INSERT INTO permanent_table VALUES (1); INSERT INTO temp_table VALUES (2)
+
+statement ok
+CREATE TEMP VIEW view_on_permanent AS SELECT a FROM permanent_table
+
+query I
+SELECT * from pg_temp.view_on_permanent
+----
+1
+
+statement ok
+CREATE TEMP VIEW view_on_temp AS SELECT a FROM temp_table
+
+query I
+SELECT * from pg_temp.view_on_temp
+----
+2
+
+# A "permanent" view on a temporary table gets upgraded to temporary.
+statement ok
+CREATE VIEW upgrade_temp_view AS SELECT a FROM temp_table
+
+query I
+SELECT * from pg_temp.upgrade_temp_view
+----
+2
+
+statement ok
+DROP VIEW view_on_temp; DROP VIEW view_on_permanent; DROP VIEW upgrade_temp_view
+
+statement ok
+DROP TABLE permanent_table; DROP TABLE temp_table

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -363,7 +364,16 @@ func (p *planner) getQualifiedTableName(
 	if err != nil {
 		return "", err
 	}
-	tbName := tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(desc.Name))
+	schemaID := desc.GetParentSchemaID()
+	schemaName, err := schema.ResolveNameByID(ctx, p.txn, desc.ParentID, schemaID)
+	if err != nil {
+		return "", err
+	}
+	tbName := tree.MakeTableNameWithSchema(
+		tree.Name(dbDesc.Name),
+		tree.Name(schemaName),
+		tree.Name(desc.Name),
+	)
 	return tbName.String(), nil
 }
 

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -110,6 +110,11 @@ func NewRelationAlreadyExistsError(name string) error {
 	return pgerror.Newf(pgcode.DuplicateRelation, "relation %q already exists", name)
 }
 
+// IsRelationAlreadyExistsError checks whether this is an error for a preexisting relation.
+func IsRelationAlreadyExistsError(err error) bool {
+	return errHasCode(err, pgcode.DuplicateRelation)
+}
+
 // NewWrongObjectTypeError creates a wrong object type error.
 func NewWrongObjectTypeError(name tree.NodeFormatter, desiredObjType string) error {
 	return pgerror.Newf(pgcode.WrongObjectType, "%q is not a %s",

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -30,9 +30,15 @@ func SchemaNewTypeCounter(t string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.new_column_type." + t)
 }
 
-// CreateTempTableCounter is to be incremented every time a TEMP TABLE
-// has been created.
-var CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")
+var (
+	// CreateTempTableCounter is to be incremented every time a TEMP TABLE
+	// has been created.
+	CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")
+
+	// CreateTempViewCounter is to be incremented every time a TEMP VIEW
+	// has been created.
+	CreateTempViewCounter = telemetry.GetCounterOnce("sql.schema.create_temp_view")
+)
 
 // SecondaryIndexColumnFamiliesCounter is a counter that is incremented every time
 // a secondary index that is separated into different column families is created.

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupSchemaObjects(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	s, db, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, `
+SET experimental_enable_temp_tables=true;
+CREATE TEMP TABLE a (a int);
+CREATE TEMP VIEW a_view AS SELECT a FROM a;
+`)
+	require.NoError(t, err)
+
+	rows, err := conn.QueryContext(ctx, `SELECT id, name FROM system.namespace`)
+	require.NoError(t, err)
+
+	namesToID := make(map[string]sqlbase.ID)
+	var schemaName string
+	for rows.Next() {
+		var id int64
+		var name string
+		err := rows.Scan(&id, &name)
+		require.NoError(t, err)
+
+		namesToID[name] = sqlbase.ID(id)
+		if strings.HasPrefix(name, sessiondata.PgTempSchemaName) {
+			schemaName = name
+		}
+	}
+
+	require.Contains(t, namesToID, "a")
+	require.Contains(t, namesToID, "a_view")
+	require.NotEqual(t, "", schemaName)
+
+	// Check tables are accessible.
+	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a", schemaName))
+	require.NoError(t, err)
+
+	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a_view", schemaName))
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			err = sql.TestingCleanupSchemaObjects(
+				ctx,
+				s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+				func(
+					ctx context.Context, _ string, _ *client.Txn, query string, _ ...interface{},
+				) (int, error) {
+					_, err := conn.ExecContext(ctx, query)
+					return 0, err
+				},
+				txn,
+				namesToID["defaultdb"],
+				schemaName,
+			)
+			require.NoError(t, err)
+			return nil
+		}),
+	)
+
+	// Ensure all the entries for the given temporary structures are gone.
+	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a", schemaName))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf(`relation "%s.a" does not exist`, schemaName))
+
+	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a_view", schemaName))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf(`relation "%s.a_view" does not exist`, schemaName))
+}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -155,11 +155,13 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		create.Name.Table(),
 		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
 		0, /* parentID */
+		0, /* parentSchemaID */
 		id,
 		columns,
 		hlc.Timestamp{}, /* creationTime */
 		publicSelectPrivileges,
-		nil, /* semaCtx */
+		nil,   /* semaCtx */
+		false, /* temporary */
 	)
 	return mutDesc.TableDescriptor, err
 }


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/cockroach/issues/44642

This change introduces support for temporary views.

Changes include:
* Modifying table creation to be more modular, for code re-use for view
creation. In particular, we abstract away the ability to infer a table
key and schema ID from initial arguments.
* Modifying view creation to use the above, plus consider schema names
for all subsequent operations.
* Modifying schema clean up to clean up views that have been created.
* Adding a new test to check whether schema cleanups work as expected by
deleting temp tables and views.

Release note (sql change): If temporary tables are enabled, we introduce
the new capability to create temporary views. Temporary views disappear
at the end of a connection. Views which depend on temporary tables will
automatically become temporary.