### PR TITLE
storage: fix flakey TestProtectedTimestampRecordApplies

### DIFF
--- a/pkg/storage/replica_protected_timestamp_test.go
+++ b/pkg/storage/replica_protected_timestamp_test.go
@@ -256,6 +256,9 @@ func TestProtectedTimestampRecordApplies(t *testing.T) {
 			tsc := TestStoreConfig(nil)
 			mc := &manualCache{}
 			tsc.ProtectedTimestampCache = mc
+			// Under extreme stressrace scenarios the single replica can somehow
+			// lose the lease. Make the timeout extremely long.
+			tsc.RaftConfig.RangeLeaseRaftElectionTimeoutMultiplier = 100
 			stopper := stop.NewStopper()
 			tc.StartWithStoreConfig(t, stopper, tsc)
 			stopper.Stop(ctx)


### PR DESCRIPTION
In rare cases it seems that test cases fail because they discover
that the replica is not the the leaseholder. Given there's a single
replica of a single range, it must be the case that the lease is
expiring. This commit makes the expiration based lease timeout
extremely long.

Before this change, when run using roachprod-stressrace with a -p flag
at 128 this would fail in a minute or two. Now it's run for 10.

Fixes #44780.

Release note: None