### PR TITLE
colexec: disallow planning CASE operators with unknown WHEN type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1093,3 +1093,11 @@ SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
 ----
 ·  true
 ·  NULL
+
+# Regression test for 44726 (unknown WHEN expression type).
+statement ok
+CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0)
+
+query I
+SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_user(), '')) THEN 0 ELSE t44726.c0 END)
+----


### PR DESCRIPTION
Release note (bug fix): When vectorize=experimental_on, CASE operators with an
unknown WHEN type fall back to row execution.

Fixes #44726 