### PR TITLE
sql: fix bug with primary key swap not setting encoding and columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -573,3 +573,15 @@ query III
 SELECT * FROM t@i
 ----
 1 2 3
+
+# Regression for old primary key not using PrimaryIndexEncoding as its encoding type.
+subtest encoding_bug
+
+# This test ensures that while the old primary key is in the mutations list it is
+# able to be updated and deleted with the primary index encoding.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, FAMILY (x, y, z));
+INSERT INTO t VALUES (1, 2, 3);
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (z);
+UPDATE t SET y = 3 WHERE z = 3


### PR DESCRIPTION
This PR fixes a bug where the primary key swap operation
during the primary key change process would not set the
encoding for the old primary index to be PrimaryIndexEncoding,
and would not include the columns that the old index stores.
This could cause a variety of potential errors, such as
errors during updates and inserts while some nodes have the
old primary index in the `DELETE_AND_WRITE_ONLY` state
and others still have the old index as the primary key.

Release note: None