### PR TITLE
colexec: exhaust input in sorter benchmarks

### DIFF
--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -295,7 +295,6 @@ func BenchmarkSortChunks(b *testing.B) {
 										}
 									}
 								}
-								rowsTotal := nBatches * int(coldata.BatchSize())
 								b.ResetTimer()
 								for n := 0; n < b.N; n++ {
 									source := newFiniteChunksSource(batch, nBatches, matchLen)
@@ -305,13 +304,7 @@ func BenchmarkSortChunks(b *testing.B) {
 									}
 
 									sorter.Init()
-									rowsEmitted := 0
-									for rowsEmitted < rowsTotal {
-										out := sorter.Next(ctx)
-										if out.Length() == 0 {
-											b.Fail()
-										}
-										rowsEmitted += int(out.Length())
+									for out := sorter.Next(ctx); out.Length() != 0; out = sorter.Next(ctx) {
 									}
 								}
 								b.StopTimer()

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -320,24 +320,17 @@ func BenchmarkSort(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						source := newFiniteBatchSource(batch, nBatches)
 						var sorter Operator
-						var resultBatches int
 						if topK {
 							sorter = NewTopKSorter(testAllocator, source, typs, ordCols, k)
-							resultBatches = 1
 						} else {
 							var err error
 							sorter, err = NewSorter(testAllocator, source, typs, ordCols)
 							if err != nil {
 								b.Fatal(err)
 							}
-							resultBatches = nBatches
 						}
 						sorter.Init()
-						for i := 0; i < resultBatches; i++ {
-							out := sorter.Next(ctx)
-							if out.Length() == 0 {
-								b.Fail()
-							}
+						for out := sorter.Next(ctx); out.Length() != 0; out = sorter.Next(ctx) {
 						}
 					}
 				})


### PR DESCRIPTION
Some benchmarks were only calling `Next` the expected number of times and
failing if a zero batch was encountered. However, operators perform cleanup
when a zero batch is returned, so this cleanup step was being elided. It's
also more in line with other benchmarks to exhaust the operator before
finishing a benchmark.

Release note: None (testing code cleanup)