### PR TITLE
colexec: fix hashing of equal decimals which are printed out differently

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -36,6 +36,12 @@ import (
 
 func {{template "opName" .}}(a {{.LTyp.GoTypeName}}, b {{.RTyp.GoTypeName}}) {{.RetTyp.GoTypeName}} {
 	var r {{.RetTyp.GoTypeName}}
+	// In order to inline the templated code of overloads, we need to have a
+	// "decimalScratch" local variable of type "decimalOverloadScratch".
+	var decimalScratch decimalOverloadScratch
+	// However, the scratch is not used in all of the functions, so we add this
+	// to go around "unused" error.
+	_ = decimalScratch
 	{{(.Assign "r" "a" "b")}}
 	return r
 }

--- a/pkg/sql/colexec/hash_utils.go
+++ b/pkg/sql/colexec/hash_utils.go
@@ -107,7 +107,8 @@ type tupleHashDistributor struct {
 	selections [][]uint16
 	// cancelChecker is used during the hashing of the rows to distribute to
 	// check for query cancellation.
-	cancelChecker CancelChecker
+	cancelChecker  CancelChecker
+	decimalScratch decimalOverloadScratch
 }
 
 func newTupleHashDistributor(initHashValue uint64, numOutputs int) *tupleHashDistributor {
@@ -129,7 +130,7 @@ func (d *tupleHashDistributor) distribute(
 	initHash(d.buckets, n, d.initHashValue)
 
 	for _, i := range hashCols {
-		rehash(ctx, d.buckets, types[i], b.ColVec(int(i)), n, b.Selection(), d.cancelChecker)
+		rehash(ctx, d.buckets, types[i], b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, d.decimalScratch)
 	}
 
 	finalizeHash(d.buckets, n, uint64(len(d.selections)))

--- a/pkg/sql/colexec/hash_utils_test.go
+++ b/pkg/sql/colexec/hash_utils_test.go
@@ -36,13 +36,16 @@ func TestHashFunctionFamily(t *testing.T) {
 		keys[0].Int64()[i] = i
 	}
 	numBuckets := uint64(16)
-	var cancelChecker CancelChecker
+	var (
+		cancelChecker  CancelChecker
+		decimalScratch decimalOverloadScratch
+	)
 
 	for initHashValue, buckets := range [][]uint64{bucketsA, bucketsB} {
 		// We need +1 here because 0 is not a valid initial hash value.
 		initHash(buckets, nKeys, uint64(initHashValue+1))
 		for i, typ := range keyTypes {
-			rehash(ctx, buckets, typ, keys[i], nKeys, nil /* sel */, cancelChecker)
+			rehash(ctx, buckets, typ, keys[i], nKeys, nil /* sel */, cancelChecker, decimalScratch)
 		}
 		finalizeHash(buckets, nKeys, numBuckets)
 	}

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -114,6 +114,7 @@ func rehash(
 	nKeys uint64,
 	sel []uint16,
 	cancelChecker CancelChecker,
+	decimalScratch decimalOverloadScratch,
 ) {
 	switch t {
 	// {{range $hashType := .}}

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -111,7 +111,8 @@ type hashTable struct {
 	// each other.
 	allowNullEquality bool
 
-	cancelChecker CancelChecker
+	decimalScratch decimalOverloadScratch
+	cancelChecker  CancelChecker
 }
 
 var _ resetter = &hashTable{}
@@ -303,7 +304,7 @@ func (ht *hashTable) computeBuckets(
 	}
 
 	for i := range ht.keyCols {
-		rehash(ctx, buckets, keyTypes[i], keys[i], nKeys, sel, ht.cancelChecker)
+		rehash(ctx, buckets, keyTypes[i], keys[i], nKeys, sel, ht.cancelChecker, ht.decimalScratch)
 	}
 
 	finalizeHash(buckets, nKeys, ht.numBuckets)

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/cockroachdb/apd"
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	// */}}
@@ -46,9 +45,6 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
-
-// Dummy import to pull in "apd" package.
-var _ apd.Decimal
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the the second input != the third input.
@@ -174,6 +170,9 @@ func _CHECK_COL_WITH_NULLS(
 func (ht *hashTable) checkCol(
 	probeType, buildType coltypes.T, keyColIdx int, nToCheck uint16, sel []uint16,
 ) {
+	// In order to inline the templated code of overloads, we need to have a
+	// `decimalScratch` local variable of type `decimalOverloadScratch`.
+	decimalScratch := ht.decimalScratch
 	switch probeType {
 	// {{range $lTyp, $rTypToOverload := .}}
 	case _PROBE_TYPE:

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -89,6 +89,12 @@ type _OP_CONST_NAME struct {
 }
 
 func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `decimalScratch` local variable of type `decimalOverloadScratch`.
+	decimalScratch := p.decimalScratch
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = decimalScratch
 	batch := p.input.Next(ctx)
 	n := batch.Length()
 	if n == 0 {

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"math"
 
-	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
@@ -43,9 +42,6 @@ import (
 
 // Dummy import to pull in "bytes" package.
 var _ bytes.Buffer
-
-// Dummy import to pull in "apd" package.
-var _ apd.Decimal
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum
@@ -92,6 +88,12 @@ type _OP_NAME struct {
 }
 
 func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `decimalScratch` local variable of type `decimalOverloadScratch`.
+	decimalScratch := p.decimalScratch
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = decimalScratch
 	batch := p.input.Next(ctx)
 	n := batch.Length()
 	if n == 0 {

--- a/pkg/sql/colexec/projection_ops.go
+++ b/pkg/sql/colexec/projection_ops.go
@@ -14,16 +14,18 @@ package colexec
 // constant, except for the constant itself.
 type projConstOpBase struct {
 	OneInputNode
-	allocator *Allocator
-	colIdx    int
-	outputIdx int
+	allocator      *Allocator
+	colIdx         int
+	outputIdx      int
+	decimalScratch decimalOverloadScratch
 }
 
 // projOpBase contains all of the fields for non-constant binary projections.
 type projOpBase struct {
 	OneInputNode
-	allocator *Allocator
-	col1Idx   int
-	col2Idx   int
-	outputIdx int
+	allocator      *Allocator
+	col1Idx        int
+	col2Idx        int
+	outputIdx      int
+	decimalScratch decimalOverloadScratch
 }

--- a/pkg/sql/colexec/selection_ops.go
+++ b/pkg/sql/colexec/selection_ops.go
@@ -14,12 +14,14 @@ package colexec
 // constant, except for the constant itself.
 type selConstOpBase struct {
 	OneInputNode
-	colIdx int
+	colIdx         int
+	decimalScratch decimalOverloadScratch
 }
 
 // selOpBase contains all of the fields for non-constant binary selections.
 type selOpBase struct {
 	OneInputNode
-	col1Idx int
-	col2Idx int
+	col1Idx        int
+	col2Idx        int
+	decimalScratch decimalOverloadScratch
 }

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -177,6 +177,12 @@ type _OP_CONST_NAME struct {
 }
 
 func (p *_OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `decimalScratch` local variable of type `decimalOverloadScratch`.
+	decimalScratch := p.decimalScratch
+	// However, the scratch is not used in all of the selection operators, so
+	// we add this to go around "unused" error.
+	_ = decimalScratch
 	for {
 		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {
@@ -212,6 +218,12 @@ type _OP_NAME struct {
 }
 
 func (p *_OP_NAME) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `decimalScratch` local variable of type `decimalOverloadScratch`.
+	decimalScratch := p.decimalScratch
+	// However, the scratch is not used in all of the selection operators, so
+	// we add this to go around "unused" error.
+	_ = decimalScratch
 	for {
 		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -30,6 +30,14 @@ var (
 	zeroIntervalValue duration.Duration
 )
 
+// decimalOverloadScratch is a utility struct that helps us avoid allocations
+// of temporary decimals on every overloaded operation with them. In order for
+// the templates to see it correctly, a local variable named `scratch` of this
+// type must be declared before the inlined overloaded code.
+type decimalOverloadScratch struct {
+	tmpDec1, tmpDec2 apd.Decimal
+}
+
 // CopyBatch copies the original batch and returns that copy. However, note that
 // the underlying capacity might be different (a new batch is created only with
 // capacity original.Length()).

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1120,3 +1120,13 @@ CREATE TABLE t44822(c0 BYTES); CREATE VIEW v0(c0) AS SELECT min(t44822.c0) FROM 
 query T
 SELECT * FROM v0 WHERE v0.c0 NOT BETWEEN v0.c0 AND v0.c0
 ----
+
+# Regression test for #44935 (decimals with different number of trailing zeroes
+# hashing to different values).
+statement ok
+CREATE TABLE t44935 (x decimal); INSERT INTO t44935 VALUES (1.0), (1.00)
+
+query I
+SELECT count(*) FROM (SELECT DISTINCT x FROM t44935)
+----
+1


### PR DESCRIPTION
In order to hash decimals, we first print them out (i.e. convert to
string) and then hash the strings. However, this is problematic when
decimals have different number of trailing zeroes because such decimals
are considered equal, yet they would hash to different values. Now this
is fixed by "reducing" decimals before stringifying them.

Additionally, this commit does a minor cleanup. Previously, we would
allocate a new apd.Decimal on each comparison and on each hash
computation. This is now fixed by providing a scratch struct that
contains two temporary decimals which are reused between iterations.
There is some fragility involved - in order to not change the number of
arguments that templated functions take in, it is now assumed that
a variable named `decimalScratch` of newly introduced
`decimalOverloadScratch` type is available for the overloaded methods.
Note that we cannot have a single global scratch struct due to possible
concurrent accesses that will interfere with each other.

Fixes: #44935.

Release note: None (this problem could occur only with `experimental_on`
vectorize setting).