### PR TITLE
import,backup: show redacted secrets in job UI

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -551,7 +551,7 @@ func backupJobDescription(
 	}
 
 	for _, t := range to {
-		sanitizedTo, err := cloud.SanitizeExternalStorageURI(t)
+		sanitizedTo, err := cloud.SanitizeExternalStorageURI(t, nil /* extraParams */)
 		if err != nil {
 			return "", err
 		}
@@ -559,7 +559,7 @@ func backupJobDescription(
 	}
 
 	for _, from := range incrementalFrom {
-		sanitizedFrom, err := cloud.SanitizeExternalStorageURI(from)
+		sanitizedFrom, err := cloud.SanitizeExternalStorageURI(from, nil /* extraParams */)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -583,11 +583,11 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	conn := sqlDB.DB.(*gosql.DB)
 	defer cleanupFn()
 
-	sanitizedIncDir := localFoo + "/inc"
-	incDir := sanitizedIncDir + "?secretCredentialsHere"
+	sanitizedIncDir := localFoo + "/inc?AWS_SESSION_TOKEN="
+	incDir := sanitizedIncDir + "secretCredentialsHere"
 
-	sanitizedFullDir := localFoo + "/full"
-	fullDir := sanitizedFullDir + "?moarSecretsHere"
+	sanitizedFullDir := localFoo + "/full?AWS_SESSION_TOKEN="
+	fullDir := sanitizedFullDir + "moarSecretsHere"
 
 	backupDatabaseID := sqlutils.QueryDatabaseID(t, conn, "data")
 	backupTableID := sqlutils.QueryTableID(t, conn, "data", "bank")
@@ -611,7 +611,7 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
 			`BACKUP TABLE bank TO '%s' INCREMENTAL FROM '%s'`,
-			sanitizedIncDir, sanitizedFullDir,
+			sanitizedIncDir+"redacted", sanitizedFullDir+"redacted",
 		),
 		DescriptorIDs: sqlbase.IDs{
 			sqlbase.ID(backupDatabaseID),
@@ -626,7 +626,7 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
 			`RESTORE TABLE bank FROM '%s', '%s' WITH into_db = 'restoredb'`,
-			sanitizedFullDir, sanitizedIncDir,
+			sanitizedFullDir+"redacted", sanitizedIncDir+"redacted",
 		),
 		DescriptorIDs: sqlbase.IDs{
 			sqlbase.ID(restoreDatabaseID + 1),

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1090,7 +1090,7 @@ func restoreJobDescription(
 	for i, backup := range from {
 		r.From[i] = make(tree.PartitionedBackup, len(backup))
 		for j, uri := range backup {
-			sf, err := cloud.SanitizeExternalStorageURI(uri)
+			sf, err := cloud.SanitizeExternalStorageURI(uri, nil /* extraParams */)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -347,7 +347,7 @@ func changefeedPlanHook(
 func changefeedJobDescription(
 	p sql.PlanHookState, changefeed *tree.CreateChangefeed, sinkURI string, opts map[string]string,
 ) (string, error) {
-	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI)
+	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{sinkParamSASLPassword})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1745,15 +1745,11 @@ func TestChangefeedDescription(t *testing.T) {
 			`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, envelope = $2`, sink.String(), `wrapped`,
 		).Scan(&jobID)
 
-		// Secrets get removed from the sink parameter.
-		expectedSink := sink
-		expectedSink.RawQuery = ``
-
 		var description string
 		sqlDB.QueryRow(t,
 			`SELECT description FROM [SHOW JOBS] WHERE job_id = $1`, jobID,
 		).Scan(&description)
-		expected := `CREATE CHANGEFEED FOR TABLE foo INTO '` + expectedSink.String() +
+		expected := `CREATE CHANGEFEED FOR TABLE foo INTO '` + sink.String() +
 			`' WITH envelope = 'wrapped', updated`
 		if description != expected {
 			t.Errorf(`got "%s" expected "%s"`, description, expected)

--- a/pkg/ccl/importccl/csv_testdata_helpers_test.go
+++ b/pkg/ccl/importccl/csv_testdata_helpers_test.go
@@ -100,8 +100,8 @@ func getTestFiles(numFiles int) csvTestFiles {
 		suffix = "-race"
 	}
 	for i := 0; i < numFiles; i++ {
-		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s", i, suffix)))
-		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?param=value"))
+		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s", i, suffix)+"?nonsecret=nosecrets"))
+		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?AWS_SESSION_TOKEN=secrets"))
 		testFiles.bzipFiles = append(testFiles.bzipFiles, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s.bz2", i, suffix)))
 		testFiles.filesWithOpts = append(testFiles.filesWithOpts, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d-opts%s", i, suffix)))
 		testFiles.filesWithDups = append(testFiles.filesWithDups, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d-dup%s", i, suffix)))

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -121,7 +121,7 @@ func importJobDescription(
 	stmt.CreateDefs = defs
 	stmt.Files = nil
 	for _, file := range files {
-		clean, err := cloud.SanitizeExternalStorageURI(file)
+		clean, err := cloud.SanitizeExternalStorageURI(file, nil /* extraParams */)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2073,9 +2073,9 @@ func TestImportIntoCSV(t *testing.T) {
 			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
-		stripFilenameQuotes := testFiles.files[0][1 : len(testFiles.files[0])-1]
+		stripFilenameQuotes := strings.ReplaceAll(testFiles.files[0][1:len(testFiles.files[0])-1], "?", "\\?")
 		sqlDB.ExpectErr(
-			t, fmt.Sprintf("\"%s\": row 1: expected 3 fields, got 2", stripFilenameQuotes),
+			t, fmt.Sprintf("%s: row 1: expected 3 fields, got 2", stripFilenameQuotes),
 			fmt.Sprintf(`IMPORT INTO t (a, b, c) CSV DATA (%s)`, testFiles.files[0]),
 		)
 	})
@@ -2086,9 +2086,9 @@ func TestImportIntoCSV(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT)`)
 		defer sqlDB.Exec(t, `DROP TABLE t`)
 
-		stripFilenameQuotes := testFiles.files[0][1 : len(testFiles.files[0])-1]
+		stripFilenameQuotes := strings.ReplaceAll(testFiles.files[0][1:len(testFiles.files[0])-1], "?", "\\?")
 		sqlDB.ExpectErr(
-			t, fmt.Sprintf("\"%s\": row 1: expected 1 fields, got 2", stripFilenameQuotes),
+			t, fmt.Sprintf("%s: row 1: expected 1 fields, got 2", stripFilenameQuotes),
 			fmt.Sprintf(`IMPORT INTO t (a) CSV DATA (%s)`, testFiles.files[0]),
 		)
 	})
@@ -2145,7 +2145,7 @@ func TestImportIntoCSV(t *testing.T) {
 	t.Run("import-into-rejects-interleaved-tables", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE parent (parent_id INT PRIMARY KEY)`)
 		sqlDB.Exec(t, `CREATE TABLE child (
-				parent_id INT, 
+				parent_id INT,
 				child_id INT,
 				PRIMARY KEY(parent_id, child_id))
 				INTERLEAVE IN PARENT parent(parent_id)`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1357,7 +1357,7 @@ func TestImportCSVStmt(t *testing.T) {
 
 			if err := jobutils.VerifySystemJob(t, sqlDB, testNum, jobspb.TypeImport, jobs.StatusSucceeded, jobs.Record{
 				Username:    security.RootUser,
-				Description: fmt.Sprintf(jobPrefix+` CSV DATA (%s)`+tc.jobOpts, strings.ReplaceAll(strings.Join(tc.files, ", "), "?param=value", "")),
+				Description: fmt.Sprintf(jobPrefix+` CSV DATA (%s)`+tc.jobOpts, strings.ReplaceAll(strings.Join(tc.files, ", "), "?AWS_SESSION_TOKEN=secrets", "?AWS_SESSION_TOKEN=redacted")),
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -1832,7 +1832,7 @@ func TestImportIntoCSV(t *testing.T) {
 			jobPrefix := fmt.Sprintf(`IMPORT INTO defaultdb.public.t(a, b)`)
 			if err := jobutils.VerifySystemJob(t, sqlDB, testNum, jobspb.TypeImport, jobs.StatusSucceeded, jobs.Record{
 				Username:    security.RootUser,
-				Description: fmt.Sprintf(jobPrefix+` CSV DATA (%s)`+tc.jobOpts, strings.ReplaceAll(strings.Join(tc.files, ", "), "?param=value", "")),
+				Description: fmt.Sprintf(jobPrefix+` CSV DATA (%s)`+tc.jobOpts, strings.ReplaceAll(strings.Join(tc.files, ", "), "?AWS_SESSION_TOKEN=secrets", "?AWS_SESSION_TOKEN=redacted")),
 			}); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -227,7 +227,7 @@ func readInputFiles(
 				grp.GoCtx(func(ctx context.Context) error {
 					defer close(rejected)
 					if err := fileFunc(ctx, src, dataFileIndex, dataFile, resumePos[dataFileIndex], rejected); err != nil {
-						return errors.Wrap(err, dataFile)
+						return err
 					}
 					return nil
 				})
@@ -333,16 +333,16 @@ func isMultiTableFormat(format roachpb.IOFileFormat_FileFormat) bool {
 	return false
 }
 
-func makeRowErr(file string, row int64, code, format string, args ...interface{}) error {
+func makeRowErr(_ string, row int64, code, format string, args ...interface{}) error {
 	return pgerror.NewWithDepthf(1, code,
-		"%q: row %d: "+format, append([]interface{}{file, row}, args...)...)
+		"row %d: "+format, append([]interface{}{row}, args...)...)
 }
 
-func wrapRowErr(err error, file string, row int64, code, format string, args ...interface{}) error {
+func wrapRowErr(err error, _ string, row int64, code, format string, args ...interface{}) error {
 	if format != "" || len(args) > 0 {
 		err = errors.WrapWithDepthf(1, err, format, args...)
 	}
-	err = errors.WrapWithDepthf(1, err, "%q: row %d", file, row)
+	err = errors.WrapWithDepthf(1, err, "row %d", row)
 	if code != pgcode.Uncategorized {
 		err = pgerror.WithCandidateCode(err, code)
 	}


### PR DESCRIPTION
Previously the IMPORT and BACKUP jobs would hide all query parameters.
This gave some users / engineers the false sense that those secrets were
gone or irrecoverable from the job record, but any super-user with read
access to the system tables can extract the raw URLs, including the params
that include things like AWS_SECRET_ACCESS_KEY, from the raw job data.

This change replaces the blanket hiding of all params with targetted
redacting of just the values for sensitive params, replacing their value
with the word 'redacted'. This is hoped to make is clearer what is going
on -- that the params are still there and we're just not showing the value.

Release note (general change): Jobs show the parameters used for connecting to external storage in SHOW JOBS and the Jobs UI page, with only the values of parameters classified as secrets redacted.

While I'm here: remove duplicate filename prefix in some IMPORT error messages (see first commit for details).
