### PR TITLE
[WIP] colcontainer: add on-disk implementation of PartitionedQueue

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,6 +89,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	raven "github.com/getsentry/raven-go"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/marusama/semaphore"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -620,7 +621,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		TempStorage:     tempEngine,
 		TempStoragePath: s.cfg.TempStorageConfig.Path,
 		TempFS:          tempFS,
-		DiskMonitor:     s.cfg.TempStorageConfig.Mon,
+		// COCKROACH_VEC_MAX_OPEN_FDS specifies the maximum number of open file
+		// descriptors that the vectorized execution engine may have open at any
+		// one time. This limit is implemented as a weighted semaphore acquired
+		// before opening files.
+		VecFDSemaphore: semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", 128)),
+		DiskMonitor:    s.cfg.TempStorageConfig.Mon,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
 		BulkAdder: func(

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -285,9 +285,9 @@ func (d *diskQueue) Close() error {
 			return err
 		}
 		d.readFile = nil
-		// The readFile will be removed below in RemoveAll.
+		// The readFile will be removed below in DeleteDirAndFiles.
 	}
-	if err := d.cfg.FS.DeleteDir(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
+	if err := d.cfg.FS.DeleteDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -1,0 +1,93 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colcontainer
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// PartitionedQueue is the abstraction for on-disk storage.
+type PartitionedQueue interface {
+	// Enqueue adds the batch to the end of the partitionIdx'th partition. If a
+	// partition at that index does not exist, a new one is created.
+	Enqueue(partitionIdx int, batch coldata.Batch) error
+	// Dequeue removes and returns the batch from the front of the
+	// partitionIdx'th partition. If the partition is empty, or no partition at
+	// that index was Enqueued to, a zero-length batch is returned.
+	Dequeue(partitionIdx int, batch coldata.Batch) error
+	// Close closes all partitions created.
+	Close() error
+}
+
+type PartitionedDiskQueue struct {
+	typs []coltypes.T
+	cfg  DiskQueueCfg
+
+	partitionIdxToIndex map[int]int
+	partitions          []Queue
+}
+
+// NewPartitionedDiskQueue creates a PartitionedDiskQueue whose partitions are
+// all on-disk queues. Note that diskQueues will be lazily created when
+// enqueueing to a new partition. Each new partition will use
+// cfg.BufferSizeBytes, so memory usage may increase in an unbounded fashion.
+func NewPartitionedDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) *PartitionedDiskQueue {
+	return &PartitionedDiskQueue{
+		typs:                typs,
+		cfg:                 cfg,
+		partitionIdxToIndex: make(map[int]int),
+		partitions:          make([]Queue, 0),
+	}
+}
+
+func (p *PartitionedDiskQueue) Enqueue(partitionIdx int, batch coldata.Batch) error {
+	idx, ok := p.partitionIdxToIndex[partitionIdx]
+	if !ok {
+		// Partition has not been created yet.
+		q, err := NewDiskQueue(p.typs, p.cfg)
+		if err != nil {
+			return err
+		}
+		idx = len(p.partitions)
+		p.partitions = append(p.partitions, q)
+		p.partitionIdxToIndex[partitionIdx] = idx
+	}
+	return p.partitions[idx].Enqueue(batch)
+}
+
+func (p *PartitionedDiskQueue) Dequeue(partitionIdx int, batch coldata.Batch) error {
+	idx, ok := p.partitionIdxToIndex[partitionIdx]
+	if !ok {
+		batch.SetLength(0)
+		return nil
+	}
+	notEmpty, err := p.partitions[idx].Dequeue(batch)
+	if err != nil {
+		return err
+	}
+	if !notEmpty {
+		// The queue was empty.
+		batch.SetLength(0)
+	}
+	return nil
+}
+
+// Close closes all the PartitionedDiskQueue's partitions. If an error is
+// encountered, the PartitionedDiskQueue will attempt to close all partitions
+// anyway and return the last error encountered.
+func (p *PartitionedDiskQueue) Close() error {
+	var lastErr error
+	for _, q := range p.partitions {
+		lastErr = q.Close()
+	}
+	return lastErr
+}

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -11,21 +11,37 @@
 package colcontainer
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/errors"
+	"github.com/marusama/semaphore"
 )
 
 // PartitionedQueue is the abstraction for on-disk storage.
 type PartitionedQueue interface {
 	// Enqueue adds the batch to the end of the partitionIdx'th partition. If a
 	// partition at that index does not exist, a new one is created.
-	Enqueue(partitionIdx int, batch coldata.Batch) error
+	Enqueue(ctx context.Context, partitionIdx int, batch coldata.Batch) error
 	// Dequeue removes and returns the batch from the front of the
 	// partitionIdx'th partition. If the partition is empty, or no partition at
-	// that index was Enqueued to, a zero-length batch is returned.
+	// that index was Enqueued to, a zero-length batch is returned. Note that
+	// it is illegal to call Enqueue on a partition after Dequeue.
+	// TODO(asubiotto): If we change the DiskQueue to have the same semantics, we
+	//  could probably reduce the memory overhead of a DiskQueue.
 	Dequeue(partitionIdx int, batch coldata.Batch) error
 	// Close closes all partitions created.
 	Close() error
+}
+
+// partition is a simple wrapper over a Queue used by the PartitionedDiskQueue.
+type partition struct {
+	Queue
+	// reading is set to true when a partition has been Dequeued from. It is
+	// illegal to Enqueue to a partition when reading=true, this is specified in
+	// the interface contract.
+	reading bool
 }
 
 type PartitionedDiskQueue struct {
@@ -33,33 +49,49 @@ type PartitionedDiskQueue struct {
 	cfg  DiskQueueCfg
 
 	partitionIdxToIndex map[int]int
-	partitions          []Queue
+	partitions          []partition
+
+	fdSemaphore semaphore.Semaphore
 }
 
 // NewPartitionedDiskQueue creates a PartitionedDiskQueue whose partitions are
 // all on-disk queues. Note that diskQueues will be lazily created when
 // enqueueing to a new partition. Each new partition will use
 // cfg.BufferSizeBytes, so memory usage may increase in an unbounded fashion.
-func NewPartitionedDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) *PartitionedDiskQueue {
+func NewPartitionedDiskQueue(
+	typs []coltypes.T, cfg DiskQueueCfg, fdSemaphore semaphore.Semaphore,
+) *PartitionedDiskQueue {
 	return &PartitionedDiskQueue{
 		typs:                typs,
 		cfg:                 cfg,
 		partitionIdxToIndex: make(map[int]int),
-		partitions:          make([]Queue, 0),
+		partitions:          make([]partition, 0),
+		fdSemaphore:         fdSemaphore,
 	}
 }
 
-func (p *PartitionedDiskQueue) Enqueue(partitionIdx int, batch coldata.Batch) error {
+func (p *PartitionedDiskQueue) Enqueue(
+	ctx context.Context, partitionIdx int, batch coldata.Batch,
+) error {
 	idx, ok := p.partitionIdxToIndex[partitionIdx]
 	if !ok {
+		// Acquire only one file descriptor. This will represent the write file
+		// descriptor. When we start Dequeueing from this partition, this will
+		// represent the read file descriptor.
+		if err := p.fdSemaphore.Acquire(ctx, 1); err != nil {
+			return err
+		}
 		// Partition has not been created yet.
 		q, err := NewDiskQueue(p.typs, p.cfg)
 		if err != nil {
 			return err
 		}
 		idx = len(p.partitions)
-		p.partitions = append(p.partitions, q)
+		p.partitions = append(p.partitions, partition{Queue: q})
 		p.partitionIdxToIndex[partitionIdx] = idx
+	}
+	if p.partitions[idx].reading {
+		return errors.New("Enqueue illegally called after Dequeue")
 	}
 	return p.partitions[idx].Enqueue(batch)
 }
@@ -69,6 +101,16 @@ func (p *PartitionedDiskQueue) Dequeue(partitionIdx int, batch coldata.Batch) er
 	if !ok {
 		batch.SetLength(0)
 		return nil
+	}
+	partition := p.partitions[idx]
+	if !partition.reading {
+		// coldata.ZeroBatch signals to the DiskQueue that no more writes will come
+		// in, which allows us to avoid acquiring a new file descriptor for the read
+		// file.
+		if err := partition.Enqueue(coldata.ZeroBatch); err != nil {
+			return err
+		}
+		p.partitions[idx].reading = true
 	}
 	notEmpty, err := p.partitions[idx].Dequeue(batch)
 	if err != nil {
@@ -89,5 +131,6 @@ func (p *PartitionedDiskQueue) Close() error {
 	for _, q := range p.partitions {
 		lastErr = q.Close()
 	}
+	p.fdSemaphore.Release(len(p.partitions))
 	return lastErr
 }

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -123,6 +123,7 @@ type NewColOperatorResult struct {
 	InternalMemUsage       int
 	MetadataSources        []execinfrapb.MetadataSource
 	IsStreaming            bool
+	CanFallBackToDisk      bool
 	BufferingOpMemMonitors []*mon.BytesMonitor
 	BufferingOpMemAccounts []*mon.BoundAccount
 }

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -93,6 +94,7 @@ type NewColOperatorArgs struct {
 	Inputs               []Operator
 	StreamingMemAccount  *mon.BoundAccount
 	ProcessorConstructor execinfra.ProcessorConstructor
+	DiskQueueCfg         colcontainer.DiskQueueCfg
 	TestingKnobs         struct {
 		// UseStreamingMemAccountForBuffering specifies whether to use
 		// StreamingMemAccount when creating buffering operators and should only be
@@ -564,14 +566,10 @@ func NewColOperator(
 							ctx, result.createBufferingMemAccount(
 								ctx, flowCtx, monitorNamePrefix,
 							))
-						diskQueuesUnlimitedAllocator := NewAllocator(
-							ctx, result.createBufferingUnlimitedMemAccount(
-								ctx, flowCtx, monitorNamePrefix+"disk-queues",
-							))
 						return newExternalHashJoiner(
 							allocator, hjSpec,
 							inputOne, inputTwo,
-							diskQueuesUnlimitedAllocator,
+							args.DiskQueueCfg,
 						)
 					},
 					args.TestingKnobs.SpillingCallbackFn,
@@ -748,16 +746,7 @@ func NewColOperator(
 							ctx, result.createBufferingUnlimitedMemAccount(
 								ctx, flowCtx, monitorNamePrefix,
 							))
-						diskQueuesUnlimitedAllocator := NewAllocator(
-							ctx, result.createBufferingUnlimitedMemAccount(
-								ctx, flowCtx, monitorNamePrefix+"disk-queues",
-							))
-						return newExternalSorter(
-							unlimitedAllocator,
-							input, inputTypes, core.Sorter.OutputOrdering,
-							execinfra.GetWorkMemLimit(flowCtx.Cfg),
-							diskQueuesUnlimitedAllocator,
-						)
+						return newExternalSorter(unlimitedAllocator, input, inputTypes, core.Sorter.OutputOrdering, execinfra.GetWorkMemLimit(flowCtx.Cfg), args.DiskQueueCfg)
 					},
 					args.TestingKnobs.SpillingCallbackFn,
 				)

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
@@ -38,6 +40,9 @@ func TestExternalHashJoiner(t *testing.T) {
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 	}
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
 
 	var (
 		memAccounts []*mon.BoundAccount
@@ -57,9 +62,7 @@ func TestExternalHashJoiner(t *testing.T) {
 				for _, tc := range tcs {
 					runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
 						spec := createSpecForHashJoiner(tc)
-						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(
-							ctx, flowCtx, spec, sources, func() {},
-						)
+						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, sources, func() {}, queueCfg)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
 						return hjOp, err
@@ -117,6 +120,8 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 				vec.Nulls().UnsetNulls()
 			}
 		}
+		queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
+		defer cleanup()
 		leftSource := newFiniteBatchSource(batch, 0)
 		rightSource := newFiniteBatchSource(batch, 0)
 		for _, fullOuter := range []bool{false, true} {
@@ -148,9 +153,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							leftSource.reset(nBatches)
 							rightSource.reset(nBatches)
-							hj, accounts, monitors, err := createDiskBackedHashJoiner(
-								ctx, flowCtx, spec, []Operator{leftSource, rightSource}, func() {},
-							)
+							hj, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, []Operator{leftSource, rightSource}, func() {}, queueCfg)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							require.NoError(b, err)
@@ -182,11 +185,13 @@ func createDiskBackedHashJoiner(
 	spec *execinfrapb.ProcessorSpec,
 	inputs []Operator,
 	spillingCallbackFn func(),
+	diskQueueCfg colcontainer.DiskQueueCfg,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
 	args := NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,
 		StreamingMemAccount: testMemAcc,
+		DiskQueueCfg:        diskQueueCfg,
 	}
 	// We will not use streaming memory account for the external hash join so
 	// that the in-memory hash join operator could hit the memory limit set on

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -16,22 +16,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
-
-// Partitioner is the abstraction for on-disk storage.
-type Partitioner interface {
-	// Enqueue adds the batch to the end of the partitionIdx'th partition.
-	Enqueue(partitionIdx int, batch coldata.Batch) error
-	// Dequeue removes and returns the batch from the front of the
-	// partitionIdx'th partition. If the partition is empty (either all batches
-	// from it have already been dequeued or no batches were ever enqueued), a
-	// zero-length batch is returned.
-	Dequeue(partitionIdx int, batch coldata.Batch) error
-	// Close closes the partitioner.
-	Close() error
-}
 
 // externalSorterState indicates the current state of the external sorter.
 type externalSorterState int
@@ -104,7 +92,7 @@ type externalSorter struct {
 	inputTypes            []coltypes.T
 	ordering              execinfrapb.Ordering
 	inMemSorter           resettableOperator
-	partitioner           Partitioner
+	partitioner           colcontainer.PartitionedQueue
 	numPartitions         int
 	merger                Operator
 	singlePartitionOutput Operator
@@ -120,14 +108,17 @@ var _ Operator = &externalSorter{}
 // - diskQueuesUnlimitedAllocator is a (temporary) unlimited allocator that
 // will be used to create dummy queues and will be removed once we have actual
 // disk-backed queues.
+// TODO(asubiotto): We need to reserve memory for the DiskQueue partitions (each
+//  will take up diskQueueCfg.BufferSizeBytes. We'll have to choose how much of
+//  memoryLimit we want each partition to take and share this with the limit
+//  passed in to the in-memory sorter.
 func newExternalSorter(
 	unlimitedAllocator *Allocator,
 	input Operator,
 	inputTypes []coltypes.T,
 	ordering execinfrapb.Ordering,
 	memoryLimit int64,
-	// TODO(yuzefovich): remove this once actual disk queues are in-place.
-	diskQueuesUnlimitedAllocator *Allocator,
+	diskQueueCfg colcontainer.DiskQueueCfg,
 ) Operator {
 	inputPartitioner := newInputPartitioningOperator(unlimitedAllocator, input, memoryLimit)
 	inMemSorter, err := newSorter(
@@ -141,7 +132,7 @@ func newExternalSorter(
 		OneInputNode:       NewOneInputNode(inMemSorter),
 		unlimitedAllocator: unlimitedAllocator,
 		inMemSorter:        inMemSorter,
-		partitioner:        newDummyPartitioner(diskQueuesUnlimitedAllocator, inputTypes),
+		partitioner:        colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg),
 		inputTypes:         inputTypes,
 		ordering:           ordering,
 	}
@@ -277,7 +268,10 @@ func (o *inputPartitioningOperator) reset() {
 }
 
 func newPartitionerToOperator(
-	allocator *Allocator, types []coltypes.T, partitioner Partitioner, partitionIdx int,
+	allocator *Allocator,
+	types []coltypes.T,
+	partitioner colcontainer.PartitionedQueue,
+	partitionIdx int,
 ) *partitionerToOperator {
 	return &partitionerToOperator{
 		partitioner:  partitioner,
@@ -288,12 +282,12 @@ func newPartitionerToOperator(
 
 // partitionerToOperator is an Operator that Dequeue's from the corresponding
 // partition on every call to Next. It is a converter from filled in
-// Partitioner to Operator.
+// PartitionedQueue to Operator.
 type partitionerToOperator struct {
 	ZeroInputNode
 	NonExplainable
 
-	partitioner  Partitioner
+	partitioner  colcontainer.PartitionedQueue
 	partitionIdx int
 	batch        coldata.Batch
 }
@@ -307,111 +301,4 @@ func (p *partitionerToOperator) Next(context.Context) coldata.Batch {
 		execerror.VectorizedInternalPanic(err)
 	}
 	return p.batch
-}
-
-func newDummyPartitioner(allocator *Allocator, types []coltypes.T) Partitioner {
-	return &dummyPartitioner{allocator: allocator, types: types}
-}
-
-// dummyPartitioner is a simple implementation of Partitioner interface that
-// uses dummy in-memory queues.
-type dummyPartitioner struct {
-	allocator  *Allocator
-	types      []coltypes.T
-	partitions []*dummyQueue
-}
-
-var _ Partitioner = &dummyPartitioner{}
-
-func (d *dummyPartitioner) Enqueue(partitionIdx int, batch coldata.Batch) error {
-	if len(d.partitions) <= partitionIdx {
-		d.partitions = append(d.partitions, make([]*dummyQueue, partitionIdx-len(d.partitions)+1)...)
-	}
-	if d.partitions[partitionIdx] == nil {
-		d.partitions[partitionIdx] = newDummyQueue(d.allocator, d.types)
-	}
-	return d.partitions[partitionIdx].Enqueue(batch)
-}
-
-func (d *dummyPartitioner) Dequeue(partitionIdx int, batch coldata.Batch) error {
-	var partition *dummyQueue
-	if partitionIdx < len(d.partitions) {
-		partition = d.partitions[partitionIdx]
-	}
-	if partition == nil {
-		batch.SetLength(0)
-		return nil
-	}
-	return partition.Dequeue(batch)
-}
-
-func (d *dummyPartitioner) Close() error {
-	for _, partition := range d.partitions {
-		if err := partition.Close(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func newDummyQueue(allocator *Allocator, types []coltypes.T) *dummyQueue {
-	return &dummyQueue{allocator: allocator, types: types}
-}
-
-// dummyQueue is an in-memory queue that simply copies the passed in batches.
-type dummyQueue struct {
-	allocator *Allocator
-	queue     []coldata.Batch
-	types     []coltypes.T
-}
-
-func (d *dummyQueue) Enqueue(batch coldata.Batch) error {
-	if batch.Length() == 0 {
-		return nil
-	}
-	batchCopy := d.allocator.NewMemBatchWithSize(d.types, int(batch.Length()))
-	d.allocator.PerformOperation(batchCopy.ColVecs(), func() {
-		for i, vec := range batchCopy.ColVecs() {
-			vec.Append(
-				coldata.SliceArgs{
-					ColType:     d.types[i],
-					Src:         batch.ColVec(i),
-					Sel:         batch.Selection(),
-					DestIdx:     0,
-					SrcStartIdx: 0,
-					SrcEndIdx:   uint64(batch.Length()),
-				})
-		}
-	})
-	batchCopy.SetLength(batch.Length())
-	d.queue = append(d.queue, batchCopy)
-	return nil
-}
-
-func (d *dummyQueue) Dequeue(batch coldata.Batch) error {
-	if len(d.queue) == 0 {
-		batch.SetLength(0)
-		return nil
-	}
-	batch.ResetInternalBatch()
-	batchToCopy := d.queue[0]
-	d.queue = d.queue[1:]
-	d.allocator.PerformOperation(batch.ColVecs(), func() {
-		for i, colVecToCopy := range batchToCopy.ColVecs() {
-			batch.ColVec(i).Append(coldata.SliceArgs{
-				ColType:     d.types[i],
-				Src:         colVecToCopy,
-				Sel:         batchToCopy.Selection(),
-				DestIdx:     0,
-				SrcStartIdx: 0,
-				SrcEndIdx:   uint64(batchToCopy.Length()),
-			})
-		}
-	})
-	batch.SetLength(batchToCopy.Length())
-	return nil
-}
-
-func (d *dummyQueue) Close() error {
-	return nil
 }

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/marusama/semaphore"
 )
 
 // routerOutput is an interface implemented by router outputs. It exists for
@@ -32,7 +33,7 @@ type routerOutput interface {
 	// addBatch adds the elements specified by the selection vector from batch to
 	// the output. It returns whether or not the output changed its state to
 	// blocked (see implementations).
-	addBatch(coldata.Batch, []uint16) bool
+	addBatch(context.Context, coldata.Batch, []uint16) bool
 	// cancel tells the output to stop producing batches.
 	cancel(ctx context.Context)
 }
@@ -112,10 +113,9 @@ func newRouterOutputOp(
 	unblockedEventsChan chan<- struct{},
 	memoryLimit int64,
 	cfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 ) *routerOutputOp {
-	return newRouterOutputOpWithBlockedThresholdAndBatchSize(
-		unlimitedAllocator, types, unblockedEventsChan, memoryLimit, cfg, getDefaultRouterOutputBlockedThreshold(), int(coldata.BatchSize()),
-	)
+	return newRouterOutputOpWithBlockedThresholdAndBatchSize(unlimitedAllocator, types, unblockedEventsChan, memoryLimit, cfg, fdSemaphore, getDefaultRouterOutputBlockedThreshold(), int(coldata.BatchSize()))
 }
 
 func newRouterOutputOpWithBlockedThresholdAndBatchSize(
@@ -124,6 +124,7 @@ func newRouterOutputOpWithBlockedThresholdAndBatchSize(
 	unblockedEventsChan chan<- struct{},
 	memoryLimit int64,
 	cfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 	blockedThreshold int,
 	outputBatchSize int,
 ) *routerOutputOp {
@@ -135,7 +136,7 @@ func newRouterOutputOpWithBlockedThresholdAndBatchSize(
 	}
 	o.mu.unlimitedAllocator = unlimitedAllocator
 	o.mu.cond = sync.NewCond(&o.mu)
-	o.mu.data = newSpillingQueue(unlimitedAllocator, types, memoryLimit, cfg, outputBatchSize)
+	o.mu.data = newSpillingQueue(unlimitedAllocator, types, memoryLimit, cfg, fdSemaphore, outputBatchSize)
 
 	return o
 }
@@ -216,7 +217,9 @@ func (o *routerOutputOp) cancel(ctx context.Context) {
 //  disk as the code is written, meaning that we impact the performance of
 //  writing rows to a fast output if we have to write to disk for a single
 //  slow output.
-func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool {
+func (o *routerOutputOp) addBatch(
+	ctx context.Context, batch coldata.Batch, selection []uint16,
+) bool {
 	if len(selection) > int(batch.Length()) {
 		selection = selection[:batch.Length()]
 	}
@@ -224,7 +227,7 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 	defer o.mu.Unlock()
 	if batch.Length() == 0 {
 		if o.mu.pendingBatch != nil {
-			if err := o.mu.data.enqueue(o.mu.pendingBatch); err != nil {
+			if err := o.mu.data.enqueue(nil, o.mu.pendingBatch); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 		}
@@ -270,7 +273,7 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 		o.mu.pendingBatch.SetLength(newLength)
 		if o.testingKnobs.alwaysFlush || int(newLength) >= o.outputBatchSize {
 			// The capacity in o.mu.pendingBatch has been filled.
-			if err := o.mu.data.enqueue(o.mu.pendingBatch); err != nil {
+			if err := o.mu.data.enqueue(nil, o.mu.pendingBatch); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			o.mu.pendingBatch = nil
@@ -354,6 +357,7 @@ func NewHashRouter(
 	hashCols []uint32,
 	memoryLimit int64,
 	cfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 ) (*HashRouter, []Operator) {
 	outputs := make([]routerOutput, len(unlimitedAllocators))
 	outputsAsOps := make([]Operator, len(unlimitedAllocators))
@@ -367,7 +371,7 @@ func NewHashRouter(
 	unblockEventsChan := make(chan struct{}, 2*len(unlimitedAllocators))
 	memoryLimitPerOutput := memoryLimit / int64(len(unlimitedAllocators))
 	for i := range unlimitedAllocators {
-		op := newRouterOutputOp(unlimitedAllocators[i], types, unblockEventsChan, memoryLimitPerOutput, cfg)
+		op := newRouterOutputOp(unlimitedAllocators[i], types, unblockEventsChan, memoryLimitPerOutput, cfg, fdSemaphore)
 		outputs[i] = op
 		outputsAsOps[i] = op
 	}
@@ -469,14 +473,14 @@ func (r *HashRouter) processNextBatch(ctx context.Context) bool {
 		// Done. Push an empty batch to outputs to tell them the data is done as
 		// well.
 		for _, o := range r.outputs {
-			o.addBatch(b, nil)
+			o.addBatch(ctx, b, nil)
 		}
 		return true
 	}
 
 	selections := r.tupleDistributor.distribute(ctx, b, r.types, r.hashCols)
 	for i, o := range r.outputs {
-		if o.addBatch(b, selections[i]) {
+		if o.addBatch(ctx, b, selections[i]) {
 			// This batch blocked the output.
 			r.numBlockedOutputs++
 		}

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -140,15 +140,13 @@ func TestRouterOutputAddBatch(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 				// Clear the testAllocator for use.
 				testAllocator.Clear()
-				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-					testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, mtc.bytes, queueCfg, tc.blockedThreshold, tc.outputBatchSize,
-				)
+				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, mtc.bytes, queueCfg, nil, tc.blockedThreshold, tc.outputBatchSize)
 				in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
 				out := newOpTestOutput(o, data[:len(tc.selection)])
 				in.Init()
 				for {
 					b := in.Next(ctx)
-					o.addBatch(b, tc.selection)
+					o.addBatch(ctx, b, tc.selection)
 					if b.Length() == 0 {
 						break
 					}
@@ -190,7 +188,7 @@ func TestRouterOutputNext(t *testing.T) {
 			unblockEvent: func(in Operator, o *routerOutputOp) {
 				for {
 					b := in.Next(ctx)
-					o.addBatch(b, fullSelection)
+					o.addBatch(ctx, b, fullSelection)
 					if b.Length() == 0 {
 						break
 					}
@@ -203,7 +201,7 @@ func TestRouterOutputNext(t *testing.T) {
 			// ReaderWaitsForZeroBatch verifies that a reader blocking on Next will
 			// also get unblocked with no data other than the zero batch.
 			unblockEvent: func(_ Operator, o *routerOutputOp) {
-				o.addBatch(coldata.ZeroBatch, nil /* selection */)
+				o.addBatch(ctx, coldata.ZeroBatch, nil)
 			},
 			expected: tuples{},
 			name:     "ReaderWaitsForZeroBatch",
@@ -235,7 +233,7 @@ func TestRouterOutputNext(t *testing.T) {
 				if queueCfg.FS == nil {
 					t.Fatal("FS was nil")
 				}
-				o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg)
+				o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg, nil)
 				in := newOpTestInput(coldata.BatchSize(), data, nil /* typs */)
 				in.Init()
 				wg.Add(1)
@@ -285,8 +283,8 @@ func TestRouterOutputNext(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("NextAfterZeroBatchDoesntBlock/memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
-			o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg)
-			o.addBatch(coldata.ZeroBatch, fullSelection)
+			o := newRouterOutputOp(testAllocator, []coltypes.T{coltypes.Int64}, unblockedEventsChan, mtc.bytes, queueCfg, nil)
+			o.addBatch(ctx, coldata.ZeroBatch, fullSelection)
 			o.Next(ctx)
 			o.Next(ctx)
 			select {
@@ -324,9 +322,7 @@ func TestRouterOutputNext(t *testing.T) {
 			}
 
 			ch := make(chan struct{}, 2)
-			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-				testAllocator, []coltypes.T{coltypes.Int64}, ch, mtc.bytes, queueCfg, blockThreshold, int(coldata.BatchSize()),
-			)
+			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, []coltypes.T{coltypes.Int64}, ch, mtc.bytes, queueCfg, nil, blockThreshold, int(coldata.BatchSize()))
 			in := newOpTestInput(uint16(smallBatchSize), data, nil /* typs */)
 			out := newOpTestOutput(o, expected)
 			in.Init()
@@ -334,19 +330,19 @@ func TestRouterOutputNext(t *testing.T) {
 			b := in.Next(ctx)
 			// Make sure the output doesn't consider itself blocked. We're right at the
 			// limit but not over.
-			if o.addBatch(b, selection) {
+			if o.addBatch(ctx, b, selection) {
 				t.Fatal("unexpectedly blocked")
 			}
 			b = in.Next(ctx)
 			// This addBatch call should now block the output.
-			if !o.addBatch(b, selection) {
+			if !o.addBatch(ctx, b, selection) {
 				t.Fatal("unexpectedly still unblocked")
 			}
 
 			// Add the rest of the data.
 			for {
 				b = in.Next(ctx)
-				if o.addBatch(b, selection) {
+				if o.addBatch(ctx, b, selection) {
 					t.Fatal("should only return true when switching from unblocked to blocked")
 				}
 				if b.Length() == 0 {
@@ -400,9 +396,7 @@ func TestRouterOutputRandom(t *testing.T) {
 			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
 				var wg sync.WaitGroup
 				unblockedEventsChans := make(chan struct{}, 2)
-				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-					testAllocator, typs, unblockedEventsChans, mtc.bytes, queueCfg, blockedThreshold, outputSize,
-				)
+				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, typs, unblockedEventsChans, mtc.bytes, queueCfg, nil, blockedThreshold, outputSize)
 				inputs[0].Init()
 
 				expected := make(tuples, 0, len(data))
@@ -427,7 +421,7 @@ func TestRouterOutputRandom(t *testing.T) {
 							}
 						}
 
-						if o.addBatch(b, selection) {
+						if o.addBatch(ctx, b, selection) {
 							if lastBlockedState {
 								// We might have missed an unblock event during the last loop.
 								select {
@@ -502,7 +496,9 @@ type callbackRouterOutput struct {
 
 var _ routerOutput = callbackRouterOutput{}
 
-func (o callbackRouterOutput) addBatch(batch coldata.Batch, selection []uint16) bool {
+func (o callbackRouterOutput) addBatch(
+	ctx context.Context, batch coldata.Batch, selection []uint16,
+) bool {
 	if o.addBatchCb != nil {
 		return o.addBatchCb(batch, selection)
 	}
@@ -712,7 +708,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 		t.Run(fmt.Sprintf("memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 			// Clear the testAllocator for use.
 			testAllocator.Clear()
-			r, routerOutputs := NewHashRouter([]*Allocator{testAllocator}, newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []uint32{0}, mtc.bytes, queueCfg)
+			r, routerOutputs := NewHashRouter([]*Allocator{testAllocator}, newOpFixedSelTestInput(sel, uint16(len(sel)), data), typs, []uint32{0}, mtc.bytes, queueCfg, nil)
 
 			if len(routerOutputs) != 1 {
 				t.Fatalf("expected 1 router output but got %d", len(routerOutputs))
@@ -812,9 +808,7 @@ func TestHashRouterRandom(t *testing.T) {
 					// Create a separate allocator for each output as a single allocator
 					// may not be used concurrently.
 					allocator := NewAllocator(ctx, &acc)
-					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-						allocator, typs, unblockEventsChan, mtc.bytes, queueCfg, blockedThreshold, outputSize,
-					)
+					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(allocator, typs, unblockEventsChan, mtc.bytes, queueCfg, nil, blockedThreshold, outputSize)
 					outputs[i] = op
 					outputsAsOps[i] = op
 				}
@@ -912,7 +906,7 @@ func BenchmarkHashRouter(b *testing.B) {
 					allocators[i] = NewAllocator(ctx, &acc)
 					defer acc.Close(ctx)
 				}
-				r, outputs := NewHashRouter(allocators, input, types, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg)
+				r, outputs := NewHashRouter(allocators, input, types, []uint32{0}, 64<<20, queueCfg, nil)
 				b.SetBytes(8 * int64(coldata.BatchSize()) * int64(numInputBatches))
 				// We expect distribution to not change. This is a sanity check that
 				// we're resetting properly.

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -814,6 +814,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			Inputs:               inputs,
 			StreamingMemAccount:  s.newStreamingMemAccount(flowCtx),
 			ProcessorConstructor: rowexec.NewProcessor,
+			DiskQueueCfg:         s.diskQueueCfg,
 		}
 		result, err := colexec.NewColOperator(ctx, flowCtx, args)
 		// Even when err is non-nil, it is possible that the buffering memory

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -157,6 +157,41 @@ func (f *vectorizedFlow) Release() {
 	vectorizedFlowPool.Put(f)
 }
 
+// tryRemoveAll tries to remove all directories and files contained in root as
+// well as root.
+// Used as a temporary solution to forcefully remove the flow's temporary
+// storage directory until #45098 is resolved.
+// TODO(asubiotto): Remove once #45098 is resolved.
+func (f *vectorizedFlow) tryRemoveAll(root string) error {
+	// Unfortunately there is no way to Stat using TempFS, so simply try all
+	// alternatives.
+	if f.Cfg.TempFS.DeleteFile(root) != nil {
+		// If there was an error, it might be a directory.
+		if f.Cfg.TempFS.DeleteDir(root) != nil {
+			// DeleteDir failed, this is probably due to children.
+			children, err := f.Cfg.TempFS.ListDir(root)
+			if err != nil {
+				// This would be a weird error, so return it.
+				return err
+			}
+			for _, child := range children {
+				if child == "." || child == ".." {
+					continue
+				}
+				// ListDir returns relative paths, so join with parent dir.
+				if err := f.tryRemoveAll(filepath.Join(root, child)); err != nil {
+					return err
+				}
+			}
+		}
+		// Now that children are cleaned up, delete the directory.
+		if err := f.Cfg.TempFS.DeleteDir(root); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Cleanup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	// This cleans up all the memory monitoring of the vectorized flow.
@@ -170,7 +205,7 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 		memMonitor.Stop(ctx)
 	}
 	flowTempStoragePath := filepath.Join(f.Cfg.TempStoragePath, f.GetID().String())
-	if err := f.Cfg.TempFS.DeleteDir(flowTempStoragePath); err != nil {
+	if err := f.tryRemoveAll(flowTempStoragePath); err != nil {
 		// Log error as a Warning but keep on going to close the memory
 		// infrastructure.
 		log.Warningf(

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -164,7 +164,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					defer acc.Close(ctxRemote)
 					allocators[i] = colexec.NewAllocator(ctxRemote, &acc)
 				}
-				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg)
+				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20, queueCfg, nil)
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -209,7 +209,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: roachpb.NodeID(1)}}
 	var wg sync.WaitGroup
-	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{})
+	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
 	defer func() {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -147,7 +147,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	}
 
 	if evalCtx.SessionData.VectorizeMode != sessiondata.VectorizeOff {
-		if !vectorizeThresholdMet && evalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto {
+		if !vectorizeThresholdMet && evalCtx.SessionData.VectorizeMode == sessiondata.Vectorize192Auto {
 			// Vectorization is not justified for this flow because the expected
 			// amount of data is too small and the overhead of pre-allocating data
 			// structures needed for the vectorized engine is expected to dominate

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -197,6 +197,7 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 	"auto",
 	map[int64]string{
 		int64(sessiondata.VectorizeOff):            "off",
+		int64(sessiondata.Vectorize192Auto):        "192auto",
 		int64(sessiondata.VectorizeAuto):           "auto",
 		int64(sessiondata.VectorizeExperimentalOn): "experimental_on",
 	},

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/marusama/semaphore"
 )
 
 // Version identifies the distsql protocol version.
@@ -132,6 +133,10 @@ type ServerConfig struct {
 	// TempFS is used by the vectorized execution engine to store columns when the
 	// working set is larger than can be stored in memory.
 	TempFS fs.FS
+
+	// VecFDSemaphore is a weighted semaphore that restricts the number of open
+	// file descriptors in the vectorized engine.
+	VecFDSemaphore semaphore.Semaphore
 
 	// BulkAdder is used by some processors to bulk-ingest data as SSTs.
 	BulkAdder storagebase.BulkAdderFactory

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -230,7 +230,7 @@ func (p *planner) populateExplain(
 		isVec = true
 		if ctxSessionData.VectorizeMode == sessiondata.VectorizeOff {
 			isVec = false
-		} else if !vectorizedThresholdMet && ctxSessionData.VectorizeMode == sessiondata.VectorizeAuto {
+		} else if !vectorizedThresholdMet && (ctxSessionData.VectorizeMode == sessiondata.Vectorize192Auto || ctxSessionData.VectorizeMode == sessiondata.VectorizeAuto) {
 			isVec = false
 		} else {
 			thisNodeID := distSQLPlanner.nodeDesc.NodeID

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -559,6 +559,7 @@ var (
 		"fakedist",
 		"fakedist-vec-off",
 		"fakedist-vec",
+		"fakedist-vec-disk",
 		"fakedist-metadata",
 		"fakedist-disk",
 	}

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -1,4 +1,4 @@
-# LogicTest: local-vec
+# LogicTest: local-vec fakedist-vec-disk
 
 # Test that the exec HashJoiner follows SQL NULL semantics for ON predicate
 # equivalence.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec
+# LogicTest: local local-vec fakedist-vec-disk
 
 # Disable automatic stats.
 statement ok

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -259,9 +259,17 @@ type VectorizeExecMode int64
 const (
 	// VectorizeOff means that columnar execution is disabled.
 	VectorizeOff VectorizeExecMode = iota
-	// VectorizeAuto means that that any supported queries that use only
+	// Vectorize192Auto means that that any supported queries that use only
 	// streaming operators (i.e. those that do not require any buffering) will be
 	// run using the columnar execution.
+	// TODO(asubiotto): This was the auto setting for 19.2 and is kept around as
+	//  an escape hatch. Remove in 20.2.
+	Vectorize192Auto
+	// VectorizeAuto means that any supported queries that use only streaming
+	// operators or buffering operators that can spill to disk will be run using
+	// columnar execution.
+	// TODO(asubiotto): Is it an issue that the integer value of this setting is
+	//  equal to what experimental on was?
 	VectorizeAuto
 	// VectorizeExperimentalOn means that any supported queries will be run using
 	// the columnar execution on.
@@ -275,6 +283,8 @@ func (m VectorizeExecMode) String() string {
 	switch m {
 	case VectorizeOff:
 		return "off"
+	case Vectorize192Auto:
+		return "192auto"
 	case VectorizeAuto:
 		return "auto"
 	case VectorizeExperimentalOn:
@@ -293,6 +303,8 @@ func VectorizeExecModeFromString(val string) (VectorizeExecMode, bool) {
 	switch strings.ToUpper(val) {
 	case "OFF":
 		m = VectorizeOff
+	case "192AUTO":
+		m = Vectorize192Auto
 	case "AUTO":
 		m = VectorizeAuto
 	case "EXPERIMENTAL_ON":

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -421,10 +421,6 @@ type Engine interface {
 	ReadFile(filename string) ([]byte, error)
 	// WriteFile writes data to a file in this RocksDB's env.
 	WriteFile(filename string, data []byte) error
-	// DeleteDirAndFiles deletes the directory and any files it contains but
-	// not subdirectories from this RocksDB's env. If dir does not exist,
-	// DeleteDirAndFiles returns nil (no error).
-	DeleteDirAndFiles(dir string) error
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine/fs/fs.go
+++ b/pkg/storage/engine/fs/fs.go
@@ -59,6 +59,11 @@ type FS interface {
 	// DeleteDir removes the named dir.
 	DeleteDir(name string) error
 
+	// DeleteDirAndFiles deletes the directory and any files it contains but
+	// not subdirectories. If dir does not exist, DeleteDirAndFiles returns nil
+	// (no error).
+	DeleteDirAndFiles(dir string) error
+
 	// ListDir returns a listing of the given directory. The names returned are
 	// relative to the directory.
 	ListDir(name string) ([]string, error)

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -42,13 +42,13 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 		path = inMemDirName
 		cleanup = ngn.Close
 	} else {
-		ngn, err := engine.NewDefaultEngine(0 /* cacheSize */, base.StorageConfig{})
+		tempPath, dirCleanup := testutils.TempDir(t)
+		path = tempPath
+		ngn, err := engine.NewDefaultEngine(0 /* cacheSize */, base.StorageConfig{Dir: tempPath})
 		if err != nil {
 			t.Fatal(err)
 		}
 		testingFS = ngn.(fs.FS)
-		tempPath, dirCleanup := testutils.TempDir(t)
-		path = tempPath
 		cleanup = func() {
 			ngn.Close()
 			dirCleanup()


### PR DESCRIPTION
The Partitioner interface has also been renamed to PartitionedQueue. The
on-disk implementation of a PartitionedQueue is now used by both the external
sorter and joiner, meaning we now have actual disk spilling for these
operators! Note that there are still some items left to take care of stability
wise before disk spilling is production ready.

Release note (sql change): Vectorized sorts (not including sorts with a LIMIT
and an existing ordering on a subset of the ordering columns) and vectorized
hash joins now spill to disk.