### PR TITLE
jobs: check GCMutations when checking for orphaned jobs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -444,7 +444,9 @@ func (r *Registry) isOrphaned(ctx context.Context, payload *jobspb.Payload) (boo
 			if err != nil {
 				return err
 			}
-			pendingMutations = len(td.GetMutations()) != 0
+			hasAnyMutations := len(td.GetMutations()) != 0 || len(td.GetGCMutations()) != 0
+			hasDropJob := td.DropJobID != 0
+			pendingMutations = hasAnyMutations || hasDropJob
 			return nil
 		}); err != nil {
 			return false, err


### PR DESCRIPTION
We periodically GC jobs from the jobs table, this includes collecting
orphaned running jobs. However, jobs could still be referenced by a
GCMutation or the job that drops the table (and therefore not be
orphaned).

Release note (bug fix): Fix a bug where drop index jobs waiting for GC
TTL might be erroneously deleted early. Usually a DROP INDEX job would
appear as "waiting for GC TTL" to indicate that the data is still on
disk, however this bug would may cause this job to be deleted before the
data was actually removed from disk.