### PR TITLE
backupccl: extend decryption parameter support to SHOW BACKUP

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,3 +1,3 @@
 show_backup_stmt ::=
-	'SHOW' 'BACKUP' location
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location
+	'SHOW' 'BACKUP' location opt_with_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location opt_with_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -465,8 +465,8 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUP' string_or_placeholder
-	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder
+	'SHOW' 'BACKUP' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1052,7 +1052,7 @@ func readEncryptionOptions(
 ) (*EncryptionInfo, error) {
 	r, err := src.ReadFile(ctx, "encryption-info")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not find or read encryption information")
 	}
 	defer r.Close()
 	encInfoBytes, err := ioutil.ReadAll(r)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1330,9 +1330,11 @@ func TestParse(t *testing.T) {
 		{`BACKUP TABLE foo.foo, baz.baz TO 'bar'`},
 
 		{`SHOW BACKUP 'bar'`},
+		{`SHOW BACKUP 'bar' WITH foo = 'bar'`},
 		{`EXPLAIN SHOW BACKUP 'bar'`},
 		{`SHOW BACKUP RANGES 'bar'`},
 		{`SHOW BACKUP FILES 'bar'`},
+		{`SHOW BACKUP FILES 'bar' WITH foo = 'bar'`},
 
 		{`BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
 		{`BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3453,35 +3453,39 @@ show_histogram_stmt:
 // %Text: SHOW BACKUP [SCHEMAS|FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
-  SHOW BACKUP string_or_placeholder
+  SHOW BACKUP string_or_placeholder opt_with_options
   {
     $$.val = &tree.ShowBackup{
       Details: tree.BackupDefaultDetails,
       Path:    $3.expr(),
+      Options: $4.kvOptions(),
     }
   }
-| SHOW BACKUP SCHEMAS string_or_placeholder
+| SHOW BACKUP SCHEMAS string_or_placeholder opt_with_options
   {
     $$.val = &tree.ShowBackup{
       Details: tree.BackupDefaultDetails,
       ShouldIncludeSchemas: true,
       Path:    $4.expr(),
+      Options: $5.kvOptions(),
     }
   }
-| SHOW BACKUP RANGES string_or_placeholder
+| SHOW BACKUP RANGES string_or_placeholder opt_with_options
   {
     /* SKIP DOC */
     $$.val = &tree.ShowBackup{
       Details: tree.BackupRangeDetails,
       Path:    $4.expr(),
+      Options: $5.kvOptions(),
     }
   }
-| SHOW BACKUP FILES string_or_placeholder
+| SHOW BACKUP FILES string_or_placeholder opt_with_options
   {
     /* SKIP DOC */
     $$.val = &tree.ShowBackup{
       Details: tree.BackupFileDetails,
       Path:    $4.expr(),
+      Options: $5.kvOptions(),
     }
   }
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
@@ -5975,7 +5979,7 @@ select_no_parens:
   {
     $$.val = &tree.Select{Select: $1.selectStmt(), OrderBy: $2.orderBy()}
   }
-| select_clause opt_sort_clause for_locking_clause opt_select_limit 
+| select_clause opt_sort_clause for_locking_clause opt_select_limit
   {
     $$.val = &tree.Select{Select: $1.selectStmt(), OrderBy: $2.orderBy(), Limit: $4.limit(), Locking: $3.lockingClause()}
   }
@@ -5991,7 +5995,7 @@ select_no_parens:
   {
     $$.val = &tree.Select{With: $1.with(), Select: $2.selectStmt(), OrderBy: $3.orderBy()}
   }
-| with_clause select_clause opt_sort_clause for_locking_clause opt_select_limit 
+| with_clause select_clause opt_sort_clause for_locking_clause opt_select_limit
   {
     $$.val = &tree.Select{With: $1.with(), Select: $2.selectStmt(), OrderBy: $3.orderBy(), Limit: $5.limit(), Locking: $4.lockingClause()}
   }

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -86,6 +86,7 @@ type ShowBackup struct {
 	Path                 Expr
 	Details              BackupDetails
 	ShouldIncludeSchemas bool
+	Options              KVOptions
 }
 
 // Format implements the NodeFormatter interface.
@@ -100,6 +101,10 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.FormatNode(node.Path)
+	if len(node.Options) > 0 {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
+	}
 }
 
 // ShowColumns represents a SHOW COLUMNS statement.


### PR DESCRIPTION
Since this required syntax changes it wasn't included in first PR, but is
essentially just extending that change so that the same encryption_passphrase
parameter also applies to SHOW BACKUP.

Release note: none.