### PR TITLE
server: adopt uber-go/automaxprocs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1626,6 +1626,19 @@
   version = "v0.18.0"
 
 [[projects]]
+  digest = "1:c3999fd8bb523555918d9d6d81da4d0f8e4ae24c6faa2c5d46ffb4bd4cdcd4bc"
+  name = "go.uber.org/automaxprocs"
+  packages = [
+    ".",
+    "internal/cgroups",
+    "internal/runtime",
+    "maxprocs",
+  ]
+  pruneopts = "UT"
+  revision = "e393bb0ea0644204c502247d647e428742196ebe"
+  version = "v1.3.0"
+
+[[projects]]
   branch = "master"
   digest = "1:1a9011794066a02df25f6487bfcb745bd653b543ecec32aac1cb1216cadae1a5"
   name = "golang.org/x/crypto"
@@ -2147,6 +2160,7 @@
     "go.etcd.io/etcd/raft/quorum",
     "go.etcd.io/etcd/raft/raftpb",
     "go.etcd.io/etcd/raft/tracker",
+    "go.uber.org/automaxprocs",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/crypto/pbkdf2",
     "golang.org/x/crypto/ssh",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,6 +91,9 @@ import (
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	// Import automaxproces to set GOMAXPROCS appropriately on linux when
+	// constrained by cgroups.
+	_ "go.uber.org/automaxprocs"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
See https://github.com/cockroachdb/docs/issues/5922

Go programs behave poorly when the GOMAXPROCS variable does not match the
allocated CPU cgroup shares.

Release note (bug fix): On linux, cockroach will now adjust the number of
cores which will be utilized to reflect the available vCPUs allocated by
cgroups. Before this change, cockroach would always consult the number of
vCPUs on the machine which could lead to too large of a threadpool and
bad performance.