### PR TITLE
storage/cloud: add pattern parameter to ListFiles

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -207,7 +207,7 @@ func importPlanHook(
 					if err != nil {
 						return err
 					}
-					expandedFiles, err := s.ListFiles(ctx)
+					expandedFiles, err := s.ListFiles(ctx, "")
 					if err != nil {
 						return err
 					}

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -255,7 +255,7 @@ func (es *generatorExternalStorage) WriteFile(
 	return errors.New("unsupported")
 }
 
-func (es *generatorExternalStorage) ListFiles(ctx context.Context) ([]string, error) {
+func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]string, error) {
 	return nil, errors.New("unsupported")
 }
 

--- a/pkg/storage/cloud/azure_storage.go
+++ b/pkg/storage/cloud/azure_storage.go
@@ -95,7 +95,11 @@ func (s *azureStorage) ReadFile(ctx context.Context, basename string) (io.ReadCl
 	return reader, nil
 }
 
-func (s *azureStorage) ListFiles(ctx context.Context) ([]string, error) {
+func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
+	pattern := s.prefix
+	if patternSuffix != "" {
+		pattern = filepath.Join(pattern, patternSuffix)
+	}
 	var fileList []string
 	response, err := s.container.ListBlobsFlatSegment(ctx,
 		azblob.Marker{},
@@ -106,7 +110,7 @@ func (s *azureStorage) ListFiles(ctx context.Context) ([]string, error) {
 	}
 
 	for _, blob := range response.Segment.BlobItems {
-		matches, err := filepath.Match(s.prefix, blob.Name)
+		matches, err := filepath.Match(pattern, blob.Name)
 		if err != nil {
 			continue
 		}

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -114,9 +114,9 @@ type ExternalStorage interface {
 	// WriteFile should write the content to requested name.
 	WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error
 
-	// ListFiles should treat the ExternalStorage URI as a glob
-	// pattern, and return a list of files that match the pattern.
-	ListFiles(ctx context.Context) ([]string, error)
+	// ListFiles should treat the ExternalStorage URI plus the passed suffix as a
+	// glob pattern, and return a list of files that match the pattern.
+	ListFiles(ctx context.Context, patternSuffix string) ([]string, error)
 
 	// Delete removes the named file from the store.
 	Delete(ctx context.Context, basename string) error

--- a/pkg/storage/cloud/external_storage_test.go
+++ b/pkg/storage/cloud/external_storage_test.go
@@ -237,26 +237,61 @@ func testListFiles(t *testing.T, storeURI string) {
 	for _, tc := range []struct {
 		name       string
 		URI        string
+		suffix     string
 		resultList []string
 	}{
 		{
 			"list-all-csv",
 			appendPath(t, storeURI, "file/*/*.csv"),
+			"",
 			fileNames,
 		},
 		{
 			"list-letter-csv",
 			appendPath(t, storeURI, "file/abc/?.csv"),
+			"",
 			letterFiles,
+		},
+		{
+			"list-letter-csv-suffix",
+			appendPath(t, storeURI, "file/abc"),
+			"?.csv",
+			letterFiles,
+		},
+		{
+			"list-letter-csv-dotdot",
+			appendPath(t, storeURI, "file/abc/xzy/../?.csv"),
+			"",
+			letterFiles,
+		},
+		{
+			"list-letter-csv-dotdotdotdot-suffix",
+			appendPath(t, storeURI, "file/abc/xzy"),
+			"../?.csv",
+			letterFiles,
+		},
+		{
+			"list-letter-csv-dotdot-suffix",
+			appendPath(t, storeURI, "file/abc/xzy"),
+			"../../?.csv",
+			nil,
 		},
 		{
 			"list-data-num-csv",
 			appendPath(t, storeURI, "file/numbers/data[0-9].csv"),
+			"",
 			dataNumberFiles,
 		},
 		{
 			"wildcard-bucket-and-filename",
 			appendPath(t, storeURI, "*/numbers/*.csv"),
+			"",
+			dataNumberFiles,
+		},
+		{
+			"wildcard-bucket-and-filename-suffix",
+			appendPath(t, storeURI, ""),
+			"*/numbers/*.csv",
 			dataNumberFiles,
 		},
 		{
@@ -264,27 +299,43 @@ func testListFiles(t *testing.T, storeURI string) {
 			// filepath.Glob() assumes that / is the separator, and enforces that it's there.
 			// So this pattern would not actually match anything.
 			appendPath(t, storeURI, "file/*.csv"),
+			"",
 			[]string{},
 		},
 		{
 			"list-no-matches",
 			appendPath(t, storeURI, "file/letters/dataD.csv"),
+			"",
 			[]string{},
 		},
 		{
 			"list-escaped-star",
 			appendPath(t, storeURI, "file/*/\\*.csv"),
+			"",
+			[]string{},
+		},
+		{
+			"list-escaped-star-suffix",
+			appendPath(t, storeURI, "file"),
+			"*/\\*.csv",
 			[]string{},
 		},
 		{
 			"list-escaped-range",
 			appendPath(t, storeURI, "file/*/data\\[0-9\\].csv"),
+			"",
+			[]string{},
+		},
+		{
+			"list-escaped-range-suffix",
+			appendPath(t, storeURI, "file"),
+			"*/data\\[0-9\\].csv",
 			[]string{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := storeFromURI(ctx, t, tc.URI, clientFactory)
-			filesList, err := s.ListFiles(ctx)
+			filesList, err := s.ListFiles(ctx, tc.suffix)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -150,11 +150,17 @@ func (g *gcsStorage) ReadFile(ctx context.Context, basename string) (io.ReadClos
 	return rc, err
 }
 
-func (g *gcsStorage) ListFiles(ctx context.Context) ([]string, error) {
+func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
 	var fileList []string
 	it := g.bucket.Objects(ctx, &gcs.Query{
 		Prefix: getBucketBeforeWildcard(g.prefix),
 	})
+
+	pattern := g.prefix
+	if patternSuffix != "" {
+		pattern = filepath.Join(pattern, patternSuffix)
+	}
+
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
@@ -164,7 +170,7 @@ func (g *gcsStorage) ListFiles(ctx context.Context) ([]string, error) {
 			return nil, errors.Wrap(err, "unable to list files in gcs bucket")
 		}
 
-		matches, errMatch := filepath.Match(g.prefix, attrs.Name)
+		matches, errMatch := filepath.Match(pattern, attrs.Name)
 		if errMatch != nil {
 			continue
 		}

--- a/pkg/storage/cloud/http_storage.go
+++ b/pkg/storage/cloud/http_storage.go
@@ -287,7 +287,7 @@ func (h *httpStorage) WriteFile(ctx context.Context, basename string, content io
 		})
 }
 
-func (h *httpStorage) ListFiles(_ context.Context) ([]string, error) {
+func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.New(`http storage does not support listing files`)
 }
 

--- a/pkg/storage/cloud/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal_storage.go
@@ -91,9 +91,15 @@ func (l *localFileStorage) ReadFile(ctx context.Context, basename string) (io.Re
 	return l.blobClient.ReadFile(ctx, joinRelativePath(l.base, basename))
 }
 
-func (l *localFileStorage) ListFiles(ctx context.Context) ([]string, error) {
+func (l *localFileStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
+
+	pattern := l.base
+	if patternSuffix != "" {
+		pattern = joinRelativePath(pattern, patternSuffix)
+	}
+
 	var fileList []string
-	matches, err := l.blobClient.List(ctx, l.base)
+	matches, err := l.blobClient.List(ctx, pattern)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to match pattern provided")
 	}

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -41,14 +41,23 @@ func TestLocalIOLimits(t *testing.T) {
 	testSettings.ExternalIODir = allowed
 
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
+
+	baseDir, err := ExternalStorageFromURI(ctx, "nodelocal:///", testSettings, clientFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
 		u := fmt.Sprintf("nodelocal://%s", dest)
 		e, err := ExternalStorageFromURI(ctx, u, testSettings, clientFactory)
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = e.ListFiles(ctx)
-		if !testutils.IsError(err, expected) {
+
+		if _, err = e.ListFiles(ctx, ""); !testutils.IsError(err, expected) {
+			t.Fatal(err)
+		}
+		if _, err = baseDir.ListFiles(ctx, dest); !testutils.IsError(err, expected) {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -155,9 +155,14 @@ func getBucketBeforeWildcard(path string) string {
 	return filepath.Dir(path[:globIndex])
 }
 
-func (s *s3Storage) ListFiles(ctx context.Context) ([]string, error) {
+func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
 	var fileList []string
 	baseBucket := getBucketBeforeWildcard(*s.bucket)
+
+	pattern := s.prefix
+	if patternSuffix != "" {
+		pattern = filepath.Join(pattern, patternSuffix)
+	}
 
 	err := s.s3.ListObjectsPagesWithContext(
 		ctx,
@@ -166,7 +171,7 @@ func (s *s3Storage) ListFiles(ctx context.Context) ([]string, error) {
 		},
 		func(page *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, fileObject := range page.Contents {
-				matches, err := filepath.Match(s.prefix, *fileObject.Key)
+				matches, err := filepath.Match(pattern, *fileObject.Key)
 				if err != nil {
 					continue
 				}

--- a/pkg/storage/cloud/s3_storage_test.go
+++ b/pkg/storage/cloud/s3_storage_test.go
@@ -83,14 +83,16 @@ func TestPutS3(t *testing.T) {
 			),
 			false,
 		)
-		testListFiles(t,
-			fmt.Sprintf(
-				"s3://%s/%s?%s=%s&%s=%s",
-				bucket, "listing-test",
-				S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
-				S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
-			),
-		)
+		t.Run("ListFiles", func(t *testing.T) {
+			testListFiles(t,
+				fmt.Sprintf(
+					"s3://%s/%s?%s=%s&%s=%s",
+					bucket, "listing-test",
+					S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
+					S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
+				),
+			)
+		})
 	})
 }
 

--- a/pkg/storage/cloud/workload_storage.go
+++ b/pkg/storage/cloud/workload_storage.go
@@ -89,7 +89,7 @@ func (s *workloadStorage) WriteFile(_ context.Context, _ string, _ io.ReadSeeker
 	return errors.Errorf(`workload storage does not support writes`)
 }
 
-func (s *workloadStorage) ListFiles(_ context.Context) ([]string, error) {
+func (s *workloadStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.Errorf(`workload storage does not support listing files`)
 }
 


### PR DESCRIPTION
Previously ListFiles did not take a pattern parameter and treated the base
path of the ExternalStorage as its pattern instead. This however meant it
was not possible to search an existing external storage for a specific pattern.

This adds a patternSuffix which is appended to the base path before it is
compared to items in the store to see if they match.

Release note: none.