### PR TITLE
colexec: remove bounds check elimination for Bytes type

### DIFF
--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -311,6 +311,8 @@ func (t T) AppendVal(target, v string) string {
 }
 
 // Len is a function that should only be used in templates.
+// WARNING: combination of Slice and Len might not work correctly for Bytes
+// type.
 func (t T) Len(target string) string {
 	if t == Bytes {
 		return fmt.Sprintf("%s.Len()", target)

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -138,10 +138,15 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	} else {
+		// {{if not (eq .LTyp.String "Bytes")}}
+		// {{/* Slice is a noop for Bytes type, so colLen below might contain an
+		// incorrect value. In order to keep bounds check elimination for all other
+		// types, we simply omit this code snippet for Bytes. */}}
 		col1 = execgen.SLICE(col1, 0, int(n))
 		colLen := execgen.LEN(col1)
 		_ = _RET_UNSAFEGET(projCol, colLen-1)
 		_ = _R_UNSAFEGET(col2, colLen-1)
+		// {{end}}
 		for execgen.RANGE(i, col1, 0, int(n)) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -141,9 +141,14 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 	} else {
 		batch.SetSelection(true)
 		sel := batch.Selection()
+		// {{if not (eq .LTyp.String "Bytes")}}
+		// {{/* Slice is a noop for Bytes type, so col1Len below might contain an
+		// incorrect value. In order to keep bounds check elimination for all other
+		// types, we simply omit this code snippet for Bytes. */}}
 		col1 = execgen.SLICE(col1, 0, int(n))
 		col1Len := execgen.LEN(col1)
 		col2 = _R_SLICE(col2, 0, col1Len)
+		// {{end}}
 		for execgen.RANGE(i, col1, 0, int(n)) {
 			var cmp bool
 			arg1 := execgen.UNSAFEGET(col1, i)

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1101,3 +1101,12 @@ CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0)
 query I
 SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_user(), '')) THEN 0 ELSE t44726.c0 END)
 ----
+
+# Regression test for wrongly performing bounds check elimination on flat bytes
+# which might lead to a crash.
+statement ok
+CREATE TABLE t44822(c0 BYTES); CREATE VIEW v0(c0) AS SELECT min(t44822.c0) FROM t44822
+
+query T
+SELECT * FROM v0 WHERE v0.c0 NOT BETWEEN v0.c0 AND v0.c0
+----


### PR DESCRIPTION
Slice method is a noop for flat bytes, so the combination of Slice + Len
for bytes might return incorrect result. Bounds check elimination code
relies on that combo, and we will be omitting BCE code snippet for bytes
now (previously it could lead to a crash).

Fixes: #44822.

Release note: None