### PR TITLE
release-19.2: sql: omit virtual tables from new column type telemetry

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1354,7 +1354,10 @@ func makeTableDesc(
 		if !ok {
 			continue
 		}
-		telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
+		// Do not include virtual tables in these statistics.
+		if !sqlbase.IsVirtualTable(id) {
+			telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
+		}
 		newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, &n.Table)
 		if err != nil {
 			return ret, err


### PR DESCRIPTION
Backport 1/1 commits from #45219.

/cc @cockroachdb/release

---

Resolves https://github.com/cockroachdb/cockroach/issues/45215.

Release note: None
