### PR TITLE
colexec: fix TestRepeatableBatchSource

### DIFF
--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1042,6 +1042,9 @@ func TestRepeatableBatchSource(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	batchLen := uint16(10)
+	if coldata.BatchSize() < batchLen {
+		batchLen = coldata.BatchSize()
+	}
 	batch.SetLength(batchLen)
 	input := NewRepeatableBatchSource(testAllocator, batch)
 


### PR DESCRIPTION
The test wasn't paying attention to whether the BatchSize was less than a
constant batchLen it uses, which results in a slice out of bounds when
performing slice operations.

Release note: None (testing change)

Fixes #45101 