### PR TITLE
workload: fix non-uniqueness error in movr workload setup

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -249,7 +249,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`intro`:      0x81c6a8cfd9c3452a,
 		`json`:       0xcbf29ce484222325,
 		`ledger`:     0xebe27d872d980271,
-		`movr`:       0x6a094e9d15a07970,
+		`movr`:       0x4c0da49085e0bc5c,
 		`queue`:      0xcbf29ce484222325,
 		`rand`:       0xcbf29ce484222325,
 		`roachmart`:  0xda5e73423dbdb2d9,

--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -12,6 +12,7 @@ package movr
 
 import (
 	gosql "database/sql"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -551,6 +552,7 @@ func (g *movr) movrVehicleLocationHistoriesInitialRow(rowIdx int) []interface{} 
 func (g *movr) movrPromoCodesInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(g.seed + uint64(rowIdx)))
 	code := strings.ToLower(strings.Join(g.faker.Words(rng, 3), `_`))
+	code = fmt.Sprintf("%d_%s", rowIdx, code)
 	description := g.faker.Paragraph(rng)
 	expirationTime := g.creationTime.Add(time.Duration(rng.Intn(30)) * 24 * time.Hour)
 	// TODO(dan): This is nil in the reference impl, is that intentional?


### PR DESCRIPTION
Fixes #44864.

The generator for the promo codes table relied on a random
word generator for the string primary key of the table.
At a large enough row count this was nearly gauranteed
to have a collision. This PR fixes it by prepending
a unique rowid to each random promo code.

Release note (cli change): This PR fixes a potential error
occurring when loading the movr dataset with a large number
of rows in the promo codes column.