### PR TITLE
colexec: fix hash and merge joiners when types of inputs in eq cols are different

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -28,15 +28,12 @@ func genCastOperators(wr io.Writer) error {
 	assignCast := makeFunctionRegex("_ASSIGN_CAST", 2)
 	s = assignCast.ReplaceAllString(s, `{{.Assign "$1" "$2"}}`)
 	s = strings.Replace(s, "_ALLTYPES", "{{$typ}}", -1)
-	s = strings.Replace(s, "_OVERLOADTYPES", "{{.ToTyp}}", -1)
 	s = strings.Replace(s, "_FROMTYPE", "{{.FromTyp}}", -1)
 	s = strings.Replace(s, "_TOTYPE", "{{.ToTyp}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.ToGoTyp}}", -1)
 
 	// replace _FROM_TYPE_SLICE's with execgen.SLICE's of the correct type.
 	s = strings.Replace(s, "_FROM_TYPE_SLICE", "execgen.SLICE", -1)
-	s = replaceManipulationFuncs(".FromTyp", s)
-
 	// replace the _FROM_TYPE_UNSAFEGET's with execgen.UNSAFEGET's of the correct type.
 	s = strings.Replace(s, "_FROM_TYPE_UNSAFEGET", "execgen.UNSAFEGET", -1)
 	s = replaceManipulationFuncs(".FromTyp", s)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -195,6 +195,20 @@ func intToFloat(floatSize int) func(string, string) string {
 	}
 }
 
+func intToInt32(to, from string) string {
+	convStr := `
+    %[1]s = int32(%[2]s)
+  `
+	return fmt.Sprintf(convStr, to, from)
+}
+
+func intToInt64(to, from string) string {
+	convStr := `
+    %[1]s = int64(%[2]s)
+  `
+	return fmt.Sprintf(convStr, to, from)
+}
+
 func floatToInt(intSize int, floatSize int) func(string, string) string {
 	return func(to, from string) string {
 		convStr := `
@@ -398,6 +412,10 @@ func init() {
 					ov.AssignFunc = intToDecimal
 				case coltypes.Int16:
 					ov.AssignFunc = castIdentity
+				case coltypes.Int32:
+					ov.AssignFunc = intToInt32
+				case coltypes.Int64:
+					ov.AssignFunc = intToInt64
 				case coltypes.Float64:
 					ov.AssignFunc = intToFloat(64)
 				}
@@ -413,6 +431,8 @@ func init() {
 					ov.AssignFunc = intToDecimal
 				case coltypes.Int32:
 					ov.AssignFunc = castIdentity
+				case coltypes.Int64:
+					ov.AssignFunc = intToInt64
 				case coltypes.Float64:
 					ov.AssignFunc = intToFloat(64)
 				}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -742,7 +742,12 @@ func (c floatCustomizer) getBinOpAssignFunc() assignFunc {
 
 func (c intCustomizer) getHashAssignFunc() assignFunc {
 	return func(op overload, target, v, _ string) string {
-		return fmt.Sprintf("%[1]s = memhash%[3]d(noescape(unsafe.Pointer(&%[2]s)), %[1]s)", target, v, c.width)
+		return fmt.Sprintf(`
+				// In order for integers with different widths but of the same value to
+				// to hash to the same value, we upcast all of them to int64.
+				asInt64 := int64(%[2]s)
+				%[1]s = memhash64(noescape(unsafe.Pointer(&asInt64)), %[1]s)`,
+			target, v)
 	}
 }
 

--- a/pkg/sql/colexec/hash.go
+++ b/pkg/sql/colexec/hash.go
@@ -130,22 +130,6 @@ tail:
 	return uintptr(h)
 }
 
-func memhash16(p unsafe.Pointer, h uintptr) uintptr {
-	return memhash(p, h, 2)
-}
-
-func memhash32(p unsafe.Pointer, seed uintptr) uintptr {
-	h := uint64(seed + 4*hashKey[0])
-	v := uint64(readUnaligned32(p))
-	h ^= v
-	h ^= v << 32
-	h = rotl31(h*m1) * m2
-	h ^= h >> 29
-	h *= m3
-	h ^= h >> 32
-	return uintptr(h)
-}
-
 func memhash64(p unsafe.Pointer, seed uintptr) uintptr {
 	h := uint64(seed + 8*hashKey[0])
 	h ^= uint64(readUnaligned32(p)) | uint64(readUnaligned32(add(p, 4)))<<32

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -330,6 +330,7 @@ func newMergeJoinBase(
 	if err != nil {
 		return base, err
 	}
+	base.scratch.tempVecByType = make(map[coltypes.T]coldata.Vec)
 	if filterConstructor != nil {
 		base.filter, err = newJoinerFilter(
 			base.allocator,
@@ -363,6 +364,12 @@ type mergeJoinBase struct {
 	state        mjState
 	proberState  mjProberState
 	builderState mjBuilderState
+	scratch      struct {
+		// tempVecByType is a map from the type to a temporary vector that can be
+		// used during a cast operation in the probing phase. These vectors should
+		// *not* be exposed outside of the merge joiner.
+		tempVecByType map[coltypes.T]coldata.Vec
+	}
 
 	filter *joinerFilter
 }

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -588,9 +588,54 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) probeBodyLSel_IS_L_SEL
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
 	for eqColIdx := 0; eqColIdx < len(o.left.eqCols); eqColIdx++ {
-		lVec := o.proberState.lBatch.ColVec(int(o.left.eqCols[eqColIdx]))
-		rVec := o.proberState.rBatch.ColVec(int(o.right.eqCols[eqColIdx]))
-		colType := o.left.sourceTypes[int(o.left.eqCols[eqColIdx])]
+		leftColIdx := o.left.eqCols[eqColIdx]
+		rightColIdx := o.right.eqCols[eqColIdx]
+		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
+		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
+		leftPhysType := o.left.sourceTypes[leftColIdx]
+		rightPhysType := o.right.sourceTypes[rightColIdx]
+		colType := leftPhysType
+		// Merge joiner only supports the case when the physical types in the
+		// equality columns in both inputs are the same. If that is not the case,
+		// we need to cast one of the vectors to another's physical type putting
+		// the result of the cast into a temporary vector that is used instead of
+		// the original.
+		if leftPhysType != rightPhysType {
+			castLeftToRight := false
+			// There is a hierarchy of valid casts:
+			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
+			// and the cast is valid if 'fromType' is mentioned before 'toType'
+			// in this chain.
+			switch leftPhysType {
+			case coltypes.Int16:
+				castLeftToRight = true
+			case coltypes.Int32:
+				castLeftToRight = rightPhysType != coltypes.Int16
+			case coltypes.Int64:
+				castLeftToRight = rightPhysType != coltypes.Int16 && rightPhysType != coltypes.Int32
+			case coltypes.Float64:
+				castLeftToRight = rightPhysType == coltypes.Decimal
+			}
+			toType := leftPhysType
+			if castLeftToRight {
+				toType = rightPhysType
+			}
+			tempVec := o.scratch.tempVecByType[toType]
+			if tempVec == nil {
+				tempVec = o.allocator.NewMemColumn(toType, int(coldata.BatchSize()))
+				o.scratch.tempVecByType[toType] = tempVec
+			} else {
+				tempVec.Nulls().UnsetNulls()
+			}
+			if castLeftToRight {
+				cast(leftPhysType, rightPhysType, lVec, tempVec, o.proberState.lBatch.Length(), lSel)
+				lVec = tempVec
+				colType = o.right.sourceTypes[rightColIdx]
+			} else {
+				cast(rightPhysType, leftPhysType, rVec, tempVec, o.proberState.rBatch.Length(), rSel)
+				rVec = tempVec
+			}
+		}
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 				_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, true, true)

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -170,13 +170,46 @@ SELECT * FROM t44207_0, t44207_1 WHERE t44207_0.c0 IS NULL
 NULL 0
 NULL 0
 
-# Regression test for the inputs that have comparable but different types.
+# Regression test for the inputs that have comparable but different types (see
+# issues #44547 and #44797).
 statement ok
 CREATE TABLE t44547_0(c0 INT4); CREATE TABLE t44547_1(c0 INT8)
 
 statement ok
 INSERT INTO t44547_0(c0) VALUES(0); INSERT INTO t44547_1(c0) VALUES(0)
 
+# Note that integers of different width are still considered equal.
 query I
 SELECT * FROM t44547_0 NATURAL JOIN t44547_1
 ----
+0
+
+statement ok
+CREATE TABLE t44797_0(a FLOAT, b DECIMAL); CREATE TABLE t44797_1(c INT2, d INT4)
+
+statement ok
+INSERT INTO t44797_0 VALUES (1.0, 1.0), (2.0, 2.0); INSERT INTO t44797_1 VALUES (1, 1), (2, 2)
+
+# Note that mixed-type comparisons - of what appears to be "same" values - do
+# not consider those values equal.
+query RRII
+SELECT * FROM t44797_0 NATURAL JOIN t44797_1
+----
+1  1.0  2  2
+1  1.0  1  1
+2  2.0  2  2
+2  2.0  1  1
+
+statement ok
+CREATE TABLE t44797_2(a FLOAT); CREATE TABLE t44797_3(b DECIMAL)
+
+statement ok
+INSERT INTO t44797_2 VALUES (1.0), (2.0); INSERT INTO t44797_3 VALUES (1.0), (2.0)
+
+query RR
+SELECT * FROM t44797_2 NATURAL JOIN t44797_3
+----
+1  2.0
+1  1.0
+2  2.0
+2  1.0

--- a/pkg/sql/logictest/testdata/logic_test/exec_merge_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_merge_join
@@ -64,3 +64,18 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMkk9r20AQxe_9FMOcErp1tP
 
 statement ok
 RESET vectorize; RESET vectorize_row_count_threshold
+
+# Regression test for the inputs that have comparable but different types (see
+# issue #44798).
+statement ok
+CREATE TABLE t44798_0(c0 INT4 PRIMARY KEY); CREATE TABLE t44798_1(c0 INT8 PRIMARY KEY)
+
+statement ok
+INSERT INTO t44798_0(c0) VALUES(0), (1), (2); INSERT INTO t44798_1(c0) VALUES(0), (2), (4)
+
+# Note that integers of different width are still considered equal.
+query I
+SELECT * FROM t44798_0 NATURAL JOIN t44798_1
+----
+0
+2


### PR DESCRIPTION
**colexec: make hashing of integers of different widths the same**

Previously we had custom hash functions for int16, int32, and int64.
This led to hash joiner not being able to correctly find matching
tuples when the types of the inputs were comparable but different. Now
this is fixed by upcasting all integers to int64 and using that value to
compute the hash.

Note that we don't need to concern ourselves with having types from
different families to hash in the same way, so only integers' hashing
function is changed.

Fixes: #44797.

Release note: None

**colexec: fix merge joiner when types of inputs in eq cols are different**

Merge joiner assumes that the types of inputs in equality columns are
the same. However, this isn't always the case - the types have to be
comparable. This problem is now fixed by performing a CAST operation when
there is a "physical" type mismatch. These "cast" operations are
performed internally by the merge joiner, and the results of the casts
are written into temporary vectors (that are reused) which are used
in-place of original uncasted "key" columns.

This required refactoring of the cast template so that there was
a single `cast` function that takes in "from" and "to" coltypes. We will
no longer generate "type-specific" CAST operators, but `cast` function
performs type switch at the batch level, so the performance hit for cast
operators should be negligible.

This commit also adds a couple of int to int casts (for different
widths).

Fixes: #44798.

Release note (bug fix): Previously, CockroachDB would return an internal
error when merge join operation was performed via the vectorized
execution engine in a case when two sides of the join have comparable
but different types in the equality columns (for example, INT2 on the
left and INT4 on the right). Now this is fixed.

**colexec: add benchmark of castOp**

Release note: None