### PR TITLE
sql: avoid lookup on unsupported schema names

### DIFF
--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -15,11 +15,32 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestIsSupportedSchemaName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		name  string
+		valid bool
+	}{
+		{"db_name", false},
+		{"public", true},
+		{"pg_temp", true},
+		{"pg_temp_1234_1", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.valid, isSupportedSchemaName(tree.Name(tc.name)))
+		})
+	}
+}
 
 func TestMakeTableDescColumns(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Refs: #44733

In `bbef8f9`, we removed the "bypass" where if schema names were not
PublicSchema names, we quickly exit. However, with custom schemas (well,
only temporary schemas for now), we can no longer do this. Since we only
support temporary schemas and public schema for now when doing these
lookups, this PR adds the bypass back in such that performance is
currently not degraded.

No release note as nothing here is publically available yet.

Release note: None