### PR TITLE
server: separate sql statement stats from telemetry refresh interval

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -283,7 +283,7 @@ func (s *Server) maybeReportDiagnostics(
 	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
 		s.reportDiagnostics(ctx)
 	}
-	s.pgServer.SQLServer.ResetSQLStats(ctx)
+	s.pgServer.SQLServer.ResetReportedSQLStats(ctx)
 
 	return scheduled.Add(diagnosticReportFrequency.Get(&s.st.SV))
 }
@@ -392,7 +392,7 @@ func (s *Server) getReportingInfo(
 		}
 	}
 
-	info.SqlStats = s.pgServer.SQLServer.GetScrubbedStmtStats()
+	info.SqlStats = s.pgServer.SQLServer.GetScrubbedReportedStmtStats()
 	return &info
 }
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -167,7 +167,8 @@ func (ex *connExecutor) prepare(
 	// anything other than getting a timestamp.
 	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get())
 
-	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
+	ex.statsCollector.reset(
+		&ex.server.sqlStats, ex.appStats, &ex.server.reportedStats, ex.reportedAppStats, &ex.phaseTimes)
 	p := &ex.planner
 	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */, stmt.NumAnnotations)
 	p.stmt = &stmt


### PR DESCRIPTION
This PR aims to solve the current problem that SQL statements
are refreshed when the telemetry update is sent, having side
effects on consumers of statement statistics, as well as making
it difficult to change the interval at which sql statements
statistics are refreshed.

I originally considered an approach where on SQL statement
stat reset the collected SQL stats would be merged into
a separate stat pool to be reported to telemetry, but this
does not work if the telemetry is collected faster than
the SQL stats are refreshed.

It seems that the only way to fully separate statement
statistics and telemtry reported statement statistics
is to just store both statisitics in separate pools
that can be reset independently of each other. This
PR implements this approach by updating the conn_executor
and server to maintain statement statistics and statement
statistics to report in separate pools.

Release note: None