### PR TITLE
release-19.2: colexec: fix substring operator for mixed type int arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -809,13 +809,14 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/proj_const_left_ops.eg.go \
   pkg/sql/colexec/proj_const_right_ops.eg.go \
   pkg/sql/colexec/proj_non_const_ops.eg.go \
+  pkg/sql/colexec/quicksort.eg.go \
   pkg/sql/colexec/rank.eg.go \
   pkg/sql/colexec/row_number.eg.go \
-  pkg/sql/colexec/quicksort.eg.go \
   pkg/sql/colexec/rowstovec.eg.go \
   pkg/sql/colexec/selection_ops.eg.go \
   pkg/sql/colexec/select_in.eg.go \
   pkg/sql/colexec/sort.eg.go \
+  pkg/sql/colexec/substring.eg.go \
   pkg/sql/colexec/sum_agg.eg.go \
   pkg/sql/colexec/tuples_differ.eg.go \
   pkg/sql/colexec/vec_comparators.eg.go \
@@ -1497,6 +1498,7 @@ pkg/sql/colexec/row_number.eg.go: pkg/sql/colexec/row_number_tmpl.go
 pkg/sql/colexec/rowstovec.eg.go: pkg/sql/colexec/rowstovec_tmpl.go
 pkg/sql/colexec/select_in.eg.go: pkg/sql/colexec/select_in_tmpl.go
 pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
+pkg/sql/colexec/substring.eg.go: pkg/sql/colexec/substring_tmpl.go
 pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
 pkg/sql/colexec/tuples_differ.eg.go: pkg/sql/colexec/tuples_differ_tmpl.go
 pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -26,6 +26,7 @@ rowstovec.eg.go
 selection_ops.eg.go
 select_in.eg.go
 sort.eg.go
+substring.eg.go
 sum_agg.eg.go
 tuples_differ.eg.go
 vec_comparators.eg.go

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -187,7 +187,6 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	}
 	batch.SetLength(coldata.BatchSize())
 	source := NewRepeatableBatchSource(batch)
-	source.Init()
 
 	// Set up the default operator.
 	expr, err := parser.ParseExpr("substring(@1, @2, @3)")
@@ -216,11 +215,9 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	defaultOp.Init()
 
 	// Set up the specialized substring operator.
-	specOp := &substringFunctionOperator{
-		OneInputNode: NewOneInputNode(source),
-		argumentCols: inputCols,
-		outputIdx:    3,
-	}
+	specOp := newSubstringOperator(
+		typs, inputCols, 3 /* outputIdx */, source,
+	)
 	specOp.Init()
 
 	b.Run("DefaultBuiltinOperator", func(b *testing.B) {

--- a/pkg/sql/colexec/execgen/cmd/execgen/substring_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/substring_gen.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+func genSubstring(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/substring_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+
+	s = strings.Replace(s, "_StartType_T", "coltypes.{{$startType}}", -1)
+	s = strings.Replace(s, "_LengthType_T", "coltypes.{{$lengthType}}", -1)
+	s = strings.Replace(s, "_StartType", "{{$startType}}", -1)
+	s = strings.Replace(s, "_LengthType", "{{$lengthType}}", -1)
+
+	tmpl, err := template.New("substring").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	intToInts := make(map[coltypes.T][]coltypes.T)
+	for _, intType := range coltypes.IntTypes {
+		intToInts[intType] = coltypes.IntTypes
+	}
+	return tmpl.Execute(wr, intToInts)
+}
+
+func init() {
+	registerGenerator(genSubstring, "substring.eg.go")
+}

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -1,0 +1,149 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for substring.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+func newSubstringOperator(
+	columnTypes []types.T, argumentCols []int, outputIdx int, input Operator,
+) Operator {
+	startType := typeconv.FromColumnType(&columnTypes[argumentCols[1]])
+	lengthType := typeconv.FromColumnType(&columnTypes[argumentCols[2]])
+	base := substringFunctionBase{
+		OneInputNode: NewOneInputNode(input),
+		argumentCols: argumentCols,
+		outputIdx:    outputIdx,
+	}
+	switch startType {
+	// {{range $startType, $lengthTypes := .}}
+	case _StartType_T:
+		switch lengthType {
+		// {{range $lengthType := $lengthTypes}}
+		case _LengthType_T:
+			return &substring_StartType_LengthTypeOperator{base}
+		// {{end}}
+		default:
+			execerror.VectorizedInternalPanic(errors.Errorf("unsupported length argument type %s", lengthType))
+			// This code is unreachable, but the compiler cannot infer that.
+			return nil
+		}
+	// {{end}}
+	default:
+		execerror.VectorizedInternalPanic(errors.Errorf("unsupported start argument type %s", startType))
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
+	}
+}
+
+type substringFunctionBase struct {
+	OneInputNode
+	argumentCols []int
+	outputIdx    int
+}
+
+func (s *substringFunctionBase) Init() {
+	s.input.Init()
+}
+
+// {{range $startType, $lengthTypes := .}}
+// {{range $lengthType := $lengthTypes}}
+
+type substring_StartType_LengthTypeOperator struct {
+	substringFunctionBase
+}
+
+var _ Operator = &substring_StartType_LengthTypeOperator{}
+
+func (s *substring_StartType_LengthTypeOperator) Next(ctx context.Context) coldata.Batch {
+	batch := s.input.Next(ctx)
+	if s.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bytes)
+	}
+
+	n := batch.Length()
+	if n == 0 {
+		return batch
+	}
+
+	sel := batch.Selection()
+	runeVec := batch.ColVec(s.argumentCols[0]).Bytes()
+	startVec := batch.ColVec(s.argumentCols[1])._StartType()
+	lengthVec := batch.ColVec(s.argumentCols[2])._LengthType()
+	outputVec := batch.ColVec(s.outputIdx).Bytes()
+	for i := uint16(0); i < n; i++ {
+		rowIdx := i
+		if sel != nil {
+			rowIdx = sel[i]
+		}
+
+		// The substring operator does not support nulls. If any of the arguments
+		// are NULL, we output NULL.
+		isNull := false
+		for _, col := range s.argumentCols {
+			if batch.ColVec(col).Nulls().NullAt(rowIdx) {
+				isNull = true
+				break
+			}
+		}
+		if isNull {
+			batch.ColVec(s.outputIdx).Nulls().SetNull(rowIdx)
+			continue
+		}
+
+		runes := runeVec.Get(int(rowIdx))
+		// Substring start is 1 indexed.
+		start := int(startVec[rowIdx]) - 1
+		length := int(lengthVec[rowIdx])
+		if length < 0 {
+			execerror.NonVectorizedPanic(errors.Errorf("negative substring length %d not allowed", length))
+		}
+
+		end := start + length
+		// Check for integer overflow.
+		if end < start {
+			end = len(runes)
+		} else if end < 0 {
+			end = 0
+		} else if end > len(runes) {
+			end = len(runes)
+		}
+
+		if start < 0 {
+			start = 0
+		} else if start > len(runes) {
+			start = len(runes)
+		}
+		outputVec.Set(int(rowIdx), runes[start:end])
+	}
+
+	return batch
+}
+
+// {{end}}
+// {{end}}

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -967,7 +967,7 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
             └ *colexec.castOpNullAny
               └ *colexec.constNullOp
                 └ *colexec.selectInOpBytes
-                  └ *colexec.substringFunctionOperator
+                  └ *colexec.substringInt64Int64Operator
                     └ *colexec.constInt64Op
                       └ *colexec.constInt64Op
                         └ *colexec.colBatchScan

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -631,6 +631,13 @@ Th
 statement error negative substring length -1 not allowed
 SELECT substring(x, 0, -1) FROM builtin_test
 
+# Regression test for #44881 (non-Int64 argument types).
+query T
+SELECT substring(x, -1::INT2, 3::INT4) FROM builtin_test
+----
+H
+T
+
 query I
 SELECT abs(y) FROM builtin_test
 ----


### PR DESCRIPTION
Backport 1/1 commits from #44887.

/cc @cockroachdb/release

---

Previously, we hard-coded `start` and `length` vectors to be of Int64
physical type. However, this is not always the case - integers of all
width are acceptable. This is now supported by generating specialized
substring operator for all variations of pair of integer types.

Fixes: #44881.

Release note (bug fix): Previously, CockroachDB would return an internal
error when `substring` function with non-INT8 start and length arguments
was executed via the vectorized engine, and now this has been fixed.
