### PR TITLE
release-19.2: colflow: error out when phys types mismatch when setting up a flow

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -511,6 +511,18 @@ func (s *vectorizedFlowCreator) setupOutput(
 		}
 		// Make the materializer, which will write to the given receiver.
 		columnTypes := s.syncFlowConsumer.Types()
+		converted, err := typeconv.FromColumnTypes(columnTypes)
+		if err != nil {
+			return errors.AssertionFailedf(
+				"unsupported types should have been caught in SupportsVectorized check\n%v", err)
+		}
+		for i, expColType := range converted {
+			if opOutputTypes[i] != expColType {
+				return errors.Errorf("mismatched physical types at index %d: expected %v\tactual %v ",
+					i, converted, opOutputTypes,
+				)
+			}
+		}
 		var outputStatsToTrace func()
 		if s.recordingStats {
 			// Make a copy given that vectorizedStatsCollectorsQueue is reset and
@@ -794,19 +806,25 @@ func (r *noopFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
 // full flow without running the components asynchronously.
 // It returns a list of the leaf operators of all flows for the purposes of
 // EXPLAIN output.
+// Note that passed-in output can be nil, but if it is non-nil, only Types()
+// method on it might be called (nothing will actually get Push()'ed into it).
 func SupportsVectorized(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorSpecs []execinfrapb.ProcessorSpec,
 	fuseOpt flowinfra.FuseOpt,
+	output execinfra.RowReceiver,
 ) (leaves []execinfra.OpNode, err error) {
+	if output == nil {
+		output = &execinfra.RowChannel{}
+	}
 	creator := newVectorizedFlowCreator(
 		newNoopFlowCreatorHelper(),
 		vectorizedRemoteComponentCreator{},
-		false,                   /* recordingStats */
-		nil,                     /* waitGroup */
-		&execinfra.RowChannel{}, /* syncFlowConsumer */
-		nil,                     /* nodeDialer */
+		false, /* recordingStats */
+		nil,   /* waitGroup */
+		output,
+		nil, /* nodeDialer */
 		execinfrapb.FlowID{},
 	)
 	// We create an unlimited memory account because we're interested whether the

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -207,7 +207,7 @@ func (ds *ServerImpl) setupFlow(
 	// sp will be Finish()ed by Flow.Cleanup().
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
-	// The monitor opened here are closed in Flow.Cleanup().
+	// The monitor opened here is closed in Flow.Cleanup().
 	monitor := mon.MakeMonitor(
 		"flow",
 		mon.MemoryResource,
@@ -351,6 +351,9 @@ func (ds *ServerImpl) setupFlow(
 	var err error
 	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
+		// Flow.Cleanup will not be called, so we have to close the memory monitor
+		// and finish the span manually.
+		monitor.Stop(ctx)
 		tracing.FinishSpan(sp)
 		ctx = opentracing.ContextWithSpan(ctx, nil)
 		return ctx, nil, err

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -171,7 +171,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 							Settings:    dsp.st,
 						},
 						NodeID: -1,
-					}, spec.Processors, fuseOpt,
+					}, spec.Processors, fuseOpt, recv,
 				); err != nil {
 					// Vectorization attempt failed with an error.
 					returnVectorizationSetupError := false

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -238,7 +238,7 @@ func (p *planner) populateExplain(
 				if nodeID == thisNodeID && !isDistSQL {
 					fuseOpt = flowinfra.FuseAggressively
 				}
-				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt)
+				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt, nil /* output */)
 				isVec = isVec && (err == nil)
 			}
 		}

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -95,7 +95,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 		if flow.nodeID == thisNodeID && !willDistributePlan {
 			fuseOpt = flowinfra.FuseAggressively
 		}
-		opChains, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors, fuseOpt)
+		opChains, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors, fuseOpt, nil /* output */)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -105,3 +105,17 @@ SELECT id FROM unsupported_type LIMIT 1 OFFSET 1100
 
 statement ok
 RESET vectorize
+
+# Regression test for #44904 (mismatched physical types between materializer's
+# input and output, root of the problem is outside of the vectorized engine).
+# We should fallback to the row-by-row engine.
+statement ok
+SET default_int_size = 4; CREATE TABLE t44904(c0 INT); INSERT INTO t44904 VALUES(0)
+
+query I
+SELECT CAST(0 BETWEEN(CASE NULL WHEN c0 = 0 THEN NULL END) AND 0 IS TRUE AS INT) FROM t44904
+----
+0
+
+statement ok
+RESET default_int_size


### PR DESCRIPTION
Backport 1/1 commits from #44930.

/cc @cockroachdb/release

---

This commit adds a check that the physical types coming out of the last
columnar operator into the materializer are the same as the materializer
expects. This check is added to SupportsVectorized check, and in case of
types mismatch, we will fallback to the row-by-row engine.

The underlying cause for this particular reproduction is that our
"logical" types system assumes that ints have width 8, which is not
always the case. But trying to fix it is beyond the scope of this PR.

Fixes: #44904.

Release note (bug fix): Previously, CockroachDB could return an internal
error on the queries that return INT columns when the default int size
has been changed, and now this has been fixed.
