### PR TITLE
sql: cache schema lookups in TableCollection

### DIFF
--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -283,6 +283,13 @@ func (a *CachedPhysicalAccessor) GetDatabaseDesc(
 	return a.SchemaAccessor.GetDatabaseDesc(ctx, txn, name, flags)
 }
 
+// IsValidSchema implements the SchemaAccessor interface.
+func (a *CachedPhysicalAccessor) IsValidSchema(
+	ctx context.Context, txn *client.Txn, dbID sqlbase.ID, scName string,
+) (bool, sqlbase.ID, error) {
+	return a.tc.resolveSchemaID(ctx, txn, dbID, scName)
+}
+
 // GetObjectDesc implements the SchemaAccessor interface.
 func (a *CachedPhysicalAccessor) GetObjectDesc(
 	ctx context.Context,


### PR DESCRIPTION
Potentially helps with #44733 for pg_temp.

Since introducing schemas other than public, we should be caching
successful schema lookups. This adds the caching to the TableCollection
layer, caching successful lookups (and falling back to direct lookup if
it fails).

Furthermore, bypass a few extraneous lookups if the dbID was not
obtainable from the cache (as the schema could not possibly exist).

Release note: None