### PR TITLE
sql: disable interleaved hash sharded indexes

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -147,6 +147,9 @@ func MakeIndexDescriptor(
 		if n.PartitionBy != nil {
 			return nil, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
 		}
+		if n.Interleave != nil {
+			return nil, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
+		}
 		shardCol, newColumn, err := setupShardedIndex(
 			params.ctx,
 			params.EvalContext().Settings,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1211,6 +1211,9 @@ func MakeTableDesc(
 				if n.PartitionBy != nil {
 					return desc, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
 				}
+				if n.Interleave != nil {
+					return desc, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
+				}
 				buckets, err := tree.EvalShardBucketCount(d.PrimaryKey.ShardBuckets)
 				if err != nil {
 					return desc, err
@@ -1332,6 +1335,9 @@ func MakeTableDesc(
 				idx.Type = sqlbase.IndexDescriptor_INVERTED
 			}
 			if d.Sharded != nil {
+				if d.Interleave != nil {
+					return desc, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
+				}
 				if err := setupShardedIndexForNewTable(d, &idx); err != nil {
 					return desc, err
 				}
@@ -1361,6 +1367,9 @@ func MakeTableDesc(
 				Version:          indexEncodingVersion,
 			}
 			if d.Sharded != nil {
+				if n.Interleave != nil && d.PrimaryKey {
+					return desc, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
+				}
 				if err := setupShardedIndexForNewTable(&d.IndexTableDef, &idx); err != nil {
 					return desc, err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -461,3 +461,18 @@ weird_names  CREATE TABLE weird_names (
                 INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH BUCKET_COUNT = 4,
                 FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4")
 )
+
+subtest interleave_disabled
+
+statement ok
+CREATE TABLE parent (x INT PRIMARY KEY);
+
+statement error pq: interleaved indexes cannot also be hash sharded
+CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 10) INTERLEAVE IN PARENT parent (x)
+
+statement error pq: interleaved indexes cannot also be hash sharded
+CREATE TABLE t (x INT, y INT, PRIMARY KEY (x, y) USING HASH WITH BUCKET_COUNT = 10) INTERLEAVE IN PARENT parent (x)
+
+statement error pq: interleaved indexes cannot also be hash sharded
+CREATE INDEX ON parent (x) USING HASH WITH BUCKET_COUNT = 10 INTERLEAVE IN PARENT parent(x)
+

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4733,7 +4733,7 @@ constraint_elem:
         Columns: $4.idxElems(),
         Sharded: $6.shardedIndexDef(),
       },
-      PrimaryKey:    true,
+      PrimaryKey: true,
     }
   }
 | FOREIGN KEY '(' name_list ')' REFERENCES table_name

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -646,6 +646,9 @@ func (node *UniqueConstraintTableDef) Format(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(&node.Columns)
 	ctx.WriteByte(')')
+	if node.Sharded != nil {
+		ctx.FormatNode(node.Sharded)
+	}
 	if node.Storing != nil {
 		ctx.WriteString(" STORING (")
 		ctx.FormatNode(&node.Storing)


### PR DESCRIPTION
Fixes #44988.

Release note (sql change): This PR disables creating a hash
sharded index that is also interleaved.