### PR TITLE
rowexec: fix a bug with distinct on arrays and composite types

### DIFF
--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -59,11 +59,11 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 25
+const Version execinfrapb.DistSQLVersion = 26
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 24
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 26
 
 // SettingUseTempStorageJoins is a cluster setting that configures whether
 // joins are allowed to spill to disk.

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -167,3 +167,14 @@ query I
 SELECT * FROM v0 WHERE v0.c0 IS NULL
 ----
 NULL
+
+# Regression test for #44079.
+statement ok
+CREATE TABLE t44079 (x INT[]);
+INSERT INTO t44079 VALUES (NULL), (ARRAY[NULL])
+
+query T rowsort
+SELECT DISTINCT * FROM t44079
+----
+NULL
+{NULL}

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -101,3 +101,6 @@
 - Version: 25 (MinAcceptedVersion: 24)
     - Add locking strength and wait policy fields to TableReader, JoinReader,
       IndexSkipTableReader, and InterleavedReaderJoiner spec.
+- Version: 26 (MinAcceptedVersion: 26)
+    - Change the table encoding for ARRAY types to differentiate between
+      NULL and ARRAY[NULL].

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -154,6 +154,7 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 		}
 		return encoding.EncodeBitArrayDescending(b, t.BitArray), nil
 	case *tree.DArray:
+		b = append(b, byte(encoding.Array))
 		for _, datum := range t.Array {
 			var err error
 			b, err = EncodeTableKey(b, datum, dir)


### PR DESCRIPTION
Fixes #44079.

This PR fixes a bug caused by the table encoding of
ARRAY types. In particular, NULL had the same encoding
as ARRAY[NULL].

Release note (bug fix): Fix a bug where the distinct operation
on ARRAY[NULL] and NULL could sometimes
return an incorrect result and omit some tuples.