### PR TITLE
roachprod: switch apache.org subdomain from www-eu to www

### DIFF
--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -39,7 +39,7 @@ sudo service cassandra stop;
     sudo mkdir -p "${thrift_dir}"
     sudo chmod 777 "${thrift_dir}"
     cd "${thrift_dir}"
-    curl "http://www-eu.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz" | sudo tar xvz --strip-components 1
+    curl "http://www.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz" | sudo tar xvz --strip-components 1
     sudo ./configure --prefix=/usr
     sudo make -j$(nproc)
     sudo make install


### PR DESCRIPTION
Fixes #44672.
Fixes #44674.
Fixes #44743.
Fixes #44801.

I saw this immediately when trying to reproduce #44105. The non-eu subdomain seems to be working much better.

Unfortunately, I haven't been able to figure out a fix for #44105 yet. I'm seeing the same thing as https://github.com/cockroachdb/cockroach/issues/41530#issuecomment-541343528. `charybdefs` creates the log dir as root so we get a permission error before starting the rest of the test.