### PR TITLE
jobs: allow Reverting jobs to have status and progress updates

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -42,9 +42,10 @@ type JobMetadata struct {
 	Progress *jobspb.Progress
 }
 
-// CheckRunning returns an InvalidStatusError if md.Status is not StatusRunning.
-func (md *JobMetadata) CheckRunning() error {
-	if md.Status != StatusRunning {
+// CheckRunningOrReverting returns an InvalidStatusError if md.Status is not
+// StatusRunning or StatusReverting.
+func (md *JobMetadata) CheckRunningOrReverting() error {
+	if md.Status != StatusRunning && md.Status != StatusReverting {
 		return &InvalidStatusError{md.ID, md.Status, "update progress on", md.Payload.Error}
 	}
 	return nil


### PR DESCRIPTION
Previously only `Running` jobs could have their status and progress updated.
This PR updates `JobMetadata.CheckRunning()` to also allow those updates on
`Reverting` jobs, as part of bringing the contract of reverting jobs in line
with running jobs.

Release note: None