### PR TITLE
release-19.2: opt: don't modify withProps.Binding.Stats in-place

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2114,9 +2114,14 @@ func (sb *statisticsBuilder) colStatWithScan(
 	withProps := withScan.BindingProps
 	inColSet := translateColSet(colSet, withScan.OutCols, withScan.InCols)
 
+	// We cannot call colStatLeaf on &withProps.Stats directly because it can
+	// modify it.
+	var statsCopy props.Statistics
+	statsCopy.CopyFrom(&withProps.Stats)
+
 	// TODO(rytaft): This would be more accurate if we could access the WithExpr
 	// itself.
-	inColStat := sb.colStatLeaf(inColSet, &withProps.Stats, &withProps.FuncDeps, withProps.NotNullCols)
+	inColStat := sb.colStatLeaf(inColSet, &statsCopy, &withProps.FuncDeps, withProps.NotNullCols)
 
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = inColStat.DistinctCount

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -468,35 +468,35 @@ GROUP BY q.b
 project
  ├── columns: "?column?":6(int!null)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=0.27]
+ ├── stats: [rows=0.292893219]
  ├── fd: ()-->(6)
  ├── select
  │    ├── columns: b:4(int) bool_or:5(bool!null)
  │    ├── cardinality: [0 - 3]
- │    ├── stats: [rows=0.27, distinct(5)=0.27, null(5)=0]
+ │    ├── stats: [rows=0.292893219, distinct(5)=0.292893219, null(5)=0]
  │    ├── key: (4)
  │    ├── fd: ()-->(5)
  │    ├── group-by
  │    │    ├── columns: b:4(int) bool_or:5(bool)
  │    │    ├── grouping columns: b:4(int)
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── stats: [rows=0.3, distinct(4)=0.3, null(4)=0.03, distinct(5)=0.3, null(5)=0.03]
+ │    │    ├── stats: [rows=1.29289322, distinct(4)=1.29289322, null(4)=1, distinct(5)=1.29289322, null(5)=1]
  │    │    ├── key: (4)
  │    │    ├── fd: (4)-->(5)
  │    │    ├── project
  │    │    │    ├── columns: a:3(bool!null) b:4(int)
  │    │    │    ├── cardinality: [0 - 3]
- │    │    │    ├── stats: [rows=3, distinct(4)=0.3, null(4)=0.03]
+ │    │    │    ├── stats: [rows=1.5, distinct(4)=1.29289322, null(4)=1]
  │    │    │    ├── fd: ()-->(3)
  │    │    │    ├── select
  │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
  │    │    │    │    ├── cardinality: [0 - 3]
- │    │    │    │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
+ │    │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=1.29289322, null(2)=1]
  │    │    │    │    ├── fd: ()-->(1)
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
  │    │    │    │    │    ├── cardinality: [3 - 3]
- │    │    │    │    │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
+ │    │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=2]
  │    │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
  │    │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
  │    │    │    │    │    └── (true, 5) [type=tuple{bool, int}]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1423,7 +1423,7 @@ with &1 (t)
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: x:5(bool)
- │    ├── stats: [rows=4e+20, distinct(5)=3, null(5)=4e+18]
+ │    ├── stats: [rows=4e+20]
  │    ├── left-join (cross)
  │    │    ├── columns: t1.x:1(bool) t2.x:3(bool)
  │    │    ├── stats: [rows=4e+20]

--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -41,7 +41,7 @@ with &1 (foo)
  ├── fd: (4)-->(5,6)
  ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=500, null(2)=50, distinct(3)=500, null(3)=50]
+ │    ├── stats: [rows=5000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── with-scan &1 (foo)
@@ -79,7 +79,7 @@ with &1 (t0)
  │    ├── left columns: column1:1(int) column2:2(oid) column3:13(date) column4:4(string)
  │    ├── right columns: column1:5(int) column2:6(oid) column3:7(date) column4:8(string)
  │    ├── cardinality: [1 - 2]
- │    ├── stats: [rows=2, distinct(10)=0.2, null(10)=0, distinct(9-12)=2, null(9-12)=2]
+ │    ├── stats: [rows=2, distinct(9-12)=2, null(9-12)=2]
  │    ├── key: (9-12)
  │    ├── values
  │    │    ├── columns: column1:1(int!null) column2:2(oid!null) column4:4(string!null) column3:13(date)

--- a/pkg/sql/opt/props/col_stats_map.go
+++ b/pkg/sql/opt/props/col_stats_map.go
@@ -280,3 +280,20 @@ func (m *ColStatsMap) rebuildIndex() {
 		m.addToIndex(m.Get(i).Cols, i)
 	}
 }
+
+// CopyFrom sets this map to a deep copy of another map, which can be modified
+// independently.
+func (m *ColStatsMap) CopyFrom(other *ColStatsMap) {
+	m.initial = other.initial
+	m.other = append([]ColumnStatistic(nil), other.other...)
+	m.count = other.count
+	m.unique = other.unique
+
+	m.index = nil
+	if other.index != nil {
+		m.index = make(map[colStatKey]colStatVal, len(other.index))
+		for k, v := range other.index {
+			m.index[k] = v
+		}
+	}
+}

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -28,6 +28,7 @@ import (
 
 // Histogram captures the distribution of values for a particular column within
 // a relational expression.
+// Histograms are immutable.
 type Histogram struct {
 	evalCtx *tree.EvalContext
 	col     opt.ColumnID
@@ -51,8 +52,8 @@ func (h *Histogram) Init(
 	h.buckets = buckets
 }
 
-// Copy returns a deep copy of the histogram.
-func (h *Histogram) Copy() *Histogram {
+// copy returns a deep copy of the histogram.
+func (h *Histogram) copy() *Histogram {
 	buckets := make([]cat.HistogramBucket, len(h.buckets))
 	copy(buckets, h.buckets)
 	return &Histogram{
@@ -327,7 +328,7 @@ func (h *Histogram) addBucket(bucket *cat.HistogramBucket) {
 // ApplySelectivity reduces the size of each histogram bucket according to
 // the given selectivity, and returns a new histogram with the results.
 func (h *Histogram) ApplySelectivity(selectivity float64) *Histogram {
-	res := h.Copy()
+	res := h.copy()
 	for i := range res.buckets {
 		b := &res.buckets[i]
 

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -78,6 +78,14 @@ func (s *Statistics) Init(relProps *Relational) (zeroCardinality bool) {
 	return false
 }
 
+// CopyFrom copies a Statistics object which can then be modified independently.
+func (s *Statistics) CopyFrom(other *Statistics) {
+	s.Available = other.Available
+	s.RowCount = other.RowCount
+	s.ColStats.CopyFrom(&other.ColStats)
+	s.Selectivity = other.Selectivity
+}
+
 // ApplySelectivity applies a given selectivity to the statistics. RowCount and
 // Selectivity are updated. Note that DistinctCounts and NullCounts are not
 // updated.
@@ -125,9 +133,11 @@ func (s *Statistics) String() string {
 // for every possible subset of columns. In practice, it is only worth
 // maintaining statistics on a few columns and column sets that are frequently
 // used in predicates, group by columns, etc.
+//
+// ColumnStatistiscs can be copied by value.
 type ColumnStatistic struct {
 	// Cols is the set of columns whose data are summarized by this
-	// ColumnStatistic struct.
+	// ColumnStatistic struct. The ColSet is never modified in-place.
 	Cols opt.ColSet
 
 	// DistinctCount is the estimated number of distinct values of this

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -197,7 +197,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -252,7 +252,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -733,7 +733,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
+ │    ├── stats: [rows=6]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -1136,7 +1136,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -200,7 +200,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -255,7 +255,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -736,7 +736,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
+ │    ├── stats: [rows=6]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -1139,7 +1139,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -194,7 +194,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -249,7 +249,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -730,7 +730,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
+ │    ├── stats: [rows=6]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -1133,7 +1133,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)


### PR DESCRIPTION
Backport 1/1 commits from #44872.

/cc @cockroachdb/release

---

The statistics builder for `WithScan` calls `colStatLeaf` on the stats
in the binding props. This function can modify those stats, which is
not allowed and leads to crashes when we are assigning placeholders to
a shared memo.

I modified a query cache test to use a query with multi-use CTE.
Without the fix, this test crashes quickly under `make stress`.

Fixes #44867.

Release note (bug fix): fixed occasional "concurrent map write" crash.
