### PR TITLE
release-19.1: opt: fix deduplication of impure expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/impure
+++ b/pkg/sql/logictest/testdata/logic_test/impure
@@ -1,0 +1,62 @@
+# LogicTest: local-opt fakedist-opt
+
+# This file contains tests for handling of duplicate impure projections.  See
+# #44865.
+
+query I
+WITH cte (a, b) AS (SELECT random(), random())
+SELECT count(*) FROM cte WHERE a = b
+----
+0
+
+query I
+WITH cte (x, a, b) AS (SELECT x, random(), random() FROM (VALUES (1), (2), (3)) AS v(x))
+SELECT count(*) FROM cte WHERE a = b
+----
+0
+
+statement ok
+CREATE TABLE kab (k INT PRIMARY KEY, a UUID, b UUID)
+
+statement ok
+INSERT INTO kab VALUES (1, gen_random_uuid(), gen_random_uuid())
+
+statement ok
+INSERT INTO kab VALUES (2, gen_random_uuid(), gen_random_uuid())
+
+statement ok
+INSERT INTO kab VALUES (3, gen_random_uuid(), gen_random_uuid()),
+                       (4, gen_random_uuid(), gen_random_uuid()),
+                       (5, gen_random_uuid(), gen_random_uuid()),
+                       (6, gen_random_uuid(), gen_random_uuid())
+
+query I
+SELECT count(*) FROM kab WHERE a=b
+----
+0
+
+statement ok
+CREATE TABLE kabcd (
+  k INT PRIMARY KEY,
+  a UUID,
+  b UUID,
+  c UUID DEFAULT gen_random_uuid(),
+  d UUID DEFAULT gen_random_uuid()
+)
+
+statement ok
+INSERT INTO kabcd VALUES (1, gen_random_uuid(), gen_random_uuid())
+
+statement ok
+INSERT INTO kabcd VALUES (2, gen_random_uuid(), gen_random_uuid())
+
+statement ok
+INSERT INTO kabcd VALUES (3, gen_random_uuid(), gen_random_uuid()),
+                         (4, gen_random_uuid(), gen_random_uuid()),
+                         (5, gen_random_uuid(), gen_random_uuid()),
+                         (6, gen_random_uuid(), gen_random_uuid())
+
+query I
+SELECT count(*) FROM kabcd WHERE a=b OR a=c OR a=d OR b=c OR b=d OR c=d
+----
+0

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -190,7 +190,9 @@ func (b *Builder) buildDistinctOnArgs(inScope, projectionsScope, distinctOnScope
 	}
 
 	for i := range distinctOnScope.cols {
-		b.addExtraColumn(inScope, projectionsScope, distinctOnScope, &distinctOnScope.cols[i])
+		b.addOrderByOrDistinctOnColumn(
+			inScope, projectionsScope, distinctOnScope, &distinctOnScope.cols[i],
+		)
 	}
 	projectionsScope.addExtraColumns(distinctOnScope.cols)
 	projectionsScope.distinctOnCols = distinctOnScope.colSet()

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -97,14 +97,18 @@ func (b *Builder) findIndexByName(table cat.Table, name tree.UnrestrictedName) (
 	return nil, fmt.Errorf(`index %q not found`, name)
 }
 
-// addExtraColumn builds extraCol.expr as a column in extraColsScope; if it is
+// addOrderByOrDistinctOnColumn builds extraCol.expr as a column in extraColsScope; if it is
 // already projected in projectionsScope then that projection is re-used.
-func (b *Builder) addExtraColumn(
+func (b *Builder) addOrderByOrDistinctOnColumn(
 	inScope, projectionsScope, extraColsScope *scope, extraCol *scopeColumn,
 ) {
-	// Use an existing projection if possible. Otherwise, build a new
+	// Use an existing projection if possible (even if it has side-effects; see
+	// the SQL99 rules described in analyzeExtraArgument). Otherwise, build a new
 	// projection.
-	if col := projectionsScope.findExistingCol(extraCol.getExpr()); col != nil {
+	if col := projectionsScope.findExistingCol(
+		extraCol.getExpr(),
+		true, /* allowSideEffects */
+	); col != nil {
 		extraCol.id = col.id
 	} else {
 		b.buildScalar(extraCol.getExpr(), inScope, extraColsScope, extraCol, nil)
@@ -172,7 +176,7 @@ func (b *Builder) buildOrderByArg(
 	inScope, projectionsScope, orderByScope *scope, orderByCol *scopeColumn,
 ) {
 	// Build the ORDER BY column.
-	b.addExtraColumn(inScope, projectionsScope, orderByScope, orderByCol)
+	b.addOrderByOrDistinctOnColumn(inScope, projectionsScope, orderByScope, orderByCol)
 
 	// Add the new column to the ordering.
 	orderByScope.ordering = append(orderByScope.ordering,

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -221,7 +221,7 @@ func (b *Builder) finishBuildScalar(
 	}
 
 	// Avoid synthesizing a new column if possible.
-	if col := outScope.findExistingCol(texpr); col != nil && col != outCol {
+	if col := outScope.findExistingCol(texpr, false /* allowSideEffects */); col != nil && col != outCol {
 		outCol.id = col.id
 		outCol.scalar = scalar
 		return scalar
@@ -270,7 +270,7 @@ func (b *Builder) finishBuildScalarRef(
 	// column id before projection.
 	if isOuterColumn {
 		// Avoid synthesizing a new column if possible.
-		existing := outScope.findExistingCol(col)
+		existing := outScope.findExistingCol(col, false /* allowSideEffects */)
 		if existing == nil || existing == outCol {
 			if outCol.name == "" {
 				outCol.name = col.name

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2908,12 +2908,12 @@ build
 SELECT max((k+v)/(k-v)) AS r, (k+v)*(k-v) AS s FROM kv GROUP BY k+v, (k+v)/(k-v), (k+v)*(k-v)
 ----
 project
- ├── columns: r:6(decimal) s:8(int)
+ ├── columns: r:6(decimal) s:9(int)
  └── group-by
-      ├── columns: column5:5(decimal) max:6(decimal) column7:7(int) column8:8(int)
-      ├── grouping columns: column5:5(decimal) column7:7(int) column8:8(int)
+      ├── columns: max:6(decimal) column7:7(int) column8:8(decimal) column9:9(int)
+      ├── grouping columns: column7:7(int) column8:8(decimal) column9:9(int)
       ├── project
-      │    ├── columns: column5:5(decimal) column7:7(int) column8:8(int)
+      │    ├── columns: column5:5(decimal) column7:7(int) column8:8(decimal) column9:9(int)
       │    ├── scan kv
       │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
       │    └── projections
@@ -2927,6 +2927,13 @@ project
       │         ├── plus [type=int]
       │         │    ├── variable: k [type=int]
       │         │    └── variable: v [type=int]
+      │         ├── div [type=decimal]
+      │         │    ├── plus [type=int]
+      │         │    │    ├── variable: k [type=int]
+      │         │    │    └── variable: v [type=int]
+      │         │    └── minus [type=int]
+      │         │         ├── variable: k [type=int]
+      │         │         └── variable: v [type=int]
       │         └── mult [type=int]
       │              ├── plus [type=int]
       │              │    ├── variable: k [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -1,0 +1,242 @@
+# Tests around deduplication of projection expressions.
+
+exec-ddl
+CREATE TABLE ab (a FLOAT, b FLOAT)
+----
+TABLE ab
+ ├── a float
+ ├── b float
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Non-side effecting expressions should be deduplicated.
+build
+SELECT a+b, a+b FROM ab
+----
+project
+ ├── columns: "?column?":4(float) "?column?":4(float)
+ ├── scan ab
+ │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+ └── projections
+      └── plus [type=float]
+           ├── variable: a [type=float]
+           └── variable: b [type=float]
+
+# Ensure whitespace differences don't prevent deduplication.
+build
+SELECT a+b, a + b FROM ab
+----
+project
+ ├── columns: "?column?":4(float) "?column?":4(float)
+ ├── scan ab
+ │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+ └── projections
+      └── plus [type=float]
+           ├── variable: a [type=float]
+           └── variable: b [type=float]
+
+# Side-effecting expressions are not deduplicated.
+build
+SELECT a/b, a/b FROM ab
+----
+project
+ ├── columns: "?column?":4(float) "?column?":5(float)
+ ├── scan ab
+ │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+ └── projections
+      ├── div [type=float]
+      │    ├── variable: a [type=float]
+      │    └── variable: b [type=float]
+      └── div [type=float]
+           ├── variable: a [type=float]
+           └── variable: b [type=float]
+
+build
+SELECT random(), random() FROM ab
+----
+project
+ ├── columns: random:4(float) random:5(float)
+ ├── scan ab
+ │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+ └── projections
+      ├── function: random [type=float]
+      └── function: random [type=float]
+
+# ORDER BY does not add a new projection if the same expression is projected
+# already, regardless of side-effects.
+build
+SELECT a, b, random(), random() FROM ab ORDER BY random()
+----
+sort
+ ├── columns: a:1(float) b:2(float) random:4(float) random:5(float)
+ ├── ordering: +4
+ └── project
+      ├── columns: random:4(float) random:5(float) a:1(float) b:2(float)
+      ├── scan ab
+      │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+      └── projections
+           ├── function: random [type=float]
+           └── function: random [type=float]
+
+# With GROUP BY, expressions identical to a grouping column are always
+# collapsed into a single value.
+build
+SELECT random(), random() FROM ab GROUP BY random()
+----
+group-by
+ ├── columns: random:4(float) random:4(float)
+ ├── grouping columns: column4:4(float)
+ └── project
+      ├── columns: column4:4(float)
+      ├── scan ab
+      │    └── columns: a:1(float) b:2(float) rowid:3(int!null)
+      └── projections
+           └── function: random [type=float]
+
+build
+INSERT INTO ab VALUES (random(), random())
+----
+insert ab
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => a:1
+ │    ├──  column2:5 => b:2
+ │    └──  column6:6 => rowid:3
+ └── project
+      ├── columns: column6:6(int) column1:4(float) column2:5(float)
+      ├── values
+      │    ├── columns: column1:4(float) column2:5(float)
+      │    └── tuple [type=tuple{float, float}]
+      │         ├── function: random [type=float]
+      │         └── function: random [type=float]
+      └── projections
+           └── function: unique_rowid [type=int]
+
+# Make sure impure default expressions are not deduplicated.
+exec-ddl
+CREATE TABLE abcd (a FLOAT, b FLOAT, c FLOAT DEFAULT random(), d FLOAT DEFAULT random())
+----
+TABLE abcd
+ ├── a float
+ ├── b float
+ ├── c float
+ ├── d float
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+INSERT INTO abcd VALUES (1, 1)
+----
+insert abcd
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:6 => a:1
+ │    ├──  column2:7 => b:2
+ │    ├──  column8:8 => c:3
+ │    ├──  column9:9 => d:4
+ │    └──  column10:10 => rowid:5
+ └── project
+      ├── columns: column8:8(float) column9:9(float) column10:10(int) column1:6(float) column2:7(float)
+      ├── values
+      │    ├── columns: column1:6(float) column2:7(float)
+      │    └── tuple [type=tuple{float, float}]
+      │         ├── const: 1.0 [type=float]
+      │         └── const: 1.0 [type=float]
+      └── projections
+           ├── function: random [type=float]
+           ├── function: random [type=float]
+           └── function: unique_rowid [type=int]
+
+build
+INSERT INTO abcd VALUES (random(), random())
+----
+insert abcd
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:6 => a:1
+ │    ├──  column2:7 => b:2
+ │    ├──  column8:8 => c:3
+ │    ├──  column9:9 => d:4
+ │    └──  column10:10 => rowid:5
+ └── project
+      ├── columns: column8:8(float) column9:9(float) column10:10(int) column1:6(float) column2:7(float)
+      ├── values
+      │    ├── columns: column1:6(float) column2:7(float)
+      │    └── tuple [type=tuple{float, float}]
+      │         ├── function: random [type=float]
+      │         └── function: random [type=float]
+      └── projections
+           ├── function: random [type=float]
+           ├── function: random [type=float]
+           └── function: unique_rowid [type=int]
+
+build
+UPSERT INTO abcd VALUES (1, 1)
+----
+upsert abcd
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├──  column1:6 => a:1
+ │    ├──  column2:7 => b:2
+ │    ├──  column8:8 => c:3
+ │    ├──  column9:9 => d:4
+ │    └──  column10:10 => rowid:5
+ └── project
+      ├── columns: column8:8(float) column9:9(float) column10:10(int) column1:6(float) column2:7(float)
+      ├── values
+      │    ├── columns: column1:6(float) column2:7(float)
+      │    └── tuple [type=tuple{float, float}]
+      │         ├── const: 1.0 [type=float]
+      │         └── const: 1.0 [type=float]
+      └── projections
+           ├── function: random [type=float]
+           ├── function: random [type=float]
+           └── function: unique_rowid [type=int]
+
+build
+UPSERT INTO abcd VALUES (random(), random())
+----
+upsert abcd
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├──  column1:6 => a:1
+ │    ├──  column2:7 => b:2
+ │    ├──  column8:8 => c:3
+ │    ├──  column9:9 => d:4
+ │    └──  column10:10 => rowid:5
+ └── project
+      ├── columns: column8:8(float) column9:9(float) column10:10(int) column1:6(float) column2:7(float)
+      ├── values
+      │    ├── columns: column1:6(float) column2:7(float)
+      │    └── tuple [type=tuple{float, float}]
+      │         ├── function: random [type=float]
+      │         └── function: random [type=float]
+      └── projections
+           ├── function: random [type=float]
+           ├── function: random [type=float]
+           └── function: unique_rowid [type=int]
+
+build
+UPDATE abcd SET a = random(), b = random() WHERE a=1
+----
+update abcd
+ ├── columns: <none>
+ ├── fetch columns: a:6(float) b:7(float) c:8(float) d:9(float) rowid:10(int)
+ ├── update-mapping:
+ │    ├──  column11:11 => a:1
+ │    └──  column12:12 => b:2
+ └── project
+      ├── columns: column11:11(float) column12:12(float) a:6(float!null) b:7(float) c:8(float) d:9(float) rowid:10(int!null)
+      ├── select
+      │    ├── columns: a:6(float!null) b:7(float) c:8(float) d:9(float) rowid:10(int!null)
+      │    ├── scan abcd
+      │    │    └── columns: a:6(float) b:7(float) c:8(float) d:9(float) rowid:10(int!null)
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: a [type=float]
+      │              └── const: 1.0 [type=float]
+      └── projections
+           ├── function: random [type=float]
+           └── function: random [type=float]


### PR DESCRIPTION
Backport 1/1 commits from #44890.

/cc @cockroachdb/release

---

We have the unexpected behavior of generating the same random value
when doing something like
`SELECT gen_random_uuid(), gen_random_uuid()`. This includes cases
where the duplicate expressions come from default column values.

This change fixes this by preventing deduplication if expressions have
side-effects. The only exceptions are ORDER BY, where the order by
column is supposed to refer to an existing projection if one exists; and
GROUP BY where all instances of a grouping expression are collapsed -
this is consistent with postgres.

Fixes #44865.

Release note (bug fix): fixed incorrect deduplication of impure
expressions (like gen_random_uuid) in projections and default values.

