### PR TITLE
sql: use a safer method for explain(vec) with subqueries

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -536,6 +536,12 @@ type PlanningCtx struct {
 	// noEvalSubqueries indicates that the plan expects any subqueries to not
 	// be replaced by evaluation. Should only be set by EXPLAIN.
 	noEvalSubqueries bool
+
+	// replaceSubqueriesWithNull indicates that all subqueries will artificially
+	// evaluate to NULL. The purpose of this flag is to let EXPLAIN run queries
+	// that have subqueries without actually having to execute the subqueries.
+	// This flag should only be set by EXPLAIN.
+	replaceSubqueriesWithNull bool
 }
 
 var _ physicalplan.ExprContext = &PlanningCtx{}
@@ -554,12 +560,17 @@ func (p *PlanningCtx) IsLocal() bool {
 	return p.isLocal
 }
 
-// EvaluateSubqueries returns true if this plan requires subqueries be fully
+// MustEvaluateSubqueries returns true if this plan requires subqueries be fully
 // executed before trying to marshal. This is normally true except for in the
 // case of EXPLAIN queries, which ultimately want to describe the subquery that
 // will run, without actually running it.
-func (p *PlanningCtx) EvaluateSubqueries() bool {
+func (p *PlanningCtx) MustEvaluateSubqueries() bool {
 	return !p.noEvalSubqueries
+}
+
+// MustReplaceSubqueriesWithNull implements the ExprContext interface.
+func (p *PlanningCtx) MustReplaceSubqueriesWithNull() bool {
+	return p.replaceSubqueriesWithNull
 }
 
 // sanityCheckAddresses returns an error if the same address is used by two

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -212,7 +212,7 @@ func (p *planner) populateExplain(
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	isDistSQL, _ = willDistributePlan(distSQLPlanner, plan, params)
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := makeExplainVecPlanningCtx(distSQLPlanner, params, stmtType, subqueryPlans, isDistSQL)
+	planCtx := makeExplainVecPlanningCtx(distSQLPlanner, params, stmtType, isDistSQL)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1153,10 +1153,9 @@ func (ef *execFactory) ConstructExplain(
 
 	case tree.ExplainVec:
 		return &explainVecNode{
-			options:       options,
-			plan:          p.plan,
-			subqueryPlans: p.subqueryPlans,
-			stmtType:      stmtType,
+			options:  options,
+			plan:     p.plan,
+			stmtType: stmtType,
 		}, nil
 
 	case tree.ExplainPlan:

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -967,7 +967,9 @@ func (*Subquery) SubqueryExpr() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Subquery) Format(ctx *FmtCtx) {
-	if ctx.HasFlags(FmtSymbolicSubqueries) {
+	if ctx.subqueryFormat != nil {
+		ctx.subqueryFormat(ctx, node)
+	} else if ctx.HasFlags(FmtSymbolicSubqueries) {
 		ctx.Printf("@S%d", node.Idx)
 	} else {
 		// Ensure that type printing is disabled during the recursion, as

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -199,6 +199,9 @@ type FmtCtx struct {
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
 	indexedVarFormat func(ctx *FmtCtx, idx int)
+	// subqueryFormat is an optional interceptor for
+	// Subquery exprs.
+	subqueryFormat func(ctx *FmtCtx, subquery *Subquery)
 	// tableNameFormatter will be called on all TableNames if it is non-nil.
 	tableNameFormatter func(*FmtCtx, *TableName)
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
@@ -288,6 +291,12 @@ func FmtExpr(base FmtFlags, showTypes bool, symbolicVars bool, showTableAliases 
 // IndexedVars using the provided function.
 func (ctx *FmtCtx) SetIndexedVarFormat(fn func(ctx *FmtCtx, idx int)) {
 	ctx.indexedVarFormat = fn
+}
+
+// SetSubqueriesFormat modifies FmtCtx to customize the printing of
+// subqueries using the provided function.
+func (ctx *FmtCtx) SetSubqueriesFormat(fn func(ctx *FmtCtx, subquery *Subquery)) {
+	ctx.subqueryFormat = fn
 }
 
 // SetPlaceholderFormat modifies FmtCtx to customize the printing of
@@ -420,6 +429,7 @@ func (ctx *FmtCtx) Close() {
 	ctx.Buffer.Reset()
 	ctx.flags = 0
 	ctx.indexedVarFormat = nil
+	ctx.subqueryFormat = nil
 	ctx.tableNameFormatter = nil
 	ctx.placeholderFormat = nil
 	fmtCtxPool.Put(ctx)


### PR DESCRIPTION
Instead of editing the planner's subquery array, we replace the
subqueries with null via the expression walker, which doesn't have the
problem of rendering the plan tree broken for future usages.

Release note: None