### PR TITLE
release-19.2: sql: wrap iteration over OpNodes in explain_vec with panic catcher

### DIFF
--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -99,8 +100,15 @@ func (n *explainVecNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		for _, op := range opChains {
-			formatOpChain(op, node, verbose)
+		// It is possible that when iterating over execinfra.OpNodes we will hit
+		// a panic (an input that doesn't implement OpNode interface), so we're
+		// catching such errors.
+		if err := execerror.CatchVectorizedRuntimeError(func() {
+			for _, op := range opChains {
+				formatOpChain(op, node, verbose)
+			}
+		}); err != nil {
+			return err
 		}
 	}
 	n.run.lines = tp.FormattedRows()


### PR DESCRIPTION
Backport 1/1 commits from #44931.

/cc @cockroachdb/release

---

Fixes: #44928.

Release note (bug fix): Previously, CockroachDB could crash when
running `EXPLAIN (VEC)` in some edge cases, and now this is fixed by
returning an internal error instead.
