### PR TITLE
sql: add inverted indexes on arrays

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1095,8 +1095,6 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="crdb_internal.get_zone_config"></a><code>crdb_internal.get_zone_config(namespace_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td></td></tr>
 <tr><td><a name="crdb_internal.is_admin"></a><code>crdb_internal.is_admin() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Retrieves the current user’s admin status.</p>
 </span></td></tr>
-<tr><td><a name="crdb_internal.json_num_index_entries"></a><code>crdb_internal.json_num_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
 <tr><td><a name="crdb_internal.lease_holder"></a><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.locality_value"></a><code>crdb_internal.locality_value(key: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the value of the specified locality key.</p>
@@ -1104,6 +1102,10 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="crdb_internal.no_constant_folding"></a><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.node_executable_version"></a><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.pretty_key"></a><code>crdb_internal.pretty_key(raw_key: <a href="bytes.html">bytes</a>, skip_fields: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>

--- a/pkg/cli/testdata/dump/inverted_index
+++ b/pkg/cli/testdata/dump/inverted_index
@@ -3,12 +3,16 @@ CREATE DATABASE d;
 CREATE TABLE d.t (
 	a JSON,
 	b JSON,
-	INVERTED INDEX idx (a)
+	c INT[],
+	d INT[],
+	INVERTED INDEX idx (a),
+	INVERTED INDEX idx3 (c)
 );
 
 CREATE INVERTED INDEX idx2 ON d.t (b);
+CREATE INVERTED INDEX idx4 ON d.t (d);
 
-INSERT INTO d.t VALUES ('{"a": "b"}', '{"c": "d"}');
+INSERT INTO d.t VALUES ('{"a": "b"}', '{"c": "d"}', ARRAY[1], ARRAY[2]);
 ----
 INSERT 1
 
@@ -18,12 +22,16 @@ dump d t
 CREATE TABLE t (
 	a JSONB NULL,
 	b JSONB NULL,
+	c INT8[] NULL,
+	d INT8[] NULL,
 	INVERTED INDEX idx (a),
+	INVERTED INDEX idx3 (c),
 	INVERTED INDEX idx2 (b),
-	FAMILY "primary" (a, b, rowid)
+	INVERTED INDEX idx4 (d),
+	FAMILY "primary" (a, b, c, d, rowid)
 );
 
-INSERT INTO t (a, b) VALUES
-	('{"a": "b"}', '{"c": "d"}');
+INSERT INTO t (a, b, c, d) VALUES
+	('{"a": "b"}', '{"c": "d"}', ARRAY[1], ARRAY[2]);
 ----
 ----

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1243,7 +1243,7 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 				row, err := ie.QueryRowEx(ctx, "verify-inverted-idx-count", txn,
 					sqlbase.InternalExecutorSessionDataOverride{},
 					fmt.Sprintf(
-						`SELECT coalesce(sum_int(crdb_internal.json_num_index_entries(%q)), 0) FROM [%d AS t]`,
+						`SELECT coalesce(sum_int(crdb_internal.num_inverted_index_entries(%q)), 0) FROM [%d AS t]`,
 						col, tableDesc.ID,
 					),
 				)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -701,3 +701,116 @@ CREATE INVERTED INDEX ON table_with_nulls (a)
 
 statement ok
 DROP TABLE table_with_nulls
+
+statement ok
+DROP TABLE c
+
+subtest arrays
+
+statement ok
+CREATE TABLE c (
+  id INT PRIMARY KEY,
+  foo INT[],
+  bar STRING[],
+  INVERTED INDEX (foo),
+  FAMILY "primary" (id, foo, bar)
+)
+
+statement ok
+INSERT INTO c VALUES(0, NULL, NULL)
+
+statement ok
+INSERT INTO c VALUES(1, ARRAY[], ARRAY['foo', 'bar', 'baz'])
+
+statement ok
+CREATE INDEX ON c USING GIN (bar)
+
+query TT
+SHOW CREATE TABLE c
+----
+c  CREATE TABLE c (
+   id INT8 NOT NULL,
+   foo INT8[] NULL,
+   bar STRING[] NULL,
+   CONSTRAINT "primary" PRIMARY KEY (id ASC),
+   INVERTED INDEX c_foo_idx (foo),
+   INVERTED INDEX c_bar_idx (bar),
+   FAMILY "primary" (id, foo, bar)
+)
+
+query ITT
+SELECT * from c WHERE bar @> ARRAY['foo']
+----
+1  {}  {foo,bar,baz}
+
+query ITT
+SELECT * from c WHERE bar @> ARRAY['bar', 'baz']
+----
+1  {}  {foo,bar,baz}
+
+query ITT
+SELECT * from c WHERE bar @> ARRAY['bar', 'qux']
+----
+
+statement ok
+INSERT INTO c VALUES(2, NULL, NULL)
+
+statement ok
+INSERT INTO c VALUES(3, ARRAY[0,1,NULL], ARRAY['a',NULL,'b',NULL])
+
+statement ok
+INSERT INTO c VALUES(4, ARRAY[1,2,3], ARRAY['b',NULL,'c'])
+
+statement ok
+INSERT INTO c VALUES(5, ARRAY[], ARRAY[NULL, NULL])
+
+# Create a second inverted index on c, to test backfills.
+statement ok
+CREATE INVERTED INDEX ON c(foo)
+
+statement ok
+CREATE INVERTED INDEX ON c(bar)
+
+query ITT
+SELECT * FROM c WHERE foo @> ARRAY[0]
+----
+3  {0,1,NULL}  {a,NULL,b,NULL}
+
+query error unsupported comparison operator
+SELECT * FROM c WHERE foo @> 0
+
+query ITT
+SELECT * FROM c WHERE foo @> ARRAY[1] ORDER BY id
+----
+3  {0,1,NULL}  {a,NULL,b,NULL}
+4  {1,2,3}     {b,NULL,c}
+
+# This is expected, although it looks odd, because in SQL,
+# ARRAY[NULL] @> ARRAY[NULL] returns false.
+query ITT
+SELECT * FROM c WHERE foo @> ARRAY[NULL]::INT[]
+----
+
+query ITT
+SELECT * FROM c WHERE bar @> ARRAY['a']
+----
+3  {0,1,NULL}  {a,NULL,b,NULL}
+
+query ITT
+SELECT * FROM c WHERE bar @> ARRAY['b'] ORDER BY id
+----
+3  {0,1,NULL}  {a,NULL,b,NULL}
+4  {1,2,3}     {b,NULL,c}
+
+query ITT
+SELECT * FROM c WHERE bar @> ARRAY['c']
+----
+4  {1,2,3}  {b,NULL,c}
+
+query ITT
+SELECT * FROM c WHERE bar @> ARRAY[]::TEXT[] ORDER BY id
+----
+1  {}          {foo,bar,baz}
+3  {0,1,NULL}  {a,NULL,b,NULL}
+4  {1,2,3}     {b,NULL,c}
+5  {}          {NULL,NULL}

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -48,7 +48,7 @@ type Index interface {
 	// IsUnique returns true if this index is declared as UNIQUE in the schema.
 	IsUnique() bool
 
-	// IsInverted returns true if this is a JSON inverted index.
+	// IsInverted returns true if this is an inverted index.
 	IsInverted() bool
 
 	// ColumnCount returns the number of columns in the index. This includes

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -8,7 +8,25 @@ CREATE TABLE d (
 )
 
 statement ok
+CREATE TABLE e (
+  a INT PRIMARY KEY,
+  b INT[],
+  FAMILY (a,b),
+  INVERTED INDEX(b)
+)
+
+statement ok
+CREATE TABLE f (
+  a INT PRIMARY KEY,
+  b DECIMAL[],
+  FAMILY (a,b),
+  INVERTED INDEX(b)
+)
+
+statement ok
 CREATE INVERTED INDEX foo_inv ON d(b)
+
+# Tests for json inverted indexes.
 
 query T kvtrace
 INSERT INTO d VALUES(0, '{"a": "b"}')
@@ -77,6 +95,60 @@ DELETE FROM d WHERE a=4
 ----
 Scan /Table/53/1/4{-/#}
 Del /Table/53/1/4/0
+
+# Tests for array inverted indexes.
+
+# Make sure that duplicate entries do not get emitted more than once, and that
+# null keys don't get emitted.
+query T kvtrace
+INSERT INTO e VALUES(0, ARRAY[7,0,0,1,NULL,10,0,1,7,NULL])
+----
+CPut /Table/54/1/0/0 -> /TUPLE/
+InitPut /Table/54/2/0/0/0 -> /BYTES/
+InitPut /Table/54/2/1/0/0 -> /BYTES/
+InitPut /Table/54/2/7/0/0 -> /BYTES/
+InitPut /Table/54/2/10/0/0 -> /BYTES/
+
+# Make sure that empty arrays do not emit any keys at all.
+query T kvtrace
+INSERT INTO e VALUES(1, ARRAY[])
+----
+CPut /Table/54/1/1/0 -> /TUPLE/
+
+# Make sure that NULL arrays do not emit any keys at all.
+query T kvtrace
+INSERT INTO e VALUES(2, NULL)
+----
+CPut /Table/54/1/2/0 -> /TUPLE/
+
+# Make sure that NULL entries within an array don't emit any keys.
+query T kvtrace
+INSERT INTO e VALUES(3, ARRAY[NULL])
+----
+CPut /Table/54/1/3/0 -> /TUPLE/
+
+# Test that array inverted indexes work okay with decimals (a type with
+# composite encoding). Also, make sure that the composite encoding is
+# de-duplicated - 1.0 and 1.00 should just have one entry.
+
+query T kvtrace
+INSERT INTO f VALUES(0, ARRAY[7,0,0,1.000,10,0,1,7,1.0,1.00])
+----
+CPut /Table/55/1/0/0 -> /TUPLE/
+InitPut /Table/55/2/0/0/0 -> /BYTES/
+InitPut /Table/55/2/1/0/0 -> /BYTES/
+InitPut /Table/55/2/7/0/0 -> /BYTES/
+InitPut /Table/55/2/1E+1/0/0 -> /BYTES/
+
+query T kvtrace
+INSERT INTO f VALUES(1, ARRAY[])
+----
+CPut /Table/55/1/1/0 -> /TUPLE/
+
+query T kvtrace
+INSERT INTO f VALUES(2, NULL)
+----
+CPut /Table/55/1/2/0 -> /TUPLE/
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
@@ -400,3 +472,98 @@ scan  ·            ·                          (a, b)  ·
 ·     table        d@primary                  ·       ·
 ·     spans        ALL                        ·       ·
 ·     filter       b @> '{"a": {}, "b": {}}'  ·       ·
+
+subtest array
+
+# Tests for array inverted indexes.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1]
+----
+·           distributed  false      ·       ·
+·           vectorized   false      ·       ·
+index-join  ·            ·          (a, b)  ·
+ │          table        e@primary  ·       ·
+ │          key columns  a          ·       ·
+ └── scan   ·            ·          (a)     ·
+·           table        e@e_b_idx  ·       ·
+·           spans        /1-/2      ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
+----
+·     distributed  false         ·       ·
+·     vectorized   false         ·       ·
+scan  ·            ·             (a, b)  ·
+·     table        e@primary     ·       ·
+·     spans        ALL           ·       ·
+·     filter       b @> ARRAY[]  ·       ·
+
+# Test that searching for a NULL element using the inverted index.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
+----
+·            distributed  false      ·       ·
+·            vectorized   false      ·       ·
+index-join   ·            ·          (a, b)  ·
+ │           table        e@primary  ·       ·
+ │           key columns  a          ·       ·
+ └── norows  ·            ·          (a)     ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> NULL
+----
+·       distributed  false  ·       ·
+·       vectorized   false  ·       ·
+norows  ·            ·      (a, b)  ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
+----
+·     distributed  false      ·       ·
+·     vectorized   false      ·       ·
+scan  ·            ·          (a, b)  ·
+·     table        e@primary  ·       ·
+·     spans        ALL        ·       ·
+·     filter       b IS NULL  ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
+----
+·                 distributed            false             ·       ·
+·                 vectorized             false             ·       ·
+lookup-join       ·                      ·                 (a, b)  ·
+ │                table                  e@primary         ·       ·
+ │                type                   inner             ·       ·
+ │                equality               (a) = (a)         ·       ·
+ │                equality cols are key  ·                 ·       ·
+ │                parallel               ·                 ·       ·
+ │                pred                   @2 @> ARRAY[1,2]  ·       ·
+ └── zigzag-join  ·                      ·                 (a)     ·
+      │           type                   inner             ·       ·
+      ├── scan    ·                      ·                 (a)     ·
+      │           table                  e@e_b_idx         ·       ·
+      │           fixedvals              1 column          ·       ·
+      └── scan    ·                      ·                 ()      ·
+·                 table                  e@e_b_idx         ·       ·
+·                 fixedvals              1 column          ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
+----
+·                 distributed            false                                  ·       ·
+·                 vectorized             false                                  ·       ·
+lookup-join       ·                      ·                                      (a, b)  ·
+ │                table                  e@primary                              ·       ·
+ │                type                   inner                                  ·       ·
+ │                equality               (a) = (a)                              ·       ·
+ │                equality cols are key  ·                                      ·       ·
+ │                parallel               ·                                      ·       ·
+ │                pred                   (@2 @> ARRAY[1]) AND (@2 @> ARRAY[2])  ·       ·
+ └── zigzag-join  ·                      ·                                      (a)     ·
+      │           type                   inner                                  ·       ·
+      ├── scan    ·                      ·                                      (a)     ·
+      │           table                  e@e_b_idx                              ·       ·
+      │           fixedvals              1 column                               ·       ·
+      └── scan    ·                      ·                                      ()      ·
+·                 table                  e@e_b_idx                              ·       ·
+·                 fixedvals              1 column                               ·       ·

--- a/pkg/sql/opt/idxconstraint/testdata/inverted
+++ b/pkg/sql/opt/idxconstraint/testdata/inverted
@@ -44,3 +44,55 @@ index-constraints vars=(jsonb, int) inverted-index=@1
 ----
 [/'{"a": 1}' - /'{"a": 1}']
 Remaining filter: (@2 = 1) AND (@1 @> '{"b": 1}')
+
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[1]
+----
+[/ARRAY[1] - /ARRAY[1]]
+
+index-constraints vars=(int[]) inverted-index=@1
+ARRAY[1] <@ @1
+----
+[/ARRAY[1] - /ARRAY[1]]
+
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[1,2]
+----
+[/ARRAY[1] - /ARRAY[1]]
+Remaining filter: @1 @> ARRAY[1,2]
+
+# Currently we only generate spans from one of the @> expressions.
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[1] AND @1 @> ARRAY[2]
+----
+[/ARRAY[1] - /ARRAY[1]]
+Remaining filter: @1 @> ARRAY[2]
+
+# This could be better - @1 @> ARRAY[] is always true, but we currently
+# don't remove the extra filter.
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[]::INT[]
+----
+[ - ]
+Remaining filter: @1 @> ARRAY[]
+
+# Arrays never contain ARRAY[NULL,...]
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[NULL]::INT[]
+----
+
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[1, NULL]::INT[]
+----
+
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> ARRAY[NULL, 1]::INT[]
+----
+
+# NOTE: this should be a contradiction, but the test harness strips the
+# constraint out too early by accident, I think.
+index-constraints vars=(int[]) inverted-index=@1
+@1 @> NULL
+----
+[ - ]
+Remaining filter: NULL

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -22,6 +22,15 @@ CREATE TABLE b
 )
 ----
 
+exec-ddl
+CREATE TABLE c
+(
+    k INT PRIMARY KEY,
+    a INT[],
+    INVERTED INDEX inv_idx(a)
+)
+----
+
 # --------------------------------------------------
 # GenerateConstrainedScans
 # --------------------------------------------------
@@ -919,3 +928,74 @@ project
            ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
            ├── locking: for-update
            └── key: (1)
+
+# Tests for array inverted indexes.
+opt
+SELECT k FROM c WHERE a @> ARRAY[1]
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── index-join c
+      ├── columns: k:1!null a:2
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      └── scan c@inv_idx
+           ├── columns: k:1!null
+           ├── constraint: /2/1: [/ARRAY[1] - /ARRAY[1]]
+           └── key: (1)
+
+opt
+SELECT k FROM c WHERE a @> ARRAY[1,3,1,5]
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── inner-join (lookup c)
+      ├── columns: k:1!null a:2
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── inner-join (zigzag c@inv_idx c@inv_idx)
+      │    ├── columns: k:1!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [2] = [ARRAY[1]]
+      │    ├── right fixed columns: [2] = [ARRAY[3]]
+      │    └── filters (true)
+      └── filters
+           └── a:2 @> ARRAY[1,3,1,5] [outer=(2)]
+
+opt
+SELECT k FROM c WHERE a @> ARRAY[]::INT[]
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan c
+      │    ├── columns: k:1!null a:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── a:2 @> ARRAY[] [outer=(2)]
+
+opt
+SELECT k FROM c WHERE a IS NULL
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan c
+      │    ├── columns: k:1!null a:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── a:2 IS NULL [outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3600,8 +3600,9 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
-	// Returns the number of distinct inverted index entries that would be generated for a JSON value.
-	"crdb_internal.json_num_index_entries": makeBuiltin(
+	// Returns the number of distinct inverted index entries that would be
+	// generated for a value.
+	"crdb_internal.num_inverted_index_entries": makeBuiltin(
 		tree.FunctionProperties{
 			Category:     categorySystemInfo,
 			NullableArgs: true,
@@ -3619,6 +3620,28 @@ may increase either contention or retry errors, or both.`,
 					return nil, err
 				}
 				return tree.NewDInt(tree.DInt(n)), nil
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.AnyArray}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				arg := args[0]
+				if arg == tree.DNull {
+					return tree.DZero, nil
+				}
+				arr := tree.MustBeDArray(arg)
+				if !arr.HasNonNulls {
+					// Inverted indexes on arrays don't contain entries for null array
+					// elements.
+					return tree.DZero, nil
+				}
+				keys, err := sqlbase.EncodeInvertedIndexTableKeys(arr, nil)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(len(keys))), nil
 			},
 			Info: "This function is used only by CockroachDB's developers for testing purposes.",
 		},

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2266,7 +2266,8 @@ func ColumnTypeIsIndexable(t *types.T) bool {
 // ColumnTypeIsInvertedIndexable returns whether the type t is valid to be indexed
 // using an inverted index.
 func ColumnTypeIsInvertedIndexable(t *types.T) bool {
-	return t.Family() == types.JsonFamily
+	family := t.Family()
+	return family == types.JsonFamily || family == types.ArrayFamily
 }
 
 func notIndexableError(cols []ColumnDescriptor, inverted bool) error {


### PR DESCRIPTION
Closes #43199.

This commit adds inverted index support to arrays. Inverted index
entries are created from arrays by simply encoding a key that contains
the array element's table key encoding. Nulls are not indexed, since in
SQL, ARRAY[1, NULL] @> ARRAY[NULL] returns false.

For example, in a table t(int, int[]) with an inverted index with id 3
on the int[] column the row (10, [1, NULL, 2]) produces 2 index keys:

```
/tableId/3/1/10
/tableId/3/2/10
```

This encoding scheme is much simpler than the one for JSON, since arrays
don't have "paths": their elements are simply ordinary datums.

Release note (sql change): The inverted index implementation now
supports indexing array columns. This permits accelerating containment
queries (@> and <@) on array columns by adding an index to them.