### PR TITLE
roachtest: set num_replicas to 1 for all zones

### DIFF
--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -43,6 +43,30 @@ func alterZoneConfigAndClusterSettings(
 		return err
 	}
 
+	if _, err := db.ExecContext(
+		ctx, `ALTER TABLE system.public.jobs CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+	); err != nil {
+		return err
+	}
+
+	if _, err := db.ExecContext(
+		ctx, `ALTER RANGE meta CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+	); err != nil {
+		return err
+	}
+
+	if _, err := db.ExecContext(
+		ctx, `ALTER RANGE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+	); err != nil {
+		return err
+	}
+
+	if _, err := db.ExecContext(
+		ctx, `ALTER RANGE liveness CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;`,
+	); err != nil {
+		return err
+	}
+
 	// TODO(rafi): remove this check once we stop testing against 2.0 and 2.1
 	if strings.HasPrefix(version, "v2.0") || strings.HasPrefix(version, "v2.1") {
 		return nil


### PR DESCRIPTION
The meta, system, and liveness ranges previously had a replication
factor of 5 for ORM/driver tests that used a single-node cluster. This
is extraneous, so now num_replicas is overriden to 1.

Release note: None