### PR TITLE
colexec: fix incorrect benchmark name for bool operator

### DIFF
--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -695,12 +695,12 @@ func BenchmarkAggregator(b *testing.B) {
 					for _, groupSize := range []int{1, 2, int(coldata.BatchSize()) / 2, int(coldata.BatchSize())} {
 						for _, hasNulls := range []bool{false, true} {
 							for _, numInputBatches := range []int{64} {
+								if aggFn == execinfrapb.AggregatorSpec_BOOL_AND || aggFn == execinfrapb.AggregatorSpec_BOOL_OR {
+									typ = coltypes.Bool
+								}
 								b.Run(fmt.Sprintf("%s/%s/groupSize=%d/hasNulls=%t/numInputBatches=%d", agg.name, typ.String(),
 									groupSize, hasNulls, numInputBatches),
 									func(b *testing.B) {
-										if aggFn == execinfrapb.AggregatorSpec_BOOL_AND || aggFn == execinfrapb.AggregatorSpec_BOOL_OR {
-											typ = coltypes.Bool
-										}
 										colTypes := []coltypes.T{coltypes.Int64, typ}
 										nTuples := numInputBatches * int(coldata.BatchSize())
 										cols := []coldata.Vec{


### PR DESCRIPTION
Fixed boolean aggregator benchmark incorrectly display of type name

Previously: 
```
pkg: github.com/cockroachdb/cockroach/pkg/sql/colexec
BenchmarkAggregator/BOOL_AND/hash/Int64/groupSize=1/hasNulls=false/numInputBatches=64-8         	       5	 218948035 ns/op	   2.39 MB/s
                                  ^^^^^
BenchmarkAggregator/BOOL_AND/hash/Bool/groupSize=1/hasNulls=true/numInputBatches=64-8           	       5	 244620047 ns/op	   2.14 MB/s
```

Release Note: None