### PR TITLE
(HACKATHON) sql: inject retry errors with test session var

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1808,7 +1808,11 @@ func (ex *connExecutor) makeErrEvent(err error, stmt tree.Statement) (fsm.Event,
 			panic(fmt.Sprintf("retriable error in unexpected state: %#v",
 				ex.machine.CurState()))
 		}
-		rc, canAutoRetry := ex.getRewindTxnCapability()
+		var rc rewindCapability
+		var canAutoRetry bool
+		if ex.implicitTxn() || !ex.sessionData.RetryErrorsEnabled {
+			rc, canAutoRetry = ex.getRewindTxnCapability()
+		}
 		ev := eventRetriableErr{
 			IsCommit:     fsm.FromBool(isCommit(stmt)),
 			CanAutoRetry: fsm.FromBool(canAutoRetry),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1872,6 +1872,10 @@ func (m *sessionDataMutator) SetRequireExplicitPrimaryKeys(val bool) {
 	m.data.RequireExplicitPrimaryKeys = val
 }
 
+func (m *sessionDataMutator) SetRetryErrorsEnabled(val bool) {
+	m.data.RetryErrorsEnabled = val
+}
+
 func (m *sessionDataMutator) SetReorderJoinsLimit(val int) {
 	m.data.ReorderJoinsLimit = val
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -61,6 +61,10 @@ type SessionData struct {
 	// RequireExplicitPrimaryKeys indicates whether CREATE TABLE statements should
 	// error out if no primary key is provided.
 	RequireExplicitPrimaryKeys bool
+
+	// RetryErrorsEnabled .... some doc
+	RetryErrorsEnabled bool
+
 	// SequenceState gives access to the SQL sequences that have been manipulated
 	// by the session.
 	SequenceState *SequenceState

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -87,6 +88,9 @@ type txnState struct {
 	// through the use of AS OF SYSTEM TIME.
 	isHistorical bool
 
+	// lastEpoch is the last observed epoch in the current txn.
+	lastEpoch enginepb.TxnEpoch
+
 	// mon tracks txn-bound objects like the running state of
 	// planNode in the midst of performing a computation.
 	mon *mon.BytesMonitor
@@ -152,6 +156,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	// Reset state vars to defaults.
 	ts.sqlTimestamp = sqlTimestamp
 	ts.isHistorical = false
+	ts.lastEpoch = 0
 
 	// Create a context for this transaction. It will include a root span that
 	// will contain everything executed as part of the upcoming SQL txn, including

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -406,6 +406,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`retry_errors_enabled`: {
+		GetStringVal: makeBoolGetStringValFn(`retry_errors_enabled`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetRetryErrorsEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.RetryErrorsEnabled)
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`vectorize`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.VectorizeExecModeFromString(s)


### PR DESCRIPTION
Written with @johnrk 

Previously, retry errors were only produced under contention.

This not good for training developers; because in developer
environments there is often no natural contention. It's thus possible
for a dev to move very far forward with their app without realizing
they need to care about retry errors.

This patch makes it possible for devs to validate that they have all
the necessary retry loops. Client side retry errors are forced; after
3 valid retry iterations (with the `cockroach_restart` savepoint
rollback) the transaction is allowed to succeed. This mechanism is
only enabled when the (new) session var `retry_errors_enabled` is set
to true—and it defaults to false.

At this point this feature is restricted to explicit transactions.

Release note: None