### PR TITLE
release-2.1: opt: minor fix for ExtractJoinEquality rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1078,3 +1078,14 @@ SELECT * FROM foo JOIN bar ON generate_series(0, 1) < 2
 
 query error aggregate functions are not allowed in ON
 SELECT * FROM foo JOIN bar ON max(foo.c) < 2
+
+# Regression test for #44746 (internal error for particular condition).
+statement ok
+CREATE TABLE t44746_0(c0 INT)
+
+statement ok
+CREATE TABLE t44746_1(c1 INT)
+
+# Note: an "error parsing regexp" would also be acceptable here.
+statement ok
+SELECT * FROM t44746_0 FULL JOIN t44746_1 ON (SUBSTRING('', ')') = '') = (c1 > 0)

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -453,13 +453,15 @@ func (c *CustomFuncs) CanExtractJoinEquality(
 		if c.HasCorrelatedSubquery(a) || c.HasCorrelatedSubquery(b) {
 			return false
 		}
+		// Disallow cases where one side is constant. It's possible for an
+		// expression to have no outer cols and still not be a ConstValue (see
+		// #44746).
+		if c.OuterCols(a).Empty() || c.OuterCols(b).Empty() {
+			return false
+		}
 		aExpr := c.mem.NormExpr(a)
 		bExpr := c.mem.NormExpr(b)
 
-		// Disallow cases where one side is constant.
-		if aExpr.IsConstValue() || bExpr.IsConstValue() {
-			return false
-		}
 		// Disallow simple equality between variables.
 		if aExpr.Operator() == opt.VariableOp && bExpr.Operator() == opt.VariableOp {
 			return false

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2276,3 +2276,24 @@ project
       │    └── true [type=bool]
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            └── x = k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+# Don't extract equalities where one side is an expression with no outer cols
+# (#44746). This is a rare case where we can't constant fold because the
+# function call errors out.
+norm expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL JOIN uv ON (substring('', ')') = '') = (u > 0)
+----
+full-join
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── scan uv
+ │    ├── columns: u:3(int!null) v:4(int)
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters [type=bool, outer=(3)]
+      └── (u > 0) = (substring('', ')') = '') [type=bool, outer=(3)]


### PR DESCRIPTION
Backport 1/1 commits from #44788.

/cc @cockroachdb/release

---

The `ExtractJoinEquality` rule does not fire if one of the equality
sides are `ConstValue`. But it is possible for an expression to have
no outer columns without it being a constant value (e.g. because
constant folding failed). In this case the rule gets confused and
incorrectly pushes down a projection to the wrong side.

Fixes #44746.

Release note (bug fix): fixed a "cannot map variable" error in some
rare cases involving joins.

Thanks to @mrigger for finding this bug.
