### PR TITLE
storage/concurrency: clean up lockTable datadriven tests

### DIFF
--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -42,17 +42,17 @@ import (
 Test needs to handle caller constraints wrt latches being held. The datadriven
 test uses the following format:
 
-locktable maxlocks=<int>
+new-locktable maxlocks=<int>
 ----
 
   Creates a lockTable.
 
-txn txn=<name> ts=<int>[,<int>] epoch=<int>
+new-txn txn=<name> ts=<int>[,<int>] epoch=<int>
 ----
 
  Creates a TxnMeta.
 
-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+...
+new-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+...
 ----
 
  Creates a Request.
@@ -192,13 +192,13 @@ func TestLockTableBasic(t *testing.T) {
 		guardsByReqName := make(map[string]lockTableGuard)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
-			case "locktable":
+			case "new-lock-table":
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
 				lt = newLockTable(int64(maxLocks))
 				return ""
 
-			case "txn":
+			case "new-txn":
 				// UUIDs for transactions are numbered from 1 by this test code and
 				// lockTableImpl.String() knows about UUIDs and not transaction names.
 				// Assigning txnNames of the form txn1, txn2, ... keeps the two in sync,
@@ -222,7 +222,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				return ""
 
-			case "request":
+			case "new-request":
 				// Seqnums for requests are numbered from 1 by lockTableImpl and
 				// lockTableImpl.String() does not know about request names. Assigning
 				// request names of the form req1, req2, ... keeps the two in sync,

--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -88,7 +88,7 @@ add-discovered r=<name> k=<key> txn=<name>
 
  Adds a discovered lock that is disovered by the named request.
 
-done r=<name>
+dequeue r=<name>
 ----
 <error string>
 
@@ -102,7 +102,7 @@ new|old: state=<state> [txn=<name> ts=<ts>]
   Calls lockTableGuard.NewStateChan() in a non-blocking manner, followed by
   CurState().
 
-guard-start-waiting r=<name>
+should-wait r=<name>
 ----
 <bool>
 
@@ -351,8 +351,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				return lt.(*lockTableImpl).String()
 
-			case "done":
-				// TODO(nvanbenschoten): rename this command to dequeue.
+			case "dequeue":
 				var reqName string
 				d.ScanArgs(t, "r", &reqName)
 				g := guardsByReqName[reqName]
@@ -364,8 +363,7 @@ func TestLockTableBasic(t *testing.T) {
 				delete(requestsByName, reqName)
 				return lt.(*lockTableImpl).String()
 
-			case "guard-start-waiting":
-				// TODO(nvanbenschoten): rename this command to should-wait.
+			case "should-wait":
 				var reqName string
 				d.ScanArgs(t, "r", &reqName)
 				g := guardsByReqName[reqName]

--- a/pkg/storage/concurrency/testdata/lock_table/basic
+++ b/pkg/storage/concurrency/testdata/lock_table/basic
@@ -1,12 +1,12 @@
-locktable maxlocks=10000
+new-lock-table maxlocks=10000
 ----
 
-txn txn=txn1 ts=10,1 epoch=0
+new-txn txn=txn1 ts=10,1 epoch=0
 ----
 
 # req1 will acquire locks for txn1
 
-request r=req1 txn=txn1 ts=10,1 spans=r@a,b+w@c,f
+new-request r=req1 txn=txn1 ts=10,1 spans=r@a,b+w@c,f
 ----
 
 scan r=req1
@@ -51,7 +51,7 @@ local: num=0
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
+new-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
 ----
 
 scan r=req2
@@ -82,11 +82,11 @@ local: num=0
 
 # txn1 holds locks on b, c, e.
 # txn2 has a smaller timestamp than txn1.
-txn txn=txn2 ts=8,12 epoch=0
+new-txn txn=txn2 ts=8,12 epoch=0
 ----
 
 # A read request for txn2 does not need to wait for locks held by txn1.
-request r=req3 txn=txn2 ts=8,12 spans=r@a,g
+new-request r=req3 txn=txn2 ts=8,12 spans=r@a,g
 ----
 
 scan r=req3
@@ -107,7 +107,7 @@ local: num=0
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
 # not conflict with lock on e since wants to read there and the read is at a lower timestamp
 # than the lock.
-request r=req4 txn=txn2 ts=8,12 spans=w@a,d+r@d,g
+new-request r=req4 txn=txn2 ts=8,12 spans=w@a,d+r@d,g
 ----
 
 scan r=req4
@@ -163,7 +163,7 @@ start-waiting: false
 # req4 proceeds to evaluation and discovers locks on a, f. The lock on a conflicts since req4
 # wants to write and the lock on f conflicts because req4's read has a higher timestamp.
 
-txn txn=txn3 ts=6 epoch=0
+new-txn txn=txn3 ts=6 epoch=0
 ----
 
 add-discovered r=req4 k=a txn=txn3
@@ -247,7 +247,7 @@ local: num=0
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
 # conflicts with the reservation holder since txn1.ts > txn2.ts, reads don't wait for
 # reservations.
-request r=req5 txn=txn1 ts=11,1 spans=r@b+r@c
+new-request r=req5 txn=txn1 ts=11,1 spans=r@b+r@c
 ----
 
 scan r=req5
@@ -274,7 +274,7 @@ local: num=0
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
 
-request r=req6 txn=txn1 ts=11,1 spans=r@f+w@b,d
+new-request r=req6 txn=txn1 ts=11,1 spans=r@f+w@b,d
 ----
 
 scan r=req6
@@ -323,7 +323,7 @@ new: state=waitForDistinguished txn=txn2 ts=8,12 key="b" held=false guard-access
 
 # req7 from txn3 only wants to write to c
 
-request r=req7 txn=txn3 ts=6 spans=w@c
+new-request r=req7 txn=txn3 ts=6 spans=w@c
 ----
 
 scan r=req7
@@ -696,7 +696,7 @@ local: num=0
 
 # e is still locked
 
-request r=req8 txn=txn3 ts=6 spans=w@e
+new-request r=req8 txn=txn3 ts=6 spans=w@e
 ----
 
 scan r=req8
@@ -727,7 +727,7 @@ local: num=0
 # All requests have been retired and the lock table is empty.
 # The following tests multiple requests from the same transaction.
 
-request r=req9 txn=txn1 ts=10,1 spans=w@c
+new-request r=req9 txn=txn1 ts=10,1 spans=w@c
 ----
 
 scan r=req9
@@ -755,7 +755,7 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-request r=req10 txn=txn2 ts=8,12 spans=w@c
+new-request r=req10 txn=txn2 ts=8,12 spans=w@c
 ----
 
 scan r=req10
@@ -766,7 +766,7 @@ guard-state r=req10
 ----
 new: state=waitForDistinguished txn=txn1 ts=10,1 key="c" held=true guard-access=write
 
-request r=req11 txn=txn3 ts=6 spans=w@c
+new-request r=req11 txn=txn3 ts=6 spans=w@c
 ----
 
 scan r=req11
@@ -777,7 +777,7 @@ guard-state r=req11
 ----
 new: state=waitFor txn=txn1 ts=10,1 key="c" held=true guard-access=write
 
-request r=req12 txn=txn2 ts=8,12 spans=w@c
+new-request r=req12 txn=txn2 ts=8,12 spans=w@c
 ----
 
 scan r=req12
@@ -927,7 +927,7 @@ local: num=0
 # Tests with non-transactional requests that triggered nil pointer
 # dereference bugs.
 
-request r=req13 txn=txn2 ts=8,12 spans=w@c
+new-request r=req13 txn=txn2 ts=8,12 spans=w@c
 ----
 
 scan r=req13
@@ -941,14 +941,14 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
 local: num=0
 
-request r=req14 txn=txn1 ts=9,0 spans=w@c
+new-request r=req14 txn=txn1 ts=9,0 spans=w@c
 ----
 
 scan r=req14
 ----
 start-waiting: true
 
-request r=req15 txn=none ts=10,12 spans=r@c
+new-request r=req15 txn=none ts=10,12 spans=r@c
 ----
 
 scan r=req15
@@ -969,7 +969,7 @@ global: num=1
   res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
 local: num=0
 
-request r=req16 txn=none ts=10,12 spans=r@c
+new-request r=req16 txn=none ts=10,12 spans=r@c
 ----
 
 scan r=req16
@@ -995,7 +995,7 @@ local: num=0
 # transaction that eventually grabs a reservation. Triggered a bug
 # in not replacing the distinguished waiter.
 
-request r=req17 txn=txn1 ts=9,0 spans=w@c+w@d
+new-request r=req17 txn=txn1 ts=9,0 spans=w@c+w@d
 ----
 
 scan r=req17
@@ -1027,14 +1027,14 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
 local: num=0
 
-request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
+new-request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
 ----
 
 scan r=req18
 ----
 start-waiting: true
 
-request r=req19 txn=txn2 ts=10,0 spans=w@d
+new-request r=req19 txn=txn2 ts=10,0 spans=w@d
 ----
 
 scan r=req19
@@ -1139,7 +1139,7 @@ local: num=0
 # Reservation can be broken while holding latches because a different
 # lock is released
 
-request r=req20 txn=txn1 ts=10 spans=w@c
+new-request r=req20 txn=txn1 ts=10 spans=w@c
 ----
 
 scan r=req20
@@ -1160,14 +1160,14 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req21 txn=txn2 ts=10 spans=w@c+w@d
+new-request r=req21 txn=txn2 ts=10 spans=w@c+w@d
 ----
 
 scan r=req21
 ----
 start-waiting: true
 
-request r=req22 txn=txn1 ts=10 spans=w@d
+new-request r=req22 txn=txn1 ts=10 spans=w@d
 ----
 
 scan r=req22
@@ -1186,7 +1186,7 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req23 txn=txn3 ts=10 spans=w@d
+new-request r=req23 txn=txn3 ts=10 spans=w@d
 ----
 
 scan r=req23

--- a/pkg/storage/concurrency/testdata/lock_table/basic
+++ b/pkg/storage/concurrency/testdata/lock_table/basic
@@ -40,7 +40,7 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-done r=req1
+dequeue r=req1
 ----
 global: num=2
  lock: "c"
@@ -69,7 +69,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-done r=req2
+dequeue r=req2
 ----
 global: num=3
  lock: "b"
@@ -93,7 +93,7 @@ scan r=req3
 ----
 start-waiting: false
 
-done r=req3
+dequeue r=req3
 ----
 global: num=3
  lock: "b"
@@ -201,7 +201,7 @@ local: num=0
 # Note that guard state has not changed yet. Discovering these locks means the caller has to
 # scan again.
 
-guard-start-waiting r=req4
+should-wait r=req4
 ----
 false
 
@@ -254,7 +254,7 @@ scan r=req5
 ----
 start-waiting: false
 
-done r=req5
+dequeue r=req5
 ----
 global: num=5
  lock: "a"
@@ -538,7 +538,7 @@ global: num=4
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-done r=req4
+dequeue r=req4
 ----
 global: num=3
  lock: "b"
@@ -670,7 +670,7 @@ scan r=req6
 start-waiting: false
 
 # Release reservation.
-done r=req6
+dequeue r=req6
 ----
 global: num=2
  lock: "c"
@@ -687,7 +687,7 @@ scan r=req7
 ----
 start-waiting: false
 
-done r=req7
+dequeue r=req7
 ----
 global: num=1
  lock: "e"
@@ -707,7 +707,7 @@ guard-state r=req8
 ----
 new: state=waitForDistinguished txn=txn1 ts=10,1 key="e" held=true guard-access=write
 
-done r=req8
+dequeue r=req8
 ----
 global: num=1
  lock: "e"
@@ -741,7 +741,7 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
 local: num=0
 
-done r=req9
+dequeue r=req9
 ----
 global: num=1
  lock: "c"
@@ -867,7 +867,7 @@ global: num=1
    distinguished req: 11
 local: num=0
 
-done r=req10
+dequeue r=req10
 ----
 global: num=1
  lock: "c"
@@ -887,7 +887,7 @@ global: num=1
    distinguished req: 11
 local: num=0
 
-done r=req12
+dequeue r=req12
 ----
 global: num=1
  lock: "c"
@@ -919,7 +919,7 @@ global: num=1
   res: req: 11, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
 local: num=0
 
-done r=req11
+dequeue r=req11
 ----
 global: num=0
 local: num=0
@@ -962,7 +962,7 @@ global: num=1
   res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
 local: num=0
 
-done r=req15
+dequeue r=req15
 ----
 global: num=1
  lock: "c"
@@ -976,12 +976,12 @@ scan r=req16
 ----
 start-waiting: false
 
-done r=req14
+dequeue r=req14
 ----
 global: num=0
 local: num=0
 
-done r=req16
+dequeue r=req16
 ----
 global: num=0
 local: num=0
@@ -1018,7 +1018,7 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
 local: num=0
 
-done r=req17
+dequeue r=req17
 ----
 global: num=2
  lock: "c"
@@ -1117,14 +1117,14 @@ scan r=req19
 ----
 start-waiting: false
 
-done r=req18
+dequeue r=req18
 ----
 global: num=1
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
 local: num=0
 
-done r=req19
+dequeue r=req19
 ----
 global: num=1
  lock: "d"
@@ -1153,7 +1153,7 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req20
+dequeue r=req20
 ----
 global: num=1
  lock: "c"
@@ -1253,7 +1253,7 @@ global: num=2
     active: false req: 21, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
 
-done r=req21
+dequeue r=req21
 ----
 global: num=1
  lock: "d"

--- a/pkg/storage/concurrency/testdata/lock_table/dup_access
+++ b/pkg/storage/concurrency/testdata/lock_table/dup_access
@@ -29,7 +29,7 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req1
+dequeue r=req1
 ----
 global: num=1
  lock: "a"
@@ -68,7 +68,7 @@ guard-state r=req2
 ----
 new: state=doneWaiting
 
-done r=req2
+dequeue r=req2
 ----
 global: num=0
 local: num=0
@@ -110,7 +110,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req3
+dequeue r=req3
 ----
 global: num=3
  lock: "a"
@@ -270,7 +270,7 @@ global: num=3
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
 local: num=0
 
-done r=req4
+dequeue r=req4
 ----
 global: num=2
  lock: "b"
@@ -279,7 +279,7 @@ global: num=2
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
 local: num=0
 
-done r=req5
+dequeue r=req5
 ----
 global: num=0
 local: num=0
@@ -328,7 +328,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req6
+dequeue r=req6
 ----
 global: num=3
  lock: "a"
@@ -485,7 +485,7 @@ global: num=2
    distinguished req: 8
 local: num=0
 
-done r=req7
+dequeue r=req7
 ----
 global: num=1
  lock: "b"
@@ -495,7 +495,7 @@ global: num=1
    distinguished req: 8
 local: num=0
 
-done r=req8
+dequeue r=req8
 ----
 global: num=1
  lock: "b"

--- a/pkg/storage/concurrency/testdata/lock_table/dup_access
+++ b/pkg/storage/concurrency/testdata/lock_table/dup_access
@@ -1,21 +1,21 @@
 # Tests where the same key is in both ReadWrite and ReadOnly spans.
 
-locktable maxlocks=10000
+new-lock-table maxlocks=10000
 ----
 
 # Test: req2 accesses "a" as both write and read. Once it has reservation for write
 # it does not wait at "a" for read.
 
-txn txn=txn1 ts=10 epoch=0
+new-txn txn=txn1 ts=10 epoch=0
 ----
 
-txn txn=txn2 ts=10 epoch=0
+new-txn txn=txn2 ts=10 epoch=0
 ----
 
-txn txn=txn3 ts=10 epoch=0
+new-txn txn=txn3 ts=10 epoch=0
 ----
 
-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
 
 scan r=req1
@@ -36,7 +36,7 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req2 txn=txn2 ts=10 spans=w@a+r@a
+new-request r=req2 txn=txn2 ts=10 spans=w@a+r@a
 ----
 
 scan r=req2
@@ -76,7 +76,7 @@ local: num=0
 # Test: req5 accesses "b" as both write and read. It has its reservation at "b" broken, but ignores
 # "b" when encounters it as reader.
 
-request r=req3 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req3 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
 
 scan r=req3
@@ -121,7 +121,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req4 txn=txn2 ts=10 spans=w@a+w@b
+new-request r=req4 txn=txn2 ts=10 spans=w@a+w@b
 ----
 
 scan r=req4
@@ -132,7 +132,7 @@ guard-state r=req4
 ----
 new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
 
-request r=req5 txn=txn3 ts=10 spans=w@b+w@c+r@b
+new-request r=req5 txn=txn3 ts=10 spans=w@b+w@c+r@b
 ----
 
 scan r=req5
@@ -294,7 +294,7 @@ local: num=0
 # "b" when encountering it as a reader. This is the non-transactional request version of the
 # previous test.
 
-request r=req6 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req6 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
 
 scan r=req6
@@ -339,7 +339,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req7 txn=txn2 ts=10 spans=w@a+w@b
+new-request r=req7 txn=txn2 ts=10 spans=w@a+w@b
 ----
 
 scan r=req7
@@ -350,7 +350,7 @@ guard-state r=req7
 ----
 new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
 
-request r=req8 txn=none ts=10 spans=w@b+w@c+r@b
+new-request r=req8 txn=none ts=10 spans=w@b+w@c+r@b
 ----
 
 scan r=req8

--- a/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
@@ -211,7 +211,7 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 
-done r=req1
+dequeue r=req1
 ----
 global: num=1
  lock: "c"
@@ -222,7 +222,7 @@ guard-state r=req2
 ----
 new: state=doneWaiting
 
-done r=req2
+dequeue r=req2
 ----
 global: num=0
 local: num=0

--- a/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/storage/concurrency/testdata/lock_table/non_active_waiter
@@ -1,15 +1,15 @@
 # Tests where a request is a non-active waiter.
 
-locktable maxlocks=10000
+new-lock-table maxlocks=10000
 ----
 
-txn txn=txn1 ts=10 epoch=0
+new-txn txn=txn1 ts=10 epoch=0
 ----
 
-txn txn=txn2 ts=10 epoch=0
+new-txn txn=txn2 ts=10 epoch=0
 ----
 
-request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
 ----
 
 scan r=req1
@@ -68,7 +68,7 @@ global: num=3
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
 
-request r=req2 txn=txn1 ts=10 spans=w@c
+new-request r=req2 txn=txn1 ts=10 spans=w@c
 ----
 
 scan r=req2

--- a/pkg/storage/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/storage/concurrency/testdata/lock_table/non_txn_write
@@ -1,17 +1,17 @@
-locktable maxlocks=10000
+new-lock-table maxlocks=10000
 ----
 
-txn txn=txn1 ts=10 epoch=0
+new-txn txn=txn1 ts=10 epoch=0
 ----
 
-txn txn=txn2 ts=10 epoch=0
+new-txn txn=txn2 ts=10 epoch=0
 ----
 
-txn txn=txn3 ts=10 epoch=0
+new-txn txn=txn3 ts=10 epoch=0
 ----
 
 # First locks at a, b, c are acquired by txn1
-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
+new-request r=req1 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
 
 scan r=req1
@@ -57,14 +57,14 @@ global: num=3
 local: num=0
 
 # Next, two different transactional requests wait at a and b.
-request r=req2 txn=txn2 ts=10 spans=w@a
+new-request r=req2 txn=txn2 ts=10 spans=w@a
 ----
 
 scan r=req2
 ----
 start-waiting: true
 
-request r=req3 txn=txn3 ts=10 spans=w@b
+new-request r=req3 txn=txn3 ts=10 spans=w@b
 ----
 
 scan r=req3
@@ -73,7 +73,7 @@ start-waiting: true
 
 # Next, a non-transactional request that wants to write a, b, c waits at a.
 
-request r=req4 txn=none ts=10 spans=w@a+w@b+w@c
+new-request r=req4 txn=none ts=10 spans=w@a+w@b+w@c
 ----
 
 scan r=req4
@@ -82,7 +82,7 @@ start-waiting: true
 
 # Next, a transactional request that arrives later than the non-transactional request waits at c
 
-request r=req5 txn=txn3 ts=10 spans=w@c
+new-request r=req5 txn=txn3 ts=10 spans=w@c
 ----
 
 scan r=req5
@@ -145,7 +145,7 @@ new: state=doneWaiting
 
 # Add another transactional request at a. It will wait behind the non-transactional request.
 
-request r=req6 txn=txn1 ts=10 spans=w@a
+new-request r=req6 txn=txn1 ts=10 spans=w@a
 ----
 
 scan r=req6

--- a/pkg/storage/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/storage/concurrency/testdata/lock_table/non_txn_write
@@ -45,7 +45,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req1
+dequeue r=req1
 ----
 global: num=3
  lock: "a"
@@ -171,7 +171,7 @@ local: num=0
 # reservation. The second waiter will acquire the reservation. The non-transactional request will
 # wait behind the reservation holder at b.
 
-done r=req2
+dequeue r=req2
 ----
 global: num=3
  lock: "a"
@@ -207,7 +207,7 @@ local: num=0
 # Release the reservation at b. The non-transactional waiter will be done at b, and when it gets
 # to c it will see a reservation holder with a higher sequence num and ignore it.
 
-done r=req3
+dequeue r=req3
 ----
 global: num=2
  lock: "a"
@@ -288,7 +288,7 @@ new: state=doneWaiting
 
 # Make all requests done.
 
-done r=req4
+dequeue r=req4
 ----
 global: num=2
  lock: "a"
@@ -297,14 +297,14 @@ global: num=2
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
 local: num=0
 
-done r=req5
+dequeue r=req5
 ----
 global: num=1
  lock: "a"
   res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req6
+dequeue r=req6
 ----
 global: num=0
 local: num=0

--- a/pkg/storage/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/storage/concurrency/testdata/lock_table/size_limit_exceeded
@@ -65,7 +65,7 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-done r=req1
+dequeue r=req1
 ----
 global: num=3
  lock: "a"

--- a/pkg/storage/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/storage/concurrency/testdata/lock_table/size_limit_exceeded
@@ -6,16 +6,16 @@
 # - lock held replicated with no active waiter (lock "d"): not cleared and inactive waiter remains
 #   in queue. The next ScanAndEnqueue call makes it an active waiter.
 
-locktable maxlocks=4
+new-lock-table maxlocks=4
 ----
 
-txn txn=txn1 ts=10 epoch=0
+new-txn txn=txn1 ts=10 epoch=0
 ----
 
-txn txn=txn2 ts=10 epoch=0
+new-txn txn=txn2 ts=10 epoch=0
 ----
 
-request r=req1 txn=txn1 ts=10 spans=w@a,e
+new-request r=req1 txn=txn1 ts=10 spans=w@a,e
 ----
 
 scan r=req1
@@ -76,14 +76,14 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req2 txn=txn2 ts=10 spans=w@a,c
+new-request r=req2 txn=txn2 ts=10 spans=w@a,c
 ----
 
 scan r=req2
 ----
 start-waiting: true
 
-request r=req3 txn=txn2 ts=10 spans=w@a,c
+new-request r=req3 txn=txn2 ts=10 spans=w@a,c
 ----
 
 scan r=req3
@@ -142,28 +142,28 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
 local: num=0
 
-request r=req4 txn=txn2 ts=10 spans=r@b
+new-request r=req4 txn=txn2 ts=10 spans=r@b
 ----
 
 scan r=req4
 ----
 start-waiting: true
 
-request r=req5 txn=txn2 ts=10 spans=w@b
+new-request r=req5 txn=txn2 ts=10 spans=w@b
 ----
 
 scan r=req5
 ----
 start-waiting: true
 
-request r=req6 txn=txn2 ts=10 spans=w@c
+new-request r=req6 txn=txn2 ts=10 spans=w@c
 ----
 
 scan r=req6
 ----
 start-waiting: true
 
-request r=req7 txn=txn2 ts=10 spans=w@d
+new-request r=req7 txn=txn2 ts=10 spans=w@d
 ----
 
 scan r=req7
@@ -200,7 +200,7 @@ global: num=4
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
 
-request r=req8 txn=txn2 ts=10 spans=w@e
+new-request r=req8 txn=txn2 ts=10 spans=w@e
 ----
 
 scan r=req8


### PR DESCRIPTION
This PR contains three small improvements that were suggested in #45062 by @tbg:
- prefix creation directives with "new-"
- rename `done` directive to `dequeue`
- rename `guard-start-waiting` directive to `should-wait`

@sumeerbhola I'll let you decide how you'd like to sequence this with #45124.