### PR TITLE
libroach: correctly iterate to next key in MVCCIncrementalIterator

### DIFF
--- a/c-deps/libroach/incremental_iterator.cc
+++ b/c-deps/libroach/incremental_iterator.cc
@@ -173,10 +173,10 @@ void DBIncrementalIterator::advanceKey() {
     }
 
     if (legacyTimestampIsLess(end_time, meta.timestamp())) {
-      DBIterNext(iter.get(), false);
+      DBIterNext(iter.get(), true);
       continue;
     } else if (!legacyTimestampIsLess(start_time, meta.timestamp())) {
-      DBIterNext(iter.get(), true);
+      DBIterNext(iter.get(), false);
       continue;
     }
 


### PR DESCRIPTION
While advancing the MVCCIncrementalIterator if we run into a key
timestamp that appears after the latest time we are interested in, we
should advance to the next key. If the key timestamp was before the
earliest timestamp we are interested in, we should try looking at the
next version of the same key.

The logic after this commit now matches the go implementation of
MVCCIncrementalIterator.

Even though this logic is probably going to be replaced soon, I think
this fix should still get checked in at least for future developers
looking at the git history.

Release note: None