### PR TITLE
colexec: add DiskQueue to HashRouter

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -412,7 +412,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// Set up the DistSQL temp engine.
 
 	useStoreSpec := cfg.Stores.Specs[s.cfg.TempStorageConfig.SpecIdx]
-	tempEngine, err := engine.NewTempEngine(s.cfg.StorageEngine, s.cfg.TempStorageConfig, useStoreSpec)
+	tempEngine, tempFS, err := engine.NewTempEngine(s.cfg.StorageEngine, s.cfg.TempStorageConfig, useStoreSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temp storage")
 	}
@@ -609,8 +609,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		ClusterID:      &s.rpcContext.ClusterID,
 		ClusterName:    s.cfg.ClusterName,
 
-		TempStorage: tempEngine,
-		DiskMonitor: s.cfg.TempStorageConfig.Mon,
+		TempStorage:     tempEngine,
+		TempStoragePath: s.cfg.TempStorageConfig.Path,
+		TempFS:          tempFS,
+		DiskMonitor:     s.cfg.TempStorageConfig.Mon,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
 		BulkAdder: func(

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -243,6 +243,7 @@ func (cfg *DiskQueueCfg) EnsureDefaults() error {
 }
 
 // NewDiskQueue creates a Queue that spills to disk.
+// TODO(asubiotto): Plumb down a monitor for disk space.
 func NewDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) (Queue, error) {
 	if err := cfg.EnsureDefaults(); err != nil {
 		return nil, err
@@ -497,6 +498,8 @@ func (d *diskQueue) maybeInitDeserializer() (bool, error) {
 	return true, nil
 }
 
+// Dequeue dequeues a batch from disk and deserializes it into b. Note that the
+// deserialized batch is only valid until the next call to Dequeue.
 func (d *diskQueue) Dequeue(b coldata.Batch) (bool, error) {
 	if d.serializer != nil && d.numBufferedBatches > 0 {
 		if err := d.writeFooterAndFlush(); err != nil {

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -33,6 +33,18 @@ type Allocator struct {
 	acc *mon.BoundAccount
 }
 
+func getVecsSize(vecs []coldata.Vec) int64 {
+	var size int64
+	for _, dest := range vecs {
+		if dest.Type() == coltypes.Bytes {
+			size += int64(dest.Bytes().Size())
+		} else {
+			size += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
+		}
+	}
+	return size
+}
+
 // NewAllocator constructs a new Allocator instance.
 func NewAllocator(ctx context.Context, acc *mon.BoundAccount) *Allocator {
 	return &Allocator{ctx: ctx, acc: acc}
@@ -52,6 +64,24 @@ func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Ba
 		execerror.VectorizedInternalPanic(err)
 	}
 	return coldata.NewMemBatchWithSize(types, size)
+}
+
+// RetainBatch adds the size of the batch to the memory account. This shouldn't
+// need to be used regularly, since most memory accounting necessary is done
+// through PerformOperation. Use this if you want to explicitly manage memory
+// accounted.
+func (a *Allocator) RetainBatch(b coldata.Batch) {
+	if err := a.acc.Grow(a.ctx, getVecsSize(b.ColVecs())); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+}
+
+// ReleaseBatch releases the size of the batch from the memory account. This
+// shouldn't need to be used regularly, since all accounts are closed by
+// Flow.Cleanup. Use this if you want to explicitly manage the memory used. An
+// example of a use case is releasing a batch before writing it to disk.
+func (a *Allocator) ReleaseBatch(b coldata.Batch) {
+	a.acc.Shrink(a.ctx, getVecsSize(b.ColVecs()))
 }
 
 // NewMemColumn returns a new coldata.Vec, initialized with a length.
@@ -101,28 +131,14 @@ func (a *Allocator) MaybeAddColumn(b coldata.Batch, t coltypes.T, colIdx int) {
 // NOTE: if some columnar vectors are not modified, they should not be included
 // in 'destVecs' to reduce the performance hit of memory accounting.
 func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
-	var before, after, delta int64
-	for _, dest := range destVecs {
-		// To simplify the accounting, we perform the operation first and then will
-		// update the memory account. The minor "drift" in accounting that is
-		// caused by this approach is ok.
-		if dest.Type() == coltypes.Bytes {
-			before += int64(dest.Bytes().Size())
-		} else {
-			before += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
-		}
-	}
-
+	before := getVecsSize(destVecs)
+	// To simplify the accounting, we perform the operation first and then will
+	// update the memory account. The minor "drift" in accounting that is
+	// caused by this approach is ok.
 	operation()
+	after := getVecsSize(destVecs)
 
-	for _, dest := range destVecs {
-		if dest.Type() == coltypes.Bytes {
-			after += int64(dest.Bytes().Size())
-		} else {
-			after += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
-		}
-	}
-	delta = after - before
+	delta := after - before
 	if delta >= 0 {
 		if err := a.acc.Grow(a.ctx, delta); err != nil {
 			execerror.VectorizedInternalPanic(err)

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -944,6 +944,20 @@ func (p *filterPlanningState) isFilterOnlyOnLeft(filter execinfrapb.Expression) 
 	return len(neededColumnsForFilter) == 0, nil
 }
 
+// createBufferingUnlimitedMemMonitor instantiates an unlimited memory monitor.
+// These should only be used when spilling to disk and an operator is made aware
+// of a memory usage limit separately.
+// The receiver is updated to have references to the unlimited memory monitor.
+func (r *NewColOperatorResult) createBufferingUnlimitedMemMonitor(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
+) *mon.BytesMonitor {
+	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+	)
+	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpUnlimitedMemMonitor)
+	return bufferingOpUnlimitedMemMonitor
+}
+
 // createBufferingMemAccount instantiates a memory monitor and a memory account
 // to be used with a buffering Operator. The receiver is updated to have
 // references to both objects.
@@ -965,10 +979,7 @@ func (r *NewColOperatorResult) createBufferingMemAccount(
 func (r *NewColOperatorResult) createBufferingUnlimitedMemAccount(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BoundAccount {
-	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
-		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
-	)
-	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpUnlimitedMemMonitor)
+	bufferingOpUnlimitedMemMonitor := r.createBufferingUnlimitedMemMonitor(ctx, flowCtx, name)
 	bufferingMemAccount := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
 	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &bufferingMemAccount)
 	return &bufferingMemAccount

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -17,9 +17,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -32,7 +34,7 @@ type routerOutput interface {
 	// blocked (see implementations).
 	addBatch(coldata.Batch, []uint16) bool
 	// cancel tells the output to stop producing batches.
-	cancel()
+	cancel(ctx context.Context)
 }
 
 // getDefaultRouterOutputBlockedThreshold returns the number of unread values
@@ -59,10 +61,21 @@ type routerOutputOp struct {
 		allocator *Allocator
 		cond      *sync.Cond
 		done      bool
-		// TODO(asubiotto): Use a ring buffer once we have disk spilling.
-		data      []coldata.Batch
+		// pendingBatch is a partially-filled batch with data added through
+		// addBatch. Once this batch reaches capacity, it is flushed to data. The
+		// main use of pendingBatch is coalescing various fragmented batches into
+		// one.
+		pendingBatch coldata.Batch
+		// data is a spillingQueue, a circular buffer backed by a disk queue.
+		data      *spillingQueue
 		numUnread int
 		blocked   bool
+	}
+
+	testingKnobs struct {
+		// alwaysFlush, if set to true will always flush o.mu.pendingBatch to
+		// o.mu.data.
+		alwaysFlush bool
 	}
 
 	// These fields default to defaultRouterOutputBlockedThreshold and
@@ -90,12 +103,19 @@ var _ Operator = &routerOutputOp{}
 
 // newRouterOutputOp creates a new router output. The caller must ensure that
 // unblockedEventsChan is a buffered channel, as the router output will write to
-// it.
+// it. The provided allocator must be not have a hard limit. The passed in
+// memoryLimit will act as a soft limit to allow the router output to use disk
+// when it is exceeded.
 func newRouterOutputOp(
-	allocator *Allocator, types []coltypes.T, unblockedEventsChan chan<- struct{},
+	allocator *Allocator,
+	types []coltypes.T,
+	unblockedEventsChan chan<- struct{},
+	memoryLimit int64,
+	cfg colcontainer.DiskQueueCfg,
 ) *routerOutputOp {
+	// TODO(asubiotto): Create testing args.
 	return newRouterOutputOpWithBlockedThresholdAndBatchSize(
-		allocator, types, unblockedEventsChan, getDefaultRouterOutputBlockedThreshold(), int(coldata.BatchSize()),
+		allocator, types, unblockedEventsChan, memoryLimit, cfg, getDefaultRouterOutputBlockedThreshold(), int(coldata.BatchSize()),
 	)
 }
 
@@ -103,6 +123,8 @@ func newRouterOutputOpWithBlockedThresholdAndBatchSize(
 	allocator *Allocator,
 	types []coltypes.T,
 	unblockedEventsChan chan<- struct{},
+	memoryLimit int64,
+	cfg colcontainer.DiskQueueCfg,
 	blockedThreshold int,
 	outputBatchSize int,
 ) *routerOutputOp {
@@ -114,7 +136,8 @@ func newRouterOutputOpWithBlockedThresholdAndBatchSize(
 	}
 	o.mu.allocator = allocator
 	o.mu.cond = sync.NewCond(&o.mu)
-	o.mu.data = make([]coldata.Batch, 0, o.blockedThreshold/o.outputBatchSize)
+	o.mu.data = newSpillingQueue(allocator, types, memoryLimit, cfg, outputBatchSize)
+
 	return o
 }
 
@@ -129,15 +152,25 @@ func (o *routerOutputOp) Next(context.Context) coldata.Batch {
 	if o.mu.done {
 		return coldata.ZeroBatch
 	}
-	for len(o.mu.data) == 0 && !o.mu.done {
+	for o.mu.pendingBatch == nil && o.mu.data.empty() && !o.mu.done {
+		// Wait until there is data to read or the output is cancelled.
 		o.mu.cond.Wait()
 	}
 	if o.mu.done {
 		return coldata.ZeroBatch
 	}
-	// Get the first batch and advance the start of the buffer.
-	b := o.mu.data[0]
-	o.mu.data = o.mu.data[1:]
+	var b coldata.Batch
+	if o.mu.pendingBatch != nil && o.mu.data.empty() {
+		// The only data available has not been flushed to the queue.
+		b = o.mu.pendingBatch
+		o.mu.pendingBatch = nil
+	} else {
+		var err error
+		b, err = o.mu.data.dequeue()
+		if err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+	}
 	o.mu.numUnread -= int(b.Length())
 	if o.mu.numUnread <= o.blockedThreshold {
 		o.maybeUnblockLocked()
@@ -153,11 +186,15 @@ func (o *routerOutputOp) Next(context.Context) coldata.Batch {
 // cancel wakes up a reader in Next if there is one and results in the output
 // returning zero length batches for every Next call after cancel. Note that
 // all accumulated data that hasn't been read will not be returned.
-func (o *routerOutputOp) cancel() {
+func (o *routerOutputOp) cancel(ctx context.Context) {
 	o.mu.Lock()
 	o.mu.done = true
-	// Release o.mu.data to GC.
-	o.mu.data = nil
+	if err := o.mu.data.close(); err != nil {
+		// This log message is Info instead of Warning because the flow will also
+		// attempt to clean up the parent directory, so this failure might not have
+		// any effect.
+		log.Info(ctx, "error closing vectorized hash router output, files may be left over: %s", err)
+	}
 	// Some goroutine might be waiting on the condition variable, so wake it up.
 	// Note that read goroutines check o.mu.done, so won't wait on the condition
 	// variable after we unlock the mutex.
@@ -173,6 +210,11 @@ func (o *routerOutputOp) cancel() {
 // same batch with different selection vectors to many different outputs.
 // True is returned if the the output changes state to blocked (note: if the
 // output is already blocked, false is returned).
+// TODO(asubiotto): We should explore pipelining addBatch if disk-spilling
+//  performance becomes a concern. The main router goroutine will be writing to
+//  disk as the code is written, meaning that we impact the performance of
+//  writing rows to a fast output if we have to write to disk for a single
+//  slow output.
 func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool {
 	if len(selection) > int(batch.Length()) {
 		selection = selection[:batch.Length()]
@@ -180,8 +222,12 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if batch.Length() == 0 {
-		// End of data. o.mu.done will be set in Next.
-		o.mu.data = append(o.mu.data, coldata.ZeroBatch)
+		if o.mu.pendingBatch != nil {
+			if err := o.mu.data.enqueue(o.mu.pendingBatch); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+		}
+		o.mu.pendingBatch = coldata.ZeroBatch
 		o.mu.cond.Signal()
 		return false
 	}
@@ -191,54 +237,45 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 		return false
 	}
 
-	writeIdx := 0
-	if len(o.mu.data) == 0 {
-		// New output batch.
-		o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
-	} else {
-		if int(o.mu.data[len(o.mu.data)-1].Length()) == o.outputBatchSize {
-			// No space in last batch, append new output batch.
-			o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
-		}
-		writeIdx = len(o.mu.data) - 1
-	}
-
 	// Increment o.mu.numUnread before going into the loop, as we will consume
 	// selection.
 	o.mu.numUnread += len(selection)
 
-	// Append the batch to o.mu.data. The batch at writeIdx is at most
-	// o.outputBatchSize-1, so if all of the elements cannot be accommodated at
-	// that index, spill over to the following batch.
-	for toAppend := uint16(len(selection)); toAppend > 0; writeIdx++ {
-		dst := o.mu.data[writeIdx]
-
-		available := uint16(o.outputBatchSize) - dst.Length()
+	for toAppend := uint16(len(selection)); toAppend > 0; {
+		if o.mu.pendingBatch == nil {
+			o.mu.pendingBatch = o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize)
+		}
+		available := uint16(o.outputBatchSize) - o.mu.pendingBatch.Length()
 		numAppended := toAppend
 		if toAppend > available {
 			numAppended = available
-			// Need to create a new batch to append to in the next o.mu.data slot.
-			// This will be used in the next iteration.
-			o.mu.data = append(o.mu.data, o.mu.allocator.NewMemBatchWithSize(o.types, o.outputBatchSize))
 		}
-
-		o.mu.allocator.PerformOperation(dst.ColVecs(), func() {
+		o.mu.allocator.PerformOperation(o.mu.pendingBatch.ColVecs(), func() {
 			for i, t := range o.types {
-				dst.ColVec(i).Append(
-					coldata.SliceArgs{
-						ColType:   t,
-						Src:       batch.ColVec(i),
-						Sel:       selection,
-						DestIdx:   uint64(dst.Length()),
-						SrcEndIdx: uint64(len(selection)),
+				o.mu.pendingBatch.ColVec(i).Copy(
+					coldata.CopySliceArgs{
+						SliceArgs: coldata.SliceArgs{
+							ColType:   t,
+							Src:       batch.ColVec(i),
+							Sel:       selection[:numAppended],
+							DestIdx:   uint64(o.mu.pendingBatch.Length()),
+							SrcEndIdx: uint64(numAppended),
+						},
 					},
 				)
 			}
-			dst.SetLength(dst.Length() + numAppended)
 		})
-
-		selection = selection[numAppended:]
+		newLength := o.mu.pendingBatch.Length() + numAppended
+		o.mu.pendingBatch.SetLength(newLength)
+		if o.testingKnobs.alwaysFlush || int(newLength) >= o.outputBatchSize {
+			// The capacity in o.mu.pendingBatch has been filled.
+			if err := o.mu.data.enqueue(o.mu.pendingBatch); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			o.mu.pendingBatch = nil
+		}
 		toAppend -= numAppended
+		selection = selection[numAppended:]
 	}
 
 	stateChanged := false
@@ -265,7 +302,7 @@ func (o *routerOutputOp) maybeUnblockLocked() {
 func (o *routerOutputOp) reset() {
 	o.mu.Lock()
 	o.mu.done = false
-	o.mu.data = o.mu.data[:0]
+	o.mu.data.reset()
 	o.mu.numUnread = 0
 	o.mu.blocked = false
 	o.mu.Unlock()
@@ -301,13 +338,22 @@ type HashRouter struct {
 }
 
 // NewHashRouter creates a new hash router that consumes coldata.Batches from
-// input and hashes each row according to hashCols to one of numOutputs outputs.
-// These outputs are exposed as Operators.
+// input and hashes each row according to hashCols to one of the outputs
+// returned as Operators.
+// The number of allocators provided will determine the number of outputs
+// returned. Each Operator must have an independent allocator (this means that
+// each allocator should be linked to an independent mem account) as
+// Operator.Next will usually be called concurrently between different outputs.
 func NewHashRouter(
-	allocator *Allocator, input Operator, types []coltypes.T, hashCols []uint32, numOutputs int,
+	allocators []*Allocator,
+	input Operator,
+	types []coltypes.T,
+	hashCols []uint32,
+	memoryLimit int64,
+	cfg colcontainer.DiskQueueCfg,
 ) (*HashRouter, []Operator) {
-	outputs := make([]routerOutput, numOutputs)
-	outputsAsOps := make([]Operator, numOutputs)
+	outputs := make([]routerOutput, len(allocators))
+	outputsAsOps := make([]Operator, len(allocators))
 	// unblockEventsChan is buffered to 2*numOutputs as we don't want the outputs
 	// writing to it to block.
 	// Unblock events only happen after a corresponding block event. Since these
@@ -315,9 +361,10 @@ func NewHashRouter(
 	// on the channel, which is why we want the channel to be buffered in the
 	// first place), every time the HashRouter blocks an output, it *must* read
 	// all unblock events preceding it since these *must* be on the channel.
-	unblockEventsChan := make(chan struct{}, 2*numOutputs)
-	for i := 0; i < numOutputs; i++ {
-		op := newRouterOutputOp(allocator, types, unblockEventsChan)
+	unblockEventsChan := make(chan struct{}, 2*len(allocators))
+	memoryLimitPerOutput := memoryLimit / int64(len(allocators))
+	for i := range allocators {
+		op := newRouterOutputOp(allocators[i], types, unblockEventsChan, memoryLimitPerOutput, cfg)
 		outputs[i] = op
 		outputsAsOps[i] = op
 	}
@@ -358,7 +405,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 			r.mu.Unlock()
 		}
 		for _, o := range r.outputs {
-			o.cancel()
+			o.cancel(ctx)
 		}
 	}
 	var done bool

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,13 +21,52 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
+
+// memoryTestCase is a helper struct for a test with memory limits.
+type memoryTestCase struct {
+	// bytes is the memory limit.
+	bytes int64
+	// skipExpSpillCheck specifies whether expSpill should be checked to assert
+	// that expected spilling behavior happened. This is true if bytes was
+	// randomly generated.
+	skipExpSpillCheck bool
+	// expSpill specifies whether a spill is expected or not. Should be ignored if
+	// skipExpSpillCheck is true.
+	expSpill bool
+}
+
+// getDiskqueueCfgAndMemoryTestCases is a test helper that creates an in-memory
+// DiskQueueCfg that can be used to create a new DiskQueue. A cleanup function
+// is also returned as well as some default memory limits that are useful to
+// test with: 0 for an immediate spill a random memory limit up to 64 MiB, and
+// 1GiB, which shouldn't result in a spill.
+// Note that not all tests will check for a spill, it is enough that some
+// deterministic tests do so for the simple cases.
+// TODO(asubiotto): Add disk spilling checks to all tests. Actually is this
+//  necessary? Might be ok to just check in unit tests *shrug*.
+// TODO(asubiotto): We might want to also return a verify() function that will
+//  check for leftover files.
+func getDiskQueueCfgAndMemoryTestCases(
+	t *testing.T, rng *rand.Rand,
+) (colcontainer.DiskQueueCfg, func(), []memoryTestCase) {
+	t.Helper()
+	queueCfg, cleanup := colcontainer.NewTestingDiskQueueCfg(t, true /* inMem */)
+
+	return queueCfg, cleanup, []memoryTestCase{
+		{bytes: 0, expSpill: true},
+		{bytes: 1 + rng.Int63n(64<<20 /* 64 MiB */), skipExpSpillCheck: true},
+		{bytes: 1 << 30 /* 1 GiB */, expSpill: false},
+	}
+}
 
 // getDataAndFullSelection is a test helper that generates tuples representing
 // a one-column coltypes.Int64 batch where each element is its ordinal and an
@@ -92,33 +132,43 @@ func TestRouterOutputAddBatch(t *testing.T) {
 	// in this test.
 	unblockEventsChan := make(chan struct{})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-				testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, tc.blockedThreshold, tc.outputBatchSize,
-			)
-			in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
-			out := newOpTestOutput(o, data[:len(tc.selection)])
-			in.Init()
-			for {
-				b := in.Next(ctx)
-				o.addBatch(b, tc.selection)
-				if b.Length() == 0 {
-					break
-				}
-			}
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
+	rng, _ := randutil.NewPseudoRand()
+	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
+	defer cleanup()
 
-			// The output should never block. This assumes test cases never send more
-			// than defaultRouterOutputBlockedThreshold values.
-			select {
-			case b := <-unblockEventsChan:
-				t.Fatalf("unexpected output state change blocked: %t", b)
-			default:
-			}
-		})
+	for _, tc := range testCases {
+		for _, mtc := range memoryTestCases {
+			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
+					testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, mtc.bytes, queueCfg, tc.blockedThreshold, tc.outputBatchSize,
+				)
+				in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
+				out := newOpTestOutput(o, data[:len(tc.selection)])
+				in.Init()
+				for {
+					b := in.Next(ctx)
+					o.addBatch(b, tc.selection)
+					if b.Length() == 0 {
+						break
+					}
+				}
+				if err := out.Verify(); err != nil {
+					t.Fatal(err)
+				}
+
+				// The output should never block. This assumes test cases never send more
+				// than defaultRouterOutputBlockedThreshold values.
+				select {
+				case b := <-unblockEventsChan:
+					t.Fatalf("unexpected output state change blocked: %t", b)
+				default:
+				}
+
+				if !mtc.skipExpSpillCheck {
+					require.Equal(t, mtc.expSpill, o.mu.data.spilled())
+				}
+			})
+		}
 	}
 }
 
@@ -161,7 +211,7 @@ func TestRouterOutputNext(t *testing.T) {
 			// CancelUnblocksReader verifies that calling cancel on an output unblocks
 			// a reader.
 			unblockEvent: func(_ Operator, o *routerOutputOp) {
-				o.cancel()
+				o.cancel(ctx)
 			},
 			expected: tuples{},
 			name:     "CancelUnblocksReader",
@@ -172,138 +222,147 @@ func TestRouterOutputNext(t *testing.T) {
 	// never write to it in this test.
 	unblockedEventsChan := make(chan struct{})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var wg sync.WaitGroup
-			batchChan := make(chan coldata.Batch)
-			o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan)
-			in := newOpTestInput(coldata.BatchSize(), data, nil /* typs */)
-			in.Init()
-			wg.Add(1)
-			go func() {
+	rng, _ := randutil.NewPseudoRand()
+	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
+	defer cleanup()
+
+	for _, mtc := range memoryTestCases {
+		for _, tc := range testCases {
+			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+				var wg sync.WaitGroup
+				batchChan := make(chan coldata.Batch)
+				if queueCfg.FS == nil {
+					t.Fatal("FS was nil")
+				}
+				o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg)
+				in := newOpTestInput(coldata.BatchSize(), data, nil /* typs */)
+				in.Init()
+				wg.Add(1)
+				go func() {
+					for {
+						b := o.Next(ctx)
+						batchChan <- b
+						if b.Length() == 0 {
+							break
+						}
+					}
+					wg.Done()
+				}()
+
+				// Sleep a long enough amount of time to make sure that if Next didn't block
+				// above, we have a good chance of reading a batch.
+				time.Sleep(time.Millisecond)
+				select {
+				case <-batchChan:
+					t.Fatal("expected reader goroutine to block when no data ready")
+				default:
+				}
+
+				tc.unblockEvent(in, o)
+
+				// Should have data available, pushed by our reader goroutine.
+				batches := NewBatchBuffer()
+				out := newOpTestOutput(batches, tc.expected)
 				for {
-					b := o.Next(ctx)
-					batchChan <- b
+					b := <-batchChan
+					batches.Add(b)
 					if b.Length() == 0 {
 						break
 					}
 				}
-				wg.Done()
-			}()
-
-			// Sleep a long enough amount of time to make sure that if Next didn't block
-			// above, we have a good chance of reading a batch.
-			time.Sleep(time.Millisecond)
-			select {
-			case <-batchChan:
-				t.Fatal("expected reader goroutine to block when no data ready")
-			default:
-			}
-
-			tc.unblockEvent(in, o)
-
-			// Should have data available, pushed by our reader goroutine.
-			batches := NewBatchBuffer()
-			out := newOpTestOutput(batches, tc.expected)
-			for {
-				b := <-batchChan
-				batches.Add(b)
-				if b.Length() == 0 {
-					break
+				if err := out.Verify(); err != nil {
+					t.Fatal(err)
 				}
-			}
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
-			wg.Wait()
+				wg.Wait()
 
+				select {
+				case <-unblockedEventsChan:
+					t.Fatal("unexpected output state change")
+				default:
+				}
+			})
+		}
+
+		t.Run(fmt.Sprintf("NextAfterZeroBatchDoesntBlock/memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+			o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg)
+			o.addBatch(coldata.ZeroBatch, fullSelection)
+			o.Next(ctx)
+			o.Next(ctx)
 			select {
 			case <-unblockedEventsChan:
 				t.Fatal("unexpected output state change")
 			default:
 			}
 		})
-	}
 
-	t.Run("NextAfterZeroBatchDoesntBlock", func(t *testing.T) {
-		o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan)
-		o.addBatch(coldata.ZeroBatch, fullSelection)
-		o.Next(ctx)
-		o.Next(ctx)
-		select {
-		case <-unblockedEventsChan:
-			t.Fatal("unexpected output state change")
-		default:
-		}
-	})
+		t.Run(fmt.Sprintf("AddBatchDoesntBlockWhenOutputIsBlocked/memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+			var (
+				smallBatchSize = 8
+				blockThreshold = smallBatchSize / 2
+			)
 
-	t.Run("AddBatchDoesntBlockWhenOutputIsBlocked", func(t *testing.T) {
-		var (
-			smallBatchSize = 8
-			blockThreshold = smallBatchSize / 2
-		)
-
-		if len(fullSelection) <= smallBatchSize {
-			// If a full batch is smaller than our small batch size, reduce it, since
-			// this test relies on multiple batches returned from the input.
-			smallBatchSize = 2
-			if smallBatchSize >= coldata.MinBatchSize {
-				// Sanity check.
-				t.Fatalf("smallBatchSize=%d still too large (must be less than MinBatchSize=%d)", smallBatchSize, coldata.MinBatchSize)
+			if len(fullSelection) <= smallBatchSize {
+				// If a full batch is smaller than our small batch size, reduce it, since
+				// this test relies on multiple batches returned from the input.
+				smallBatchSize = 2
+				if smallBatchSize >= coldata.MinBatchSize {
+					// Sanity check.
+					t.Fatalf("smallBatchSize=%d still too large (must be less than MinBatchSize=%d)", smallBatchSize, coldata.MinBatchSize)
+				}
+				blockThreshold = 1
 			}
-			blockThreshold = 1
-		}
 
-		// Use a smaller selection than the batch size; it increases test coverage.
-		selection := fullSelection[:blockThreshold]
+			// Use a smaller selection than the batch size; it increases test coverage.
+			selection := fullSelection[:blockThreshold]
 
-		expected := make(tuples, 0, len(data))
-		for i := 0; i < len(data); i += smallBatchSize {
-			for k := 0; k < blockThreshold && i+k < len(data); k++ {
-				expected = append(expected, data[i+k])
+			expected := make(tuples, 0, len(data))
+			for i := 0; i < len(data); i += smallBatchSize {
+				for k := 0; k < blockThreshold && i+k < len(data); k++ {
+					expected = append(expected, data[i+k])
+				}
 			}
-		}
 
-		ch := make(chan struct{}, 2)
-		o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-			testAllocator, []coltypes.T{coltypes.Int64}, ch, blockThreshold, int(coldata.BatchSize()),
-		)
-		in := newOpTestInput(uint16(smallBatchSize), data, nil /* typs */)
-		out := newOpTestOutput(o, expected)
-		in.Init()
+			ch := make(chan struct{}, 2)
+			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
+				testAllocator, []coltypes.T{coltypes.Int64}, ch, mtc.bytes, queueCfg, blockThreshold, int(coldata.BatchSize()),
+			)
+			in := newOpTestInput(uint16(smallBatchSize), data, nil /* typs */)
+			out := newOpTestOutput(o, expected)
+			in.Init()
 
-		b := in.Next(ctx)
-		// Make sure the output doesn't consider itself blocked. We're right at the
-		// limit but not over.
-		if o.addBatch(b, selection) {
-			t.Fatal("unexpectedly blocked")
-		}
-		b = in.Next(ctx)
-		// This addBatch call should now block the output.
-		if !o.addBatch(b, selection) {
-			t.Fatal("unexpectedly still unblocked")
-		}
-
-		// Add the rest of the data.
-		for {
-			b = in.Next(ctx)
+			b := in.Next(ctx)
+			// Make sure the output doesn't consider itself blocked. We're right at the
+			// limit but not over.
 			if o.addBatch(b, selection) {
-				t.Fatal("should only return true when switching from unblocked to blocked")
+				t.Fatal("unexpectedly blocked")
 			}
-			if b.Length() == 0 {
-				break
+			b = in.Next(ctx)
+			// This addBatch call should now block the output.
+			if !o.addBatch(b, selection) {
+				t.Fatal("unexpectedly still unblocked")
 			}
-		}
 
-		// Unblock the output.
-		if err := out.Verify(); err != nil {
-			t.Fatal(err)
-		}
+			// Add the rest of the data.
+			for {
+				b = in.Next(ctx)
+				if o.addBatch(b, selection) {
+					t.Fatal("should only return true when switching from unblocked to blocked")
+				}
+				if b.Length() == 0 {
+					break
+				}
+			}
 
-		// Verify that an unblock event is sent on the channel. This test will fail
-		// with a timeout on a channel read if not.
-		<-ch
-	})
+			// Unblock the output.
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify that an unblock event is sent on the channel. This test will fail
+			// with a timeout on a channel read if not.
+			<-ch
+		})
+	}
 }
 
 func TestRouterOutputRandom(t *testing.T) {
@@ -329,98 +388,109 @@ func TestRouterOutputRandom(t *testing.T) {
 		}
 	}
 
+	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
+	defer cleanup()
+
 	testName := fmt.Sprintf(
 		"blockedThreshold=%d/outputSize=%d/totalInputSize=%d", blockedThreshold, outputSize, len(data),
 	)
-	t.Run(testName, func(t *testing.T) {
-		runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
-			var wg sync.WaitGroup
-			unblockedEventsChans := make(chan struct{}, 2)
-			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-				testAllocator, typs, unblockedEventsChans, blockedThreshold, outputSize,
-			)
-			inputs[0].Init()
+	for _, mtc := range memoryTestCases {
+		t.Run(fmt.Sprintf("%s/memoryLimit=%s", testName, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
+				var wg sync.WaitGroup
+				unblockedEventsChans := make(chan struct{}, 2)
+				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
+					testAllocator, typs, unblockedEventsChans, mtc.bytes, queueCfg, blockedThreshold, outputSize,
+				)
+				inputs[0].Init()
 
-			expected := make(tuples, 0, len(data))
+				expected := make(tuples, 0, len(data))
 
-			// Producer.
-			errCh := make(chan error)
-			go func() {
-				lastBlockedState := false
-				for {
-					b := inputs[0].Next(ctx)
-					selection := b.Selection()
-					if selection == nil {
-						selection = randomSel(rng, b.Length(), rng.Float64())
-					}
-
-					selection = selection[:b.Length()]
-
-					for _, i := range selection {
-						expected = append(expected, make(tuple, len(typs)))
-						for j := range typs {
-							expected[len(expected)-1][j] = b.ColVec(j).Int64()[i]
+				// Producer.
+				errCh := make(chan error)
+				go func() {
+					lastBlockedState := false
+					for {
+						b := inputs[0].Next(ctx)
+						selection := b.Selection()
+						if selection == nil {
+							selection = randomSel(rng, b.Length(), rng.Float64())
 						}
-					}
 
-					if o.addBatch(b, selection) {
-						if lastBlockedState {
-							// We might have missed an unblock event during the last loop.
+						selection = selection[:b.Length()]
+
+						for _, i := range selection {
+							expected = append(expected, make(tuple, len(typs)))
+							for j := range typs {
+								expected[len(expected)-1][j] = b.ColVec(j).Int64()[i]
+							}
+						}
+
+						if o.addBatch(b, selection) {
+							if lastBlockedState {
+								// We might have missed an unblock event during the last loop.
+								select {
+								case <-unblockedEventsChans:
+								default:
+									errCh <- errors.New("output returned state change to blocked when already blocked")
+								}
+							}
+							lastBlockedState = true
+						}
+
+						// Read any state changes.
+						for moreToRead := true; moreToRead; {
 							select {
 							case <-unblockedEventsChans:
+								if !lastBlockedState {
+									errCh <- errors.New("received unblocked state change when output is already unblocked")
+								}
+								lastBlockedState = false
 							default:
-								errCh <- errors.New("output returned state change to blocked when already blocked")
+								moreToRead = false
 							}
 						}
-						lastBlockedState = true
-					}
 
-					// Read any state changes.
-					for moreToRead := true; moreToRead; {
-						select {
-						case <-unblockedEventsChans:
-							if !lastBlockedState {
-								errCh <- errors.New("received unblocked state change when output is already unblocked")
-							}
-							lastBlockedState = false
-						default:
-							moreToRead = false
+						if b.Length() == 0 {
+							errCh <- nil
+							return
 						}
 					}
+				}()
 
-					if b.Length() == 0 {
-						errCh <- nil
-						return
+				actual := NewBatchBuffer()
+
+				// Consumer.
+				wg.Add(1)
+				go func() {
+					// Create a new allocator to copy the resulting batches. We need
+					// a separate allocator to testAllocator since this is a separate
+					// goroutine and allocators may not be used concurrently.
+					acc := testMemMonitor.MakeBoundAccount()
+					allocator := NewAllocator(ctx, &acc)
+					defer acc.Close(ctx)
+					for {
+						b := o.Next(ctx)
+						actual.Add(CopyBatch(allocator, b))
+						if b.Length() == 0 {
+							wg.Done()
+							return
+						}
 					}
+				}()
+
+				if err := <-errCh; err != nil {
+					t.Fatal(err)
 				}
-			}()
 
-			actual := NewBatchBuffer()
+				wg.Wait()
 
-			// Consumer.
-			wg.Add(1)
-			go func() {
-				for {
-					b := o.Next(ctx)
-					actual.Add(b)
-					if b.Length() == 0 {
-						wg.Done()
-						return
-					}
+				if err := newOpTestOutput(actual, expected).Verify(); err != nil {
+					t.Fatal(err)
 				}
-			}()
-
-			if err := <-errCh; err != nil {
-				t.Fatal(err)
-			}
-
-			wg.Wait()
-
-			if err := newOpTestOutput(actual, expected).Verify(); err != nil {
-				t.Fatal(err)
-			}
+			})
 		})
-	})
+	}
 }
 
 type callbackRouterOutput struct {
@@ -438,7 +508,7 @@ func (o callbackRouterOutput) addBatch(batch coldata.Batch, selection []uint16) 
 	return false
 }
 
-func (o callbackRouterOutput) cancel() {
+func (o callbackRouterOutput) cancel(context.Context) {
 	if o.cancelCb != nil {
 		o.cancelCb()
 	}
@@ -629,32 +699,47 @@ func TestHashRouterOneOutput(t *testing.T) {
 	data, _ := getDataAndFullSelection()
 	typs := []coltypes.T{coltypes.Int64}
 
-	r, routerOutputs := NewHashRouter(
-		testAllocator, newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []uint32{0}, 1, /* numOutputs */
-	)
-
-	if len(routerOutputs) != 1 {
-		t.Fatalf("expected 1 router output but got %d", len(routerOutputs))
-	}
-
 	expected := make(tuples, 0, len(data))
 	for _, i := range sel {
 		expected = append(expected, data[i])
 	}
 
-	o := newOpTestOutput(routerOutputs[0], expected)
+	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
+	defer cleanup()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		r.Run(ctx)
-		wg.Done()
-	}()
+	for _, mtc := range memoryTestCases {
+		t.Run(fmt.Sprintf("memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
+			r, routerOutputs := NewHashRouter([]*Allocator{testAllocator}, newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []uint32{0}, mtc.bytes, queueCfg)
 
-	if err := o.Verify(); err != nil {
-		t.Fatal(err)
+			if len(routerOutputs) != 1 {
+				t.Fatalf("expected 1 router output but got %d", len(routerOutputs))
+			}
+
+			o := newOpTestOutput(routerOutputs[0], expected)
+
+			ro := routerOutputs[0].(*routerOutputOp)
+			// Set alwaysFlush so that data is always flushed to the spillingQueue.
+			ro.testingKnobs.alwaysFlush = true
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				r.Run(ctx)
+				wg.Done()
+			}()
+
+			if err := o.Verify(); err != nil {
+				t.Fatal(err)
+			}
+			wg.Wait()
+			if !mtc.skipExpSpillCheck {
+				// If len(sel) == 0, no items will have been enqueued so override an
+				// expected spill if this is the case.
+				mtc.expSpill = mtc.expSpill && len(sel) != 0
+				require.Equal(t, mtc.expSpill, ro.mu.data.spilled())
+			}
+		})
 	}
-	wg.Wait()
 }
 
 func TestHashRouterRandom(t *testing.T) {
@@ -705,88 +790,98 @@ func TestHashRouterRandom(t *testing.T) {
 		cancel,
 	)
 
+	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
+	defer cleanup()
+
 	// expectedDistribution is set after the first run and used to verify that the
 	// distribution of results does not change between runs, as we are sending the
 	// same data to the same number of outputs.
 	var expectedDistribution []int
-	t.Run(testName, func(t *testing.T) {
-		runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
-			unblockEventsChan := make(chan struct{}, 2*numOutputs)
-			outputs := make([]routerOutput, numOutputs)
-			outputsAsOps := make([]Operator, numOutputs)
-			for i := range outputs {
-				op := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-					testAllocator, typs, unblockEventsChan, blockedThreshold, outputSize,
+	for _, mtc := range memoryTestCases {
+		t.Run(testName, func(t *testing.T) {
+			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
+				unblockEventsChan := make(chan struct{}, 2*numOutputs)
+				outputs := make([]routerOutput, numOutputs)
+				outputsAsOps := make([]Operator, numOutputs)
+				for i := range outputs {
+					acc := testMemMonitor.MakeBoundAccount()
+					defer acc.Close(ctx)
+					// Create a separate allocator for each output as a single allocator
+					// may not be used concurrently.
+					allocator := NewAllocator(ctx, &acc)
+					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(
+						allocator, typs, unblockEventsChan, mtc.bytes, queueCfg, blockedThreshold, outputSize,
+					)
+					outputs[i] = op
+					outputsAsOps[i] = op
+				}
+
+				r := newHashRouterWithOutputs(
+					inputs[0], typs, hashCols, unblockEventsChan, outputs,
 				)
-				outputs[i] = op
-				outputsAsOps[i] = op
-			}
 
-			r := newHashRouterWithOutputs(
-				inputs[0], typs, hashCols, unblockEventsChan, outputs,
-			)
-
-			var (
-				results uint64
-				wg      sync.WaitGroup
-			)
-			resultsByOp := make([]int, len(outputsAsOps))
-			wg.Add(len(outputsAsOps))
-			for i := range outputsAsOps {
-				go func(i int) {
-					for {
-						b := outputsAsOps[i].Next(ctx)
-						if b.Length() == 0 {
-							break
+				var (
+					results uint64
+					wg      sync.WaitGroup
+				)
+				resultsByOp := make([]int, len(outputsAsOps))
+				wg.Add(len(outputsAsOps))
+				for i := range outputsAsOps {
+					go func(i int) {
+						for {
+							b := outputsAsOps[i].Next(ctx)
+							if b.Length() == 0 {
+								break
+							}
+							atomic.AddUint64(&results, uint64(b.Length()))
+							resultsByOp[i] += int(b.Length())
 						}
-						atomic.AddUint64(&results, uint64(b.Length()))
-						resultsByOp[i] += int(b.Length())
-					}
+						wg.Done()
+					}(i)
+				}
+
+				ctx, cancelFunc := context.WithCancel(context.Background())
+				wg.Add(1)
+				go func() {
+					r.Run(ctx)
 					wg.Done()
-				}(i)
-			}
+				}()
 
-			ctx, cancelFunc := context.WithCancel(context.Background())
-			wg.Add(1)
-			go func() {
-				r.Run(ctx)
-				wg.Done()
-			}()
-
-			if cancel {
-				// Sleep between 0 and ~5 milliseconds.
-				time.Sleep(time.Microsecond * time.Duration(rng.Intn(5000)))
-				cancelFunc()
-			} else {
-				// Satisfy linter context leak error.
-				defer cancelFunc()
-			}
-
-			// Ensure all goroutines end. If a test fails with a hang here it is most
-			// likely due to a cancellation bug.
-			wg.Wait()
-			if !cancel {
-				// Only do output verification if no cancellation happened.
-				if actualTotal := atomic.LoadUint64(&results); actualTotal != uint64(len(data)) {
-					t.Fatalf("unexpected number of results %d, expected %d", actualTotal, len(data))
+				if cancel {
+					// Sleep between 0 and ~5 milliseconds.
+					time.Sleep(time.Microsecond * time.Duration(rng.Intn(5000)))
+					cancelFunc()
+				} else {
+					// Satisfy linter context leak error.
+					defer cancelFunc()
 				}
-				if expectedDistribution == nil {
-					expectedDistribution = resultsByOp
-					return
-				}
-				for i, numVals := range expectedDistribution {
-					if numVals != resultsByOp[i] {
-						t.Fatalf(
-							"distribution of results changed compared to first run at output %d. expected: %v, actual: %v",
-							i,
-							expectedDistribution,
-							resultsByOp,
-						)
+
+				// Ensure all goroutines end. If a test fails with a hang here it is most
+				// likely due to a cancellation bug.
+				wg.Wait()
+				if !cancel {
+					// Only do output verification if no cancellation happened.
+					if actualTotal := atomic.LoadUint64(&results); actualTotal != uint64(len(data)) {
+						t.Fatalf("unexpected number of results %d, expected %d", actualTotal, len(data))
+					}
+					if expectedDistribution == nil {
+						expectedDistribution = resultsByOp
+						return
+					}
+					for i, numVals := range expectedDistribution {
+						if numVals != resultsByOp[i] {
+							t.Fatalf(
+								"distribution of results changed compared to first run at output %d. expected: %v, actual: %v",
+								i,
+								expectedDistribution,
+								resultsByOp,
+							)
+						}
 					}
 				}
-			}
+			})
 		})
-	})
+	}
 }
 
 func BenchmarkHashRouter(b *testing.B) {
@@ -801,11 +896,20 @@ func BenchmarkHashRouter(b *testing.B) {
 	batch.SetLength(coldata.BatchSize())
 	input := NewRepeatableBatchSource(testAllocator, batch)
 
+	queueCfg, cleanup := colcontainer.NewTestingDiskQueueCfg(b, true /* inMem */)
+	defer cleanup()
+
 	var wg sync.WaitGroup
 	for _, numOutputs := range []int{2, 4, 8, 16} {
 		for _, numInputBatches := range []int{2, 4, 8, 16} {
 			b.Run(fmt.Sprintf("numOutputs=%d/numInputBatches=%d", numOutputs, numInputBatches), func(b *testing.B) {
-				r, outputs := NewHashRouter(testAllocator, input, types, []uint32{0}, numOutputs)
+				allocators := make([]*Allocator, numOutputs)
+				for i := range allocators {
+					acc := testMemMonitor.MakeBoundAccount()
+					allocators[i] = NewAllocator(ctx, &acc)
+					defer acc.Close(ctx)
+				}
+				r, outputs := NewHashRouter(allocators, input, types, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg)
 				b.SetBytes(8 * int64(coldata.BatchSize()) * int64(numInputBatches))
 				// We expect distribution to not change. This is a sanity check that
 				// we're resetting properly.

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -1,0 +1,203 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// spillingQueue is a Queue that uses a fixed-size in-memory circular buffer
+// and spills to disk if the capacity is exceeded or the allocator reports that
+// more memory than the caller-provided maxMemoryLimit is in use.
+// When spilling to disk, a DiskQueue will be created. When spilling batches to
+// disk, their memory will first be released using the allocator. When batches
+// are read from disk back into memory, that memory will be reclaimed.
+// NOTE: When a batch is returned, that batch's memory will still be tracked
+// using the allocator. Since the memory in use is fixed, a previously returned
+// batch may be overwritten by a batch read from disk. This new batch's memory
+// footprint will replace the footprint of the previously returned batch. Since
+// batches are unsafe for reuse, it is assumed that the previously returned
+// batch is not kept around and thus its referenced memory will be GCed as soon
+// as the batch is updated.
+type spillingQueue struct {
+	allocator      *Allocator
+	maxMemoryLimit int64
+
+	typs             []coltypes.T
+	items            []coldata.Batch
+	curHeadIdx       int
+	curTailIdx       int
+	numInMemoryItems int
+	numOnDiskItems   int
+
+	diskQueueCfg colcontainer.DiskQueueCfg
+	diskQueue    colcontainer.Queue
+}
+
+func newSpillingQueue(
+	allocator *Allocator,
+	typs []coltypes.T,
+	memoryLimit int64,
+	cfg colcontainer.DiskQueueCfg,
+	batchSize int,
+) *spillingQueue {
+	// Reduce the memory limit by what the DiskQueue may need to buffer
+	// writes/reads.
+	memoryLimit -= int64(cfg.BufferSizeBytes)
+	if memoryLimit < 0 {
+		memoryLimit = 0
+	}
+	itemsLen := memoryLimit / int64(estimateBatchSizeBytes(typs, batchSize))
+	if itemsLen == 0 {
+		// Make items at least of length 1. Even though batches will spill to disk
+		// directly (this can only happen with a very low memory limit), it's nice
+		// to have at least one item in order to be able to deserialize from disk
+		// into this slice.
+		itemsLen = 1
+	}
+	return &spillingQueue{
+		allocator:      allocator,
+		maxMemoryLimit: memoryLimit,
+		typs:           typs,
+		items:          make([]coldata.Batch, itemsLen),
+		diskQueueCfg:   cfg,
+	}
+}
+
+func (q *spillingQueue) enqueue(batch coldata.Batch) error {
+	if batch.Length() == 0 {
+		return nil
+	}
+
+	if q.numOnDiskItems > 0 || q.allocator.Used() > q.maxMemoryLimit || q.numInMemoryItems == len(q.items) {
+		// In this case, there is not enough memory available to keep this batch in
+		// memory, or the in-memory circular buffer has no slots available (we do
+		// an initial estimate of how many batches would fit into the buffer, which
+		// might be wrong). The tail of the queue might also already be on disk, in
+		// which case that is where the batch must be enqueued to maintain order.
+		if err := q.maybeSpillToDisk(); err != nil {
+			return err
+		}
+		q.allocator.ReleaseBatch(batch)
+		q.numOnDiskItems++
+		return q.diskQueue.Enqueue(batch)
+	}
+
+	q.items[q.curTailIdx] = batch
+	q.curTailIdx++
+	if q.curTailIdx == len(q.items) {
+		q.curTailIdx = 0
+	}
+	q.numInMemoryItems++
+	return nil
+}
+
+func (q *spillingQueue) dequeue() (coldata.Batch, error) {
+	if q.empty() {
+		return coldata.ZeroBatch, nil
+	}
+
+	if q.numInMemoryItems == 0 {
+		// No more in-memory items. Fill the circular buffer as much as possible.
+		// Note that there must be at least one element on disk.
+		if q.curHeadIdx != q.curTailIdx {
+			// TODO(asubiotto): Should these panics be errors?
+			panic(fmt.Sprintf("assertion failed in spillingQueue: curHeadIdx != curTailIdx, %d != %d", q.curHeadIdx, q.curTailIdx))
+		}
+		// NOTE: Only one item is dequeued from disk since a deserialized batch is
+		// only valid until the next call to Dequeue. In practice we could Dequeue
+		// up until a new file region is loaded (which will overwrite the memory of
+		// the previous batches), but Dequeue calls are already amortized, so this
+		// is acceptable.
+		if q.items[q.curTailIdx] == nil {
+			// This occurs when q.items is not enqueued to. This might be due to
+			// some batches taking too much memory at the front of the buffer, so
+			// we never end up using the whole length of q.items and prefer to
+			// enqueue to disk directly.
+			q.items[q.curTailIdx] = q.allocator.NewMemBatchWithSize(q.typs, 0 /* size */)
+		}
+		// Release a batch to make space for a new batch from disk.
+		q.allocator.ReleaseBatch(q.items[q.curTailIdx])
+		ok, err := q.diskQueue.Dequeue(q.items[q.curTailIdx])
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			// There was no batch to dequeue from disk. This should not really
+			// happen, as it should have been caught by the q.empty() check above.
+			panic("disk queue was not empty but failed to dequeue element in spillingQueue")
+		}
+		q.numOnDiskItems--
+		q.numInMemoryItems++
+		// Account for this batch's memory.
+		q.allocator.RetainBatch(q.items[q.curTailIdx])
+		// Move to the next slot in the circular buffer.
+		q.curTailIdx++
+		if q.curTailIdx == len(q.items) {
+			q.curTailIdx = 0
+		}
+	}
+
+	res := q.items[q.curHeadIdx]
+	q.curHeadIdx++
+	if q.curHeadIdx == len(q.items) {
+		q.curHeadIdx = 0
+	}
+	q.numInMemoryItems--
+	return res, nil
+}
+
+func (q *spillingQueue) maybeSpillToDisk() error {
+	if q.diskQueue != nil {
+		return nil
+	}
+	diskQueue, err := colcontainer.NewDiskQueue(q.typs, q.diskQueueCfg)
+	log.Infof(context.TODO(), "created new diskQueue with path: %s\n", q.diskQueueCfg.Path)
+	if err != nil {
+		return err
+	}
+	q.diskQueue = diskQueue
+	return nil
+}
+
+// isDone returns whether there are currently no items to be dequeued.
+func (q *spillingQueue) empty() bool {
+	return q.numInMemoryItems == 0 && q.numOnDiskItems == 0
+}
+
+func (q *spillingQueue) spilled() bool {
+	return q.diskQueue != nil
+}
+
+func (q *spillingQueue) close() error {
+	if q.diskQueue != nil {
+		return q.diskQueue.Close()
+	}
+	return nil
+}
+
+func (q *spillingQueue) reset() {
+	if err := q.close(); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	q.diskQueue = nil
+	q.numInMemoryItems = 0
+	q.numOnDiskItems = 0
+	q.curHeadIdx = 0
+	q.curTailIdx = 0
+}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -14,11 +14,13 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
@@ -83,6 +85,16 @@ func (f *vectorizedFlow) Setup(
 		recordingStats = true
 	}
 	helper := &vectorizedFlowCreatorHelper{f: f.FlowBase}
+	// flowTempStoragePath is the directory to use for this flow's temporary
+	// storage.
+	flowTempStoragePath := filepath.Join(f.Cfg.TempStoragePath, f.GetID().String())
+	if err := f.Cfg.TempFS.CreateDir(flowTempStoragePath); err != nil {
+		return ctx, err
+	}
+	diskQueueCfg := colcontainer.DiskQueueCfg{FS: f.Cfg.TempFS, Path: flowTempStoragePath}
+	if err := diskQueueCfg.EnsureDefaults(); err != nil {
+		return ctx, err
+	}
 	creator := newVectorizedFlowCreator(
 		helper,
 		vectorizedRemoteComponentCreator{},
@@ -91,6 +103,7 @@ func (f *vectorizedFlow) Setup(
 		f.GetSyncFlowConsumer(),
 		f.GetFlowCtx().Cfg.NodeDialer,
 		f.GetID(),
+		diskQueueCfg,
 	)
 	_, err = creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, opt)
 	if err == nil {
@@ -100,6 +113,17 @@ func (f *vectorizedFlow) Setup(
 		f.bufferingMemAccounts = append(f.bufferingMemAccounts, creator.bufferingMemAccounts...)
 		log.VEventf(ctx, 1, "vectorized flow setup succeeded")
 		return ctx, nil
+	}
+	if err := f.Cfg.TempFS.DeleteDir(flowTempStoragePath); err != nil {
+		// log error as a Warning but keep on going to close the memory
+		// infrastructure.
+		log.Warning(
+			ctx,
+			"unable to remove flow %s's temporary directory at %s, files may be left over: %v",
+			f.GetID().Short(),
+			flowTempStoragePath,
+			err,
+		)
 	}
 	// It is (theoretically) possible that some of the memory monitoring
 	// infrastructure was created even in case of an error, and we need to clean
@@ -144,6 +168,18 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	}
 	for _, memMonitor := range f.bufferingMemMonitors {
 		memMonitor.Stop(ctx)
+	}
+	flowTempStoragePath := filepath.Join(f.Cfg.TempStoragePath, f.GetID().String())
+	if err := f.Cfg.TempFS.DeleteDir(flowTempStoragePath); err != nil {
+		// log error as a Warning but keep on going to close the memory
+		// infrastructure.
+		log.Warning(
+			ctx,
+			"unable to remove flow %s's temporary directory at %s, files may be left over: %v",
+			f.GetID().Short(),
+			flowTempStoragePath,
+			err,
+		)
 	}
 	f.FlowBase.Cleanup(ctx)
 	f.Release()
@@ -298,6 +334,8 @@ type vectorizedFlowCreator struct {
 	// bufferingMemAccounts contains all memory accounts of the buffering
 	// components in the vectorized flow.
 	bufferingMemAccounts []*mon.BoundAccount
+
+	diskQueueCfg colcontainer.DiskQueueCfg
 }
 
 func newVectorizedFlowCreator(
@@ -308,6 +346,7 @@ func newVectorizedFlowCreator(
 	syncFlowConsumer execinfra.RowReceiver,
 	nodeDialer *nodedialer.Dialer,
 	flowID execinfrapb.FlowID,
+	diskQueueCfg colcontainer.DiskQueueCfg,
 ) *vectorizedFlowCreator {
 	return &vectorizedFlowCreator{
 		flowCreatorHelper:              helper,
@@ -320,7 +359,25 @@ func newVectorizedFlowCreator(
 		syncFlowConsumer:               syncFlowConsumer,
 		nodeDialer:                     nodeDialer,
 		flowID:                         flowID,
+		diskQueueCfg:                   diskQueueCfg,
 	}
+}
+
+// createBufferingUnlimitedMemAccount instantiates an unlimited memory monitor.
+// These should only be used when spilling to disk and an operator is made aware
+// of a memory usage limit separately.
+// The receiver is updated to have references to the unlimited memory monitor.
+// TODO(asubiotto): This identical to the helper function in
+//  NewColOperatorResult, meaning that we should probably find a way to refactor
+//  this.
+func (s *vectorizedFlowCreator) createBufferingUnlimitedMemMonitor(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
+) *mon.BytesMonitor {
+	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+	)
+	s.bufferingMemMonitors = append(s.bufferingMemMonitors, bufferingOpUnlimitedMemMonitor)
+	return bufferingOpUnlimitedMemMonitor
 }
 
 // newStreamingMemAccount creates a new memory account bound to the monitor in
@@ -391,16 +448,14 @@ func (s *vectorizedFlowCreator) setupRouter(
 		return errors.Errorf("vectorized output router type %s unsupported", output.Type)
 	}
 
-	hashRouterMemMonitor := execinfra.NewLimitedMonitor(
-		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "hash-router-limited",
-	)
-	hashRouterMemAccount := hashRouterMemMonitor.MakeBoundAccount()
-	s.bufferingMemMonitors = append(s.bufferingMemMonitors, hashRouterMemMonitor)
-	s.bufferingMemAccounts = append(s.bufferingMemAccounts, &hashRouterMemAccount)
-	router, outputs := colexec.NewHashRouter(
-		colexec.NewAllocator(ctx, &hashRouterMemAccount), input, outputTyps,
-		output.HashColumns, len(output.Streams),
-	)
+	hashRouterMemMonitor := s.createBufferingUnlimitedMemMonitor(ctx, flowCtx, "hash-router")
+	allocators := make([]*colexec.Allocator, len(output.Streams))
+	for i := range allocators {
+		acc := hashRouterMemMonitor.MakeBoundAccount()
+		allocators[i] = colexec.NewAllocator(ctx, &acc)
+		s.bufferingMemAccounts = append(s.bufferingMemAccounts, &acc)
+	}
+	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, execinfra.GetWorkMemLimit(flowCtx.Cfg), s.diskQueueCfg)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
 		router.Run(ctx)
 	}
@@ -920,15 +975,7 @@ func SupportsVectorized(
 	processorSpecs []execinfrapb.ProcessorSpec,
 	fuseOpt flowinfra.FuseOpt,
 ) (leaves []execinfra.OpNode, err error) {
-	creator := newVectorizedFlowCreator(
-		newNoopFlowCreatorHelper(),
-		vectorizedRemoteComponentCreator{},
-		false,                   /* recordingStats */
-		nil,                     /* waitGroup */
-		&execinfra.RowChannel{}, /* syncFlowConsumer */
-		nil,                     /* nodeDialer */
-		execinfrapb.FlowID{},
-	)
+	creator := newVectorizedFlowCreator(newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, nil, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{})
 	// We create an unlimited memory account because we're interested whether the
 	// flow is supported via the vectorized engine in general (without paying
 	// attention to the memory since it is node-dependent in the distributed

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -208,15 +209,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: roachpb.NodeID(1)}}
 	var wg sync.WaitGroup
-	vfc := newVectorizedFlowCreator(
-		&vectorizedFlowCreatorHelper{f: f},
-		componentCreator,
-		false, /* recordingStats */
-		&wg,
-		&execinfra.RowChannel{},
-		nil, /* nodeDialer */
-		execinfrapb.FlowID{},
-	)
+	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{})
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
 	defer func() {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -58,7 +58,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -123,6 +124,14 @@ type ServerConfig struct {
 	// TempStorage is used by some DistSQL processors to store rows when the
 	// working set is larger than can be stored in memory.
 	TempStorage diskmap.Factory
+
+	// TempStoragePath is the path where the vectorized execution engine should
+	// create files using TempFS.
+	TempStoragePath string
+
+	// TempFS is used by the vectorized execution engine to store columns when the
+	// working set is larger than can be stored in memory.
+	TempFS engine.FS
 
 	// BulkAdder is used by some processors to bulk-ingest data as SSTs.
 	BulkAdder storagebase.BulkAdderFactory

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -388,9 +388,10 @@ type testClusterConfig struct {
 	overrideVectorize string
 	// if non-empty, overrides the default automatic statistics mode.
 	overrideAutoStats string
-	// if set, queries using distSQL processors that can fall back to disk do
-	// so immediately, using only their disk-based implementation.
-	distSQLUseDisk bool
+	// if set, queries using distSQL processors or vectorized operators that can
+	// fall back to disk do so immediately, using only their disk-based
+	// implementation.
+	sqlExecUseDisk bool
 	// if set, enables DistSQL metadata propagation tests.
 	distSQLMetadataTestEnabled bool
 	// if set and the -test.short flag is passed, skip this config.
@@ -474,6 +475,15 @@ var logicTestConfigs = []testClusterConfig{
 		overrideVectorize:   "experimental_on",
 	},
 	{
+		name:                "fakedist-vec-disk",
+		numNodes:            3,
+		useFakeSpanResolver: true,
+		overrideDistSQLMode: "on",
+		overrideAutoStats:   "false",
+		sqlExecUseDisk:      true,
+		skipShort:           true,
+	},
+	{
 		name:                       "fakedist-metadata",
 		numNodes:                   3,
 		useFakeSpanResolver:        true,
@@ -488,7 +498,7 @@ var logicTestConfigs = []testClusterConfig{
 		useFakeSpanResolver: true,
 		overrideDistSQLMode: "on",
 		overrideAutoStats:   "false",
-		distSQLUseDisk:      true,
+		sqlExecUseDisk:      true,
 		skipShort:           true,
 	},
 	{
@@ -522,7 +532,7 @@ var logicTestConfigs = []testClusterConfig{
 		name:                "5node-dist-disk",
 		numNodes:            5,
 		overrideDistSQLMode: "on",
-		distSQLUseDisk:      true,
+		sqlExecUseDisk:      true,
 		skipShort:           true,
 		overrideAutoStats:   "false",
 	},
@@ -1072,7 +1082,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	distSQLKnobs := &execinfra.TestingKnobs{
 		MetadataTestLevel: execinfra.Off, DeterministicStats: true,
 	}
-	if cfg.distSQLUseDisk {
+	if cfg.sqlExecUseDisk {
 		distSQLKnobs.MemoryLimitBytes = 1
 	}
 	if cfg.distSQLMetadataTestEnabled {

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -63,7 +63,7 @@ func TestDiskRowContainer(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	alloc := &sqlbase.DatumAlloc{}
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -413,7 +413,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -35,7 +35,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -187,7 +187,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -822,7 +822,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -50,7 +50,7 @@ func TestHashJoiner(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestHashJoinerError(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 			DiskMonitor: diskMonitor,
 		},
 	}
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -385,7 +385,7 @@ func TestJoinReader(t *testing.T) {
 		},
 	}
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +498,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
 	st := s.ClusterSettings()
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -293,7 +293,7 @@ func TestSorter(t *testing.T) {
 					t.Run(name, func(t *testing.T) {
 						ctx := context.Background()
 						st := cluster.MakeTestingClusterSettings()
-						tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+						tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -50,7 +50,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -710,7 +710,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
-	tempEngine, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := engine.NewTempEngine(engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -305,7 +305,7 @@ func BenchmarkRocksDBMapWrite(b *testing.B) {
 		}
 	}()
 	ctx := context.Background()
-	tempEngine, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func BenchmarkRocksDBMapIteration(b *testing.B) {
 			b.Fatal(err)
 		}
 	}()
-	tempEngine, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestPebbleMap(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	e, _, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestPebbleMultiMap(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	e, _, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func BenchmarkPebbleMapWrite(b *testing.B) {
 		}
 	}()
 	ctx := context.Background()
-	tempEngine, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -480,7 +480,7 @@ func BenchmarkPebbleMapIteration(b *testing.B) {
 			b.Fatal(err)
 		}
 	}()
-	tempEngine, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/engine/temp_engine_test.go
+++ b/pkg/storage/engine/temp_engine_test.go
@@ -25,7 +25,7 @@ func TestNewRocksDBTempEngine(t *testing.T) {
 	tempDir, tempDirCleanup := testutils.TempDir(t)
 	defer tempDirCleanup()
 
-	engine, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: tempDir}, base.StoreSpec{Path: tempDir})
+	engine, _, err := NewRocksDBTempEngine(base.TempStorageConfig{Path: tempDir}, base.StoreSpec{Path: tempDir})
 	if err != nil {
 		t.Fatalf("error encountered when invoking NewRocksDBTempEngine: %+v", err)
 	}


### PR DESCRIPTION
Release note: None (mostly adds infrastructure for disk-spilling, future
commits will call the use of this infrastructure out)