### PR TITLE
colexec: fix hash joiner when types of inputs are different

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -169,3 +169,14 @@ SELECT * FROM t44207_0, t44207_1 WHERE t44207_0.c0 IS NULL
 ----
 NULL 0
 NULL 0
+
+# Regression test for the inputs that have comparable but different types.
+statement ok
+CREATE TABLE t44547_0(c0 INT4); CREATE TABLE t44547_1(c0 INT8)
+
+statement ok
+INSERT INTO t44547_0(c0) VALUES(0); INSERT INTO t44547_1(c0) VALUES(0)
+
+query I
+SELECT * FROM t44547_0 NATURAL JOIN t44547_1
+----


### PR DESCRIPTION
Previously, an assumption that two inputs to the hash joiner have
exactly the same types in the equality columns was built in into the
operator. However, this is incorrect - the types have to comparable.
This is now fixed by specifying the types of the probe side explicitly.

Fixes: #44547.

Release note: None (hash joiner was planned only with experimental_on
vectorize setting).