### PR TITLE
sql: add slow query log

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -41,6 +41,7 @@
 <tr><td><code>sql.distsql.max_running_flows</code></td><td>integer</td><td><code>500</code></td><td>maximum number of concurrent flows that can be run on a node</td></tr>
 <tr><td><code>sql.distsql.temp_storage.joins</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql joins. Note that disabling this can have negative impact on memory usage and performance.</td></tr>
 <tr><td><code>sql.distsql.temp_storage.sorts</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql sorts. Note that disabling this can have negative impact on memory usage and performance.</td></tr>
+<tr><td><code>sql.log.slow_query.latency_threshold</code></td><td>duration</td><td><code>0s</code></td><td>when set to non-zero, log statements whose service latency exceeds the threshold to a secondary logger on each node</td></tr>
 <tr><td><code>sql.metrics.statement_details.dump_to_logs</code></td><td>boolean</td><td><code>false</code></td><td>dump collected statement statistics to node logs when periodically cleared</td></tr>
 <tr><td><code>sql.metrics.statement_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-statement query statistics</td></tr>
 <tr><td><code>sql.metrics.statement_details.plan_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>periodically save a logical plan for each fingerprint</td></tr>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -758,6 +758,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			true /*enableGc*/, true /*forceSyncWrites*/, true, /* enableMsgCount */
 		),
 
+		SlowQueryLogger: log.NewSecondaryLogger(
+			loggerCtx, nil, "sql-slow",
+			true /*enableGc*/, false /*forceSyncWrites*/, true, /* enableMsgCount */
+		),
+
 		QueryCache:                 querycache.New(s.cfg.SQLQueryCacheSize),
 		ProtectedTimestampProvider: s.protectedtsProvider,
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -548,6 +548,7 @@ type ExecutorConfig struct {
 	StatsRefresher    *stats.Refresher
 	ExecLogger        *log.SecondaryLogger
 	AuditLogger       *log.SecondaryLogger
+	SlowQueryLogger   *log.SecondaryLogger
 	InternalExecutor  *InternalExecutor
 	QueryCache        *querycache.C
 


### PR DESCRIPTION
This commit adds an optional slow query log, which logs every SQL query
that the current node was the gateway for that took longer than a
duration. The duration is configurable via the
sql.log.slow_query.latency_threshold cluster setting. The slow query log
entries will be written to a new log file with the prefix sql-slow.

Slow query logs are a standard way of exposing slow queries to the
user. See for example Postgres's version of this,
log_min_duration_statement. This setting causes all queries that exceed
the duration to be logged. In Postgres, the queries are logged to the
main query file, but in MySQL, the queries are logged to a special slow
query file. Since our logs are often hard to read, having a separate
file just for slow queries is better for usability.

Release note (general change): add a slow query log facility to
CockroachDB, configurable by setting the
sql.log.slow_query.latency_threshold cluster setting.