### PR TITLE
ui: Parse splat params with react-router-v4

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.spec.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.spec.tsx
@@ -1,0 +1,75 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { assert } from "chai";
+import { shallow } from "enzyme";
+import { createMemoryHistory, History } from "history";
+import { match as Match } from "react-router-dom";
+
+import "src/enzymeInit";
+import { ClusterVisualization } from "./index";
+import { Breadcrumbs } from "./breadcrumbs";
+
+describe("ClusterVisualization", () => {
+  describe("parse tiers params from URL path", () => {
+    let history: History;
+    let match: Match;
+
+    beforeEach(() => {
+      history = createMemoryHistory();
+      match = {
+        path: "/overview/map",
+        params: {},
+        url: "http://localhost/overview/map",
+        isExact: true,
+      };
+    });
+
+    // parsed tiers from params are not stored in state and passed directly to <Breadcrumbs />
+    // component so we can validate the parsed result by checking Breadcrumbs props.
+    it("parses tiers as empty array for /overview/map path", () => {
+      const wrapper = shallow(
+        <ClusterVisualization
+          history={history}
+          location={history.location}
+          clusterDataError={null}
+          enterpriseEnabled={true}
+          licenseDataExists={true}
+          match={match}
+        />,
+      );
+      history.push("/overview/map");
+      wrapper.update();
+      assert.lengthOf(wrapper.find(Breadcrumbs).prop("tiers"), 0);
+    });
+
+    it("parses multiple tiers in path for `/overview/map/region=us-west/az=a` path", () => {
+      history.push("/overview/map/region=us-west/az=a");
+      const wrapper = shallow(
+        <ClusterVisualization
+          history={history}
+          location={history.location}
+          clusterDataError={null}
+          enterpriseEnabled={true}
+          licenseDataExists={true}
+          match={match}
+        />,
+      );
+
+      wrapper.update();
+      const expectedTiers = [
+        { key: "region", value: "us-west"},
+        { key: "az", value: "a"},
+      ];
+      assert.deepEqual(wrapper.find(Breadcrumbs).prop("tiers"), expectedTiers);
+    });
+  });
+});

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.spec.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.spec.tsx
@@ -1,12 +1,10 @@
 // Copyright 2020 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
 import React from "react";
 import { assert } from "chai";

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -20,9 +20,8 @@ import { parseLocalityRoute } from "src/util/localities";
 import Loading from "src/views/shared/components/loading";
 import { AdminUIState } from "src/redux/state";
 import { selectEnterpriseEnabled } from "src/redux/license";
-import { getMatchParamByName } from "src/util/query";
-
 import { Dropdown } from "src/components/dropdown";
+import { parseSplatParams } from "src/util/parseSplatParams";
 
 // tslint:disable-next-line:variable-name
 const NodeCanvasContent = swapByLicense(NeedEnterpriseLicense, NodeCanvasContainer);
@@ -43,9 +42,14 @@ export class ClusterVisualization extends React.Component<ClusterVisualizationPr
     this.props.history.push(`/overview/${value}`);
   }
 
+  getTiers() {
+    const { match, location } = this.props;
+    const splat = parseSplatParams(match, location);
+    return parseLocalityRoute(splat);
+  }
+
   render() {
-    const splat = getMatchParamByName(this.props.match, "splat");
-    const tiers = parseLocalityRoute(splat);
+    const tiers = this.getTiers();
 
     // TODO(couchand): integrate with license swapper
     const showingLicensePage = this.props.licenseDataExists && !this.props.enterpriseEnabled;

--- a/pkg/ui/src/util/parseSplatParams.spec.ts
+++ b/pkg/ui/src/util/parseSplatParams.spec.ts
@@ -1,0 +1,50 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { assert } from "chai";
+import { createMemoryHistory, History } from "history";
+import { match as Match } from "react-router-dom";
+import { parseSplatParams } from "./parseSplatParams";
+
+describe("parseSplatParams", () => {
+  let history: History;
+  let match: Match;
+
+  beforeEach(() => {
+    history = createMemoryHistory({initialEntries: ["/"]});
+    match = {
+      path: "/",
+      params: {},
+      url: "http://localhost/",
+      isExact: true,
+    };
+  });
+
+  it("returns remaining part of location path", () => {
+    history.push("/overview/map/region=us-west/zone=a");
+    match.path = "/overview/map/";
+
+    assert.equal(parseSplatParams(match, history.location), "region=us-west/zone=a");
+  });
+
+  it("trims out leading / from remaining path", () => {
+    history.push("/overview/map/region=us-west/zone=a");
+    match.path = "/overview/map";
+
+    assert.equal(parseSplatParams(match, history.location), "region=us-west/zone=a");
+  });
+
+  it("returns empty string if path is fully matched", () => {
+    history.push("/overview/map");
+    match.path = "/overview/map";
+
+    assert.equal(parseSplatParams(match, history.location), "");
+  });
+});

--- a/pkg/ui/src/util/parseSplatParams.ts
+++ b/pkg/ui/src/util/parseSplatParams.ts
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Location } from "history";
+import { match as Match } from "react-router-dom";
+
+/*
+* parseSplatParams function returns remaining part of the path
+* after matched part.
+* ```
+* For example:
+* match.path: `overview/map`
+* location.path: `overview/map/region=us-west/zone=a`
+* result: region=us-west/zone=a
+* ```
+*/
+export function parseSplatParams(match: Match, location: Location) {
+  let splat = location.pathname.replace(`${match.path}`, "");
+  if (splat.startsWith("/")) {
+    splat = splat.slice(1);
+  }
+  return splat;
+}


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/45033

Before, with react-router v3, it was possible
to get remaining part of path in splat param.
After upgrading to version 4, it isn't possible.
To achieve the same behavior `parseSplatParams` is
added.