### PR TITLE
ui: show a hint when a RPC result encounters HTTP 403

### DIFF
--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -142,6 +142,15 @@ export function toArrayBuffer(encodedRequest: Uint8Array): ArrayBuffer {
   return encodedRequest.buffer.slice(encodedRequest.byteOffset, encodedRequest.byteOffset + encodedRequest.byteLength);
 }
 
+export class RequestError extends Error {
+  status: number;
+  constructor(statusText: string, status: number) {
+    super(statusText);
+    this.status = status;
+    this.name = "RequestError";
+  }
+}
+
 // timeoutFetch is a wrapper around fetch that provides timeout and protocol
 // buffer marshaling and unmarshalling.
 //
@@ -173,7 +182,7 @@ function timeoutFetch<TResponse$Properties, TResponse, TResponseBuilder extends 
 
   return withTimeout(fetch(url, params), timeout).then((res) => {
     if (!res.ok) {
-      throw Error(res.statusText);
+      throw new RequestError(res.statusText, res.status);
     }
     return res.arrayBuffer().then((buffer) => builder.decode(new Uint8Array(buffer)));
   });

--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -30,6 +30,7 @@ export const cancelJob = docsURL("cancel-job.html");
 export const enableNodeMap = docsURL("enable-node-map.html");
 export const configureReplicationZones = docsURL("configure-replication-zones.html");
 export const transactionalPipelining = docsURL("architecture/transaction-layer.html#transaction-pipelining");
+export const adminUIAccess = docsURL("admin-ui-overview.html#admin-ui-access");
 
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.

--- a/pkg/ui/src/views/shared/components/loading/index.styl
+++ b/pkg/ui/src/views/shared/components/loading/index.styl
@@ -11,7 +11,7 @@
 @require "~styl/base/palette.styl"
 
 .loading-error
-  padding 10px
+  padding 10px 20px 10px 20px
   border thin solid $notification-alert-border-color
   background $notification-alert-fill-color
   border-radius 5px

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -8,9 +8,10 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
+import React, { ReactNode } from "react";
 import { RequestError } from "src/util/api";
 import spinner from "assets/spinner.gif";
+import { adminUIAccess } from "src/util/docs";
 import "./index.styl";
 
 interface LoadingProps {
@@ -45,13 +46,19 @@ function getValidErrorsList (errors?: Error | Error[] | null): Error[] | null {
 /**
  * getDetails produces a hint for the given error object.
  */
-function getDetails (error: Error): string {
+function getDetails (error: Error): ReactNode {
   if (error instanceof RequestError) {
      if (error.status === 403) {
-       return "insufficient privileges to view this resource";
+       return (
+         <p>
+           Insufficient privileges to view this resource. <a href={adminUIAccess} target="_blank">
+             Learn more
+           </a>
+         </p>
+       );
      }
   }
-  return "no details available";
+  return <p>no details available</p>;
 }
 
 /**
@@ -77,7 +84,7 @@ export default function Loading(props: LoadingProps) {
         <ul>
           {errors.map((error, idx) => (
             <li key={idx}><b>{error.message}</b>
-            <p>{getDetails(error)}</p></li>
+            {getDetails(error)}</li>
           ))}
         </ul>
       </div>

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import React from "react";
-
+import { RequestError } from "src/util/api";
 import spinner from "assets/spinner.gif";
 import "./index.styl";
 
@@ -43,6 +43,18 @@ function getValidErrorsList (errors?: Error | Error[] | null): Error[] | null {
 }
 
 /**
+ * getDetails produces a hint for the given error object.
+ */
+function getDetails (error: Error): string {
+  if (error instanceof RequestError) {
+     if (error.status === 403) {
+       return "insufficient privileges to view this resource";
+     }
+  }
+  return "no details available";
+}
+
+/**
  * Loading will display a background image instead of the content if the
  * loading prop is true.
  */
@@ -64,9 +76,8 @@ export default function Loading(props: LoadingProps) {
         <p>{errorCountMessage} while loading this data:</p>
         <ul>
           {errors.map((error, idx) => (
-            <li key={idx}>
-              <pre>{error.message}</pre>
-            </li>
+            <li key={idx}><b>{error.message}</b>
+            <p>{getDetails(error)}</p></li>
           ))}
         </ul>
       </div>


### PR DESCRIPTION
Fixes #44600.
Fixes #45073.

A user hint is now displayed in the UI when
error 403 is encountered.

![image](https://user-images.githubusercontent.com/642886/74594603-51c34900-5006-11ea-8928-55ec0b54a81a.png)

Release note (admin ui change): The web UI now reports a clearer
message when a non-admin user uses an admin-only feature.