### PR TITLE
release-19.2: opt: fold IN / NOT IN empty tuple

### DIFF
--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -13,7 +13,6 @@ package norm_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -48,24 +47,6 @@ func TestNormRules(t *testing.T) {
 			return tester.RunCommand(t, d)
 		})
 	})
-}
-
-// Test the FoldNullInEmpty rule. Can't create empty tuple on right side of
-// IN/NOT IN in SQL, so do it here.
-func TestRuleFoldNullInEmpty(t *testing.T) {
-	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	var f norm.Factory
-	f.Init(&evalCtx)
-
-	in := f.ConstructIn(memo.NullSingleton, memo.EmptyTuple)
-	if in.Op() != opt.FalseOp {
-		t.Errorf("expected NULL IN () to fold to False")
-	}
-
-	notIn := f.ConstructNotIn(memo.NullSingleton, memo.EmptyTuple)
-	if notIn.Op() != opt.TrueOp {
-		t.Errorf("expected NULL NOT IN () to fold to True")
-	}
 }
 
 // Ensure that every binary commutative operator overload can have its operands

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -37,31 +37,25 @@
 # set is non-empty, it is unknown whether it's in/not in the set.
 [FoldNullInNonEmpty, Normalize]
 (In | NotIn
-    $left:(Null)
+    (Null)
     (Tuple ^[])
 )
 =>
 (Null (BoolType))
 
-# FoldNullInEmpty replaces the In with False when the left input is null and
-# the right input is empty, since even an unknown value can't be in an empty
-# set.
-[FoldNullInEmpty, Normalize]
-(In
-    $left:(Null)
-    (Tuple [])
-)
+# FoldInEmpty replaces the In with False when the the right input is empty. Note
+# that this is correct even if the left side is Null, since even an unknown
+# value can't be in an empty set.
+[FoldInEmpty, Normalize]
+(In * (Tuple []))
 =>
 (False)
 
-# FoldNullNotInEmpty replaces the NotIn with True when the left input is null
-# and the right input is empty, since even an unknown value can't be in an
-# empty set.
-[FoldNullNotInEmpty, Normalize]
-(NotIn
-    $left:(Null)
-    (Tuple [])
-)
+# FoldNotInEmpty replaces the NotIn with True when the right input is empty.
+# Note that this is correct even if the left side is Null, since even an unknown
+# value can't be in an empty set.
+[FoldNotInEmpty, Normalize]
+(NotIn * (Tuple []))
 =>
 (True)
 

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -132,6 +132,61 @@ project
       └── null [type=bool]
 
 # --------------------------------------------------
+# FoldInEmpty
+# --------------------------------------------------
+norm expect=FoldInEmpty
+SELECT 1 IN ()
+----
+values
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+norm expect=FoldInEmpty
+SELECT NULL IN ()
+----
+values
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+norm expect=FoldInEmpty
+SELECT i FROM a WHERE i = ANY ARRAY[]
+----
+values
+ ├── columns: i:2(int!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(2)
+
+# --------------------------------------------------
+# FoldNotInEmpty
+# --------------------------------------------------
+norm expect=FoldNotInEmpty
+SELECT 1 NOT IN ()
+----
+values
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+norm expect=FoldNotInEmpty
+SELECT NULL NOT IN ()
+----
+values
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+# --------------------------------------------------
 # FoldArray
 # --------------------------------------------------
 opt expect=FoldArray

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -45,7 +45,7 @@ inner-join (cross)
 # --------------------------------------------------
 
 opt expect=DetectJoinContradiction
-SELECT * FROM a INNER JOIN b ON k IN ()
+SELECT * FROM a INNER JOIN b ON (k<1 AND k>2) OR (k<4 AND k>5)
 ----
 values
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) x:6(int!null) y:7(int!null)
@@ -54,7 +54,7 @@ values
  └── fd: ()-->(1-7)
 
 opt expect=DetectJoinContradiction
-SELECT * FROM a LEFT JOIN b ON i=5 AND k IN () AND s='foo'
+SELECT * FROM a LEFT JOIN b ON (k<1 AND k>2) OR (k<4 AND k>5)
 ----
 left-join (cross)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
@@ -72,7 +72,7 @@ left-join (cross)
  └── filters (true)
 
 opt expect=DetectJoinContradiction
-SELECT * FROM a FULL JOIN b ON i=5 AND k IN () AND s='foo'
+SELECT * FROM a FULL JOIN b ON i=5 AND ((k<1 AND k>2) OR (k<4 AND k>5)) AND s='foo'
 ----
 full-join (cross)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1360,7 +1360,7 @@ project
 # --------------------------------------------------
 
 opt expect=DetectSelectContradiction
-SELECT k FROM b WHERE k IN ()
+SELECT k FROM b WHERE k<1 AND k>2
 ----
 values
  ├── columns: k:1(int!null)
@@ -1369,7 +1369,7 @@ values
  └── fd: ()-->(1)
 
 opt expect=DetectSelectContradiction
-SELECT k FROM b WHERE i=5 AND k IN () AND s='foo'
+SELECT k FROM b WHERE i=5 AND k<1 AND k>2 AND s='foo'
 ----
 values
  ├── columns: k:1(int!null)


### PR DESCRIPTION
Backport 1/1 commits from #45170.

/cc @cockroachdb/release

---

We have rules that fold expressions `NULL IN ()` and `NULL NOT IN ()` but we can
fold these for any left-hand side, not just NULL. Extending the rules to allow
any left-hand side.

Informs #45168.

Release note (performance improvement): faster execution plans in some cases
that involve IN / NOT IN with an empty tuple (or `= ANY` with an empty array).
