### PR TITLE
engine: let maxKeys=0 scan unboundedly

### DIFF
--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -134,7 +134,7 @@ template <bool reverse> class mvccScanner {
     while (getAndAdvance()) {
     }
 
-    if (kvs_->Count() == max_keys_ && advanceKey()) {
+    if (max_keys_ > 0 && kvs_->Count() == max_keys_ && advanceKey()) {
       if (reverse) {
         // It is possible for cur_key_ to be pointing into mvccScanner.saved_buf_
         // instead of iter_rep_'s underlying storage if iterating in reverse (see
@@ -363,7 +363,7 @@ template <bool reverse> class mvccScanner {
       // historical timestamp < the intent timestamp. However, we
       // return the intent separately; the caller may want to resolve
       // it.
-      if (kvs_->Count() == max_keys_) {
+      if (max_keys_ > 0 && kvs_->Count() == max_keys_) {
         // We've already retrieved the desired number of keys and now
         // we're adding the resume key. We don't want to add the
         // intent here as the intents should only correspond to KVs
@@ -562,7 +562,7 @@ template <bool reverse> class mvccScanner {
       if (target_bytes_ > 0 && kvs_->NumBytes() >= target_bytes_) {
         max_keys_ = kvs_->Count();
       }
-      if (kvs_->Count() == max_keys_) {
+      if (max_keys_ > 0 && kvs_->Count() == max_keys_) {
         return false;
       }
     }

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -12,7 +12,6 @@ package kv
 
 import (
 	"context"
-	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -116,7 +115,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	}
 
 	testutils.SucceedsSoon(t, func() error {
-		if _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
+		if _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil
@@ -226,7 +225,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	testutils.SucceedsSoon(t, func() error {
-		if _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
+		if _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"net"
 	"reflect"
 	"sort"
@@ -216,7 +215,7 @@ func TestBootstrapCluster(t *testing.T) {
 	}
 
 	// Scan the complete contents of the local database directly from the engine.
-	res, err := engine.MVCCScan(ctx, e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
+	res, err := engine.MVCCScan(ctx, e, keys.LocalMax, roachpb.KeyMax, hlc.MaxTimestamp, engine.MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -167,7 +166,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		var kvs []roachpb.KeyValue
 		testutils.SucceedsSoon(t, func() error {
 			res, err := engine.MVCCScan(ctx, store.Engine(), keys.MetaMin, keys.MetaMax,
-				math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
+				hlc.MaxTimestamp, engine.MVCCScanOptions{})
 			if err != nil {
 				// Wait for the intent to be resolved.
 				if _, ok := err.(*roachpb.WriteIntentError); ok {

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -13,7 +13,6 @@ package storage
 import (
 	"bytes"
 	"context"
-	"math"
 	"reflect"
 	"testing"
 
@@ -556,7 +555,7 @@ func TestSpanSetMVCCResolveWriteIntentRangeUsingIter(t *testing.T) {
 	defer iterAndBuf.Cleanup()
 
 	if _, _, err := engine.MVCCResolveWriteIntentRangeUsingIter(
-		ctx, batch, iterAndBuf, nil /* ms */, intent, math.MaxInt64,
+		ctx, batch, iterAndBuf, nil /* ms */, intent, 0,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -52,7 +52,7 @@ func DeleteRange(
 		timestamp = h.Timestamp
 	}
 	deleted, resumeSpan, num, err := engine.MVCCDeleteRange(
-		ctx, readWriter, cArgs.Stats, args.Key, args.EndKey, cArgs.MaxKeys, timestamp, h.Txn, args.ReturnKeys,
+		ctx, readWriter, cArgs.Stats, args.Key, args.EndKey, h.MaxSpanRequestKeys, timestamp, h.Txn, args.ReturnKeys,
 	)
 	if err == nil {
 		reply.Keys = deleted

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -48,7 +48,7 @@ func ResolveIntentRange(
 	defer iterAndBuf.Cleanup()
 
 	numKeys, resumeSpan, err := engine.MVCCResolveWriteIntentRangeUsingIter(
-		ctx, readWriter, iterAndBuf, ms, update, cArgs.MaxKeys,
+		ctx, readWriter, iterAndBuf, ms, update, h.MaxSpanRequestKeys,
 	)
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -215,12 +215,13 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 
 			declareKeysResolveIntentRange(&desc, h, &rir, &spans)
 
+			h := h
+			h.MaxSpanRequestKeys = 10
 			if _, err := ResolveIntentRange(ctx, rbatch,
 				CommandArgs{
 					Header:  h,
 					EvalCtx: (&MockEvalCtx{}).EvalContext(),
 					Args:    &rir,
-					MaxKeys: 10,
 				},
 				&roachpb.ResolveIntentRangeResponse{},
 			); err != nil {

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -215,7 +215,6 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 
 			declareKeysResolveIntentRange(&desc, h, &rir, &spans)
 
-			h := h
 			h.MaxSpanRequestKeys = 10
 			if _, err := ResolveIntentRange(ctx, rbatch,
 				CommandArgs{

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -48,14 +48,14 @@ func ReverseScan(
 	switch args.ScanFormat {
 	case roachpb.BATCH_RESPONSE:
 		res, err = engine.MVCCScanToBytes(
-			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
 		reply.BatchResponses = res.KVData
 	case roachpb.KEY_VALUES:
 		res, err = engine.MVCCScan(
-			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -40,7 +40,7 @@ func ReverseScan(
 	opts := engine.MVCCScanOptions{
 		Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:          h.Txn,
-		MaxKeys:      cArgs.MaxKeys,
+		MaxKeys:      h.MaxSpanRequestKeys,
 		TargetBytes:  h.TargetBytes,
 		Reverse:      true,
 	}

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -40,6 +40,7 @@ func ReverseScan(
 	opts := engine.MVCCScanOptions{
 		Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:          h.Txn,
+		MaxKeys:      cArgs.MaxKeys,
 		TargetBytes:  h.TargetBytes,
 		Reverse:      true,
 	}
@@ -47,14 +48,14 @@ func ReverseScan(
 	switch args.ScanFormat {
 	case roachpb.BATCH_RESPONSE:
 		res, err = engine.MVCCScanToBytes(
-			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
 		reply.BatchResponses = res.KVData
 	case roachpb.KEY_VALUES:
 		res, err = engine.MVCCScan(
-			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_revert_range.go
+++ b/pkg/storage/batcheval/cmd_revert_range.go
@@ -88,9 +88,8 @@ func RevertRange(
 
 	log.VEventf(ctx, 2, "clearing keys with timestamp (%v, %v]", args.TargetTime, cArgs.Header.Timestamp)
 
-	resume, err := engine.MVCCClearTimeRange(
-		ctx, readWriter, cArgs.Stats, args.Key, args.EndKey, args.TargetTime, cArgs.Header.Timestamp, cArgs.MaxKeys,
-	)
+	resume, err := engine.MVCCClearTimeRange(ctx, readWriter, cArgs.Stats, args.Key, args.EndKey,
+		args.TargetTime, cArgs.Header.Timestamp, cArgs.Header.MaxSpanRequestKeys)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -110,7 +109,7 @@ func RevertRange(
 		// currently response combining's handling of resume spans prefers that
 		// there only be one. Thus we just set it to MaxKeys when, and only when,
 		// we're returning a ResumeSpan.
-		reply.NumKeys = cArgs.MaxKeys
+		reply.NumKeys = cArgs.Header.MaxSpanRequestKeys
 		reply.ResumeReason = roachpb.RESUME_KEY_LIMIT
 	}
 

--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -134,7 +134,7 @@ func TestCmdRevertRange(t *testing.T) {
 				StartKey: roachpb.RKey(startKey),
 				EndKey:   roachpb.RKey(endKey),
 			}
-			cArgs := CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC}, MaxKeys: 2}
+			cArgs := CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC, MaxSpanRequestKeys: 2}}
 			evalCtx := &MockEvalCtx{Desc: &desc, Clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), Stats: stats}
 			cArgs.EvalCtx = evalCtx.EvalContext()
 			afterStats := getStats(t, eng)

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -40,11 +40,9 @@ func Scan(
 	opts := engine.MVCCScanOptions{
 		Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:          h.Txn,
-		// TODO(tbg): MaxKeys should be sourced from h.MaxSpanRequestKeys and
-		// cArgs.MaxKeys removed.
-		MaxKeys:     cArgs.MaxKeys,
-		TargetBytes: h.TargetBytes,
-		Reverse:     false,
+		MaxKeys:      h.MaxSpanRequestKeys,
+		TargetBytes:  h.TargetBytes,
+		Reverse:      false,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -40,21 +40,24 @@ func Scan(
 	opts := engine.MVCCScanOptions{
 		Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:          h.Txn,
-		TargetBytes:  h.TargetBytes,
-		Reverse:      false,
+		// TODO(tbg): MaxKeys should be sourced from h.MaxSpanRequestKeys and
+		// cArgs.MaxKeys removed.
+		MaxKeys:     cArgs.MaxKeys,
+		TargetBytes: h.TargetBytes,
+		Reverse:     false,
 	}
 
 	switch args.ScanFormat {
 	case roachpb.BATCH_RESPONSE:
 		res, err = engine.MVCCScanToBytes(
-			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
 		reply.BatchResponses = res.KVData
 	case roachpb.KEY_VALUES:
 		res, err = engine.MVCCScan(
-			ctx, reader, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -50,14 +50,14 @@ func Scan(
 	switch args.ScanFormat {
 	case roachpb.BATCH_RESPONSE:
 		res, err = engine.MVCCScanToBytes(
-			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
 		reply.BatchResponses = res.KVData
 	case roachpb.KEY_VALUES:
 		res, err = engine.MVCCScan(
-			ctx, reader, args.Key, args.EndKey, -1, h.Timestamp, opts)
+			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_scan_test.go
+++ b/pkg/storage/batcheval/cmd_scan_test.go
@@ -77,8 +77,7 @@ func testScanReverseScanInner(
 	req.SetHeader(roachpb.RequestHeader{Key: k1, EndKey: roachpb.KeyMax})
 
 	cArgs := CommandArgs{
-		MaxKeys: 100000,
-		Args:    req,
+		Args: req,
 		Header: roachpb.Header{
 			Timestamp:   ts,
 			TargetBytes: tb,

--- a/pkg/storage/batcheval/declare.go
+++ b/pkg/storage/batcheval/declare.go
@@ -63,12 +63,6 @@ type CommandArgs struct {
 	EvalCtx EvalContext
 	Header  roachpb.Header
 	Args    roachpb.Request
-
-	// If MaxKeys is non-zero, span requests should limit themselves to
-	// that many keys. Commands using this feature should also set
-	// NumKeys and ResumeSpan in their responses.
-	MaxKeys int64
-
 	// *Stats should be mutated to reflect any writes made by the command.
 	Stats *enginepb.MVCCStats
 }

--- a/pkg/storage/batcheval/transaction_test.go
+++ b/pkg/storage/batcheval/transaction_test.go
@@ -12,7 +12,6 @@ package batcheval
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -129,7 +128,6 @@ func TestUpdateAbortSpan(t *testing.T) {
 		args := CommandArgs{
 			EvalCtx: rec,
 			Args:    &req,
-			MaxKeys: math.MaxInt64,
 		}
 
 		var resp roachpb.ResolveIntentRangeResponse

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -242,7 +242,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 		endKey = endKey.Next()
 		walltime := int64(5 * (rand.Int31n(int32(opts.numVersions)) + 1))
 		ts := hlc.Timestamp{WallTime: walltime}
-		res, err := MVCCScan(ctx, eng, startKey, endKey, -1, ts, MVCCScanOptions{
+		res, err := MVCCScan(ctx, eng, startKey, endKey, ts, MVCCScanOptions{
 			MaxKeys: int64(opts.numRows),
 			Reverse: opts.reverse,
 		})

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -242,7 +242,8 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 		endKey = endKey.Next()
 		walltime := int64(5 * (rand.Int31n(int32(opts.numVersions)) + 1))
 		ts := hlc.Timestamp{WallTime: walltime}
-		res, err := MVCCScan(ctx, eng, startKey, endKey, int64(opts.numRows), ts, MVCCScanOptions{
+		res, err := MVCCScan(ctx, eng, startKey, endKey, -1, ts, MVCCScanOptions{
+			MaxKeys: int64(opts.numRows),
 			Reverse: opts.reverse,
 		})
 		if err != nil {

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -144,7 +144,7 @@ type MVCCIterator interface {
 	// alternating from key to value, where numKVs specifies the number of pairs
 	// in the buffer.
 	MVCCScan(
-		start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
+		start, end roachpb.Key, timestamp hlc.Timestamp, opts MVCCScanOptions,
 	) (MVCCScanResult, error)
 }
 

--- a/pkg/storage/engine/metamorphic/operations.go
+++ b/pkg/storage/engine/metamorphic/operations.go
@@ -110,7 +110,7 @@ func runMvccScan(
 	// m.engine instead of a readWriterManager-generated engine.Reader, otherwise
 	// we will try MVCCScanning on batches and produce diffs between runs on
 	// different engines that don't point to an actual issue.
-	result, err := engine.MVCCScan(ctx, m.engine, key.Key, endKey.Key, math.MaxInt64, ts, engine.MVCCScanOptions{
+	result, err := engine.MVCCScan(ctx, m.engine, key.Key, endKey.Key, ts, engine.MVCCScanOptions{
 		Inconsistent: inconsistent,
 		Tombstones:   true,
 		Reverse:      reverse,

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2447,7 +2447,9 @@ type MVCCScanOptions struct {
 	Txn              *roachpb.Transaction
 	// MaxKeys is the maximum number of kv pairs returned from this operation.
 	// The zero value represents an unbounded scan. If the limit stops the scan,
-	// a corresponding ResumeSpan is returned.
+	// a corresponding ResumeSpan is returned. As a special case, the value -1
+	// returns no keys in the result (returning the first key via the
+	// ResumeSpan).
 	MaxKeys int64
 	// TargetBytes is a byte threshold to limit the amount of data pulled into
 	// memory during a Scan operation. Once the target is satisfied (i.e. met or

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2249,6 +2249,7 @@ func MVCCClearTimeRange(
 // end keys. It returns the range of keys deleted when returnedKeys is set,
 // the next span to resume from, and the number of keys deleted.
 // The returned resume span is nil if max keys aren't processed.
+// The choice max=0 disables the limit.
 func MVCCDeleteRange(
 	ctx context.Context,
 	rw ReadWriter,
@@ -2273,7 +2274,7 @@ func MVCCDeleteRange(
 		scanTxn = prevSeqTxn
 	}
 	res, err := MVCCScan(
-		ctx, rw, key, endKey, max, scanTs, MVCCScanOptions{Txn: scanTxn})
+		ctx, rw, key, endKey, -1, scanTs, MVCCScanOptions{Txn: scanTxn, MaxKeys: max})
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -2307,7 +2308,6 @@ func mvccScanToBytes(
 	ctx context.Context,
 	iter Iterator,
 	key, endKey roachpb.Key,
-	max int64,
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
@@ -2317,14 +2317,14 @@ func mvccScanToBytes(
 	if err := opts.validate(); err != nil {
 		return MVCCScanResult{}, err
 	}
-	if max == 0 {
+	if opts.MaxKeys < 0 {
 		resumeSpan := &roachpb.Span{Key: key, EndKey: endKey}
 		return MVCCScanResult{ResumeSpan: resumeSpan}, nil
 	}
 
 	// If the iterator has a specialized implementation, defer to that.
 	if mvccIter, ok := iter.(MVCCIterator); ok && mvccIter.MVCCOpsSpecialized() {
-		return mvccIter.MVCCScan(key, endKey, max, timestamp, opts)
+		return mvccIter.MVCCScan(key, endKey, opts.MaxKeys /* TODO(tbg): remove */, timestamp, opts)
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
@@ -2336,7 +2336,7 @@ func mvccScanToBytes(
 		start:            key,
 		end:              endKey,
 		ts:               timestamp,
-		maxKeys:          max,
+		maxKeys:          opts.MaxKeys,
 		targetBytes:      opts.TargetBytes,
 		inconsistent:     opts.Inconsistent,
 		tombstones:       opts.Tombstones,
@@ -2374,11 +2374,10 @@ func mvccScanToKvs(
 	ctx context.Context,
 	iter Iterator,
 	key, endKey roachpb.Key,
-	max int64,
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
-	res, err := mvccScanToBytes(ctx, iter, key, endKey, max, timestamp, opts)
+	res, err := mvccScanToBytes(ctx, iter, key, endKey, timestamp, opts)
 	if err != nil {
 		return MVCCScanResult{}, err
 	}
@@ -2446,6 +2445,10 @@ type MVCCScanOptions struct {
 	Reverse          bool
 	FailOnMoreRecent bool
 	Txn              *roachpb.Transaction
+	// MaxKeys is the maximum number of kv pairs returned from this operation.
+	// The zero value represents an unbounded scan. If the limit stops the scan,
+	// a corresponding ResumeSpan is returned.
+	MaxKeys int64
 	// TargetBytes is a byte threshold to limit the amount of data pulled into
 	// memory during a Scan operation. Once the target is satisfied (i.e. met or
 	// exceeded) by the emitted emitted KV pairs, iteration stops (with a
@@ -2485,17 +2488,30 @@ type MVCCScanResult struct {
 	Intents    []roachpb.Intent
 }
 
+func assertMaxKeys(ctx context.Context, max int64, opts MVCCScanOptions) {
+	if max == -1 {
+		// Caller was already updated to use opts.MaxKeys correctly.
+		return
+	}
+	if max == math.MaxInt64 {
+		// Legacy path. We'll just remove the max parameter in all of those
+		// callers.
+		if opts.MaxKeys != 0 {
+			log.Fatalf(ctx, "need to set MaxKeys=0, it's %d", opts.MaxKeys)
+		}
+		return
+	}
+	// We need to still update the caller.
+	log.Fatalf(ctx, "need to set MaxKeys")
+}
+
 // MVCCScan scans the key range [key, endKey) in the provided reader up to some
 // maximum number of results in ascending order. If it hits max, it returns a
 // "resume span" to be used in the next call to this function. If the limit is
 // not hit, the resume span will be nil. Otherwise, it will be the sub-span of
 // [key, endKey) that has not been scanned.
 //
-// For an unbounded scan, specify a max of MaxInt64. A max of zero means to
-// return no keys at all, which is probably not what you intend.
-//
-// TODO(benesch): Evaluate whether our behavior when max is zero still makes
-// sense. See #8084 for historical context.
+// For an unbounded scan, specify a max of zero.
 //
 // Only keys that with a timestamp less than or equal to the supplied timestamp
 // will be included in the scan results. If a transaction is provided and the
@@ -2528,9 +2544,11 @@ func MVCCScan(
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
+	assertMaxKeys(ctx, max, opts)
+
 	iter := reader.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
 	defer iter.Close()
-	return mvccScanToKvs(ctx, iter, key, endKey, max, timestamp, opts)
+	return mvccScanToKvs(ctx, iter, key, endKey, timestamp, opts)
 }
 
 // MVCCScanToBytes is like MVCCScan, but it returns the results in a byte array.
@@ -2542,9 +2560,11 @@ func MVCCScanToBytes(
 	timestamp hlc.Timestamp,
 	opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
+	assertMaxKeys(ctx, max, opts)
+
 	iter := reader.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
 	defer iter.Close()
-	return mvccScanToBytes(ctx, iter, key, endKey, max, timestamp, opts)
+	return mvccScanToBytes(ctx, iter, key, endKey, timestamp, opts)
 }
 
 // MVCCIterate iterates over the key range [start,end). At each step of the
@@ -2568,8 +2588,10 @@ func MVCCIterate(
 	var intents []roachpb.Intent
 	for {
 		const maxKeysPerScan = 1000
+		opts := opts
+		opts.MaxKeys = maxKeysPerScan
 		res, err := mvccScanToKvs(
-			ctx, iter, key, endKey, maxKeysPerScan, timestamp, opts)
+			ctx, iter, key, endKey, timestamp, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -3094,7 +3116,7 @@ func MVCCResolveWriteIntentRange(
 // the range of write intents specified by start and end keys for a
 // given txn. ResolveWriteIntentRange will skip write intents of other
 // txns. Returns the number of intents resolved and a resume span if
-// the max keys limit was exceeded.
+// the max keys limit was exceeded. A max of zero means unbounded.
 func MVCCResolveWriteIntentRangeUsingIter(
 	ctx context.Context,
 	rw ReadWriter,
@@ -3112,7 +3134,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 	intent.EndKey = nil
 
 	for {
-		if num == max {
+		if max > 0 && num == max {
 			return num, &roachpb.Span{Key: nextKey.Key, EndKey: encEndKey.Key}, nil
 		}
 

--- a/pkg/storage/engine/mvcc_history_test.go
+++ b/pkg/storage/engine/mvcc_history_test.go
@@ -697,18 +697,17 @@ func cmdScan(e *evalCtx) error {
 	if e.hasArg("failOnMoreRecent") {
 		opts.FailOnMoreRecent = true
 	}
-	max := int64(-1)
 	if e.hasArg("max") {
-		var imax int
-		e.scanArg("max", &imax)
-		max = int64(imax)
+		var n int
+		e.scanArg("max", &n)
+		opts.MaxKeys = int64(n)
 	}
 	if key := "targetbytes"; e.hasArg(key) {
 		var tb int
 		e.scanArg(key, &tb)
 		opts.TargetBytes = int64(tb)
 	}
-	res, err := MVCCScan(e.ctx, e.engine, key, endKey, max, ts, opts)
+	res, err := MVCCScan(e.ctx, e.engine, key, endKey, -1, ts, opts)
 	// NB: the error is returned below. This ensures the test can
 	// ascertain no result is populated in the intents when an error
 	// occurs.

--- a/pkg/storage/engine/mvcc_history_test.go
+++ b/pkg/storage/engine/mvcc_history_test.go
@@ -707,7 +707,7 @@ func cmdScan(e *evalCtx) error {
 		e.scanArg(key, &tb)
 		opts.TargetBytes = int64(tb)
 	}
-	res, err := MVCCScan(e.ctx, e.engine, key, endKey, -1, ts, opts)
+	res, err := MVCCScan(e.ctx, e.engine, key, endKey, ts, opts)
 	// NB: the error is returned below. This ensures the test can
 	// ascertain no result is populated in the intents when an error
 	// occurs.

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -471,7 +471,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
 					}
 					if res, err := MVCCScan(
-						ctx, engine, testKey1, testKey1.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey1, testKey1.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err != nil {
 						t.Fatal(err)
 					} else if len(res.KVs) != 1 {
@@ -500,7 +500,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -521,7 +521,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -539,7 +539,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -570,7 +570,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a WriteIntentError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
@@ -590,7 +590,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a WriteIntentError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
@@ -608,7 +608,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -638,7 +638,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -661,7 +661,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -681,7 +681,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -1058,7 +1058,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 				if scan.consistent {
 					cStr = "consistent"
 				}
-				res, err := MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
+				res, err := MVCCScan(ctx, engine, testKey1, testKey4.Next(),
 					hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn})
 				wiErr, _ := err.(*roachpb.WriteIntentError)
 				if (err == nil) != (wiErr == nil) {
@@ -1318,7 +1318,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 					case "get":
 						_, _, err = MVCCGet(ctx, batch, key, ts2, MVCCGetOptions{})
 					case "scan":
-						_, err = MVCCScan(ctx, batch, key, roachpb.KeyMax, math.MaxInt64, ts2, MVCCScanOptions{})
+						_, err = MVCCScan(ctx, batch, key, roachpb.KeyMax, ts2, MVCCScanOptions{})
 					case "findSplitKey":
 						_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
 					case "computeStats":
@@ -1433,7 +1433,7 @@ func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 		t.Fatal(err)
 	}
 
-	res, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+	res, err := MVCCScan(ctx, engine, testKey2, testKey4,
 		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -1451,7 +1451,7 @@ func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	res, err = MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+	res, err = MVCCScan(ctx, engine, testKey2, testKey4,
 		hlc.Timestamp{WallTime: 4}, MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -1469,8 +1469,9 @@ func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	res, err = MVCCScan(ctx, engine, testKey4, keyMax, math.MaxInt64,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+	res, err = MVCCScan(
+		ctx, engine, testKey4, keyMax, hlc.Timestamp{WallTime: 1}, MVCCScanOptions{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1490,7 +1491,7 @@ func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	res, err = MVCCScan(ctx, engine, keyMin, testKey2, math.MaxInt64,
+	res, err = MVCCScan(ctx, engine, keyMin, testKey2,
 		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -1542,7 +1543,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey2, testKey4, -1,
+			res, err := MVCCScan(ctx, engine, testKey2, testKey4,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
@@ -1556,7 +1557,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1,
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: -1})
 			if err != nil {
 				t.Fatal(err)
@@ -1570,7 +1571,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 
 			// Note: testKey6, though not scanned directly, is important in testing that
 			// the computed resume span does not extend beyond the upper bound of a scan.
-			res, err = MVCCScan(ctx, engine, testKey4, testKey5, -1,
+			res, err = MVCCScan(ctx, engine, testKey4, testKey5,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
@@ -1582,7 +1583,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatalf("resumeSpan = %+v", res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(), -1,
+			res, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(),
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true, MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
@@ -1633,7 +1634,7 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64,
+			res, err := MVCCScan(ctx, engine, roachpb.Key("/a"), roachpb.Key("/b"),
 				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -1672,7 +1673,7 @@ func TestMVCCScanInTxn(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+			res, err := MVCCScan(ctx, engine, testKey2, testKey4,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Txn: txn1})
 			if err != nil {
 				t.Fatal(err)
@@ -1686,7 +1687,7 @@ func TestMVCCScanInTxn(t *testing.T) {
 			}
 
 			if _, err := MVCCScan(
-				ctx, engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, MVCCScanOptions{},
+				ctx, engine, testKey2, testKey4, hlc.Timestamp{WallTime: 1}, MVCCScanOptions{},
 			); err == nil {
 				t.Fatal("expected error on uncommitted write intent")
 			}
@@ -1707,7 +1708,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 
 			// A scan with consistent=false should fail in a txn.
 			if _, err := MVCCScan(
-				ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 1},
+				ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Inconsistent: true, Txn: txn1},
 			); err == nil {
 				t.Error("expected an error scanning with consistent=false in txn")
@@ -1745,7 +1746,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 				roachpb.MakeIntent(&txn2ts5.TxnMeta, testKey3),
 			}
 			res, err := MVCCScan(
-				ctx, engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7},
+				ctx, engine, testKey1, testKey4.Next(), hlc.Timestamp{WallTime: 7},
 				MVCCScanOptions{Inconsistent: true},
 			)
 			if err != nil {
@@ -1771,7 +1772,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 
 			// Now try a scan at a historical timestamp.
 			expIntents = expIntents[:1]
-			res, err = MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
+			res, err = MVCCScan(ctx, engine, testKey1, testKey4.Next(),
 				hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Inconsistent: true})
 			if !reflect.DeepEqual(res.Intents, expIntents) {
 				t.Fatal(err)
@@ -1831,7 +1832,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64,
+			res, _ := MVCCScan(ctx, engine, keyMin, keyMax,
 				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1887,7 +1888,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1915,7 +1916,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, err = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, err = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -1940,7 +1941,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, err = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -2001,7 +2002,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ := MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -2030,7 +2031,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -2067,7 +2068,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 1 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -2092,7 +2093,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 0 {
 				t.Fatal("the value should be empty")
@@ -2217,7 +2218,7 @@ func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
 			}
 
 			txn.Epoch++
-			res, _ := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
+			res, _ := MVCCScan(ctx, engine, testKey1, testKey4,
 				hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Txn: txn})
 			if e := 2; len(res.KVs) != e {
 				t.Fatalf("e = %d, got %d", e, len(res.KVs))
@@ -2315,7 +2316,7 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 					Value: value6,
 				},
 			}
-			res, err := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, err := MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -2397,7 +2398,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 
 			assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
 				t.Helper()
-				res, err := MVCCScan(ctx, reader, keyMin, keyMax, math.MaxInt64, at, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, reader, keyMin, keyMax, at, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, expected, res.KVs)
 			}
@@ -2524,17 +2525,17 @@ func TestMVCCClearTimeRange(t *testing.T) {
 
 				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
 				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err := MVCCScan(ctx, e, keyMin, testKey3, math.MaxInt64, ts5, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, e, keyMin, testKey3, ts5, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, ts3Content[:2], res.KVs)
 
 				// Verify the intent was left alone.
-				_, err = MVCCScan(ctx, e, testKey3, testKey4, math.MaxInt64, ts5, MVCCScanOptions{})
+				_, err = MVCCScan(ctx, e, testKey3, testKey4, ts5, MVCCScanOptions{})
 				require.Error(t, err)
 
 				// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
 				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err = MVCCScan(ctx, e, testKey4, keyMax, math.MaxInt64, ts5, MVCCScanOptions{})
+				res, err = MVCCScan(ctx, e, testKey4, keyMax, ts5, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, ts3Content[2:], res.KVs)
 			})
@@ -2648,7 +2649,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
 					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
 					// MVCC-Scan at the revert time.
-					resBefore, err := MVCCScan(ctx, e, keyMin, keyMax, -1, revertTo, MVCCScanOptions{MaxKeys: numKVs})
+					resBefore, err := MVCCScan(ctx, e, keyMin, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 
 					// Revert to the revert time.
@@ -2665,7 +2666,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 					require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
 					// Scanning at "now" post-revert should yield the same result as scanning
 					// at revert-time pre-revert.
-					resAfter, err := MVCCScan(ctx, e, keyMin, keyMax, -1, now, MVCCScanOptions{MaxKeys: numKVs})
+					resAfter, err := MVCCScan(ctx, e, keyMin, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 					require.Equal(t, resBefore.KVs, resAfter.KVs)
 				})
@@ -2862,7 +2863,7 @@ func TestMVCCReverseScan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+			res, err := MVCCScan(ctx, engine, testKey2, testKey4,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
 
 			if err != nil {
@@ -2879,7 +2880,7 @@ func TestMVCCReverseScan(t *testing.T) {
 				t.Fatalf("resumeSpan = %+v", res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1, hlc.Timestamp{WallTime: 1},
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4, hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
@@ -2894,7 +2895,7 @@ func TestMVCCReverseScan(t *testing.T) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1, hlc.Timestamp{WallTime: 1},
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4, hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Reverse: true, MaxKeys: -1})
 
 			if err != nil {
@@ -2909,7 +2910,7 @@ func TestMVCCReverseScan(t *testing.T) {
 
 			// The first key we encounter has multiple versions and we need to read the
 			// latest.
-			res, err = MVCCScan(ctx, engine, testKey2, testKey3, -1, hlc.Timestamp{WallTime: 4},
+			res, err = MVCCScan(ctx, engine, testKey2, testKey3, hlc.Timestamp{WallTime: 4},
 				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
@@ -2923,7 +2924,7 @@ func TestMVCCReverseScan(t *testing.T) {
 
 			// The first key we encounter is newer than our read timestamp and we need to
 			// back up to the previous key.
-			res, err = MVCCScan(ctx, engine, testKey4, testKey6, -1, hlc.Timestamp{WallTime: 1},
+			res, err = MVCCScan(ctx, engine, testKey4, testKey6, hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
@@ -2936,7 +2937,7 @@ func TestMVCCReverseScan(t *testing.T) {
 			}
 
 			// Scan only the first key in the key space.
-			res, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), -1, hlc.Timestamp{WallTime: 1},
+			res, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
@@ -2979,7 +2980,7 @@ func TestMVCCReverseScanFirstKeyInFuture(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
+			res, err := MVCCScan(ctx, engine, testKey1, testKey4,
 				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Reverse: true})
 			if err != nil {
 				t.Fatal(err)
@@ -3020,7 +3021,7 @@ func TestMVCCReverseScanSeeksOverRepeatedKeys(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
+			res, err := MVCCScan(ctx, engine, testKey1, testKey3,
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
 			if err != nil {
 				t.Fatal(err)
@@ -3067,7 +3068,7 @@ func TestMVCCReverseScanStopAtSmallestKey(t *testing.T) {
 					}
 				}
 
-				res, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
+				res, err := MVCCScan(ctx, engine, testKey1, testKey3,
 					hlc.Timestamp{WallTime: ts}, MVCCScanOptions{Reverse: true})
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -471,7 +471,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
 					}
 					if res, err := MVCCScan(
-						ctx, engine, testKey1, testKey1.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey1, testKey1.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err != nil {
 						t.Fatal(err)
 					} else if len(res.KVs) != 1 {
@@ -500,7 +500,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -521,7 +521,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -539,7 +539,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey2, testKey2.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -570,7 +570,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a WriteIntentError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
@@ -590,7 +590,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a WriteIntentError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
@@ -608,7 +608,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey3, testKey3.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -638,7 +638,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -661,7 +661,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
 					); err == nil {
 						t.Fatal("wanted an error")
 					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
@@ -681,7 +681,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 						t.Fatal(err)
 					}
 					if _, err := MVCCScan(
-						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+						ctx, engine, testKey4, testKey4.PrefixEnd(), -1, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
 					); err != nil {
 						t.Fatal(err)
 					}
@@ -1542,8 +1542,8 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res, err := MVCCScan(ctx, engine, testKey2, testKey4, 1,
-				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			res, err := MVCCScan(ctx, engine, testKey2, testKey4, -1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1556,8 +1556,8 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, 0,
-				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: -1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1570,8 +1570,8 @@ func TestMVCCScanMaxNum(t *testing.T) {
 
 			// Note: testKey6, though not scanned directly, is important in testing that
 			// the computed resume span does not extend beyond the upper bound of a scan.
-			res, err = MVCCScan(ctx, engine, testKey4, testKey5, 1,
-				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			res, err = MVCCScan(ctx, engine, testKey4, testKey5, -1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1582,8 +1582,8 @@ func TestMVCCScanMaxNum(t *testing.T) {
 				t.Fatalf("resumeSpan = %+v", res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(), 1,
-				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(), -1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true, MaxKeys: 1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1874,7 +1874,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 
 			// Attempt to delete no keys.
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, false)
+				ctx, engine, nil, testKey2, testKey6, -1, hlc.Timestamp{WallTime: 2}, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1902,7 +1902,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			}
 
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
+				ctx, engine, nil, testKey4, keyMax, 0, hlc.Timestamp{WallTime: 2}, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1915,16 +1915,19 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, err = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if len(res.KVs) != 1 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
 				!bytes.Equal(res.KVs[0].Value.RawBytes, value1.RawBytes) {
-				t.Fatal("the value should not be empty")
+				t.Fatalf("the value should not be empty: %+v", res.KVs)
 			}
 
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
+				ctx, engine, nil, keyMin, testKey2, 0, hlc.Timestamp{WallTime: 2}, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1937,8 +1940,11 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+			res, err = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if len(res.KVs) != 0 {
 				t.Fatal("the value should be empty")
 			}
@@ -2011,7 +2017,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 
 			// Attempt to delete no keys.
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, true)
+				ctx, engine, nil, testKey2, testKey6, -1, hlc.Timestamp{WallTime: 2}, nil, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2391,7 +2397,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 
 			assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
 				t.Helper()
-				res, err := MVCCScan(ctx, reader, keyMin, keyMax, 100, at, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, reader, keyMin, keyMax, math.MaxInt64, at, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, expected, res.KVs)
 			}
@@ -2518,17 +2524,17 @@ func TestMVCCClearTimeRange(t *testing.T) {
 
 				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
 				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err := MVCCScan(ctx, e, keyMin, testKey3, 100, ts5, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, e, keyMin, testKey3, math.MaxInt64, ts5, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, ts3Content[:2], res.KVs)
 
 				// Verify the intent was left alone.
-				_, err = MVCCScan(ctx, e, testKey3, testKey4, 100, ts5, MVCCScanOptions{})
+				_, err = MVCCScan(ctx, e, testKey3, testKey4, math.MaxInt64, ts5, MVCCScanOptions{})
 				require.Error(t, err)
 
 				// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
 				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err = MVCCScan(ctx, e, testKey4, keyMax, 100, ts5, MVCCScanOptions{})
+				res, err = MVCCScan(ctx, e, testKey4, keyMax, math.MaxInt64, ts5, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, ts3Content[2:], res.KVs)
 			})
@@ -2642,7 +2648,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
 					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
 					// MVCC-Scan at the revert time.
-					resBefore, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, revertTo, MVCCScanOptions{})
+					resBefore, err := MVCCScan(ctx, e, keyMin, keyMax, -1, revertTo, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 
 					// Revert to the revert time.
@@ -2659,7 +2665,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 					require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
 					// Scanning at "now" post-revert should yield the same result as scanning
 					// at revert-time pre-revert.
-					resAfter, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, now, MVCCScanOptions{})
+					resAfter, err := MVCCScan(ctx, e, keyMin, keyMax, -1, now, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 					require.Equal(t, resBefore.KVs, resAfter.KVs)
 				})
@@ -2873,8 +2879,8 @@ func TestMVCCReverseScan(t *testing.T) {
 				t.Fatalf("resumeSpan = %+v", res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, 1, hlc.Timestamp{WallTime: 1},
-				MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
 				t.Fatal(err)
@@ -2888,8 +2894,8 @@ func TestMVCCReverseScan(t *testing.T) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, res.ResumeSpan)
 			}
 
-			res, err = MVCCScan(ctx, engine, testKey2, testKey4, 0, hlc.Timestamp{WallTime: 1},
-				MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey2, testKey4, -1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true, MaxKeys: -1})
 
 			if err != nil {
 				t.Fatal(err)
@@ -2903,8 +2909,8 @@ func TestMVCCReverseScan(t *testing.T) {
 
 			// The first key we encounter has multiple versions and we need to read the
 			// latest.
-			res, err = MVCCScan(ctx, engine, testKey2, testKey3, 1, hlc.Timestamp{WallTime: 4},
-				MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey2, testKey3, -1, hlc.Timestamp{WallTime: 4},
+				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
 				t.Fatal(err)
@@ -2917,8 +2923,8 @@ func TestMVCCReverseScan(t *testing.T) {
 
 			// The first key we encounter is newer than our read timestamp and we need to
 			// back up to the previous key.
-			res, err = MVCCScan(ctx, engine, testKey4, testKey6, 1, hlc.Timestamp{WallTime: 1},
-				MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey4, testKey6, -1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
 				t.Fatal(err)
@@ -2930,8 +2936,8 @@ func TestMVCCReverseScan(t *testing.T) {
 			}
 
 			// Scan only the first key in the key space.
-			res, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), 1, hlc.Timestamp{WallTime: 1},
-				MVCCScanOptions{Reverse: true})
+			res, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), -1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true, MaxKeys: 1})
 
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/storage/engine/pebble_mvcc_scanner.go
+++ b/pkg/storage/engine/pebble_mvcc_scanner.go
@@ -179,7 +179,7 @@ func (p *pebbleMVCCScanner) scan() (*roachpb.Span, error) {
 	}
 
 	var resume *roachpb.Span
-	if p.results.count == p.maxKeys && p.advanceKey() {
+	if p.maxKeys > 0 && p.results.count == p.maxKeys && p.advanceKey() {
 		if p.reverse {
 			// curKey was not added to results, so it needs to be included in the
 			// resume span.
@@ -356,7 +356,7 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 		// historical timestamp < the intent timestamp. However, we
 		// return the intent separately; the caller may want to resolve
 		// it.
-		if p.results.count == p.maxKeys {
+		if p.maxKeys > 0 && p.results.count == p.maxKeys {
 			// We've already retrieved the desired number of keys and now
 			// we're adding the resume key. We don't want to add the
 			// intent here as the intents should only correspond to KVs
@@ -409,7 +409,7 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 		// history that has a sequence number equal to or less than the read
 		// sequence, read that value.
 		if p.getFromIntentHistory() {
-			if p.results.count == p.maxKeys {
+			if p.maxKeys > 0 && p.results.count == p.maxKeys {
 				return false
 			}
 			return p.advanceKey()
@@ -564,7 +564,7 @@ func (p *pebbleMVCCScanner) addAndAdvance(val []byte) bool {
 			// TODO(bilal): see if this can be implemented more transparently.
 			p.maxKeys = p.results.count
 		}
-		if p.results.count == p.maxKeys {
+		if p.maxKeys > 0 && p.results.count == p.maxKeys {
 			return false
 		}
 	}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1585,10 +1585,10 @@ func (r *batchIterator) MVCCGet(
 }
 
 func (r *batchIterator) MVCCScan(
-	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
+	start, end roachpb.Key, timestamp hlc.Timestamp, opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
 	r.batch.flushMutations()
-	return r.iter.MVCCScan(start, end, max, timestamp, opts)
+	return r.iter.MVCCScan(start, end, timestamp, opts)
 }
 
 func (r *batchIterator) SetUpperBound(key roachpb.Key) {
@@ -2471,7 +2471,7 @@ func (r *rocksDBIterator) MVCCGet(
 }
 
 func (r *rocksDBIterator) MVCCScan(
-	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
+	start, end roachpb.Key, timestamp hlc.Timestamp, opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
 	if opts.Inconsistent && opts.Txn != nil {
 		return MVCCScanResult{}, errors.Errorf("cannot allow inconsistent reads within a transaction")

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2479,7 +2479,7 @@ func (r *rocksDBIterator) MVCCScan(
 	if len(end) == 0 {
 		return MVCCScanResult{}, emptyKeyError()
 	}
-	if max == 0 {
+	if opts.MaxKeys < 0 {
 		resumeSpan := &roachpb.Span{Key: start, EndKey: end}
 		return MVCCScanResult{ResumeSpan: resumeSpan}, nil
 	}
@@ -2487,7 +2487,7 @@ func (r *rocksDBIterator) MVCCScan(
 	r.clearState()
 	state := C.MVCCScan(
 		r.iter, goToCSlice(start), goToCSlice(end), goToCTimestamp(timestamp),
-		C.int64_t(max), C.int64_t(opts.TargetBytes),
+		C.int64_t(opts.MaxKeys), C.int64_t(opts.TargetBytes),
 		goToCTxn(opts.Txn), C.bool(opts.Inconsistent),
 		C.bool(opts.Reverse), C.bool(opts.Tombstones),
 		C.bool(opts.FailOnMoreRecent),

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -12,7 +12,6 @@ package engine
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -65,7 +64,7 @@ func TestIterStats(t *testing.T) {
 			// Scanning a key range containing the tombstone sees it.
 			for i := 0; i < 10; i++ {
 				if _, err := mvccScanToKvs(
-					ctx, iter, roachpb.KeyMin, roachpb.KeyMax, math.MaxInt64, hlc.Timestamp{}, MVCCScanOptions{},
+					ctx, iter, roachpb.KeyMin, roachpb.KeyMax, hlc.Timestamp{}, MVCCScanOptions{},
 				); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/engine/tee.go
+++ b/pkg/storage/engine/tee.go
@@ -1223,7 +1223,7 @@ func kvDataEqual(ctx context.Context, data1 []byte, data2 [][]byte) bool {
 
 // MVCCScan implements the MVCCIterator interface.
 func (t *TeeEngineIter) MVCCScan(
-	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
+	start, end roachpb.Key, timestamp hlc.Timestamp, opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
 	res1, err := mvccScanToBytes(t.ctx, t.iter1, start, end, timestamp, opts)
 	res2, err2 := mvccScanToBytes(t.ctx, t.iter2, start, end, timestamp, opts)

--- a/pkg/storage/engine/tee.go
+++ b/pkg/storage/engine/tee.go
@@ -1225,8 +1225,8 @@ func kvDataEqual(ctx context.Context, data1 []byte, data2 [][]byte) bool {
 func (t *TeeEngineIter) MVCCScan(
 	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
 ) (MVCCScanResult, error) {
-	res1, err := mvccScanToBytes(t.ctx, t.iter1, start, end, max, timestamp, opts)
-	res2, err2 := mvccScanToBytes(t.ctx, t.iter2, start, end, max, timestamp, opts)
+	res1, err := mvccScanToBytes(t.ctx, t.iter1, start, end, timestamp, opts)
+	res2, err2 := mvccScanToBytes(t.ctx, t.iter2, start, end, timestamp, opts)
 
 	if err := fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return MVCCScanResult{}, err

--- a/pkg/storage/engine/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/engine/testdata/mvcc_histories/max_keys
@@ -1,0 +1,88 @@
+# Test opts.MaxKeys.
+
+# Put some test data.
+run ok
+with ts=1,0
+  put      k=a v=val-a
+  put      k=aa v=val-aa
+  put      k=c v=val-c
+  put      k=e v=val-e
+del        k=aa ts=2,0
+----
+>> at end:
+data: "a"/0.000000001,0 -> /BYTES/val-a
+data: "aa"/0.000000002,0 -> /<empty>
+data: "aa"/0.000000001,0 -> /BYTES/val-aa
+data: "c"/0.000000001,0 -> /BYTES/val-c
+data: "e"/0.000000001,0 -> /BYTES/val-e
+
+# Limit 1 works.
+run ok
+with ts=300,0 k=a end=z max=1
+  scan
+  scan reverse=true
+----
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: resume span ["aa","z")
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: resume span ["a","c\x00")
+
+# Limit -1 works: nothing is returned, go straight to resume span. We use this
+# when executing the remaining scans in a batch after already exhausting the
+# batch-wide allowable number of rows returned.
+run ok
+with ts=300,0 k=a end=z max=-1
+  scan
+  scan reverse=true
+----
+scan: resume span ["a","z")
+scan: "a"-"z" -> <no data>
+scan: resume span ["a","z")
+scan: "a"-"z" -> <no data>
+
+# Limit and tombstones: the tombstones count.
+run ok
+with ts=300,0 k=a end=z max=2 tombstones=true
+  scan
+----
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "aa" -> /<empty> @0.000000002,0
+scan: resume span ["c","z")
+
+# Ditto in reverse.
+run ok
+with ts=300,0 k=a end=d max=2 tombstones=true reverse=true
+  scan
+----
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "aa" -> /<empty> @0.000000002,0
+scan: resume span ["a","a\x00")
+
+# No limit = zero limit = infinity limit (zero is preferred).
+run ok
+with ts=300,0 k=a end=z
+  scan
+  scan reverse=true
+  scan max=0
+  scan reverse=true max=0
+  scan max=99999
+  scan reverse=true max=9999
+----
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "a" -> /BYTES/val-a @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "e" -> /BYTES/val-e @0.000000001,0
+scan: "c" -> /BYTES/val-c @0.000000001,0
+scan: "a" -> /BYTES/val-a @0.000000001,0

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -235,7 +235,7 @@ func evaluateBatch(
 		var pErr *roachpb.Error
 
 		curResult, pErr = evaluateCommand(
-			ctx, idKey, index, readWriter, rec, ms, baHeader, baHeader.MaxSpanRequestKeys, args, reply)
+			ctx, idKey, index, readWriter, rec, ms, baHeader, args, reply)
 
 		// If an EndTxn wants to restart because of a write too old, we
 		// might have a better error to return to the client.
@@ -389,7 +389,6 @@ func evaluateCommand(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	h roachpb.Header,
-	maxKeys int64,
 	args roachpb.Request,
 	reply roachpb.Response,
 ) (result.Result, *roachpb.Error) {
@@ -420,7 +419,6 @@ func evaluateCommand(
 			EvalCtx: rec,
 			Header:  h,
 			Args:    args,
-			MaxKeys: maxKeys,
 			Stats:   ms,
 		}
 

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -13,7 +13,6 @@ package storage
 import (
 	"bytes"
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
@@ -235,19 +234,8 @@ func evaluateBatch(
 		var curResult result.Result
 		var pErr *roachpb.Error
 
-		// Translate from MaxSpanRequestKeys (0=unlimited, -1=nothing) to
-		// MVCC (0=nothing, infinity=unlimited).
-		//
-		// TODO(tbg): fix this in the MVCC layer and address long-standing TODO
-		// of moving the key count limit to MVCCScanOptions.
-		maxKeys := baHeader.MaxSpanRequestKeys
-		if maxKeys < 0 {
-			maxKeys = 0
-		} else if maxKeys == 0 {
-			maxKeys = math.MaxInt64
-		}
 		curResult, pErr = evaluateCommand(
-			ctx, idKey, index, readWriter, rec, ms, baHeader, maxKeys, args, reply)
+			ctx, idKey, index, readWriter, rec, ms, baHeader, baHeader.MaxSpanRequestKeys, args, reply)
 
 		// If an EndTxn wants to restart because of a write too old, we
 		// might have a better error to return to the client.

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -249,7 +249,7 @@ func (i *Iterator) MVCCGet(
 
 // MVCCScan is part of the engine.MVCCIterator interface.
 func (i *Iterator) MVCCScan(
-	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts engine.MVCCScanOptions,
+	start, end roachpb.Key, timestamp hlc.Timestamp, opts engine.MVCCScanOptions,
 ) (engine.MVCCScanResult, error) {
 	if i.spansOnly {
 		if err := i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
@@ -260,7 +260,7 @@ func (i *Iterator) MVCCScan(
 			return engine.MVCCScanResult{}, err
 		}
 	}
-	return i.i.(engine.MVCCIterator).MVCCScan(start, end, max, timestamp, opts)
+	return i.i.(engine.MVCCIterator).MVCCScan(start, end, timestamp, opts)
 }
 
 type spanSetReader struct {

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -122,7 +122,7 @@ func (tm *testModelRunner) getActualData() map[string]roachpb.Value {
 	// Scan over all TS Keys stored in the engine
 	startKey := keys.TimeseriesPrefix
 	endKey := startKey.PrefixEnd()
-	res, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, math.MaxInt64, tm.Clock.Now(), engine.MVCCScanOptions{})
+	res, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, tm.Clock.Now(), engine.MVCCScanOptions{})
 	if err != nil {
 		tm.t.Fatalf("error scanning TS data from engine: %s", err)
 	}


### PR DESCRIPTION
First two commits are https://github.com/cockroachdb/cockroach/pull/45008, please ignore them here.

----

For historical reasons, specifying maxKeys=0 meant "return no results".
Following the Go koan of "making the zero value useful", zero should
correspond to "no limit". In particular, maxKeys can move to
MVCCScanOptions, where it belongs.

This PR makes that change in two steps. First, it adds MaxKeys to
MVCCScanOptions and updates all callers to use it there. To keep
the review fun(ish), this first commit does not yet drop the original
maxKeys parameter that threads itself through large chunks of the
codebase. Instead, there are assertions that make sure the old one
is essentially unused: all callers will supply `-1` (=ignore me) or
`MaxInt64` (=ignore me). The next commit then drops these parameters
altogether.

Note that no external contracts were changed here, i.e., there isn't a
migration concern.

Release note: None

