### PR TITLE
storage/concurrency: changes to lock table to handle requests that

### DIFF
--- a/pkg/storage/concurrency/lock_table.go
+++ b/pkg/storage/concurrency/lock_table.go
@@ -231,7 +231,7 @@ type lockTableGuardImpl struct {
 	// The key for the lockState is contained in the Span specified by
 	// spans[sa][ss][index].
 	ss    spanset.SpanScope
-	sa    spanset.SpanAccess
+	sa    spanset.SpanAccess // Iterates from stronger to weaker strength
 	index int
 
 	mu struct {
@@ -241,8 +241,8 @@ type lockTableGuardImpl struct {
 		state  waitingState
 		signal chan struct{}
 
-		// locks for which this request has a reservation or is in the queue or
-		// actively waiting as a reader.
+		// locks for which this request has a reservation or is in the queue of
+		// writers (active or inactive) or actively waiting as a reader.
 		//
 		// TODO(sbhola): investigate whether the logic to maintain this locks map
 		// can be simplified so it doesn't need to be adjusted by various
@@ -483,19 +483,29 @@ type lockWaitQueue struct {
 	// - Holders: only shared locks are compatible with themselves, so there can
 	//   be one of (a) no holder (b) multiple shared lock holders, (c) one
 	//   exclusive holder, (d) one upgrade holder. Non-locking reads will
-	//   continue to wait in waitingReaders for only an incompatible exclusive
-	//   holder.
+	//   wait in waitingReaders for only an incompatible exclusive holder.
 	//
 	// - Reservers: This follows the same pattern as holders. Non-locking reads
 	//   do not wait on reservers.
 	//
-	// - Queueing and dependencies: All potential lockers will wait in the same
-	//   queue. A sequence of consecutive requests that have the potential to
-	//   acquire a shared lock will jointly reserve that shared lock. Such
-	//   requests cannot jump ahead of requests with a lower seqnum just because
-	//   there is currently a shared lock reservation (this can cause lockTable
-	//   induced deadlocks). Such joint reservations can be partially broken by
-	//   a waiter desiring an exclusive or upgrade lock.
+	// - Queueing and dependencies: All potential lockers and non-transactional
+	//   writers will wait in the same queue. A sequence of consecutive requests
+	//   that have the potential to acquire a shared lock will jointly reserve
+	//   that shared lock. Such requests cannot jump ahead of requests with a
+	//   lower seqnum just because there is currently a shared lock reservation
+	//   (this can cause lockTable induced deadlocks). Such joint reservations
+	//   can be partially broken by a waiter desiring an exclusive or upgrade
+	//   lock. Like the current code, non-transactional writes will wait for
+	//   reservations that have a lower sequence num, but not make their own
+	//   reservation. Additionally, they can partially break joint reservations.
+	//
+	//   Reservations that are (partially or fully) broken cause requests to
+	//   reenter the queue as inactive waiters. This is no different than the
+	//   current behavior. Each request can specify the same key in spans for
+	//   ReadOnly, ReadShared, ReadUpgrade, ReadWrite. The spans will be
+	//   iterated over in decreasing order of strength, to only wait at a lock
+	//   at the highest strength (this is similar to the current behavior using
+	//   accessDecreasingStrength).
 	//
 	//   For dependencies, a waiter desiring an exclusive or upgrade lock always
 	//   conflicts with the holder(s) or reserver(s) so that is the dependency
@@ -757,6 +767,25 @@ func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, 
 		if g.ts.Less(waitForTs) {
 			return false
 		}
+		g.mu.Lock()
+		_, alsoHasStrongerAccess := g.mu.locks[l]
+		g.mu.Unlock()
+
+		// If the request already has this lock in its locks map, it must also be
+		// writing to this key and must be either a reservation holder or inactive
+		// waiter at this lock. The former has already been handled above. For the
+		// latter, it must have had its reservation broken. Since this is a weaker
+		// access we defer to the stronger access and don't wait here.
+		//
+		// For non-transactional requests that have the key specified as both
+		// SpanReadOnly and SpanReadWrite, the request never acquires a
+		// reservation, so using the locks map to detect this duplication of the
+		// key is not possible. In the rare case, the lock is now held at a
+		// timestamp that is not compatible with this request and it will wait
+		// here -- there is no correctness issue with doing that.
+		if alsoHasStrongerAccess {
+			return false
+		}
 	}
 
 	// Incompatible with whoever is holding lock or reservation.
@@ -950,9 +979,13 @@ func (l *lockState) acquireLock(
 						panic("lockTable bug")
 					}
 				}
+				g.doneWaitingAtLock(false, l)
+			} else {
+				g.mu.Lock()
+				delete(g.mu.locks, l)
+				g.mu.Unlock()
 			}
 			l.queuedWriters.Remove(curr)
-			g.doneWaitingAtLock(false, l)
 		}
 	}
 
@@ -986,13 +1019,6 @@ func (l *lockState) discoveredLock(
 		l.holder.holder[lock.Replicated].ts = ts
 	}
 
-	g.mu.Lock()
-	_, presentHere := g.mu.locks[l]
-	if !presentHere {
-		g.mu.locks[l] = struct{}{}
-	}
-	g.mu.Unlock()
-
 	// Queue the existing reservation holder. Note that this reservation
 	// holder may not be equal to g due to two reasons (a) the reservation
 	// of g could have been broken even though g is holding latches (see
@@ -1012,7 +1038,16 @@ func (l *lockState) discoveredLock(
 		informWaiters = false
 	}
 
-	if !presentHere && sa == spanset.SpanReadWrite {
+	g.mu.Lock()
+	_, presentHere := g.mu.locks[l]
+	addToQueue := !presentHere && sa == spanset.SpanReadWrite
+	if addToQueue {
+		// Since g will place itself in queue as inactive waiter below.
+		g.mu.locks[l] = struct{}{}
+	}
+	g.mu.Unlock()
+
+	if addToQueue {
 		// Put self in queue as inactive waiter.
 		qg := &queuedGuard{
 			guard:  g,
@@ -1357,6 +1392,7 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTa
 			table:  t,
 			spans:  req.Spans,
 			ts:     req.Timestamp,
+			sa:     spanset.NumSpanAccess - 1,
 			index:  -1,
 		}
 		if req.Txn != nil {
@@ -1368,7 +1404,7 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTa
 		g = guard.(*lockTableGuardImpl)
 		g.mu.Lock()
 		g.key = nil
-		g.sa = spanset.SpanAccess(0)
+		g.sa = spanset.NumSpanAccess - 1
 		g.ss = spanset.SpanScope(0)
 		g.index = -1
 		g.mu.startWait = false
@@ -1510,10 +1546,12 @@ func (t *lockTableImpl) clearMostLocks() {
 	}
 }
 
+// Given the key with scope ss must be in spans, returns the strongest access
+// specified in the spans.
 func findAccessInSpans(
 	key roachpb.Key, ss spanset.SpanScope, spans *spanset.SpanSet,
 ) (spanset.SpanAccess, error) {
-	for sa := spanset.SpanAccess(0); sa < spanset.NumSpanAccess; sa++ {
+	for sa := spanset.NumSpanAccess - 1; sa >= 0; sa-- {
 		s := spans.GetSpans(sa, ss)
 		// First span that starts after key
 		i := sort.Search(len(s), func(i int) bool {
@@ -1595,7 +1633,7 @@ func (t *lockTableImpl) UpdateLocks(intent *roachpb.Intent) error {
 func stepToNextSpan(g *lockTableGuardImpl) *spanset.Span {
 	g.index++
 	for ; g.ss < spanset.NumSpanScope; g.ss++ {
-		for ; g.sa < spanset.NumSpanAccess; g.sa++ {
+		for ; g.sa >= 0; g.sa-- {
 			spans := g.spans.GetSpans(g.sa, g.ss)
 			if g.index < len(spans) {
 				span := &spans[g.index]
@@ -1604,7 +1642,7 @@ func stepToNextSpan(g *lockTableGuardImpl) *spanset.Span {
 			}
 			g.index = 0
 		}
-		g.sa = 0
+		g.sa = spanset.NumSpanAccess - 1
 	}
 	return nil
 }
@@ -1625,7 +1663,6 @@ func (t *lockTableImpl) findNextLockAfter(g *lockTableGuardImpl, notify bool) {
 	}
 	for span != nil {
 		tree := &t.locks[g.ss]
-		sa := g.sa
 		if len(span.EndKey) == 0 {
 			// NB: !resumingInSameSpan
 			tree.mu.RLock()
@@ -1634,7 +1671,7 @@ func (t *lockTableImpl) findNextLockAfter(g *lockTableGuardImpl, notify bool) {
 			tree.mu.RUnlock()
 			if i != nil {
 				l := i.(*lockState)
-				if l.tryActiveWait(g, sa, notify) {
+				if l.tryActiveWait(g, g.sa, notify) {
 					return
 				}
 			}
@@ -1665,7 +1702,7 @@ func (t *lockTableImpl) findNextLockAfter(g *lockTableGuardImpl, notify bool) {
 						// Else, past the lock where it stopped waiting. We may not
 						// encounter that lock since it may have been garbage collected.
 					}
-					waiting = l.tryActiveWait(g, sa, notify)
+					waiting = l.tryActiveWait(g, g.sa, notify)
 					return !waiting
 				})
 			resumingInSameSpan = false

--- a/pkg/storage/concurrency/testdata/lock_table/basic
+++ b/pkg/storage/concurrency/testdata/lock_table/basic
@@ -219,14 +219,12 @@ start-waiting: true
 #  res           req4  req4
 #                txn2  txn2
 #                8,12  8,12
-# Requests: * is active wait, + is in queue as inactive.
-#  req4      w+     w     w    r   r    r*
-#
-# Note that req4 is waiting on f since SpanReadOnly spans are ordered before SpanReadWrite spans.
+# Requests: * is active wait.
+#  req4      w*     w     w    r   r    r
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 ts=6 key="f" held=true guard-access=read
+new: state=waitForDistinguished txn=txn3 ts=6 key="a" held=true guard-access=write
 
 print
 ----
@@ -234,7 +232,8 @@ global: num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
  lock: "b"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "c"
@@ -243,9 +242,6 @@ global: num=5
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   waiting readers:
-    req: 4, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
 local: num=0
 
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
@@ -264,7 +260,8 @@ global: num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
  lock: "b"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "c"
@@ -273,9 +270,6 @@ global: num=5
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   waiting readers:
-    req: 4, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
 local: num=0
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
@@ -287,7 +281,7 @@ scan r=req6
 ----
 start-waiting: true
 
-# req6 is not a distinguished waiter at f.
+# req6 is a distinguished waiter at b.
 #
 # Locks:
 #             a    b    c    d    e    f    g
@@ -296,9 +290,9 @@ start-waiting: true
 #  res           req4  req4
 #                txn2  txn2
 #                8,12  8,12
-# Requests: * is active wait, + is in queue as inactive.
-#  req4      w+   w     w    r   r    r*
-#  req6           w     w             r*
+# Requests: * is active wait.
+#  req4      w*   w     w    r   r    r
+#  req6           w*    w             r
 #   txn1
 #   11,1
 
@@ -308,24 +302,24 @@ global: num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
  lock: "b"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+   queued writers:
+    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 6
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   waiting readers:
-    req: 6, txn: 00000000-0000-0000-0000-000000000001
-    req: 4, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
 local: num=0
 
 guard-state r=req6
 ----
-new: state=waitFor txn=txn3 ts=6 key="f" held=true guard-access=read
+new: state=waitForDistinguished txn=txn2 ts=8,12 key="b" held=false guard-access=write
 
 # req7 from txn3 only wants to write to c
 
@@ -343,9 +337,9 @@ start-waiting: true
 #  res           req4  req4
 #                txn2  txn2
 #                8,12  8,12
-# Requests: * is active wait, + is in queue as inactive.
-#  req4      w+    w     w    r   r    r*
-#  req6            w     w             r*
+# Requests: * is active wait.
+#  req4      w*    w     w    r   r    r
+#  req6            w*    w             r
 #   txn1
 #   11,1
 #  req7                  w*
@@ -359,73 +353,6 @@ new: state=waitForDistinguished txn=txn2 ts=8,12 key="c" held=false guard-access
 print
 ----
 global: num=5
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
- lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
- lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
-   queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
- lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
- lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   waiting readers:
-    req: 6, txn: 00000000-0000-0000-0000-000000000001
-    req: 4, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
-local: num=0
-
-# Release f. This will cause req4 to wait at a, and req6 to wait at b.
-release txn=txn3 span=f
-----
-global: num=4
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
-   queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
- lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
- lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
-   queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
- lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
-local: num=0
-
-guard-state r=req6
-----
-new: state=waitForDistinguished txn=txn2 ts=8,12 key="b" held=false guard-access=write
-
-guard-state r=req4
-----
-new: state=waitForDistinguished txn=txn3 ts=6 key="a" held=true guard-access=write
-
-# Locks:
-#             a    b    c    d    e    f    g
-#  holder   txn3                 txn1
-#            6                   10,1
-#  res           req4  req4
-#                txn2  txn2
-#                8,12  8,12
-# Requests: * is active wait, + is in queue as inactive.
-#  req4      w*    w     w    r   r    r
-#  req6            w*    w             r
-#   txn1
-#   11,1
-#  req7                  w*
-#   txn3
-#   6
-
-print
-----
-global: num=4
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
    queued writers:
@@ -443,10 +370,67 @@ global: num=4
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "f"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
 local: num=0
 
-# Release a. req4 is done waiting.
+# Release a. req4 waits at f.
 release txn=txn3 span=a
+----
+global: num=5
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+ lock: "b"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+   queued writers:
+    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 6
+ lock: "c"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 7
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "f"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+local: num=0
+
+guard-state r=req4
+----
+new: state=waitForDistinguished txn=txn3 ts=6 key="f" held=true guard-access=read
+
+guard-state r=req6
+----
+old: state=waitForDistinguished txn=txn2 ts=8,12 key="b" held=false guard-access=write
+
+print
+----
+global: num=5
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+ lock: "b"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+   queued writers:
+    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 6
+ lock: "c"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 7
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+ lock: "f"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+   waiting readers:
+    req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
+local: num=0
+
+# Release f. This will cause req4 to be done waiting.
+
+release txn=txn3 span=f
 ----
 global: num=4
  lock: "a"
@@ -465,10 +449,6 @@ global: num=4
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-guard-state r=req6
-----
-old: state=waitForDistinguished txn=txn2 ts=8,12 key="b" held=false guard-access=write
-
 guard-state r=req4
 ----
 new: state=doneWaiting
@@ -480,7 +460,7 @@ new: state=doneWaiting
 #  res     req4  req4  req4
 #          txn2  txn2  txn2
 #          8,12  8,12  8,12
-# Requests: * is active wait, + is in queue as inactive.
+# Requests: * is active wait.
 #  req4      w     w     w    r   r    r
 #  req6            w*    w             r
 #   txn1
@@ -580,7 +560,7 @@ local: num=0
 #  holder        txn2  txn2      txn1
 #                8,12  8,12      10,1
 #  res
-# Requests: * is active wait, + is in queue as inactive.
+# Requests: * is active wait.
 #  req6            w*    w             r
 #   txn1
 #   11,1
@@ -656,7 +636,7 @@ old: state=doneWaiting
 #  res            req6 req6
 #                 txn1 txn1
 #                 11,1 11,1
-# Requests: * is active wait, + is in queue as inactive.
+# Requests: * is active wait.
 #  req6            w    w              r
 #   txn1
 #   11,1

--- a/pkg/storage/concurrency/testdata/lock_table/dup_access
+++ b/pkg/storage/concurrency/testdata/lock_table/dup_access
@@ -1,0 +1,508 @@
+# Tests where the same key is in both ReadWrite and ReadOnly spans.
+
+locktable maxlocks=10000
+----
+
+# Test: req2 accesses "a" as both write and read. Once it has reservation for write
+# it does not wait at "a" for read.
+
+txn txn=txn1 ts=10 epoch=0
+----
+
+txn txn=txn2 ts=10 epoch=0
+----
+
+txn txn=txn3 ts=10 epoch=0
+----
+
+request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
+----
+
+scan r=req1
+----
+start-waiting: false
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+done r=req1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+request r=req2 txn=txn2 ts=10 spans=w@a+r@a
+----
+
+scan r=req2
+----
+start-waiting: true
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 2
+local: num=0
+
+release txn=txn1 span=a
+----
+global: num=1
+ lock: "a"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+done r=req2
+----
+global: num=0
+local: num=0
+
+# Test: req5 accesses "b" as both write and read. It has its reservation at "b" broken, but ignores
+# "b" when encounters it as reader.
+
+request r=req3 txn=txn1 ts=10 spans=w@a+w@b+w@c
+----
+
+scan r=req3
+----
+start-waiting: false
+
+acquire r=req3 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+acquire r=req3 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+acquire r=req3 k=c durability=u
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+done r=req3
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+request r=req4 txn=txn2 ts=10 spans=w@a+w@b
+----
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
+
+request r=req5 txn=txn3 ts=10 spans=w@b+w@c+r@b
+----
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="b" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+# req5 reserves "b" and waits at "c".
+
+release txn=txn1 span=b
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
+ lock: "b"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="c" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 4
+ lock: "b"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+local: num=0
+
+# req4 breaks the reservation of req4 at "b".
+
+release txn=txn1 span=a
+----
+global: num=3
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+local: num=0
+
+guard-state r=req4
+----
+new: state=doneWaiting
+
+print
+----
+global: num=3
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+local: num=0
+
+# req5 encounters the reservation by req4 at "b" when looking at it for its read access, but ignores
+# it.
+release txn=txn1 span=c
+----
+global: num=3
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+ lock: "c"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req5
+----
+new: state=doneWaiting
+
+scan r=req5
+----
+start-waiting: true
+
+print
+----
+global: num=3
+ lock: "a"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+ lock: "c"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+done r=req4
+----
+global: num=2
+ lock: "b"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+ lock: "c"
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+done r=req5
+----
+global: num=0
+local: num=0
+
+print
+----
+global: num=0
+local: num=0
+
+# Test: Non-transactional req8 accesses "b" as both write and read. After it has stopped waiting
+# at "b", the reservation for "b" is acquired by a request with a lower seqnum. req8 does not ignore
+# "b" when encountering it as a reader. This is the non-transactional request version of the
+# previous test.
+
+request r=req6 txn=txn1 ts=10 spans=w@a+w@b+w@c
+----
+
+scan r=req6
+----
+start-waiting: false
+
+acquire r=req6 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+acquire r=req6 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+acquire r=req6 k=c durability=u
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+done r=req6
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+request r=req7 txn=txn2 ts=10 spans=w@a+w@b
+----
+
+scan r=req7
+----
+start-waiting: true
+
+guard-state r=req7
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
+
+request r=req8 txn=none ts=10 spans=w@b+w@c+r@b
+----
+
+scan r=req8
+----
+start-waiting: true
+
+guard-state r=req8
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="b" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 7
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 8, txn: none
+   distinguished req: 8
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+# req8 waits at "c".
+
+release txn=txn1 span=b
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 7
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req8
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="c" held=true guard-access=write
+
+print
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 7
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+# req7 is doneWaiting and proceeds to acquire the lock at "b".
+
+release txn=txn1 span=a
+----
+global: num=2
+ lock: "a"
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+guard-state r=req7
+----
+new: state=doneWaiting
+
+print
+----
+global: num=2
+ lock: "a"
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+scan r=req7
+----
+start-waiting: false
+
+acquire r=req7 k=b durability=u
+----
+global: num=3
+ lock: "a"
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+# req8 encounters the lock held by req7 at "b" when looking at it for its read access.
+release txn=txn1 span=c
+----
+global: num=2
+ lock: "a"
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req8
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="b" held=true guard-access=read
+
+print
+----
+global: num=2
+ lock: "a"
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   waiting readers:
+    req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+done r=req7
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   waiting readers:
+    req: 8, txn: none
+   distinguished req: 8
+local: num=0
+
+done r=req8
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+release txn=txn2 span=b
+----
+global: num=0
+local: num=0

--- a/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
@@ -1,0 +1,228 @@
+# Tests where a request is a non-active waiter.
+
+locktable maxlocks=10000
+----
+
+txn txn=txn1 ts=10 epoch=0
+----
+
+txn txn=txn2 ts=10 epoch=0
+----
+
+request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
+----
+
+scan r=req1
+----
+start-waiting: false
+
+add-discovered r=req1 k=a txn=txn2
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+add-discovered r=req1 k=b txn=txn2
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+local: num=0
+
+add-discovered r=req1 k=c txn=txn2
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# req1 is not in the queue for "b" as readers are never inactive waiters.
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+request r=req2 txn=txn1 ts=10 spans=w@c
+----
+
+scan r=req2
+----
+start-waiting: true
+
+# req2 is the distinguished waiter at "c".
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 2
+local: num=0
+
+scan r=req1
+----
+start-waiting: true
+
+guard-state r=req1
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="a" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 2
+local: num=0
+
+# req1 waits at "c" but not as distinguished waiter.
+release txn=txn2 span=a
+----
+global: num=3
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 2
+local: num=0
+
+guard-state r=req1
+----
+new: state=waitFor txn=txn2 ts=10 key="c" held=true guard-access=write
+
+print
+----
+global: num=3
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 2
+local: num=0
+
+# req1 waits at "b" as reader.
+
+release txn=txn2 span=c
+----
+global: num=3
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "c"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+guard-state r=req1
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="b" held=true guard-access=read
+
+guard-state r=req2
+----
+new: state=waitSelf
+
+print
+----
+global: num=3
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   waiting readers:
+    req: 1, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 1
+ lock: "c"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# req1 is done waiting.
+
+release txn=txn2 span=b
+----
+global: num=2
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+ lock: "c"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+done r=req1
+----
+global: num=1
+ lock: "c"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+done r=req2
+----
+global: num=0
+local: num=0


### PR DESCRIPTION
have the same key as ReadWrite and ReadOnly

- This new functionality is covered by the dup_access test and the
  randomized test.
- The existing basic test lost some coverage of inactive waiters so
  there is now a separate non_active_waiter test.
- The comment on future extensions to shared and upgrade locks now
  includes a discussion on non-transactional requests, and how active
  and inactive wait states will work.
- There was a bug in the code that handles a discovered lock, when
  the lock was discovered by a reader, which was triggered by changes
  to the basic test. The lockTableGuardImpl.mu.locks was being
  incorrectly updated to add the *lockState.

Release note: None