### PR TITLE
storage: test evaluateBatch

### DIFF
--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -104,7 +104,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			h.RangeID = desc.RangeID
 
 			cArgs := CommandArgs{Header: h}
-			cArgs.EvalCtx = &mockEvalCtx{desc: &desc, clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), stats: stats}
+			cArgs.EvalCtx = (&MockEvalCtx{Desc: &desc, Clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), Stats: stats}).EvalContext()
 			cArgs.Args = &roachpb.ClearRangeRequest{
 				RequestHeader: roachpb.RequestHeader{
 					Key:    startKey,

--- a/pkg/storage/batcheval/cmd_end_transaction_test.go
+++ b/pkg/storage/batcheval/cmd_end_transaction_test.go
@@ -902,17 +902,17 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}
 			var resp roachpb.EndTxnResponse
 			_, err := EndTxn(ctx, batch, CommandArgs{
-				EvalCtx: &mockEvalCtx{
-					desc:      &desc,
-					abortSpan: as,
-					canCreateTxnFn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+				EvalCtx: (&MockEvalCtx{
+					Desc:      &desc,
+					AbortSpan: as,
+					CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
 						require.NotNil(t, c.canCreateTxn, "CanCreateTxnRecord unexpectedly called")
 						if can, minTS := c.canCreateTxn(); can {
 							return true, minTS, 0
 						}
 						return false, hlc.Timestamp{}, roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
 					},
-				},
+				}).EvalContext(),
 				Args: &req,
 				Header: roachpb.Header{
 					Timestamp: ts,
@@ -1014,12 +1014,12 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 		}
 		var resp roachpb.EndTxnResponse
 		if _, err := EndTxn(ctx, batch, CommandArgs{
-			EvalCtx: &mockEvalCtx{
-				desc: &desc,
-				canCreateTxnFn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+			EvalCtx: (&MockEvalCtx{
+				Desc: &desc,
+				CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
 					return true, ts, 0
 				},
-			},
+			}).EvalContext(),
 			Args: &req,
 			Header: roachpb.Header{
 				Timestamp: ts,

--- a/pkg/storage/batcheval/cmd_lease_test.go
+++ b/pkg/storage/batcheval/cmd_lease_test.go
@@ -119,10 +119,10 @@ func TestLeaseCommandLearnerReplica(t *testing.T) {
 	desc := roachpb.RangeDescriptor{}
 	desc.SetReplicas(roachpb.MakeReplicaDescriptors(replicas))
 	cArgs := CommandArgs{
-		EvalCtx: &mockEvalCtx{
-			storeID: voterStoreID,
-			desc:    &desc,
-		},
+		EvalCtx: (&MockEvalCtx{
+			StoreID: voterStoreID,
+			Desc:    &desc,
+		}).EvalContext(),
 		Args: &roachpb.TransferLeaseRequest{
 			Lease: roachpb.Lease{
 				Replica: replicas[1],

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -16,126 +16,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
-	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
-	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
-
-type mockEvalCtx struct {
-	clusterSettings  *cluster.Settings
-	desc             *roachpb.RangeDescriptor
-	storeID          roachpb.StoreID
-	clock            *hlc.Clock
-	stats            enginepb.MVCCStats
-	qps              float64
-	abortSpan        *abortspan.AbortSpan
-	gcThreshold      hlc.Timestamp
-	term, firstIndex uint64
-	canCreateTxnFn   func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason)
-	lease            roachpb.Lease
-}
-
-func (m *mockEvalCtx) String() string {
-	return "mock"
-}
-func (m *mockEvalCtx) ClusterSettings() *cluster.Settings {
-	return m.clusterSettings
-}
-func (m *mockEvalCtx) EvalKnobs() storagebase.BatchEvalTestingKnobs {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) Engine() engine.Engine {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) Clock() *hlc.Clock {
-	return m.clock
-}
-func (m *mockEvalCtx) DB() *client.DB {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) GetLimiters() *Limiters {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) AbortSpan() *abortspan.AbortSpan {
-	return m.abortSpan
-}
-func (m *mockEvalCtx) GetTxnWaitQueue() *txnwait.Queue {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) NodeID() roachpb.NodeID {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) GetNodeLocality() roachpb.Locality {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) StoreID() roachpb.StoreID {
-	return m.storeID
-}
-func (m *mockEvalCtx) GetRangeID() roachpb.RangeID {
-	return m.desc.RangeID
-}
-func (m *mockEvalCtx) IsFirstRange() bool {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) GetFirstIndex() (uint64, error) {
-	return m.firstIndex, nil
-}
-func (m *mockEvalCtx) GetTerm(uint64) (uint64, error) {
-	return m.term, nil
-}
-func (m *mockEvalCtx) GetLeaseAppliedIndex() uint64 {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) Desc() *roachpb.RangeDescriptor {
-	return m.desc
-}
-func (m *mockEvalCtx) ContainsKey(key roachpb.Key) bool {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) GetMVCCStats() enginepb.MVCCStats {
-	return m.stats
-}
-func (m *mockEvalCtx) GetSplitQPS() float64 {
-	return m.qps
-}
-func (m *mockEvalCtx) CanCreateTxnRecord(
-	uuid.UUID, []byte, hlc.Timestamp,
-) (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
-	return m.canCreateTxnFn()
-}
-func (m *mockEvalCtx) GetGCThreshold() hlc.Timestamp {
-	return m.gcThreshold
-}
-func (m *mockEvalCtx) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
-	panic("unimplemented")
-}
-func (m *mockEvalCtx) GetLease() (roachpb.Lease, roachpb.Lease) {
-	return m.lease, roachpb.Lease{}
-}
-
-func (m *mockEvalCtx) GetExternalStorage(
-	ctx context.Context, dest roachpb.ExternalStorage,
-) (cloud.ExternalStorage, error) {
-	panic("unimplemented")
-}
-
-func (m *mockEvalCtx) GetExternalStorageFromURI(
-	ctx context.Context, uri string,
-) (cloud.ExternalStorage, error) {
-	panic("unimplemented")
-}
 
 func TestDeclareKeysResolveIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -212,7 +103,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 				h.RangeID = desc.RangeID
 
 				cArgs := CommandArgs{Header: h}
-				cArgs.EvalCtx = &mockEvalCtx{abortSpan: as}
+				cArgs.EvalCtx = (&MockEvalCtx{AbortSpan: as}).EvalContext()
 
 				if !ranged {
 					cArgs.Args = &ri
@@ -305,7 +196,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 			if _, err := ResolveIntent(ctx, rbatch,
 				CommandArgs{
 					Header:  h,
-					EvalCtx: &mockEvalCtx{},
+					EvalCtx: (&MockEvalCtx{}).EvalContext(),
 					Args:    &ri,
 				},
 				&roachpb.ResolveIntentResponse{},
@@ -327,7 +218,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 			if _, err := ResolveIntentRange(ctx, rbatch,
 				CommandArgs{
 					Header:  h,
-					EvalCtx: &mockEvalCtx{},
+					EvalCtx: (&MockEvalCtx{}).EvalContext(),
 					Args:    &rir,
 					MaxKeys: 10,
 				},

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -135,8 +135,8 @@ func TestCmdRevertRange(t *testing.T) {
 				EndKey:   roachpb.RKey(endKey),
 			}
 			cArgs := CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC}, MaxKeys: 2}
-			evalCtx := &mockEvalCtx{desc: &desc, clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), stats: stats}
-			cArgs.EvalCtx = evalCtx
+			evalCtx := &MockEvalCtx{Desc: &desc, Clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), Stats: stats}
+			cArgs.EvalCtx = evalCtx.EvalContext()
 			afterStats := getStats(t, eng)
 			for _, tc := range []struct {
 				name     string
@@ -190,7 +190,7 @@ func TestCmdRevertRange(t *testing.T) {
 			t.Run("checks gc threshold", func(t *testing.T) {
 				batch := &wrappedBatch{Batch: eng.NewBatch()}
 				defer batch.Close()
-				evalCtx.gcThreshold = tsB
+				evalCtx.GCThreshold = tsB
 				cArgs.Args = &roachpb.RevertRangeRequest{
 					RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey}, TargetTime: tsB,
 				}
@@ -221,7 +221,7 @@ func TestCmdRevertRange(t *testing.T) {
 
 			cArgs.Header.Timestamp = tsD
 			// Re-set EvalCtx to pick up revised stats.
-			cArgs.EvalCtx = &mockEvalCtx{desc: &desc, clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), stats: stats}
+			cArgs.EvalCtx = (&MockEvalCtx{Desc: &desc, Clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), Stats: stats}).EvalContext()
 			for _, tc := range []struct {
 				name        string
 				ts          hlc.Timestamp

--- a/pkg/storage/batcheval/cmd_truncate_log_test.go
+++ b/pkg/storage/batcheval/cmd_truncate_log_test.go
@@ -118,10 +118,10 @@ func runUnreplicatedTruncatedState(t *testing.T, tc unreplicatedTruncStateTest) 
 		firstIndex = 100
 	)
 
-	evalCtx := mockEvalCtx{
-		desc:       &roachpb.RangeDescriptor{RangeID: rangeID},
-		term:       term,
-		firstIndex: firstIndex,
+	evalCtx := &MockEvalCtx{
+		Desc:       &roachpb.RangeDescriptor{RangeID: rangeID},
+		Term:       term,
+		FirstIndex: firstIndex,
 	}
 
 	eng := engine.NewDefaultInMem()
@@ -141,7 +141,7 @@ func runUnreplicatedTruncatedState(t *testing.T, tc unreplicatedTruncStateTest) 
 		Index:   firstIndex + 7,
 	}
 	cArgs := CommandArgs{
-		EvalCtx: &evalCtx,
+		EvalCtx: evalCtx.EvalContext(),
 		Args:    &req,
 	}
 	resp := &roachpb.TruncateLogResponse{}

--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -96,3 +96,121 @@ type EvalContext interface {
 	GetExternalStorage(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error)
 	GetExternalStorageFromURI(ctx context.Context, uri string) (cloud.ExternalStorage, error)
 }
+
+// MockEvalCtx is a dummy implementation of EvalContext for testing purposes.
+// For technical reasons, the interface is implemented by a wrapper .EvalContext().
+type MockEvalCtx struct {
+	ClusterSettings  *cluster.Settings
+	Desc             *roachpb.RangeDescriptor
+	StoreID          roachpb.StoreID
+	Clock            *hlc.Clock
+	Stats            enginepb.MVCCStats
+	QPS              float64
+	AbortSpan        *abortspan.AbortSpan
+	GCThreshold      hlc.Timestamp
+	Term, FirstIndex uint64
+	CanCreateTxn     func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason)
+	Lease            roachpb.Lease
+}
+
+// EvalContext returns the MockEvalCtx as an EvalContext. It will reflect future
+// modifications to the underlying MockEvalContext.
+func (m *MockEvalCtx) EvalContext() EvalContext {
+	return &mockEvalCtxImpl{m}
+}
+
+type mockEvalCtxImpl struct {
+	// Hide the fields of MockEvalCtx which have names that conflict with some
+	// of the interface methods.
+	*MockEvalCtx
+}
+
+func (m *mockEvalCtxImpl) String() string {
+	return "mock"
+}
+func (m *mockEvalCtxImpl) ClusterSettings() *cluster.Settings {
+	return m.MockEvalCtx.ClusterSettings
+}
+func (m *mockEvalCtxImpl) EvalKnobs() storagebase.BatchEvalTestingKnobs {
+	return storagebase.BatchEvalTestingKnobs{}
+}
+func (m *mockEvalCtxImpl) Engine() engine.Engine {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) Clock() *hlc.Clock {
+	return m.MockEvalCtx.Clock
+}
+func (m *mockEvalCtxImpl) DB() *client.DB {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) GetLimiters() *Limiters {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) AbortSpan() *abortspan.AbortSpan {
+	return m.MockEvalCtx.AbortSpan
+}
+func (m *mockEvalCtxImpl) GetTxnWaitQueue() *txnwait.Queue {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) NodeID() roachpb.NodeID {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) GetNodeLocality() roachpb.Locality {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) StoreID() roachpb.StoreID {
+	return m.MockEvalCtx.StoreID
+}
+func (m *mockEvalCtxImpl) GetRangeID() roachpb.RangeID {
+	return m.MockEvalCtx.Desc.RangeID
+}
+func (m *mockEvalCtxImpl) IsFirstRange() bool {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) GetFirstIndex() (uint64, error) {
+	return m.FirstIndex, nil
+}
+func (m *mockEvalCtxImpl) GetTerm(uint64) (uint64, error) {
+	return m.Term, nil
+}
+func (m *mockEvalCtxImpl) GetLeaseAppliedIndex() uint64 {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) Desc() *roachpb.RangeDescriptor {
+	return m.MockEvalCtx.Desc
+}
+func (m *mockEvalCtxImpl) ContainsKey(key roachpb.Key) bool {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) GetMVCCStats() enginepb.MVCCStats {
+	return m.Stats
+}
+func (m *mockEvalCtxImpl) GetSplitQPS() float64 {
+	return m.QPS
+}
+func (m *mockEvalCtxImpl) CanCreateTxnRecord(
+	uuid.UUID, []byte, hlc.Timestamp,
+) (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+	return m.CanCreateTxn()
+}
+func (m *mockEvalCtxImpl) GetGCThreshold() hlc.Timestamp {
+	return m.GCThreshold
+}
+func (m *mockEvalCtxImpl) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
+	panic("unimplemented")
+}
+func (m *mockEvalCtxImpl) GetLease() (roachpb.Lease, roachpb.Lease) {
+	return m.Lease, roachpb.Lease{}
+}
+
+func (m *mockEvalCtxImpl) GetExternalStorage(
+	ctx context.Context, dest roachpb.ExternalStorage,
+) (cloud.ExternalStorage, error) {
+	panic("unimplemented")
+}
+
+func (m *mockEvalCtxImpl) GetExternalStorageFromURI(
+	ctx context.Context, uri string,
+) (cloud.ExternalStorage, error) {
+	panic("unimplemented")
+}

--- a/pkg/storage/batcheval/transaction_test.go
+++ b/pkg/storage/batcheval/transaction_test.go
@@ -684,19 +684,19 @@ func TestUpdateAbortSpan(t *testing.T) {
 			defer db.Close()
 			batch := db.NewBatch()
 			defer batch.Close()
-			evalCtx := &mockEvalCtx{
-				desc:      &desc,
-				abortSpan: as,
-				canCreateTxnFn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+			evalCtx := &MockEvalCtx{
+				Desc:      &desc,
+				AbortSpan: as,
+				CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
 					return true, hlc.Timestamp{}, 0
 				},
 			}
 
 			if c.before != nil {
-				require.NoError(t, c.before(batch, evalCtx))
+				require.NoError(t, c.before(batch, evalCtx.EvalContext()))
 			}
 
-			err := c.run(batch, evalCtx)
+			err := c.run(batch, evalCtx.EvalContext())
 			if c.expErr != "" {
 				require.Regexp(t, c.expErr, err)
 			} else {

--- a/pkg/storage/intent_resolver_integration_test.go
+++ b/pkg/storage/intent_resolver_integration_test.go
@@ -479,7 +479,7 @@ func TestContendedIntentPushedByHighPriorityScan(t *testing.T) {
 	// Perform a scan over the same keyspace with a high priority transaction.
 	txnHigh := newTransaction("high-priority", nil, roachpb.MaxUserPriority, store.Clock())
 	scan := scanArgs(keyA, keyB)
-	scanResp, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txnHigh}, &scan)
+	scanResp, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txnHigh}, scan)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -695,7 +695,7 @@ func TestTruncateLog(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		args := incrementArgs([]byte("a"), int64(i))
 
-		if _, pErr := tc.SendWrapped(&args); pErr != nil {
+		if _, pErr := tc.SendWrapped(args); pErr != nil {
 			t.Fatal(pErr)
 		}
 		idx, err := tc.repl.GetLastIndex()

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -159,13 +159,6 @@ func evaluateBatch(
 	baHeader := ba.Header
 	br := ba.CreateReply()
 
-	maxKeys := int64(math.MaxInt64)
-	if baHeader.MaxSpanRequestKeys != 0 {
-		// We have a batch of requests with a limit. We keep track of how many
-		// remaining keys we can touch.
-		maxKeys = baHeader.MaxSpanRequestKeys
-	}
-
 	// Optimize any contiguous sequences of put and conditional put ops.
 	if len(baReqs) >= optimizePutThreshold && !readOnly {
 		baReqs = optimizePuts(readWriter, baReqs, baHeader.DistinctSpans)
@@ -241,6 +234,18 @@ func evaluateBatch(
 
 		var curResult result.Result
 		var pErr *roachpb.Error
+
+		// Translate from MaxSpanRequestKeys (0=unlimited, -1=nothing) to
+		// MVCC (0=nothing, infinity=unlimited).
+		//
+		// TODO(tbg): fix this in the MVCC layer and address long-standing TODO
+		// of moving the key count limit to MVCCScanOptions.
+		maxKeys := baHeader.MaxSpanRequestKeys
+		if maxKeys < 0 {
+			maxKeys = 0
+		} else if maxKeys == 0 {
+			maxKeys = math.MaxInt64
+		}
 		curResult, pErr = evaluateCommand(
 			ctx, idKey, index, readWriter, rec, ms, baHeader, maxKeys, args, reply)
 
@@ -322,12 +327,21 @@ func evaluateBatch(
 			}
 		}
 
-		if maxKeys != math.MaxInt64 {
+		// If the last request was carried out with a limit, subtract the number
+		// of results from the limit going forward. Exhausting the limit results
+		// in a limit of -1. This makes sure that we still execute the rest of
+		// the batch, but with limit-aware operations returning no data.
+		if limit := baHeader.MaxSpanRequestKeys; limit > 0 {
 			retResults := reply.Header().NumKeys
-			if retResults > maxKeys {
-				log.Fatalf(ctx, "received %d results, limit was %d", retResults, maxKeys)
+			if retResults > limit {
+				log.Fatalf(ctx, "received %d results, limit was %d", retResults, limit)
+			} else if retResults < limit {
+				baHeader.MaxSpanRequestKeys -= retResults
+			} else {
+				// They were equal, so drop to -1 instead of zero (which would
+				// mean "no limit").
+				baHeader.MaxSpanRequestKeys = -1
 			}
-			maxKeys -= retResults
 		}
 
 		// If transactional, we use ba.Txn for each individual command and

--- a/pkg/storage/replica_evaluate_test.go
+++ b/pkg/storage/replica_evaluate_test.go
@@ -1,0 +1,325 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tcs := []testCase{
+		{
+			// We should never evaluate empty batches, but here's what would happen
+			// if we did.
+			name:  "all empty",
+			setup: func(t *testing.T, d *data) {},
+			check: func(t *testing.T, r resp) {
+				require.Nil(t, r.pErr)
+				require.NotNil(t, r.br)
+				require.Empty(t, r.br.Responses)
+			},
+		}, {
+			// Scanning without limit should return everything.
+			name: "scan without MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				req := scan("a", "z")
+				d.ba.Add(req)
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"a", "b", "c", "d", "e", "f"})
+				verifyResumeSpans(t, r, "")
+			},
+		}, {
+			// Ditto in reverse.
+			name: "reverse scan without MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				req := rscan("a", "z")
+				d.ba.Add(req)
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"f", "e", "d", "c", "b", "a"})
+				verifyResumeSpans(t, r, "")
+			},
+		}, {
+			// Scanning with "giant" limit should return everything.
+			name: "scan with giant MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				req := scan("a", "z")
+				d.ba.Add(req)
+				d.ba.MaxSpanRequestKeys = 100000
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"a", "b", "c", "d", "e", "f"})
+				verifyResumeSpans(t, r, "")
+			},
+		}, {
+			// Ditto in reverse.
+			name: "reverse scan with giant MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				req := rscan("a", "z")
+				d.ba.Add(req)
+				d.ba.MaxSpanRequestKeys = 100000
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"f", "e", "d", "c", "b", "a"})
+				verifyResumeSpans(t, r, "")
+			},
+		}, {
+			// Similar to above, just two scans.
+			name: "scans with giant MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(scan("a", "c"))
+				d.ba.Add(scan("d", "g"))
+				d.ba.MaxSpanRequestKeys = 100000
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"a", "b"}, []string{"d", "e", "f"})
+				verifyResumeSpans(t, r, "", "")
+			},
+		}, {
+			// Ditto in reverse.
+			name: "reverse scans with giant MaxSpanRequestKeys",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(rscan("d", "g"))
+				d.ba.Add(rscan("a", "c"))
+				d.ba.MaxSpanRequestKeys = 100000
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"f", "e", "d"}, []string{"b", "a"})
+				verifyResumeSpans(t, r, "", "")
+			},
+		}, {
+			// A batch limited to return only one key. Throw in a Get which is
+			// not subject to limitation and should thus have returned a value.
+			// However, the second scan comes up empty because there's no quota left.
+			//
+			// Note that there is currently a lot of undesirable behavior in the KV
+			// API for pretty much any batch that's not a nonoverlapping sorted run
+			// of only scans or only reverse scans. For example, in the example
+			// below, one would get a response for get(f) even though the resume
+			// span on the first scan is `[c,...)`. The higher layers of KV don't
+			// handle that correctly. Right now we just trust that nobody will
+			// send such requests.
+			name: "scans with MaxSpanRequestKeys=1",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(scan("a", "c"))
+				d.ba.Add(get("f"))
+				d.ba.Add(scan("d", "f"))
+				d.ba.MaxSpanRequestKeys = 1
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"a"}, []string{"f"}, nil)
+				verifyResumeSpans(t, r, "b-c", "", "d-f")
+				b, err := r.br.Responses[1].GetGet().Value.GetBytes()
+				require.NoError(t, err)
+				require.Equal(t, "value-f", string(b))
+			},
+		}, {
+			// Ditto in reverse.
+			name: "reverse scans with MaxSpanRequestKeys=1",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(rscan("d", "f"))
+				d.ba.Add(get("f"))
+				d.ba.Add(rscan("a", "c"))
+				d.ba.MaxSpanRequestKeys = 1
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"e"}, []string{"f"}, nil)
+				verifyResumeSpans(t, r, "d-d\x00", "", "a-c")
+				b, err := r.br.Responses[1].GetGet().Value.GetBytes()
+				require.NoError(t, err)
+				require.Equal(t, "value-f", string(b))
+			},
+		}, {
+			// Similar, but this time the request allows the second scan to
+			// return one (but not more) remaining key. Again there's a Get
+			// that isn't counted against the limit.
+			name: "scans with MaxSpanRequestKeys=3",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(scan("a", "c"))
+				d.ba.Add(get("e"))
+				d.ba.Add(scan("c", "e"))
+				d.ba.MaxSpanRequestKeys = 3
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"a", "b"}, []string{"e"}, []string{"c"})
+				verifyResumeSpans(t, r, "", "", "d-e")
+				b, err := r.br.Responses[1].GetGet().Value.GetBytes()
+				require.NoError(t, err)
+				require.Equal(t, "value-e", string(b))
+			},
+		}, {
+			// Ditto in reverse.
+			name: "reverse scans with MaxSpanRequestKeys=3",
+			setup: func(t *testing.T, d *data) {
+				writeABCDEF(t, d)
+				d.ba.Add(rscan("c", "e"))
+				d.ba.Add(get("e"))
+				d.ba.Add(rscan("a", "c"))
+				d.ba.MaxSpanRequestKeys = 3
+			},
+			check: func(t *testing.T, r resp) {
+				verifyScanResult(t, r, []string{"d", "c"}, []string{"e"}, []string{"b"})
+				verifyResumeSpans(t, r, "", "", "a-a\x00")
+				b, err := r.br.Responses[1].GetGet().Value.GetBytes()
+				require.NoError(t, err)
+				require.Equal(t, "value-e", string(b))
+			},
+		}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			eng := engine.NewDefaultInMem()
+			defer eng.Close()
+
+			d := &data{
+				idKey: storagebase.CmdIDKey("testing"),
+				eng:   eng,
+			}
+			d.ba.Header.Timestamp = hlc.Timestamp{WallTime: 1}
+
+			tc.setup(t, d)
+
+			var r resp
+			r.d = d
+			r.br, r.res, r.pErr = evaluateBatch(
+				ctx,
+				d.idKey,
+				d.eng,
+				d.MockEvalCtx.EvalContext(),
+				&d.ms,
+				&d.ba,
+				d.readOnly,
+			)
+
+			tc.check(t, r)
+		})
+	}
+}
+
+type data struct {
+	batcheval.MockEvalCtx
+	ba       roachpb.BatchRequest
+	idKey    storagebase.CmdIDKey
+	eng      engine.Engine
+	ms       enginepb.MVCCStats
+	readOnly bool
+}
+type resp struct {
+	d    *data
+	br   *roachpb.BatchResponse
+	res  result.Result
+	pErr *roachpb.Error
+}
+type testCase struct {
+	name  string
+	setup func(*testing.T, *data)
+	check func(*testing.T, resp)
+}
+
+func writeABCDEF(t *testing.T, d *data) {
+	for _, k := range []string{"a", "b", "c", "d", "e", "f"} {
+		require.NoError(t, engine.MVCCPut(
+			context.Background(), d.eng, nil /* ms */, roachpb.Key(k), d.ba.Timestamp,
+			roachpb.MakeValueFromString("value-"+k), nil /* txn */))
+	}
+}
+
+func scan(s, e string) *roachpb.ScanRequest {
+	return &roachpb.ScanRequest{
+		RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(s), EndKey: roachpb.Key(e)},
+	}
+}
+
+func rscan(s, e string) *roachpb.ReverseScanRequest {
+	return &roachpb.ReverseScanRequest{
+		RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(s), EndKey: roachpb.Key(e)},
+	}
+}
+
+func get(k string) *roachpb.GetRequest {
+	return &roachpb.GetRequest{
+		RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(k)},
+	}
+}
+
+func verifyScanResult(t *testing.T, r resp, keysPerResp ...[]string) {
+	require.Nil(t, r.pErr)
+	require.NotNil(t, r.br)
+	require.Len(t, r.br.Responses, len(keysPerResp))
+	for i, keys := range keysPerResp {
+		var isGet bool
+		scan := r.br.Responses[i].GetInner()
+		var rows []roachpb.KeyValue
+		switch req := scan.(type) {
+		case *roachpb.ScanResponse:
+			rows = req.Rows
+		case *roachpb.ReverseScanResponse:
+			rows = req.Rows
+		case *roachpb.GetResponse:
+			isGet = true
+			rows = []roachpb.KeyValue{{
+				Key:   r.d.ba.Requests[i].GetGet().Key,
+				Value: *req.Value,
+			}}
+		default:
+		}
+
+		if !isGet {
+			require.EqualValues(t, len(keys), scan.Header().NumKeys, "in response #%d", i+1)
+		} else {
+			require.Zero(t, scan.Header().NumKeys, "in response #%d", i+1)
+		}
+		var actKeys []string
+		for _, row := range rows {
+			actKeys = append(actKeys, string(row.Key))
+		}
+		require.Equal(t, keys, actKeys, "in response #%i", i+1)
+	}
+}
+
+func verifyResumeSpans(t *testing.T, r resp, resumeSpans ...string) {
+	for i, span := range resumeSpans {
+		if span == "" {
+			continue // don't check request
+		}
+		rs := r.br.Responses[i].GetInner().Header().ResumeSpan
+		var act string
+		if rs != nil {
+			act = fmt.Sprintf("%s-%s", string(rs.Key), string(rs.EndKey))
+		}
+		require.Equal(t, span, act, "#%d", i+1)
+	}
+}


### PR DESCRIPTION
`evaluateBatch` didn't have any direct testing, though it contains
enough logic that could use some.

Since I'll be modifying it shortly (to add TargetBytes support) I went
ahead and added comprehensive unit testing around the MaxSpanRequestKeys
pagination.

I also made a small (noop) change to `evaluateBatch` itself in
preparation for an upcoming change in the MVCC layer to treat
`maxKeys==0` as "unbounded", which will allow us to take care
of a long-standing TODO to move maxKeys into `MVCCScanOptions`.
I'll leave actually doing that for the next PR, though.

Release note: None