### PR TITLE
release-19.2: colexec: disallow planning CASE operators with unknown WHEN type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1069,3 +1069,11 @@ CREATE TABLE t44304(c0 INT); INSERT INTO t44304 VALUES (0)
 query I
 SELECT * FROM t44304 WHERE CASE WHEN t44304.c0 > 0 THEN NULL END
 ----
+
+# Regression test for 44726 (unknown WHEN expression type).
+statement ok
+CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0)
+
+query I
+SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_user(), '')) THEN 0 ELSE t44726.c0 END)
+----


### PR DESCRIPTION
Backport 1/1 commits from #44756.

/cc @cockroachdb/release

---

Release note (bug fix): When vectorize=experimental_on, CASE operators with an
unknown WHEN type fall back to row execution.

Fixes #44726 
