### PR TITLE
roachprod: use start-single-node for single-node clusters

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -407,7 +407,7 @@ func initTempStorageConfig(
 	return tempStorageConfig, nil
 }
 
-var errCannotUseJoin = errors.New("cannot use --join with 'cockroach start-single-node' -- use 'cockrach start' instead")
+var errCannotUseJoin = errors.New("cannot use --join with 'cockroach start-single-node' -- use 'cockroach start' instead")
 
 func runStartSingleNode(cmd *cobra.Command, args []string) error {
 	joinFlag := flagSetForCmd(cmd).Lookup(cliflags.Join.Name)


### PR DESCRIPTION
Previously, the `start` CLI command was used for all invocations of
`roachprod start`. Now, the `start-single-node` command will be used if
it is available. This will set up the cluster to have a replication
factor of 1.

Currently, using `start` without the `--join` flag is deprecated, and this
behavior will be disallowed in a future version, so using `start-single-node`
will eventually become mandatory.

Additionally, fix a typo in the warning message advising use of
start-single-node.

Release note: None