### PR TITLE
sql: refactor system.namespace calls to use indexes where available

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -676,7 +676,7 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	fullDir := sanitizedFullDir + "moarSecretsHere"
 
 	backupDatabaseID := sqlutils.QueryDatabaseID(t, conn, "data")
-	backupTableID := sqlutils.QueryTableID(t, conn, "data", "bank")
+	backupTableID := sqlutils.QueryTableID(t, conn, "data", "public", "bank")
 
 	sqlDB.Exec(t, `CREATE DATABASE restoredb`)
 	restoreDatabaseID := sqlutils.QueryDatabaseID(t, conn, "restoredb")
@@ -775,7 +775,7 @@ func checkInProgressBackupRestore(
 
 	sqlDB.Exec(t, `CREATE DATABASE restoredb`)
 
-	backupTableID := sqlutils.QueryTableID(t, conn, "data", "bank")
+	backupTableID := sqlutils.QueryTableID(t, conn, "data", "public", "bank")
 
 	do := func(query string, check inProgressChecker) {
 		jobDone := make(chan error)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -804,7 +804,7 @@ func fetchDescVersionModificationTime(
 		Key:    tblKey,
 		EndKey: tblKey.PrefixEnd(),
 	}
-	dropColTblID := sqlutils.QueryTableID(t, db, `d`, tableName)
+	dropColTblID := sqlutils.QueryTableID(t, db, `d`, "public", tableName)
 	req := &roachpb.ExportRequest{
 		RequestHeader: header,
 		MVCCFilter:    roachpb.MVCCFilter_All,

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -53,7 +53,7 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 	partialZoneOverride.GC = &zonepb.GCPolicy{TTLSeconds: 42}
 
 	dbID := sqlutils.QueryDatabaseID(t, db, "d")
-	tableID := sqlutils.QueryTableID(t, db, "d", "t")
+	tableID := sqlutils.QueryTableID(t, db, "d", "public", "t")
 
 	defaultRow := sqlutils.ZoneRow{
 		ID:     keys.RootNamespaceID,

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -155,7 +155,7 @@ func TestAmbiguousCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		tableID := sqlutils.QueryTableID(t, sqlDB, "test", "t")
+		tableID := sqlutils.QueryTableID(t, sqlDB, "test", "public", "t")
 		tableStartKey.Store(keys.MakeTablePrefix(tableID))
 
 		// Wait for new table to split & replication.

--- a/pkg/sql/zone_test.go
+++ b/pkg/sql/zone_test.go
@@ -66,7 +66,7 @@ func TestValidSetShowZones(t *testing.T) {
 	}
 
 	dbID := sqlutils.QueryDatabaseID(t, db, "d")
-	tableID := sqlutils.QueryTableID(t, db, "d", "t")
+	tableID := sqlutils.QueryTableID(t, db, "d", "public", "t")
 
 	dbRow := sqlutils.ZoneRow{
 		ID:     dbID,
@@ -246,7 +246,7 @@ func TestZoneInheritField(t *testing.T) {
 	}
 
 	newReplicationFactor := 10
-	tableID := sqlutils.QueryTableID(t, db, "d", "t")
+	tableID := sqlutils.QueryTableID(t, db, "d", "public", "t")
 	newDefCfg := s.(*server.TestServer).Cfg.DefaultZoneConfig
 	newDefCfg.NumReplicas = proto.Int32(int32(newReplicationFactor))
 


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44230.

Refactoring all system.namespace calls such that they always use indexes
when querying data if it previously used indexes before.

I left `crdb_internal.lookup_namespace_id` as functional as it was
before in that it does not lookup anything that isn't a public schema
or database. This is because the admin UI only looks up tables into the
public schema.

Release note: None

