### PR TITLE
config/zonepb: increase default range size from 64/16 MB to 512/128 MB

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -79,29 +79,29 @@ SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] ORDER BY 1
 INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
                                 num_replicas = 5
 RANGE default                   ALTER RANGE default CONFIGURE ZONE USING
-                                range_min_bytes = 16777216,
-                                range_max_bytes = 67108864,
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
                                 gc.ttlseconds = 90000,
                                 num_replicas = 3,
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE liveness                  ALTER RANGE liveness CONFIGURE ZONE USING
-                                range_min_bytes = 16777216,
-                                range_max_bytes = 67108864,
+                                range_min_bytes = 137438953472,
+                                range_max_bytes = 549755813888,
                                 gc.ttlseconds = 600,
                                 num_replicas = 5,
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE meta                      ALTER RANGE meta CONFIGURE ZONE USING
-                                range_min_bytes = 16777216,
-                                range_max_bytes = 67108864,
+                                range_min_bytes = 137438953472,
+                                range_max_bytes = 549755813888,
                                 gc.ttlseconds = 3600,
                                 num_replicas = 5,
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE system                    ALTER RANGE system CONFIGURE ZONE USING
-                                range_min_bytes = 16777216,
-                                range_max_bytes = 67108864,
+                                range_min_bytes = 137438953472,
+                                range_max_bytes = 549755813888,
                                 gc.ttlseconds = 90000,
                                 num_replicas = 5,
                                 constraints = '[]',
@@ -125,8 +125,8 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX myt4index
 ----
 INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
-                                range_min_bytes = 16777216,
-                                range_max_bytes = 67108864,
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
                                 gc.ttlseconds = 90000,
                                 num_replicas = 5,
                                 constraints = '[]',
@@ -136,8 +136,8 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE t4
 ----
 TABLE t4  ALTER TABLE t4 CONFIGURE ZONE USING
-          range_min_bytes = 16777216,
-          range_max_bytes = 67108864,
+          range_min_bytes = 134217728,
+          range_max_bytes = 536870912,
           gc.ttlseconds = 90000,
           num_replicas = 7,
           constraints = '[]',
@@ -147,8 +147,8 @@ query TT
 SHOW ZONE CONFIGURATION FOR RANGE default
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 16777216,
-               range_max_bytes = 67108864,
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
                gc.ttlseconds = 90000,
                num_replicas = 3,
                constraints = '[]',

--- a/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
@@ -16,20 +16,20 @@ query TTTTTTTTT colnames
 SHOW PARTITIONS FROM DATABASE test
 ----
 database_name  table_name  partition_name  parent_partition  column_names  index_name  partition_value  zone_config  full_zone_config
-test           t1          p1              NULL              x             t1@primary  (1)              NULL         range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test           t1          p1              NULL              x             t1@primary  (1)              NULL         range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[]',
 lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@primary  (2)  NULL  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p2  NULL  x  t1@primary  (2)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[]',
 lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@primary  (3)  NULL  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p3  NULL  x  t1@primary  (3)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[]',
@@ -44,20 +44,20 @@ query TTTTTTTTT colnames
 SHOW PARTITIONS FROM DATABASE test
 ----
 database_name  table_name  partition_name  parent_partition  column_names  index_name  partition_value  zone_config                full_zone_config
-test           t1          p1              NULL              x             t1@primary  (1)              constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test           t1          p1              NULL              x             t1@primary  (1)              constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
@@ -66,20 +66,20 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t1
 ----
-test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
@@ -88,20 +88,20 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t1@primary
 ----
-test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
@@ -123,32 +123,32 @@ ALTER PARTITION p2 OF TABLE t2 CONFIGURE ZONE USING constraints='[+dc=dc2]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE test
 ----
-test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t1  p1  NULL  x  t1@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p2  NULL  x  t1@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t1  p3  NULL  x  t1@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
 lease_preferences = '[]'
-test                      t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
@@ -157,14 +157,14 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t2
 ----
-test  t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
@@ -173,14 +173,14 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t2@primary
 ----
-test  t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t2  p1  NULL  x  t2@primary  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t2  p2  NULL  x  t2@primary  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
@@ -210,26 +210,26 @@ ALTER PARTITION p4 OF INDEX t3@sec CONFIGURE ZONE USING constraints='[+dc=dc4]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t3
 ----
-test  t3  p1  NULL  x  t3@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t3  p1  NULL  x  t3@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t3  p2  NULL  x  t3@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p2  NULL  x  t3@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
 lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc4]',
@@ -238,26 +238,26 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t3@*
 ----
-test  t3  p1  NULL  x  t3@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t3  p1  NULL  x  t3@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t3  p2  NULL  x  t3@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p2  NULL  x  t3@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
 lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc4]',
@@ -266,14 +266,14 @@ lease_preferences = '[]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t3@sec
 ----
-test  t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
 lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc4]',
@@ -303,32 +303,32 @@ ALTER PARTITION p2_a OF TABLE t4 CONFIGURE ZONE USING constraints='[+dc=dc5]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t4
 ----
-test  t4  p1  NULL  x  t4@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test  t4  p1  NULL  x  t4@primary  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc1]',
 lease_preferences = '[]'
-test                      t4  p1_a  p1  y  t4@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t4  p1_a  p1  y  t4@primary  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc2]',
 lease_preferences = '[]'
-test                      t4  p1_b  p1  y  t4@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t4  p1_b  p1  y  t4@primary  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc3]',
 lease_preferences = '[]'
-test                      t4  p2  NULL  x  t4@primary  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t4  p2  NULL  x  t4@primary  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc4]',
 lease_preferences = '[]'
-test                      t4  p2_a  p2  y  t4@primary  (5)  constraints = '[+dc=dc5]'  range_min_bytes = 16777216,
-range_max_bytes = 67108864,
+test                      t4  p2_a  p2  y  t4@primary  (5)  constraints = '[+dc=dc5]'  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
 gc.ttlseconds = 90000,
 num_replicas = 3,
 constraints = '[+dc=dc5]',

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -949,32 +949,32 @@ CREATE TABLE d_show_partitions.t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PAR
 query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE d_show_partitions
 ----
-d_show_partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                                 range_max_bytes = 67108864,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 3,
-                                                 constraints = '[]',
-                                                 lease_preferences = '[]'
+d_show_partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE d_show_partitions.t
 ----
-d_show_partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                                 range_max_bytes = 67108864,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 3,
-                                                 constraints = '[]',
-                                                 lease_preferences = '[]'
+d_show_partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX d_show_partitions.t@primary
 ----
-d_show_partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                                 range_max_bytes = 67108864,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 3,
-                                                 constraints = '[]',
-                                                 lease_preferences = '[]'
+d_show_partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 statement ok
 CREATE DATABASE "show partitions"
@@ -985,32 +985,32 @@ CREATE TABLE "show partitions".t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PAR
 query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE "show partitions"
 ----
-show partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                               range_max_bytes = 67108864,
-                                               gc.ttlseconds = 90000,
-                                               num_replicas = 3,
-                                               constraints = '[]',
-                                               lease_preferences = '[]'
+show partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE "show partitions".t
 ----
-show partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                               range_max_bytes = 67108864,
-                                               gc.ttlseconds = 90000,
-                                               num_replicas = 3,
-                                               constraints = '[]',
-                                               lease_preferences = '[]'
+show partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX "show partitions".t@primary
 ----
-show partitions t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                               range_max_bytes = 67108864,
-                                               gc.ttlseconds = 90000,
-                                               num_replicas = 3,
-                                               constraints = '[]',
-                                               lease_preferences = '[]'
+show partitions  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 statement ok
 CREATE DATABASE """"
@@ -1021,32 +1021,32 @@ CREATE TABLE """".t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PARTITION p1 VAL
 query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE """"
 ----
-" t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                 range_max_bytes = 67108864,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 constraints = '[]',
-                                 lease_preferences = '[]'
+"  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE """".t
 ----
-" t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                 range_max_bytes = 67108864,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 constraints = '[]',
-                                 lease_preferences = '[]'
+"  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX """".t@primary
 ----
-" t p1 NULL x t@primary (1) NULL range_min_bytes = 16777216,
-                                 range_max_bytes = 67108864,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 constraints = '[]',
-                                 lease_preferences = '[]'
+"  t  p1  NULL  x  t@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.partitions' AND usage_count > 0
@@ -1063,12 +1063,12 @@ ALTER TABLE t_inherit PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1) )
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit
 ----
-test  t_inherit  p1  NULL  x  t_inherit@primary  (1)  NULL  range_min_bytes = 16777216,
-                                                            range_max_bytes = 67108864,
-                                                            gc.ttlseconds = 90000,
-                                                            num_replicas = 3,
-                                                            constraints = '[]',
-                                                            lease_preferences = '[]'
+test  t_inherit  p1  NULL  x  t_inherit@primary  (1)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 statement ok
 ALTER PARTITION p1 of TABLE t_inherit CONFIGURE ZONE USING num_replicas=5
@@ -1076,12 +1076,12 @@ ALTER PARTITION p1 of TABLE t_inherit CONFIGURE ZONE USING num_replicas=5
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit
 ----
-test  t_inherit  p1  NULL  x  t_inherit@primary  (1)  num_replicas = 5  range_min_bytes = 16777216,
-                                                                        range_max_bytes = 67108864,
-                                                                        gc.ttlseconds = 90000,
-                                                                        num_replicas = 5,
-                                                                        constraints = '[]',
-                                                                        lease_preferences = '[]'
+test  t_inherit  p1  NULL  x  t_inherit@primary  (1)  num_replicas = 5  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+constraints = '[]',
+lease_preferences = '[]'
 
 statement ok
 CREATE TABLE t_inherit_range (x INT PRIMARY KEY)
@@ -1092,12 +1092,12 @@ ALTER TABLE t_inherit_range PARTITION BY RANGE (x) ( PARTITION p1 VALUES FROM (1
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
-test  t_inherit_range  p1  NULL  x  t_inherit_range@primary  (1) TO (2)  NULL  range_min_bytes = 16777216,
-                                                                               range_max_bytes = 67108864,
-                                                                               gc.ttlseconds = 90000,
-                                                                               num_replicas = 3,
-                                                                               constraints = '[]',
-                                                                               lease_preferences = '[]'
+test  t_inherit_range  p1  NULL  x  t_inherit_range@primary  (1) TO (2)  NULL  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+constraints = '[]',
+lease_preferences = '[]'
 
 statement ok
 ALTER PARTITION p1 of TABLE t_inherit_range CONFIGURE ZONE USING num_replicas=5
@@ -1105,9 +1105,9 @@ ALTER PARTITION p1 of TABLE t_inherit_range CONFIGURE ZONE USING num_replicas=5
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
-test  t_inherit_range  p1  NULL  x  t_inherit_range@primary  (1) TO (2)  num_replicas = 5  range_min_bytes = 16777216,
-                                                                                           range_max_bytes = 67108864,
-                                                                                           gc.ttlseconds = 90000,
-                                                                                           num_replicas = 5,
-                                                                                           constraints = '[]',
-                                                                                           lease_preferences = '[]'
+test  t_inherit_range  p1  NULL  x  t_inherit_range@primary  (1) TO (2)  num_replicas = 5  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+constraints = '[]',
+lease_preferences = '[]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -482,8 +482,8 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION x1 OF TABLE t35756
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 16777216,
-               range_max_bytes = 67108864,
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
                gc.ttlseconds = 90000,
                num_replicas = 3,
                constraints = '[]',
@@ -512,8 +512,8 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION x1_idx OF INDEX t38391@foo
 ----
 PARTITION x1_idx OF INDEX t38391@foo  ALTER PARTITION x1_idx OF INDEX t38391@foo CONFIGURE ZONE USING
-                                      range_min_bytes = 16777216,
-                                      range_max_bytes = 67108864,
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
                                       gc.ttlseconds = 31337,
                                       num_replicas = 3,
                                       constraints = '[]',
@@ -863,20 +863,20 @@ query TTT
 SELECT table_name, index_name, full_config_sql FROM crdb_internal.zones WHERE
 table_name='t38074'
 ----
-t38074 NULL ALTER TABLE test.public.t38074 CONFIGURE ZONE USING
-                               range_min_bytes = 16777216,
-                               range_max_bytes = 67108864,
-                               gc.ttlseconds = 70000,
-                               num_replicas = 3,
-                               constraints = '[]',
-                               lease_preferences = '[]'
-t38074 i ALTER INDEX test.public.t38074@i CONFIGURE ZONE USING
-                               range_min_bytes = 16777216,
-                               range_max_bytes = 67108864,
-                               gc.ttlseconds = 80000,
-                               num_replicas = 3,
-                               constraints = '[]',
-                               lease_preferences = '[]'
+t38074  NULL  ALTER TABLE test.public.t38074 CONFIGURE ZONE USING
+        range_min_bytes = 134217728,
+        range_max_bytes = 536870912,
+        gc.ttlseconds = 70000,
+        num_replicas = 3,
+        constraints = '[]',
+        lease_preferences = '[]'
+t38074  i                         ALTER INDEX test.public.t38074@i CONFIGURE ZONE USING
+        range_min_bytes = 134217728,
+        range_max_bytes = 536870912,
+        gc.ttlseconds = 80000,
+        num_replicas = 3,
+        constraints = '[]',
+        lease_preferences = '[]'
 
 # Regression test for #39994: verify that certain fields have to be set in tandem in indexes and partitions.
 statement ok

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -189,8 +189,8 @@ func EmptyCompleteZoneConfig() *ZoneConfig {
 func DefaultZoneConfig() ZoneConfig {
 	return ZoneConfig{
 		NumReplicas:   proto.Int32(3),
-		RangeMinBytes: proto.Int64(16 << 20), // 16 MB
-		RangeMaxBytes: proto.Int64(64 << 20), // 64 MB
+		RangeMinBytes: proto.Int64(128 << 20), // 128 MB
+		RangeMaxBytes: proto.Int64(512 << 20), // 512 MB
 		GC: &GCPolicy{
 			// Use 25 hours instead of the previous 24 to make users successful by
 			// default. Users desiring to take incremental backups every 24h may
@@ -217,8 +217,8 @@ func DefaultZoneConfigRef() *ZoneConfig {
 func DefaultSystemZoneConfig() ZoneConfig {
 	return ZoneConfig{
 		NumReplicas:   proto.Int32(5),
-		RangeMinBytes: proto.Int64(16 << 20), // 16 MB
-		RangeMaxBytes: proto.Int64(64 << 20), // 64 MB
+		RangeMinBytes: proto.Int64(128 << 30), // 128 MB
+		RangeMaxBytes: proto.Int64(512 << 30), // 512 MB
 		GC: &GCPolicy{
 			// Use 25 hours instead of the previous 24 to make users successful by
 			// default. Users desiring to take incremental backups every 24h may

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -242,14 +242,14 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 query T
 SELECT quote_literal(raw_config_yaml) FROM crdb_internal.zones WHERE zone_id = 0
 ----
-e'range_min_bytes: 16777216\nrange_max_bytes: 67108864\ngc:\n  ttlseconds: 90000\nnum_replicas: 3\nconstraints: []\nlease_preferences: []\n'
+e'range_min_bytes: 134217728\nrange_max_bytes: 536870912\ngc:\n  ttlseconds: 90000\nnum_replicas: 3\nconstraints: []\nlease_preferences: []\n'
 
 query T
 SELECT raw_config_sql FROM crdb_internal.zones WHERE zone_id = 0
 ----
 ALTER RANGE default CONFIGURE ZONE USING
-  range_min_bytes = 16777216,
-  range_max_bytes = 67108864,
+  range_min_bytes = 134217728,
+  range_max_bytes = 536870912,
   gc.ttlseconds = 90000,
   num_replicas = 3,
   constraints = '[]',

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -475,4 +475,3 @@ CREATE TABLE t (x INT, y INT, PRIMARY KEY (x, y) USING HASH WITH BUCKET_COUNT = 
 
 statement error pq: interleaved indexes cannot also be hash sharded
 CREATE INDEX ON parent (x) USING HASH WITH BUCKET_COUNT = 10 INTERLEAVE IN PARENT parent(x)
-

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -7,8 +7,8 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR RANGE default]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
-   range_min_bytes = 16777216,
-   range_max_bytes = 67108864,
+   range_min_bytes = 134217728,
+   range_max_bytes = 536870912,
    gc.ttlseconds = 90000,
    num_replicas = 1,
    constraints = '[]',
@@ -23,8 +23,8 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR RANGE default]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
-   range_min_bytes = 16777216,
-   range_max_bytes = 67108864,
+   range_min_bytes = 134217728,
+   range_max_bytes = 536870912,
    gc.ttlseconds = 90000,
    num_replicas = 3,
    constraints = '[]',
@@ -45,7 +45,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
    range_min_bytes = 1234567,
-   range_max_bytes = 67108864,
+   range_max_bytes = 536870912,
    gc.ttlseconds = 90000,
    num_replicas = 3,
    constraints = '[]',
@@ -62,7 +62,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 53  ALTER TABLE a CONFIGURE ZONE USING
     range_min_bytes = 1234567,
-    range_max_bytes = 67108864,
+    range_max_bytes = 536870912,
     gc.ttlseconds = 90000,
     num_replicas = 3,
     constraints = '[]',
@@ -133,7 +133,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 53  ALTER TABLE a CONFIGURE ZONE USING
     range_min_bytes = 1234567,
-    range_max_bytes = 67108864,
+    range_max_bytes = 536870912,
     gc.ttlseconds = 90000,
     num_replicas = 3,
     constraints = '[]',


### PR DESCRIPTION
This change increases the default range size by a factor of 8.
There has been a good bit of manual testing at a much larger
configuration of 64/16GB. At that configuration several issues
were observed and will continue to be worked through. At this size
no negative implications are anticipated.

Release note (general change): New clusters will have a larger default
range size which will result in fewer ranges for the same amount of data. 