### PR TITLE
storage/spanset: clarify and clean up "reversed" span checks

### DIFF
--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -81,11 +81,13 @@ func (i *Iterator) SeekGE(key engine.MVCCKey) {
 
 // SeekLT is part of the engine.Iterator interface.
 func (i *Iterator) SeekLT(key engine.MVCCKey) {
-	const spanKeyExclusive = true
+	// CheckAllowed{At} supports the span representation of [,key), which
+	// corresponds to the span [key.Prev(),).
+	revSpan := roachpb.Span{EndKey: key.Key}
 	if i.spansOnly {
-		i.err = i.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}, spanKeyExclusive)
+		i.err = i.spans.CheckAllowed(SpanReadOnly, revSpan)
 	} else {
-		i.err = i.spans.checkAllowedAt(SpanReadOnly, roachpb.Span{Key: key.Key}, i.ts, spanKeyExclusive)
+		i.err = i.spans.CheckAllowedAt(SpanReadOnly, revSpan, i.ts)
 	}
 	if i.err == nil {
 		i.invalid = false

--- a/pkg/storage/spanset/spanset_test.go
+++ b/pkg/storage/spanset/spanset_test.go
@@ -228,23 +228,23 @@ func TestSpanSetCheckAllowedReversed(t *testing.T) {
 
 	allowed := []roachpb.Span{
 		// Exactly as declared.
-		{Key: roachpb.Key("d")},
-		{Key: roachpb.Key("q")},
+		{EndKey: roachpb.Key("d")},
+		{EndKey: roachpb.Key("q")},
 	}
 	for _, span := range allowed {
-		if err := bdGkq.checkAllowed(SpanReadOnly, span, true /* spanKeyExclusive */); err != nil {
+		if err := bdGkq.CheckAllowed(SpanReadOnly, span); err != nil {
 			t.Errorf("expected %s to be allowed, but got error: %+v", span, err)
 		}
 	}
 
 	disallowed := []roachpb.Span{
 		// Points outside the declared spans, and on the endpoints.
-		{Key: roachpb.Key("b")},
-		{Key: roachpb.Key("g")},
-		{Key: roachpb.Key("k")},
+		{EndKey: roachpb.Key("b")},
+		{EndKey: roachpb.Key("g")},
+		{EndKey: roachpb.Key("k")},
 	}
 	for _, span := range disallowed {
-		if err := bdGkq.checkAllowed(SpanReadOnly, span, true /* spanKeyExclusive */); err == nil {
+		if err := bdGkq.CheckAllowed(SpanReadOnly, span); err == nil {
 			t.Errorf("expected %s to be disallowed", span)
 		}
 	}
@@ -261,23 +261,23 @@ func TestSpanSetCheckAllowedAtReversed(t *testing.T) {
 
 	allowed := []roachpb.Span{
 		// Exactly as declared.
-		{Key: roachpb.Key("d")},
-		{Key: roachpb.Key("q")},
+		{EndKey: roachpb.Key("d")},
+		{EndKey: roachpb.Key("q")},
 	}
 	for _, span := range allowed {
-		if err := bdGkq.checkAllowedAt(SpanReadOnly, span, ts, true /* spanKeyExclusive */); err != nil {
+		if err := bdGkq.CheckAllowedAt(SpanReadOnly, span, ts); err != nil {
 			t.Errorf("expected %s to be allowed, but got error: %+v", span, err)
 		}
 	}
 
 	disallowed := []roachpb.Span{
 		// Points outside the declared spans, and on the endpoints.
-		{Key: roachpb.Key("b")},
-		{Key: roachpb.Key("g")},
-		{Key: roachpb.Key("k")},
+		{EndKey: roachpb.Key("b")},
+		{EndKey: roachpb.Key("g")},
+		{EndKey: roachpb.Key("k")},
 	}
 	for _, span := range disallowed {
-		if err := bdGkq.checkAllowedAt(SpanReadOnly, span, ts, true /* spanKeyExclusive */); err == nil {
+		if err := bdGkq.CheckAllowedAt(SpanReadOnly, span, ts); err == nil {
 			t.Errorf("expected %s to be disallowed", span)
 		}
 	}


### PR DESCRIPTION
The notion of "reversed" span checks was introduced in 5176bac. That was a good change which allowed for proper validation of spans when using `spanset.Iterator.SeekLT`. However, the semantics around the `reversed` argument added to `SpanSet.checkAllowed` were strange and under-specified. Now that the start key of the span was exclusive, what did it mean to provide a reversed multi-key span to `checkAllowed`? Was the start key before or after the end key? Was it ok that only the exclusive portion of the span was being provided by all callers? Were reversed multi-key spans even supported? The comment said that "the reversed arguments makes the lower bound exclusive and the upper bound inclusive, i.e. [a,b) will be considered (a,b]". It's unclear whether this was mistakenly meaning that "[a,b) will be considered (b,a]". This all led to a terribly confusing condition: https://github.com/cockroachdb/cockroach/blob/5d69fd053ba52ae7ce94567b7b5fbb7cd857f1af/pkg/storage/spanset/spanset.go#L197.

This commit clarifies these semantics by removing the `reversed` flag while retaining roughly the same idea in a way that's consistent with the existing meaning of a "Span". `SpanSet.checkAllowed` now supports an extended span format with a nil start key and a non-nil end key (e.g. "[nil, c)"). In this form, s2.Key (inclusive) is considered to be the previous key to s2.EndKey (exclusive). This avoids any ambiguity around multi-key "reversed" spans and fits in better with the existing definition of a Span.