### PR TITLE
release-19.1: opt: minor fix for ExtractJoinEquality rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1086,3 +1086,14 @@ SELECT * FROM (VALUES (1, 2)) a(a1,a2) FULL JOIN (VALUES (3, 4)) b(b1,b2) ON a1=
 ----
 NULL  NULL  3     4
 1     2     NULL  NULL
+
+# Regression test for #44746 (internal error for particular condition).
+statement ok
+CREATE TABLE t44746_0(c0 INT)
+
+statement ok
+CREATE TABLE t44746_1(c1 INT)
+
+# Note: an "error parsing regexp" would also be acceptable here.
+statement ok
+SELECT * FROM t44746_0 FULL JOIN t44746_1 ON (SUBSTRING('', ')') = '') = (c1 > 0)

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -587,6 +587,12 @@ func (c *CustomFuncs) CanExtractJoinEquality(
 		return false
 	}
 
+	if leftProps.OuterCols.Empty() || rightProps.OuterCols.Empty() {
+		// It's possible for one side to have no outer cols and still not be a
+		// ConstValue (see #44746).
+		return false
+	}
+
 	if (leftProps.OuterCols.SubsetOf(leftCols) && rightProps.OuterCols.SubsetOf(rightCols)) ||
 		(leftProps.OuterCols.SubsetOf(rightCols) && rightProps.OuterCols.SubsetOf(leftCols)) {
 		// The equality is of the form:

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2578,3 +2578,24 @@ project
       │    └── filters (true)
       └── filters
            └── x = k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+# Don't extract equalities where one side is an expression with no outer cols
+# (#44746). This is a rare case where we can't constant fold because the
+# function call errors out.
+norm expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL JOIN uv ON (substring('', ')') = '') = (u > 0)
+----
+full-join
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── scan uv
+ │    ├── columns: u:3(int!null) v:4(int)
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters
+      └── (substring('', ')') = '') = (u > 0) [type=bool, outer=(3)]


### PR DESCRIPTION
Backport 1/1 commits from #44788.

/cc @cockroachdb/release

---

The `ExtractJoinEquality` rule does not fire if one of the equality
sides are `ConstValue`. But it is possible for an expression to have
no outer columns without it being a constant value (e.g. because
constant folding failed). In this case the rule gets confused and
incorrectly pushes down a projection to the wrong side.

Fixes #44746.

Release note (bug fix): fixed a "cannot map variable" error in some
rare cases involving joins.

Thanks to @mrigger for finding this bug.
