### PR TITLE
sql: add the getdatabaseencoding() builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1170,6 +1170,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tbody>
 <tr><td><a name="format_type"></a><code>format_type(type_oid: oid, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</p>
 </span></td></tr>
+<tr><td><a name="getdatabaseencoding"></a><code>getdatabaseencoding() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current encoding name used by the database.</p>
+</span></td></tr>
 <tr><td><a name="has_any_column_privilege"></a><code>has_any_column_privilege(table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for any column of table.</p>
 </span></td></tr>
 <tr><td><a name="has_any_column_privilege"></a><code>has_any_column_privilege(table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for any column of table.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2556,3 +2556,10 @@ SELECT timezone('1970-01-01 01:00'::timestamptz, 'UTC+6')
 
 statement ok
 SET TIME ZONE +0
+
+subtest getdatabaseencoding
+
+query T
+SELECT getdatabaseencoding()
+----
+UTF8

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1078,9 +1078,11 @@ CREATE TABLE pg_catalog.pg_database (
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
-				defaultOid(db.ID),          // oid
-				tree.NewDName(db.Name),     // datname
-				tree.DNull,                 // datdba
+				defaultOid(db.ID),      // oid
+				tree.NewDName(db.Name), // datname
+				tree.DNull,             // datdba
+				// If there is a change in encoding value for the database we must update
+				// the definitions of getdatabaseencoding within pg_builtin.
 				builtins.DatEncodingUTFId,  // encoding
 				builtins.DatEncodingEnUTF8, // datcollate
 				builtins.DatEncodingEnUTF8, // datctype

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -573,6 +573,23 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	// Here getdatabaseencoding just returns UTF8 because,
+	// CockroachDB supports just UTF8 for now.
+	"getdatabaseencoding": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// We only support UTF-8 right now.
+				// If we allow more encodings, we must also change the virtual schema
+				// entry for pg_catalog.pg_database.
+				return datEncodingUTF8ShortName, nil
+			},
+			Info: "Returns the current encoding name used by the database.",
+		},
+	),
+
 	// Postgres defines pg_get_expr as a function that "decompiles the internal form
 	// of an expression", which is provided in the pg_node_tree type. In Cockroach's
 	// pg_catalog implementation, we populate all pg_node_tree columns with the


### PR DESCRIPTION
Resolves #41771.

This commit adds builtin function, getdatabaseencoding(),
and the unit-test case for it.

Release note (sql change): This PR is introduced to add builtin
function, getdatabaseencoding(), which returns the current encoding
name used by the database.