### PR TITLE
sql: improve "couldn't find With expression" error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -324,3 +324,27 @@ SELECT
 FROM
 	t40589 AS t, t40589;
 ----
+
+# Test that a reasonable error is generated for the unsupported case of an
+# apply join that references a top-level WITH clause.
+
+statement ok
+CREATE TABLE IF NOT EXISTS "cpk" (
+  "key" VARCHAR(255) NOT NULL, 
+  "value" INTEGER NOT NULL, 
+  "extra" INTEGER NOT NULL, 
+  PRIMARY KEY ("key", "value"))
+
+statement ok
+INSERT INTO "cpk" ("key", "value", "extra")
+  VALUES ('k1', 1, 1), ('k2', 2, 2), ('k3', 3, 3)
+  RETURNING "cpk"."key", "cpk"."value";
+
+query error couldn't find WITH expression \"new_values\" with ID 1
+WITH "new_values" ("k", "v", "x") AS (
+  VALUES ('k1', 1, 10), ('k3', 3, 30))
+UPDATE "cpk" SET "extra" = (
+    SELECT "new_values"."x" FROM "new_values" 
+    WHERE (("cpk"."key" = "new_values"."k") AND ("cpk"."value" = "new_values"."v"))
+) 
+WHERE (("cpk"."key", "cpk"."value") IN (SELECT "new_values"."k", "new_values"."v" FROM "new_values"));

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1519,7 +1519,9 @@ func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {
 		}
 	}
 	if e == nil {
-		panic(errors.AssertionFailedf("couldn't find With expression with ID %d", withID))
+		err := errors.Errorf("couldn't find WITH expression %q with ID %d", withScan.Name, withID)
+		return execPlan{}, errors.WithHint(
+			err, "references to WITH expressions from correlated subqueries are unsupported")
 	}
 
 	var label bytes.Buffer


### PR DESCRIPTION
There is a known issue where apply joins cannot reference top-level WITH
expressions. I improved the error messaging in this case by changing it
from a panic to an error and adding a hint about what's going on.

Fixes #42373

Release note: None