### PR TITLE
colexec: add spilling from sort chunks and top K to external sorter

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -104,17 +104,23 @@ func NewMemBatch(types []coltypes.T) Batch {
 // NewMemBatchWithSize allocates a new in-memory Batch with the given column
 // size. Use for operators that have a precisely-sized output batch.
 func NewMemBatchWithSize(types []coltypes.T, size int) Batch {
+	b := NewMemBatchNoCols(types, size).(*MemBatch)
+	for i, t := range types {
+		b.b[i] = NewMemColumn(t, size)
+	}
+	return b
+}
+
+// NewMemBatchNoCols creates a "skeleton" of new in-memory Batch. It allocates
+// memory for the selection vector but does *not* allocate any memory for the
+// column vectors - those will have to be added separately.
+func NewMemBatchNoCols(types []coltypes.T, size int) Batch {
 	if max := math.MaxUint16; size > max {
 		panic(fmt.Sprintf(`batches cannot have length larger than %d; requested %d`, max, size))
 	}
 	b := &MemBatch{}
 	b.b = make([]Vec, len(types))
-
-	for i, t := range types {
-		b.b[i] = NewMemColumn(t, size)
-	}
 	b.sel = make([]uint16, size)
-
 	return b
 }
 

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -546,6 +546,8 @@ func (hj *hashJoiner) ExportBuffered(input Operator) coldata.Batch {
 		}
 		startIdx, endIdx := hj.exportBufferedState.rightExported, newRightExported
 		b := hj.exportBufferedState.rightWindowedBatch
+		// We don't need to worry about selection vectors on hj.ht.vals because the
+		// tuples have been already selected during building of the hash table.
 		for i, t := range hj.spec.right.sourceTypes {
 			window := hj.ht.vals.colVecs[i].Window(t, startIdx, endIdx)
 			b.ReplaceCol(window, i)

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/pkg/errors"
@@ -1207,4 +1208,14 @@ func (tc *joinTestCase) init() {
 			tc.rightDirections[i] = execinfrapb.Ordering_Column_ASC
 		}
 	}
+}
+
+type sortTestCase struct {
+	description string
+	tuples      tuples
+	expected    tuples
+	logTypes    []types.T
+	ordCols     []execinfrapb.Ordering_Column
+	matchLen    int
+	k           uint16
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -457,7 +457,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y
 ----
 ·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
+·               vectorized   false        ·       ·
 limit           ·            ·            (x, y)  +y
  │              count        1            ·       ·
  └── sort       ·            ·            (x, y)  +y
@@ -471,7 +471,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y)
 ----
 ·                         distributed  false         ·        ·
-·                         vectorized   true          ·        ·
+·                         vectorized   false         ·        ·
 group                     ·            ·             (count)  ·
  │                        aggregate 0  count_rows()  ·        ·
  │                        scalar       ·             ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -186,7 +186,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
 ----
 ·                         distributed  true               ·              ·
-·                         vectorized   true               ·              ·
+·                         vectorized   false              ·              ·
 render                    ·            ·                  (y, str, res)  ·
  │                        render 0     y                  ·              ·
  │                        render 1     str                ·              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -29,7 +29,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) 
 ----
 tree                      field        description  columns  ordering
 ·                         distributed  false        ·        ·
-·                         vectorized   true         ·        ·
+·                         vectorized   false        ·        ·
 limit                     ·            ·            (w)      +w
  │                        count        25           ·        ·
  └── distinct             ·            ·            (w)      +w
@@ -92,7 +92,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
 ·                         distributed  false            ·                       ·
-·                         vectorized   true             ·                       ·
+·                         vectorized   false            ·                       ·
 render                    ·            ·                (sum)                   ·
  │                        render 0     sum              ·                       ·
  └── limit                ·            ·                (k, sum, any_not_null)  -any_not_null

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -35,7 +35,7 @@ query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
 ·               distributed  false
-·               vectorized   true
+·               vectorized   false
 limit           ·            ·
  │              count        2
  └── sort       ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -143,7 +143,7 @@ query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
 ·                     distributed  false
-·                     vectorized   true
+·                     vectorized   false
 limit                 ·            ·
  │                    count        5
  └── sort             ·            ·


### PR DESCRIPTION
This commit makes sortChunksOp implement bufferingInMemoryOperator
interface and adds the planning code so that sort chunks could spill to
external sorter in case of OOM error. The same goes for top K sorter.
Top K sorter is no longer considered a "streaming" operator (well, the
boundary here has always been blurred).

Another change worth calling out is that top K sort will no longer
allocate the batch for `topK` vector of `K` size - the memory will be
allocated dynamically. This is needed to support our approach of not
catching OOM errors if they occur during `Init`.

This commit also removes memory accounting from general sorter and top
K sorter when both operators are emitting output. At that point the
input has already been fully consumed and ordered, and it would be
a shame to fallback to disk. The output batch in both cases is still
created through an allocator, so the minor deviation from out estimate
(which could happen in case of Bytes) seems acceptable.

Release note: None