### PR TITLE
storage/concurrency: implement concurrency Manager

### DIFF
--- a/pkg/storage/concurrency/concurrency_manager.go
+++ b/pkg/storage/concurrency/concurrency_manager.go
@@ -1,0 +1,381 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// managerImpl implements the Manager interface.
+type managerImpl struct {
+	// Synchronizes conflicting in-flight requests.
+	lm latchManager
+	// Synchronizes conflicting in-progress transactions.
+	lt lockTable
+	// Waits for locks that conflict with a request to be released.
+	ltw lockTableWaiter
+	// Waits for transaction completion and detects deadlocks.
+	twq txnWaitQueue
+	// The Store and Range that the manager is responsible for.
+	str Store
+	rng *roachpb.RangeDescriptor
+}
+
+// Store provides some parts of a Store without incurring a dependency. It is a
+// superset of txnwait.StoreInterface.
+type Store interface {
+	// Identification.
+	NodeDescriptor() *roachpb.NodeDescriptor
+	// Components.
+	DB() *client.DB
+	Clock() *hlc.Clock
+	Stopper() *stop.Stopper
+	IntentResolver() IntentResolver
+	// Knobs.
+	GetTxnWaitKnobs() txnwait.TestingKnobs
+	// Metrics.
+	GetTxnWaitMetrics() *txnwait.Metrics
+	GetSlowLatchGauge() *metric.Gauge
+}
+
+// NewManager creates a new concurrency Manager structure.
+func NewManager(store Store, rng *roachpb.RangeDescriptor) Manager {
+	// TODO(nvanbenschoten): make the lockTable size and lockTableWaiter
+	// dependencyCyclePushDelay configurable.
+	m := new(managerImpl)
+	*m = managerImpl{
+		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
+		// pkg/storage/concurrency/latch package. Make it implement the
+		// latchManager interface directly, if possible.
+		lm: &latchManagerImpl{
+			m: spanlatch.Make(store.Stopper(), store.GetSlowLatchGauge()),
+		},
+		lt: newLockTable(10000 /* arbitrary */),
+		ltw: &lockTableWaiterImpl{
+			nodeID:                   store.NodeDescriptor().NodeID,
+			stopper:                  store.Stopper(),
+			ir:                       store.IntentResolver(),
+			dependencyCyclePushDelay: defaultDependencyCyclePushDelay,
+		},
+		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new
+		// pkg/storage/concurrency/txnwait package.
+		twq: txnwait.NewQueue(store, m),
+		str: store,
+		rng: rng,
+	}
+	return m
+}
+
+// SequenceReq implements the RequestSequencer interface.
+func (m *managerImpl) SequenceReq(
+	ctx context.Context, prev *Guard, req Request,
+) (*Guard, Response, *Error) {
+	var g *Guard
+	if prev == nil {
+		g = newGuard(req)
+		log.Event(ctx, "sequencing request")
+	} else {
+		g = prev
+		g.assertNoLatches()
+		log.Event(ctx, "re-sequencing request")
+	}
+
+	resp, err := m.sequenceReqWithGuard(ctx, g, req)
+	if resp != nil || err != nil {
+		// Ensure that we release the guard if we return a response or an error.
+		m.FinishReq(g)
+		return nil, resp, err
+	}
+	return g, nil, nil
+}
+
+func (m *managerImpl) sequenceReqWithGuard(
+	ctx context.Context, g *Guard, req Request,
+) (Response, *Error) {
+	// Some requests don't need to acquire latches at all.
+	if !shouldAcquireLatches(req) {
+		log.Event(ctx, "not acquiring latches")
+		return nil, nil
+	}
+
+	// Provide the manager with an opportunity to intercept the request. It
+	// may be able to serve the request directly, and even if not, it may be
+	// able to update its internal state based on the request.
+	resp, err := m.maybeInterceptReq(ctx, req)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
+	for {
+		// Acquire latches for the request. This synchronizes the request
+		// with all conflicting in-flight requests.
+		log.Event(ctx, "acquiring latches")
+		g.lg, err = m.lm.Acquire(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Some requests don't want the wait on locks.
+		if !shouldWaitOnConflicts(req) {
+			return nil, nil
+		}
+
+		// Scan for conflicting locks.
+		log.Event(ctx, "scanning lock table for conflicting locks")
+		g.ltg = m.lt.ScanAndEnqueue(g.req, g.ltg)
+
+		// Wait on conflicting locks, if necessary.
+		if g.ltg.ShouldWait() {
+			m.lm.Release(g.moveLatchGuard())
+
+			log.Event(ctx, "waiting in lock wait-queues")
+			if err := m.ltw.WaitOn(ctx, g.req, g.ltg); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		return nil, nil
+	}
+}
+
+// maybeInterceptReq allows the concurrency manager to intercept requests before
+// sequencing and evaluation so that it can immediately act on them. This allows
+// the concurrency manager to route certain concurrency control-related requests
+// into queues and optionally update its internal state based on the requests.
+func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Response, *Error) {
+	switch {
+	case req.isSingle(roachpb.PushTxn):
+		// If necessary, wait in the txnWaitQueue for the pushee transaction to
+		// expire or to move to a finalized state.
+		t := req.Requests[0].GetPushTxn()
+		resp, err := m.twq.MaybeWaitForPush(ctx, t)
+		if err != nil {
+			return nil, err
+		} else if resp != nil {
+			return makeSingleResponse(resp), nil
+		}
+	case req.isSingle(roachpb.QueryTxn):
+		// If necessary, wait in the txnWaitQueue for a transaction state update
+		// or for a dependent transaction to change.
+		t := req.Requests[0].GetQueryTxn()
+		return nil, m.twq.MaybeWaitForQuery(ctx, t)
+	default:
+		// TODO(nvanbenschoten): in the future, use this hook to update the lock
+		// table to allow contending transactions to proceed.
+		// for _, arg := range req.Requests {
+		// 	switch t := arg.GetInner().(type) {
+		// 	case *roachpb.ResolveIntentRequest:
+		// 		_ = t
+		// 	case *roachpb.ResolveIntentRangeRequest:
+		// 		_ = t
+		// 	}
+		// }
+	}
+	return nil, nil
+}
+
+// shouldAcquireLatches determines whether the request should acquire latches
+// before proceeding to evaluate. Latches are used to synchronize with other
+// conflicting requests, based on the Spans collected for the request. Most
+// request types will want to acquire latches.
+func shouldAcquireLatches(req Request) bool {
+	switch {
+	case req.ReadConsistency != roachpb.CONSISTENT:
+		// Only acquire latches for consistent operations.
+		return false
+	case req.isSingle(roachpb.RequestLease):
+		// Do not acquire latches for lease requests. These requests are run on
+		// replicas that do not hold the lease, so acquiring latches wouldn't
+		// help synchronize with other requests.
+		return false
+	}
+	return true
+}
+
+// shouldWaitOnConflicts determines whether the request should wait on locks and
+// wait-queues owned by other transactions before proceeding to evaluate. Most
+// requests will want to wait on conflicting transactions to ensure that they
+// are sufficiently isolated during their evaluation, but some "isolation aware"
+// requests want to proceed to evaluation even in the presence of conflicts
+// because they know how to handle them.
+func shouldWaitOnConflicts(req Request) bool {
+	for _, ru := range req.Requests {
+		arg := ru.GetInner()
+		if roachpb.IsTransactional(arg) {
+			switch arg.Method() {
+			case roachpb.Refresh, roachpb.RefreshRange:
+				// Refresh and RefreshRange requests scan inconsistently so that
+				// they can collect all intents in their key span. If they run
+				// into intents written by other transactions, they simply fail
+				// the refresh without trying to push the intents and blocking.
+			default:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FinishReq implements the RequestSequencer interface.
+func (m *managerImpl) FinishReq(g *Guard) {
+	if ltg := g.moveLockTableGuard(); ltg != nil {
+		m.lt.Dequeue(ltg)
+	}
+	if lg := g.moveLatchGuard(); lg != nil {
+		m.lm.Release(lg)
+	}
+}
+
+// HandleWriterIntentError implements the ContentionHandler interface.
+func (m *managerImpl) HandleWriterIntentError(
+	ctx context.Context, g *Guard, t *roachpb.WriteIntentError,
+) *Guard {
+	// Add a discovered lock to lock-table for each intent and enter each lock's
+	// wait-queue.
+	for i := range t.Intents {
+		intent := &t.Intents[i]
+		if err := m.lt.AddDiscoveredLock(intent, g.ltg); err != nil {
+			log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+		}
+	}
+
+	// Release the Guard's latches but continue to remain in lock wait-queues by
+	// not releasing lockWaitQueueGuards. We expect the caller of this method to
+	// then re-sequence the Request by calling SequenceReq with the un-latched
+	// Guard. This is analogous to iterating through the loop in SequenceReq.
+	m.lm.Release(g.moveLatchGuard())
+	return g
+}
+
+// HandleTransactionPushError implements the ContentionHandler interface.
+func (m *managerImpl) HandleTransactionPushError(
+	ctx context.Context, g *Guard, t *roachpb.TransactionPushError,
+) *Guard {
+	m.twq.EnqueueTxn(&t.PusheeTxn)
+
+	// Release the Guard's latches. The PushTxn request should not be in any
+	// lock wait-queues because it does not scan the lockTable. We expect the
+	// caller of this method to then re-sequence the Request by calling
+	// SequenceReq with the un-latched Guard. This is analogous to iterating
+	// through the loop in SequenceReq.
+	m.lm.Release(g.moveLatchGuard())
+	return g
+}
+
+// OnLockAcquired implements the LockManager interface.
+func (m *managerImpl) OnLockAcquired(ctx context.Context, in *roachpb.Intent) {
+	// TODO(nvanbenschoten): rename roachpb.Intent and add a lock.Durability
+	// field to it.
+	if err := m.lt.AcquireLock(&in.Txn, in.Key, lock.Exclusive, lock.Unreplicated); err != nil {
+		log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+	}
+}
+
+// OnLockUpdated implements the LockManager interface.
+func (m *managerImpl) OnLockUpdated(ctx context.Context, in *roachpb.Intent) {
+	if err := m.lt.UpdateLocks(in); err != nil {
+		log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+	}
+}
+
+// OnTransactionUpdated implements the TransactionManager interface.
+func (m *managerImpl) OnTransactionUpdated(ctx context.Context, txn *roachpb.Transaction) {
+	m.twq.UpdateTxn(ctx, txn)
+}
+
+// GetDependents implements the TransactionManager interface.
+func (m *managerImpl) GetDependents(txnID uuid.UUID) []uuid.UUID {
+	return m.twq.GetDependents(txnID)
+}
+
+// OnDescriptorUpdated implements the RangeStateListener interface.
+func (m *managerImpl) OnDescriptorUpdated(desc *roachpb.RangeDescriptor) {
+	m.rng = desc
+}
+
+// OnLeaseUpdated implements the RangeStateListener interface.
+func (m *managerImpl) OnLeaseUpdated(iAmTheLeaseHolder bool) {
+	if iAmTheLeaseHolder {
+		m.twq.Enable()
+	} else {
+		m.lt.Clear()
+		m.twq.Clear(true /* disable */)
+	}
+}
+
+// OnSplit implements the RangeStateListener interface.
+func (m *managerImpl) OnSplit() {
+	// TODO(nvanbenschoten): it only essential that we clear the half of the
+	// lockTable which contains locks in the key range that is being split off
+	// from the current range. For now though, we clear it all.
+	m.lt.Clear()
+	m.twq.Clear(false /* disable */)
+}
+
+// OnMerge implements the RangeStateListener interface.
+func (m *managerImpl) OnMerge() {
+	m.lt.Clear()
+	m.twq.Clear(true /* disable */)
+}
+
+// ContainsKey implements the txnwait.ReplicaInterface interface.
+func (m *managerImpl) ContainsKey(key roachpb.Key) bool {
+	return storagebase.ContainsKey(m.rng, key)
+}
+
+func (r *Request) isSingle(m roachpb.Method) bool {
+	if len(r.Requests) != 1 {
+		return false
+	}
+	return r.Requests[0].GetInner().Method() == m
+}
+
+func newGuard(req Request) *Guard {
+	// TODO(nvanbenschoten): Pool these guard objects.
+	return &Guard{req: req}
+}
+
+func (g *Guard) assertNoLatches() {
+	if g.lg != nil {
+		panic("unexpected latches held")
+	}
+}
+
+func (g *Guard) moveLatchGuard() latchGuard {
+	lg := g.lg
+	g.lg = nil
+	return lg
+}
+
+func (g *Guard) moveLockTableGuard() lockTableGuard {
+	ltg := g.ltg
+	g.ltg = nil
+	return ltg
+}
+
+func makeSingleResponse(r roachpb.Response) Response {
+	ru := make(Response, 1)
+	ru[0].MustSetInner(r)
+	return ru
+}

--- a/pkg/storage/concurrency/concurrency_manager_test.go
+++ b/pkg/storage/concurrency/concurrency_manager_test.go
@@ -1,0 +1,841 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/intentresolver"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/maruel/panicparse/stack"
+	"github.com/petermattis/goid"
+)
+
+// TestConcurrencyManagerBasic verifies that sequences of requests interacting
+// with a concurrency manager perform properly.
+//
+// The input files use the following DSL:
+//
+// new-txn      name=<txn-name> ts=<int>[,<int>] epoch=<int>
+// new-request  name=<req-name> txn=<txn-name>|none ts=<int>[,<int>] [priority] [consistency]
+//   <proto-name> [<field-name>=<field-value>...]
+// sequence     req=<req-name>
+// finish       req=<req-name>
+//
+// handle-write-intent-error  req=<req-name> txn=<txn-name> key=<key>
+// handle-txn-push-error      req=<req-name> txn=<txn-name> key=<key>  TODO(nvanbenschoten): implement this
+//
+// on-lock-acquired  txn=<txn-name> key=<key>
+// on-txn-updated    txn=<txn-name> status=[committed|aborted|pending] [ts<int>[,<int>]]
+//
+// on-desc-updated   TODO(nvanbenschoten): implement this
+// on-lease-updated  TODO(nvanbenschoten): implement this
+// on-split          TODO(nvanbenschoten): implement this
+// on-merge          TODO(nvanbenschoten): implement this
+//
+// debug-latch-manager
+// debug-lock-table
+// reset
+//
+func TestConcurrencyManagerBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	datadriven.Walk(t, "testdata/concurrency_manager", func(t *testing.T, path string) {
+		c := newCluster()
+		m := NewManager(c, c.rangeDesc)
+		c.m = m
+		mon := newMonitor()
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "new-txn":
+				var txnName string
+				d.ScanArgs(t, "name", &txnName)
+				ts := scanTimestamp(t, d)
+
+				var epoch int
+				d.ScanArgs(t, "epoch", &epoch)
+
+				txn, ok := c.txnsByName[txnName]
+				var id uuid.UUID
+				if ok {
+					id = txn.ID
+				} else {
+					id = c.newTxnID()
+				}
+				txn = &roachpb.Transaction{
+					TxnMeta: enginepb.TxnMeta{
+						ID:             id,
+						Epoch:          enginepb.TxnEpoch(epoch),
+						WriteTimestamp: ts,
+						MinTimestamp:   ts,
+					},
+					ReadTimestamp: ts,
+				}
+				txn.UpdateObservedTimestamp(c.NodeDescriptor().NodeID, ts)
+				c.registerTxn(txnName, txn)
+				return ""
+
+			case "new-request":
+				var reqName string
+				d.ScanArgs(t, "name", &reqName)
+				if _, ok := c.requestsByName[reqName]; ok {
+					d.Fatalf(t, "duplicate request: %s", reqName)
+				}
+
+				var txnName string
+				d.ScanArgs(t, "txn", &txnName)
+				txn, ok := c.txnsByName[txnName]
+				if !ok && txnName != "none" {
+					d.Fatalf(t, "unknown txn %s", txnName)
+				}
+
+				ts := scanTimestamp(t, d)
+				if txn != nil && txn.ReadTimestamp != ts {
+					d.Fatalf(t, "txn read timestamp != timestamp")
+				}
+
+				readConsistency := roachpb.CONSISTENT
+				if d.HasArg("inconsistent") {
+					readConsistency = roachpb.INCONSISTENT
+				}
+
+				// Each roachpb.Request is provided on an indented line.
+				var reqs []roachpb.Request
+				singleReqLines := strings.Split(d.Input, "\n")
+				for _, line := range singleReqLines {
+					req := scanSingleRequest(t, d, line)
+					reqs = append(reqs, req)
+				}
+				reqUnions := make([]roachpb.RequestUnion, len(reqs))
+				for i, req := range reqs {
+					reqUnions[i].MustSetInner(req)
+				}
+				spans := c.collectSpans(t, txn, ts, reqs)
+
+				c.requestsByName[reqName] = Request{
+					Txn:       txn,
+					Timestamp: ts,
+					// TODO(nvanbenschoten): test Priority
+					ReadConsistency: readConsistency,
+					Requests:        reqUnions,
+					Spans:           spans,
+				}
+				return ""
+
+			case "sequence":
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				req, ok := c.requestsByName[reqName]
+				if !ok {
+					d.Fatalf(t, "unknown request: %s", reqName)
+				}
+
+				c.mu.Lock()
+				prev := c.guardsByReqName[reqName]
+				delete(c.guardsByReqName, reqName)
+				c.mu.Unlock()
+
+				opName := fmt.Sprintf("sequence %s", reqName)
+				mon.runAsync(opName, func(ctx context.Context) {
+					guard, resp, err := m.SequenceReq(ctx, prev, req)
+					if err != nil {
+						log.Eventf(ctx, "sequencing complete, returned error: %v", err)
+					} else if resp != nil {
+						log.Eventf(ctx, "sequencing complete, returned response: %v", resp)
+					} else if guard != nil {
+						log.Event(ctx, "sequencing complete, returned guard")
+						c.mu.Lock()
+						c.guardsByReqName[reqName] = guard
+						c.mu.Unlock()
+					} else {
+						log.Event(ctx, "sequencing complete, returned no guard")
+					}
+				})
+				return mon.waitAndCollect(t)
+
+			case "finish":
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				guard, ok := c.guardsByReqName[reqName]
+				if !ok {
+					d.Fatalf(t, "unknown request: %s", reqName)
+				}
+
+				opName := fmt.Sprintf("finish %s", reqName)
+				mon.runSync(opName, func(ctx context.Context) {
+					log.Event(ctx, "finishing request")
+					m.FinishReq(guard)
+					c.mu.Lock()
+					delete(c.guardsByReqName, reqName)
+					c.mu.Unlock()
+				})
+				return mon.waitAndCollect(t)
+
+			case "handle-write-intent-error":
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				guard, ok := c.guardsByReqName[reqName]
+				if !ok {
+					d.Fatalf(t, "unknown request: %s", reqName)
+				}
+
+				var txnName string
+				d.ScanArgs(t, "txn", &txnName)
+				txn, ok := c.txnsByName[txnName]
+				if !ok {
+					d.Fatalf(t, "unknown txn %s", txnName)
+				}
+
+				var key string
+				d.ScanArgs(t, "key", &key)
+
+				opName := fmt.Sprintf("handle write intent error %s", reqName)
+				mon.runSync(opName, func(ctx context.Context) {
+					err := &roachpb.WriteIntentError{Intents: []roachpb.Intent{{
+						Span: roachpb.Span{Key: roachpb.Key(key)},
+						Txn:  txn.TxnMeta,
+					}}}
+					log.Eventf(ctx, "handling %v", err)
+					guard = m.HandleWriterIntentError(ctx, guard, err)
+				})
+				return mon.waitAndCollect(t)
+
+			case "on-lock-acquired":
+				var txnName string
+				d.ScanArgs(t, "txn", &txnName)
+				txn, ok := c.txnsByName[txnName]
+				if !ok {
+					d.Fatalf(t, "unknown txn %s", txnName)
+				}
+
+				var key string
+				d.ScanArgs(t, "key", &key)
+
+				mon.runSync("acquire lock", func(ctx context.Context) {
+					log.Eventf(ctx, "%s @ %s", txnName, key)
+					m.OnLockAcquired(ctx, &roachpb.Intent{
+						Span: roachpb.Span{Key: roachpb.Key(key)},
+						Txn:  txn.TxnMeta,
+					})
+				})
+				return mon.waitAndCollect(t)
+
+			case "on-txn-updated":
+				var txnName string
+				d.ScanArgs(t, "txn", &txnName)
+				txn, ok := c.txnsByName[txnName]
+				if !ok {
+					d.Fatalf(t, "unknown txn %s", txnName)
+				}
+
+				var statusStr, verb string
+				var status roachpb.TransactionStatus
+				d.ScanArgs(t, "status", &statusStr)
+				switch statusStr {
+				case "committed":
+					verb = "committing"
+					status = roachpb.COMMITTED
+				case "aborted":
+					verb = "aborting"
+					status = roachpb.ABORTED
+				case "pending":
+					verb = "increasing timestamp of"
+					status = roachpb.PENDING
+				default:
+					d.Fatalf(t, "unknown txn statusStr: %s", status)
+				}
+
+				var ts hlc.Timestamp
+				if d.HasArg("ts") {
+					ts = scanTimestamp(t, d)
+				}
+
+				mon.runSync("update txn", func(ctx context.Context) {
+					log.Eventf(ctx, "%s %s", verb, txnName)
+					if err := c.updateTxnRecord(txn.ID, status, ts); err != nil {
+						d.Fatalf(t, err.Error())
+					}
+				})
+				return mon.waitAndCollect(t)
+
+			case "debug-latch-manager":
+				global, local := m.(*managerImpl).lm.Info()
+				output := []string{
+					fmt.Sprintf("write count: %d", global.WriteCount+local.WriteCount),
+					fmt.Sprintf(" read count: %d", global.ReadCount+local.ReadCount),
+				}
+				return strings.Join(output, "\n")
+
+			case "debug-lock-table":
+				return c.lockTable().String()
+
+			case "reset":
+				if n := mon.numMonitored(); n > 0 {
+					d.Fatalf(t, "%d requests still in flight", n)
+				}
+				mon.resetSeqNums()
+				if err := c.reset(); err != nil {
+					d.Fatalf(t, "could not reset cluster: %v", err)
+				}
+				return ""
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+	})
+}
+
+// cluster encapsulates the state of a running cluster and a set of requests.
+// It serves as the test harness in TestConcurrencyManagerBasic - maintaining
+// transaction and request declarations, recording the state of in-flight
+// requests as they flow through the concurrency manager, and mocking out the
+// interfaces that the concurrency manager interacts with.
+type cluster struct {
+	nodeDesc  *roachpb.NodeDescriptor
+	rangeDesc *roachpb.RangeDescriptor
+	m         Manager
+
+	// Definitions.
+	txnCounter     uint128.Uint128
+	txnsByName     map[string]*roachpb.Transaction
+	requestsByName map[string]Request
+
+	// Request state. Cleared on reset.
+	mu              syncutil.Mutex
+	guardsByReqName map[string]*Guard
+	txnRecords      map[uuid.UUID]*txnRecord
+}
+
+type txnRecord struct {
+	mu               syncutil.Mutex
+	cond             sync.Cond
+	txn              *roachpb.Transaction // immutable, modify fields below
+	updatedStatus    roachpb.TransactionStatus
+	updatedTimestamp hlc.Timestamp
+}
+
+func newCluster() *cluster {
+	return &cluster{
+		nodeDesc:  &roachpb.NodeDescriptor{NodeID: 1},
+		rangeDesc: &roachpb.RangeDescriptor{RangeID: 1},
+
+		txnsByName:      make(map[string]*roachpb.Transaction),
+		requestsByName:  make(map[string]Request),
+		guardsByReqName: make(map[string]*Guard),
+		txnRecords:      make(map[uuid.UUID]*txnRecord),
+	}
+}
+
+// cluster implements the Store interface. Many of these methods are only used
+// by the txnWaitQueue, whose functionality is fully mocked out in this test by
+// cluster's implementation of IntentResolver.
+func (c *cluster) NodeDescriptor() *roachpb.NodeDescriptor { return c.nodeDesc }
+func (c *cluster) DB() *client.DB                          { return nil }
+func (c *cluster) Clock() *hlc.Clock                       { return nil }
+func (c *cluster) Stopper() *stop.Stopper                  { return nil }
+func (c *cluster) IntentResolver() IntentResolver          { return c }
+func (c *cluster) GetTxnWaitKnobs() txnwait.TestingKnobs   { return txnwait.TestingKnobs{} }
+func (c *cluster) GetTxnWaitMetrics() *txnwait.Metrics     { return nil }
+func (c *cluster) GetSlowLatchGauge() *metric.Gauge        { return nil }
+
+// PushTransaction implements the IntentResolver interface.
+func (c *cluster) PushTransaction(
+	ctx context.Context, pushee *enginepb.TxnMeta, h roachpb.Header, pushType roachpb.PushTxnType,
+) (roachpb.Transaction, *Error) {
+	log.Eventf(ctx, "pushing txn %s", pushee.ID)
+	pusheeRecord, err := c.getTxnRecord(pushee.ID)
+	if err != nil {
+		return roachpb.Transaction{}, roachpb.NewError(err)
+	}
+	// Wait for the transaction to be pushed.
+	pusheeRecord.mu.Lock()
+	defer pusheeRecord.mu.Unlock()
+	for {
+		pusheeTxn := pusheeRecord.asTxnLocked()
+		var pushed bool
+		switch pushType {
+		case roachpb.PUSH_TIMESTAMP:
+			pushed = h.Timestamp.Less(pusheeTxn.WriteTimestamp) || pusheeTxn.Status.IsFinalized()
+		case roachpb.PUSH_ABORT:
+			pushed = pusheeTxn.Status.IsFinalized()
+		default:
+			return roachpb.Transaction{}, roachpb.NewErrorf("unexpected push type: %s", pushType)
+		}
+		if pushed {
+			return pusheeTxn, nil
+		}
+		pusheeRecord.cond.Wait()
+	}
+}
+
+// ResolveIntent implements the IntentResolver interface.
+func (c *cluster) ResolveIntent(
+	ctx context.Context, intent roachpb.Intent, _ intentresolver.ResolveOptions,
+) *Error {
+	log.Eventf(ctx, "resolving intent %s for txn %s with %s status", intent.Key, intent.Txn.ID, intent.Status)
+	c.m.OnLockUpdated(ctx, &intent)
+	return nil
+}
+
+// TODO(nvanbenschoten): remove the following methods once all their uses are
+// possible through the external interface of the concurrency Manager.
+func (c *cluster) latchManager() *latchManagerImpl { return c.m.(*managerImpl).lm.(*latchManagerImpl) }
+func (c *cluster) lockTable() *lockTableImpl       { return c.m.(*managerImpl).lt.(*lockTableImpl) }
+
+func (c *cluster) newTxnID() uuid.UUID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return nextUUID(&c.txnCounter)
+}
+
+func (c *cluster) registerTxn(name string, txn *roachpb.Transaction) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.txnsByName[name] = txn
+	r := &txnRecord{txn: txn}
+	r.cond.L = &r.mu
+	c.txnRecords[txn.ID] = r
+}
+
+func (c *cluster) getTxnRecord(id uuid.UUID) (*txnRecord, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.txnRecords[id]
+	if !ok {
+		return nil, errors.Errorf("unknown txn %v: %v", id, c.txnRecords)
+	}
+	return r, nil
+}
+
+func (c *cluster) updateTxnRecord(
+	id uuid.UUID, status roachpb.TransactionStatus, ts hlc.Timestamp,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.txnRecords[id]
+	if !ok {
+		return errors.Errorf("unknown txn %v: %v", id, c.txnRecords)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updatedStatus = status
+	r.updatedTimestamp = ts
+	r.cond.Broadcast()
+	return nil
+}
+
+func (r *txnRecord) asTxnLocked() roachpb.Transaction {
+	txn := *r.txn
+	if r.updatedStatus > txn.Status {
+		txn.Status = r.updatedStatus
+	}
+	txn.WriteTimestamp.Forward(r.updatedTimestamp)
+	return txn
+}
+
+// reset clears all request state in the cluster. This avoids portions of tests
+// leaking into one another and also serves as an assertion that a sequence of
+// commands has completed without leaking any requests.
+func (c *cluster) reset() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Reset all transactions to their original state.
+	for id := range c.txnRecords {
+		r := c.txnRecords[id]
+		r.mu.Lock()
+		r.updatedStatus = roachpb.PENDING
+		r.updatedTimestamp = hlc.Timestamp{}
+		r.mu.Unlock()
+	}
+	// There should be no remaining concurrency guards.
+	for name := range c.guardsByReqName {
+		return errors.Errorf("unfinished guard for request: %s", name)
+	}
+	// There should be no outstanding latches.
+	lm := c.latchManager()
+	global, local := lm.Info()
+	if global.ReadCount > 0 || global.WriteCount > 0 ||
+		local.ReadCount > 0 || local.WriteCount > 0 {
+		return errors.Errorf("outstanding latches")
+	}
+	// Clear the lock table.
+	c.lockTable().Clear()
+	return nil
+}
+
+// collectSpans collects the declared spans for a set of requests.
+// Its logic mirrors that in Replica.collectSpans.
+func (c *cluster) collectSpans(
+	t *testing.T, txn *roachpb.Transaction, ts hlc.Timestamp, reqs []roachpb.Request,
+) *spanset.SpanSet {
+	spans := &spanset.SpanSet{}
+	h := roachpb.Header{Txn: txn, Timestamp: ts}
+	for _, req := range reqs {
+		if cmd, ok := batcheval.LookupCommand(req.Method()); ok {
+			cmd.DeclareKeys(c.rangeDesc, h, req, spans)
+		} else {
+			t.Fatalf("unrecognized command %s", req.Method())
+		}
+	}
+
+	// Commands may create a large number of duplicate spans. De-duplicate
+	// them to reduce the number of spans we pass to the spanlatch manager.
+	spans.SortAndDedup()
+	if err := spans.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	return spans
+
+}
+
+// monitor tracks a set of running goroutines as they execute and captures
+// tracing recordings from them. It is capable of watching its set of goroutines
+// until they all mutually stall.
+//
+// It is NOT safe to use multiple monitors concurrently.
+type monitor struct {
+	seq int
+	gs  map[*monitoredGoroutine]struct{}
+	buf []byte // avoids allocations
+}
+
+type monitoredGoroutine struct {
+	opSeq    int
+	opName   string
+	gID      int64
+	finished int32
+
+	ctx        context.Context
+	collect    func() tracing.Recording
+	cancel     func()
+	prevEvents int
+}
+
+func newMonitor() *monitor {
+	return &monitor{
+		gs: make(map[*monitoredGoroutine]struct{}),
+	}
+}
+
+func (m *monitor) runSync(opName string, fn func(context.Context)) {
+	ctx, collect, cancel := tracing.ContextWithRecordingSpan(context.Background(), opName)
+	g := &monitoredGoroutine{
+		opSeq:   0, // synchronous
+		opName:  opName,
+		ctx:     ctx,
+		collect: collect,
+		cancel:  cancel,
+	}
+	m.gs[g] = struct{}{}
+	fn(ctx)
+	atomic.StoreInt32(&g.finished, 1)
+}
+
+func (m *monitor) runAsync(opName string, fn func(context.Context)) {
+	m.seq++
+	ctx, collect, cancel := tracing.ContextWithRecordingSpan(context.Background(), opName)
+	g := &monitoredGoroutine{
+		opSeq:   m.seq,
+		opName:  opName,
+		ctx:     ctx,
+		collect: collect,
+		cancel:  cancel,
+	}
+	m.gs[g] = struct{}{}
+	go func() {
+		atomic.StoreInt64(&g.gID, goid.Get())
+		fn(ctx)
+		atomic.StoreInt32(&g.finished, 1)
+	}()
+}
+
+func (m *monitor) numMonitored() int {
+	return len(m.gs)
+}
+
+func (m *monitor) resetSeqNums() {
+	m.seq = 0
+}
+
+func (m *monitor) waitAndCollect(t *testing.T) string {
+	m.waitForAsyncGoroutinesToStall(t)
+	return m.collectRecordings()
+}
+
+func (m *monitor) collectRecordings() string {
+	// Collect trace recordings from each goroutine.
+	type logRecord struct {
+		g     *monitoredGoroutine
+		value string
+	}
+	var logs []logRecord
+	for g := range m.gs {
+		prev := g.prevEvents
+		rec := g.collect()
+		for _, span := range rec {
+			for _, log := range span.Logs {
+				for _, field := range log.Fields {
+					if prev > 0 {
+						prev--
+						continue
+					}
+					logs = append(logs, logRecord{
+						g: g, value: field.Value,
+					})
+					g.prevEvents++
+				}
+			}
+		}
+		if atomic.LoadInt32(&g.finished) == 1 {
+			g.cancel()
+			delete(m.gs, g)
+		}
+	}
+
+	// Sort logs by g.opSeq. This will sort synchronous goroutines before
+	// asynchronous goroutines. Use a stable sort to break ties within
+	// goroutines and keep logs in event order.
+	sort.SliceStable(logs, func(i int, j int) bool {
+		return logs[i].g.opSeq < logs[j].g.opSeq
+	})
+
+	var buf strings.Builder
+	for i, log := range logs {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		seq := "-"
+		if log.g.opSeq != 0 {
+			seq = strconv.Itoa(log.g.opSeq)
+		}
+		fmt.Fprintf(&buf, "[%s] %s: %s", seq, log.g.opName, log.value)
+	}
+	return buf.String()
+}
+
+func (m *monitor) hasNewEvents(g *monitoredGoroutine) bool {
+	events := 0
+	rec := g.collect()
+	for _, span := range rec {
+		for _, log := range span.Logs {
+			for range log.Fields {
+				events++
+			}
+		}
+	}
+	return events > g.prevEvents
+}
+
+// waitForAsyncGoroutinesToStall waits for all goroutines that were launched by
+// the monitor's runAsync method to stall due to cross-goroutine synchronization
+// dependencies. For instance, it waits for all goroutines to stall while
+// receiving from channels. When the method returns, the caller has exclusive
+// access to any memory that it shares only with monitored goroutines until it
+// performs an action that may unblock any of the goroutines.
+func (m *monitor) waitForAsyncGoroutinesToStall(t *testing.T) {
+	// Iterate until we see two iterations in a row that both observe all
+	// monitored goroutines to be stalled and also both observe the exact
+	// same goroutine state. Waiting for two iterations to be identical
+	// isn't required for correctness because the goroutine dump itself
+	// should provide a consistent snapshot of all goroutine states and
+	// statuses (runtime.Stack(all=true) stops the world), but it still
+	// seems like a generally good idea.
+	var status []*stack.Goroutine
+	filter := funcName((*monitor).runAsync)
+	testutils.SucceedsSoon(t, func() error {
+		prevStatus := status
+		status = goroutineStatus(t, filter, &m.buf)
+		if len(status) == 0 {
+			// No monitored goroutines.
+			return nil
+		}
+
+		if prevStatus == nil {
+			// First iteration.
+			return errors.Errorf("previous status unset")
+		}
+
+		// Check whether all monitored goroutines are stalled. If not, retry.
+		for _, stat := range status {
+			stalled, ok := goroutineStalledStates[stat.State]
+			if !ok {
+				// NB: this will help us avoid rotting on Go runtime changes.
+				t.Fatalf("unknown goroutine state: %s", stat.State)
+			}
+			if !stalled {
+				return errors.Errorf("goroutine %d is not stalled; status %s", stat.ID, stat.State)
+			}
+		}
+
+		// Make sure the goroutines haven't changed since the last iteration.
+		// This ensures that the goroutines stay stable for some amount of time.
+		// NB: status and lastStatus are sorted by goroutine id.
+		if !reflect.DeepEqual(status, prevStatus) {
+			return errors.Errorf("goroutines rapidly changing")
+		}
+		return nil
+	})
+
+	// Add a trace event indicating where each stalled goroutine is waiting.
+	byID := make(map[int64]*monitoredGoroutine, len(m.gs))
+	for g := range m.gs {
+		byID[atomic.LoadInt64(&g.gID)] = g
+	}
+	for _, stat := range status {
+		g, ok := byID[int64(stat.ID)]
+		if !ok {
+			// If we're not tracking this goroutine, just ignore it. This can
+			// happen when goroutines from earlier subtests haven't finished
+			// yet.
+			continue
+		}
+		// If the goroutine hasn't produced any new events, don't create a new
+		// "blocked on" trace event. It likely hasn't moved since the last one.
+		if !m.hasNewEvents(g) {
+			continue
+		}
+		stalledCall := firstNonStdlib(stat.Stack.Calls)
+		log.Eventf(g.ctx, "blocked on %s in %s", stat.State, stalledCall.Func.PkgDotName())
+	}
+}
+
+func funcName(f interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+}
+
+// goroutineStalledStates maps all goroutine states as reported by runtime.Stack
+// to a boolean representing whether that state indicates a stalled goroutine. A
+// stalled goroutine is one that is waiting on a change on another goroutine in
+// order for it to make forward progress itself. If all goroutines enter stalled
+// states simultaneously, a process would encounter a deadlock.
+var goroutineStalledStates = map[string]bool{
+	// See gStatusStrings in runtime/traceback.go and associated comments about
+	// the corresponding G statuses in runtime/runtime2.go.
+	"idle":      false,
+	"runnable":  false,
+	"running":   false,
+	"syscall":   false,
+	"waiting":   true,
+	"dead":      false,
+	"copystack": false,
+	"???":       false, // catch-all in runtime.goroutineheader
+
+	// runtime.goroutineheader may override these G statuses with a waitReason.
+	// See waitReasonStrings in runtime/runtime2.go.
+	"GC assist marking":       false,
+	"IO wait":                 false,
+	"chan receive (nil chan)": true,
+	"chan send (nil chan)":    true,
+	"dumping heap":            false,
+	"garbage collection":      false,
+	"garbage collection scan": false,
+	"panicwait":               false,
+	"select":                  true,
+	"select (no cases)":       true,
+	"GC assist wait":          false,
+	"GC sweep wait":           false,
+	"GC scavenge wait":        false,
+	"chan receive":            true,
+	"chan send":               true,
+	"finalizer wait":          false,
+	"force gc (idle)":         false,
+	// Perhaps surprisingly, we mark "semacquire" as a non-stalled state. This
+	// is because it is possible to see goroutines briefly enter this state when
+	// performing fine-grained memory synchronization, occasionally in the Go
+	// runtime itself. No request-level synchronization points use mutexes to
+	// wait for state transitions by other requests, so it is safe to ignore
+	// this state and wait for it to exit.
+	"semacquire":             false,
+	"sleep":                  false,
+	"sync.Cond.Wait":         true,
+	"timer goroutine (idle)": false,
+	"trace reader (blocked)": false,
+	"wait for GC cycle":      false,
+	"GC worker (idle)":       false,
+}
+
+// goroutineStatus returns a stack trace for each goroutine whose stack frame
+// matches the provided filter. It uses the provided buffer to avoid repeat
+// allocations.
+func goroutineStatus(t *testing.T, filter string, buf *[]byte) []*stack.Goroutine {
+	// We don't know how big the buffer needs to be to collect all the
+	// goroutines. Start with 64 KB and try a few times, doubling each time.
+	// NB: This is inspired by runtime/pprof/pprof.go:writeGoroutineStacks.
+	if len(*buf) == 0 {
+		*buf = make([]byte, 1<<16)
+	}
+	var truncBuf []byte
+	for i := 0; ; i++ {
+		n := runtime.Stack(*buf, true /* all */)
+		if n < len(*buf) {
+			truncBuf = (*buf)[:n]
+			break
+		}
+		*buf = make([]byte, 2*len(*buf))
+	}
+
+	// guesspaths=true is required for Call objects to have IsStdlib filled in.
+	guesspaths := true
+	ctx, err := stack.ParseDump(bytes.NewBuffer(truncBuf), ioutil.Discard, guesspaths)
+	if err != nil {
+		t.Fatalf("could not parse goroutine dump: %v", err)
+		return nil
+	}
+
+	matching := ctx.Goroutines[:0]
+	for _, g := range ctx.Goroutines {
+		for _, call := range g.Stack.Calls {
+			if strings.Contains(call.Func.Raw, filter) {
+				matching = append(matching, g)
+				break
+			}
+		}
+	}
+	return matching
+}
+
+func firstNonStdlib(calls []stack.Call) stack.Call {
+	for _, call := range calls {
+		if !call.IsStdlib {
+			return call
+		}
+	}
+	panic("unexpected")
+}

--- a/pkg/storage/concurrency/datadriven_util_test.go
+++ b/pkg/storage/concurrency/datadriven_util_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
+)
+
+func nextUUID(counter *uint128.Uint128) uuid.UUID {
+	*counter = counter.Add(1)
+	return uuid.FromUint128(*counter)
+}
+
+func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
+	var ts hlc.Timestamp
+	var tsS string
+	d.ScanArgs(t, "ts", &tsS)
+	parts := strings.Split(tsS, ",")
+
+	// Find the wall time part.
+	tsW, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		d.Fatalf(t, "%v", err)
+	}
+	ts.WallTime = tsW
+
+	// Find the logical part, if there is one.
+	var tsL int64
+	if len(parts) > 1 {
+		tsL, err = strconv.ParseInt(parts[1], 10, 32)
+		if err != nil {
+			d.Fatalf(t, "%v", err)
+		}
+	}
+	ts.Logical = int32(tsL)
+	return ts
+}
+
+func getSpan(t *testing.T, d *datadriven.TestData, str string) roachpb.Span {
+	parts := strings.Split(str, ",")
+	span := roachpb.Span{Key: roachpb.Key(parts[0])}
+	if len(parts) > 2 {
+		d.Fatalf(t, "incorrect span format: %s", str)
+	} else if len(parts) == 2 {
+		span.EndKey = roachpb.Key(parts[1])
+	}
+	return span
+}
+
+func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.SpanSet {
+	spans := &spanset.SpanSet{}
+	var spansStr string
+	d.ScanArgs(t, "spans", &spansStr)
+	parts := strings.Split(spansStr, "+")
+	for _, p := range parts {
+		if len(p) < 2 || p[1] != '@' {
+			d.Fatalf(t, "incorrect span with access format: %s", p)
+		}
+		c := p[0]
+		p = p[2:]
+		var sa spanset.SpanAccess
+		switch c {
+		case 'r':
+			sa = spanset.SpanReadOnly
+		case 'w':
+			sa = spanset.SpanReadWrite
+		default:
+			d.Fatalf(t, "incorrect span access: %c", c)
+		}
+		spans.AddMVCC(sa, getSpan(t, d, p), ts)
+	}
+	return spans
+}
+
+func scanSingleRequest(t *testing.T, d *datadriven.TestData, line string) roachpb.Request {
+	cmd, cmdArgs, err := datadriven.ParseLine(line)
+	if err != nil {
+		d.Fatalf(t, "error parsing single request: %v", err)
+		return nil
+	}
+
+	fields := make(map[string]string, len(cmdArgs))
+	for _, cmdArg := range cmdArgs {
+		if len(cmdArg.Vals) != 1 {
+			d.Fatalf(t, "unexpected command values: %+v", cmdArg)
+			return nil
+		}
+		fields[cmdArg.Key] = cmdArg.Vals[0]
+	}
+	mustGetField := func(f string) string {
+		v, ok := fields[f]
+		if !ok {
+			d.Fatalf(t, "missing required field: %s", f)
+		}
+		return v
+	}
+
+	switch cmd {
+	case "get":
+		var r roachpb.GetRequest
+		r.Key = roachpb.Key(mustGetField("key"))
+		return &r
+
+	case "scan":
+		var r roachpb.ScanRequest
+		r.Key = roachpb.Key(mustGetField("key"))
+		if v, ok := fields["endkey"]; ok {
+			r.EndKey = roachpb.Key(v)
+		}
+		return &r
+
+	case "put":
+		var r roachpb.PutRequest
+		r.Key = roachpb.Key(mustGetField("key"))
+		r.Value.SetString(mustGetField("value"))
+		return &r
+
+	case "request-lease":
+		var r roachpb.RequestLeaseRequest
+		return &r
+
+	default:
+		d.Fatalf(t, "unknown request type: %s", cmd)
+		return nil
+	}
+}

--- a/pkg/storage/concurrency/latch_manager.go
+++ b/pkg/storage/concurrency/latch_manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 )
 
 // latchManagerImpl implements the latchManager interface.
@@ -32,4 +33,8 @@ func (m *latchManagerImpl) Acquire(ctx context.Context, req Request) (latchGuard
 
 func (m *latchManagerImpl) Release(lg latchGuard) {
 	m.m.Release(lg.(*spanlatch.Guard))
+}
+
+func (m *latchManagerImpl) Info() (global, local storagepb.LatchManagerInfo) {
+	return m.m.Info()
 }

--- a/pkg/storage/concurrency/lock_table.go
+++ b/pkg/storage/concurrency/lock_table.go
@@ -1076,11 +1076,11 @@ func (l *lockState) discoveredLock(
 }
 
 // Acquires l.mu.
-func (l *lockState) tryClearLock() bool {
+func (l *lockState) tryClearLock(force bool) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	replicatedHeld := l.holder.locked && l.holder.holder[lock.Replicated].txn != nil
-	if replicatedHeld && l.distinguishedWaiter == nil {
+	if replicatedHeld && l.distinguishedWaiter == nil && !force {
 		// Replicated lock is held and has no distinguished waiter.
 		return false
 	}
@@ -1088,7 +1088,7 @@ func (l *lockState) tryClearLock() bool {
 	// Remove unreplicated holder.
 	l.holder.holder[lock.Unreplicated] = lockHolderInfo{}
 	var waitState waitingState
-	if replicatedHeld {
+	if replicatedHeld && !force {
 		holderTxn, holderTs := l.getLockerInfo()
 		// Note that none of the current waiters can be requests
 		// from holderTxn.
@@ -1512,35 +1512,42 @@ func (t *lockTableImpl) AcquireLock(
 		totalLocks += atomic.LoadInt64(&t.locks[i].numLocks)
 	}
 	if totalLocks > t.maxLocks {
-		t.clearMostLocks()
+		t.tryClearLocks(false /* force */)
 	}
 	return err
 }
 
-// Removes all locks, except for those that are held with replicated
-// durability and have no distinguished waiter, and tells those waiters to
-// wait elsewhere or that they are done waiting. A replicated lock which has
-// been discovered by a request but no request is actively waiting on it will
-// be preserved since we need to tell that request who it is waiting for when
-// it next calls ScanAndEnqueue(). If we aggressively removed even these
+// If force is false, removes all locks, except for those that are held with
+// replicated durability and have no distinguished waiter, and tells those
+// waiters to wait elsewhere or that they are done waiting. A replicated lock
+// which has been discovered by a request but no request is actively waiting on
+// it will be preserved since we need to tell that request who it is waiting for
+// when it next calls ScanAndEnqueue(). If we aggressively removed even these
 // locks, the next ScanAndEnqueue() would not find the lock, the request would
-// evaluate again, again discover that lock and if clearMostLocks() keeps
-// getting called would be stuck in this loop without pushing.
-func (t *lockTableImpl) clearMostLocks() {
+// evaluate again, again discover that lock and if tryClearLocks() keeps getting
+// called would be stuck in this loop without pushing.
+//
+// If force is true, removes all locks and marks all guards as doneWaiting.
+func (t *lockTableImpl) tryClearLocks(force bool) {
 	for i := 0; i < int(spanset.NumSpanScope); i++ {
 		tree := &t.locks[i]
 		tree.mu.Lock()
 		var locksToClear []*lockState
 		tree.Ascend(func(it btree.Item) bool {
 			l := it.(*lockState)
-			if l.tryClearLock() {
+			if l.tryClearLock(force) {
 				locksToClear = append(locksToClear, l)
 			}
 			return true
 		})
 		atomic.AddInt64(&tree.numLocks, int64(-len(locksToClear)))
-		for _, l := range locksToClear {
-			tree.Delete(l)
+		if tree.Len() == len(locksToClear) {
+			// Fast-path full clear.
+			tree.Clear(true /* addNodesToFreelist */)
+		} else {
+			for _, l := range locksToClear {
+				tree.Delete(l)
+			}
 		}
 		tree.mu.Unlock()
 	}
@@ -1722,7 +1729,7 @@ func (t *lockTableImpl) findNextLockAfter(g *lockTableGuardImpl, notify bool) {
 }
 
 func (t *lockTableImpl) Clear() {
-	// TODO(nvanbenschoten): implement and test this.
+	t.tryClearLocks(true /* force */)
 }
 
 // For tests.

--- a/pkg/storage/concurrency/lock_table.go
+++ b/pkg/storage/concurrency/lock_table.go
@@ -1245,7 +1245,7 @@ func (l *lockState) increasedLockTs(newTs hlc.Timestamp) {
 		g := e.Value.(*lockTableGuardImpl)
 		curr := e
 		e = e.Next()
-		if !g.ts.LessEq(newTs) {
+		if g.ts.Less(newTs) {
 			// Stop waiting.
 			l.waitingReaders.Remove(curr)
 			if g == l.distinguishedWaiter {

--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -14,8 +14,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -120,72 +118,6 @@ print
 
  Calls lockTable.String.
 */
-
-func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
-	var ts hlc.Timestamp
-	var tsS string
-	d.ScanArgs(t, "ts", &tsS)
-	parts := strings.Split(tsS, ",")
-
-	// Find the wall time part.
-	tsW, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		d.Fatalf(t, "%v", err)
-	}
-	ts.WallTime = tsW
-
-	// Find the logical part, if there is one.
-	var tsL int64
-	if len(parts) > 1 {
-		tsL, err = strconv.ParseInt(parts[1], 10, 32)
-		if err != nil {
-			d.Fatalf(t, "%v", err)
-		}
-	}
-	ts.Logical = int32(tsL)
-	return ts
-}
-
-func nextUUID(counter *uint128.Uint128) uuid.UUID {
-	*counter = counter.Add(1)
-	return uuid.FromUint128(*counter)
-}
-
-func getSpan(t *testing.T, d *datadriven.TestData, str string) roachpb.Span {
-	parts := strings.Split(str, ",")
-	span := roachpb.Span{Key: roachpb.Key(parts[0])}
-	if len(parts) > 2 {
-		d.Fatalf(t, "incorrect span format: %s", str)
-	} else if len(parts) == 2 {
-		span.EndKey = roachpb.Key(parts[1])
-	}
-	return span
-}
-
-func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.SpanSet {
-	spans := &spanset.SpanSet{}
-	var spansStr string
-	d.ScanArgs(t, "spans", &spansStr)
-	parts := strings.Split(spansStr, "+")
-	for _, p := range parts {
-		if len(p) < 2 || p[1] != '@' {
-			d.Fatalf(t, "incorrect span with access format: %s", p)
-		}
-		c := p[0]
-		p = p[2:]
-		var sa spanset.SpanAccess
-		switch c {
-		case 'r':
-			sa = spanset.SpanReadOnly
-		case 'w':
-			sa = spanset.SpanReadWrite
-		default:
-			d.Fatalf(t, "incorrect span access: %c", c)
-		}
-		spans.AddMVCC(sa, getSpan(t, d, p), ts)
-	}
-	return spans
-}
 
 func TestLockTableBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -92,27 +92,33 @@ dequeue r=<name>
 ----
 <error string>
 
- Calls lockTable.Dequeue() for the named request. The request and guard are
+ Calls lockTable.Dequeue for the named request. The request and guard are
  discarded after this.
 
 guard-state r=<name>
 ----
 new|old: state=<state> [txn=<name> ts=<ts>]
 
-  Calls lockTableGuard.NewStateChan() in a non-blocking manner, followed by
-  CurState().
+  Calls lockTableGuard.NewStateChan in a non-blocking manner, followed by
+  CurState.
 
 should-wait r=<name>
 ----
 <bool>
 
- Calls lockTableGuard.ShouldWait().
+ Calls lockTableGuard.ShouldWait.
+
+clear
+----
+<state of lock table>
+
+ Calls lockTable.Clear.
 
 print
 ----
 <state of lock table>
 
- Calls lockTable.String()
+ Calls lockTable.String.
 */
 
 func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
@@ -417,6 +423,10 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				return fmt.Sprintf("%sstate=%s txn=%s ts=%s key=%s held=%t guard-access=%s",
 					str, typeStr, txnS, tsS, state.key, state.held, state.guardAccess)
+
+			case "clear":
+				lt.Clear()
+				return lt.(*lockTableImpl).String()
 
 			case "print":
 				return lt.(*lockTableImpl).String()

--- a/pkg/storage/concurrency/lock_table_waiter.go
+++ b/pkg/storage/concurrency/lock_table_waiter.go
@@ -34,17 +34,17 @@ type lockTableWaiterImpl struct {
 	stopper *stop.Stopper
 
 	// Used to push conflicting transactions and resolve conflicting intents.
-	ir intentResolver
+	ir IntentResolver
 
 	// How long to wait until pushing conflicting transactions to detect
 	// dependency cycles.
 	dependencyCyclePushDelay time.Duration
 }
 
-// intentResolver is an interface used by lockTableWaiterImpl to push
+// IntentResolver is an interface used by lockTableWaiterImpl to push
 // transactions and to resolve intents. It contains only the subset of the
 // intentresolver.IntentResolver interface that lockTableWaiterImpl needs.
-type intentResolver interface {
+type IntentResolver interface {
 	// PushTransaction pushes the provided transaction. The method will push the
 	// provided pushee transaction immediately, if possible. Otherwise, it will
 	// block until the pushee transaction is finalized or eventually can be

--- a/pkg/storage/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/basic
@@ -1,0 +1,238 @@
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-txn name=txn3 ts=14,1 epoch=0
+----
+
+# -------------------------------------------------------------
+# Simple read-only request
+# -------------------------------------------------------------
+
+new-request name=req1 txn=txn1 ts=10,1
+  get  key=k
+  scan key=k endkey=k2
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+debug-latch-manager
+----
+write count: 0
+ read count: 1
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset
+----
+
+# -------------------------------------------------------------
+# Simple read-write request that acquires a lock
+# -------------------------------------------------------------
+
+new-request name=req2 txn=txn2 ts=12,1
+  put key=k value=v
+----
+
+sequence req=req2
+----
+[1] sequence req2: sequencing request
+[1] sequence req2: acquiring latches
+[1] sequence req2: scanning lock table for conflicting locks
+[1] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired txn=txn2 key=k
+----
+[-] acquire lock: txn2 @ k
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000012,1
+local: num=0
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000012,1
+local: num=0
+
+reset
+----
+
+# Demonstrate that 'reset' clears the lock table.
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+# -------------------------------------------------------------
+# 1. Acquire a lock
+# 2. Read-only requests blocks on lock
+# 3. Lock is released
+# 4. Read-only request proceeds
+# 5. Read-write request blocks on latches
+# 6. Requests proceed in order
+# -------------------------------------------------------------
+
+on-lock-acquired txn=txn2 key=k
+----
+[-] acquire lock: txn2 @ k
+
+new-request name=req3 txn=txn3 ts=14,1
+  get  key=k
+  scan key=k endkey=k2
+----
+
+sequence req=req3
+----
+[1] sequence req3: sequencing request
+[1] sequence req3: acquiring latches
+[1] sequence req3: scanning lock table for conflicting locks
+[1] sequence req3: waiting in lock wait-queues
+[1] sequence req3: pushing txn 00000000-0000-0000-0000-000000000002
+[1] sequence req3: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+[1] sequence req3: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with COMMITTED status
+[1] sequence req3: acquiring latches
+[1] sequence req3: scanning lock table for conflicting locks
+[1] sequence req3: sequencing complete, returned guard
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+new-request name=req4 txn=txn1 ts=10,1
+  put key=k value=v
+----
+
+sequence req=req4
+----
+[2] sequence req4: sequencing request
+[2] sequence req4: acquiring latches
+[2] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
+
+debug-latch-manager
+----
+write count: 1
+ read count: 1
+
+finish req=req3
+----
+[-] finish req3: finishing request
+[2] sequence req4: scanning lock table for conflicting locks
+[2] sequence req4: sequencing complete, returned guard
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+reset
+----
+
+# -------------------------------------------------------------
+# 1. Acquire a lock
+# 2. Two read-only requests block on lock, one pushes
+# 3. Txn is updated to a timestamp above the read's
+# 4. Read-only request proceeds
+# 5. Read-write request blocks on lock
+# 6. Lock is released
+# 7. Read-write request blocks on latches
+# 8. Requests proceed in order
+# -------------------------------------------------------------
+
+on-lock-acquired txn=txn2 key=k
+----
+[-] acquire lock: txn2 @ k
+
+new-request name=req5 txn=none ts=14,1
+  scan key=a endkey=m
+----
+
+sequence req=req5
+----
+[1] sequence req5: sequencing request
+[1] sequence req5: acquiring latches
+[1] sequence req5: scanning lock table for conflicting locks
+[1] sequence req5: waiting in lock wait-queues
+[1] sequence req5: pushing txn 00000000-0000-0000-0000-000000000002
+[1] sequence req5: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+
+new-request name=req6 txn=none ts=16,1
+  scan key=c endkey=z
+----
+
+sequence req=req6
+----
+[2] sequence req6: sequencing request
+[2] sequence req6: acquiring latches
+[2] sequence req6: scanning lock table for conflicting locks
+[2] sequence req6: waiting in lock wait-queues
+[2] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+on-txn-updated txn=txn2 status=pending ts=18,1
+----
+[-] update txn: increasing timestamp of txn2
+[1] sequence req5: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with PENDING status
+[1] sequence req5: acquiring latches
+[1] sequence req5: scanning lock table for conflicting locks
+[1] sequence req5: sequencing complete, returned guard
+[2] sequence req6: acquiring latches
+[2] sequence req6: scanning lock table for conflicting locks
+[2] sequence req6: sequencing complete, returned guard
+
+new-request name=req7 txn=none ts=12,1
+  put key=k value=v
+----
+
+sequence req=req7
+----
+[3] sequence req7: sequencing request
+[3] sequence req7: acquiring latches
+[3] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
+
+finish req=req5
+----
+[-] finish req5: finishing request
+
+finish req=req6
+----
+[-] finish req6: finishing request
+[3] sequence req7: scanning lock table for conflicting locks
+[3] sequence req7: waiting in lock wait-queues
+[3] sequence req7: pushing txn 00000000-0000-0000-0000-000000000002
+[3] sequence req7: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+[3] sequence req7: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with COMMITTED status
+[3] sequence req7: acquiring latches
+[3] sequence req7: scanning lock table for conflicting locks
+[3] sequence req7: sequencing complete, returned guard
+
+finish req=req7
+----
+[-] finish req7: finishing request
+
+reset
+----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------
+# Read-only request runs into replicated intent. It informs the
+# lock table and waits for the intent to be resolved.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[-] handle write intent error req1: handling conflicting intents on "k"
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+sequence req=req1
+----
+[2] sequence req1: re-sequencing request
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: waiting in lock wait-queues
+[2] sequence req1: pushing txn 00000000-0000-0000-0000-000000000001
+[2] sequence req1: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[2] sequence req1: resolving intent "k" for txn 00000000-0000-0000-0000-000000000001 with ABORTED status
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset
+----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/no_latches
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/no_latches
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------
+# Inconsistent reads do not acquire latches
+# -------------------------------------------------------------
+
+new-request name=inconsistentReq txn=none ts=10,1 inconsistent
+  get key=k
+----
+
+sequence req=inconsistentReq
+----
+[1] sequence inconsistentReq: sequencing request
+[1] sequence inconsistentReq: not acquiring latches
+[1] sequence inconsistentReq: sequencing complete, returned guard
+
+debug-latch-manager
+----
+write count: 0
+ read count: 0
+
+finish req=inconsistentReq
+----
+[-] finish inconsistentReq: finishing request
+
+reset
+----
+
+# -------------------------------------------------------------
+# Lease requests do not acquire latches
+# -------------------------------------------------------------
+
+new-request name=leaseReq txn=none ts=10,1
+  request-lease
+----
+
+sequence req=leaseReq
+----
+[1] sequence leaseReq: sequencing request
+[1] sequence leaseReq: not acquiring latches
+[1] sequence leaseReq: sequencing complete, returned guard
+
+debug-latch-manager
+----
+write count: 0
+ read count: 0
+
+finish req=leaseReq
+----
+[-] finish leaseReq: finishing request
+
+reset
+----

--- a/pkg/storage/concurrency/testdata/lock_table/clear
+++ b/pkg/storage/concurrency/testdata/lock_table/clear
@@ -1,0 +1,187 @@
+new-lock-table maxlocks=10000
+----
+
+# Define three transaction that we'll use below.
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+new-txn txn=txn2 ts=8,1 epoch=0
+----
+
+new-txn txn=txn3 ts=12,1 epoch=0
+----
+
+# txn1 acquires unreplicated exclusive locks at a and b.
+
+new-request r=req1 txn=txn1 ts=10,1 spans=w@a+w@b
+----
+
+scan r=req1
+----
+start-waiting: false
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+acquire r=req1 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+dequeue r=req1
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+# In its next request, txn1 discovers a lock at c held by txn2.
+
+new-request r=req2 txn=txn1 ts=10,1 spans=r@c
+----
+
+scan r=req2
+----
+start-waiting: false
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+add-discovered r=req2 k=c txn=txn2
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1
+local: num=0
+
+# A non-transactional read comes in at a and blocks on the lock.
+
+new-request r=req3 txn=none ts=10,1 spans=r@a
+----
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn1 ts=10,1 key="a" held=true guard-access=read
+
+# Similarly, a non-transactional write at a arrives and blocks.
+
+new-request r=req4 txn=none ts=10,1 spans=w@a
+----
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitFor txn=txn1 ts=10,1 key="a" held=true guard-access=write
+
+# txn3 tries to write to b which also has a lock held, so txn3 has to wait.
+
+new-request r=req5 txn=txn3 ts=12,1 spans=w@b
+----
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn1 ts=10,1 key="b" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+   waiting readers:
+    req: 3, txn: none
+   queued writers:
+    active: true req: 4, txn: none
+   distinguished req: 3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1
+local: num=0
+
+# Clearing removes all locks and allows all waiting requests to proceed.
+
+clear
+----
+global: num=0
+local: num=0
+
+guard-state r=req2
+----
+old: state=doneWaiting
+
+scan r=req2
+----
+start-waiting: false
+
+guard-state r=req3
+----
+new: state=doneWaiting
+
+scan r=req3
+----
+start-waiting: false
+
+dequeue r=req3
+----
+global: num=0
+local: num=0
+
+guard-state r=req4
+----
+new: state=doneWaiting
+
+scan r=req4
+----
+start-waiting: false
+
+dequeue r=req4
+----
+global: num=0
+local: num=0
+
+guard-state r=req5
+----
+new: state=doneWaiting
+
+scan r=req5
+----
+start-waiting: false
+
+dequeue r=req5
+----
+global: num=0
+local: num=0

--- a/pkg/storage/concurrency/testdata/lock_table/update
+++ b/pkg/storage/concurrency/testdata/lock_table/update
@@ -1,0 +1,279 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+new-txn txn=txn2 ts=12,1 epoch=0
+----
+
+new-txn txn=txn3 ts=14,1 epoch=0
+----
+
+# -------------------------------------------------------------
+# Acquire a lock on key a at timestamp 10,1
+# -------------------------------------------------------------
+
+new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+dequeue r=req1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+# -------------------------------------------------------------
+# Wait on this lock as:
+# 1. transactional read-only request
+# 2. transactional read-write request
+# 3. non-transactional read-only request
+# 4. non-transactional read-write request
+# -------------------------------------------------------------
+
+new-request r=req2 txn=txn2 ts=12,1 spans=r@a
+----
+
+new-request r=req3 txn=txn3 ts=14,1 spans=w@a
+----
+
+new-request r=req4 txn=none ts=16,1 spans=r@a
+----
+
+new-request r=req5 txn=none ts=18,1 spans=w@a
+----
+
+scan r=req2
+----
+start-waiting: true
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn1 ts=10,1 key="a" held=true guard-access=read
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitFor txn=txn1 ts=10,1 key="a" held=true guard-access=write
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitFor txn=txn1 ts=10,1 key="a" held=true guard-access=read
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitFor txn=txn1 ts=10,1 key="a" held=true guard-access=write
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+   waiting readers:
+    req: 4, txn: none
+    req: 2, txn: 00000000-0000-0000-0000-000000000002
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 2
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 11,1 - nothing moves
+# -------------------------------------------------------------
+
+update txn=txn1 ts=11,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1
+   waiting readers:
+    req: 4, txn: none
+    req: 2, txn: 00000000-0000-0000-0000-000000000002
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 2
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 13,1 - the transactional read at
+# at timestamp 12,1 is allowed to proceed without acquire a
+# reservation
+# -------------------------------------------------------------
+
+update txn=txn1 ts=13,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1
+   waiting readers:
+    req: 4, txn: none
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 4
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+scan r=req2
+----
+start-waiting: false
+
+dequeue r=req2
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1
+   waiting readers:
+    req: 4, txn: none
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 15,1 - nothing moves
+# -------------------------------------------------------------
+
+update txn=txn1 ts=15,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,1
+   waiting readers:
+    req: 4, txn: none
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 17,1 - the transactional read at
+# at timestamp 16,1 is allowed to proceed without acquire a
+# reservation
+# -------------------------------------------------------------
+
+update txn=txn1 ts=17,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 3
+local: num=0
+
+guard-state r=req4
+----
+new: state=doneWaiting
+
+scan r=req4
+----
+start-waiting: false
+
+dequeue r=req4
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 3
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 19,1 - nothing moves
+# -------------------------------------------------------------
+
+update txn=txn1 ts=19,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000019,1
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 3
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock epoch to 1 - the lock is dropped and the transactional
+# write at timestamp 14,1 is allowed to acquire a reservation. Once
+# it finishes, the non-transactional write is allowed to proceed
+# without grabbing a reservation
+# -------------------------------------------------------------
+
+update txn=txn1 ts=19,1 epoch=1 span=a
+----
+global: num=1
+ lock: "a"
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000014,1
+   queued writers:
+    active: true req: 5, txn: none
+   distinguished req: 5
+local: num=0
+
+guard-state r=req3
+----
+new: state=doneWaiting
+
+scan r=req3
+----
+start-waiting: false
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn3 ts=14,1 key="a" held=false guard-access=write
+
+dequeue r=req3
+----
+global: num=0
+local: num=0
+
+guard-state r=req5
+----
+new: state=doneWaiting
+
+scan r=req5
+----
+start-waiting: false
+
+dequeue r=req5
+----
+global: num=0
+local: num=0

--- a/pkg/storage/spanset/spanset.go
+++ b/pkg/storage/spanset/spanset.go
@@ -132,6 +132,16 @@ func (s *SpanSet) AddMVCC(access SpanAccess, span roachpb.Span, timestamp hlc.Ti
 	s.spans[access][scope] = append(s.spans[access][scope], Span{Span: span, Timestamp: timestamp})
 }
 
+// Merge merges all spans in s2 into s. s2 is not modified.
+func (s *SpanSet) Merge(s2 *SpanSet) {
+	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
+		}
+	}
+	s.SortAndDedup()
+}
+
 // SortAndDedup sorts the spans in the SpanSet and removes any duplicates.
 func (s *SpanSet) SortAndDedup() {
 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {

--- a/pkg/storage/spanset/spanset_test.go
+++ b/pkg/storage/spanset/spanset_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 // Test that spans are properly classified as global or local and that
@@ -46,6 +47,45 @@ func TestSpanSetGetSpansScope(t *testing.T) {
 	if act := ss.GetSpans(SpanReadOnly, SpanGlobal); !reflect.DeepEqual(act, exp) {
 		t.Errorf("get global spans: got %v, expected %v", act, exp)
 	}
+}
+
+func TestSpanSetMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	spA := roachpb.Span{Key: roachpb.Key("a")}
+	spBC := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}
+	spCE := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}
+	spBE := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")}
+	spLocal := roachpb.Span{Key: keys.RangeLastGCKey(1)}
+
+	var ss SpanSet
+	ss.AddNonMVCC(SpanReadOnly, spLocal)
+	ss.AddNonMVCC(SpanReadOnly, spA)
+	ss.AddNonMVCC(SpanReadWrite, spBC)
+	require.Equal(t, []Span{{Span: spLocal}}, ss.GetSpans(SpanReadOnly, SpanLocal))
+	require.Equal(t, []Span{{Span: spA}}, ss.GetSpans(SpanReadOnly, SpanGlobal))
+	require.Equal(t, []Span{{Span: spBC}}, ss.GetSpans(SpanReadWrite, SpanGlobal))
+
+	var ss2 SpanSet
+	ss2.AddNonMVCC(SpanReadWrite, spCE)
+	require.Nil(t, ss2.GetSpans(SpanReadOnly, SpanLocal))
+	require.Nil(t, ss2.GetSpans(SpanReadOnly, SpanGlobal))
+	require.Equal(t, []Span{{Span: spCE}}, ss2.GetSpans(SpanReadWrite, SpanGlobal))
+
+	// Merge merges all spans. Notice the new spBE span.
+	ss2.Merge(&ss)
+	require.Equal(t, []Span{{Span: spLocal}}, ss2.GetSpans(SpanReadOnly, SpanLocal))
+	require.Equal(t, []Span{{Span: spA}}, ss2.GetSpans(SpanReadOnly, SpanGlobal))
+	require.Equal(t, []Span{{Span: spBE}}, ss2.GetSpans(SpanReadWrite, SpanGlobal))
+
+	// The source set is not mutated on future changes to the merged set.
+	ss2.AddNonMVCC(SpanReadOnly, spCE)
+	require.Equal(t, []Span{{Span: spLocal}}, ss.GetSpans(SpanReadOnly, SpanLocal))
+	require.Equal(t, []Span{{Span: spA}}, ss.GetSpans(SpanReadOnly, SpanGlobal))
+	require.Equal(t, []Span{{Span: spBC}}, ss.GetSpans(SpanReadWrite, SpanGlobal))
+	require.Equal(t, []Span{{Span: spLocal}}, ss2.GetSpans(SpanReadOnly, SpanLocal))
+	require.Equal(t, []Span{{Span: spA}, {Span: spCE}}, ss2.GetSpans(SpanReadOnly, SpanGlobal))
+	require.Equal(t, []Span{{Span: spBE}}, ss2.GetSpans(SpanReadWrite, SpanGlobal))
 }
 
 // Test that CheckAllowed properly enforces span boundaries.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2173,6 +2173,14 @@ func (s *Store) Metrics() *StoreMetrics {
 	return s.metrics
 }
 
+// NodeDescriptor returns the NodeDescriptor of the node that holds the Store.
+func (s *Store) NodeDescriptor() *roachpb.NodeDescriptor {
+	return s.nodeDesc
+}
+
+// Silence unused warning.
+var _ = (*Store).NodeDescriptor
+
 // Descriptor returns a StoreDescriptor including current store
 // capacity information.
 func (s *Store) Descriptor(useCached bool) (*roachpb.StoreDescriptor, error) {


### PR DESCRIPTION
Informs #41720.
Informs #44976.
Initially drawn out in #43775.

This PR implements the concurrency.Manager interface, which is the core structure that ties together the new concurrency package. 

The concurrency manager is a structure that sequences incoming requests and provides isolation between requests that intend to perform conflicting operations. During sequencing, conflicts are discovered and any found are resolved through a combination of passive queuing and active pushing. Once a request has been sequenced, it is free to evaluate without concerns of conflicting with other in-flight requests due to the isolation provided by the manager. This isolation is guaranteed for the lifetime of the request but terminates once the request completes.

The manager accomplishes this by piecing together the following components in its request sequencing path:
- `latchManager`
- `lockTable`
- `lockTableWaiter`
- `txnWaitQueue`

The largest part of this change is introducing the datadriven testing framework to deterministically test the concurrency manager. This proved difficult for two reasons:
1. the concurrency manager composes several components to perform it work (latchManager, lockTable, lockTableWaiter, txnWaitQueue). It was difficult to get consistent observability into each of these components in such a way that tests could be run against a set of concurrent requests interacting with them all.
2. the concurrency manager exposes a primarily blocking interface. Requests call `Sequence()` and wait for sequencing to complete. This may block in a number of different places - while waiting on latches, while waiting on locks, and while waiting on other transactions. The most important part of these tests is to assert _where_ a given request blocks based on the current state of the concurrency manager and then assert _how_ the request reacts to a state transition by another request.

To address the first problem, the testing harness uses the context-carried tracing infrastructure to track the path of a request. We already had log events scattered throughout these various components, so this did not require digging testing hooks into each of them. Instead, the harness attached a trace recording span to each request and watches as events are added to the span. It then uses these events as the output of the text.

To address the second problem, the testing harness introduces a monitor object which manages a collection of "monitored" goroutines. The monitor watches as these goroutines run and keeps track of their goroutine state as is reported by a goroutine dump. During each step of the datadriven test, the monitor allows all goroutines to proceed until they have either terminated or stalled due to cross-goroutine synchronization dependencies. For instance, it waits for all goroutines to stall while receiving from channels. We can be sure that the goroutine dump provides a consistent snapshot of all goroutine states and statuses because `runtime.Stack(all=true)` stops the world when called. This means that when all monitored goroutines are simultaneously stalled, we have a deadlock that can only be resolved by proceeding forward with the test and releasing latches, resolving locks, or committing transactions. This structure worked surprisingly well and has held up to long periods of stressrace.