### PR TITLE
jobs: fix flake introduced by #45096

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -373,17 +373,15 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.mu.e.ResumeStart = true
 		rts.check(t, jobs.StatusRunning)
 		rts.sqlDB.Exec(t, "CANCEL JOB $1", *job.ID())
-		// Test for a canceled error message.
-		if err := job.CheckStatus(rts.ctx); !testutils.IsError(err, "cannot update progress") {
-			t.Fatalf("unexpected %v", err)
-		}
 		rts.mu.e.OnFailOrCancelStart = true
 		rts.failOrCancelCheckCh <- struct{}{}
+		// Test for Reverting status.
 		rts.check(t, jobs.StatusReverting)
 		rts.mu.e.OnFailOrCancelExit++
 		rts.failOrCancelCh <- nil
 		rts.mu.e.Terminal++
 		rts.termCh <- struct{}{}
+		// Test for Canceled status.
 		rts.check(t, jobs.StatusCanceled)
 	})
 


### PR DESCRIPTION
In the test there is a race condition between
checking that job cannot update progress and
switching the job to status Reverting. I removed
the check as it is unnecessary since we already
check in the end of the test that the job is marked
as Canceled.

In the future it is advisable to stress test all PRs
that touch jobs infrastructure to avoid flakes.

Fixes #45131.
Fixes #45204.

Release note: none.