### PR TITLE
sql: add telemetry for CONFIGURE ZONE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -78,6 +78,23 @@ ALTER TABLE a CONFIGURE ZONE USING
   constraints = '[+region=test]',
   lease_preferences = '[[+region=test]]'
 
+# This should reflect in the metrics.
+query T
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.zone_config.table.range_min_bytes',
+  'sql.schema.zone_config.table.range_max_bytes',
+  'sql.schema.zone_config.table.gc.ttlseconds',
+  'sql.schema.zone_config.table.num_replicas',
+  'sql.schema.zone_config.table.constraints'
+) AND usage_count > 0 ORDER BY feature_name
+----
+sql.schema.zone_config.table.constraints
+sql.schema.zone_config.table.gc.ttlseconds
+sql.schema.zone_config.table.num_replicas
+sql.schema.zone_config.table.range_max_bytes
+sql.schema.zone_config.table.range_min_bytes
+
 query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -145,6 +145,12 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 				return nil, pgerror.Newf(pgcode.InvalidParameterValue,
 					"unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
+			telemetry.Inc(
+				sqltelemetry.SchemaSetZoneConfig(
+					n.ZoneSpecifier.TelemetryName(),
+					string(opt.Key),
+				),
+			)
 			if opt.Value == nil {
 				options[opt.Key] = optionValue{inheritValue: true, explicitValue: nil}
 				continue

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -52,6 +52,14 @@ func SchemaChangeDrop(typ string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.drop_" + typ)
 }
 
+// SchemaSetZoneConfig is to be incremented every time a ZoneConfig
+// argument is parsed.
+func SchemaSetZoneConfig(configName, keyChange string) telemetry.Counter {
+	return telemetry.GetCounter(
+		fmt.Sprintf("sql.schema.zone_config.%s.%s", configName, keyChange),
+	)
+}
+
 // SchemaChangeAlter behaves the same as SchemaChangeAlterWithExtra
 // but with no extra metadata.
 func SchemaChangeAlter(typ string) telemetry.Counter {


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/44309

This PR adds telemetry for instances where CONFIGURE ZONE was used. It
is separated into changes to ranges, databases, tables or indexes.

Release note: None