### PR TITLE
sql: fix truncation of time/timestamp/interval precision on writes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -330,3 +330,34 @@ query T
 SELECT interval ' 5  ' year
 ----
 5 years
+
+# Check default types and expressions get truncated on insert / update.
+subtest regression_44774
+
+statement ok
+CREATE TABLE regression_44774 (
+  a interval(3) DEFAULT '1:2:3.123456'
+)
+
+statement ok
+INSERT INTO regression_44774 VALUES (default), ('4:5:6.123456')
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+01:02:03.123
+04:05:06.123
+
+statement ok
+UPDATE regression_44774
+SET a = '13:14:15.123456'::interval + '1 sec'::interval
+WHERE 1 = 1
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+13:14:16.123
+13:14:16.123
+
+statement ok
+DROP TABLE regression_44774

--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -488,3 +488,34 @@ ORDER BY id ASC
 ----
 1
 2
+
+# Check default types and expressions get truncated on insert / update.
+subtest regression_44774
+
+statement ok
+CREATE TABLE regression_44774 (
+  a time(3) DEFAULT '12:13:14.123456'
+)
+
+statement ok
+INSERT INTO regression_44774 VALUES (default), ('19:21:57.261286')
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+0000-01-01 12:13:14.123 +0000 UTC
+0000-01-01 19:21:57.261 +0000 UTC
+
+statement ok
+UPDATE regression_44774
+SET a = '13:14:15.123456'::time + '1 sec'::interval
+WHERE 1 = 1
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+0000-01-01 13:14:16.123 +0000 UTC
+0000-01-01 13:14:16.123 +0000 UTC
+
+statement ok
+DROP TABLE regression_44774

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -295,3 +295,35 @@ true
 
 statement ok
 SET TIME ZONE 0
+
+# Check default types and expressions get truncated on insert / update.
+subtest regression_44774
+
+statement ok
+CREATE TABLE regression_44774 (
+  a timestamp(3) DEFAULT '1970-02-03 12:13:14.123456',
+  b timestamptz(3) DEFAULT '1970-02-03 12:13:14.123456'
+)
+
+statement ok
+INSERT INTO regression_44774 VALUES (default, default), ('2020-02-05 19:21:57.261286', '2020-02-05 19:21:57.261286')
+
+query TT
+SELECT a, b FROM regression_44774 ORDER BY a
+----
+1970-02-03 12:13:14.123 +0000 +0000  1970-02-03 12:13:14.123 +0000 +0000
+2020-02-05 19:21:57.261 +0000 +0000  2020-02-05 19:21:57.261 +0000 +0000
+
+statement ok
+UPDATE regression_44774
+SET a = '1970-03-04 13:14:15.123456'::timestamp + '1 sec'::interval, b = '1970-03-04 13:14:15.123456'::timestamptz + '1 sec'::interval
+WHERE 1 = 1
+
+query TT
+SELECT a, b FROM regression_44774 ORDER BY a
+----
+1970-03-04 13:14:16.123 +0000 +0000  1970-03-04 13:14:16.123 +0000 +0000
+1970-03-04 13:14:16.123 +0000 +0000  1970-03-04 13:14:16.123 +0000 +0000
+
+statement ok
+DROP TABLE regression_44774

--- a/pkg/sql/logictest/testdata/logic_test/timetz
+++ b/pkg/sql/logictest/testdata/logic_test/timetz
@@ -639,3 +639,34 @@ SELECT f1::string AS "Ten" FROM TIMETZ_TBL WHERE f1 >= '00:00-07' ORDER BY id
 
 query error pq: unsupported binary operator: <timetz\(2\)> \+ <timetz>
 SELECT f1 + time with time zone '00:01' AS "Illegal" FROM TIMETZ_TBL ORDER BY id
+
+# check default types and expressions get truncated on insert / update.
+subtest regression_44774
+
+statement ok
+CREATE TABLE regression_44774 (
+  a timetz(3) DEFAULT '12:13:14.123456'
+)
+
+statement ok
+INSERT INTO regression_44774 VALUES (default), ('19:21:57.261286')
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+0000-01-01 12:13:14.123 +0000 UTC
+0000-01-01 19:21:57.261 +0000 UTC
+
+statement ok
+UPDATE regression_44774
+SET a = '13:14:15.123456'::timetz + '1 sec'::interval
+WHERE 1 = 1
+
+query T
+SELECT a FROM regression_44774 ORDER BY a
+----
+0000-01-01 13:14:16.123 +0000 UTC
+0000-01-01 13:14:16.123 +0000 UTC
+
+statement ok
+DROP TABLE regression_44774


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44774.

We previously rounded precision related string-data correctly and wrote
it into the database as such, but this does not cover cases where
operators/builtins are used as values in INSERT/UPDATE, thus inserting
rows into the database with the incorrect precision (we do not know the
precision of values when using operators / builtins as our overload
resolution system is not rich enough to do this).

In this PR, we fix the above behavior by modifying `LimitValueWidth` to
do precision-based rounding.

No release note as this fixes bugs in new features that is not out on the
main branch yet.

Release note: None