### PR TITLE
importccl: bump up memory limit in TestImportCSVStmt

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1103,7 +1103,10 @@ func TestImportCSVStmt(t *testing.T) {
 
 	ctx := context.Background()
 	baseDir := filepath.Join("testdata", "csv")
-	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		SQLMemoryPoolSize: 256 << 20,
+		ExternalIODir:     baseDir,
+	}})
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)


### PR DESCRIPTION
Something somewhere has changed recently such that the default SQL pool (128mib)
does not have 32mib available for IMPORT in some cases leading this test to flake.

Release note: none.