### PR TITLE
sqlbase: make AllocateIDs not give ExtraColumns to pk encoded secondary indexes

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1307,7 +1307,7 @@ func (desc *MutableTableDescriptor) allocateIndexIDs(columnNames map[string]Colu
 			}
 		}
 
-		if index != &desc.PrimaryIndex {
+		if index != &desc.PrimaryIndex && index.EncodingType == SecondaryIndexEncoding {
 			indexHasOldStoredColumns := index.HasOldStoredColumns()
 			// Need to clear ExtraColumnIDs and StoreColumnIDs because they are used
 			// by ContainsColumnID.

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -61,6 +61,11 @@ func TestAllocateIDs(t *testing.T) {
 		Indexes: []IndexDescriptor{
 			makeIndexDescriptor("d", []string{"b", "a"}),
 			makeIndexDescriptor("e", []string{"b"}),
+			func() IndexDescriptor {
+				idx := makeIndexDescriptor("f", []string{"c"})
+				idx.EncodingType = PrimaryIndexEncoding
+				return idx
+			}(),
 		},
 		Privileges:    NewDefaultPrivilegeDescriptor(),
 		FormatVersion: FamilyFormatVersion,
@@ -99,11 +104,14 @@ func TestAllocateIDs(t *testing.T) {
 			{ID: 3, Name: "e", ColumnIDs: []ColumnID{2}, ColumnNames: []string{"b"},
 				ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 				ExtraColumnIDs:   []ColumnID{1}},
+			{ID: 4, Name: "f", ColumnIDs: []ColumnID{3}, ColumnNames: []string{"c"},
+				ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				EncodingType:     PrimaryIndexEncoding},
 		},
 		Privileges:     NewDefaultPrivilegeDescriptor(),
 		NextColumnID:   4,
 		NextFamilyID:   1,
-		NextIndexID:    4,
+		NextIndexID:    5,
 		NextMutationID: 1,
 		FormatVersion:  FamilyFormatVersion,
 	})


### PR DESCRIPTION
This PR makes AllocateIDs aware that some secondary indexes are encoded
using the primary key encoding, and therefore shouldn't have extra
columns etc.

Release note: None