### PR TITLE
sql: reorganize plan tree collection code

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -38,7 +38,6 @@ type stmtKey struct {
 	stmt        string
 	failed      bool
 	distSQLUsed bool
-	optUsed     bool
 	implicitTxn bool
 }
 
@@ -116,9 +115,6 @@ func (s stmtKey) flags() string {
 	if s.distSQLUsed {
 		b.WriteByte('+')
 	}
-	if !s.optUsed {
-		b.WriteByte('-')
-	}
 	return b.String()
 }
 
@@ -129,7 +125,6 @@ func (a *appStats) recordStatement(
 	stmt *Statement,
 	samplePlanDescription *roachpb.ExplainTreePlanNode,
 	distSQLUsed bool,
-	optUsed bool,
 	implicitTxn bool,
 	automaticRetryCount int,
 	numRows int,
@@ -146,7 +141,7 @@ func (a *appStats) recordStatement(
 	}
 
 	// Get the statistics object.
-	s := a.getStatsForStmt(stmt, distSQLUsed, optUsed, implicitTxn, err, true /* createIfNonexistent */)
+	s := a.getStatsForStmt(stmt, distSQLUsed, implicitTxn, err, true /* createIfNonexistent */)
 
 	// Collect the per-statement statistics.
 	s.Lock()
@@ -177,16 +172,11 @@ func (a *appStats) recordStatement(
 
 // getStatsForStmt retrieves the per-stmt stat object.
 func (a *appStats) getStatsForStmt(
-	stmt *Statement,
-	distSQLUsed bool,
-	optimizerUsed bool,
-	implicitTxn bool,
-	err error,
-	createIfNonexistent bool,
+	stmt *Statement, distSQLUsed bool, implicitTxn bool, err error, createIfNonexistent bool,
 ) *stmtStats {
 	// Extend the statement key with various characteristics, so
 	// that we use separate buckets for the different situations.
-	key := stmtKey{failed: err != nil, distSQLUsed: distSQLUsed, optUsed: optimizerUsed, implicitTxn: implicitTxn}
+	key := stmtKey{failed: err != nil, distSQLUsed: distSQLUsed, implicitTxn: implicitTxn}
 	if stmt.AnonymizedStr != "" {
 		// Use the cached anonymized string.
 		key.stmt = stmt.AnonymizedStr
@@ -413,7 +403,7 @@ func (s *sqlStats) getStmtStats(
 				k := roachpb.StatementStatisticsKey{
 					Query:       maybeScrubbed,
 					DistSQL:     q.distSQLUsed,
-					Opt:         q.optUsed,
+					Opt:         true,
 					ImplicitTxn: q.implicitTxn,
 					Failed:      q.failed,
 					App:         maybeHashedAppName,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -291,7 +291,6 @@ func makeMetrics(internal bool) Metrics {
 	return Metrics{
 		EngineMetrics: EngineMetrics{
 			DistSQLSelectCount:    metric.NewCounter(getMetricMeta(MetaDistSQLSelect, internal)),
-			SQLOptCount:           metric.NewCounter(getMetricMeta(MetaSQLOpt, internal)),
 			SQLOptFallbackCount:   metric.NewCounter(getMetricMeta(MetaSQLOptFallback, internal)),
 			SQLOptPlanCacheHits:   metric.NewCounter(getMetricMeta(MetaSQLOptPlanCacheHits, internal)),
 			SQLOptPlanCacheMisses: metric.NewCounter(getMetricMeta(MetaSQLOptPlanCacheMisses, internal)),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -636,13 +636,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		res.DisableBuffering()
 	}
 
-	// Ensure that the plan is collected just before closing.
-	if sampleLogicalPlans.Get(&ex.appStats.st.SV) {
-		planner.curPlan.maybeSavePlan = func(ctx context.Context) *roachpb.ExplainTreePlanNode {
-			return ex.maybeSavePlan(ctx, planner)
-		}
-	}
-
 	defer func() {
 		planner.maybeLogStatement(
 			ctx,
@@ -733,37 +726,13 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 // makeExecPlan creates an execution plan and populates planner.curPlan, using
 // either the optimizer or the heuristic planner.
 func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) error {
-	stmt := planner.stmt
-	// Initialize planner.curPlan.AST early; it might be used by maybeLogStatement
-	// in error cases.
-	planner.curPlan = planTop{AST: stmt.AST}
+	planner.curPlan.init(planner.stmt, ex.appStats)
 
-	log.VEvent(ctx, 2, "generating optimizer plan")
 	if err := planner.makeOptimizerPlan(ctx); err != nil {
 		log.VEventf(ctx, 1, "optimizer plan failed: %v", err)
 		return err
 	}
 	return nil
-}
-
-// saveLogicalPlanDescription returns whether we should save this as a sample logical plan
-// for its corresponding fingerprint. We use `logicalPlanCollectionPeriod`
-// to assess how frequently to sample logical plans.
-func (ex *connExecutor) saveLogicalPlanDescription(
-	stmt *Statement, useDistSQL bool, implicitTxn bool, err error,
-) bool {
-	stats := ex.appStats.getStatsForStmt(
-		stmt, useDistSQL, implicitTxn, err, false /* createIfNonexistent */)
-	if stats == nil {
-		// Save logical plan the first time we see new statement fingerprint.
-		return true
-	}
-	now := timeutil.Now()
-	period := logicalPlanCollectionPeriod.Get(&ex.appStats.st.SV)
-	stats.Lock()
-	defer stats.Unlock()
-	timeLastSampled := stats.data.SensitiveInfo.MostRecentPlanTimestamp
-	return now.Sub(timeLastSampled) >= period
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -750,10 +750,10 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 // for its corresponding fingerprint. We use `logicalPlanCollectionPeriod`
 // to assess how frequently to sample logical plans.
 func (ex *connExecutor) saveLogicalPlanDescription(
-	stmt *Statement, useDistSQL bool, optimizerUsed bool, implicitTxn bool, err error,
+	stmt *Statement, useDistSQL bool, implicitTxn bool, err error,
 ) bool {
 	stats := ex.appStats.getStatsForStmt(
-		stmt, useDistSQL, optimizerUsed, implicitTxn, err, false /* createIfNonexistent */)
+		stmt, useDistSQL, implicitTxn, err, false /* createIfNonexistent */)
 	if stats == nil {
 		// Save logical plan the first time we see new statement fingerprint.
 		return true

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -164,7 +164,7 @@ func (p *planner) maybeLogStatementInternal(
 		logTrigger = buf.String()
 	}
 
-	stmtStr := p.curPlan.AST.String()
+	stmtStr := p.curPlan.stmt.AST.String()
 
 	plStr := p.extendedEvalCtx.Placeholders.Values.String()
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -263,12 +263,6 @@ var (
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-	MetaSQLOpt = metric.Metadata{
-		Name:        "sql.optimizer.count",
-		Help:        "Number of statements which ran with the cost-based optimizer",
-		Measurement: "SQL Statements",
-		Unit:        metric.Unit_COUNT,
-	}
 	MetaSQLOptFallback = metric.Metadata{
 		Name:        "sql.optimizer.fallback.count",
 		Help:        "Number of statements which the cost-based optimizer was unable to plan",
@@ -1968,7 +1962,6 @@ func (s *sqlStatsCollector) recordStatement(
 	stmt *Statement,
 	samplePlanDescription *roachpb.ExplainTreePlanNode,
 	distSQLUsed bool,
-	optUsed bool,
 	implicitTxn bool,
 	automaticRetryCount int,
 	numRows int,
@@ -1977,7 +1970,7 @@ func (s *sqlStatsCollector) recordStatement(
 	bytesRead, rowsRead int64,
 ) {
 	s.appStats.recordStatement(
-		stmt, samplePlanDescription, distSQLUsed, optUsed, implicitTxn, automaticRetryCount, numRows, err,
+		stmt, samplePlanDescription, distSQLUsed, implicitTxn, automaticRetryCount, numRows, err,
 		parseLat, planLat, runLat, svcLat, ovhLat, bytesRead, rowsRead)
 }
 

--- a/pkg/sql/metric_util_test.go
+++ b/pkg/sql/metric_util_test.go
@@ -26,7 +26,6 @@ func initializeQueryCounter(s serverutils.TestServerInterface) queryCounter {
 		txnBeginCount:                   s.MustGetSQLCounter(sql.MetaTxnBeginStarted.Name),
 		selectCount:                     s.MustGetSQLCounter(sql.MetaSelectStarted.Name),
 		selectExecutedCount:             s.MustGetSQLCounter(sql.MetaSelectExecuted.Name),
-		optCount:                        s.MustGetSQLCounter(sql.MetaSQLOpt.Name),
 		distSQLSelectCount:              s.MustGetSQLCounter(sql.MetaDistSQLSelect.Name),
 		updateCount:                     s.MustGetSQLCounter(sql.MetaUpdateStarted.Name),
 		insertCount:                     s.MustGetSQLCounter(sql.MetaInsertStarted.Name),

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -421,12 +421,9 @@ func (p *planner) maybeSetSystemConfig(id sqlbase.ID) error {
 type planFlags uint32
 
 const (
-	// planFlagOptUsed is set if the optimizer was used to create the plan.
-	planFlagOptUsed planFlags = (1 << iota)
-
 	// planFlagOptCacheHit is set if a plan from the query plan cache was used (and
 	// re-optimized).
-	planFlagOptCacheHit
+	planFlagOptCacheHit = (1 << iota)
 
 	// planFlagOptCacheMiss is set if we looked for a plan in the query plan cache but
 	// did not find one.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -269,8 +269,8 @@ var _ planNodeSpooled = &spoolNode{}
 // TODO(jordan): investigate whether/how per-plan state like
 // placeholder data can be concentrated in a single struct.
 type planTop struct {
-	// AST is the syntax tree for the current statement.
-	AST tree.Statement
+	// stmt is a reference to the current statement (AST and other metadata).
+	stmt *Statement
 
 	// plan is the top-level node of the logical plan.
 	plan planNode
@@ -299,17 +299,11 @@ type planTop struct {
 	// execErr retains the last execution error, if any.
 	execErr error
 
-	// maybeSavePlan, if defined, is called during close() to
-	// conditionally save the logical plan to savedPlanForStats.
-	maybeSavePlan func(context.Context) *roachpb.ExplainTreePlanNode
-
-	// savedPlanForStats is conditionally populated at the end of
-	// statement execution, for registration in statement statistics.
-	savedPlanForStats *roachpb.ExplainTreePlanNode
-
 	// avoidBuffering, when set, causes the execution to avoid buffering
 	// results.
 	avoidBuffering bool
+
+	instrumentation planInstrumentation
 }
 
 // postquery is a query tree that is executed after the main one. It can only
@@ -318,12 +312,17 @@ type postquery struct {
 	plan planNode
 }
 
+// init resets planTop to point to a given statement; used at the start of the
+// planning process.
+func (p *planTop) init(stmt *Statement, appStats *appStats) {
+	*p = planTop{stmt: stmt}
+	p.instrumentation.init(appStats)
+}
+
 // close ensures that the plan's resources have been deallocated.
 func (p *planTop) close(ctx context.Context) {
 	if p.plan != nil {
-		if p.maybeSavePlan != nil && p.flags.IsSet(planFlagExecDone) {
-			p.savedPlanForStats = p.maybeSavePlan(ctx)
-		}
+		p.instrumentation.savePlanInfo(ctx, p)
 		p.plan.Close(ctx)
 		p.plan = nil
 	}
@@ -451,4 +450,30 @@ func (pf planFlags) IsSet(flag planFlags) bool {
 
 func (pf *planFlags) Set(flag planFlags) {
 	*pf |= flag
+}
+
+// planInstrumentation handles collection of plan information before the plan is
+// closed.
+type planInstrumentation struct {
+	appStats          *appStats
+	savedPlanForStats *roachpb.ExplainTreePlanNode
+}
+
+func (pi *planInstrumentation) init(appStats *appStats) {
+	pi.appStats = appStats
+}
+
+// savePlanInfo is called before the plan is closed.
+func (pi *planInstrumentation) savePlanInfo(ctx context.Context, curPlan *planTop) {
+	if !curPlan.flags.IsSet(planFlagExecDone) {
+		return
+	}
+	if pi.appStats != nil && pi.appStats.shouldSaveLogicalPlanDescription(
+		curPlan.stmt,
+		curPlan.flags.IsSet(planFlagDistributed),
+		curPlan.flags.IsSet(planFlagImplicitTxn),
+		curPlan.execErr,
+	) {
+		pi.savedPlanForStats = planToTree(ctx, curPlan)
+	}
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -170,7 +170,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	}
 
 	result := plan.(*planTop)
-	result.AST = stmt.AST
+	result.stmt = stmt
 	result.flags = opc.flags
 
 	cols := planColumns(result.plan)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -37,8 +37,6 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 //  - Types
 //  - AnonymizedStr
 //  - Memo (for reuse during exec, if appropriate).
-//
-// On success, the returned flags always have planFlagOptUsed set.
 func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) {
 	stmt := p.stmt
 
@@ -151,8 +149,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 }
 
 // makeOptimizerPlan generates a plan using the cost-based optimizer.
-// On success, it populates p.curPlan (and the flags always have
-// planFlagOptUsed set).
+// On success, it populates p.curPlan.
 func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	stmt := p.stmt
 
@@ -221,7 +218,7 @@ func (opc *optPlanningCtx) reset() {
 	p := opc.p
 	opc.catalog.reset()
 	opc.optimizer.Init(p.EvalContext(), &opc.catalog)
-	opc.flags = planFlagOptUsed
+	opc.flags = 0
 
 	// We only allow memo caching for SELECT/INSERT/UPDATE/DELETE. We could
 	// support it for all statements in principle, but it would increase the


### PR DESCRIPTION
#### opt: remove "optimizer used" flag and metric

Remove the flag and metric that indicates when the optimizer is used
(since it's always used now).

Release note: None

#### sql: reorganize plan tree collection code

This change reorganizes the code responsible for periodically
extracting the execution plan that shows up in the UI. We encapsulate
the logic into a `planInstrumentation` type, which will allow easily
adding other usecases for extracting plan info before close.

Release note: None
