### PR TITLE
server: make UI customizations work for non-admin users

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -246,10 +246,13 @@ func GetJSONProtoWithAdminOption(
 	return httputil.GetJSON(httpClient, ts.AdminURL()+path, response)
 }
 
-// PostJSONProto uses the supplied client to POST request to the URL specified by
-// the parameters and unmarshals the result into response.
-func PostJSONProto(ts TestServerInterface, path string, request, response protoutil.Message) error {
-	httpClient, err := ts.GetAdminAuthenticatedHTTPClient()
+// PostJSONProtoWithAdminOption is like PostJSONProto but the caller
+// can customize whether the request is performed with admin
+// privilege.
+func PostJSONProtoWithAdminOption(
+	ts TestServerInterface, path string, request, response protoutil.Message, isAdmin bool,
+) error {
+	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes  #45126.

cc @piyush-singh  - I am considering this for backporting in 19.1/19.2 since it fixes a regression introduced in a previous patch revision.

Summary table:

| Time frame  | R/W of UI customization | different customizations per user |
|-------------|-------------------------|-----------------------------------|
| Pre-#42563  | all users               | broken (shared between users)     |
| Post-#42563 | admin only (regression) | broken                            |
| This commit | all users               | yes - each user has its own       |

The separation of customization between users is done by mixing the
username with the key with a `$` character when looking up rows in
`system.ui`.

This approach can look perhaps baroque when SQL would prefer us to
have two separate *columns* in the PK of `system.ui` and use that for
lookups and updates. Unfortunately PK changes are not yet supported,
and a PK change would incur a complex story in mixed-version clusters.

Additionally, this approach is suitable for backporting in 2.1, 19.1
and 19.2 clusters where the functionality was broken by #42563.

Release note (admin ui change): The display options are now saved
separately for each authenticated user. Note: when upgrading to a
version with this change, all current display customizations for admin
users are lost.

Release note (bug fix): Customizations of the Admin UI are again
properly saved across sessions.