### PR TITLE
storage/concurrency: randomized test for lockTable with concurrency

### DIFF
--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -11,20 +11,28 @@
 package concurrency
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/rand"
+	"golang.org/x/sync/errgroup"
 )
 
 /*
@@ -36,7 +44,7 @@ txn txn=<name> ts=<int>[,<int>] epoch=<int>
 
  Creates a TxnMeta.
 
-request r=<name> txn=<name> ts=<int>[,<int>] spans=r|w@<start>[,<end>]+...
+request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+...
 ----
 
  Creates a Request.
@@ -222,7 +230,7 @@ func TestLockTableBasic(t *testing.T) {
 			var txnName string
 			d.ScanArgs(t, "txn", &txnName)
 			txnMeta, ok := txnsByName[txnName]
-			if !ok {
+			if !ok && txnName != "none" {
 				d.Fatalf(t, "unknown txn %s", txnName)
 			}
 			ts := scanTimestamp(t, d)
@@ -415,15 +423,548 @@ func TestLockTableBasic(t *testing.T) {
 	})
 }
 
+type workItem struct {
+	// Contains one of request or intents.
+
+	// Request.
+	request        *testRequest
+	locksToAcquire []roachpb.Key
+
+	// updateLocks
+	intents []*roachpb.Intent
+}
+
+func (w *workItem) getRequestTxnID() uuid.UUID {
+	if w.request != nil && w.request.tM != nil {
+		return w.request.tM.ID
+	}
+	return uuid.UUID{}
+}
+
+func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
+	defer func() {
+		e.doneWork <- item
+	}()
+	if item.request != nil {
+		var lg *spanlatch.Guard
+		var g requestGuard
+		var err error
+		for {
+			// Since we can't do a select involving latch acquisition and context
+			// cancellation, the code makes sure to release latches when returning
+			// early due to error. Otherwise other requests will get stuck and
+			// group.Wait() will not return until the test times out.
+			lg, err = e.lm.Acquire(context.TODO(), item.request.s)
+			if err != nil {
+				return err
+			}
+			g, err = e.lt.scanAndEnqueue(item.request, g)
+			if err != nil {
+				e.lm.Release(lg)
+				return err
+			}
+			if !g.startWaiting() {
+				break
+			}
+			e.lm.Release(lg)
+			var lastID uuid.UUID
+		L:
+			for {
+				select {
+				case <-g.newState():
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				state, err := g.currentState()
+				if err != nil {
+					_ = e.lt.done(g)
+					return err
+				}
+				switch state.stateKind {
+				case doneWaiting:
+					if !lastID.Equal(uuid.UUID{}) && item.request.tM != nil {
+						_, err = e.waitingFor(item.request.tM.ID, lastID, uuid.UUID{})
+						if err != nil {
+							_ = e.lt.done(g)
+							return err
+						}
+					}
+					break L
+				case waitSelf:
+					if item.request.tM == nil {
+						_ = e.lt.done(g)
+						return errors.Errorf("non-transactional request cannot waitSelf")
+					}
+				case waitForDistinguished, waitFor, waitElsewhere:
+					if item.request.tM != nil {
+						var aborted bool
+						aborted, err = e.waitingFor(item.request.tM.ID, lastID, state.txn.ID)
+						if !aborted {
+							lastID = state.txn.ID
+						}
+						if aborted {
+							_ = e.lt.done(g)
+							return err
+						}
+					}
+				default:
+					return errors.Errorf("unexpected state: %v", state.stateKind)
+				}
+			}
+		}
+
+		// acquire locks.
+		for _, k := range item.locksToAcquire {
+			err = e.acquireLock(k, g, item.request.tM.ID)
+			if err != nil {
+				break
+			}
+		}
+		err = firstError(err, e.lt.done(g))
+		e.lm.Release(lg)
+		return err
+	}
+	for _, intent := range item.intents {
+		if err := e.lt.updateLocks(intent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Contains either a request or the ID of the transactions whose locks should
+// be released.
+type workloadItem struct {
+	// Request to be executed, iff request != nil
+	request *testRequest
+	// locks to be acquired by the request.
+	locksToAcquire []roachpb.Key
+
+	// Non-empty when transaction should release locks.
+	finish uuid.UUID
+}
+
+// state of a transaction maintained by workloadExecutor, for deadlock
+// detection, and deciding when transaction can be finished (when a
+// workloadItem has instructed that it be finished and all its ongoing
+// requests have finished). Requests can be aborted due to deadlock. For
+// workload execution convenience this does not abort the whole transaction,
+// but it does mean that the locks acquired by the transaction can be a subset
+// of what it was instructed to acquire. The locks acquired are tracked in
+// acquiredLocks.
+type transactionState struct {
+	txn *enginepb.TxnMeta
+
+	// A map of each transaction it depends on and a refcount (the refcount is >
+	// 0).
+	dependsOn       map[uuid.UUID]int
+	ongoingRequests map[*workItem]struct{}
+	acquiredLocks   []roachpb.Key
+	finish          bool
+}
+
+func makeWorkItemFinishTxn(tstate *transactionState) workItem {
+	wItem := workItem{}
+	for i := range tstate.acquiredLocks {
+		intent := &roachpb.Intent{
+			Span:   roachpb.Span{Key: tstate.acquiredLocks[i]},
+			Txn:    *tstate.txn,
+			Status: roachpb.COMMITTED,
+		}
+		wItem.intents = append(wItem.intents, intent)
+	}
+	return wItem
+}
+
+func makeWorkItemForRequest(wi workloadItem) workItem {
+	wItem := workItem{
+		request:        wi.request,
+		locksToAcquire: wi.locksToAcquire,
+	}
+	return wItem
+}
+
+type workloadExecutor struct {
+	lm spanlatch.Manager
+	lt lockTable
+
+	// Protects the following fields in transactionState: acquiredLocks and
+	// dependsOn, and the transactions map.
+	mu                syncutil.Mutex
+	items             []workloadItem
+	transactions      map[uuid.UUID]*transactionState
+	doneWork          chan *workItem
+	concurrency       int
+	numAborted        int
+	numConcViolations int
+}
+
+func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
+	return &workloadExecutor{
+		lm:           spanlatch.Manager{},
+		lt:           newLockTable(1000),
+		items:        items,
+		transactions: make(map[uuid.UUID]*transactionState),
+		doneWork:     make(chan *workItem),
+		concurrency:  concurrency,
+	}
+}
+
+func (e *workloadExecutor) acquireLock(k roachpb.Key, g requestGuard, txnID uuid.UUID) error {
+	err := e.lt.acquireLock(k, lock.Exclusive, lock.Unreplicated, g)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	tstate, ok := e.transactions[txnID]
+	if !ok {
+		return errors.Errorf("testbug: lock acquiring request with txnID %v has no transaction", txnID)
+	}
+	tstate.acquiredLocks = append(tstate.acquiredLocks, k)
+	return nil
+}
+
+// Returns true if cycle was found. err != nil => true
+func (e *workloadExecutor) findCycle(node uuid.UUID, cycleNode uuid.UUID) (bool, error) {
+	if node == cycleNode {
+		return true, nil
+	}
+	tstate, ok := e.transactions[node]
+	if !ok {
+		return true, errors.Errorf("edge to txn that is not in map")
+	}
+	for k := range tstate.dependsOn {
+		found, err := e.findCycle(k, cycleNode)
+		if err != nil || found {
+			return true, err
+		}
+	}
+	return false, nil
+}
+
+// Returns true if request should abort. err != nil => true
+func (e *workloadExecutor) waitingFor(
+	waiter uuid.UUID, lastID uuid.UUID, currID uuid.UUID,
+) (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	tstate, ok := e.transactions[waiter]
+	if !ok {
+		return true, errors.Errorf("testbug: request calling waitingFor with txnID %v has no transaction", waiter)
+	}
+	if !lastID.Equal(uuid.UUID{}) {
+		refcount := tstate.dependsOn[lastID]
+		refcount--
+		if refcount > 0 {
+			tstate.dependsOn[lastID] = refcount
+		} else if refcount == 0 {
+			delete(tstate.dependsOn, lastID)
+		} else {
+			return true, errors.Errorf("testbug: txn %v has a negative refcount %d for dependency on %v", waiter, refcount, lastID)
+		}
+	}
+	if !currID.Equal(uuid.UUID{}) {
+		refcount := tstate.dependsOn[currID]
+		// Cycle detection to detect if this new edge has introduced any
+		// cycle. We know there cannot be a cycle preceding this edge,
+		// so any cycle must involve waiter. We do a trivial recursive
+		// DFS (does not avoid exploring the same node multiple times).
+		if refcount == 0 {
+			found, err := e.findCycle(currID, waiter)
+			if found {
+				return found, err
+			}
+		}
+		refcount++
+		tstate.dependsOn[currID] = refcount
+	}
+	return false, nil
+}
+
+// Returns true if it started a goroutine.
+func (e *workloadExecutor) tryFinishTxn(
+	ctx context.Context, group *errgroup.Group, txnID uuid.UUID, tstate *transactionState,
+) bool {
+	if !tstate.finish || len(tstate.ongoingRequests) > 0 {
+		return false
+	}
+	if len(tstate.acquiredLocks) > 0 {
+		work := makeWorkItemFinishTxn(tstate)
+		group.Go(func() error { return doWork(ctx, &work, e) })
+		return true
+	}
+	return false
+}
+
+// Execution can be either in strict or non-strict mode. In strict mode
+// the executor expects to be able to limit concurrency to the configured
+// value L by waiting for the L ongoing requests to finish. It sets a
+// deadline for this, and returns with an error if the deadline expires
+// (this is just a slightly cleaner error than the test exceeding the
+// deadline since it prints out the lock table contents).
+//
+// When executing in non-strict mode, the concurrency bound is not necessarily
+// respected since requests may be waiting for locks to be released. The
+// executor waits for a tiny interval when concurrency is >= L and if
+// no request completes it starts another request. Just for our curiosity
+// these "concurrency violations" are tracked in a counter.
+func (e *workloadExecutor) execute(strict bool) error {
+	numOutstanding := 0
+	i := 0
+	group, ctx := errgroup.WithContext(context.TODO())
+	timer := time.NewTimer(time.Second)
+	timer.Stop()
+	var err error
+L:
+	for i < len(e.items) || numOutstanding > 0 {
+		if numOutstanding >= e.concurrency || (i == len(e.items) && numOutstanding > 0) {
+			strictIter := strict || i == len(e.items)
+			if strictIter {
+				timer.Reset(30 * time.Second)
+			} else {
+				timer.Reset(time.Millisecond)
+			}
+			var w *workItem
+			select {
+			case w = <-e.doneWork:
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
+				if strictIter {
+					err = errors.Errorf("timer expired with lock table: %v", e.lt)
+					break L
+				} else {
+					e.numConcViolations++
+				}
+			}
+			if w != nil {
+				numOutstanding--
+				txnID := w.getRequestTxnID()
+				if !txnID.Equal(uuid.UUID{}) {
+					tstate, ok := e.transactions[txnID]
+					if !ok {
+						err = errors.Errorf("testbug: finished request with txnID %v has no transaction", txnID)
+						break
+					}
+					delete(tstate.ongoingRequests, w)
+					if e.tryFinishTxn(ctx, group, txnID, tstate) {
+						numOutstanding++
+						continue
+					}
+				}
+			}
+		}
+		if i == len(e.items) {
+			continue
+		}
+
+		wi := e.items[i]
+		i++
+		if wi.request != nil {
+			work := makeWorkItemForRequest(wi)
+			if wi.request.tM != nil {
+				txnID := wi.request.tM.ID
+				_, ok := e.transactions[txnID]
+				if !ok {
+					// New transaction
+					tstate := &transactionState{
+						txn:             wi.request.tM,
+						dependsOn:       make(map[uuid.UUID]int),
+						ongoingRequests: make(map[*workItem]struct{}),
+					}
+					e.mu.Lock()
+					e.transactions[txnID] = tstate
+					e.mu.Unlock()
+				}
+				e.transactions[txnID].ongoingRequests[&work] = struct{}{}
+			}
+			group.Go(func() error { return doWork(ctx, &work, e) })
+			numOutstanding++
+			continue
+		}
+		tstate, ok := e.transactions[wi.finish]
+		if !ok {
+			err = errors.Errorf("testbug: txn to finish not found: %v", wi.finish)
+			break
+		}
+		tstate.finish = true
+		if e.tryFinishTxn(ctx, group, wi.finish, tstate) {
+			numOutstanding++
+		}
+	}
+	err2 := group.Wait()
+	if err2 != nil {
+		err = err2
+	}
+	fmt.Printf("items: %d, aborted: %d, concurrency violations: %d, lock table: %v\n",
+		len(e.items), e.numAborted, e.numConcViolations, e.lt)
+	return err
+}
+
+// Randomized test with each transaction having a single request that does not
+// acquire locks. Note that this ensures there will be no deadlocks. And the
+// test executor can run in strict concurrency mode (see comment in execute()).
+func TestLockTableConcurrentSingleRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	txnCounter := uint128.FromInts(0, 0)
+	var timestamps []hlc.Timestamp
+	for i := 0; i < 10; i++ {
+		timestamps = append(timestamps, hlc.Timestamp{WallTime: int64(i + 1)})
+	}
+	var keys []roachpb.Key
+	for i := 0; i < 10; i++ {
+		keys = append(keys, roachpb.Key(string('a'+i)))
+	}
+	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
+
+	const numKeys = 2
+	var items []workloadItem
+	var startedTxnIDs []uuid.UUID // inefficient queue, but ok for a test.
+	const maxStartedTxns = 10
+	const numRequests = 5000
+	for i := 0; i < numRequests; i++ {
+		ts := timestamps[rng.Intn(len(timestamps))]
+		keysPerm := rng.Perm(len(keys))
+		spans := &spanset.SpanSet{}
+		onlyReads := true
+		for i := 0; i < numKeys; i++ {
+			span := roachpb.Span{Key: keys[keysPerm[i]]}
+			acc := spanset.SpanAccess(rng.Intn(int(spanset.NumSpanAccess)))
+			spans.AddMVCC(acc, span, ts)
+			if acc != spanset.SpanReadOnly {
+				onlyReads = false
+			}
+		}
+		var txnMeta *enginepb.TxnMeta
+		if !onlyReads || rng.Intn(2) == 0 {
+			txnMeta = &enginepb.TxnMeta{
+				ID:             nextUUID(&txnCounter),
+				WriteTimestamp: ts,
+			}
+		}
+		request := &testRequest{
+			tM: txnMeta,
+			s:  spans,
+			t:  ts,
+		}
+		items = append(items, workloadItem{request: request})
+		if txnMeta != nil {
+			startedTxnIDs = append(startedTxnIDs, txnMeta.ID)
+		}
+		randomMaxStartedTxns := rng.Intn(maxStartedTxns)
+		for len(startedTxnIDs) > randomMaxStartedTxns {
+			items = append(items, workloadItem{finish: startedTxnIDs[0]})
+			startedTxnIDs = startedTxnIDs[1:]
+		}
+	}
+	for len(startedTxnIDs) > 0 {
+		items = append(items, workloadItem{finish: startedTxnIDs[0]})
+		startedTxnIDs = startedTxnIDs[1:]
+	}
+	concurrency := []int{2, 8, 16, 32}
+	for _, c := range concurrency {
+		t.Run(fmt.Sprintf("concurrency %d", c), func(t *testing.T) {
+			exec := newWorkLoadExecutor(items, c)
+			if err := exec.execute(true); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// General randomized test.
+func TestLockTableConcurrentRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// TODO(sbhola): different test cases with different settings of the
+	// randomization parameters.
+	txnCounter := uint128.FromInts(0, 0)
+	var timestamps []hlc.Timestamp
+	for i := 0; i < 2; i++ {
+		timestamps = append(timestamps, hlc.Timestamp{WallTime: int64(i + 1)})
+	}
+	var keys []roachpb.Key
+	for i := 0; i < 10; i++ {
+		keys = append(keys, roachpb.Key(string('a'+i)))
+	}
+	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
+	const numActiveTxns = 8
+	var activeTxns [numActiveTxns]*enginepb.TxnMeta
+	var items []workloadItem
+	const numRequests = 5000
+	for i := 0; i < numRequests; i++ {
+		var txnMeta *enginepb.TxnMeta
+		var ts hlc.Timestamp
+		if rng.Intn(10) != 0 {
+			txnIndex := rng.Intn(len(activeTxns))
+			newTxn := rng.Intn(4) != 0 || activeTxns[txnIndex] == nil
+			if newTxn {
+				ts = timestamps[rng.Intn(len(timestamps))]
+				txnMeta = &enginepb.TxnMeta{
+					ID:             nextUUID(&txnCounter),
+					WriteTimestamp: ts,
+				}
+				oldTxn := activeTxns[txnIndex]
+				if oldTxn != nil {
+					items = append(items, workloadItem{finish: oldTxn.ID})
+				}
+				activeTxns[txnIndex] = txnMeta
+			} else {
+				txnMeta = activeTxns[txnIndex]
+				ts = txnMeta.WriteTimestamp
+			}
+		} else {
+			ts = timestamps[rng.Intn(len(timestamps))]
+		}
+		keysPerm := rng.Perm(len(keys))
+		spans := &spanset.SpanSet{}
+		onlyReads := txnMeta == nil
+		numKeys := rng.Intn(len(keys)-1) + 1
+		request := &testRequest{
+			tM: txnMeta,
+			s:  spans,
+			t:  ts,
+		}
+		wi := workloadItem{request: request}
+		for i := 0; i < numKeys; i++ {
+			span := roachpb.Span{Key: keys[keysPerm[i]]}
+			acc := spanset.SpanReadOnly
+			if !onlyReads {
+				acc = spanset.SpanAccess(rng.Intn(int(spanset.NumSpanAccess)))
+				if acc == spanset.SpanReadWrite && rng.Intn(2) == 0 {
+					wi.locksToAcquire = append(wi.locksToAcquire, span.Key)
+				}
+			}
+			spans.AddMVCC(acc, span, ts)
+		}
+		items = append(items, wi)
+	}
+	for i := range activeTxns {
+		if txnMeta := activeTxns[i]; txnMeta != nil {
+			items = append(items, workloadItem{finish: txnMeta.ID})
+		}
+	}
+	concurrency := []int{2, 8, 16, 32}
+	for _, c := range concurrency {
+		t.Run(fmt.Sprintf("concurrency %d", c), func(t *testing.T) {
+			exec := newWorkLoadExecutor(items, c)
+			if err := exec.execute(false); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 // TODO(sbhola):
-// - More datadriven test cases:
+// - More datadriven and randomized test cases:
 //   - both local and global keys
 //   - repeated lock acquisition at same seqnums, different seqnums, epoch changes
 //   - updates with ignored seqs
 //   - error paths
 // - Test with concurrency in lockTable calls.
-//   - general concurrency testing
 //   - test for race in gc'ing lock that has since become non-empty or new
 //     non-empty one has been inserted.
 // - Benchmark.
-// - Randomized test.

--- a/pkg/storage/concurrency/testdata/lock_table
+++ b/pkg/storage/concurrency/testdata/lock_table
@@ -948,3 +948,349 @@ done r=req11
 ----
 global: num=0
 local: num=0
+
+# Tests with non-transactional requests that triggered nil pointer
+# dereference bugs.
+
+request r=req13 txn=txn2 ts=8,12 spans=w@c
+----
+
+scan r=req13
+----
+start-waiting: false
+
+acquire r=req13 k=c durability=u
+----
+global: num=1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+local: num=0
+
+request r=req14 txn=txn1 ts=9,0 spans=w@c
+----
+
+scan r=req14
+----
+start-waiting: true
+
+request r=req15 txn=none ts=10,12 spans=r@c
+----
+
+scan r=req15
+----
+start-waiting: true
+
+release txn=txn2 span=b,d
+----
+global: num=1
+ lock: "c"
+  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+local: num=0
+
+done r=req15
+----
+global: num=1
+ lock: "c"
+  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+local: num=0
+
+request r=req16 txn=none ts=10,12 spans=r@c
+----
+
+scan r=req16
+----
+start-waiting: false
+
+done r=req14
+----
+global: num=0
+local: num=0
+
+done r=req16
+----
+global: num=0
+local: num=0
+
+print
+----
+global: num=0
+local: num=0
+
+# Test with distinguished waiter being a later request from the same
+# transaction that eventually grabs a reservation. Triggered a bug
+# in not replacing the distinguished waiter.
+
+request r=req17 txn=txn1 ts=9,0 spans=w@c+w@d
+----
+
+scan r=req17
+----
+start-waiting: false
+
+acquire r=req17 k=c durability=u
+----
+global: num=1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+local: num=0
+
+acquire r=req17 k=d durability=u
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+local: num=0
+
+done r=req17
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+local: num=0
+
+request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
+----
+
+scan r=req18
+----
+start-waiting: true
+
+request r=req19 txn=txn2 ts=10,0 spans=w@d
+----
+
+scan r=req19
+----
+start-waiting: true
+
+print
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+   queued writers:
+    active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 18
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+   queued writers:
+    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 19
+local: num=0
+
+release txn=txn1 span=c
+----
+global: num=2
+ lock: "c"
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+   queued writers:
+    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 19
+local: num=0
+
+guard-state r=req18
+----
+new: state=waitFor txn=txn1 ts=9
+
+print
+----
+global: num=2
+ lock: "c"
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+   queued writers:
+    active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 19
+local: num=0
+
+release txn=txn1 span=d
+----
+global: num=2
+ lock: "c"
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+local: num=0
+
+scan r=req18
+----
+start-waiting: false
+
+acquire r=req18 k=d durability=u
+----
+global: num=2
+ lock: "c"
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req19
+----
+new: state=doneWaiting
+
+scan r=req19
+----
+start-waiting: false
+
+done r=req18
+----
+global: num=1
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+done r=req19
+----
+global: num=1
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+release txn=txn2 span=d
+----
+global: num=0
+local: num=0
+
+# Reservation can be broken while holding latches because a different
+# lock is released
+
+request r=req20 txn=txn1 ts=10 spans=w@c
+----
+
+scan r=req20
+----
+start-waiting: false
+
+acquire r=req20 k=c durability=u
+----
+global: num=1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+done r=req20
+----
+global: num=1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+request r=req21 txn=txn2 ts=10 spans=w@c+w@d
+----
+
+scan r=req21
+----
+start-waiting: true
+
+request r=req22 txn=txn1 ts=10 spans=w@d
+----
+
+scan r=req22
+----
+start-waiting: false
+
+acquire r=req22 k=d durability=u
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 21, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 21
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+request r=req23 txn=txn3 ts=10 spans=w@d
+----
+
+scan r=req23
+----
+start-waiting: true
+
+release txn=txn1 span=d
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 21, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 21
+ lock: "d"
+  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req23
+----
+new: state=doneWaiting
+
+scan r=req23
+----
+start-waiting: false
+
+# holds latch on d and proceeds to evaluation, but lock on c
+# is released concurrently allowing req21 to break the reservation
+# at d. Note that reservation breaking is not constrained
+# by latches.
+
+release txn=txn1 span=c
+----
+global: num=2
+ lock: "c"
+  res: req: 21, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req21
+----
+new: state=doneWaiting
+
+print
+----
+global: num=2
+ lock: "c"
+  res: req: 21, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  res: req: 21, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 23, txn: 00000000-0000-0000-0000-000000000003
+local: num=0
+
+acquire r=req23 k=d durability=u
+----
+global: num=2
+ lock: "c"
+  res: req: 21, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+   queued writers:
+    active: false req: 21, txn: 00000000-0000-0000-0000-000000000002
+local: num=0
+
+done r=req21
+----
+global: num=1
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+release txn=txn3 span=d
+----
+global: num=0
+local: num=0
+
+print
+----
+global: num=0
+local: num=0


### PR DESCRIPTION
and additional datadriven tests

There are two randomized tests:
- with only non-transactional requests
- with transactional requests. This can result in deadlock
  so the test includes simple cycle detecting and aborting
  of requests.

This includes fixes for bugs found by these tests:
- Two nil pointer deferences for non-transactional requests.
- The distinguished waiter was not being updated correctly
  when a reservation was acquired on a free lock -- this
  could cause a different request from the same transaction
  to be a distinguished waiter which triggered a later
  invariant to be broken and a "bug" error to be returned.
  Found by the randomized test, and there is now a datadriven
  test for it.
- Small design flaw: A reservation held by a request can be broken
  while that request is holding latches and has proceeded
  to evaluation. This is harmless since the request that
  has broken the reservation cannot evaluate yet since it
  is not holding latches, but it tripped up an invariant
  in the lock acquire path which checked that the reservation
  was not held by some other request.
  Found by the randomized test, and there is now a datadriven
  test for it.

Release note: None