### PR TITLE
colexec: add partially ordered distinct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -833,7 +833,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/sort.eg.go \
   pkg/sql/colexec/substring.eg.go \
   pkg/sql/colexec/sum_agg.eg.go \
-  pkg/sql/colexec/tuples_differ.eg.go \
+  pkg/sql/colexec/values_differ.eg.go \
   pkg/sql/colexec/vec_comparators.eg.go \
   pkg/sql/colexec/window_peer_grouper.eg.go
 
@@ -1531,7 +1531,7 @@ pkg/sql/colexec/selection_ops.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
 pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
 pkg/sql/colexec/substring.eg.go: pkg/sql/colexec/substring_tmpl.go
 pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
-pkg/sql/colexec/tuples_differ.eg.go: pkg/sql/colexec/tuples_differ_tmpl.go
+pkg/sql/colexec/values_differ.eg.go: pkg/sql/colexec/values_differ_tmpl.go
 pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go
 pkg/sql/colexec/window_peer_grouper.eg.go: pkg/sql/colexec/window_peer_grouper_tmpl.go
 

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -34,6 +34,6 @@ select_in.eg.go
 sort.eg.go
 substring.eg.go
 sum_agg.eg.go
-tuples_differ.eg.go
+values_differ.eg.go
 vec_comparators.eg.go
 window_peer_grouper.eg.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-func genTuplesDiffer(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/tuples_differ_tmpl.go")
+func genValuesDiffer(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/colexec/values_differ_tmpl.go")
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func genTuplesDiffer(wr io.Writer) error {
 	s = replaceManipulationFuncs(".LTyp", s)
 
 	// Now, generate the op, from the template.
-	tmpl, err := template.New("tuples_differ").Parse(s)
+	tmpl, err := template.New("values_differ").Parse(s)
 	if err != nil {
 		return err
 	}
@@ -47,5 +47,5 @@ func genTuplesDiffer(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genTuplesDiffer, "tuples_differ.eg.go")
+	registerGenerator(genValuesDiffer, "values_differ.eg.go")
 }

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -236,7 +236,7 @@ func (ht *hashTable) build(ctx context.Context, input Operator) {
 	}
 
 	// ht.next is used to store the computed hash value of each key.
-	ht.next = make([]uint64, ht.vals.Length()+1)
+	ht.next = maybeAllocateUint64Array(ht.next, ht.vals.Length()+1)
 	ht.computeBuckets(ctx, ht.next[1:], ht.keyTypes, keyCols, ht.vals.Length(), nil)
 	ht.buildNextChains(ctx)
 }
@@ -246,7 +246,7 @@ func (ht *hashTable) build(ctx context.Context, input Operator) {
 // mode findTupleGroups also populates the ht.same array.
 // NOTE: the hashTable *must* have been already built.
 func (ht *hashTable) findTupleGroups(ctx context.Context) {
-	ht.head = make([]bool, ht.vals.Length()+1)
+	ht.head = maybeAllocateBoolArray(ht.head, ht.vals.Length()+1)
 	ht.maybeAllocateSameAndVisited()
 
 	nKeyCols := len(ht.keyCols)
@@ -342,25 +342,31 @@ func (ht *hashTable) buildNextChains(ctx context.Context) {
 	}
 }
 
-// maybeAllocateSameAndVisited makes sure that same and visited arrays of the
-// hashTable are allocated and of the correct size. If the hashTable is reused,
-// the allocation will occur only if the previous arrays' capacity is not
-// sufficient.
-func (ht *hashTable) maybeAllocateSameAndVisited() {
-	if ht.same == nil || cap(ht.same) < ht.vals.Length()+1 {
-		ht.same = make([]uint64, ht.vals.Length()+1)
-		ht.visited = make([]bool, ht.vals.Length()+1)
-	} else {
-		// We don't need to allocate new arrays, but we'll need to slice them up
-		// and reset.
-		ht.same = ht.same[:ht.vals.Length()+1]
-		ht.visited = ht.visited[:ht.vals.Length()+1]
-		for n := 0; n < len(ht.same); n += copy(ht.same[n:], zeroUint64Column) {
-		}
-		for n := 0; n < len(ht.visited); n += copy(ht.visited[n:], zeroBoolColumn) {
-		}
+// maybeAllocate* methods make sure that the passed in array is allocated and
+// of the desired length.
+func maybeAllocateUint64Array(array []uint64, length int) []uint64 {
+	if array == nil || cap(array) < length {
+		return make([]uint64, length)
 	}
+	array = array[:length]
+	for n := 0; n < length; n += copy(array[n:], zeroUint64Column) {
+	}
+	return array
+}
 
+func maybeAllocateBoolArray(array []bool, length int) []bool {
+	if array == nil || cap(array) < length {
+		return make([]bool, length)
+	}
+	array = array[:length]
+	for n := 0; n < length; n += copy(array[n:], zeroBoolColumn) {
+	}
+	return array
+}
+
+func (ht *hashTable) maybeAllocateSameAndVisited() {
+	ht.same = maybeAllocateUint64Array(ht.same, ht.vals.Length()+1)
+	ht.visited = maybeAllocateBoolArray(ht.visited, ht.vals.Length()+1)
 	// Since keyID = 0 is reserved for end of list, it can be marked as visited
 	// at the beginning.
 	ht.visited[0] = true
@@ -423,15 +429,12 @@ func (ht *hashTable) distinctCheck(probeKeyTypes []coltypes.T, nToCheck uint64, 
 // allocation is needed, and at that time the allocator will update the memory
 // account accordingly.
 func (ht *hashTable) reset() {
-	// TODO(yuzefovich): support resetting with a different numBuckets.
 	for n := 0; n < len(ht.first); n += copy(ht.first[n:], zeroUint64Column) {
-	}
-	for n := 0; n < len(ht.next); n += copy(ht.next[n:], zeroUint64Column) {
-	}
-	for n := 0; n < len(ht.head); n += copy(ht.head[n:], zeroBoolColumn) {
 	}
 	ht.vals.ResetInternalBatch()
 	ht.vals.SetLength(0)
+	// ht.next, ht.same, ht.visited, and ht.head are reset separately before
+	// they are used (these slices are not used in all of the code paths).
 	// ht.buckets doesn't need to be reset because buckets are always initialized
 	// when computing the hash.
 	copy(ht.groupID[:coldata.BatchSize()], zeroUint64Column)

--- a/pkg/sql/colexec/partially_ordered_distinct.go
+++ b/pkg/sql/colexec/partially_ordered_distinct.go
@@ -1,0 +1,244 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/errors"
+)
+
+// TODO(yuzefovich): tune.
+const partiallyOrderedDistinctNumHashBuckets = 1024
+
+// newPartiallyOrderedDistinct creates a distinct operator on the given
+// distinct columns when we have partial ordering on some of the distinct
+// columns.
+func newPartiallyOrderedDistinct(
+	allocator *Allocator,
+	input Operator,
+	distinctCols []uint32,
+	orderedCols []uint32,
+	colTypes []coltypes.T,
+) (Operator, error) {
+	if len(orderedCols) == 0 || len(orderedCols) == len(distinctCols) {
+		return nil, errors.AssertionFailedf(
+			"partially ordered distinct wrongfully planned: numDistinctCols=%d "+
+				"numOrderedCols=%d", len(distinctCols), len(orderedCols))
+	}
+	chunker, err := newChunker(allocator, input, colTypes, orderedCols)
+	if err != nil {
+		return nil, err
+	}
+	chunkerOperator := newChunkerOperator(allocator, chunker, colTypes)
+	// distinctUnorderedCols will contain distinct columns that are not present
+	// among orderedCols. The unordered distinct operator will use these columns
+	// to find distinct tuples within "chunks" of tuples that are the same on the
+	// ordered columns.
+	distinctUnorderedCols := make([]uint32, 0, len(distinctCols)-len(orderedCols))
+	for _, distinctCol := range distinctCols {
+		isOrdered := false
+		for _, orderedCol := range orderedCols {
+			if orderedCol == distinctCol {
+				isOrdered = true
+				break
+			}
+		}
+		if !isOrdered {
+			distinctUnorderedCols = append(distinctUnorderedCols, distinctCol)
+		}
+	}
+	distinct := NewUnorderedDistinct(
+		allocator, chunkerOperator, distinctUnorderedCols, colTypes,
+		partiallyOrderedDistinctNumHashBuckets,
+	)
+	return &partiallyOrderedDistinct{
+		input:    chunkerOperator,
+		distinct: distinct.(resettableOperator),
+	}, nil
+}
+
+// partiallyOrderedDistinct implements DISTINCT operation using a combination
+// of chunkerOperator and unorderedDistinct. It's only job is to check whether
+// the input has been fully processed and, if not, to move to the next chunk
+// (where "chunk" is all tuples that are equal on the ordered columns).
+type partiallyOrderedDistinct struct {
+	input    *chunkerOperator
+	distinct resettableOperator
+}
+
+var _ Operator = &partiallyOrderedDistinct{}
+
+func (p *partiallyOrderedDistinct) ChildCount(bool) int {
+	return 1
+}
+
+func (p *partiallyOrderedDistinct) Child(nth int, _ bool) execinfra.OpNode {
+	if nth == 0 {
+		return p.input
+	}
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
+func (p *partiallyOrderedDistinct) Init() {
+	p.distinct.Init()
+}
+
+func (p *partiallyOrderedDistinct) Next(ctx context.Context) coldata.Batch {
+	for {
+		batch := p.distinct.Next(ctx)
+		if batch.Length() == 0 {
+			if p.input.done() {
+				// We're done, so return a zero-length batch.
+				return coldata.ZeroBatch
+			}
+			// p.distinct will reset p.input.
+			p.distinct.reset()
+		} else {
+			return batch
+		}
+	}
+}
+
+func newChunkerOperator(
+	allocator *Allocator, input *chunker, inputTypes []coltypes.T,
+) *chunkerOperator {
+	return &chunkerOperator{
+		input:         input,
+		inputTypes:    inputTypes,
+		windowedBatch: allocator.NewMemBatchWithSize(inputTypes, 0),
+	}
+}
+
+// chunkerOperator is an adapter from chunker to Operator interface. It outputs
+// all tuples from a single chunk followed by zero-length batches until it is
+// reset.
+// It will have returned all tuples from all of the chunks only when it returns
+// a zero-length *and* done() method returns true (i.e. a zero-length batch
+// indicates the end of a chunk, but when done() returns true, it indicates
+// that the input has been fully processed).
+type chunkerOperator struct {
+	input      *chunker
+	inputTypes []coltypes.T
+	// haveChunksToEmit indicates whether we have spooled input and still there
+	// are more chunks to emit.
+	haveChunksToEmit bool
+	// numTuplesInChunks stores the number of tuples that are currently spooled
+	// by input.
+	numTuplesInChunks int
+	// currentChunkFinished indicates whether we have emitted all tuples from the
+	// current chunk and should be returning a zero-length batch.
+	currentChunkFinished bool
+	// newChunksCol, when non-nil, stores the boundaries of chunks. Every true
+	// value indicates that a new chunk begins at the corresponding index. If
+	// newChunksCol is nil, all spooled tuples belong to the same chunk.
+	newChunksCol []bool
+	// outputTupleStartIdx indicates the index of the first tuple to be included
+	// in the output batch.
+	outputTupleStartIdx int
+	// windowedBatch is the output batch of chunkerOperator. For performance
+	// reasons, the spooled tuples are not copied into it, instead we use a
+	// "window" approach.
+	windowedBatch coldata.Batch
+}
+
+var _ resettableOperator = &chunkerOperator{}
+
+func (c *chunkerOperator) ChildCount(bool) int {
+	return 1
+}
+
+func (c *chunkerOperator) Child(nth int, _ bool) execinfra.OpNode {
+	if nth == 0 {
+		return c.input
+	}
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
+func (c *chunkerOperator) Init() {
+	c.input.init()
+}
+
+func (c *chunkerOperator) Next(ctx context.Context) coldata.Batch {
+	if c.currentChunkFinished {
+		return coldata.ZeroBatch
+	}
+	if !c.haveChunksToEmit {
+		// We don't have any chunks to emit, so we need to spool the input.
+		c.input.spool(ctx)
+		c.haveChunksToEmit = true
+		c.numTuplesInChunks = c.input.getNumTuples()
+		c.newChunksCol = c.input.getPartitionsCol()
+	}
+	outputTupleEndIdx := c.numTuplesInChunks
+	if c.outputTupleStartIdx == outputTupleEndIdx {
+		// Current chunk has been fully output.
+		c.currentChunkFinished = true
+		return coldata.ZeroBatch
+	}
+	if c.newChunksCol == nil {
+		// When newChunksCol is nil, then all tuples that are returned via
+		// getValues are equal on the ordered columns, so we simply emit the next
+		// "window" of those tuples.
+		if outputTupleEndIdx-c.outputTupleStartIdx > coldata.BatchSize() {
+			outputTupleEndIdx = c.outputTupleStartIdx + coldata.BatchSize()
+		}
+	} else {
+		// newChunksCol is non-nil, so there are multiple chunks within the
+		// current tuples. We will emit a single chunk as a separate batch and
+		// then will proceed to emitting zero-length batches until we're reset.
+		outputTupleEndIdx = c.outputTupleStartIdx + 1
+		for outputTupleEndIdx < c.numTuplesInChunks && !c.newChunksCol[outputTupleEndIdx] {
+			outputTupleEndIdx++
+		}
+		c.currentChunkFinished = true
+	}
+	for i, typ := range c.inputTypes {
+		window := c.input.getValues(i).Window(typ, c.outputTupleStartIdx, outputTupleEndIdx)
+		c.windowedBatch.ReplaceCol(window, i)
+	}
+	c.windowedBatch.SetSelection(false)
+	c.windowedBatch.SetLength(outputTupleEndIdx - c.outputTupleStartIdx)
+	c.outputTupleStartIdx = outputTupleEndIdx
+	return c.windowedBatch
+}
+
+func (c *chunkerOperator) done() bool {
+	return c.input.done()
+}
+
+func (c *chunkerOperator) reset() {
+	c.currentChunkFinished = false
+	if c.newChunksCol != nil {
+		if c.outputTupleStartIdx == c.numTuplesInChunks {
+			// We have processed all chunks among the current tuples, so we will need
+			// to get new chunks.
+			c.haveChunksToEmit = false
+		}
+	} else {
+		// We have processed all current tuples (that comprised a single chunk), so
+		// we will need to get new chunks.
+		c.haveChunksToEmit = false
+	}
+	if !c.haveChunksToEmit {
+		c.input.emptyBuffer()
+		c.outputTupleStartIdx = 0
+	}
+}

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -180,6 +180,7 @@ func (p *allSpooler) getWindowedBatch(startIdx, endIdx int) coldata.Batch {
 		window := p.bufferedTuples.ColVec(i).Window(t, startIdx, endIdx)
 		p.windowedBatch.ReplaceCol(window, i)
 	}
+	p.windowedBatch.SetSelection(false)
 	p.windowedBatch.SetLength(endIdx - startIdx)
 	return p.windowedBatch
 }

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -38,7 +38,11 @@ func NewSortChunks(
 				"already ordered on at least one column but not fully ordered; "+
 				"num ordering cols = %d, matchLen = %d", len(orderingCols), matchLen))
 	}
-	chunker, err := newChunker(allocator, input, inputTypes, orderingCols[:matchLen])
+	alreadySortedCols := make([]uint32, matchLen)
+	for i := range alreadySortedCols {
+		alreadySortedCols[i] = orderingCols[i].ColIdx
+	}
+	chunker, err := newChunker(allocator, input, inputTypes, alreadySortedCols)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +63,11 @@ type sortChunksOp struct {
 	windowedBatch      coldata.Batch
 }
 
+var _ Operator = &sortChunksOp{}
+var _ bufferingInMemoryOperator = &sortChunksOp{}
+
 func (c *sortChunksOp) ChildCount(verbose bool) int {
-	return 0
+	return 1
 }
 
 func (c *sortChunksOp) Child(nth int, verbose bool) execinfra.OpNode {
@@ -71,9 +78,6 @@ func (c *sortChunksOp) Child(nth int, verbose bool) execinfra.OpNode {
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
 }
-
-var _ Operator = &sortChunksOp{}
-var _ bufferingInMemoryOperator = &sortChunksOp{}
 
 func (c *sortChunksOp) Init() {
 	c.input.init()
@@ -174,9 +178,9 @@ const (
 	// last read batch directly. Only tuples that are fully contained within the
 	// last read batch are "emitted".
 	chunkerReadFromBatch
-	// inputDone indicates that the input has been fully consumed and there are
-	// no more tuples to read from the chunker.
-	inputDone
+	// chunkerDone indicates that the input has been fully consumed and all
+	// tuples have already been emitted.
+	chunkerDone
 )
 
 // chunker is a spooler that produces chunks from its input when the tuples
@@ -202,7 +206,7 @@ type chunker struct {
 	inputDone bool
 	// alreadySortedCols indicates the columns on which the input is already
 	// ordered.
-	alreadySortedCols []execinfrapb.Ordering_Column
+	alreadySortedCols []uint32
 
 	// batch is the last read batch from input.
 	batch coldata.Batch
@@ -246,15 +250,12 @@ type chunker struct {
 var _ spooler = &chunker{}
 
 func newChunker(
-	allocator *Allocator,
-	input Operator,
-	inputTypes []coltypes.T,
-	alreadySortedCols []execinfrapb.Ordering_Column,
+	allocator *Allocator, input Operator, inputTypes []coltypes.T, alreadySortedCols []uint32,
 ) (*chunker, error) {
 	var err error
 	partitioners := make([]partitioner, len(alreadySortedCols))
 	for i, col := range alreadySortedCols {
-		partitioners[i], err = newPartitioner(inputTypes[col.ColIdx])
+		partitioners[i], err = newPartitioner(inputTypes[col])
 		if err != nil {
 			return nil, err
 		}
@@ -279,7 +280,7 @@ func (s *chunker) init() {
 
 // done indicates whether the chunker has fully consumed its input.
 func (s *chunker) done() bool {
-	return s.readFrom == inputDone
+	return s.readFrom == chunkerDone
 }
 
 // prepareNextChunks prepares the chunks for the chunker spooler.
@@ -312,7 +313,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 			// boundaries of the chunks (stored in s.chunks) to sort further.
 			copy(s.partitionCol, zeroBoolColumn)
 			for i, orderedCol := range s.alreadySortedCols {
-				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol.ColIdx)), s.partitionCol,
+				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol)), s.partitionCol,
 					s.batch.Length())
 			}
 			s.chunks = boolVecToSel64(s.partitionCol, s.chunks[:0])
@@ -339,10 +340,10 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 				i := 0
 				for !differ && i < len(s.alreadySortedCols) {
 					differ = valuesDiffer(
-						s.inputTypes[s.alreadySortedCols[i].ColIdx],
-						s.bufferedTuples.ColVec(int(s.alreadySortedCols[i].ColIdx)),
+						s.inputTypes[s.alreadySortedCols[i]],
+						s.bufferedTuples.ColVec(int(s.alreadySortedCols[i])),
 						0, /*aValueIdx */
-						s.batch.ColVec(int(s.alreadySortedCols[i].ColIdx)),
+						s.batch.ColVec(int(s.alreadySortedCols[i])),
 						0, /* bValueIdx */
 					)
 					i++
@@ -376,7 +377,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 			s.state = chunkerEmittingFromBatch
 			return chunkerReadFromBuffer
 		case chunkerEmittingFromBatch:
-			if s.chunksProcessedIdx+1 < len(s.chunks) {
+			if s.chunksProcessedIdx < len(s.chunks)-1 {
 				// There is at least one chunk that is fully contained within s.batch.
 				// We don't know yet whether the tuples from the next batch belong to
 				// the last chunk of the current batch, so we will buffer those and can
@@ -397,7 +398,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 			} else {
 				// All tuples in s.batch have been emitted.
 				if s.inputDone {
-					return inputDone
+					return chunkerDone
 				}
 				execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected: chunkerEmittingFromBatch state" +
 					"when s.chunks is fully processed and input is not done"))
@@ -454,7 +455,7 @@ func (s *chunker) getNumTuples() int {
 		return s.bufferedTuples.Length()
 	case chunkerReadFromBatch:
 		return s.chunks[len(s.chunks)-1] - s.chunks[s.chunksStartIdx]
-	case inputDone:
+	case chunkerDone:
 		return 0
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getNumTuples: %v", s.state))
@@ -482,6 +483,8 @@ func (s *chunker) getPartitionsCol() []bool {
 			s.partitionCol[s.chunks[i]-s.chunks[s.chunksStartIdx]] = true
 		}
 		return s.partitionCol
+	case chunkerDone:
+		return nil
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getPartitionsCol: %v", s.state))
 		// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -354,8 +354,8 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 	seed := rand.Int()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	nRuns := 5
-	nRows := 100
-	maxCols := 5
+	nRows := 5 * coldata.BatchSize() / 4
+	maxCols := 3
 	maxNum := 10
 	intTyps := make([]types.T, maxCols)
 	for i := range intTyps {
@@ -409,8 +409,8 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 						forceDiskSpill: spillForced,
 					}
 					if err := verifyColOperator(args); err != nil {
-						fmt.Printf("--- seed = %d spillForced = %t nCols = %d matchLen = %d ---\n",
-							seed, spillForced, nCols, matchLen)
+						fmt.Printf("--- seed = %d spillForced = %t orderingCols = %v matchLen = %d run = %d ---\n",
+							seed, spillForced, orderingCols, matchLen, run)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
 						prettyPrintInput(rows, inputTypes, "t" /* tableName */)
 						t.Fatal(err)


### PR DESCRIPTION
**colexec: fix null handling in sort chunks**

Previously, `tuplesDiffer` function (which checks whether a value in one
colvec differs from a value in another colvec) didn't pay attention to
NULLs which is wrong. This could cause sortChunksOp to incorrectly find
the boundaries of the chunks. Now this is fixed, as well as
`tuples_differ` has been renamed to `values_differ` as it describes it
better. The likelihood of such occurrence is very low, and out tests
never caught this (I believe eventually it would have since we now
randomize coldata.BatchSize) due to fixed number of rows with which we
had only a single input batch.

Release note: None (no release note since this bug could only be hit
with vectorize=experimental_on up until few days ago).

**colexec: add partially ordered distinct**
This commit adds a specialized distinct operator for the case when we
have partial ordering on the distinct columns. It uses newly added
chunkerOperator (which is an adapter from chunker spooler to Operator,
it returns all tuples that belong to the same "chunk" - i.e. those
equal on the already ordered columns - followed by zero-length batches
until it is reset) and unorderedDistinct on the tuples from the same
"chunk" (with its distinct columns being the subset of the original
distinct columns that is not included in the ordered columns). Both of
these operators are reset when a chunk is processed.

Unfortunately, the benchmarks have shown that this partially ordered
distinct operator is better than pure unordered distinct only when the
fraction of distinct tuples coming from the input is on the order of
0.01. When that fraction is exceeded, then the performance degrades
significantly because we spend most of the times resetting the hash
table used by unordered distinct. Therefore, currently this newly
introduced operator is not planned.

I still think that it is beneficial to merge this commit because,
hopefully, in the future we will estimate this fraction at runtime and
will be able to plan it if it'd be worth it.

Fixes: #43562.

Release note: None