### PR TITLE
sql: run postqueries with EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -65,3 +65,11 @@ EXECUTE x(1, 1)
 # Regression test for #34927.
 statement ok
 EXPLAIN ANALYZE (DISTSQL) DELETE FROM a WHERE true
+
+# Regression test for #45099 (not running postqueries with EXPLAIN ANALYZE).
+statement ok
+CREATE TABLE p (p INT8 PRIMARY KEY);
+CREATE TABLE c (c INT8 PRIMARY KEY, p INT8 REFERENCES p (p))
+
+query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1148,11 +1148,12 @@ func (ef *execFactory) ConstructExplain(
 	switch options.Mode {
 	case tree.ExplainDistSQL:
 		return &explainDistSQLNode{
-			options:       options,
-			plan:          p.plan,
-			subqueryPlans: p.subqueryPlans,
-			analyze:       analyzeSet,
-			stmtType:      stmtType,
+			options:        options,
+			plan:           p.plan,
+			subqueryPlans:  p.subqueryPlans,
+			postqueryPlans: p.postqueryPlans,
+			analyze:        analyzeSet,
+			stmtType:       stmtType,
 		}, nil
 
 	case tree.ExplainVec:


### PR DESCRIPTION
Previously, postqueries didn't run when executing a query with EXPLAIN
ANALYZE. This is incorrect (for example, this allows for circumventing
foreign key checks) and is now fixed.

Fixes: #45099.

Release note: None (the bug is present only with experimental settings).