### PR TITLE
release-19.2: opt: fix remaining filters when using partitioned constraints

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_constrained_scans
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_constrained_scans
@@ -238,3 +238,25 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.partitioning.partition-constrained-scan' AND usage_count > 0
 ----
 sql.partitioning.partition-constrained-scan
+
+# Regression test for #44154: a remaining filter that is not identical to an
+# input filter should not be dropped.
+statement ok
+CREATE TABLE t0(c0 BOOL UNIQUE, c1 BOOL CHECK (true))
+
+statement ok
+INSERT INTO t0(c0) VALUES (true)
+
+query T
+EXPLAIN (OPT) SELECT * FROM t0 WHERE t0.c0 AND (c1 OR (c0 > false AND c0 < false))
+----
+select
+ ├── index-join t0
+ │    └── scan t0@t0_c0_key
+ │         └── constraint: /1: [/true - /true]
+ └── filters
+      └── c1 OR (c0 < false)
+
+query BB
+SELECT * FROM t0 WHERE t0.c0 AND (c1 OR (c0 > false AND c0 < false))
+----

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1061,7 +1061,10 @@ func (c *indexConstraintCtx) simplifyFilter(
 type Instance struct {
 	indexConstraintCtx
 
-	filters memo.FiltersExpr
+	requiredFilters memo.FiltersExpr
+	// allFilters includes requiredFilters along with optional filters that don't
+	// need to generate remaining filters (see Instance.Init()).
+	allFilters memo.FiltersExpr
 
 	constraint   constraint.Constraint
 	consolidated constraint.Constraint
@@ -1069,27 +1072,42 @@ type Instance struct {
 	initialized  bool
 }
 
-// Init processes the filter and calculates the spans.
+// Init processes the filters and calculates the spans.
+//
+// Optional filters are filters that can be used for determining spans, but
+// they need not generate remaining filters. This is e.g. used for check
+// constraints that can help generate better spans but don't actually need to be
+// enforced.
 func (ic *Instance) Init(
-	filters memo.FiltersExpr,
+	requiredFilters memo.FiltersExpr,
+	optionalFilters memo.FiltersExpr,
 	columns []opt.OrderingColumn,
 	notNullCols opt.ColSet,
 	isInverted bool,
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 ) {
-	ic.filters = filters
+	ic.requiredFilters = requiredFilters
+	if len(optionalFilters) == 0 {
+		ic.allFilters = requiredFilters
+	} else {
+		// Force allocation of a bigger slice.
+		// TODO(radu): we should keep the required and optional filters separate and
+		// add a helper for iterating through all of them.
+		ic.allFilters = requiredFilters[:len(requiredFilters):len(requiredFilters)]
+		ic.allFilters = append(ic.allFilters, optionalFilters...)
+	}
 	ic.indexConstraintCtx.init(columns, notNullCols, isInverted, evalCtx, factory)
-	constraints := make([]*constraint.Constraint, 0, 1)
 	if isInverted {
-		ic.tight, constraints = ic.makeInvertedIndexSpansForExpr(
-			&ic.filters, constraints, false,
+		tight, constraints := ic.makeInvertedIndexSpansForExpr(
+			&ic.allFilters, nil /* constraints */, false,
 		)
 		// makeInvertedIndexSpansForExpr is guaranteed to add at least one
 		// constraint. It may be an "unconstrained" constraint.
+		ic.tight = tight
 		ic.constraint = *constraints[0]
 	} else {
-		ic.tight = ic.makeSpansForExpr(0 /* offset */, &ic.filters, &ic.constraint)
+		ic.tight = ic.makeSpansForExpr(0 /* offset */, &ic.allFilters, &ic.constraint)
 	}
 	// Note: we only consolidate spans at the end; consolidating partial results
 	// can lead to worse spans, for example:
@@ -1125,8 +1143,7 @@ func (ic *Instance) Constraint() *constraint.Constraint {
 // AllInvertedIndexConstraints returns all constraints that can be created on
 // the specified inverted index. Only works for inverted indexes.
 func (ic *Instance) AllInvertedIndexConstraints() ([]*constraint.Constraint, error) {
-	allConstraints := make([]*constraint.Constraint, 0)
-	_, allConstraints = ic.makeInvertedIndexSpansForExpr(&ic.filters, allConstraints, true)
+	_, allConstraints := ic.makeInvertedIndexSpansForExpr(&ic.allFilters, nil /* constraints */, true /* allPaths */)
 
 	return allConstraints, nil
 }
@@ -1139,15 +1156,15 @@ func (ic *Instance) RemainingFilters() memo.FiltersExpr {
 		return memo.TrueFilter
 	}
 	if ic.constraint.IsUnconstrained() {
-		return ic.filters
+		return ic.requiredFilters
 	}
 	var newFilters memo.FiltersExpr
-	for i := range ic.filters {
+	for i := range ic.requiredFilters {
 		prefix := ic.getMaxSimplifyPrefix(&ic.constraint)
-		condition := ic.simplifyFilter(ic.filters[i].Condition, &ic.constraint, prefix)
+		condition := ic.simplifyFilter(ic.requiredFilters[i].Condition, &ic.constraint, prefix)
 		if condition.Op() != opt.TrueOp {
 			if newFilters == nil {
-				newFilters = make(memo.FiltersExpr, 0, len(ic.filters))
+				newFilters = make(memo.FiltersExpr, 0, len(ic.requiredFilters))
 			}
 			newFilters = append(newFilters, memo.FiltersItem{Condition: condition})
 		}

--- a/pkg/sql/opt/idxconstraint/testdata/optional
+++ b/pkg/sql/opt/idxconstraint/testdata/optional
@@ -1,0 +1,16 @@
+index-constraints vars=(int, int) index=(@1)
+@1 > 2 AND @1 < 4 AND @2 = 2
+----
+[/3 - /3]
+Remaining filter: @2 = 2
+
+index-constraints vars=(int, int) index=(@1)
+@1 > 2
+optional: @1 < 4 AND @2 = 2
+----
+[/3 - /3]
+
+index-constraints vars=(int, int) index=(@1 desc, @2 desc)
+optional: @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
+----
+[/4/3 - /2/1]

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -234,21 +234,6 @@ func (n *FiltersExpr) Deduplicate() {
 	*n = dedup
 }
 
-// RetainCommonFilters retains only the filters found in n and other.
-func (n *FiltersExpr) RetainCommonFilters(other FiltersExpr) {
-	// TODO(ridwanmsharif): Faster intersection using a map
-	common := (*n)[:0]
-	for _, filter := range *n {
-		for _, otherFilter := range other {
-			if filter.Condition == otherFilter.Condition {
-				common = append(common, filter)
-				break
-			}
-		}
-	}
-	*n = common
-}
-
 // RemoveCommonFilters removes the filters found in other from n.
 func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
 	// TODO(ridwanmsharif): Faster intersection using a map

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -223,10 +223,8 @@ func (m *Memo) SetRoot(e RelExpr, phys *physical.Required) {
 }
 
 // SetScalarRoot stores the root memo expression when it is a scalar expression.
+// Used only for testing.
 func (m *Memo) SetScalarRoot(scalar opt.ScalarExpr) {
-	if m.rootExpr != nil {
-		panic(errors.AssertionFailedf("cannot set scalar root multiple times"))
-	}
 	m.rootExpr = scalar
 }
 

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -190,10 +190,10 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	sb.init(c, scanPrivate.Table)
 
 	// Generate appropriate filters from constraints.
-	checkFilters := c.checkConstraintFilters(scanPrivate.Table)
+	optionalFilters := c.checkConstraintFilters(scanPrivate.Table)
 
-	// Consider the checkFilters as well to constrain each of the indexes.
-	explicitAndCheckFilters := append(explicitFilters, checkFilters...)
+	filterColumns := c.FilterOuterCols(explicitFilters)
+	filterColumns.UnionWith(c.FilterOuterCols(optionalFilters))
 
 	// Iterate over all indexes.
 	var iter scanIndexIter
@@ -201,46 +201,25 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	tabMeta := md.TableMeta(scanPrivate.Table)
 	iter.init(c.e.mem, scanPrivate)
 	for iter.next() {
-		// We may append to this slice below; avoid any potential aliasing by
-		// limiting its capacity (forcing append to reallocate).
-		filters := explicitAndCheckFilters[:len(explicitAndCheckFilters):len(explicitAndCheckFilters)]
-		indexColumns := tabMeta.IndexKeyColumns(iter.indexOrdinal)
-		filterColumns := c.FilterOuterCols(filters)
-		firstIndexCol := scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)
-
 		// We only consider the partition values when a particular index can otherwise
 		// not be constrained. For indexes that are constrained, the partitioned values
 		// add no benefit as they don't really constrain anything.
 		// Furthermore, if the filters don't take advantage of the index (use any of the
 		// index columns), using the partition values add no benefit.
-		var constrainedInBetweenFilters memo.FiltersExpr
-		var isIndexPartitioned bool
-		if !filterColumns.Contains(firstIndexCol) && indexColumns.Intersects(filterColumns) {
-			// Add any partition filters if appropriate.
-			partitionFilters, inBetweenFilters := c.partitionValuesFilters(scanPrivate.Table, iter.index)
-
-			if len(partitionFilters) > 0 {
-				// We must add the filters so when we generate the inBetween spans, they are
-				// also constrained. This is also needed so the remaining filters are generated
-				// correctly using the in between spans (some remaining filters may be blown
-				// by the partition constraints).
-				constrainedInBetweenFilters = append(inBetweenFilters, filters...)
-				filters = append(filters, partitionFilters...)
-				isIndexPartitioned = true
-			}
-		}
-
-		// Check whether the filter can constrain the index.
-		constraint, remainingFilters, ok := c.tryConstrainIndex(
-			filters, scanPrivate.Table, iter.indexOrdinal, false /* isInverted */)
-		if !ok {
-			continue
-		}
-
-		// If the index is partitioned (by list), then the constraints above only
-		// contain spans within the partition ranges. For correctness, we must
-		// also add the spans for the in between ranges. Consider the following index
-		// and its partition:
+		//
+		// If the index is partitioned (by list), we generate two constraints and
+		// union them: the "main" constraint and the "in-between" constraint.The
+		// "main" constraint restricts the index to the known partition ranges. The
+		// "in-between" constraint restricts the index to the rest of the ranges
+		// (i.e. everything that falls in-between the main ranges); the in-between
+		// constraint is necessary for correctness (there can be rows outside of the
+		// partitioned ranges).
+		//
+		// For both constraints, the partition-related filters are passed as
+		// "optional" which guarantees that they return no remaining filters. This
+		// allows us to merge the remaining filters from both constraints.
+		//
+		// Consider the following index and its partition:
 		//
 		// CREATE INDEX orders_by_seq_num
 		//     ON orders (region, seq_num, id)
@@ -259,8 +238,8 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 		//   [/'us-east1'/100 - /'us-east1'/199]
 		//   [/'us-west1'/100 - /'us-west1'/199]
 		//
-		// You'll notice that the spans before europe-west2, after us-west1 and in between
-		// the defined partitions are missing. We must add these spans now, appropriately
+		// The spans before europe-west2, after us-west1 and in between the defined
+		// partitions are missing. We must add these spans now, appropriately
 		// constrained using the filters.
 		//
 		// It is important that we add these spans after the partition spans are generated
@@ -283,11 +262,37 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 		//
 		// Notice how we 'skip' all the europe-west2 rows with seq_num < 100.
 		//
-		if isIndexPartitioned {
+		var partitionFilters, inBetweenFilters memo.FiltersExpr
+
+		indexColumns := tabMeta.IndexKeyColumns(iter.indexOrdinal)
+		firstIndexCol := scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)
+		if !filterColumns.Contains(firstIndexCol) && indexColumns.Intersects(filterColumns) {
+			// Calculate any partition filters if appropriate (see below.
+			partitionFilters, inBetweenFilters = c.partitionValuesFilters(scanPrivate.Table, iter.index)
+		}
+
+		// Check whether the filter (along with any partitioning filters) can constrain the index.
+		constraint, remainingFilters, ok := c.tryConstrainIndex(
+			explicitFilters,
+			append(optionalFilters, partitionFilters...),
+			scanPrivate.Table,
+			iter.indexOrdinal,
+			false, /* isInverted */
+		)
+		if !ok {
+			continue
+		}
+
+		if len(partitionFilters) > 0 {
 			inBetweenConstraint, inBetweenRemainingFilters, ok := c.tryConstrainIndex(
-				constrainedInBetweenFilters, scanPrivate.Table, iter.indexOrdinal, false /* isInverted */)
+				explicitFilters,
+				append(optionalFilters, inBetweenFilters...),
+				scanPrivate.Table,
+				iter.indexOrdinal,
+				false, /* isInverted */
+			)
 			if !ok {
-				panic(errors.AssertionFailedf("constraining index should not failed with the in between filters"))
+				panic(errors.AssertionFailedf("in-between filters didn't yield a constraint"))
 			}
 
 			constraint.UnionWith(c.e.evalCtx, inBetweenConstraint)
@@ -304,26 +309,12 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 			remainingFilters.Deduplicate()
 		}
 
-		// If a check constraint filter or a partition filter wasn't able to
-		// constrain the index, it should not be used anymore for this group
-		// expression.
-		// TODO(ridwanmsharif): Does it ever make sense for us to continue
-		// using any constraint filter that wasn't able to constrain a scan?
-		// Maybe once we have more information about data distribution, we may
-		// use it to further constrain an index scan. We should revisit this
-		// once we have index skip scans.  A constraint that may not constrain
-		// an index scan may still allow the index to be used more effectively
-		// if an index skip scan is possible.
-		if len(checkFilters) != 0 || isIndexPartitioned {
-			remainingFilters.RetainCommonFilters(explicitFilters)
-		}
-
 		// Construct new constrained ScanPrivate.
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Index = iter.indexOrdinal
 		newScanPrivate.Constraint = constraint
 		// Record whether we were able to use partitions to constrain the scan.
-		newScanPrivate.PartitionConstrainedScan = isIndexPartitioned
+		newScanPrivate.PartitionConstrainedScan = (len(partitionFilters) > 0)
 
 		// If the alternate index includes the set of needed columns, then construct
 		// a new Scan operator using that index.
@@ -694,7 +685,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	for iter.nextInverted() {
 		// Check whether the filter can constrain the index.
 		constraint, remaining, ok := c.tryConstrainIndex(
-			filters, scanPrivate.Table, iter.indexOrdinal, true /* isInverted */)
+			filters, nil /* optioanlFilters */, scanPrivate.Table, iter.indexOrdinal, true /* isInverted */)
 		if !ok {
 			continue
 		}
@@ -727,7 +718,10 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 }
 
 func (c *CustomFuncs) initIdxConstraintForIndex(
-	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int, isInverted bool,
+	requiredFilters, optionalFilters memo.FiltersExpr,
+	tabID opt.TableID,
+	indexOrd int,
+	isInverted bool,
 ) (ic *idxconstraint.Instance) {
 	ic = &idxconstraint.Instance{}
 
@@ -750,7 +744,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 	}
 
 	// Generate index constraints.
-	ic.Init(filters, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
+	ic.Init(requiredFilters, optionalFilters, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
 	return ic
 }
 
@@ -759,14 +753,19 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 // filter remaining after extracting the constraint. If no constraint can be
 // derived, then tryConstrainIndex returns ok = false.
 func (c *CustomFuncs) tryConstrainIndex(
-	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int, isInverted bool,
+	requiredFilters, optionalFilters memo.FiltersExpr,
+	tabID opt.TableID,
+	indexOrd int,
+	isInverted bool,
 ) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
 	// Start with fast check to rule out indexes that cannot be constrained.
-	if !isInverted && !c.canMaybeConstrainIndex(filters, tabID, indexOrd) {
+	if !isInverted &&
+		!c.canMaybeConstrainIndex(requiredFilters, tabID, indexOrd) &&
+		!c.canMaybeConstrainIndex(optionalFilters, tabID, indexOrd) {
 		return nil, nil, false
 	}
 
-	ic := c.initIdxConstraintForIndex(filters, tabID, indexOrd, isInverted)
+	ic := c.initIdxConstraintForIndex(requiredFilters, optionalFilters, tabID, indexOrd, isInverted)
 	constraint = ic.Constraint()
 	if constraint.IsUnconstrained() {
 		return nil, nil, false
@@ -786,7 +785,7 @@ func (c *CustomFuncs) tryConstrainIndex(
 func (c *CustomFuncs) allInvIndexConstraints(
 	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int,
 ) (constraints []*constraint.Constraint, ok bool) {
-	ic := c.initIdxConstraintForIndex(filters, tabID, indexOrd, true /* isInverted */)
+	ic := c.initIdxConstraintForIndex(filters, nil /* optionalFilters */, tabID, indexOrd, true /* isInverted */)
 	constraints, err := ic.AllInvertedIndexConstraints()
 	if err != nil {
 		return nil, false


### PR DESCRIPTION
Backport 1/1 commits from #44668.

/cc @cockroachdb/release

---

The index constraint code can use check expressions or partitioning
information to better refine the spans. However, the code related to
the handling of remaining filters is very fragile. For check
constraints, the code needs to remove any remaining filters due to
check constraints (to avoid unnecessary overhead). For the
partitioning code, this is necessary for correctness - we can't have
any "in-between" filters as part of the final remaining filters (see
big comment in `GenerateConstrainedScans`).

The code assumes that a remaining filter is identical to one of the
input filters (and thus only keeps the remaining filters that are the
same with an explicit filter); unfortunately, this is not necessarily
the case - the library tries to simplify the filters w.r.t the spans
to make them cheaper to evaluate.

This change cleans this up by extending the index constraints library
a little bit: we can now specify the "required" and "optional" filters
separately, with the only difference being that optional filters don't
generate remaining filters. This way we don't have to "guess" what
filters we need to keep.

Fixes #44154.

Release note (bug fix): fixed invalid query results in some corner
cases where part of a WHERE clause is incorrectly discarded.

Thanks to @mrigger for finding this bug.
