### PR TITLE
[rfc] sql: teach cockroach how to do "assignment" casts

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -134,7 +134,7 @@ func (r *insertRun) initRowContainer(
 // processSourceRow processes one row from the source for insertion and, if
 // result rows are needed, saves it in the result row container.
 func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceLocalColumnConstraints(rowVals, r.insertCols); err != nil {
+	if err := enforceLocalColumnConstraints(params.EvalContext(), rowVals, r.insertCols); err != nil {
 		return err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1,0 +1,31 @@
+# These tests specifically for assignment cast situations.
+subtest assignment_casts
+
+statement ok
+CREATE TABLE a (a timestamp)
+
+statement ok
+INSERT INTO a VALUES ('1970-01-01'::timestamptz)
+
+query T
+SELECT * FROM a ORDER BY a
+----
+1970-01-01 00:00:00 +0000 +0000
+
+statement ok
+UPSERT INTO a VALUES ('1971-01-01'::timestamptz)
+
+query T
+SELECT * FROM a ORDER BY a
+----
+1970-01-01 00:00:00 +0000 +0000
+1971-01-01 00:00:00 +0000 +0000
+
+statement ok
+UPDATE a SET a = '2001-01-01'::timestamptz WHERE 1 = 1
+
+query T
+SELECT * FROM a ORDER BY a
+----
+2001-01-01 00:00:00 +0000 +0000
+2001-01-01 00:00:00 +0000 +0000

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -758,8 +758,11 @@ CREATE TABLE x (
   b INT AS (a+1) STORED
 )
 
-query error value type decimal doesn't match type int of column "a"
+query error unsupported binary operator: <decimal> \+ <int> \(desired <int>\)
 INSERT INTO x VALUES(1.4)
+
+query error value type date doesn't match type int of column "a"
+INSERT INTO x VALUES('1970-01-01'::date)
 
 # Regression test for #34901: verify that builtins can be used in computed
 # column expressions without a "memory budget exceeded" error while backfilling

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -16,8 +16,8 @@ SELECT * FROM f
 statement ok
 CREATE TABLE i (x INT)
 
-statement error value type decimal doesn't match type int of column "x"
-INSERT INTO i(x) VALUES (4.5)
+statement error value type timestamptz doesn't match type int of column "x"
+INSERT INTO i(x) VALUES ('1970-01-01'::timestamptz)
 
 statement ok
 INSERT INTO i(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6)

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,20 +1,26 @@
 statement ok
+CREATE TABLE invalid_assign_cast (
+  k TIMESTAMPTZ PRIMARY KEY,
+  v TIMESTAMPTZ
+)
+
+statement error value type tuple{int, int} doesn't match type timestamptz of column "v"
+UPDATE invalid_assign_cast SET v = (SELECT (10, 11))
+
+statement error value type decimal doesn't match type timestamptz of column "v"
+UPDATE invalid_assign_cast SET v = 3.2
+
+statement error value type int doesn't match type timestamptz of column "k"
+UPDATE invalid_assign_cast SET (k, v) = (3, 3.2)
+
+statement error value type int doesn't match type timestamptz of column "k"
+UPDATE invalid_assign_cast SET (k, v) = (SELECT 3, 3.2)
+
+statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT
 )
-
-statement error value type tuple{int, int} doesn't match type int of column "v"
-UPDATE kv SET v = (SELECT (10, 11))
-
-statement error value type decimal doesn't match type int of column "v"
-UPDATE kv SET v = 3.2
-
-statement error value type decimal doesn't match type int of column "v"
-UPDATE kv SET (k, v) = (3, 3.2)
-
-statement error value type decimal doesn't match type int of column "v"
-UPDATE kv SET (k, v) = (SELECT 3, 3.2)
 
 statement count 4
 INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1474,6 +1474,11 @@ func checkDatumTypeFitsColumnType(col cat.Column, typ *types.T) {
 		return
 	}
 
+	// See if we can cast this with the assign context.
+	if _, ok := tree.FindCast(typ.Oid(), col.DatumType().Oid(), tree.CastContextAssignment); ok {
+		return
+	}
+
 	colName := string(col.ColName())
 	panic(pgerror.Newf(pgcode.DatatypeMismatch,
 		"value type %s doesn't match type %s of column %q",

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1584,6 +1584,7 @@ func (ef *execFactory) ConstructUpsert(
 			checkOrds:  checks,
 			insertCols: ri.InsertCols,
 			tw: optTableUpserter{
+				evalCtx:       ef.planner.EvalContext(),
 				ri:            ri,
 				alloc:         &ef.planner.alloc,
 				canaryOrdinal: int(canaryCol),

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1,0 +1,414 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import (
+	"fmt"
+
+	"github.com/lib/pq/oid"
+)
+
+// CastContext specifies how a given Castable can be used.
+// A higher value corresponds to a higher strictness.
+// Higher value CastContext can use lower value CastContexts.
+type CastContext uint8
+
+const (
+	_ CastContext = iota
+	// CastContextExplicit implies that the cast can only be used
+	// in an explicit context.
+	CastContextExplicit
+	// CastContextAssignment implies that the cast can done implicitly
+	// in assign contexts (e.g. on UPDATE and INSERT).
+	CastContextAssignment
+	// CastContextImplicit implies the cast can be set implicitly
+	// in any context.
+	CastContextImplicit
+)
+
+// CastMethod specifies how the cast is done.
+// This is legacy from postgres, but affects type overloads,
+// so we also include it.
+type CastMethod byte
+
+const (
+	// CastMethodFunc means that the function specified in the
+	// castfunc field is used.
+	CastMethodFunc = 'f'
+	// CastMethodIO means that the input/output functions are used
+	CastMethodIO = 'i'
+	// CastMethodBinary means that the types are binary-coercible,
+	// thus no conversion is required.
+	CastMethodBinary = 'b'
+)
+
+// Castable defines how a method can be cast.
+type Castable struct {
+	Source  oid.Oid
+	Target  oid.Oid
+	Context CastContext
+	Method  CastMethod
+	// TODO(XXX): evaluate whether we should move eval.go's PerformCast
+	// to here.
+}
+
+// CastableMap defines which oids can be cast to which other oids.
+// The map goes from src oid -> target oid -> Castable.
+// Source and Target are initialized in init().
+// Adapted from `pg_cast.dat` from postgres.
+// TODO(XXX): test everything in CastableMap is possible in PerformCast,
+// and vice versa.
+var CastableMap = map[oid.Oid]map[oid.Oid]Castable{
+	oid.T_bit: {
+		oid.T_bit:    {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int4:   {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_int8:   {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_varbit: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_bool: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_box: {
+		oid.T_circle:  {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_lseg:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_point:   {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_polygon: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_bpchar: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_char:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_name:    {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_xml:     {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_char: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_cidr: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_inet:    {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_circle: {
+		oid.T_box:     {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_point:   {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_polygon: {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_date: {
+		oid.T_timestamp:   {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_timestamptz: {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_float4: {
+		oid.T_float8:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int2:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_numeric: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_float8: {
+		oid.T_float4:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int2:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_numeric: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_inet: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_cidr:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_int2: {
+		oid.T_float4:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_float8:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int4:          {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int8:          {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_numeric:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_oid:           {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regclass:      {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regconfig:     {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regdictionary: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regnamespace:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regoper:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regoperator:   {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regproc:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regprocedure:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regrole:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regtype:       {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_int4: {
+		oid.T_bit:           {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_bool:          {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_char:          {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_float4:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_float8:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int2:          {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int8:          {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_money:         {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_numeric:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_oid:           {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regclass:      {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regconfig:     {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regdictionary: {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regnamespace:  {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoper:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoperator:   {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regproc:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regprocedure:  {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regrole:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regtype:       {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_int8: {
+		oid.T_bit:           {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_float4:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_float8:        {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int2:          {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:          {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_money:         {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_numeric:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_oid:           {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regclass:      {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regconfig:     {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regdictionary: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regnamespace:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regoper:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regoperator:   {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regproc:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regprocedure:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regrole:       {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regtype:       {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_interval: {
+		oid.T_interval: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_time:     {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_json: {
+		oid.T_jsonb: {Method: CastMethodIO, Context: CastContextAssignment},
+	},
+	oid.T_jsonb: {
+		oid.T_bool:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_float4:  {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_float8:  {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_int2:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_json:    {Method: CastMethodIO, Context: CastContextAssignment},
+		oid.T_numeric: {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_lseg: {
+		oid.T_point: {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	//oid.T_macaddr:{
+	//	oid.T_macaddr8: {Method: CastMethodFunc, Context: CastContextImplicit},
+	//},
+	//oid.T_macaddr8:{
+	//	oid.T_macaddr: {Method: CastMethodFunc, Context: CastContextImplicit},
+	//},
+	oid.T_money: {
+		oid.T_numeric: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_name: {
+		oid.T_bpchar:  {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_text:    {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_varchar: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_numeric: {
+		oid.T_float4:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_float8:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_int2:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int4:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_money:   {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_numeric: {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_oid: {
+		oid.T_int4:          {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8:          {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_regclass:      {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regconfig:     {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regdictionary: {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regnamespace:  {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoper:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoperator:   {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regproc:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regprocedure:  {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regrole:       {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regtype:       {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_path: {
+		oid.T_point:   {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_polygon: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	//oid.T_pg_dependencies:{
+	//	oid.T_bytea: {Method: CastMethodBinary, Context: CastContextImplicit},
+	//	oid.T_text:  {Method: CastMethodIO, Context: CastContextImplicit},
+	//},
+	//oid.T_pg_mcv_list:{
+	//	oid.T_bytea: {Method: CastMethodBinary, Context: CastContextImplicit},
+	//	oid.T_text:  {Method: CastMethodIO, Context: CastContextImplicit},
+	//},
+	//oid.T_pg_ndistinct:{
+	//	oid.T_bytea: {Method: CastMethodBinary, Context: CastContextImplicit},
+	//	oid.T_text:  {Method: CastMethodIO, Context: CastContextImplicit},
+	//},
+	oid.T_pg_node_tree: {
+		oid.T_text: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_point: {
+		oid.T_box: {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_polygon: {
+		oid.T_box:    {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_circle: {Method: CastMethodFunc, Context: CastContextExplicit},
+		oid.T_path:   {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_point:  {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_regclass: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regconfig: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regdictionary: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regnamespace: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regoper: {
+		oid.T_int4:        {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8:        {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:         {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoperator: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regoperator: {
+		oid.T_int4:    {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:     {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regoper: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regproc: {
+		oid.T_int4:         {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8:         {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:          {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regprocedure: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regprocedure: {
+		oid.T_int4:    {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8:    {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:     {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_regproc: {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regrole: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_regtype: {
+		oid.T_int4: {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_int8: {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_oid:  {Method: CastMethodBinary, Context: CastContextImplicit},
+	},
+	oid.T_text: {
+		oid.T_bpchar:   {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_char:     {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_name:     {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regclass: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_varchar:  {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_xml:      {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_time: {
+		oid.T_interval: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_time:     {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_timetz:   {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_timestamp: {
+		oid.T_date:        {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_time:        {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_timestamp:   {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_timestamptz: {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_timestamptz: {
+		oid.T_date:        {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_time:        {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_timestamp:   {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_timestamptz: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_timetz:      {Method: CastMethodFunc, Context: CastContextAssignment},
+	},
+	oid.T_timetz: {
+		oid.T_time:   {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_timetz: {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_varbit: {
+		oid.T_bit:    {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_varbit: {Method: CastMethodFunc, Context: CastContextImplicit},
+	},
+	oid.T_varchar: {
+		oid.T_bpchar:   {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_char:     {Method: CastMethodFunc, Context: CastContextAssignment},
+		oid.T_name:     {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_regclass: {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_text:     {Method: CastMethodBinary, Context: CastContextImplicit},
+		oid.T_varchar:  {Method: CastMethodFunc, Context: CastContextImplicit},
+		oid.T_xml:      {Method: CastMethodFunc, Context: CastContextExplicit},
+	},
+	oid.T_xml: {
+		oid.T_bpchar:  {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_text:    {Method: CastMethodBinary, Context: CastContextAssignment},
+		oid.T_varchar: {Method: CastMethodBinary, Context: CastContextAssignment},
+	},
+}
+
+// FindCast returns whether the given src oid can be cast to
+// the target oid, given the CastContext.
+// Returns a Castable object if it can be cast, and a bool whether the cast is valid.
+func FindCast(src oid.Oid, tgt oid.Oid, ctx CastContext) (Castable, bool) {
+	if tgts, ok := CastableMap[src]; ok {
+		if castable, ok := tgts[tgt]; ok {
+			return castable, ctx >= castable.Context
+		}
+	}
+	return Castable{}, false
+}
+
+// init does sanity checks on the given CastableMap.
+func init() {
+	for src, tgts := range CastableMap {
+		for tgt := range tgts {
+			ent := CastableMap[src][tgt]
+			ent.Source = src
+			ent.Target = tgt
+			if ent.Context == CastContext(0) {
+				panic(fmt.Sprintf("cast from %d to %d has no Context set", src, tgt))
+			}
+			if ent.Method == CastMethod(0) {
+				panic(fmt.Sprintf("cast from %d to %d has no Method set", src, tgt))
+			}
+			CastableMap[src][tgt] = ent
+		}
+	}
+}

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -45,6 +45,8 @@ import (
 type optTableUpserter struct {
 	tableWriterBase
 
+	evalCtx *tree.EvalContext
+
 	ri    row.Inserter
 	alloc *sqlbase.DatumAlloc
 
@@ -367,7 +369,11 @@ func (tu *optTableUpserter) updateConflictingRow(
 	//   via GenerateInsertRow().
 	// - for the fetched part, we assume that the data in the table is
 	//   correct already.
-	if err := enforceLocalColumnConstraints(updateValues, tu.updateCols); err != nil {
+	if err := enforceLocalColumnConstraints(
+		tu.evalCtx,
+		updateValues,
+		tu.updateCols,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -295,7 +295,11 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// Verify the schema constraints. For consistency with INSERT/UPSERT
 	// and compatibility with PostgreSQL, we must do this before
 	// processing the CHECK constraints.
-	if err := enforceLocalColumnConstraints(u.run.updateValues, u.run.tu.ru.UpdateCols); err != nil {
+	if err := enforceLocalColumnConstraints(
+		params.EvalContext(),
+		u.run.updateValues,
+		u.run.tu.ru.UpdateCols,
+	); err != nil {
 		return err
 	}
 
@@ -422,17 +426,31 @@ func (ss scalarSlot) checkColumnTypes(row []tree.TypedExpr) error {
 //
 // The row buffer is modified in-place with the result of the
 // checks.
-func enforceLocalColumnConstraints(row tree.Datums, cols []sqlbase.ColumnDescriptor) error {
+func enforceLocalColumnConstraints(
+	ctx *tree.EvalContext, row tree.Datums, cols []sqlbase.ColumnDescriptor,
+) error {
 	for i := range cols {
 		col := &cols[i]
 		if !col.Nullable && row[i] == tree.DNull {
 			return sqlbase.NewNonNullViolationError(col.Name)
 		}
-		outVal, err := sqlbase.LimitValueWidth(&col.Type, row[i], &col.Name)
+		var err error
+		if !col.Type.Equivalent(row[i].ResolvedType()) {
+			if _, ok := tree.FindCast(
+				row[i].ResolvedType().Oid(),
+				col.Type.Oid(),
+				tree.CastContextAssignment,
+			); ok {
+				row[i], err = tree.PerformCast(ctx, row[i], &col.Type)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		row[i], err = sqlbase.LimitValueWidth(&col.Type, row[i], &col.Name)
 		if err != nil {
 			return err
 		}
-		row[i] = outVal
 	}
 	return nil
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -152,7 +152,11 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 // processSourceRow processes one row from the source for upsertion.
 // The table writer is in charge of accumulating the result rows.
 func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceLocalColumnConstraints(rowVals, n.run.insertCols); err != nil {
+	if err := enforceLocalColumnConstraints(
+		params.EvalContext(),
+		rowVals,
+		n.run.insertCols,
+	); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Assign casts are used in INSERT and UPDATE (and UPSERT). They can be
used to implicit cast certain columns to certain other values, if they
are so inclined.

Example:

```
CREATE TABLE a (a timestamp);

INSERT INTO a VALUES ('1970-01-01'::timestamptz); -- note timestamptz
```

This should be allowed behaviour but is currently prohibited by us.

Release note: None