### PR TITLE
workload: fix ycsb -json

### DIFF
--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -254,7 +254,13 @@ func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 
 	readFieldStmts := make([]*gosql.Stmt, numTableFields)
 	for i := 0; i < numTableFields; i++ {
-		q := fmt.Sprintf(`SELECT field%d FROM usertable WHERE ycsb_key = $1`, i)
+		var q string
+		if g.json {
+			q = fmt.Sprintf(`SELECT field->>'field%d' FROM usertable WHERE ycsb_key = $1`, i)
+		} else {
+			q = fmt.Sprintf(`SELECT field%d FROM usertable WHERE ycsb_key = $1`, i)
+		}
+
 		stmt, err := db.Prepare(q)
 		if err != nil {
 			return workload.QueryLoad{}, err


### PR DESCRIPTION
In #39430 we enhanced our workload ycsb implementation. In the process we broke
the json functionality. This fixes it. If you want tests I'll write them later.

Release note: None