### PR TITLE
ui: (fix) Display node name as address_field in Node List tables

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -58,6 +58,7 @@ enum AggregatedNodeStatus {
 export interface NodeStatusRow {
   key: string;
   nodeId?: number;
+  nodeName?: string;
   region: string;
   nodesCount?: number;
   uptime?: string;
@@ -80,6 +81,7 @@ export interface NodeStatusRow {
 interface DecommissionedNodeStatusRow {
   key: string;
   nodeId: number;
+  nodeName: string;
   region: string;
   status: LivenessStatus;
   decommissionedDate: Moment;
@@ -136,7 +138,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
             <React.Fragment>
               <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
                 <Text textType={TextTypes.BodyStrong}>{`N${record.nodeId} `}</Text>
-                <Text>{record.region}</Text>
+                <Text>{record.nodeName}</Text>
               </Link>
             </React.Fragment>);
         } else {
@@ -286,7 +288,7 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
       render: (_text, record) => (
         <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
           <Text textType={TextTypes.BodyStrong}>{`N${record.nodeId} `}</Text>
-          <Text>{record.region}</Text>
+          <Text>{record.nodeName}</Text>
         </Link>),
     },
     {
@@ -363,6 +365,7 @@ export const liveNodesTableDataSelector = createSelector(
           return {
             key: `${regionKey}-${idx}`,
             nodeId: ns.desc.node_id,
+            nodeName: ns.desc.address.address_field,
             region: getNodeRegion(ns),
             uptime: moment.duration(LongToMoment(ns.started_at).diff(moment())).humanize(),
             replicas: ns.metrics[MetricConstants.replicas],
@@ -417,6 +420,7 @@ export const decommissionedNodesTableDataSelector = createSelector(
         return {
           key: `${idx}`,
           nodeId: ns.desc.node_id,
+          nodeName: ns.desc.address.address_field,
           region: getNodeRegion(ns),
           status: nodesSummary.livenessStatusByNodeID[ns.desc.node_id],
           decommissionedDate: getDecommissionedTime(ns.desc.node_id),

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
@@ -47,6 +47,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-east1-0",
             "nodeId": 1,
+            "nodeName": "127.0.0.1:50945",
             "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 78,
@@ -60,6 +61,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-east1-1",
             "nodeId": 2,
+            "nodeName": "127.0.0.2:50945",
             "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 74,
@@ -73,6 +75,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-east1-2",
             "nodeId": 3,
+            "nodeName": "127.0.0.3:50945",
             "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 72,
@@ -99,6 +102,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-west1-0",
             "nodeId": 4,
+            "nodeName": "127.0.0.4:50945",
             "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 73,
@@ -112,6 +116,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-west1-1",
             "nodeId": 5,
+            "nodeName": "127.0.0.5:50945",
             "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 78,
@@ -125,6 +130,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "us-west1-2",
             "nodeId": 6,
+            "nodeName": "127.0.0.6:50945",
             "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 78,
@@ -151,6 +157,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "europe-west1-0",
             "nodeId": 7,
+            "nodeName": "127.0.0.7:50945",
             "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 71,
@@ -164,6 +171,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "europe-west1-1",
             "nodeId": 8,
+            "nodeName": "127.0.0.8:50945",
             "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 74,
@@ -177,6 +185,7 @@ describe("Nodes Overview page", () => {
           {
             "key": "europe-west1-2",
             "nodeId": 9,
+            "nodeName": "127.0.0.9:50945",
             "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 71,
@@ -277,7 +286,13 @@ describe("Nodes Overview page", () => {
         nodes: {
           data: times(7).map(idx => (
             {
-              desc: { node_id: idx + 1, locality: {}},
+              desc: {
+                node_id: idx + 1,
+                locality: {},
+                address: {
+                  address_field: `127.0.0.${idx + 1}:50945`,
+                },
+              },
               metrics: {
                 "capacity.used": 0,
                 "capacity.available": 0,
@@ -353,6 +368,14 @@ describe("Nodes Overview page", () => {
           assert.isTrue(expectedDecommissionedNodeIds.some(nodeId => nodeId === record.nodeId));
         });
       });
+
+      it("returns correct node name", () => {
+        const recordsGroupedByRegion = decommissionedNodesTableDataSelector.resultFunc(partitionedNodes, nodeSummary);
+        recordsGroupedByRegion.forEach(record => {
+          const expectedName = `127.0.0.${record.nodeId}:50945`;
+          assert.equal(record.nodeName, expectedName);
+        });
+      });
     });
 
     describe("liveNodesTableDataSelector", () => {
@@ -364,6 +387,14 @@ describe("Nodes Overview page", () => {
         assert.lengthOf(recordsGroupedByRegion[0].children, expectedLiveNodeIds.length);
         recordsGroupedByRegion[0].children.forEach(record => {
           assert.isTrue(expectedLiveNodeIds.some(nodeId => nodeId === record.nodeId));
+        });
+      });
+
+      it("returns correct node name", () => {
+        const recordsGroupedByRegion = liveNodesTableDataSelector.resultFunc(partitionedNodes, nodeSummary);
+        recordsGroupedByRegion[0].children.forEach(record => {
+          const expectedName = `127.0.0.${record.nodeId}:50945`;
+          assert.equal(record.nodeName, expectedName);
         });
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/44920
Depends on PR: https://github.com/cockroachdb/cockroach/pull/44212

Node name is represented as address_fields across entire
application (metrics charts for example) and the same way
it has to be displayed in Node List tables (Nodes and
Decommissioned node lists).

Preview:
<img width="1005" alt="Screenshot 2020-02-12 at 12 45 28" src="https://user-images.githubusercontent.com/3106437/74328378-6bf6f000-4d96-11ea-8a1f-83cb60be716b.png">

