### PR TITLE
colflow: fix vectorized flow temporary directory creation

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -218,6 +218,10 @@ type DiskQueueCfg struct {
 	// rolling over to a new one.
 	MaxFileSizeBytes int
 
+	// OnNewDiskQueueCb is an optional callback function that will be called when
+	// NewDiskQueue is called.
+	OnNewDiskQueueCb func()
+
 	// TestingKnobs are used to test the queue implementation.
 	TestingKnobs struct {
 		// AlwaysCompress, if true, will skip a check that determines whether
@@ -247,6 +251,9 @@ func (cfg *DiskQueueCfg) EnsureDefaults() error {
 func NewDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) (Queue, error) {
 	if err := cfg.EnsureDefaults(); err != nil {
 		return nil, err
+	}
+	if cfg.OnNewDiskQueueCb != nil {
+		cfg.OnNewDiskQueueCb()
 	}
 	d := &diskQueue{
 		dirName: uuid.FastMakeV4().String(),

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -436,8 +436,12 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 	}
 	f.status = FlowFinished
 	f.ctxCancel()
-	f.doneFn()
-	sp.Finish()
+	if f.doneFn != nil {
+		f.doneFn()
+	}
+	if sp != nil {
+		sp.Finish()
+	}
 }
 
 // cancel iterates through all unconnected streams of this flow and marks them canceled.


### PR DESCRIPTION
This commit fixes a bug where local flows would create the directory with the
same name, since their IDs are unset, and the flow ID is used as a directory
name. When calling Cleanup() on one of these flows, it would delete the
directory that the other flow was using. This is now fixed by checking for an
unset FlowID and generating a directory name with "local-flow" as the prefix
followed by a generated UUID.

Additionally, temporary directory creation is now lazy using a callback on the
DiskQueue. When the first DiskQueue is created, this callback will set an
atomic on the flow to indicate directory creation and proceed with creating
the flow's directory. On Cleanup(), this atomic is checked to see if a
directory needs to be cleaned up.

Release note: None (no release shipped with bug)