### PR TITLE
tree: fix type checking error with `BETWEEN`

### DIFF
--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1103,6 +1103,11 @@ func (expr *RangeCond) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr,
 	if err != nil {
 		return nil, err
 	}
+	// Ensure that the boundaries of the comparison are well typed.
+	_, _, _, _, err = typeCheckComparisonOp(ctx, LT, expr.From, expr.To)
+	if err != nil {
+		return nil, err
+	}
 	expr.Left, expr.From = leftFromTyped, fromTyped
 	expr.leftTo, expr.To = leftToTyped, toTyped
 	expr.typ = types.Bool

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -230,6 +230,7 @@ func TestTypeCheckError(t *testing.T) {
 		{`1 = ANY ARRAY[2, 'a']`, `unsupported comparison operator: 1 = ANY ARRAY[2, 'a']: could not parse "a" as type int`},
 		{`1 = ALL current_schemas(true)`, `unsupported comparison operator: <int> = ALL <string[]>`},
 		{`1.0 BETWEEN 2 AND 'a'`, `unsupported comparison operator: <decimal> < <string>`},
+		{`NULL BETWEEN 2 AND 'a'`, `unsupported comparison operator: <int> < <string>`},
 		{`IF(1, 2, 3)`, `incompatible IF condition type: int`},
 		{`IF(true, 'a', 2)`, `incompatible IF expressions: could not parse "a" as type int`},
 		{`IF(true, 2, 'a')`, `incompatible IF expressions: could not parse "a" as type int`},


### PR DESCRIPTION
Part of #44148.

This PR fixes a bug in typechecking where the
boundaries of a `BETWEEN` clause could be of
a different type, but the typechecking would
succeed if the candidate expression was NULL.

Release note (bug fix): This PR fixes a typechecking
error where `BETWEEN` would sometimes allow boundary
expressions of a different type.