### PR TITLE
sql: disable primary changes on a table created in the same transaction

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -328,6 +328,11 @@ func (n *alterTableNode) startExec(params runParams) error {
 					"session variable experimental_enable_primary_key_changes is set to false, cannot perform primary key change")
 			}
 
+			if n.tableDesc.IsNewTable() {
+				return pgerror.Newf(pgcode.FeatureNotSupported,
+					"cannot create table and change it's primary key in the same transaction")
+			}
+
 			// Ensure that there is not another primary key change attempted within this transaction.
 			currentMutationID := n.tableDesc.ClusterVersion.NextMutationID
 			for i := range n.tableDesc.Mutations {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -419,3 +419,16 @@ query IIIIT
 SELECT * FROM t@i5
 ----
 1 2 3 4 {}
+
+# Regression test for #44782
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t44782 (x INT PRIMARY KEY, y INT NOT NULL)
+
+statement error pq: cannot create table and change it's primary key in the same transaction
+ALTER TABLE t44782 ALTER PRIMARY KEY USING COLUMNS (y)
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Fixes #44782.

Release note (sql change): This commit disallows changing the primary
key of the table in the same transaction as the create table statement.