### PR TITLE
storage/cloud: Make it possible to disable external http storage

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -699,6 +699,16 @@ type TempStorageConfig struct {
 	SpecIdx int
 }
 
+// ExternalIOConfig describes various configuration options pertaining
+// to external storage implementations.
+type ExternalIOConfig struct {
+	// Disables the use of external HTTP endpoints.
+	// This turns off http:// external storage as well as any custom
+	// endpoints cloud storage implementations.
+	DisableHTTP bool
+	// TODO(yevgeniy): Support disabling of implicit credentials in cloud storage.
+}
+
 // TempStorageConfigFromEnv creates a TempStorageConfig.
 // If parentDir is not specified and the specified store is in-memory,
 // then the temp storage will also be in-memory.

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -76,7 +77,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, settings, clientFactory)
+		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIOConfig{}, settings, clientFactory)
 	}
 
 	t.Run(`golden`, func(t *testing.T) {

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
@@ -58,7 +59,8 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 	}
 
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
+		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIOConfig{},
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
 	}
 	// This reads the raw backup descriptor (with table descriptors possibly not
 	// upgraded from the old FK representation, or even older formats). If more

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -798,7 +798,8 @@ func externalStorageFactory(
 	if err != nil {
 		return nil, err
 	}
-	return cloud.MakeExternalStorage(ctx, dest, nil, blobs.TestBlobServiceClient(workdir))
+	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIOConfig{},
+		nil, blobs.TestBlobServiceClient(workdir))
 }
 
 // Helper to create and initialize testSpec.

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"math/rand"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
@@ -118,7 +119,8 @@ func Load(
 	if err != nil {
 		return backupccl.BackupManifest{}, err
 	}
-	dir, err := cloud.MakeExternalStorage(ctx, conf, cluster.NoSettings, blobClientFactory)
+	dir, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIOConfig{},
+		cluster.NoSettings, blobClientFactory)
 	if err != nil {
 		return backupccl.BackupManifest{}, errors.Wrap(err, "export storage from URI")
 	}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -579,6 +579,11 @@ strongly discouraged for production usage and should never be used on
 a public network without combining it with --listen-addr.`,
 	}
 
+	ExternalIODisableHTTP = FlagInfo{
+		Name:        "external-io-disable-http",
+		Description: `Disable use of HTTP when accessing external data.`,
+	}
+
 	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for
 	// certificate generation functions.
 	KeySize = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -360,6 +360,10 @@ func init() {
 		// We share the default with the ClientInsecure flag.
 		BoolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure, startCtx.serverInsecure)
 
+		// Enable/disable various external storage endpoints.
+		serverCfg.ExternalIOConfig = base.ExternalIOConfig{}
+		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableHTTP, cliflags.ExternalIODisableHTTP, false)
+
 		// Certificates directory. Use a server-specific flag and value to ignore environment
 		// variables, but share the same default.
 		StringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir, startCtx.serverSSLCertsDir)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -134,6 +134,10 @@ type Config struct {
 	// ephemeral data when processing large queries.
 	TempStorageConfig base.TempStorageConfig
 
+	// ExternalIOConfig is used to configure external storage
+	// access (http://, nodelocal://, etc)
+	ExternalIOConfig base.ExternalIOConfig
+
 	// Attrs specifies a colon-separated list of node topography or machine
 	// capabilities, used to match capabilities or location preferences specified
 	// in zone configs.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -459,7 +459,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// This function defines how ExternalStorage objects are created.
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		return cloud.MakeExternalStorage(
-			ctx, dest, st,
+			ctx, dest, s.cfg.ExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
 				s.nodeIDContainer.Get(),
 				s.nodeDialer,
@@ -469,7 +469,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
 		return cloud.ExternalStorageFromURI(
-			ctx, uri, st,
+			ctx, uri, s.cfg.ExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
 				s.nodeIDContainer.Get(),
 				s.nodeDialer,

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -42,14 +43,16 @@ func TestLocalIOLimits(t *testing.T) {
 
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 
-	baseDir, err := ExternalStorageFromURI(ctx, "nodelocal:///", testSettings, clientFactory)
+	baseDir, err := ExternalStorageFromURI(
+		ctx, "nodelocal:///", base.ExternalIOConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
 		u := fmt.Sprintf("nodelocal://%s", dest)
-		e, err := ExternalStorageFromURI(ctx, u, testSettings, clientFactory)
+		e, err := ExternalStorageFromURI(
+			ctx, u, base.ExternalIOConfig{}, testSettings, clientFactory)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Informs #44320

Make it possible to disable external http storage.

This change enables the operators to disable access
 to external http servers as well as custom http endpoints
 overrides for cloud storage implementations.

Release note (security update): Make it possible for operators
to disable external http access when performing certain
operations (BACKUP, IMPORT, etc).

The external http access, as well as custom http endpoints, are
disabled by providing an --external-io-disable-http flag.

This flag provides a light weight option to disable http external
access in the environments where running a full fledged proxy
server may not be feasible.  If running a proxy service is
acceptible, operators may choose to start cockroach binary
specifying HTTP(s)_PROXY environment setting.


