### PR TITLE
cmd/roachtest: wait-for-full-replication before starting {sysbench,ycsb}

### DIFF
--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -90,6 +90,7 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 	t.Status("installing cockroach")
 	c.Put(ctx, cockroach, "./cockroach", allNodes)
 	c.Start(ctx, t, roachNodes)
+	waitForFullReplication(t, c.Conn(ctx, allNodes[0]))
 
 	t.Status("installing haproxy")
 	if err := c.Install(ctx, t.l, loadNode, "haproxy"); err != nil {

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -22,6 +22,7 @@ func registerYCSB(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, t, c.Range(1, nodes))
+		waitForFullReplication(t, c.Conn(ctx, 1))
 
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))


### PR DESCRIPTION
The `sysbench` and `ycsb` roachtests were not waiting for full
replication before starting the workload. The `sysbench` roachtests send
traffic so fast and furious, that up-replication cannot keep up with
splitting. I didn't observe this in `ycsb`, but presumably it had the
same problem. Simply waiting for full replication at startup removes
this problem, and brings `sysbench` and `ycsb` in line with the other
perf roachtests such as `kv*` and `tpcc*`.

Release note: None