### PR TITLE
ui: Update Locality hierarchy on Node List 

### DIFF
--- a/pkg/ui/src/components/tooltip/tooltip.tsx
+++ b/pkg/ui/src/components/tooltip/tooltip.tsx
@@ -16,17 +16,24 @@ import "./tooltip.styl";
 
 export interface TooltipProps {
   title: React.ReactNode;
+  placement?: "top" | "bottom";
   children: React.ReactNode;
 }
 
 export function Tooltip(props: TooltipProps & AntTooltipProps) {
-  const { title, children } = props;
+  const { title, children, placement } = props;
   return (
     <AntTooltip
       title={title}
       mouseEnterDelay={0.5}
-      overlayClassName="tooltip-overlay">
+      overlayClassName="tooltip-overlay"
+      placement={placement}
+    >
       {children}
     </AntTooltip>
   );
 }
+
+Tooltip.defaultProps = {
+  placement: "top",
+};

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -31,6 +31,8 @@ import { INodeStatus, MetricConstants } from "src/util/proto";
 import { ColumnsConfig, Table, Text, TextTypes, Tooltip } from "src/components";
 import { Percentage } from "src/util/format";
 import { FixLong } from "src/util/fixLong";
+import { getNodeLocalityTiers } from "src/util/localities";
+import { LocalityTier } from "src/redux/localities";
 
 import TableSection from "./tableSection";
 import "./nodes.styl";
@@ -59,7 +61,8 @@ export interface NodeStatusRow {
   key: string;
   nodeId?: number;
   nodeName?: string;
-  region: string;
+  region?: string;
+  tiers?: LocalityTier[];
   nodesCount?: number;
   uptime?: string;
   replicas: number;
@@ -83,7 +86,6 @@ interface DecommissionedNodeStatusRow {
   key: string;
   nodeId: number;
   nodeName: string;
-  region: string;
   status: LivenessStatus;
   decommissionedDate: Moment;
 }
@@ -136,18 +138,30 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       render: (_text, record) => {
         if (!!record.nodeId) {
           return (
-            <React.Fragment>
-              <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
-                <Text textType={TextTypes.BodyStrong}>{`N${record.nodeId} `}</Text>
-                <Text>{record.nodeName}</Text>
-              </Link>
-            </React.Fragment>);
+            <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
+              <Text textType={TextTypes.BodyStrong}>{`N${record.nodeId} `}</Text>
+              <Text>{record.nodeName}</Text>
+            </Link>
+          );
         } else {
           // Top level grouping item does not have nodeId
           return (
-            <React.Fragment>
-              <Text>{record.region}</Text>
-            </React.Fragment>);
+            <Text>
+              <Tooltip
+                placement={"bottom"}
+                title={
+                  <div>
+                    {
+                      record.tiers.map((tier, idx) =>
+                        <div key={idx}>{`${tier.key} = ${tier.value}`}</div>)
+                    }
+                  </div>
+                }
+              >
+                {record.region}
+              </Tooltip>
+            </Text>
+          );
         }
       },
       sorter: (a, b) => {
@@ -346,11 +360,6 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
   }
 }
 
-const getNodeRegion = (nodeStatus: INodeStatus) => {
-  const region = nodeStatus.desc.locality?.tiers?.find(tier => tier.key === "region");
-  return region ? region.value : undefined;
-};
-
 export const liveNodesTableDataSelector = createSelector(
   partitionedStatuses,
   nodesSummarySelector,
@@ -368,7 +377,9 @@ export const liveNodesTableDataSelector = createSelector(
     // In case cluster is setup without localities:
     // - it represents a flat structure.
     const data = _.chain(liveStatuses)
-      .groupBy(getNodeRegion)
+      .groupBy((node: INodeStatus) => {
+        return node.desc.locality.tiers.map(tier => tier.value).join(".");
+      })
       .map((nodesPerRegion: INodeStatus[], regionKey: string): NodeStatusRow => {
         const nestedRows = nodesPerRegion.map((ns, idx): NodeStatusRow => {
           const { used: usedCapacity, usable: availableCapacity } = nodeCapacityStats(ns);
@@ -376,7 +387,6 @@ export const liveNodesTableDataSelector = createSelector(
             key: `${regionKey}-${idx}`,
             nodeId: ns.desc.node_id,
             nodeName: ns.desc.address.address_field,
-            region: getNodeRegion(ns),
             uptime: moment.duration(LongToMoment(ns.started_at).diff(moment())).humanize(),
             replicas: ns.metrics[MetricConstants.replicas],
             usedCapacity,
@@ -389,9 +399,18 @@ export const liveNodesTableDataSelector = createSelector(
           };
         });
 
+        // Grouped buckets with node statuses contain at least one element.
+        // The list of tires and lower level location are the same for every
+        // element in the group because grouping is made by string composed
+        // from location values.
+        const firstNodeInGroup = nodesPerRegion[0];
+        const tiers = getNodeLocalityTiers(firstNodeInGroup);
+        const location = _.last(tiers);
+
         return {
           key: `${regionKey}`,
-          region: regionKey,
+          region: location?.value,
+          tiers,
           nodesCount: nodesPerRegion.length,
           replicas: _.sum(nestedRows.map(nr => nr.replicas)),
           usedCapacity: _.sum(nestedRows.map(nr => nr.usedCapacity)),
@@ -433,7 +452,6 @@ export const decommissionedNodesTableDataSelector = createSelector(
           key: `${idx}`,
           nodeId: ns.desc.node_id,
           nodeName: ns.desc.address.address_field,
-          region: getNodeRegion(ns),
           status: nodesSummary.livenessStatusByNodeID[ns.desc.node_id],
           decommissionedDate: getDecommissionedTime(ns.desc.node_id),
         };

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
@@ -36,6 +36,10 @@ describe("Nodes Overview page", () => {
       {
         "key": "us-east1",
         "region": "us-east1",
+        "tiers": [
+          { "key": "region", "value": "us-west"},
+          { "key": "az", "value": "us-west-01"},
+        ],
         "nodesCount": 3,
         "replicas": 224,
         "usedCapacity": 0,
@@ -49,7 +53,6 @@ describe("Nodes Overview page", () => {
             "key": "us-east1-0",
             "nodeId": 1,
             "nodeName": "127.0.0.1:50945",
-            "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 78,
             "usedCapacity": 0,
@@ -64,7 +67,6 @@ describe("Nodes Overview page", () => {
             "key": "us-east1-1",
             "nodeId": 2,
             "nodeName": "127.0.0.2:50945",
-            "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 74,
             "usedCapacity": 0,
@@ -79,7 +81,6 @@ describe("Nodes Overview page", () => {
             "key": "us-east1-2",
             "nodeId": 3,
             "nodeName": "127.0.0.3:50945",
-            "region": "us-east1",
             "uptime": "3 minutes",
             "replicas": 72,
             "usedCapacity": 0,
@@ -95,6 +96,10 @@ describe("Nodes Overview page", () => {
       {
         "key": "us-west1",
         "region": "us-west1",
+        "tiers": [
+          { "key": "region", "value": "us-west"},
+          { "key": "az", "value": "us-west-01"},
+        ],
         "nodesCount": 3,
         "replicas": 229,
         "usedCapacity": 0,
@@ -108,7 +113,6 @@ describe("Nodes Overview page", () => {
             "key": "us-west1-0",
             "nodeId": 4,
             "nodeName": "127.0.0.4:50945",
-            "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 73,
             "usedCapacity": 0,
@@ -123,7 +127,6 @@ describe("Nodes Overview page", () => {
             "key": "us-west1-1",
             "nodeId": 5,
             "nodeName": "127.0.0.5:50945",
-            "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 78,
             "usedCapacity": 0,
@@ -138,7 +141,6 @@ describe("Nodes Overview page", () => {
             "key": "us-west1-2",
             "nodeId": 6,
             "nodeName": "127.0.0.6:50945",
-            "region": "us-west1",
             "uptime": "3 minutes",
             "replicas": 78,
             "usedCapacity": 0,
@@ -154,6 +156,10 @@ describe("Nodes Overview page", () => {
       {
         "key": "europe-west1",
         "region": "europe-west1",
+        "tiers": [
+          { "key": "region", "value": "europe-west1"},
+          { "key": "az", "value": "us-west-01"},
+        ],
         "nodesCount": 3,
         "replicas": 216,
         "usedCapacity": 0,
@@ -167,7 +173,6 @@ describe("Nodes Overview page", () => {
             "key": "europe-west1-0",
             "nodeId": 7,
             "nodeName": "127.0.0.7:50945",
-            "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 71,
             "usedCapacity": 0,
@@ -182,7 +187,6 @@ describe("Nodes Overview page", () => {
             "key": "europe-west1-1",
             "nodeId": 8,
             "nodeName": "127.0.0.8:50945",
-            "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 74,
             "usedCapacity": 0,
@@ -197,7 +201,6 @@ describe("Nodes Overview page", () => {
             "key": "europe-west1-2",
             "nodeId": 9,
             "nodeName": "127.0.0.9:50945",
-            "region": "europe-west1",
             "uptime": "3 minutes",
             "replicas": 71,
             "usedCapacity": 0,
@@ -252,7 +255,7 @@ describe("Nodes Overview page", () => {
         (columnName, idx) => assert.equal(columnCells.at(idx).text(), columnName));
     });
 
-    it("doesn't display '# of nodes column' when nodes are in single regions", () => {
+    it("doesn't display 'node count' column when nodes are in single regions", () => {
       const expectedColumns = [
         "nodes",
         // should not be displayed "node count",
@@ -302,7 +305,11 @@ describe("Nodes Overview page", () => {
             {
               desc: {
                 node_id: idx + 1,
-                locality: {},
+                locality: {
+                  tiers: [
+                    { key: "region", value: "us-west" },
+                  ],
+                },
                 address: {
                   address_field: `127.0.0.${idx + 1}:50945`,
                 },


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/44919
Depends on: https://github.com/cockroachdb/cockroach/pull/45007

Before, Node list with geo partitioned nodes was
grouped by 'region' key what was incorrect due to
locality keys might have arbitrary names and it
doesn't represent the lowest locality tier.

Now, nodes are grouped by lowest level tier and
also display all tiers in tooltip.

Preview:
<img width="722" alt="Screenshot 2020-02-12 at 23 13 03" src="https://user-images.githubusercontent.com/3106437/74383887-c163e900-4df8-11ea-9822-134edbfa520c.png">