### PR TITLE
sql: support CREATE VIEW IF NOT EXISTS

### DIFF
--- a/docs/generated/sql/bnf/create_view_stmt.bnf
+++ b/docs/generated/sql/bnf/create_view_stmt.bnf
@@ -1,3 +1,5 @@
 create_view_stmt ::=
 	'CREATE' opt_temp 'VIEW' view_name '(' name_list ')' 'AS' select_stmt
 	| 'CREATE' opt_temp 'VIEW' view_name  'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name '(' name_list ')' 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name  'AS' select_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1034,6 +1034,7 @@ create_table_as_stmt ::=
 
 create_view_stmt ::=
 	'CREATE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name opt_column_list 'AS' select_stmt
 
 create_sequence_stmt ::=
 	'CREATE' opt_temp 'SEQUENCE' sequence_name opt_sequence_option_list

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -16,8 +16,12 @@ CREATE VIEW v1 AS SELECT a, b FROM t
 statement error pgcode 42P07 relation \"t\" already exists
 CREATE VIEW t AS SELECT a, b FROM t
 
+# view statement ignored if other way around.
 statement ok
-CREATE VIEW v2 (x, y) AS SELECT a, b FROM t
+CREATE VIEW IF NOT EXISTS v1 AS SELECT b, a FROM v1
+
+statement ok
+CREATE VIEW IF NOT EXISTS v2 (x, y) AS SELECT a, b FROM t
 
 statement error pgcode 42601 CREATE VIEW specifies 1 column name, but data source has 2 columns
 CREATE VIEW v3 (x) AS SELECT a, b FROM t

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -380,6 +380,7 @@ func (f *stubFactory) ConstructCancelSessions(input exec.Node, ifExists bool) (e
 func (f *stubFactory) ConstructCreateView(
 	schema cat.Schema,
 	viewName string,
+	ifNotExists bool,
 	temporary bool,
 	viewQuery string,
 	columns sqlbase.ResultColumns,

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -62,6 +62,7 @@ func (b *Builder) buildCreateView(cv *memo.CreateViewExpr) (execPlan, error) {
 	root, err := b.factory.ConstructCreateView(
 		schema,
 		cv.ViewName,
+		cv.IfNotExists,
 		cv.Temporary,
 		cv.ViewQuery,
 		cols,

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -481,6 +481,7 @@ type Factory interface {
 	ConstructCreateView(
 		schema cat.Schema,
 		viewName string,
+		ifNotExists bool,
 		temporary bool,
 		viewQuery string,
 		columns sqlbase.ResultColumns,

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -43,6 +43,8 @@ define CreateViewPrivate {
 
     Temporary bool
 
+    IfNotExists bool
+
     # ViewQuery contains the query for the view; data sources are always fully
     # qualified.
     ViewQuery string

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -60,12 +60,13 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 
 	expr := b.factory.ConstructCreateView(
 		&memo.CreateViewPrivate{
-			Schema:    schID,
-			ViewName:  cv.Name.Table(),
-			Temporary: cv.Temporary,
-			ViewQuery: tree.AsStringWithFlags(cv.AsSource, tree.FmtParsable),
-			Columns:   p,
-			Deps:      b.viewDeps,
+			Schema:      schID,
+			ViewName:    cv.Name.Table(),
+			IfNotExists: cv.IfNotExists,
+			Temporary:   cv.Temporary,
+			ViewQuery:   tree.AsStringWithFlags(cv.AsSource, tree.FmtParsable),
+			Columns:     p,
+			Deps:        b.viewDeps,
 		},
 	)
 	return &scope{builder: b, expr: expr}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1774,6 +1774,7 @@ func (ef *execFactory) ConstructCreateTable(
 func (ef *execFactory) ConstructCreateView(
 	schema cat.Schema,
 	viewName string,
+	ifNotExists bool,
 	temporary bool,
 	viewQuery string,
 	columns sqlbase.ResultColumns,
@@ -1804,12 +1805,13 @@ func (ef *execFactory) ConstructCreateView(
 	}
 
 	return &createViewNode{
-		viewName:  tree.Name(viewName),
-		temporary: temporary,
-		viewQuery: viewQuery,
-		dbDesc:    schema.(*optSchema).desc,
-		columns:   columns,
-		planDeps:  planDeps,
+		viewName:    tree.Name(viewName),
+		ifNotExists: ifNotExists,
+		temporary:   temporary,
+		viewQuery:   viewQuery,
+		dbDesc:      schema.(*optSchema).desc,
+		columns:     columns,
+		planDeps:    planDeps,
 	}, nil
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5140,6 +5140,18 @@ create_view_stmt:
       ColumnNames: $6.nameList(),
       AsSource: $8.slct(),
       Temporary: $2.persistenceType(),
+      IfNotExists: false,
+    }
+  }
+| CREATE opt_temp opt_view_recursive VIEW IF NOT EXISTS view_name opt_column_list AS select_stmt
+  {
+    name := $8.unresolvedObjectName().ToTableName()
+    $$.val = &tree.CreateView{
+      Name: name,
+      ColumnNames: $9.nameList(),
+      AsSource: $11.slct(),
+      Temporary: $2.persistenceType(),
+      IfNotExists: true,
     }
   }
 | CREATE OR REPLACE opt_temp opt_view_recursive VIEW error { return unimplementedWithIssue(sqllex, 24897) }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1238,6 +1238,7 @@ type CreateView struct {
 	Name        TableName
 	ColumnNames NameList
 	AsSource    *Select
+	IfNotExists bool
 	Temporary   bool
 }
 
@@ -1250,6 +1251,10 @@ func (node *CreateView) Format(ctx *FmtCtx) {
 	}
 
 	ctx.WriteString("VIEW ")
+
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
 	ctx.FormatNode(&node.Name)
 
 	if len(node.ColumnNames) > 0 {

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1233,6 +1233,9 @@ func (node *CreateView) doc(p *PrettyCfg) pretty.Doc {
 		title = pretty.ConcatSpace(title, pretty.Keyword("TEMPORARY"))
 	}
 	title = pretty.ConcatSpace(title, pretty.Keyword("VIEW"))
+	if node.IfNotExists {
+		title = pretty.ConcatSpace(title, pretty.Keyword("IF NOT EXISTS"))
+	}
 	d := pretty.ConcatSpace(
 		title,
 		p.Doc(&node.Name),


### PR DESCRIPTION
Release note (sql change): This PR introduces the ability to create
views using `CREATE VIEW IF NOT EXISTS` which ignores the create if the
view already existed.