### PR TITLE
roachprod: fix "install charybdefs"

### DIFF
--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -39,7 +39,7 @@ sudo service cassandra stop;
     sudo mkdir -p "${thrift_dir}"
     sudo chmod 777 "${thrift_dir}"
     cd "${thrift_dir}"
-    curl "http://www.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz" | sudo tar xvz --strip-components 1
+    curl "https://downloads.apache.org/thrift/0.10.0/thrift-0.10.0.tar.gz" | sudo tar xvz --strip-components 1
     sudo ./configure --prefix=/usr
     sudo make -j$(nproc)
     sudo make install


### PR DESCRIPTION
The location of the thrift tar moved.

Fixes #45138
Fixes #45137
Fixes #45110
Fixes #44750

Release note: None