### PR TITLE
storage/cloud: return relative paths for explicit patterns, preserve URI params

### DIFF
--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -282,8 +282,8 @@ func TestBlobClientList(t *testing.T) {
 
 	blobClientFactory := setUpService(t, rpcContext, localNodeID, remoteNodeID, localExternalDir, remoteExternalDir)
 
-	localFileNames := []string{"file/local/dataA.csv", "file/local/dataB.csv", "file/local/dataC.csv"}
-	remoteFileNames := []string{"file/remote/A.csv", "file/remote/B.csv", "file/remote/C.csv"}
+	localFileNames := []string{"/file/local/dataA.csv", "/file/local/dataB.csv", "/file/local/dataC.csv"}
+	remoteFileNames := []string{"/file/remote/A.csv", "/file/remote/B.csv", "/file/remote/C.csv"}
 	for _, fileName := range localFileNames {
 		fullPath := filepath.Join(localExternalDir, fileName)
 		writeTestFile(t, fullPath, []byte("testLocalFile"))
@@ -340,7 +340,7 @@ func TestBlobClientList(t *testing.T) {
 			"list-star",
 			remoteNodeID,
 			"*",
-			[]string{"file"},
+			[]string{"/file"},
 			"",
 		},
 		{

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -159,7 +159,7 @@ func (l *LocalStorage) List(pattern string) ([]string, error) {
 
 	var fileList []string
 	for _, file := range matches {
-		fileList = append(fileList, strings.TrimPrefix(strings.TrimPrefix(file, l.externalIODir), "/"))
+		fileList = append(fileList, strings.TrimPrefix(file, l.externalIODir))
 	}
 	return fileList, nil
 }

--- a/pkg/blobs/service_test.go
+++ b/pkg/blobs/service_test.go
@@ -25,7 +25,7 @@ func TestBlobServiceList(t *testing.T) {
 	defer cleanupFn()
 
 	fileContent := []byte("a")
-	files := []string{"file/dir/a.csv", "file/dir/b.csv", "file/dir/c.csv"}
+	files := []string{"/file/dir/a.csv", "/file/dir/b.csv", "/file/dir/c.csv"}
 	for _, file := range files {
 		writeTestFile(t, filepath.Join(tmpDir, file), fileContent)
 	}

--- a/pkg/storage/cloud/azure_storage.go
+++ b/pkg/storage/cloud/azure_storage.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -59,7 +59,7 @@ func makeAzureStorage(
 }
 
 func (s *azureStorage) getBlob(basename string) azblob.BlockBlobURL {
-	name := filepath.Join(s.prefix, basename)
+	name := path.Join(s.prefix, basename)
 	return s.container.NewBlockBlobURL(name)
 }
 
@@ -98,7 +98,7 @@ func (s *azureStorage) ReadFile(ctx context.Context, basename string) (io.ReadCl
 func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
 	pattern := s.prefix
 	if patternSuffix != "" {
-		pattern = filepath.Join(pattern, patternSuffix)
+		pattern = path.Join(pattern, patternSuffix)
 	}
 	var fileList []string
 	response, err := s.container.ListBlobsFlatSegment(ctx,
@@ -110,7 +110,7 @@ func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]s
 	}
 
 	for _, blob := range response.Segment.BlobItems {
-		matches, err := filepath.Match(pattern, blob.Name)
+		matches, err := path.Match(pattern, blob.Name)
 		if err != nil {
 			continue
 		}

--- a/pkg/storage/cloud/azure_storage.go
+++ b/pkg/storage/cloud/azure_storage.go
@@ -25,6 +25,17 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+func azureQueryParams(conf *roachpb.ExternalStorage_Azure) string {
+	q := make(url.Values)
+	if conf.AccountName != "" {
+		q.Set(AzureAccountNameParam, conf.AccountName)
+	}
+	if conf.AccountKey != "" {
+		q.Set(AzureAccountKeyParam, conf.AccountKey)
+	}
+	return q.Encode()
+}
+
 type azureStorage struct {
 	conf      *roachpb.ExternalStorage_Azure
 	container azblob.ContainerURL
@@ -116,9 +127,10 @@ func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]s
 		}
 		if matches {
 			azureURL := url.URL{
-				Scheme: "azure",
-				Host:   strings.TrimPrefix(s.container.URL().Path, "/"),
-				Path:   blob.Name,
+				Scheme:   "azure",
+				Host:     strings.TrimPrefix(s.container.URL().Path, "/"),
+				Path:     blob.Name,
+				RawQuery: azureQueryParams(s.conf),
 			}
 			fileList = append(fileList, azureURL.String())
 		}

--- a/pkg/storage/cloud/azure_storage.go
+++ b/pkg/storage/cloud/azure_storage.go
@@ -109,12 +109,15 @@ func (s *azureStorage) ReadFile(ctx context.Context, basename string) (io.ReadCl
 func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
 	pattern := s.prefix
 	if patternSuffix != "" {
+		if containsGlob(s.prefix) {
+			return nil, errors.New("prefix cannot contain globs pattern when passing an explicit pattern")
+		}
 		pattern = path.Join(pattern, patternSuffix)
 	}
 	var fileList []string
 	response, err := s.container.ListBlobsFlatSegment(ctx,
 		azblob.Marker{},
-		azblob.ListBlobsSegmentOptions{Prefix: getBucketBeforeWildcard(s.prefix)},
+		azblob.ListBlobsSegmentOptions{Prefix: getPrefixBeforeWildcard(s.prefix)},
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list files for specified blob")

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -144,6 +144,7 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 			Endpoint:  uri.Query().Get(S3EndpointParam),
 			Region:    uri.Query().Get(S3RegionParam),
 			Auth:      uri.Query().Get(AuthParam),
+			/* NB: additions here should also update s3QueryParams() serializer */
 		}
 		conf.S3Config.Prefix = strings.TrimLeft(conf.S3Config.Prefix, "/")
 		// AWS secrets often contain + characters, which must be escaped when
@@ -162,6 +163,7 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 			Auth:           uri.Query().Get(AuthParam),
 			BillingProject: uri.Query().Get(GoogleBillingProjectParam),
 			Credentials:    uri.Query().Get(CredentialsParam),
+			/* NB: additions here should also update gcsQueryParams() serializer */
 		}
 		conf.GoogleCloudConfig.Prefix = strings.TrimLeft(conf.GoogleCloudConfig.Prefix, "/")
 	case "azure":
@@ -171,6 +173,7 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 			Prefix:      uri.Path,
 			AccountName: uri.Query().Get(AzureAccountNameParam),
 			AccountKey:  uri.Query().Get(AzureAccountKeyParam),
+			/* NB: additions here should also update azureQueryParams() serializer */
 		}
 		if conf.AzureConfig.AccountName == "" {
 			return conf, errors.Errorf("azure uri missing %q parameter", AzureAccountNameParam)

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -30,6 +30,20 @@ import (
 	"google.golang.org/api/option"
 )
 
+func gcsQueryParams(conf *roachpb.ExternalStorage_GCS) string {
+	q := make(url.Values)
+	if conf.Auth != "" {
+		q.Set(AuthParam, conf.Auth)
+	}
+	if conf.Credentials != "" {
+		q.Set(CredentialsParam, conf.Credentials)
+	}
+	if conf.BillingProject != "" {
+		q.Set(GoogleBillingProjectParam, conf.BillingProject)
+	}
+	return q.Encode()
+}
+
 type gcsStorage struct {
 	bucket   *gcs.BucketHandle
 	client   *gcs.Client
@@ -176,9 +190,10 @@ func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]str
 		}
 		if matches {
 			gsURL := url.URL{
-				Scheme: "gs",
-				Host:   attrs.Bucket,
-				Path:   attrs.Name,
+				Scheme:   "gs",
+				Host:     attrs.Bucket,
+				Path:     attrs.Name,
+				RawQuery: gcsQueryParams(g.conf),
 			}
 			fileList = append(fileList, gsURL.String())
 		}

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -30,7 +30,7 @@ func TestPutLocal(t *testing.T) {
 	dest := MakeLocalStorageURI(p)
 
 	testExportStore(t, dest, false)
-	testListFiles(t, fmt.Sprintf("nodelocal:///%s", "listing-test"))
+	testListFiles(t, "nodelocal:///listing-test/basepath")
 }
 
 func TestLocalIOLimits(t *testing.T) {

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"io"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -127,7 +127,7 @@ func (s *s3Storage) WriteFile(ctx context.Context, basename string, content io.R
 		func(ctx context.Context) error {
 			_, err := s.s3.PutObjectWithContext(ctx, &s3.PutObjectInput{
 				Bucket: s.bucket,
-				Key:    aws.String(filepath.Join(s.prefix, basename)),
+				Key:    aws.String(path.Join(s.prefix, basename)),
 				Body:   content,
 			})
 			return err
@@ -139,7 +139,7 @@ func (s *s3Storage) ReadFile(ctx context.Context, basename string) (io.ReadClose
 	// https://github.com/cockroachdb/cockroach/issues/23859
 	out, err := s.s3.GetObjectWithContext(ctx, &s3.GetObjectInput{
 		Bucket: s.bucket,
-		Key:    aws.String(filepath.Join(s.prefix, basename)),
+		Key:    aws.String(path.Join(s.prefix, basename)),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get s3 object")
@@ -147,12 +147,12 @@ func (s *s3Storage) ReadFile(ctx context.Context, basename string) (io.ReadClose
 	return out.Body, nil
 }
 
-func getBucketBeforeWildcard(path string) string {
-	globIndex := strings.IndexAny(path, "*?[")
+func getBucketBeforeWildcard(p string) string {
+	globIndex := strings.IndexAny(p, "*?[")
 	if globIndex < 0 {
-		return path
+		return p
 	}
-	return filepath.Dir(path[:globIndex])
+	return path.Dir(p[:globIndex])
 }
 
 func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
@@ -161,7 +161,7 @@ func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]stri
 
 	pattern := s.prefix
 	if patternSuffix != "" {
-		pattern = filepath.Join(pattern, patternSuffix)
+		pattern = path.Join(pattern, patternSuffix)
 	}
 
 	err := s.s3.ListObjectsPagesWithContext(
@@ -171,7 +171,7 @@ func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]stri
 		},
 		func(page *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, fileObject := range page.Contents {
-				matches, err := filepath.Match(pattern, *fileObject.Key)
+				matches, err := path.Match(pattern, *fileObject.Key)
 				if err != nil {
 					continue
 				}
@@ -200,7 +200,7 @@ func (s *s3Storage) Delete(ctx context.Context, basename string) error {
 		func(ctx context.Context) error {
 			_, err := s.s3.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
 				Bucket: s.bucket,
-				Key:    aws.String(filepath.Join(s.prefix, basename)),
+				Key:    aws.String(path.Join(s.prefix, basename)),
 			})
 			return err
 		})
@@ -214,7 +214,7 @@ func (s *s3Storage) Size(ctx context.Context, basename string) (int64, error) {
 			var err error
 			out, err = s.s3.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
 				Bucket: s.bucket,
-				Key:    aws.String(filepath.Join(s.prefix, basename)),
+				Key:    aws.String(path.Join(s.prefix, basename)),
 			})
 			return err
 		})

--- a/pkg/storage/cloud/s3_storage_test.go
+++ b/pkg/storage/cloud/s3_storage_test.go
@@ -83,16 +83,14 @@ func TestPutS3(t *testing.T) {
 			),
 			false,
 		)
-		t.Run("ListFiles", func(t *testing.T) {
-			testListFiles(t,
-				fmt.Sprintf(
-					"s3://%s/%s?%s=%s&%s=%s",
-					bucket, "listing-test",
-					S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
-					S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
-				),
-			)
-		})
+		testListFiles(t,
+			fmt.Sprintf(
+				"s3://%s/%s?%s=%s&%s=%s",
+				bucket, "listing-test",
+				S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
+				S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
+			),
+		)
 	})
 }
 


### PR DESCRIPTION
This changes the results returned by `ListFiles` to be relative paths when a relative pattern is used for listing.

Specifically, when `ListFiles` is invoked with an explicit pattern argument (as opposed to when the entire base-path for the storage connection is itself the pattern), the paths returned in the results are the relative paths of each match, relative to the connection's configured base path, rather than individually fully-qualified URIs (which are what it returns when not passed a relative pattern as an argument).

The reason for this is that a storage connection instance can be used two ways: 1) initialized with a single, full path to some file or globs pattern as its "base" path and used once, to perform the intended operation on that file and then closed, or 2) initialized with some common base path in which it can then be reused to read, write and list different files, passing their relative path within that prefix each time, without having to recreate the client on every operation. When `ListFiles` is used in the later case, returning relative results when queried for files matching a pattern and means it can then be asked to open those files it returned, e.g:
```
x := cloud.NewFoo('somebucket', 'some/path/prefix')
for _, i := range x.ListFiles('*.csv') {
  f := x.ReadFile(i)
...
```

Note: For now, this also imposes the restriction that all matched results are within the base path (i.e. that the pattern wasn't `../../*.csv`) for simplicity of calculating its relative paths (via simple prefix removal). For more  fundamental reasons, the base path cannot itself contain patterns since a) that would make it hard to define what the relative path is and b) in the intended usage of re-using a single long-lived connection object to also read/write, that doesn't make sense.

Release note: none.

While I'm here:
These fully qualified URIs did not previously include provider-specific query parameters, so even if
the correct access keys / tokens were provided to do the initial listing connection, after expansion,
the result file URIs would encounter missing permission errors if the implementation required them (e.g. s3).

Release note: none.

While I'm here: we should be using `path` instead of `filepath` throughout.