### PR TITLE
vendor: bump pebble to b9b70cfab7dac7e8427b11ee6b145fa5ab4db487

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b9ff2b36e421c1acce4c33a359e3757e0802b71b1def7ff81362c30a95878467"
+  digest = "1:4ab04b62cf7bccc6112aba859e91c968e65ec2d6514a4f22c2d6a0a25c9eec00"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -486,6 +486,7 @@
     "internal/humanize",
     "internal/invariants",
     "internal/manifest",
+    "internal/manual",
     "internal/private",
     "internal/rangedel",
     "internal/rate",
@@ -496,7 +497,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "dc0074b9a99adde01cda1afdfbcee4a6e1f2ed98"
+  revision = "9fa17a27f5d9d849ae4da919535c77f837dfcd2e"
 
 [[projects]]
   branch = "master"

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -191,6 +191,8 @@ func TestPebbleEncryption(t *testing.T) {
 
 	opts := engine.DefaultPebbleOptions()
 	opts.Cache = pebble.NewCache(1 << 20)
+	defer opts.Cache.Unref()
+
 	memFS := vfs.NewMem()
 	opts.FS = memFS
 	keyFile128 := "111111111111111111111111111111111234567890123456"
@@ -238,6 +240,8 @@ func TestPebbleEncryption(t *testing.T) {
 
 	opts2 := engine.DefaultPebbleOptions()
 	opts2.Cache = pebble.NewCache(1 << 20)
+	defer opts2.Cache.Unref()
+
 	opts2.FS = memFS
 	db, err = engine.NewPebble(
 		context.Background(),

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -147,6 +147,8 @@ func OpenEngine(dir string, stopper *stop.Stopper, opts OpenEngineOptions) (engi
 			Opts:          engine.DefaultPebbleOptions(),
 		}
 		cfg.Opts.Cache = pebble.NewCache(server.DefaultCacheSize)
+		defer cfg.Opts.Cache.Unref()
+
 		cfg.Opts.MaxOpenFiles = int(maxOpenFiles)
 		cfg.Opts.ReadOnly = opts.ReadOnly
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -432,6 +432,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 	if cfg.StorageEngine == enginepb.EngineTypePebble || cfg.StorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
 		details = append(details, fmt.Sprintf("Pebble cache size: %s", humanizeutil.IBytes(cfg.CacheSize)))
 		pebbleCache = pebble.NewCache(cfg.CacheSize)
+		defer pebbleCache.Unref()
 	} else if cfg.StorageEngine == enginepb.EngineTypeRocksDB || cfg.StorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
 		details = append(details, fmt.Sprintf("RocksDB cache size: %s", humanizeutil.IBytes(cfg.CacheSize)))
 		cache = engine.NewRocksDBCache(cfg.CacheSize)

--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -26,21 +26,19 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-func testPebbleOptions(fs vfs.FS) *pebble.Options {
-	opts := DefaultPebbleOptions()
-	opts.Cache = pebble.NewCache(testCacheSize)
-	opts.FS = fs
-	return opts
-}
-
 func setupMVCCPebble(b testing.TB, dir string) Engine {
+	opts := DefaultPebbleOptions()
+	opts.FS = vfs.Default
+	opts.Cache = pebble.NewCache(testCacheSize)
+	defer opts.Cache.Unref()
+
 	peb, err := NewPebble(
 		context.Background(),
 		PebbleConfig{
 			StorageConfig: base.StorageConfig{
 				Dir: dir,
 			},
-			Opts: testPebbleOptions(vfs.Default),
+			Opts: opts,
 		})
 	if err != nil {
 		b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
@@ -49,10 +47,15 @@ func setupMVCCPebble(b testing.TB, dir string) Engine {
 }
 
 func setupMVCCInMemPebble(b testing.TB, loc string) Engine {
+	opts := DefaultPebbleOptions()
+	opts.FS = vfs.NewMem()
+	opts.Cache = pebble.NewCache(testCacheSize)
+	defer opts.Cache.Unref()
+
 	peb, err := NewPebble(
 		context.Background(),
 		PebbleConfig{
-			Opts: testPebbleOptions(vfs.NewMem()),
+			Opts: opts,
 		})
 	if err != nil {
 		b.Fatalf("could not create new in-mem pebble instance: %+v", err)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -534,6 +534,8 @@ func NewEngine(
 			Opts:          DefaultPebbleOptions(),
 		}
 		pebbleConfig.Opts.Cache = pebble.NewCache(cacheSize)
+		defer pebbleConfig.Opts.Cache.Unref()
+
 		pebbleConfig.Dir = filepath.Join(pebbleConfig.Dir, "pebble")
 		cache := NewRocksDBCache(cacheSize)
 		defer cache.Release()
@@ -558,6 +560,7 @@ func NewEngine(
 			Opts:          DefaultPebbleOptions(),
 		}
 		pebbleConfig.Opts.Cache = pebble.NewCache(cacheSize)
+		defer pebbleConfig.Opts.Cache.Unref()
 
 		return NewPebble(context.Background(), pebbleConfig)
 	case enginepb.EngineTypeRocksDB:

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -1309,13 +1310,18 @@ var engineRealFSImpls = []struct {
 	}},
 	{"pebble", func(t *testing.T, dir string) Engine {
 
+		opts := DefaultPebbleOptions()
+		opts.FS = vfs.Default
+		opts.Cache = pebble.NewCache(testCacheSize)
+		defer opts.Cache.Unref()
+
 		db, err := NewPebble(
 			context.Background(),
 			PebbleConfig{
 				StorageConfig: base.StorageConfig{
 					Dir: dir,
 				},
-				Opts: testPebbleOptions(vfs.Default),
+				Opts: opts,
 			})
 		if err != nil {
 			t.Fatalf("could not create new pebble instance at %s: %+v", dir, err)

--- a/pkg/storage/engine/metamorphic/generator.go
+++ b/pkg/storage/engine/metamorphic/generator.go
@@ -53,6 +53,7 @@ func createTestPebbleEngine(path string) (engine.Engine, error) {
 		Opts:          engine.DefaultPebbleOptions(),
 	}
 	pebbleConfig.Opts.Cache = pebble.NewCache(1 << 20)
+	defer pebbleConfig.Opts.Cache.Unref()
 
 	return engine.NewPebble(context.Background(), pebbleConfig)
 }

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -431,6 +431,8 @@ func newTeeInMem(ctx context.Context, attrs roachpb.Attributes, cacheSize int64)
 func newPebbleInMem(ctx context.Context, attrs roachpb.Attributes, cacheSize int64) *Pebble {
 	opts := DefaultPebbleOptions()
 	opts.Cache = pebble.NewCache(cacheSize)
+	defer opts.Cache.Unref()
+
 	opts.FS = vfs.NewMem()
 	db, err := NewPebble(
 		ctx,

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -135,6 +135,8 @@ func NewPebbleTempEngine(
 	// Pebble doesn't currently support 0-size caches, so use a 128MB cache for
 	// now.
 	opts.Cache = pebble.NewCache(128 << 20)
+	defer opts.Cache.Unref()
+
 	// The Pebble temp engine does not use MVCC Encoding. Instead, the
 	// caller-provided key is used as-is (with the prefix prepended). See
 	// pebbleMap.makeKey and pebbleMap.makeKeyWithSequence on how this works.


### PR DESCRIPTION
* db: manually managed memTable arena memory
* sstable: Unset external format version for self-made SSTs
* sstable: document "rocksdb.external_sst_file.version" property
* internal/cache: explicitly manage Cache lifetime
* internal/cache: add robinHoodMap
* docs: add doc describing manual memory management
* ci: add no-invariants test configuration
* internal/cache: optimize allocation of entry objects
* internal/cache: optimize allocation of manual Values
* internal/cache: move the bulk of allocations off the Go heap
* db: properly lock compaction picking and ingestion
* db: fix WAL replay in read-only mode
* ci: trim down build matrix
* ci: only build PRs targeted at master
* db: better ingestion heuristic
* db: move flushable and flushableEntry to their own file
* db: add flushableEntry which wraps a flushable
* internal/arenaskl: remove extValueThreshold detritus

Release note: None