### PR TITLE
sql: add ForceDiskSpill testing knob

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -455,7 +455,11 @@ func (s *vectorizedFlowCreator) setupRouter(
 		allocators[i] = colexec.NewAllocator(ctx, &acc)
 		s.bufferingMemAccounts = append(s.bufferingMemAccounts, &acc)
 	}
-	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, execinfra.GetWorkMemLimit(flowCtx.Cfg), s.diskQueueCfg)
+	limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
+	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
+		limit = 1
+	}
+	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
 		router.Run(ctx)
 	}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -878,12 +878,16 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon
 
 // NewLimitedMonitor is a utility function used by processors to create a new
 // limited memory monitor with the given name and start it. The returned
-// monitor must be closed. The limit is determined by SettingWorkMemBytes
-// or config.TestingKnobs.MemoryLimitBytes.
+// monitor must be closed. The limit is determined by SettingWorkMemBytes but
+// overridden to 1 if config.TestingKnobs.ForceDiskSpill is set or
+// config.TestingKnobs.MemoryLimitBytes if not.
 func NewLimitedMonitor(
 	ctx context.Context, parent *mon.BytesMonitor, config *ServerConfig, name string,
 ) *mon.BytesMonitor {
 	limit := GetWorkMemLimit(config)
+	if config.TestingKnobs.ForceDiskSpill {
+		limit = 1
+	}
 	limitedMon := mon.MakeMonitorInheritWithLimit(name, limit, parent)
 	limitedMon.Start(ctx, parent, mon.BoundAccount{})
 	return &limitedMon

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -194,10 +194,16 @@ type TestingKnobs struct {
 	// function returns an error, or if the table has already been dropped.
 	RunAfterBackfillChunk func()
 
+	// ForceDiskSpill forces any processors/operators that can fall back to disk
+	// to fall back to disk immediately.
+	ForceDiskSpill bool
+
 	// MemoryLimitBytes specifies a maximum amount of working memory that a
 	// processor that supports falling back to disk can use. Must be >= 1 to
-	// enable. Once this limit is hit, processors employ their on-disk
-	// implementation regardless of applicable cluster settings.
+	// enable. This is a more fine-grained knob than ForceDiskSpill when the
+	// available memory needs to be controlled. Once this limit is hit, processors
+	// employ their on-disk implementation regardless of applicable cluster
+	// settings.
 	MemoryLimitBytes int64
 
 	// DrainFast, if enabled, causes the server to not wait for any currently

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1084,7 +1084,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		MetadataTestLevel: execinfra.Off, DeterministicStats: true,
 	}
 	if cfg.sqlExecUseDisk {
-		distSQLKnobs.MemoryLimitBytes = 1
+		distSQLKnobs.ForceDiskSpill = true
 	}
 	if cfg.distSQLMetadataTestEnabled {
 		distSQLKnobs.MetadataTestLevel = execinfra.On

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -531,10 +531,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 
 	const numCols = 1
 	for _, spill := range []bool{true, false} {
-		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 0
-		if spill {
-			flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 1
-		}
+		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spill
 		b.Run(fmt.Sprintf("spill=%t", spill), func(b *testing.B) {
 			for _, numRows := range []int{0, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
 				if spill && numRows < 1<<8 {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -229,6 +229,9 @@ func newJoinReader(
 		// Limit the memory use by creating a child monitor with a hard limit.
 		// joinReader will overflow to disk if this limit is not enough.
 		limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
+		if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
+			limit = 1
+		}
 		jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joiner-limited")
 		jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "joinreader-disk")
 		drc := rowcontainer.NewDiskBackedIndexedRowContainer(

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -59,6 +59,7 @@ func (s *sorterBase) init(
 	}
 
 	useTempStorage := execinfra.SettingUseTempStorageSorts.Get(&flowCtx.Cfg.Settings.SV) ||
+		flowCtx.Cfg.TestingKnobs.ForceDiskSpill ||
 		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes > 0
 	var memMonitor *mon.BytesMonitor
 	if useTempStorage {

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -214,7 +214,7 @@ func newWindower(
 				memRequiredByWindower, limit)
 		}
 	} else {
-		if limit < memRequiredByWindower {
+		if flowCtx.Cfg.TestingKnobs.ForceDiskSpill || limit < memRequiredByWindower {
 			// The limit is set very low by the tests, but the windower requires
 			// some amount of RAM, so we override the limit.
 			limit = memRequiredByWindower


### PR DESCRIPTION
Previously, disk spilling was forced in tests by setting MemoryLimitBytes to 1.
For row execution, this worked fine. However, for columnar execution,
disk spilling operators assume that they may allocate a certain amount of
memory on initialization and panic if not (this panic is caught and returned as
an out of memory error). To simplify the forcing of disk spilling from a
testing perspective, a knob named ForceDiskSpill has been added to explicitly
state that execution should fall back to disk where it can, rather than relying
on the fact that setting MemoryLimitBytes to 1 would do this.

In the row execution engine, this knob forces limited monitors to be created
with a memory limit of 1, as was previously the case. In the columnar execution
engine, the planning stage will create memory monitors with a limit of 1 for
the in-memory components but give enough memory to the on-disk components to
perform the work they need to do.

It is important to note that MemoryLimitBytes retains its meaning, and can be
used to limit the amount of memory available separately from the explicit
signal that execution should spill to disk.

Release note: None (testing change)