### PR TITLE
colflow: check that physical types match on the ends of streams

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -123,5 +123,15 @@ SELECT CAST(0 BETWEEN(CASE NULL WHEN c0 = 0 THEN NULL END) AND 0 IS TRUE AS INT)
 ----
 0
 
+# Regression test for #45038 (mismatched physical types between expected and
+# actual physical types when wrapping unsupported processor cores).
+statement ok
+CREATE TABLE t45038(c0 INT); INSERT INTO t45038 VALUES(NULL)
+
+query R
+SELECT sum(c) FROM (SELECT CAST((IF(IF(false, false, c0 IS NULL), NULL, NULL)) BETWEEN 0 AND 0 IS TRUE AS INT) c FROM t45038)
+----
+0
+
 statement ok
 RESET default_int_size


### PR DESCRIPTION
Previously, it was possible to have a types mismatch on the ends of
a stream (for example, output Int64 when the input expects Int32). This
would result in an internal error. Now we check for this, and if such
scenario occurs, we fallback to row-by-row engine.

I'm not sure whether it was possible to get into this scenario without
wrapped processors, but we should backport this anyway.

There is no release note since we have just fixed a related issue and an
additional release note would sound repetitive.

Fixes: #45038.

Release note: None