### PR TITLE
opt: prepare to support multi-argument aggregate functions

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -636,8 +636,8 @@ scalar-group-by
  │              ├── variable: s_quantity [type=int]
  │              └── const: 15 [type=int]
  └── aggregations
-      └── count [type=int, outer=(11)]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int, outer=(11)]
+           └── count [type=int]
                 └── variable: s_i_id [type=int]
 
 stats table=stock_level_02_scan_3

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
@@ -127,8 +127,8 @@ sort
       │    └── filters
       │         └── p_partkey = ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── aggregations
-           └── count [type=int, outer=(2)]
-                └── agg-distinct [type=int]
+           └── agg-distinct [type=int, outer=(2)]
+                └── count [type=int]
                      └── variable: ps_suppkey [type=int]
 
 stats table=q16_sort_1

--- a/pkg/sql/opt/norm/rules/agg.opt
+++ b/pkg/sql/opt/norm/rules/agg.opt
@@ -6,8 +6,8 @@
 # EliminateAggDistinct removes AggDistinct for aggregations where DISTINCT
 # never modifies the result; for example: min(DISTINCT x).
 [EliminateAggDistinct, Normalize]
-(Min | Max | BoolAnd | BoolOr
-    (AggDistinct $in:*)
+(AggDistinct
+    $input:(Min | Max | BoolAnd | BoolOr)
 )
 =>
-((OpName) $in)
+$input

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -25,7 +25,7 @@
 (DistinctOn
     $input:*
     $aggs:*
-    $groupingPrivate:* & (ColsAreKey (GroupingCols $groupingPrivate) $input)
+    $groupingPrivate:* & (ColsAreStrictKey (GroupingCols $groupingPrivate) $input)
 )
 =>
 (Project
@@ -74,14 +74,39 @@
 # it is known that the aggregation argument is unique within each group.
 [EliminateAggDistinctForKeys, Normalize]
 (GroupBy | ScalarGroupBy
-    $input:*
-    $aggregations:*
-    $groupingPrivate:* & (CanRemoveAggDistinctForKeys $aggregations $groupingPrivate $input)
+    $input:* & (HasStrictKey $input)
+    $aggregations:
+    [
+        ...
+        $item:(AggregationsItem (AggDistinct $agg:*))
+        ...
+    ]
+    $groupingPrivate:* & (CanRemoveAggDistinctForKeys $input $groupingPrivate $agg)
 )
 =>
 ((OpName)
     $input
-    (RemoveAggDistinctForKeys $aggregations $groupingPrivate $input)
+    (ReplaceAggregationsItem $aggregations $item $agg)
+    $groupingPrivate
+)
+
+# EliminateAggFilteredDistinctForKeys is similar to EliminateAggDistinctForKeys,
+# except that it works when an AggFilter operator is also present.
+[EliminateAggFilteredDistinctForKeys, Normalize]
+(GroupBy | ScalarGroupBy
+    $input:* & (HasStrictKey $input)
+    $aggregations:
+    [
+        ...
+        $item:(AggregationsItem (AggFilter (AggDistinct $agg:*) $filter:*))
+        ...
+    ]
+    $groupingPrivate:* & (CanRemoveAggDistinctForKeys $input $groupingPrivate $agg)
+)
+=>
+((OpName)
+    $input
+    (ReplaceAggregationsItem $aggregations $item (AggFilter $agg $filter))
     $groupingPrivate
 )
 

--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -30,11 +30,53 @@ scalar-group-by
       └── bool-or [type=bool, outer=(9)]
            └── variable: column9 [type=bool]
 
+# The rule should still work when FILTER is present.
+norm expect=EliminateAggDistinct
+SELECT
+    min(DISTINCT i) FILTER (WHERE i > 5),
+    max(DISTINCT i) FILTER (WHERE i > 5),
+    bool_and(DISTINCT i>f) FILTER (WHERE f > 0.0),
+    bool_or(DISTINCT i>f) FILTER (WHERE f > 1.0)
+FROM a
+----
+scalar-group-by
+ ├── columns: min:8(int) max:9(int) bool_and:12(bool) bool_or:14(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(8,9,12,14)
+ ├── project
+ │    ├── columns: column7:7(bool) column10:10(bool) column11:11(bool) column13:13(bool) i:2(int)
+ │    ├── fd: (2)-->(7)
+ │    ├── scan a
+ │    │    └── columns: i:2(int) f:3(float)
+ │    └── projections
+ │         ├── i > 5 [type=bool, outer=(2)]
+ │         ├── i > f [type=bool, outer=(2,3)]
+ │         ├── f > 0.0 [type=bool, outer=(3)]
+ │         └── f > 1.0 [type=bool, outer=(3)]
+ └── aggregations
+      ├── agg-filter [type=int, outer=(2,7)]
+      │    ├── min [type=int]
+      │    │    └── variable: i [type=int]
+      │    └── variable: column7 [type=bool]
+      ├── agg-filter [type=int, outer=(2,7)]
+      │    ├── max [type=int]
+      │    │    └── variable: i [type=int]
+      │    └── variable: column7 [type=bool]
+      ├── agg-filter [type=bool, outer=(10,11)]
+      │    ├── bool-and [type=bool]
+      │    │    └── variable: column10 [type=bool]
+      │    └── variable: column11 [type=bool]
+      └── agg-filter [type=bool, outer=(10,13)]
+           ├── bool-or [type=bool]
+           │    └── variable: column10 [type=bool]
+           └── variable: column13 [type=bool]
+
 # The rule should not apply to these aggregations.
 norm expect-not=EliminateAggDistinct
 SELECT
     count(DISTINCT i),
-    sum(DISTINCT i),
+    sum(DISTINCT i) FILTER (WHERE i > 5),
     sum_int(DISTINCT i),
     avg(DISTINCT i),
     stddev(DISTINCT f),
@@ -45,41 +87,45 @@ SELECT
 FROM a
 ----
 scalar-group-by
- ├── columns: count:7(int) sum:8(decimal) sum_int:9(int) avg:10(decimal) stddev:11(float) variance:12(float) xor_agg:14(bytes) array_agg:15(int[]) json_agg:16(jsonb)
+ ├── columns: count:7(int) sum:9(decimal) sum_int:10(int) avg:11(decimal) stddev:12(float) variance:13(float) xor_agg:15(bytes) array_agg:16(int[]) json_agg:17(jsonb)
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(7-12,14-16)
+ ├── fd: ()-->(7,9-13,15-17)
  ├── project
- │    ├── columns: column13:13(bytes) i:2(int) f:3(float) j:5(jsonb)
+ │    ├── columns: column8:8(bool) column14:14(bytes) i:2(int) f:3(float) j:5(jsonb)
+ │    ├── fd: (2)-->(8)
  │    ├── scan a
  │    │    └── columns: i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    └── projections
+ │         ├── i > 5 [type=bool, outer=(2)]
  │         └── s::BYTES [type=bytes, outer=(4)]
  └── aggregations
-      ├── count [type=int, outer=(2)]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=int, outer=(2)]
+      │    └── count [type=int]
       │         └── variable: i [type=int]
-      ├── sum [type=decimal, outer=(2)]
-      │    └── agg-distinct [type=int]
+      ├── agg-filter [type=decimal, outer=(2,8)]
+      │    ├── agg-distinct [type=decimal]
+      │    │    └── sum [type=decimal]
+      │    │         └── variable: i [type=int]
+      │    └── variable: column8 [type=bool]
+      ├── agg-distinct [type=int, outer=(2)]
+      │    └── sum-int [type=int]
       │         └── variable: i [type=int]
-      ├── sum-int [type=int, outer=(2)]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal, outer=(2)]
+      │    └── avg [type=decimal]
       │         └── variable: i [type=int]
-      ├── avg [type=decimal, outer=(2)]
-      │    └── agg-distinct [type=int]
-      │         └── variable: i [type=int]
-      ├── std-dev [type=float, outer=(3)]
-      │    └── agg-distinct [type=float]
+      ├── agg-distinct [type=float, outer=(3)]
+      │    └── std-dev [type=float]
       │         └── variable: f [type=float]
-      ├── variance [type=float, outer=(3)]
-      │    └── agg-distinct [type=float]
+      ├── agg-distinct [type=float, outer=(3)]
+      │    └── variance [type=float]
       │         └── variable: f [type=float]
-      ├── xor-agg [type=bytes, outer=(13)]
-      │    └── agg-distinct [type=bytes]
-      │         └── variable: column13 [type=bytes]
-      ├── array-agg [type=int[], outer=(2)]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=bytes, outer=(14)]
+      │    └── xor-agg [type=bytes]
+      │         └── variable: column14 [type=bytes]
+      ├── agg-distinct [type=int[], outer=(2)]
+      │    └── array-agg [type=int[]]
       │         └── variable: i [type=int]
-      └── json-agg [type=jsonb, outer=(5)]
-           └── agg-distinct [type=jsonb]
+      └── agg-distinct [type=jsonb, outer=(5)]
+           └── json-agg [type=jsonb]
                 └── variable: j [type=jsonb]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1702,8 +1702,8 @@ group-by
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── aggregations
- │    │         ├── count [type=int, outer=(9)]
- │    │         │    └── agg-distinct [type=int]
+ │    │         ├── agg-distinct [type=int, outer=(9)]
+ │    │         │    └── count [type=int]
  │    │         │         └── variable: v [type=int]
  │    │         ├── const-agg [type=int, outer=(2)]
  │    │         │    └── variable: i [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -318,8 +318,8 @@ group-by
  │    ├── scan xy
  │    └── filters (true)
  └── aggregations
-      ├── sum [type=decimal, outer=(2)]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal, outer=(2)]
+      │    └── sum [type=decimal]
       │         └── variable: i [type=int]
       ├── const-agg [type=float, outer=(3)]
       │    └── variable: f [type=float]
@@ -422,8 +422,8 @@ scalar-group-by
  └── aggregations
       ├── sum [type=decimal, outer=(1)]
       │    └── variable: k [type=int]
-      └── sum [type=decimal, outer=(2)]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=decimal, outer=(2)]
+           └── sum [type=decimal]
                 └── variable: i [type=int]
 
 norm expect=EliminateAggDistinctForKeys
@@ -481,8 +481,8 @@ project
       ├── scan abc
       │    └── columns: a:1(int!null) b:2(int!null)
       └── aggregations
-           └── sum [type=decimal, outer=(1)]
-                └── agg-distinct [type=int]
+           └── agg-distinct [type=decimal, outer=(1)]
+                └── sum [type=decimal]
                      └── variable: a [type=int]
 
 # GroupBy with composite key formed by argument plus grouping columns.
@@ -545,9 +545,224 @@ project
            │    └── variable: u [type=int]
            ├── std-dev [type=decimal, outer=(3)]
            │    └── variable: w [type=int]
-           └── avg [type=decimal, outer=(4)]
-                └── agg-distinct [type=int]
+           └── agg-distinct [type=decimal, outer=(4)]
+                └── avg [type=decimal]
                      └── variable: z [type=int]
+
+# --------------------------------------------------
+# EliminateAggFilteredDistinctForKeys
+# --------------------------------------------------
+
+# ScalarGroupBy with key argument. Only the first aggregation can be
+# simplified.
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT sum(DISTINCT k) FILTER (WHERE k > 0), sum(DISTINCT i) FILTER (WHERE i > 0) FROM a
+----
+scalar-group-by
+ ├── columns: sum:7(decimal) sum:9(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,9)
+ ├── project
+ │    ├── columns: column6:6(bool!null) column8:8(bool!null) k:1(int!null) i:2(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,6), (2)-->(8)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int!null)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── projections
+ │         ├── k > 0 [type=bool, outer=(1)]
+ │         └── i > 0 [type=bool, outer=(2)]
+ └── aggregations
+      ├── agg-filter [type=decimal, outer=(1,6)]
+      │    ├── sum [type=decimal]
+      │    │    └── variable: k [type=int]
+      │    └── variable: column6 [type=bool]
+      └── agg-filter [type=decimal, outer=(2,8)]
+           ├── agg-distinct [type=decimal]
+           │    └── sum [type=decimal]
+           │         └── variable: i [type=int]
+           └── variable: column8 [type=bool]
+
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT string_agg(DISTINCT s, ',') FILTER (WHERE s > 'a') FROM s
+----
+scalar-group-by
+ ├── columns: string_agg:4(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── project
+ │    ├── columns: column2:2(string!null) column3:3(bool!null) s:1(string!null)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    ├── scan s
+ │    │    ├── columns: s:1(string!null)
+ │    │    └── key: (1)
+ │    └── projections
+ │         ├── const: ',' [type=string]
+ │         └── s > 'a' [type=bool, outer=(1)]
+ └── aggregations
+      └── agg-filter [type=string, outer=(1,3)]
+           ├── string-agg [type=string]
+           │    ├── variable: s [type=string]
+           │    └── const: ',' [type=string]
+           └── variable: column3 [type=bool]
+
+# GroupBy with key argument.
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT sum(DISTINCT k) FILTER (WHERE f > 0) FROM a GROUP BY i
+----
+project
+ ├── columns: sum:7(decimal)
+ └── group-by
+      ├── columns: i:2(int!null) sum:7(decimal)
+      ├── grouping columns: i:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(7)
+      ├── project
+      │    ├── columns: column6:6(bool) k:1(int!null) i:2(int!null)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,6)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+      │    └── projections
+      │         └── f > 0.0 [type=bool, outer=(3)]
+      └── aggregations
+           └── agg-filter [type=decimal, outer=(1,6)]
+                ├── sum [type=decimal]
+                │    └── variable: k [type=int]
+                └── variable: column6 [type=bool]
+
+# GroupBy with no key.
+norm expect-not=EliminateAggFilteredDistinctForKeys
+SELECT sum(DISTINCT a) FILTER (WHERE c > 0) FROM abc GROUP BY b
+----
+project
+ ├── columns: sum:5(decimal)
+ └── group-by
+      ├── columns: b:2(int!null) sum:5(decimal)
+      ├── grouping columns: b:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(5)
+      ├── project
+      │    ├── columns: column4:4(bool!null) a:1(int!null) b:2(int!null)
+      │    ├── scan abc
+      │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    └── key: (1-3)
+      │    └── projections
+      │         └── c > 0 [type=bool, outer=(3)]
+      └── aggregations
+           └── agg-filter [type=decimal, outer=(1,4)]
+                ├── agg-distinct [type=decimal]
+                │    └── sum [type=decimal]
+                │         └── variable: a [type=int]
+                └── variable: column4 [type=bool]
+
+# GroupBy with composite key formed by argument plus grouping columns.
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT sum(DISTINCT a) FILTER (WHERE c > 0) FROM abc GROUP BY b, c
+----
+project
+ ├── columns: sum:5(decimal)
+ └── group-by
+      ├── columns: b:2(int!null) c:3(int!null) sum:5(decimal)
+      ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── key: (2,3)
+      ├── fd: (2,3)-->(5)
+      ├── project
+      │    ├── columns: column4:4(bool!null) a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── key: (1-3)
+      │    ├── fd: (3)-->(4)
+      │    ├── scan abc
+      │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    └── key: (1-3)
+      │    └── projections
+      │         └── c > 0 [type=bool, outer=(3)]
+      └── aggregations
+           └── agg-filter [type=decimal, outer=(1,4)]
+                ├── sum [type=decimal]
+                │    └── variable: a [type=int]
+                └── variable: column4 [type=bool]
+
+# GroupBy with multiple aggregations simplified.
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT sum(DISTINCT i) FILTER (WHERE f > 0), avg(DISTINCT f) FILTER (WHERE i > 0) FROM a GROUP BY k
+----
+project
+ ├── columns: sum:7(decimal) avg:9(float)
+ └── group-by
+      ├── columns: k:1(int!null) sum:7(decimal) avg:9(float)
+      ├── grouping columns: k:1(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(7,9)
+      ├── project
+      │    ├── columns: column6:6(bool) column8:8(bool!null) k:1(int!null) i:2(int!null) f:3(float)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3,6), (2,3)~~>(1), (2)-->(8)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+      │    └── projections
+      │         ├── f > 0.0 [type=bool, outer=(3)]
+      │         └── i > 0 [type=bool, outer=(2)]
+      └── aggregations
+           ├── agg-filter [type=decimal, outer=(2,6)]
+           │    ├── sum [type=decimal]
+           │    │    └── variable: i [type=int]
+           │    └── variable: column6 [type=bool]
+           └── agg-filter [type=float, outer=(3,8)]
+                ├── avg [type=float]
+                │    └── variable: f [type=float]
+                └── variable: column8 [type=bool]
+
+# GroupBy where only some aggregations are simplified (the table has
+# keys u,v and v,w).
+norm expect=EliminateAggFilteredDistinctForKeys
+SELECT
+    sum(DISTINCT u) FILTER (WHERE u > 0),
+    stddev(DISTINCT w) FILTER (WHERE w > 0),
+    avg(DISTINCT z) FILTER (WHERE z > 0)
+FROM uvwz
+GROUP BY v
+----
+project
+ ├── columns: sum:7(decimal) stddev:9(decimal) avg:11(decimal)
+ └── group-by
+      ├── columns: v:2(int!null) sum:7(decimal) stddev:9(decimal) avg:11(decimal)
+      ├── grouping columns: v:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(7,9,11)
+      ├── project
+      │    ├── columns: column6:6(bool!null) column8:8(bool!null) column10:10(bool!null) u:1(int!null) v:2(int!null) w:3(int!null) z:4(int!null)
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4), (1)-->(6), (3)-->(8), (4)-->(10)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1(int!null) v:2(int!null) w:3(int!null) z:4(int!null)
+      │    │    ├── key: (2,3)
+      │    │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    └── projections
+      │         ├── u > 0 [type=bool, outer=(1)]
+      │         ├── w > 0 [type=bool, outer=(3)]
+      │         └── z > 0 [type=bool, outer=(4)]
+      └── aggregations
+           ├── agg-filter [type=decimal, outer=(1,6)]
+           │    ├── sum [type=decimal]
+           │    │    └── variable: u [type=int]
+           │    └── variable: column6 [type=bool]
+           ├── agg-filter [type=decimal, outer=(3,8)]
+           │    ├── std-dev [type=decimal]
+           │    │    └── variable: w [type=int]
+           │    └── variable: column8 [type=bool]
+           └── agg-filter [type=decimal, outer=(4,10)]
+                ├── agg-distinct [type=decimal]
+                │    └── avg [type=decimal]
+                │         └── variable: z [type=int]
+                └── variable: column10 [type=bool]
 
 # --------------------------------------------------
 # EliminateDistinctOnNoColumns

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -275,8 +275,8 @@ project
       │    │    │         └── y IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
       │    │    └── filters (true)
       │    └── aggregations
-      │         └── sum [type=decimal, outer=(6)]
-      │              └── agg-distinct [type=int]
+      │         └── agg-distinct [type=decimal, outer=(6)]
+      │              └── sum [type=decimal]
       │                   └── variable: y [type=int]
       └── filters
            └── sum = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
@@ -385,8 +385,8 @@ project
       │    │    │         └── y IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── sum [type=decimal, outer=(6)]
-      │         │    └── agg-distinct [type=int]
+      │         ├── agg-distinct [type=decimal, outer=(6)]
+      │         │    └── sum [type=decimal]
       │         │         └── variable: y [type=int]
       │         └── max [type=int, outer=(6)]
       │              └── variable: y [type=int]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -826,7 +826,7 @@ define StringAgg {
 
     # Sep is the constant expression which separates the input strings.
     # Note that it must always be a constant expression.
-    Sep   ScalarExpr
+    Sep ScalarExpr
 }
 
 # ConstAgg is used in the special case when the value of a column is known to be
@@ -872,18 +872,17 @@ define FirstAgg {
     Input ScalarExpr
 }
 
-# AggDistinct is used as a modifier that wraps the input of an aggregate
-# function. It causes the respective aggregation to only process each distinct
-# value once.
+# AggDistinct is used as a modifier that wraps an aggregate function. It causes
+# the respective aggregation to only process each distinct value once.
 [Scalar]
 define AggDistinct {
     Input ScalarExpr
 }
 
-# AggFilter is used as a modifier that wraps the input of an aggregate
-# function. It causes only rows for which the filter expression is true
-# to be processed. AggFilter should always occur on top of AggDistinct
-# if they are both present.
+# AggFilter is used as a modifier that wraps an aggregate function (or an
+# AggDistinct operator that wraps an aggregate function). It causes only rows
+# for which the filter expression is true to be processed. AggFilter should
+# always occur on top of AggDistinct if they are both present.
 [Scalar]
 define AggFilter {
     Input  ScalarExpr
@@ -994,8 +993,9 @@ define Lag {
 define Lead {
     Value  ScalarExpr
     Offset ScalarExpr
+
     # Def is the default value.
-    Def    ScalarExpr
+    Def ScalarExpr
 }
 
 # FirstValue returns Value evaluated at the first row in the row's frame.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -802,11 +802,11 @@ scalar-group-by
  │    └── scan kv
  │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  └── aggregations
-      ├── count [type=int]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=int]
+      │    └── count [type=int]
       │         └── variable: k [type=int]
-      └── count [type=int]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int]
+           └── count [type=int]
                 └── variable: v [type=int]
 
 build
@@ -823,11 +823,11 @@ group-by
  │         └── function: upper [type=string]
  │              └── variable: s [type=string]
  └── aggregations
-      ├── count [type=int]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=int]
+      │    └── count [type=int]
       │         └── variable: k [type=int]
-      └── count [type=int]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int]
+           └── count [type=int]
                 └── variable: v [type=int]
 
 build
@@ -861,8 +861,8 @@ scalar-group-by
  │              ├── variable: k [type=int]
  │              └── variable: v [type=int]
  └── aggregations
-      └── count [type=int]
-           └── agg-distinct [type=tuple{int, int}]
+      └── agg-distinct [type=int]
+           └── count [type=int]
                 └── variable: column5 [type=tuple{int, int}]
 
 build
@@ -879,8 +879,8 @@ scalar-group-by
  │              ├── variable: k [type=int]
  │              └── variable: v [type=int]
  └── aggregations
-      └── count [type=int]
-           └── agg-distinct [type=tuple{int, int}]
+      └── agg-distinct [type=int]
+           └── count [type=int]
                 └── variable: column5 [type=tuple{int, int}]
 
 build
@@ -1172,17 +1172,17 @@ scalar-group-by
  │    └── scan kv
  │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  └── aggregations
-      ├── avg [type=decimal]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal]
+      │    └── avg [type=decimal]
       │         └── variable: k [type=int]
-      ├── avg [type=decimal]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal]
+      │    └── avg [type=decimal]
       │         └── variable: v [type=int]
-      ├── sum [type=decimal]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal]
+      │    └── sum [type=decimal]
       │         └── variable: k [type=int]
-      └── sum [type=decimal]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=decimal]
+           └── sum [type=decimal]
                 └── variable: v [type=int]
 
 build
@@ -2565,8 +2565,8 @@ scalar-group-by
  │    └── scan abc
  │         └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
-      └── sum [type=decimal]
-           └── agg-distinct [type=decimal]
+      └── agg-distinct [type=decimal]
+           └── sum [type=decimal]
                 └── variable: d [type=decimal]
 
 # FILTER.
@@ -2585,11 +2585,10 @@ scalar-group-by
  │              ├── variable: d [type=decimal]
  │              └── const: 0 [type=decimal]
  └── aggregations
-      └── sum [type=decimal]
-           └── agg-filter [type=decimal]
-                ├── variable: d [type=decimal]
-                └── filter
-                     └── variable: column5 [type=bool]
+      └── agg-filter [type=decimal]
+           ├── sum [type=decimal]
+           │    └── variable: d [type=decimal]
+           └── variable: column5 [type=bool]
 
 # Ensure aggregates with FILTER coexist properly with non-FILTER aggregates.
 build
@@ -2610,20 +2609,18 @@ scalar-group-by
  │              ├── variable: y [type=int]
  │              └── const: 0 [type=int]
  └── aggregations
-      ├── sum [type=decimal]
-      │    └── agg-filter [type=int]
-      │         ├── variable: x [type=int]
-      │         └── filter
-      │              └── variable: column4 [type=bool]
-      ├── avg [type=float]
-      │    └── agg-distinct [type=float]
+      ├── agg-filter [type=decimal]
+      │    ├── sum [type=decimal]
+      │    │    └── variable: x [type=int]
+      │    └── variable: column4 [type=bool]
+      ├── agg-distinct [type=float]
+      │    └── avg [type=float]
       │         └── variable: z [type=float]
-      └── avg [type=float]
-           └── agg-filter [type=float]
-                ├── agg-distinct [type=float]
-                │    └── variable: z [type=float]
-                └── filter
-                     └── variable: column4 [type=bool]
+      └── agg-filter [type=float]
+           ├── agg-distinct [type=float]
+           │    └── avg [type=float]
+           │         └── variable: z [type=float]
+           └── variable: column4 [type=bool]
 
 # Ensure aggregates involving FILTER are deduplicated.
 build
@@ -2645,15 +2642,14 @@ scalar-group-by
  │              ├── variable: y [type=int]
  │              └── const: 0 [type=int]
  └── aggregations
-      ├── avg [type=decimal]
-      │    └── agg-distinct [type=int]
+      ├── agg-distinct [type=decimal]
+      │    └── avg [type=decimal]
       │         └── variable: x [type=int]
-      └── avg [type=decimal]
-           └── agg-filter [type=int]
-                ├── agg-distinct [type=int]
-                │    └── variable: x [type=int]
-                └── filter
-                     └── variable: column5 [type=bool]
+      └── agg-filter [type=decimal]
+           ├── agg-distinct [type=decimal]
+           │    └── avg [type=decimal]
+           │         └── variable: x [type=int]
+           └── variable: column5 [type=bool]
 
 build
 SELECT
@@ -2674,12 +2670,11 @@ scalar-group-by
  │              ├── variable: y [type=int]
  │              └── const: 0 [type=int]
  └── aggregations
-      └── string-agg [type=string]
-           ├── agg-filter [type=string]
+      └── agg-filter [type=string]
+           ├── string-agg [type=string]
            │    ├── variable: column4 [type=string]
-           │    └── filter
-           │         └── variable: column6 [type=bool]
-           └── const: 'foo' [type=string]
+           │    └── const: 'foo' [type=string]
+           └── variable: column6 [type=bool]
 
 build
 SELECT y, count(*) FILTER (WHERE x > 5) FROM xyz GROUP BY y
@@ -2697,11 +2692,10 @@ group-by
  │              ├── variable: x [type=int]
  │              └── const: 5 [type=int]
  └── aggregations
-      └── count [type=int]
-           └── agg-filter [type=bool]
-                ├── variable: column4 [type=bool]
-                └── filter
-                     └── variable: column5 [type=bool]
+      └── agg-filter [type=int]
+           ├── count [type=int]
+           │    └── variable: column4 [type=bool]
+           └── variable: column5 [type=bool]
 
 build
 SELECT y, count(*) FILTER (WHERE count(*) > 5) FROM xyz GROUP BY y
@@ -2920,10 +2914,10 @@ scalar-group-by
  │    └── projections
  │         └── const: 'separator' [type=string]
  └── aggregations
-      └── string-agg [type=string]
-           ├── agg-distinct [type=string]
-           │    └── variable: s [type=string]
-           └── const: 'separator' [type=string]
+      └── agg-distinct [type=string]
+           └── string-agg [type=string]
+                ├── variable: s [type=string]
+                └── const: 'separator' [type=string]
 
 build
 SELECT max(s), string_agg(s, 'sep1'), string_agg(s, 'sep2'), min(s) FROM kv
@@ -2984,7 +2978,7 @@ scalar-group-by
            └── null [type=unknown]
 
 build
-SELECT string_agg('foo', s) FROM kv
+SELECT string_agg(s, s) FROM kv
 ----
 error (0A000): unimplemented: aggregate functions with multiple non-constant expressions are not supported
 

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -269,9 +269,7 @@ func (b *Builder) buildAggregationAsWindow(
 	// so that we can group functions over the same partition and ordering.
 	frames := make([]memo.WindowExpr, 0, len(g.aggs))
 	for i, agg := range g.aggs {
-		// Using this instead of constructAggregate so we can have non-constant second
-		// arguments for string_agg.
-		fn := b.constructWindowFn(agg.def.Name, argLists[i])
+		fn := b.constructAggregate(agg.def.Name, argLists[i])
 		if filterCols[i] != 0 {
 			fn = b.factory.ConstructAggFilter(
 				fn,
@@ -338,7 +336,7 @@ func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
 	return argExprs
 }
 
-// buildWindowArgs builds the argExprs into a memo.ScalarListExpr.
+// buildWindowArgs builds the argExprs into a slice of memo.ScalarListExpr.
 func (b *Builder) buildWindowArgs(
 	argExprs []tree.TypedExpr, windowIndex int, funcName string, inScope, outScope *scope,
 ) memo.ScalarListExpr {

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -3,12 +3,13 @@
 # =============================================================================
 
 
-# ReplaceScalarMinWithLimit replaces a min with a limit 1. This rule may result
-# in a lower cost plan if the column min(x) is applied to is indexed.
-[ReplaceScalarMinWithLimit, Explore]
+# ReplaceScalarMinMaxWithLimit replaces a min or max group by aggregation with a
+# limit 1 on an ordered set. This rule may result in a lower cost plan if the
+# aggregated column (e.g. the "x" in min(x)) is indexed.
+[ReplaceScalarMinMaxWithLimit, Explore]
 (ScalarGroupBy
     $input:*
-    [ (AggregationsItem (Min $variable:(Variable $col:*)) $aggPrivate:*) ]
+    [ (AggregationsItem $agg:(Min | Max $variable:(Variable $col:*)) $aggPrivate:*) ]
     $groupingPrivate:* & (IsCanonicalGroupBy $groupingPrivate)
 )
 =>
@@ -19,30 +20,7 @@
             [ (FiltersItem (IsNot $variable (Null (AnyType)))) ]
         )
         (Const 1)
-        (MakeOrderingChoiceFromColumn Min $col)
-    )
-    [ (AggregationsItem (ConstAgg $variable) $aggPrivate) ]
-    $groupingPrivate
-)
-
-# ReplaceScalarMaxWithLimit is analogous to the ReplaceScalarMinWithLimit rule.
-# Due to limitations with OpName in exploration rules, the rule had to be
-# duplicated with minor modifications (we replace occurrences of Min with Max).
-[ReplaceScalarMaxWithLimit, Explore]
-(ScalarGroupBy
-    $input:*
-    [ (AggregationsItem (Max $variable:(Variable $col:*)) $aggPrivate:*) ]
-    $groupingPrivate:* & (IsCanonicalGroupBy $groupingPrivate)
-)
-=>
-(ScalarGroupBy
-    (Limit
-        (Select
-            $input
-            [ (FiltersItem (IsNot $variable (Null (AnyType)))) ]
-        )
-        (Const 1)
-        (MakeOrderingChoiceFromColumn Max $col)
+        (MakeOrderingChoiceFromColumn (OpName $agg) $col)
     )
     [ (AggregationsItem (ConstAgg $variable) $aggPrivate) ]
     $groupingPrivate

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1735,8 +1735,8 @@ scalar-group-by
  │              ├── variable: s_quantity [type=int]
  │              └── const: 15 [type=int]
  └── aggregations
-      └── count [type=int, outer=(11)]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int, outer=(11)]
+           └── count [type=int]
                 └── variable: s_i_id [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -1737,8 +1737,8 @@ scalar-group-by
  │              ├── variable: s_quantity [type=int]
  │              └── const: 15 [type=int]
  └── aggregations
-      └── count [type=int, outer=(11)]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int, outer=(11)]
+           └── count [type=int]
                 └── variable: s_i_id [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -1731,8 +1731,8 @@ scalar-group-by
  │              ├── variable: s_quantity [type=int]
  │              └── const: 15 [type=int]
  └── aggregations
-      └── count [type=int, outer=(11)]
-           └── agg-distinct [type=int]
+      └── agg-distinct [type=int, outer=(11)]
+           └── count [type=int]
                 └── variable: s_i_id [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1747,8 +1747,8 @@ sort
       │    └── filters
       │         └── p_partkey = ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── aggregations
-           └── count [type=int, outer=(2)]
-                └── agg-distinct [type=int]
+           └── agg-distinct [type=int, outer=(2)]
+                └── count [type=int]
                      └── variable: ps_suppkey [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1716,8 +1716,8 @@ sort
       │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10), constraints=(/10: (/NULL - ])]
       │         └── p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
       └── aggregations
-           └── count [type=int, outer=(2)]
-                └── agg-distinct [type=int]
+           └── agg-distinct [type=int, outer=(2)]
+                └── count [type=int]
                      └── variable: ps_suppkey [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -33,7 +33,7 @@ CREATE TABLE kuvw (
 ----
 
 # --------------------------------------------------
-# ReplaceScalarMinWithLimit
+# ReplaceScalarMinMaxWithLimit (Min variations)
 # --------------------------------------------------
 
 opt
@@ -70,6 +70,30 @@ scalar-group-by
  └── aggregations
       └── const-agg [type=char, outer=(1)]
            └── variable: a [type=char]
+
+# Verify the rule does not fire when FILTER is used.
+opt
+SELECT min(a) FILTER (WHERE a > 'a') FROM abc
+----
+scalar-group-by
+ ├── columns: min:6(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── project
+ │    ├── columns: column5:5(bool!null) a:1(char!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(5)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(char!null)
+ │    │    └── key: (1)
+ │    └── projections
+ │         └── a > 'a' [type=bool, outer=(1)]
+ └── aggregations
+      └── agg-filter [type=char, outer=(1,5)]
+           ├── min [type=char]
+           │    └── variable: a [type=char]
+           └── variable: column5 [type=bool]
 
 opt
 SELECT min(b) FROM abc
@@ -591,7 +615,7 @@ memo (optimized, ~6KB, required=[presentation: max:5])
  └── G13: (null)
 
 # --------------------------------------------------
-# ReplaceScalarMaxWithLimit
+# ReplaceScalarMinMaxWithLimit (Max variations)
 # --------------------------------------------------
 
 opt
@@ -628,6 +652,30 @@ scalar-group-by
  └── aggregations
       └── const-agg [type=char, outer=(1)]
            └── variable: a [type=char]
+
+# Verify the rule does not fire when FILTER is used.
+opt
+SELECT max(a) FILTER (WHERE a > 'a') FROM abc
+----
+scalar-group-by
+ ├── columns: max:6(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── project
+ │    ├── columns: column5:5(bool!null) a:1(char!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(5)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(char!null)
+ │    │    └── key: (1)
+ │    └── projections
+ │         └── a > 'a' [type=bool, outer=(1)]
+ └── aggregations
+      └── agg-filter [type=char, outer=(1,5)]
+           ├── max [type=char]
+           │    └── variable: a [type=char]
+           └── variable: column5 [type=bool]
 
 opt
 SELECT max(b) FROM abc


### PR DESCRIPTION
PR #44628 is attempting to add the corr() aggregate function, which
will be the first true multi-argument aggregate in CRDB (besides
string_agg, which is special-cased). That PR runs into problems
when dealing with aggregate DISTINCT and FILTER clauses. The main
issue is that the optimizer currently adds the AggDistinct and
AggFilter operators as *inputs* to the aggregate function. This
doesn't make sense when there are multiple inputs, since it's now
ambiguous which input to use for that purpose.

This commit flips the situation by wrapping the aggregate function
with AggDistinct and AggFilter rather than having them wrap the
input to the aggregate function:

  (AggFilter (AggDistinct (Sum (Variable 1))))

instead of:

  (Sum (AggFilter (AggDistinct (Variable 1))))

As part of this change, it was also convenient to refactor the
EliminateAggDistinctForKeys rule and also to consolidate the
ReplaceScalarMinWithLimit and ReplaceScalarMaxWithLimit rules
into one rule.

Release note: None