### PR TITLE
release-19.2: colflow: check that physical types match on the ends of streams

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -511,17 +512,8 @@ func (s *vectorizedFlowCreator) setupOutput(
 		}
 		// Make the materializer, which will write to the given receiver.
 		columnTypes := s.syncFlowConsumer.Types()
-		converted, err := typeconv.FromColumnTypes(columnTypes)
-		if err != nil {
-			return errors.AssertionFailedf(
-				"unsupported types should have been caught in SupportsVectorized check\n%v", err)
-		}
-		for i, expColType := range converted {
-			if opOutputTypes[i] != expColType {
-				return errors.Errorf("mismatched physical types at index %d: expected %v\tactual %v ",
-					i, converted, opOutputTypes,
-				)
-			}
+		if err := assertTypesMatch(columnTypes, opOutputTypes); err != nil {
+			return err
 		}
 		var outputStatsToTrace func()
 		if s.recordingStats {
@@ -662,26 +654,31 @@ func (s *vectorizedFlowCreator) setupFlow(
 	NEXTOUTPUT:
 		for i := range pspec.Output {
 			for j := range pspec.Output[i].Streams {
-				stream := &pspec.Output[i].Streams[j]
-				if stream.Type != execinfrapb.StreamEndpointSpec_LOCAL {
+				outputStream := &pspec.Output[i].Streams[j]
+				if outputStream.Type != execinfrapb.StreamEndpointSpec_LOCAL {
 					continue
 				}
-				procIdx, ok := streamIDToSpecIdx[stream.StreamID]
+				procIdx, ok := streamIDToSpecIdx[outputStream.StreamID]
 				if !ok {
-					return nil, errors.Errorf("couldn't find stream %d", stream.StreamID)
+					return nil, errors.Errorf("couldn't find stream %d", outputStream.StreamID)
 				}
 				outputSpec := &processorSpecs[procIdx]
 				for k := range outputSpec.Input {
 					for l := range outputSpec.Input[k].Streams {
-						stream := outputSpec.Input[k].Streams[l]
-						if stream.Type == execinfrapb.StreamEndpointSpec_REMOTE {
+						inputStream := outputSpec.Input[k].Streams[l]
+						if inputStream.StreamID == outputStream.StreamID {
+							if err := assertTypesMatch(outputSpec.Input[k].ColumnTypes, opOutputTypes); err != nil {
+								return nil, err
+							}
+						}
+						if inputStream.Type == execinfrapb.StreamEndpointSpec_REMOTE {
 							// Remote streams are not present in streamIDToInputOp. The
 							// Inboxes that consume these streams are created at the same time
 							// as the operator that needs them, so skip the creation check for
 							// this input.
 							continue
 						}
-						if _, ok := s.streamIDToInputOp[stream.StreamID]; !ok {
+						if _, ok := s.streamIDToInputOp[inputStream.StreamID]; !ok {
 							continue NEXTOUTPUT
 						}
 					}
@@ -697,6 +694,23 @@ func (s *vectorizedFlowCreator) setupFlow(
 		execerror.VectorizedInternalPanic("not all vectorized stats collectors have been processed")
 	}
 	return s.leaves, nil
+}
+
+// assertTypesMatch checks whether expected logical types match with actual
+// physical types and returns an error if not.
+func assertTypesMatch(expected []types.T, actual []coltypes.T) error {
+	converted, err := typeconv.FromColumnTypes(expected)
+	if err != nil {
+		return err
+	}
+	for i := range converted {
+		if converted[i] != actual[i] {
+			return errors.Errorf("mismatched physical types at index %d: expected %v\tactual %v ",
+				i, converted, actual,
+			)
+		}
+	}
+	return nil
 }
 
 type vectorizedInboundStreamHandler struct {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -117,5 +117,15 @@ SELECT CAST(0 BETWEEN(CASE NULL WHEN c0 = 0 THEN NULL END) AND 0 IS TRUE AS INT)
 ----
 0
 
+# Regression test for #45038 (mismatched physical types between expected and
+# actual physical types when wrapping unsupported processor cores).
+statement ok
+CREATE TABLE t45038(c0 INT); INSERT INTO t45038 VALUES(NULL)
+
+query R
+SELECT sum(c) FROM (SELECT CAST((IF(IF(false, false, c0 IS NULL), NULL, NULL)) BETWEEN 0 AND 0 IS TRUE AS INT) c FROM t45038)
+----
+0
+
 statement ok
 RESET default_int_size


### PR DESCRIPTION
Backport 1/1 commits from #45042.

/cc @cockroachdb/release

---

Previously, it was possible to have a types mismatch on the ends of
a stream (for example, output Int64 when the input expects Int32). This
would result in an internal error. Now we check for this, and if such
scenario occurs, we fallback to row-by-row engine.

I'm not sure whether it was possible to get into this scenario without
wrapped processors, but we should backport this anyway.

There is no release note since we have just fixed a related issue and an
additional release note would sound repetitive.

Fixes: #45038.

Release note: None
