### PR TITLE
colexec: implement online aggregation for hash aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -807,6 +807,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/distinct.eg.go \
   pkg/sql/colexec/hashjoiner.eg.go \
   pkg/sql/colexec/hashtable.eg.go \
+  pkg/sql/colexec/hash_aggregator.eg.go \
   pkg/sql/colexec/hash_utils.eg.go \
   pkg/sql/colexec/like_ops.eg.go \
   pkg/sql/colexec/mergejoinbase.eg.go \

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -9,6 +9,7 @@ distinct.eg.go
 hashjoiner.eg.go
 hashtable.eg.go
 hash_utils.eg.go
+hash_aggregator.eg.go
 like_ops.eg.go
 mergejoinbase.eg.go
 mergejoiner_fullouter.eg.go

--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -13,7 +13,7 @@ package colexec
 import (
 	"context"
 	"fmt"
-	"math"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/apd"
@@ -515,11 +515,15 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				if err := tc.init(); err != nil {
 					t.Fatal(err)
 				}
+				verifier := orderedVerifier
+				if strings.Contains(agg.name, "hash") {
+					verifier = unorderedVerifier
+				}
 				runTests(
 					t,
 					[]tuples{tc.input},
 					tc.expected,
-					orderedVerifier,
+					verifier,
 					func(input []Operator) (Operator, error) {
 						return agg.new(testAllocator, input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols, false /* isScalar */)
 					})
@@ -534,7 +538,6 @@ func TestAggregatorRandom(t *testing.T) {
 	// This test aggregates random inputs, keeping track of the expected results
 	// to make sure the aggregations are correct.
 	rng, _ := randutil.NewPseudoRand()
-	ctx := context.Background()
 	for _, groupSize := range []int{1, 2, int(coldata.BatchSize()) / 4, int(coldata.BatchSize()) / 2} {
 		if groupSize == 0 {
 			// We might be varying coldata.BatchSize() so that when it is divided by
@@ -553,6 +556,8 @@ func TestAggregatorRandom(t *testing.T) {
 								testAllocator.NewMemColumn(typs[1], nTuples),
 							}
 							groups, aggCol, aggColNulls := cols[0].Int64(), cols[1].Float64(), cols[1].Nulls()
+							expectedTuples := tuples{}
+
 							var expRowCounts, expCounts []int64
 							var expSums, expMins, expMaxs []float64
 							// SUM, MIN, MAX, and AVG aggregators can output null.
@@ -560,6 +565,17 @@ func TestAggregatorRandom(t *testing.T) {
 							curGroup := -1
 							for i := range groups {
 								if i%groupSize == 0 {
+									if curGroup != -1 {
+										if expNulls[curGroup] {
+											expectedTuples = append(expectedTuples, tuple{
+												expRowCounts[curGroup], expCounts[curGroup], nil, nil, nil, nil,
+											})
+										} else {
+											expectedTuples = append(expectedTuples, tuple{
+												expRowCounts[curGroup], expCounts[curGroup], expSums[curGroup], expMins[curGroup], expMaxs[curGroup], expSums[curGroup] / float64(expCounts[curGroup]),
+											})
+										}
+									}
 									expRowCounts = append(expRowCounts, 0)
 									expCounts = append(expCounts, 0)
 									expSums = append(expSums, 0)
@@ -587,6 +603,16 @@ func TestAggregatorRandom(t *testing.T) {
 								}
 								groups[i] = int64(curGroup)
 							}
+							// Add result for last group.
+							if expNulls[curGroup] {
+								expectedTuples = append(expectedTuples, tuple{
+									expRowCounts[curGroup], expCounts[curGroup], nil, nil, nil, nil,
+								})
+							} else {
+								expectedTuples = append(expectedTuples, tuple{
+									expRowCounts[curGroup], expCounts[curGroup], expSums[curGroup], expMins[curGroup], expMaxs[curGroup], expSums[curGroup] / float64(expCounts[curGroup]),
+								})
+							}
 
 							source := newChunkingBatchSource(typs, cols, uint64(nTuples))
 							a, err := agg.new(
@@ -609,76 +635,15 @@ func TestAggregatorRandom(t *testing.T) {
 							}
 							a.Init()
 
-							// Exhaust aggregator until all batches have been read.
-							i := 0
-							tupleIdx := 0
-							for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
-								rowCountCol := b.ColVec(0)
-								countCol := b.ColVec(1)
-								sumCol := b.ColVec(2)
-								minCol := b.ColVec(3)
-								maxCol := b.ColVec(4)
-								avgCol := b.ColVec(5)
-								for j := uint16(0); j < b.Length(); j++ {
-									rowCount := rowCountCol.Int64()[j]
-									count := countCol.Int64()[j]
-									sum := sumCol.Float64()[j]
-									min := minCol.Float64()[j]
-									max := maxCol.Float64()[j]
-									avg := avgCol.Float64()[j]
-									expRowCount := expRowCounts[tupleIdx]
-									if rowCount != expRowCount {
-										t.Fatalf("Found rowCount %d, expected %d, idx %d of batch %d", rowCount, expRowCount, j, i)
-									}
-									expCount := expCounts[tupleIdx]
-									if count != expCount {
-										t.Fatalf("Found count %d, expected %d, idx %d of batch %d", count, expCount, j, i)
-									}
+							testOutput := newOpTestOutput(a, expectedTuples)
+							if strings.Contains(agg.name, "hash") {
+								err = testOutput.VerifyAnyOrder()
+							} else {
+								err = testOutput.Verify()
+							}
 
-									expNull := expNulls[tupleIdx]
-									if expNull {
-										if !sumCol.Nulls().NullAt(j) {
-											t.Fatalf("Found non-null sum %f, expected null, idx %d of batch %d", sum, j, i)
-										}
-										if !minCol.Nulls().NullAt(j) {
-											t.Fatalf("Found non-null min %f, expected null, idx %d of batch %d", sum, j, i)
-										}
-										if !maxCol.Nulls().NullAt(j) {
-											t.Fatalf("Found non-null max %f, expected null, idx %d of batch %d", sum, j, i)
-										}
-										if !avgCol.Nulls().NullAt(j) {
-											t.Fatalf("Found non-null avg %f, expected null, idx %d of batch %d", sum, j, i)
-										}
-									} else {
-										expSum := expSums[tupleIdx]
-										if math.Abs(sum-expSum) > 1e-6 {
-											t.Fatalf("Found sum %f, expected %f, idx %d of batch %d", sum, expSum, j, i)
-										}
-										expMin := expMins[tupleIdx]
-										if min != expMin {
-											t.Fatalf("Found min %f, expected %f, idx %d of batch %d", min, expMin, j, i)
-										}
-										expMax := expMaxs[tupleIdx]
-										if max != expMax {
-											t.Fatalf("Found max %f, expected %f, idx %d of batch %d", max, expMax, j, i)
-										}
-										expAvg := expSum / float64(expCount)
-										if math.Abs(avg-expAvg) > 1e-6 {
-											t.Fatalf("Found avg %f, expected %f, idx %d of batch %d", avg, expAvg, j, i)
-										}
-									}
-									tupleIdx++
-								}
-								i++
-							}
-							totalInputRows := numInputBatches * int(coldata.BatchSize())
-							nOutputRows := totalInputRows / groupSize
-							expBatches := nOutputRows / int(coldata.BatchSize())
-							if nOutputRows%int(coldata.BatchSize()) != 0 {
-								expBatches++
-							}
-							if i != expBatches {
-								t.Fatalf("expected %d batches, found %d", expBatches, i)
+							if err != nil {
+								t.Fatal(err)
 							}
 						})
 				}

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genHashAggregator(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/hash_aggregator_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
+	s = replaceManipulationFuncs(".Global.LTyp", s)
+
+	assignCmpRe := makeFunctionRegex("_ASSIGN_NE", 3)
+	s = assignCmpRe.ReplaceAllString(s, `{{.Global.Assign "$1" "$2" "$3"}}`)
+
+	matchLoop := makeFunctionRegex("_MATCH_LOOP", 8)
+	s = matchLoop.ReplaceAllString(
+		s, `{{template "matchLoop" buildDict "Global" . "LhsMaybeHasNulls" $7 "RhsMaybeHasNulls" $8}}`)
+
+	tmpl, err := template.New("hash_aggregator").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
+}
+
+func init() {
+	registerGenerator(genHashAggregator, "hash_aggregator.eg.go")
+}

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -442,7 +442,7 @@ func NewColOperator(
 				}
 				result.Op, err = NewHashAggregator(
 					NewAllocator(ctx, hashAggregatorMemAccount), inputs[0], typs, aggFns,
-					aggSpec.GroupCols, aggCols, execinfrapb.IsScalarAggregate(aggSpec),
+					aggSpec.GroupCols, aggCols,
 				)
 			} else {
 				result.Op, err = NewOrderedAggregator(

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -1,0 +1,177 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for hash_aggregator.eg.go. It's formatted
+// in a special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	// */}}
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// {{/*
+
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "tree" package.
+var _ tree.Operator
+
+// Dummy import to pull in "math" package.
+var _ int = math.MaxInt16
+
+// _ASSIGN_NE is the template function for assigning the result of comparing
+// the second input to the third input into the first input.
+func _ASSIGN_NE(_, _, _ interface{}) uint64 {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// {{/*
+func _MATCH_LOOP(
+	sel []uint16,
+	lhs coldata.Vec,
+	rhs coldata.Vec,
+	aggKeyIdx uint16,
+	lhsNull bool,
+	diff []bool,
+	_LHS_MAYBE_HAS_NULLS bool,
+	_RHS_MAYBE_HAS_NULLS bool,
+) { // */}}
+	// {{define "matchLoop" -}}
+
+	lhsVal := execgen.UNSAFEGET(lhsCol, int(aggKeyIdx))
+
+	for selIdx, rowIdx := range sel {
+		// {{if .LhsMaybeHasNulls}}
+		// {{if .RhsMaybeHasNulls}}
+		diffNull := (lhsNull != rhs.Nulls().NullAt(rowIdx))
+		if diffNull {
+			diff[selIdx] = true
+			continue
+		}
+		// {{else}}
+		if lhsNull {
+			diff[selIdx] = true
+			continue
+		}
+		// {{end}}
+		// {{end}}
+
+		rhsVal := execgen.UNSAFEGET(rhsCol, int(rowIdx))
+
+		var cmp bool
+		_ASSIGN_NE(cmp, lhsVal, rhsVal)
+		diff[selIdx] = diff[selIdx] || cmp
+	}
+
+	// {{end}}
+	// {{/*
+} // */}}
+
+// match takes a selection vector and compares it against the values of the key
+// of its aggregation function. It returns a selection vector representing the
+// unmatched tuples and a boolean to indicate whether or not there are any
+// matching tuples. It directly writes the result of matched tuples into the
+// selection vector of 'b' and sets the length of the batch to the number of
+// matching tuples. match also takes a diff boolean slice for internal use.
+// This slice need to be allocated to be at at least as big as sel and set to
+// all false. diff will be reset to all false when match returns. This is to
+// avoid additional slice allocation.
+// NOTE: the return vector will reuse the memory allocated for the selection
+//       vector.
+func (v hashAggFuncs) match(
+	sel []uint16,
+	b coldata.Batch,
+	keyCols []uint32,
+	keyTypes []coltypes.T,
+	keyMapping coldata.Batch,
+	diff []bool,
+) (bool, []uint16) {
+	// We want to directly write to the selection vector to avoid extra
+	// allocation.
+	b.SetSelection(true)
+	matched := b.Selection()
+	matched = matched[:0]
+
+	aggKeyIdx := v.keyIdx
+
+	for keyIdx, colIdx := range keyCols {
+		lhs := keyMapping.ColVec(keyIdx)
+		lhsHasNull := lhs.MaybeHasNulls()
+		lhsNull := lhs.Nulls().NullAt64(v.keyIdx)
+
+		rhs := b.ColVec(int(colIdx))
+		rhsHasNull := rhs.MaybeHasNulls()
+
+		keyTyp := keyTypes[keyIdx]
+
+		switch keyTyp {
+		// {{range .}}
+		case _TYPES_T:
+			lhsCol := lhs._TemplateType()
+			rhsCol := rhs._TemplateType()
+			if lhsHasNull && rhsHasNull {
+				_MATCH_LOOP(sel, lhs, rhs, aggKeyIdx, lhsNull, diff, true, true)
+			} else if lhsHasNull && !rhsHasNull {
+				_MATCH_LOOP(sel, lhs, rhs, aggKeyIdx, lhsNull, diff, true, false)
+			} else if !lhsHasNull && rhsHasNull {
+				_MATCH_LOOP(sel, lhs, rhs, aggKeyIdx, lhsNull, diff, false, true)
+			} else {
+				_MATCH_LOOP(sel, lhs, rhs, aggKeyIdx, lhsNull, diff, false, false)
+			}
+		// {{end}}
+		default:
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", keyTyp))
+		}
+	}
+
+	remaining := sel[:0]
+	anyMatched := false
+
+	for selIdx, isDiff := range diff {
+		if isDiff {
+			remaining = append(remaining, sel[selIdx])
+		} else {
+			matched = append(matched, sel[selIdx])
+		}
+	}
+
+	if len(matched) > 0 {
+		b.SetLength(uint16(len(matched)))
+		anyMatched = true
+	}
+
+	// Reset diff slice back to all false.
+	for n := uint16(0); n < uint16(len(diff)); n += uint16(copy(diff, zeroBoolColumn)) {
+	}
+
+	return anyMatched, remaining
+}

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -931,6 +931,8 @@ func tupleEquals(expected tuple, actual tuple) bool {
 				if f2, ok := actual[i].(float64); ok {
 					if math.IsNaN(f1) && math.IsNaN(f2) {
 						continue
+					} else if !math.IsNaN(f1) && !math.IsNaN(f2) && math.Abs(f1-f2) < 1e-6 {
+						continue
 					}
 				}
 			}

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -56,8 +56,88 @@ func (t tuple) String() string {
 	return sb.String()
 }
 
+func (t tuple) less(other tuple) bool {
+	for i := range t {
+		// If either side is nil, we short circuit the comparison. For nil, we
+		// define: nil < {any_none_nil}
+		if t[i] == nil && other[i] == nil {
+			continue
+		} else if t[i] == nil && other[i] != nil {
+			return true
+		} else if t[i] != nil && other[i] == nil {
+			return false
+		}
+
+		lhsVal := reflect.ValueOf(t[i])
+		rhsVal := reflect.ValueOf(other[i])
+
+		// apd.Decimal are not comparable, so we check that first.
+		if lhsVal.Type().Name() == "Decimal" && lhsVal.CanInterface() {
+			lhsDecimal := lhsVal.Interface().(apd.Decimal)
+			rhsDecimal := rhsVal.Interface().(apd.Decimal)
+			cmp := (&lhsDecimal).CmpTotal(&rhsDecimal)
+			if cmp == 0 {
+				continue
+			} else if cmp == -1 {
+				return true
+			} else {
+				return false
+			}
+		}
+
+		// coltypes.Bytes is represented as []uint8.
+		if lhsVal.Type().String() == "[]uint8" {
+			lhsStr := string(lhsVal.Interface().([]uint8))
+			rhsStr := string(rhsVal.Interface().([]uint8))
+			if lhsStr == rhsStr {
+				continue
+			} else if lhsStr < rhsStr {
+				return true
+			} else {
+				return false
+			}
+		}
+
+		// No need to compare these two elements when they are the same.
+		if t[i] == other[i] {
+			continue
+		}
+
+		switch typ := lhsVal.Type().Name(); typ {
+		case "int", "int16", "int32", "int64":
+			return lhsVal.Int() < rhsVal.Int()
+		case "uint", "uint16", "uint32", "uint64":
+			return lhsVal.Uint() < rhsVal.Uint()
+		case "float", "float64":
+			return lhsVal.Float() < rhsVal.Float()
+		case "bool":
+			return lhsVal.Bool() == false && rhsVal.Bool() == true
+		case "string":
+			return lhsVal.String() < rhsVal.String()
+		default:
+			execerror.VectorizedInternalPanic(fmt.Sprintf("Unhandled comparison type: %s", typ))
+		}
+	}
+	return false
+}
+
 // tuples represents a table with any-type columns.
 type tuples []tuple
+
+// sort returns a copy of sorted tuples.
+func (t tuples) sort() tuples {
+	b := make(tuples, len(t))
+	for i := range b {
+		b[i] = make(tuple, len(t[i]))
+		copy(b[i], t[i])
+	}
+	sort.SliceStable(b, func(i, j int) bool {
+		lhs := b[i]
+		rhs := b[j]
+		return lhs.less(rhs)
+	})
+	return b
+}
 
 type verifier func(output *opTestOutput) error
 
@@ -894,23 +974,9 @@ func assertTuplesSetsEqual(expected tuples, actual tuples) error {
 	if len(expected) != len(actual) {
 		return makeError(expected, actual)
 	}
-	actualTupleUsed := make([]bool, len(actual))
-	for _, te := range expected {
-		matched := false
-		for j, ta := range actual {
-			if !actualTupleUsed[j] {
-				if tupleEquals(te, ta) {
-					actualTupleUsed[j] = true
-					matched = true
-					break
-				}
-			}
-		}
-		if !matched {
-			return makeError(expected, actual)
-		}
-	}
-	return nil
+	actual = actual.sort()
+	expected = expected.sort()
+	return assertTuplesOrderedEqual(expected, actual)
 }
 
 // assertTuplesOrderedEqual asserts that two permutations of tuples are equal

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -533,16 +533,15 @@ EXPLAIN (VEC) SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projPlusFloat64Float64ConstOp
-            └ *colexec.projMultFloat64Float64Op
-              └ *colexec.projMinusFloat64ConstFloat64Op
-                └ *colexec.projMultFloat64Float64Op
-                  └ *colexec.projMinusFloat64ConstFloat64Op
-                    └ *colexec.selLEInt64Int64ConstOp
-                      └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *colexec.projMultFloat64Float64Op
+        └ *colexec.projPlusFloat64Float64ConstOp
+          └ *colexec.projMultFloat64Float64Op
+            └ *colexec.projMinusFloat64ConstFloat64Op
+              └ *colexec.projMultFloat64Float64Op
+                └ *colexec.projMinusFloat64ConstFloat64Op
+                  └ *colexec.selLEInt64Int64ConstOp
+                    └ *colexec.colBatchScan
 
 # Query 2
 query T
@@ -553,28 +552,27 @@ EXPLAIN (VEC) SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_
   └ *colexec.limitOp
     └ *colexec.topKSorter
       └ *colexec.selEQFloat64Float64Op
-        └ *colexec.orderedAggregator
-          └ *colexec.hashGrouper
+        └ *colexec.hashAggregator
+          └ *colexec.hashJoiner
+            ├ *colexec.hashJoiner
+            │ ├ *colexec.colBatchScan
+            │ └ *rowexec.joinReader
+            │   └ *colexec.mergeJoinInnerOp
+            │     ├ *colexec.colBatchScan
+            │     └ *colexec.selEQBytesBytesConstOp
+            │       └ *colexec.colBatchScan
             └ *colexec.hashJoiner
               ├ *colexec.hashJoiner
               │ ├ *colexec.colBatchScan
-              │ └ *rowexec.joinReader
-              │   └ *colexec.mergeJoinInnerOp
+              │ └ *colexec.hashJoiner
+              │   ├ *colexec.colBatchScan
+              │   └ *colexec.hashJoiner
               │     ├ *colexec.colBatchScan
               │     └ *colexec.selEQBytesBytesConstOp
               │       └ *colexec.colBatchScan
-              └ *colexec.hashJoiner
-                ├ *colexec.hashJoiner
-                │ ├ *colexec.colBatchScan
-                │ └ *colexec.hashJoiner
-                │   ├ *colexec.colBatchScan
-                │   └ *colexec.hashJoiner
-                │     ├ *colexec.colBatchScan
-                │     └ *colexec.selEQBytesBytesConstOp
-                │       └ *colexec.colBatchScan
-                └ *colexec.selSuffixBytesBytesConstOp
-                  └ *colexec.selEQInt64Int64ConstOp
-                    └ *colexec.colBatchScan
+              └ *colexec.selSuffixBytesBytesConstOp
+                └ *colexec.selEQInt64Int64ConstOp
+                  └ *colexec.colBatchScan
 
 # Query 3
 query T
@@ -584,14 +582,13 @@ EXPLAIN (VEC) SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS reve
 └ Node 1
   └ *colexec.limitOp
     └ *colexec.topKSorter
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
-          └ *rowexec.joinReader
-            └ *colexec.hashJoiner
-              ├ *colexec.selLTInt64Int64ConstOp
-              │ └ *colexec.colBatchScan
-              └ *colexec.selEQBytesBytesConstOp
-                └ *colexec.colBatchScan
+      └ *colexec.hashAggregator
+        └ *rowexec.joinReader
+          └ *colexec.hashJoiner
+            ├ *colexec.selLTInt64Int64ConstOp
+            │ └ *colexec.colBatchScan
+            └ *colexec.selEQBytesBytesConstOp
+              └ *colexec.colBatchScan
 
 # Query 4
 query T
@@ -600,13 +597,12 @@ EXPLAIN (VEC) SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE 
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.hashJoiner
-          ├ *rowexec.indexJoiner
-          │ └ *colexec.colBatchScan
-          └ *colexec.selLTInt64Int64Op
-            └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *colexec.hashJoiner
+        ├ *rowexec.indexJoiner
+        │ └ *colexec.colBatchScan
+        └ *colexec.selLTInt64Int64Op
+          └ *colexec.colBatchScan
 
 # Query 5
 query T
@@ -615,22 +611,21 @@ EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue 
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projMinusFloat64ConstFloat64Op
-            └ *colexec.hashJoiner
-              ├ *colexec.hashJoiner
-              │ ├ *colexec.hashJoiner
-              │ │ ├ *colexec.colBatchScan
-              │ │ └ *rowexec.joinReader
-              │ │   └ *colexec.hashJoiner
-              │ │     ├ *colexec.colBatchScan
-              │ │     └ *colexec.selEQBytesBytesConstOp
-              │ │       └ *colexec.colBatchScan
-              │ └ *rowexec.indexJoiner
-              │   └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *colexec.projMultFloat64Float64Op
+        └ *colexec.projMinusFloat64ConstFloat64Op
+          └ *colexec.hashJoiner
+            ├ *colexec.hashJoiner
+            │ ├ *colexec.hashJoiner
+            │ │ ├ *colexec.colBatchScan
+            │ │ └ *rowexec.joinReader
+            │ │   └ *colexec.hashJoiner
+            │ │     ├ *colexec.colBatchScan
+            │ │     └ *colexec.selEQBytesBytesConstOp
+            │ │       └ *colexec.colBatchScan
+            │ └ *rowexec.indexJoiner
+            │   └ *colexec.colBatchScan
+            └ *colexec.colBatchScan
 
 # Query 6
 query T
@@ -651,34 +646,33 @@ EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FR
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projMinusFloat64ConstFloat64Op
-            └ *colexec.defaultBuiltinFuncOperator
-              └ *colexec.constBytesOp
-                └ *colexec.hashJoiner
-                  ├ *rowexec.joinReader
-                  │ └ *rowexec.joinReader
-                  │   └ *rowexec.joinReader
-                  │     └ *colexec.caseOp
-                  │       ├ *colexec.bufferOp
-                  │       │ └ *colexec.hashJoiner
-                  │       │   ├ *colexec.colBatchScan
-                  │       │   └ *colexec.colBatchScan
-                  │       ├ *colexec.constBoolOp
-                  │       │ └ *colexec.andProjOp
-                  │       │   ├ *colexec.bufferOp
-                  │       │   ├ *colexec.projEQBytesBytesConstOp
-                  │       │   └ *colexec.projEQBytesBytesConstOp
-                  │       ├ *colexec.constBoolOp
-                  │       │ └ *colexec.andProjOp
-                  │       │   ├ *colexec.bufferOp
-                  │       │   ├ *colexec.projEQBytesBytesConstOp
-                  │       │   └ *colexec.projEQBytesBytesConstOp
-                  │       └ *colexec.constBoolOp
-                  │         └ *colexec.bufferOp
-                  └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *colexec.projMultFloat64Float64Op
+        └ *colexec.projMinusFloat64ConstFloat64Op
+          └ *colexec.defaultBuiltinFuncOperator
+            └ *colexec.constBytesOp
+              └ *colexec.hashJoiner
+                ├ *rowexec.joinReader
+                │ └ *rowexec.joinReader
+                │   └ *rowexec.joinReader
+                │     └ *colexec.caseOp
+                │       ├ *colexec.bufferOp
+                │       │ └ *colexec.hashJoiner
+                │       │   ├ *colexec.colBatchScan
+                │       │   └ *colexec.colBatchScan
+                │       ├ *colexec.constBoolOp
+                │       │ └ *colexec.andProjOp
+                │       │   ├ *colexec.bufferOp
+                │       │   ├ *colexec.projEQBytesBytesConstOp
+                │       │   └ *colexec.projEQBytesBytesConstOp
+                │       ├ *colexec.constBoolOp
+                │       │ └ *colexec.andProjOp
+                │       │   ├ *colexec.bufferOp
+                │       │   ├ *colexec.projEQBytesBytesConstOp
+                │       │   └ *colexec.projEQBytesBytesConstOp
+                │       └ *colexec.constBoolOp
+                │         └ *colexec.bufferOp
+                └ *colexec.colBatchScan
 
 # Query 8
 query T
@@ -688,36 +682,35 @@ EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 
 └ Node 1
   └ *colexec.sortOp
     └ *colexec.projDivFloat64Float64Op
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
-          └ *colexec.caseOp
-            ├ *colexec.bufferOp
-            │ └ *colexec.projMultFloat64Float64Op
-            │   └ *colexec.projMinusFloat64ConstFloat64Op
-            │     └ *colexec.defaultBuiltinFuncOperator
-            │       └ *colexec.constBytesOp
-            │         └ *colexec.hashJoiner
-            │           ├ *colexec.hashJoiner
-            │           │ ├ *colexec.hashJoiner
-            │           │ │ ├ *colexec.colBatchScan
-            │           │ │ └ *colexec.hashJoiner
-            │           │ │   ├ *colexec.hashJoiner
-            │           │ │   │ ├ *rowexec.joinReader
-            │           │ │   │ │ └ *colexec.mergeJoinInnerOp
-            │           │ │   │ │   ├ *colexec.selEQBytesBytesConstOp
-            │           │ │   │ │   │ └ *colexec.colBatchScan
-            │           │ │   │ │   └ *colexec.colBatchScan
-            │           │ │   │ └ *colexec.colBatchScan
-            │           │ │   └ *colexec.selLEInt64Int64ConstOp
-            │           │ │     └ *colexec.selGEInt64Int64ConstOp
-            │           │ │       └ *colexec.colBatchScan
-            │           │ └ *colexec.colBatchScan
-            │           └ *colexec.selEQBytesBytesConstOp
-            │             └ *colexec.colBatchScan
-            ├ *colexec.projEQBytesBytesConstOp
-            │ └ *colexec.bufferOp
-            └ *colexec.constFloat64Op
-              └ *colexec.bufferOp
+      └ *colexec.hashAggregator
+        └ *colexec.caseOp
+          ├ *colexec.bufferOp
+          │ └ *colexec.projMultFloat64Float64Op
+          │   └ *colexec.projMinusFloat64ConstFloat64Op
+          │     └ *colexec.defaultBuiltinFuncOperator
+          │       └ *colexec.constBytesOp
+          │         └ *colexec.hashJoiner
+          │           ├ *colexec.hashJoiner
+          │           │ ├ *colexec.hashJoiner
+          │           │ │ ├ *colexec.colBatchScan
+          │           │ │ └ *colexec.hashJoiner
+          │           │ │   ├ *colexec.hashJoiner
+          │           │ │   │ ├ *rowexec.joinReader
+          │           │ │   │ │ └ *colexec.mergeJoinInnerOp
+          │           │ │   │ │   ├ *colexec.selEQBytesBytesConstOp
+          │           │ │   │ │   │ └ *colexec.colBatchScan
+          │           │ │   │ │   └ *colexec.colBatchScan
+          │           │ │   │ └ *colexec.colBatchScan
+          │           │ │   └ *colexec.selLEInt64Int64ConstOp
+          │           │ │     └ *colexec.selGEInt64Int64ConstOp
+          │           │ │       └ *colexec.colBatchScan
+          │           │ └ *colexec.colBatchScan
+          │           └ *colexec.selEQBytesBytesConstOp
+          │             └ *colexec.colBatchScan
+          ├ *colexec.projEQBytesBytesConstOp
+          │ └ *colexec.bufferOp
+          └ *colexec.constFloat64Op
+            └ *colexec.bufferOp
 
 # Query 9
 query T
@@ -726,17 +719,16 @@ EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_n
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *rowexec.joinReader
-          └ *colexec.hashJoiner
-            ├ *colexec.hashJoiner
-            │ ├ *rowexec.joinReader
-            │ │ └ *colexec.hashJoiner
-            │ │   ├ *colexec.colBatchScan
-            │ │   └ *colexec.colBatchScan
-            │ └ *colexec.colBatchScan
-            └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *rowexec.joinReader
+        └ *colexec.hashJoiner
+          ├ *colexec.hashJoiner
+          │ ├ *rowexec.joinReader
+          │ │ └ *colexec.hashJoiner
+          │ │   ├ *colexec.colBatchScan
+          │ │   └ *colexec.colBatchScan
+          │ └ *colexec.colBatchScan
+          └ *colexec.colBatchScan
 
 # Query 10
 query T
@@ -746,15 +738,14 @@ EXPLAIN (VEC) SELECT c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) 
 └ Node 1
   └ *colexec.limitOp
     └ *colexec.topKSorter
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
-          └ *rowexec.joinReader
-            └ *colexec.hashJoiner
-              ├ *colexec.hashJoiner
-              │ ├ *colexec.colBatchScan
-              │ └ *rowexec.indexJoiner
-              │   └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+      └ *colexec.hashAggregator
+        └ *rowexec.joinReader
+          └ *colexec.hashJoiner
+            ├ *colexec.hashJoiner
+            │ ├ *colexec.colBatchScan
+            │ └ *rowexec.indexJoiner
+            │   └ *colexec.colBatchScan
+            └ *colexec.colBatchScan
 
 # Query 11
 query T
@@ -766,13 +757,12 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
     └ *colexec.selGTFloat64Float64Op
       └ *colexec.castOpNullAny
         └ *colexec.constNullOp
-          └ *colexec.orderedAggregator
-            └ *colexec.hashGrouper
+          └ *colexec.hashAggregator
+            └ *rowexec.joinReader
               └ *rowexec.joinReader
                 └ *rowexec.joinReader
-                  └ *rowexec.joinReader
-                    └ *colexec.selEQBytesBytesConstOp
-                      └ *colexec.colBatchScan
+                  └ *colexec.selEQBytesBytesConstOp
+                    └ *colexec.colBatchScan
 
 # Query 12
 query T
@@ -793,14 +783,12 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *colexec.orderedAggregator
-          └ *colexec.hashGrouper
-            └ *colexec.hashJoiner
-              ├ *colexec.selNotRegexpBytesBytesConstOp
-              │ └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+    └ *colexec.hashAggregator
+      └ *colexec.hashAggregator
+        └ *colexec.hashJoiner
+          ├ *colexec.selNotRegexpBytesBytesConstOp
+          │ └ *colexec.colBatchScan
+          └ *colexec.colBatchScan
 
 # Query 14
 query T
@@ -880,18 +868,17 @@ EXPLAIN (VEC) SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, s
 └ Node 1
   └ *colexec.limitOp
     └ *colexec.topKSorter
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
+      └ *colexec.hashAggregator
+        └ *colexec.hashJoiner
+          ├ *colexec.colBatchScan
           └ *colexec.hashJoiner
-            ├ *colexec.colBatchScan
-            └ *colexec.hashJoiner
-              ├ *colexec.mergeJoinLeftSemiOp
-              │ ├ *colexec.colBatchScan
-              │ └ *colexec.selGTFloat64Float64ConstOp
-              │   └ *colexec.orderedAggregator
-              │     └ *colexec.distinctChainOps
-              │       └ *colexec.colBatchScan
-              └ *colexec.colBatchScan
+            ├ *colexec.mergeJoinLeftSemiOp
+            │ ├ *colexec.colBatchScan
+            │ └ *colexec.selGTFloat64Float64ConstOp
+            │   └ *colexec.orderedAggregator
+            │     └ *colexec.distinctChainOps
+            │       └ *colexec.colBatchScan
+            └ *colexec.colBatchScan
 
 # Query 19
 query T
@@ -960,12 +947,11 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
       │ └ *colexec.hashJoiner
       │   ├ *colexec.selGTInt64Float64Op
       │   │ └ *colexec.projMultFloat64Float64ConstOp
-      │   │   └ *colexec.orderedAggregator
-      │   │     └ *colexec.hashGrouper
-      │   │       └ *colexec.hashJoiner
-      │   │         ├ *rowexec.indexJoiner
-      │   │         │ └ *colexec.colBatchScan
-      │   │         └ *colexec.colBatchScan
+      │   │   └ *colexec.hashAggregator
+      │   │     └ *colexec.hashJoiner
+      │   │       ├ *rowexec.indexJoiner
+      │   │       │ └ *colexec.colBatchScan
+      │   │       └ *colexec.colBatchScan
       │   └ *colexec.selPrefixBytesBytesConstOp
       │     └ *colexec.colBatchScan
       └ *colexec.selEQBytesBytesConstOp
@@ -979,21 +965,20 @@ EXPLAIN (VEC) SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, ord
 └ Node 1
   └ *colexec.limitOp
     └ *colexec.topKSorter
-      └ *colexec.orderedAggregator
-        └ *colexec.hashGrouper
-          └ *rowexec.joinReader
-            └ *colexec.hashJoiner
-              ├ *rowexec.hashJoiner
-              │ ├ *colexec.mergeJoinLeftAntiWithOnExprOp
-              │ │ ├ *colexec.selGTInt64Int64Op
-              │ │ │ └ *colexec.colBatchScan
-              │ │ └ *colexec.selGTInt64Int64Op
-              │ │   └ *colexec.colBatchScan
-              │ └ *colexec.colBatchScan
+      └ *colexec.hashAggregator
+        └ *rowexec.joinReader
+          └ *colexec.hashJoiner
+            ├ *rowexec.hashJoiner
+            │ ├ *colexec.mergeJoinLeftAntiWithOnExprOp
+            │ │ ├ *colexec.selGTInt64Int64Op
+            │ │ │ └ *colexec.colBatchScan
+            │ │ └ *colexec.selGTInt64Int64Op
+            │ │   └ *colexec.colBatchScan
+            │ └ *colexec.colBatchScan
+            └ *rowexec.joinReader
               └ *rowexec.joinReader
-                └ *rowexec.joinReader
-                  └ *colexec.selEQBytesBytesConstOp
-                    └ *colexec.colBatchScan
+                └ *colexec.selEQBytesBytesConstOp
+                  └ *colexec.colBatchScan
 
 # Query 22
 query T
@@ -1002,14 +987,13 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexec.orderedAggregator
-      └ *colexec.hashGrouper
-        └ *rowexec.joinReader
-          └ *colexec.selGTFloat64Float64Op
-            └ *colexec.castOpNullAny
-              └ *colexec.constNullOp
-                └ *colexec.selectInOpBytes
-                  └ *colexec.substringInt64Int64Operator
+    └ *colexec.hashAggregator
+      └ *rowexec.joinReader
+        └ *colexec.selGTFloat64Float64Op
+          └ *colexec.castOpNullAny
+            └ *colexec.constNullOp
+              └ *colexec.selectInOpBytes
+                └ *colexec.substringInt64Int64Operator
+                  └ *colexec.constInt64Op
                     └ *colexec.constInt64Op
-                      └ *colexec.constInt64Op
-                        └ *colexec.colBatchScan
+                      └ *colexec.colBatchScan

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_agg
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_agg
@@ -28,8 +28,8 @@ INSERT INTO bools VALUES
 (4, NULL),  (4, true),
 (5, false), (5, NULL)
 
-query BB
-SELECT bool_and(b), bool_or(b) FROM bools GROUP BY a
+query BB rowsort
+SELECT bool_and(b), bool_or(b) FROM bools GROUP BY a;
 ----
 NULL NULL
 true true


### PR DESCRIPTION
This PR change the implementation of hash aggregator to online aggregation.

Since the online aggregation implementation no longer uses `orderedAggregator`,
the order of the output is no longer guaranteed. Therefore the aggregator tests
are updated to use `unorderedVerifier` for hash aggregator.

Closes #41678