### PR TITLE
storage/rangefeed: deflake TestProcessorSlowConsumer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1572,15 +1572,15 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
+  digest = "1:99d32780e5238c2621fff621123997c3e3cca96db8be13179013aea77dfab551"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
   ]
   pruneopts = "UT"
-  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
-  version = "v1.3.0"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -432,9 +432,6 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	p, stopper := newTestProcessor(nil /* rtsIter */)
 	defer stopper.Stop(context.Background())
 
-	// Set the Processor's eventC timeout.
-	p.EventChanTimeout = 100 * time.Millisecond
-
 	// Add a registration.
 	r1Stream := newTestStream()
 	r1ErrC := make(chan *roachpb.Error, 1)
@@ -465,57 +462,56 @@ func TestProcessorSlowConsumer(t *testing.T) {
 		)},
 		r1Stream.Events(),
 	)
+	require.Equal(t,
+		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+			roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
+			hlc.Timestamp{WallTime: 0},
+		)},
+		r2Stream.Events(),
+	)
 
-	// Block its Send method and fill up the processor's input channel.
+	// Block its Send method and fill up the registration's input channel.
 	unblock := r1Stream.BlockSend()
 	defer func() {
 		if unblock != nil {
 			unblock()
 		}
 	}()
-	fillEventC := func() {
-		// Need one more message to fill the channel because the first one
-		// will be Sent to the stream and block the processor goroutine.
-		toFill := testProcessorEventCCap + 1
-		for i := 0; i < toFill; i++ {
-			ts := hlc.Timestamp{WallTime: int64(i + 2)}
-			p.ConsumeLogicalOps(
-				writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")),
-			)
-		}
-	}
-	fillEventC()
-	p.syncEventC()
-
-	// Wait for just the unblocked registration to catch up. This prevents the
-	// race condition where this registration overflows anyway due to the rapid
-	// event consumption and small buffer size.
-	p.syncEventAndRegistrationSpan(spXY)
-
-	// Consume one more event. Should not block.
-	consumedC := make(chan struct{})
-	go func() {
+	// Need one more message to fill the channel because the first one will be
+	// sent to the stream and block the registration outputLoop goroutine.
+	toFill := testProcessorEventCCap + 1
+	for i := 0; i < toFill; i++ {
+		ts := hlc.Timestamp{WallTime: int64(i + 2)}
 		p.ConsumeLogicalOps(
-			writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 15}, []byte("val")),
+			writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")),
 		)
-		close(consumedC)
-	}()
-	<-consumedC
-	p.syncEventC()
+
+		// Wait for just the unblocked registration to catch up. This prevents
+		// the race condition where this registration overflows anyway due to
+		// the rapid event consumption and small buffer size.
+		p.syncEventAndRegistrationSpan(spXY)
+	}
+
+	// Consume one more event. Should not block, but should cause r1 to overflow
+	// its registration buffer and drop the event.
+	p.ConsumeLogicalOps(
+		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 18}, []byte("val")),
+	)
 
 	// Wait for just the unblocked registration to catch up.
 	p.syncEventAndRegistrationSpan(spXY)
-	events := r2Stream.Events()
-	require.Equal(t, testProcessorEventCCap+3, len(events))
+	require.Equal(t, toFill+1, len(r2Stream.Events()))
 	require.Equal(t, 2, p.reg.Len())
 
 	// Unblock the send channel. The events should quickly be consumed.
 	unblock()
 	unblock = nil
-	<-consumedC
 	p.syncEventAndRegistrations()
-	// One event was dropped due to overflow.
-	require.Equal(t, testProcessorEventCCap+1, len(r1Stream.Events()))
+	// At least one event should have been dropped due to overflow. We expect
+	// exactly one event to be dropped, but it is possible that multiple events
+	// were dropped due to rapid event consumption before the r1's outputLoop
+	// began consuming from its event buffer.
+	require.True(t, len(r1Stream.Events()) <= toFill)
 	require.Equal(t, newErrBufferCapacityExceeded().GoError(), (<-r1ErrC).GoError())
 	testutils.SucceedsSoon(t, func() error {
 		if act, exp := p.Len(), 1; exp != act {

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -511,7 +511,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	// exactly one event to be dropped, but it is possible that multiple events
 	// were dropped due to rapid event consumption before the r1's outputLoop
 	// began consuming from its event buffer.
-	require.True(t, len(r1Stream.Events()) <= toFill)
+	require.LessOrEqual(t, len(r1Stream.Events()), toFill)
 	require.Equal(t, newErrBufferCapacityExceeded().GoError(), (<-r1ErrC).GoError())
 	testutils.SucceedsSoon(t, func() error {
 		if act, exp := p.Len(), 1; exp != act {

--- a/pkg/storage/reports/reporter_test.go
+++ b/pkg/storage/reports/reporter_test.go
@@ -188,7 +188,7 @@ func TestCriticalLocalitiesReportIntegration(t *testing.T) {
 		}
 		require.NoError(t, rows.Err())
 	}
-	require.True(t, len(systemZoneIDs) > 0, "expected some system zones, got none")
+	require.Greater(t, len(systemZoneIDs), 0, "expected some system zones, got none")
 	// Remove the entries in systemZoneIDs that don't get critical locality reports.
 	i := 0
 	for j, zid := range systemZoneIDs {
@@ -395,7 +395,7 @@ func TestMeta2RangeIter(t *testing.T) {
 		}
 		numRanges++
 	}
-	require.True(t, numRanges > 20, "expected over 20 ranges, got: %d", numRanges)
+	require.Greater(t, numRanges, 20, "expected over 20 ranges, got: %d", numRanges)
 
 	// Now make an interator with a small page size and check that we get just as many ranges.
 	iter = makeMeta2RangeIter(db, 2 /* batch size */)
@@ -427,7 +427,7 @@ func TestRetriableErrorWhenGenerationReport(t *testing.T) {
 	realIter := makeMeta2RangeIter(db, 10000 /* batchSize */)
 	require.NoError(t, visitRanges(ctx, &realIter, cfg, &v))
 	expReport := v.report
-	require.True(t, len(expReport.stats) > 0, "unexpected empty report")
+	require.Greater(t, len(expReport.stats), 0, "unexpected empty report")
 
 	realIter = makeMeta2RangeIter(db, 10000 /* batchSize */)
 	errorIter := erroryRangeIterator{
@@ -436,7 +436,7 @@ func TestRetriableErrorWhenGenerationReport(t *testing.T) {
 	}
 	v = makeReplicationStatsVisitor(ctx, cfg, func(id roachpb.NodeID) bool { return true }, &saver)
 	require.NoError(t, visitRanges(ctx, &errorIter, cfg, &v))
-	require.True(t, len(v.report.stats) > 0, "unexpected empty report")
+	require.Greater(t, len(v.report.stats), 0, "unexpected empty report")
 	require.Equal(t, expReport, v.report)
 }
 

--- a/pkg/storage/spanlatch/latch_interval_btree_test.go
+++ b/pkg/storage/spanlatch/latch_interval_btree_test.go
@@ -71,8 +71,8 @@ func (t *btree) verifyCountAllowed(tt *testing.T) {
 
 func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 	if !root {
-		require.True(t, n.count >= minItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
-		require.True(t, n.count <= maxItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.GreaterOrEqual(t, n.count, int16(minItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.LessOrEqual(t, n.count, int16(maxItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
 	}
 	for i, item := range n.items {
 		if i < int(n.count) {
@@ -101,15 +101,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, cmp(n.items[i-1], n.items[i]) <= 0)
+		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.True(t, cmp(prev.items[prev.count-1], n.items[i]) <= 0)
-			require.True(t, cmp(n.items[i], next.items[0]) <= 0)
+			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -124,12 +124,12 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 func (n *node) isUpperBoundCorrect(t *testing.T) {
 	require.Equal(t, 0, n.findUpperBound().compare(n.max))
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, upperBound(n.items[i]).compare(n.max) <= 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.True(t, child.max.compare(n.max) <= 0)
+			require.LessOrEqual(t, child.max.compare(n.max), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/storage/txn_wait_queue_test.go
+++ b/pkg/storage/txn_wait_queue_test.go
@@ -760,7 +760,7 @@ func TestTxnWaitQueueDependencyCycle(t *testing.T) {
 		}
 	}
 	require.True(t, pushed)
-	require.True(t, m.DeadlocksTotal.Count() >= 1)
+	require.GreaterOrEqual(t, m.DeadlocksTotal.Count(), int64(1))
 }
 
 // TestTxnWaitQueueDependencyCycleWithPriorityInversion verifies that

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -71,8 +71,8 @@ func (t *btree) verifyCountAllowed(tt *testing.T) {
 
 func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 	if !root {
-		require.True(t, n.count >= minItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
-		require.True(t, n.count <= maxItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.GreaterOrEqual(t, n.count, int16(minItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.LessOrEqual(t, n.count, int16(maxItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
 	}
 	for i, item := range n.items {
 		if i < int(n.count) {
@@ -101,15 +101,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, cmp(n.items[i-1], n.items[i]) <= 0)
+		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.True(t, cmp(prev.items[prev.count-1], n.items[i]) <= 0)
-			require.True(t, cmp(n.items[i], next.items[0]) <= 0)
+			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -124,12 +124,12 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 func (n *node) isUpperBoundCorrect(t *testing.T) {
 	require.Equal(t, 0, n.findUpperBound().compare(n.max))
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, upperBound(n.items[i]).compare(n.max) <= 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.True(t, child.max.compare(n.max) <= 0)
+			require.LessOrEqual(t, child.max.compare(n.max), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -71,8 +71,8 @@ func (t *btree) verifyCountAllowed(tt *testing.T) {
 
 func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 	if !root {
-		require.True(t, n.count >= minItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
-		require.True(t, n.count <= maxItems, "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.GreaterOrEqual(t, n.count, int16(minItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.LessOrEqual(t, n.count, int16(maxItems), "latch count %d must be in range [%d,%d]", n.count, minItems, maxItems)
 	}
 	for i, item := range n.items {
 		if i < int(n.count) {
@@ -101,15 +101,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, cmp(n.items[i-1], n.items[i]) <= 0)
+		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.True(t, cmp(prev.items[prev.count-1], n.items[i]) <= 0)
-			require.True(t, cmp(n.items[i], next.items[0]) <= 0)
+			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -124,12 +124,12 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 func (n *node) isUpperBoundCorrect(t *testing.T) {
 	require.Equal(t, 0, n.findUpperBound().compare(n.max))
 	for i := int16(1); i < n.count; i++ {
-		require.True(t, upperBound(n.items[i]).compare(n.max) <= 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.True(t, child.max.compare(n.max) <= 0)
+			require.LessOrEqual(t, child.max.compare(n.max), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -509,7 +509,7 @@ func TestIntpoolRelease(t *testing.T) {
 				if acq == nil {
 					continue
 				}
-				require.True(t, acq.q <= capacity)
+				require.LessOrEqual(t, acq.q, uint64(capacity))
 				alloc, err := pools[acq.pool].Acquire(ctx, acq.q)
 				require.NoError(t, err)
 				allocs[i] = alloc


### PR DESCRIPTION
Fixes #43052.

This commit fixes TestProcessorSlowConsumer, which was flaky in two different places for the same reason. The test was blocking a rangefeed registration's stream (r1) and then consuming exactly enough events to fill the rangefeed's event buffer. It then consumed one more event and asserted that this event, and only this event, was dropped due to overflow. The test was assuming that to fill the registration's buffer, it needed to consume the capacity of the buffer + 1 because the registration's output loop would pull the first event out of the buffer. However, it was possible with the right timing that the registration's outputLoop would be too slow to pull from its channel and two events would be dropped instead. This case what referenced but not being properly handled.

The same issue was possible with the registration that was not blocked. Even that registration could fall prey to rapid event consumption which would cause its channel to overflow.

This commit fixes both cases. The test is no longer flaky with the timing patch referenced in #43052.