### PR TITLE
backup,import: count system table rows as rows

### DIFF
--- a/c-deps/libroach/row_counter.cc
+++ b/c-deps/libroach/row_counter.cc
@@ -99,17 +99,13 @@ bool RowCounter::Count(const rocksdb::Slice& key, cockroach::roachpb::BulkOpSumm
     return false;
   }
 
-  if (tbl < MaxReservedDescID) {
-    summary->set_system_records(summary->system_records() + 1);
+  uint64_t index_id;
+  if (!DecodeUvarint64(&decoded_key, &index_id)) {
+    return false;
+  } else if (index_id == 1) {
+    summary->set_rows(summary->rows() + 1);
   } else {
-    uint64_t index_id;
-    if (!DecodeUvarint64(&decoded_key, &index_id)) {
-      return false;
-    } else if (index_id == 1) {
-      summary->set_rows(summary->rows() + 1);
-    } else {
-      summary->set_index_entries(summary->index_entries() + 1);
-    }
+    summary->set_index_entries(summary->index_entries() + 1);
   }
 
   return true;

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -537,7 +537,6 @@ func (b *backupResumer) OnTerminal(
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(b.res.Rows)),
 			tree.NewDInt(tree.DInt(b.res.IndexEntries)),
-			tree.NewDInt(tree.DInt(b.res.SystemRecords)),
 			tree.NewDInt(tree.DInt(b.res.DataSize)),
 		}
 	}

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -270,7 +270,6 @@ func backupPlanHook(
 		{Name: "fraction_completed", Typ: types.Float},
 		{Name: "rows", Typ: types.Int},
 		{Name: "index_entries", Typ: types.Int},
-		{Name: "system_records", Typ: types.Int},
 		{Name: "bytes", Typ: types.Int},
 	}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -170,7 +170,7 @@ func verifyBackupRestoreStatementResult(
 		return err
 	}
 	if e, a := columns, []string{
-		"job_id", "status", "fraction_completed", "rows", "index_entries", "system_records", "bytes",
+		"job_id", "status", "fraction_completed", "rows", "index_entries", "bytes",
 	}; !reflect.DeepEqual(e, a) {
 		return errors.Errorf("unexpected columns:\n%s", strings.Join(pretty.Diff(e, a), "\n"))
 	}
@@ -189,7 +189,7 @@ func verifyBackupRestoreStatementResult(
 		return errors.New("zero rows in result")
 	}
 	if err := rows.Scan(
-		&actualJob.id, &actualJob.status, &actualJob.fractionCompleted, &unused, &unused, &unused, &unused,
+		&actualJob.id, &actualJob.status, &actualJob.fractionCompleted, &unused, &unused, &unused,
 	); err != nil {
 		return err
 	}
@@ -480,13 +480,13 @@ func backupAndRestore(
 
 		var unused string
 		var exported struct {
-			rows, idx, sys, bytes int64
+			rows, idx, bytes int64
 		}
 
 		backupURIFmtString, backupURIArgs := uriFmtStringAndArgs(backupURIs)
 		backupQuery := fmt.Sprintf("BACKUP DATABASE data TO %s", backupURIFmtString)
 		sqlDB.QueryRow(t, backupQuery, backupURIArgs...).Scan(
-			&unused, &unused, &unused, &exported.rows, &exported.idx, &exported.sys, &exported.bytes,
+			&unused, &unused, &unused, &exported.rows, &exported.idx, &exported.bytes,
 		)
 		// When numAccounts == 0, our approxBytes formula breaks down because
 		// backups of no data still contain the system.users and system.descriptor
@@ -553,13 +553,13 @@ func backupAndRestore(
 
 		var unused string
 		var restored struct {
-			rows, idx, sys, bytes int64
+			rows, idx, bytes int64
 		}
 
 		restoreURIFmtString, restoreURIArgs := uriFmtStringAndArgs(restoreURIs)
 		restoreQuery := fmt.Sprintf("RESTORE DATABASE DATA FROM %s", restoreURIFmtString)
 		sqlDBRestore.QueryRow(t, restoreQuery, restoreURIArgs...).Scan(
-			&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.sys, &restored.bytes,
+			&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.bytes,
 		)
 		approxBytes := int64(backupRestoreRowPayloadSize * numAccounts)
 		if max := approxBytes * 3; restored.bytes < approxBytes || restored.bytes > max {
@@ -1366,7 +1366,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	var unused string
 	var exportedRows int
 	sqlDB.QueryRow(t, `BACKUP DATABASE data TO $1`, localFoo).Scan(
-		&unused, &unused, &unused, &exportedRows, &unused, &unused, &unused,
+		&unused, &unused, &unused, &exportedRows, &unused, &unused,
 	)
 	if exportedRows != totalRows {
 		// TODO(dt): fix row-count including interleaved garbarge
@@ -1383,7 +1383,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 		var importedRows int
 		sqlDBRestore.QueryRow(t, `RESTORE data.* FROM $1`, localFoo).Scan(
-			&unused, &unused, &unused, &importedRows, &unused, &unused, &unused,
+			&unused, &unused, &unused, &importedRows, &unused, &unused,
 		)
 
 		if importedRows != totalRows {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1217,7 +1217,6 @@ func (r *restoreResumer) OnTerminal(
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(r.res.Rows)),
 			tree.NewDInt(tree.DInt(r.res.IndexEntries)),
-			tree.NewDInt(tree.DInt(r.res.SystemRecords)),
 			tree.NewDInt(tree.DInt(r.res.DataSize)),
 		}
 	}

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -68,7 +68,7 @@ func restoreOldVersionTest(exportDir string) func(t *testing.T) {
 		var unused string
 		var importedRows int
 		sqlDB.QueryRow(t, `RESTORE test.* FROM $1`, localFoo).Scan(
-			&unused, &unused, &unused, &importedRows, &unused, &unused, &unused,
+			&unused, &unused, &unused, &importedRows, &unused, &unused,
 		)
 		const totalRows = 12
 		if importedRows != totalRows {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -594,7 +594,6 @@ var RestoreHeader = sqlbase.ResultColumns{
 	{Name: "fraction_completed", Typ: types.Float},
 	{Name: "rows", Typ: types.Int},
 	{Name: "index_entries", Typ: types.Int},
-	{Name: "system_records", Typ: types.Int},
 	{Name: "bytes", Typ: types.Int},
 }
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1182,7 +1182,6 @@ func (r *importResumer) OnTerminal(
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(r.res.Rows)),
 			tree.NewDInt(tree.DInt(r.res.IndexEntries)),
-			tree.NewDInt(tree.DInt(r.res.SystemRecords)),
 			tree.NewDInt(tree.DInt(r.res.DataSize)),
 		}
 	}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1342,7 +1342,7 @@ func TestImportCSVStmt(t *testing.T) {
 
 			var unused string
 			var restored struct {
-				rows, idx, sys, bytes int
+				rows, idx, bytes int
 			}
 
 			var result int
@@ -1353,7 +1353,7 @@ func TestImportCSVStmt(t *testing.T) {
 				return
 			}
 			sqlDB.QueryRow(t, query, tc.args...).Scan(
-				&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.sys, &restored.bytes,
+				&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.bytes,
 			)
 
 			jobPrefix := fmt.Sprintf(`IMPORT TABLE %s.public.t (a INT8 PRIMARY KEY, b STRING, INDEX (b), INDEX (a, b))`, intodb)
@@ -1855,7 +1855,7 @@ func TestImportIntoCSV(t *testing.T) {
 
 			var unused string
 			var restored struct {
-				rows, idx, sys, bytes int
+				rows, idx, bytes int
 			}
 
 			// Insert the test data
@@ -1875,7 +1875,7 @@ func TestImportIntoCSV(t *testing.T) {
 			}
 
 			sqlDB.QueryRow(t, query).Scan(
-				&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.sys, &restored.bytes,
+				&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.bytes,
 			)
 
 			jobPrefix := fmt.Sprintf(`IMPORT INTO defaultdb.public.t(a, b)`)

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -418,7 +418,7 @@ func importFixtureTable(
 	var rows, index, tableBytes int64
 	var discard driver.Value
 	err := sqlDB.QueryRow(buf.String(), params...).Scan(
-		&discard, &discard, &discard, &rows, &index, &discard, &tableBytes,
+		&discard, &discard, &discard, &rows, &index, &tableBytes,
 	)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/engine/row_counter.go
+++ b/pkg/storage/engine/row_counter.go
@@ -52,21 +52,17 @@ func (r *RowCounter) Count(key roachpb.Key) error {
 
 	r.prev = append(r.prev[:0], row...)
 
-	rest, tbl, err := keys.DecodeTablePrefix(row)
+	rest, _, err := keys.DecodeTablePrefix(row)
 	if err != nil {
 		return err
 	}
 
-	if tbl < keys.MaxReservedDescID {
-		r.SystemRecords++
+	if _, indexID, err := encoding.DecodeUvarintAscending(rest); err != nil {
+		return err
+	} else if indexID == 1 {
+		r.Rows++
 	} else {
-		if _, indexID, err := encoding.DecodeUvarintAscending(rest); err != nil {
-			return err
-		} else if indexID == 1 {
-			r.Rows++
-		} else {
-			r.IndexEntries++
-		}
+		r.IndexEntries++
 	}
 
 	return nil


### PR DESCRIPTION
Previously we counted any KVs belonging to non-user tables as 'system records'
rather than as 'rows' or 'index entries' the way they are counted for regular
tables. This however meant that BACKUP or RESTORE would confusingly say that
it had backed up 0 rows from a given system table when it in fact backed up
its rows normally, unless one separately looked at the 'system record' count.
Even if one does so, that is also confusing since it doesn't distinguish rows
from index entries so the count does not match. Given that these counts are
rolled up by table anyway the distinction gains us little.

Release note: none.