### PR TITLE
sql: add tests around concurrent pk change and other schema changes

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -327,10 +327,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// Ensure that there is not another primary key change attempted within this transaction.
 			currentMutationID := n.tableDesc.ClusterVersion.NextMutationID
 			for i := range n.tableDesc.Mutations {
-				if desc := n.tableDesc.Mutations[i].GetPrimaryKeySwap(); desc != nil &&
-					n.tableDesc.Mutations[i].MutationID == currentMutationID {
-					return unimplemented.NewWithIssue(
-						43376, "multiple primary key changes in the same transaction are unsupported")
+				if desc := n.tableDesc.Mutations[i].GetPrimaryKeySwap(); desc != nil {
+					if n.tableDesc.Mutations[i].MutationID == currentMutationID {
+						return unimplemented.NewWithIssue(
+							43376, "multiple primary key changes in the same transaction are unsupported")
+					}
+					if n.tableDesc.Mutations[i].MutationID < currentMutationID {
+						return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+							"table %s is currently undergoing a primary key change", n.tableDesc.Name)
+					}
 				}
 			}
 
@@ -436,6 +441,18 @@ func (n *alterTableNode) startExec(params runParams) error {
 			for i := range n.tableDesc.Indexes {
 				idx := &n.tableDesc.Indexes[i]
 				if idx.ID != newPrimaryIndexDesc.ID && shouldRewriteIndex(idx) {
+					indexesToRewrite = append(indexesToRewrite, idx)
+				}
+			}
+
+			for i := range n.tableDesc.Mutations {
+				mut := &n.tableDesc.Mutations[i]
+				// TODO (rohany): It's unclear about what to do if there are other mutations within
+				//  this transaction too.
+				// If there is an index that is getting built right now that started in a previous txn, we
+				// need to potentially rebuild that index as well.
+				if idx := mut.GetIndex(); mut.MutationID < currentMutationID && idx != nil &&
+					mut.Direction == sqlbase.DescriptorMutation_ADD && shouldRewriteIndex(idx) {
 					indexesToRewrite = append(indexesToRewrite, idx)
 				}
 			}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2331,6 +2331,157 @@ INSERT INTO t.test VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
 	}
 }
 
+// TestPrimaryKeyChangeWithPrecedingIndexCreation tests that a primary key change
+// successfully rewrites indexes that are being created while the primary key change starts.
+func TestPrimaryKeyChangeWithPrecedingIndexCreation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	var chunkSize int64 = 100
+	var maxValue = 4000
+	if util.RaceEnabled {
+		// Race builds are a lot slower, so use a smaller number of rows.
+		maxValue = 200
+		chunkSize = 5
+	}
+
+	// Protects backfillNotification.
+	var mu syncutil.Mutex
+	var backfillNotification chan struct{}
+	// We have to have initBackfillNotification return the new
+	// channel rather than having later users read the original
+	// backfillNotification to make the race detector happy.
+	initBackfillNotification := func() chan struct{} {
+		mu.Lock()
+		defer mu.Unlock()
+		backfillNotification = make(chan struct{})
+		return backfillNotification
+	}
+	notifyBackfill := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if backfillNotification != nil {
+			close(backfillNotification)
+			backfillNotification = nil
+		}
+	}
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: chunkSize,
+			AsyncExecQuickly:  true,
+		},
+		DistSQL: &execinfra.TestingKnobs{
+			RunBeforeBackfillChunk: func(_ roachpb.Span) error {
+				notifyBackfill()
+				return nil
+			},
+		},
+	}
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	t.Run("create-index-before", func(t *testing.T) {
+		if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT NOT NULL, v INT);
+`); err != nil {
+			t.Fatal(err)
+		}
+		if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
+			t.Fatal(err)
+		}
+
+		backfillNotif := initBackfillNotification()
+		var wg sync.WaitGroup
+		wg.Add(1)
+		// Create an index on the table that will need to get rewritten.
+		go func() {
+			if _, err := sqlDB.Exec(`CREATE INDEX i ON t.test (v)`); err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		// Wait until the create index mutation has progressed before starting the alter primary key.
+		<-backfillNotif
+
+		if _, err := sqlDB.Exec(`
+SET experimental_enable_primary_key_changes = true;
+ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`); err != nil {
+			t.Fatal(err)
+		}
+
+		wg.Wait()
+
+		// There should be 4 k/v pairs per row:
+		// * the original rowid index.
+		// * the old index on v.
+		// * the new primary key on k.
+		// * the new index for v with k as the unique column.
+		testutils.SucceedsSoon(t, func() error {
+			return checkTableKeyCount(ctx, kvDB, 4, maxValue)
+		})
+	})
+
+	// Repeat the prior process but with a primary key change before.
+	t.Run("pk-change-before", func(t *testing.T) {
+		var wg sync.WaitGroup
+		if _, err := sqlDB.Exec(`
+DROP TABLE IF EXISTS t.test;
+CREATE TABLE t.test (k INT NOT NULL, v INT, v2 INT NOT NULL)`); err != nil {
+			t.Fatal(err)
+		}
+		backfillNotif := initBackfillNotification()
+		// Can't use bulkInsertIntoTable here because that only works with 2 columns.
+		inserts := make([]string, maxValue+1)
+		for i := 0; i < maxValue+1; i++ {
+			inserts[i] = fmt.Sprintf(`(%d, %d, %d)`, i, maxValue-i, i)
+		}
+		if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES ` + strings.Join(inserts, ",")); err != nil {
+			t.Fatal(err)
+		}
+		wg.Add(1)
+		// Alter the primary key of the table.
+		go func() {
+			if _, err := sqlDB.Exec(`
+SET experimental_enable_primary_key_changes = true;
+ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v2)`); err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		<-backfillNotif
+
+		// This must be rejected, because there is a primary key change already in progress.
+		_, err := sqlDB.Exec(`
+SET experimental_enable_primary_key_changes = true;
+ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`)
+		if !testutils.IsError(err, "pq: table test is currently undergoing a primary key change") {
+			t.Errorf("expected to concurrent primary key change to error, but got %+v", err)
+		}
+
+		wg.Wait()
+
+		// After the first primary key change is done, the follow up primary key change should succeed.
+		if _, err := sqlDB.Exec(`
+SET experimental_enable_primary_key_changes = true;
+ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`); err != nil {
+			t.Fatal(err)
+		}
+
+		// There should be 4 k/v pairs per row:
+		// * the original rowid index.
+		// * the new primary index on v2.
+		// * the new primary index on k.
+		// * the rewritten demoted index on v2.
+		testutils.SucceedsSoon(t, func() error {
+			return checkTableKeyCount(ctx, kvDB, 4, maxValue)
+		})
+	})
+}
+
 // TestPrimaryKeyChangeWithOperations ensures that different operations succeed
 // while a primary key change is happening.
 func TestPrimaryKeyChangeWithOperations(t *testing.T) {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2918,7 +2918,7 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m DescriptorMutation) e
 				return err
 			}
 			newIndex.Name = "primary"
-			desc.PrimaryIndex = *newIndex
+			desc.PrimaryIndex = *protoutil.Clone(newIndex).(*IndexDescriptor)
 			idx, err := getIndexIdxByID(newIndex.ID)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes #44777.

This PR ensures that when a primary key change is issued
all indexes that are currently building are rewritten as needed.

Additionally, this PR disallows starting a primary key change
on a table t if a primary key change is currently executing on t.

Release note (sql change): This PR disallows primary key changes
on tables that are currently undergoing a primary key change.