### PR TITLE
colflow: error out when phys types mismatch when setting up a flow

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -207,7 +207,7 @@ func (ds *ServerImpl) setupFlow(
 	// sp will be Finish()ed by Flow.Cleanup().
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
-	// The monitor opened here are closed in Flow.Cleanup().
+	// The monitor opened here is closed in Flow.Cleanup().
 	monitor := mon.MakeMonitor(
 		"flow",
 		mon.MemoryResource,
@@ -348,6 +348,9 @@ func (ds *ServerImpl) setupFlow(
 	var err error
 	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
+		// Flow.Cleanup will not be called, so we have to close the memory monitor
+		// and finish the span manually.
+		monitor.Stop(ctx)
 		tracing.FinishSpan(sp)
 		ctx = opentracing.ContextWithSpan(ctx, nil)
 		return ctx, nil, err

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -173,7 +173,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 							ClusterID:   &dsp.rpcCtx.ClusterID,
 						},
 						NodeID: -1,
-					}, spec.Processors, fuseOpt,
+					}, spec.Processors, fuseOpt, recv,
 				); err != nil {
 					// Vectorization attempt failed with an error.
 					returnVectorizationSetupError := false

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -239,7 +239,7 @@ func (p *planner) populateExplain(
 				if nodeID == thisNodeID && !isDistSQL {
 					fuseOpt = flowinfra.FuseAggressively
 				}
-				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt)
+				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt, nil /* output */)
 				isVec = isVec && (err == nil)
 			}
 		}

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -96,7 +96,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 		if flow.nodeID == thisNodeID && !willDistributePlan {
 			fuseOpt = flowinfra.FuseAggressively
 		}
-		opChains, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors, fuseOpt)
+		opChains, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors, fuseOpt, nil /* output */)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -111,3 +111,17 @@ SELECT id FROM unsupported_type LIMIT 1 OFFSET 1100
 
 statement ok
 RESET vectorize
+
+# Regression test for #44904 (mismatched physical types between materializer's
+# input and output, root of the problem is outside of the vectorized engine).
+# We should fallback to the row-by-row engine.
+statement ok
+SET default_int_size = 4; CREATE TABLE t44904(c0 INT); INSERT INTO t44904 VALUES(0)
+
+query I
+SELECT CAST(0 BETWEEN(CASE NULL WHEN c0 = 0 THEN NULL END) AND 0 IS TRUE AS INT) FROM t44904
+----
+0
+
+statement ok
+RESET default_int_size


### PR DESCRIPTION
This commit adds a check that the physical types coming out of the last
columnar operator into the materializer are the same as the materializer
expects. This check is added to SupportsVectorized check, and in case of
types mismatch, we will fallback to the row-by-row engine.

The underlying cause for this particular reproduction is that our
"logical" types system assumes that ints have width 8, which is not
always the case. But trying to fix it is beyond the scope of this PR.

Fixes: #44904.

Release note (bug fix): Previously, CockroachDB could return an internal
error on the queries that return INT columns when the default int size
has been changed, and now this has been fixed.