### PR TITLE
sql: add support for temporary sequences

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -406,11 +407,27 @@ func mysqlTableToCockroach(
 		if p != nil {
 			params := p.RunParams(ctx)
 			desc, err = sql.MakeSequenceTableDesc(
-				seqName, opts, parentID, id, time, priv, &params,
+				seqName,
+				opts,
+				parentID,
+				keys.PublicSchemaID,
+				id,
+				time,
+				priv,
+				false, /* temporary */
+				&params,
 			)
 		} else {
 			desc, err = sql.MakeSequenceTableDesc(
-				seqName, opts, parentID, id, time, priv, nil, /* params */
+				seqName,
+				opts,
+				parentID,
+				keys.PublicSchemaID,
+				id,
+				time,
+				priv,
+				false, /* temporary */
+				nil,   /* params */
 			)
 		}
 		if err != nil {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -239,9 +240,11 @@ func readPostgresCreateTable(
 					name,
 					seq.Options,
 					parentID,
+					keys.PublicSchemaID,
 					id,
 					hlc.Timestamp{WallTime: walltime},
 					sqlbase.NewDefaultPrivilegeDescriptor(),
+					false, /* temporary */
 					&params,
 				)
 				if err != nil {

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -51,7 +52,15 @@ func descForTable(
 		ts := hlc.Timestamp{WallTime: nanos}
 		priv := sqlbase.NewDefaultPrivilegeDescriptor()
 		desc, err := sql.MakeSequenceTableDesc(
-			name, tree.SequenceOptions{}, parent, id-1, ts, priv, nil, /* params */
+			name,
+			tree.SequenceOptions{},
+			parent,
+			keys.PublicSchemaID,
+			id-1,
+			ts,
+			priv,
+			false, /* temporary */
+			nil,   /* params */
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -124,7 +124,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 			if seqName != nil {
-				if err := doCreateSequence(params, n.n.String(), seqDbDesc, seqName, seqOpts); err != nil {
+				if err := doCreateSequence(
+					params,
+					n.n.String(),
+					seqDbDesc,
+					n.tableDesc.GetParentSchemaID(),
+					seqName,
+					n.tableDesc.Temporary,
+					seqOpts,
+				); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1532,7 +1532,15 @@ func makeTableDesc(
 			return ret, err
 		}
 		if seqName != nil {
-			if err := doCreateSequence(params, n.String(), seqDbDesc, seqName, seqOpts); err != nil {
+			if err := doCreateSequence(
+				params,
+				n.String(),
+				seqDbDesc,
+				parentSchemaID,
+				seqName,
+				temporary,
+				seqOpts,
+			); err != nil {
 				return ret, err
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -142,3 +142,60 @@ DROP VIEW view_on_temp; DROP VIEW view_on_permanent; DROP VIEW upgrade_temp_view
 
 statement ok
 DROP TABLE permanent_table; DROP TABLE temp_table
+
+# Tests for temporary sequences working as expected.
+subtest temp_sequences
+
+statement ok
+CREATE TEMP SEQUENCE temp_seq; CREATE TABLE a (a int DEFAULT nextval('temp_seq'))
+
+statement ok
+INSERT INTO a VALUES (default), (default), (100)
+
+query I
+SELECT * FROM a ORDER BY a
+----
+1
+2
+100
+
+# Permanent tables can reference temporary schemas.
+statement ok
+CREATE TABLE perm_table(a int DEFAULT nextval('pg_temp.temp_seq'))
+
+statement ok
+INSERT INTO perm_table VALUES (default), (default), (101)
+
+query I
+SELECT * FROM perm_table ORDER BY a
+----
+3
+4
+101
+
+statement ok
+ALTER TABLE a ALTER COLUMN a DROP DEFAULT
+
+statement error cannot drop sequence temp_seq because other objects depend on it
+DROP SEQUENCE pg_temp.temp_seq
+
+# Allow temporary tables to use serial for temporary schemas.
+statement ok
+SET experimental_serial_normalization='sql_sequence'
+
+statement ok
+CREATE TEMP TABLE ref_temp_table (a SERIAL)
+
+query I
+SELECT nextval('pg_temp.ref_temp_table_a_seq')
+----
+1
+
+statement ok
+DROP TABLE perm_table; DROP TABLE ref_temp_table
+
+statement ok
+DROP SEQUENCE pg_temp.temp_seq; DROP SEQUENCE pg_temp.ref_temp_table_a_seq; DROP TABLE a
+
+statement ok
+SET experimental_serial_normalization='rowid'

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -141,7 +141,7 @@ func (p *planner) processSerialInColumnDef(
 		seqType = "virtual "
 		seqOpts = virtualSequenceOpts
 	}
-	log.VEventf(ctx, 2, "new column %q of %q will have %ssequence name %q and default %q",
+	log.VEventf(ctx, 2, "new column %q of %q will have %s sequence name %q and default %q",
 		d, tableName, seqType, seqName, defaultExpr)
 
 	newSpec.DefaultExpr.Expr = defaultExpr

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -78,7 +78,11 @@ func ShowCreateView(
 	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE VIEW ")
+	f.WriteString("CREATE ")
+	if desc.Temporary {
+		f.WriteString("TEMP ")
+	}
+	f.WriteString("VIEW ")
 	f.FormatNode(tn)
 	f.WriteString(" (")
 	for i := range desc.Columns {
@@ -195,7 +199,11 @@ func ShowCreateSequence(
 	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE SEQUENCE ")
+	f.WriteString("CREATE ")
+	if desc.Temporary {
+		f.WriteString("TEMP ")
+	}
+	f.WriteString("SEQUENCE ")
 	f.FormatNode(tn)
 	opts := desc.SequenceOpts
 	f.Printf(" MINVALUE %d", opts.MinValue)

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -35,6 +35,10 @@ var (
 	// has been created.
 	CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")
 
+	// CreateTempSequenceCounter is to be incremented every time a TEMP SEQUENCE
+	// has been created.
+	CreateTempSequenceCounter = telemetry.GetCounterOnce("sql.schema.create_temp_sequence")
+
 	// CreateTempViewCounter is to be incremented every time a TEMP VIEW
 	// has been created.
 	CreateTempViewCounter = telemetry.GetCounterOnce("sql.schema.create_temp_view")

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -12,6 +12,7 @@ package sql_test
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,8 +41,13 @@ func TestCleanupSchemaObjects(t *testing.T) {
 
 	_, err = conn.ExecContext(ctx, `
 SET experimental_enable_temp_tables=true;
-CREATE TEMP TABLE a (a int);
+SET experimental_serial_normalization='sql_sequence';
+CREATE TEMP TABLE a (a SERIAL, c INT);
+ALTER TABLE a ADD COLUMN b SERIAL;
+CREATE TEMP SEQUENCE a_sequence;
 CREATE TEMP VIEW a_view AS SELECT a FROM a;
+CREATE TABLE perm_table (a int DEFAULT nextval('a_sequence'), b int);
+INSERT INTO perm_table VALUES (DEFAULT, 1);
 `)
 	require.NoError(t, err)
 
@@ -61,16 +68,24 @@ CREATE TEMP VIEW a_view AS SELECT a FROM a;
 		}
 	}
 
-	require.Contains(t, namesToID, "a")
-	require.Contains(t, namesToID, "a_view")
 	require.NotEqual(t, "", schemaName)
 
-	// Check tables are accessible.
-	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a", schemaName))
-	require.NoError(t, err)
-
-	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a_view", schemaName))
-	require.NoError(t, err)
+	tempNames := []string{
+		"a",
+		"a_view",
+		"a_sequence",
+		"a_a_seq",
+		"a_b_seq",
+	}
+	selectableTempNames := []string{"a", "a_view"}
+	for _, name := range append(tempNames, schemaName) {
+		require.Contains(t, namesToID, name)
+	}
+	for _, name := range selectableTempNames {
+		// Check tables are accessible.
+		_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", schemaName, name))
+		require.NoError(t, err)
+	}
 
 	require.NoError(
 		t,
@@ -93,12 +108,22 @@ CREATE TEMP VIEW a_view AS SELECT a FROM a;
 		}),
 	)
 
-	// Ensure all the entries for the given temporary structures are gone.
-	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a", schemaName))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf(`relation "%s.a" does not exist`, schemaName))
+	for _, name := range selectableTempNames {
+		// Ensure all the entries for the given temporary structures are gone.
+		_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", schemaName, name))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf(`relation "%s.%s" does not exist`, schemaName, name))
+	}
 
-	_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.a_view", schemaName))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf(`relation "%s.a_view" does not exist`, schemaName))
+	// Check perm_table performs correctly, and has the right schema.
+	_, err = db.Query("SELECT * FROM perm_table")
+	require.NoError(t, err)
+
+	var colDefault gosql.NullString
+	err = db.QueryRow(
+		`SELECT column_default FROM information_schema.columns
+		WHERE table_name = 'perm_table' and column_name = 'a'`,
+	).Scan(&colDefault)
+	require.NoError(t, err)
+	assert.False(t, colDefault.Valid)
 }


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44642.

This PR adds support for creating temporary sequences:
* Modified create_sequence.go to re-use the same logic for checking
whether the schema exists.
* Modified other callers (implicit sequence creators) to create
temporary sequences if required.
* Modified schema cleanup to take care of sequences, adding on the
necessary dirty work to clean up any permanent tables requiring access
to the temporary schema.

Release note (sql change): If temporary table creation is enabled, users
now have the ability to create temporary sequences as well.