### PR TITLE
roachprod: fix permission error in disk-stalled/log=true,data=false

### DIFF
--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -59,7 +59,9 @@ func runDiskStalledDetection(
 	if err := execCmd(ctx, t.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real && chmod 777 {store-dir}/{real,faulty}")
+	c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real")
+	c.Run(ctx, n, "sudo mkdir -p {store-dir}/real/logs")
+	c.Run(ctx, n, "sudo chmod -R 777 {store-dir}/{real,faulty}")
 	l, err := t.l.ChildLogger("cockroach")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #44105.
Related to #45111.

This change creates the `/mnt/data1/cockroach/real/logs` directory and manually
sets its permissions before starting Cockroach. Doing so ensures that `charybdefs`
doesn't create the directory as root and cause the permission errors we've been
seeing.

```
=== RUN   disk-stalled/log=true,data=false
=== RUN   disk-stalled/log=false,data=true
=== RUN   disk-stalled/log=true,data=true
=== RUN   disk-stalled/log=false,data=false
--- PASS: disk-stalled/log=true,data=false (444.50s)
--- PASS: disk-stalled/log=false,data=true (430.55s)
--- PASS: disk-stalled/log=true,data=true (429.77s)
--- PASS: disk-stalled/log=false,data=false (427.97s)
```