### PR TITLE
colexec: make hashing of integers of different widths the same

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -742,7 +742,12 @@ func (c floatCustomizer) getBinOpAssignFunc() assignFunc {
 
 func (c intCustomizer) getHashAssignFunc() assignFunc {
 	return func(op overload, target, v, _ string) string {
-		return fmt.Sprintf("%[1]s = memhash%[3]d(noescape(unsafe.Pointer(&%[2]s)), %[1]s)", target, v, c.width)
+		return fmt.Sprintf(`
+				// In order for integers with different widths but of the same value to
+				// to hash to the same value, we upcast all of them to int64.
+				asInt64 := int64(%[2]s)
+				%[1]s = memhash64(noescape(unsafe.Pointer(&asInt64)), %[1]s)`,
+			target, v)
 	}
 }
 

--- a/pkg/sql/colexec/hash.go
+++ b/pkg/sql/colexec/hash.go
@@ -130,22 +130,6 @@ tail:
 	return uintptr(h)
 }
 
-func memhash16(p unsafe.Pointer, h uintptr) uintptr {
-	return memhash(p, h, 2)
-}
-
-func memhash32(p unsafe.Pointer, seed uintptr) uintptr {
-	h := uint64(seed + 4*hashKey[0])
-	v := uint64(readUnaligned32(p))
-	h ^= v
-	h ^= v << 32
-	h = rotl31(h*m1) * m2
-	h ^= h >> 29
-	h *= m3
-	h ^= h >> 32
-	return uintptr(h)
-}
-
 func memhash64(p unsafe.Pointer, seed uintptr) uintptr {
 	h := uint64(seed + 8*hashKey[0])
 	h ^= uint64(readUnaligned32(p)) | uint64(readUnaligned32(add(p, 4)))<<32

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -170,13 +170,46 @@ SELECT * FROM t44207_0, t44207_1 WHERE t44207_0.c0 IS NULL
 NULL 0
 NULL 0
 
-# Regression test for the inputs that have comparable but different types.
+# Regression test for the inputs that have comparable but different types (see
+# issues #44547 and #44797).
 statement ok
 CREATE TABLE t44547_0(c0 INT4); CREATE TABLE t44547_1(c0 INT8)
 
 statement ok
 INSERT INTO t44547_0(c0) VALUES(0); INSERT INTO t44547_1(c0) VALUES(0)
 
+# Note that integers of different width are still considered equal.
 query I
 SELECT * FROM t44547_0 NATURAL JOIN t44547_1
 ----
+0
+
+statement ok
+CREATE TABLE t44797_0(a FLOAT, b DECIMAL); CREATE TABLE t44797_1(c INT2, d INT4)
+
+statement ok
+INSERT INTO t44797_0 VALUES (1.0, 1.0), (2.0, 2.0); INSERT INTO t44797_1 VALUES (1, 1), (2, 2)
+
+# Note that mixed-type comparisons - of what appears to be "same" values - do
+# not consider those values equal.
+query RRII
+SELECT * FROM t44797_0 NATURAL JOIN t44797_1
+----
+1  1.0  2  2
+1  1.0  1  1
+2  2.0  2  2
+2  2.0  1  1
+
+statement ok
+CREATE TABLE t44797_2(a FLOAT); CREATE TABLE t44797_3(b DECIMAL)
+
+statement ok
+INSERT INTO t44797_2 VALUES (1.0), (2.0); INSERT INTO t44797_3 VALUES (1.0), (2.0)
+
+query RR
+SELECT * FROM t44797_2 NATURAL JOIN t44797_3
+----
+1  2.0
+1  1.0
+2  2.0
+2  1.0


### PR DESCRIPTION
Previously we had custom hash functions for int16, int32, and int64.
This led to hash joiner not being able to correctly find matching
tuples when the types of the inputs were comparable but different. Now
this is fixed by upcasting all integers to int64 and using that value to
compute the hash.

Note that we don't need to concern ourselves with having types from
different families to hash in the same way, so only integers' hashing
function is changed.

Fixes: #44797.

Release note: None