### PR TITLE
colexec: fix TestHashRouterRandom

### DIFF
--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -801,11 +801,12 @@ func TestHashRouterRandom(t *testing.T) {
 	// same data to the same number of outputs.
 	var expectedDistribution []int
 	for _, mtc := range memoryTestCases {
-		t.Run(testName, func(t *testing.T) {
+		t.Run(fmt.Sprintf(testName+"/memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []Operator) {
 				unblockEventsChan := make(chan struct{}, 2*numOutputs)
 				outputs := make([]routerOutput, numOutputs)
 				outputsAsOps := make([]Operator, numOutputs)
+				memoryLimitPerOutput := mtc.bytes / int64(len(outputs))
 				for i := range outputs {
 					acc := testMemMonitor.MakeBoundAccount()
 					defer acc.Close(ctx)
@@ -813,7 +814,7 @@ func TestHashRouterRandom(t *testing.T) {
 					// may not be used concurrently.
 					allocator := NewAllocator(ctx, &acc)
 					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(
-						allocator, typs, unblockEventsChan, mtc.bytes, queueCfg, blockedThreshold, outputSize,
+						allocator, typs, unblockEventsChan, memoryLimitPerOutput, queueCfg, blockedThreshold, outputSize,
 					)
 					outputs[i] = op
 					outputsAsOps[i] = op


### PR DESCRIPTION
TestHashRouterRandom would previously create each output with the overall
memory limit, resulting in a possible memory use of 128GiB (max 128 outputs,
max 1GiB memory limit) and OOM errors. This is now fixed by calculating a
memory limit per output, as is done in `NewHashRouter`.

Release note: None (testing fix)

Fixes #45136 