### PR TITLE
sql: change encoding strategy for distsql datum hashing

### DIFF
--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -60,11 +60,11 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 26
+const Version execinfrapb.DistSQLVersion = 27
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 24
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 27
 
 // SettingUseTempStorageJoins is a cluster setting that configures whether
 // joins are allowed to spill to disk.

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2149,3 +2149,24 @@ statement ok
 SELECT DISTINCT ON (b) b
 FROM t44469_a INNER LOOKUP JOIN t44469_b ON a = b INNER LOOKUP JOIN t44469_cd ON c = 1 AND d = a
 ORDER BY b
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x JSONB, y INT);
+INSERT INTO t VALUES
+  ('{"foo": "bar"}', 5),
+  ('{"foo": "bar"}', 10),
+  ('[1, 2]', 5),
+  ('[1, 2]', 20),
+  ('{"foo": "bar", "bar": "baz"}', 5),
+  ('{"foo": "bar", "bar": "baz"}', 30),
+  ('{"foo": {"bar" : "baz"}}', 5),
+  ('{"foo": {"bar" : "baz"}}', 40)
+
+query TT
+SELECT x, SUM (y) FROM t GROUP BY (x) ORDER BY SUM (y)
+----
+{"foo": "bar"}                15
+[1, 2]                        25
+{"bar": "baz", "foo": "bar"}  35
+{"foo": {"bar": "baz"}}       45

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -167,3 +167,46 @@ query I
 SELECT * FROM v0 WHERE v0.c0 IS NULL
 ----
 NULL
+
+# Regression test for #44079.
+statement ok
+CREATE TABLE t44079 (x INT[]);
+INSERT INTO t44079 VALUES (NULL), (ARRAY[NULL])
+
+query T rowsort
+SELECT DISTINCT * FROM t44079
+----
+NULL
+{NULL}
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x JSONB);
+INSERT INTO t VALUES
+  ('{"foo" : "bar"}'),
+  ('{"foo" : "bar"}'),
+  ('[1, 2]'),
+  ('[2, 1]'),
+  ('[1, 2]'),
+  ('{"foo": {"bar" : "baz"}}')
+
+query T rowsort
+SELECT DISTINCT (x) FROM t
+----
+[2, 1]
+[1, 2]
+{"foo": {"bar": "baz"}}
+{"foo": "bar"}
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x DECIMAL);
+INSERT INTO t VALUES (1.0), (1.00), (1.000)
+
+# We want to ensure that this only returns 1 element. We don't
+# check the element directly because it returns 1.0, 1.00, or
+# 1.000 non-deterministically in a distributed setting.
+query I
+SELECT COUNT (*) FROM (SELECT DISTINCT (array[x]) FROM t)
+----
+1

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -313,3 +313,33 @@ SELECT 1 FROM ((SELECT * FROM tab41973) UNION ALL (SELECT * FROM tab41973))
 1
 1
 1
+
+statement ok
+DROP TABLE IF EXISTS t1, t2;
+CREATE TABLE t1 (j JSONB);
+CREATE TABLE t2 (j JSONB);
+INSERT INTO t1 VALUES ('{"a": "b"}'), ('{"foo": "bar"}'), (NULL);
+INSERT INTO t2 VALUES ('{"c": "d"}'), ('{"foo": "bar"}'), (NULL);
+
+query T rowsort
+(SELECT j FROM t1) UNION (SELECT j FROM t2)
+----
+{"a": "b"}
+{"c": "d"}
+{"foo": "bar"}
+NULL
+
+statement ok
+DROP TABLE IF EXISTS t1, t2;
+CREATE TABLE t1 (a INT[]);
+CREATE TABLE t2 (b INT[]);
+INSERT INTO t1 VALUES (ARRAY[1]), (ARRAY[2]), (NULL);
+INSERT INTO t2 VALUES (ARRAY[2]), (ARRAY[3]), (NULL);
+
+query T rowsort
+(SELECT a FROM t1) UNION (SELECT b FROM t2)
+----
+{1}
+{2}
+NULL
+{3}

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -121,12 +121,7 @@ func encodeColumnsOfRow(
 		if row[colIdx].IsNull() && !encodeNull {
 			return nil, true, nil
 		}
-		// Note: we cannot compare VALUE encodings because they contain column IDs
-		// which can vary.
-		// TODO(radu): we should figure out what encoding is readily available and
-		// use that (though it needs to be consistent across all rows). We could add
-		// functionality to compare VALUE encodings ignoring the column ID.
-		appendTo, err = row[colIdx].Encode(&colTypes[i], da, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
+		appendTo, err = row[colIdx].Fingerprint(&colTypes[i], da, appendTo)
 		if err != nil {
 			return appendTo, false, err
 		}
@@ -427,7 +422,7 @@ func (i *hashMemRowIterator) computeKey() error {
 	i.curKey = i.curKey[:0]
 	for _, col := range i.storedEqCols {
 		var err error
-		i.curKey, err = row[col].Encode(&i.types[col], &i.columnEncoder.datumAlloc, sqlbase.DatumEncoding_ASCENDING_KEY, i.curKey)
+		i.curKey, err = row[col].Fingerprint(&i.types[col], &i.columnEncoder.datumAlloc, i.curKey)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -864,8 +864,8 @@ func (ag *aggregatorBase) encode(
 	appendTo []byte, row sqlbase.EncDatumRow,
 ) (encoding []byte, err error) {
 	for _, colIdx := range ag.groupCols {
-		appendTo, err = row[colIdx].Encode(
-			&ag.inputTypes[colIdx], &ag.datumAlloc, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
+		appendTo, err = row[colIdx].Fingerprint(
+			&ag.inputTypes[colIdx], &ag.datumAlloc, appendTo)
 		if err != nil {
 			return appendTo, err
 		}

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -196,13 +196,7 @@ func (d *distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, err
 			continue
 		}
 
-		// TODO(irfansharif): Different rows may come with different encodings,
-		// e.g. if they come from different streams that were merged, in which
-		// case the encodings don't match (despite having the same underlying
-		// datums). We instead opt to always choose sqlbase.DatumEncoding_ASCENDING_KEY
-		// but we may want to check the first row for what encodings are already
-		// available.
-		appendTo, err = datum.Encode(&d.types[i], &d.datumAlloc, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
+		appendTo, err = datum.Fingerprint(&d.types[i], &d.datumAlloc, appendTo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -308,9 +308,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 				binary.LittleEndian.PutUint64(intbuf[:], uint64(val))
 				s.sketches[i].sketch.Insert(intbuf[:])
 			} else {
-				// We need to use a KEY encoding because equal values should have the same
-				// encoding.
-				buf, err = row[col].Encode(&s.outTypes[col], &da, sqlbase.DatumEncoding_ASCENDING_KEY, buf[:0])
+				buf, err = row[col].Fingerprint(&s.outTypes[col], &da, buf[:0])
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -103,3 +103,5 @@
       IndexSkipTableReader, and InterleavedReaderJoiner spec.
 - Version: 26 (MinAcceptedVersion: 24)
     - Add the numeric tuple field accessor and the ByIndex field to ColumnAccessExpr.
+- Version: 27 (MinAcceptedVersion: 27)
+    - Change how DArray datums are hashed for distinct and aggregation operations.

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -585,12 +585,8 @@ func (hr *hashRouter) computeDestination(row sqlbase.EncDatumRow) (int, error) {
 			err := errors.Errorf("hash column %d, row with only %d columns", col, len(row))
 			return -1, err
 		}
-		// TODO(radu): we should choose an encoding that is already available as
-		// much as possible. However, we cannot decide this locally as multiple
-		// nodes may be doing the same hashing and the encodings need to match. The
-		// encoding needs to be determined at planning time. #13829
 		var err error
-		hr.buffer, err = row[col].Encode(&hr.types[col], &hr.alloc, flowinfra.PreferredEncoding, hr.buffer)
+		hr.buffer, err = row[col].Fingerprint(&hr.types[col], &hr.alloc, hr.buffer)
 		if err != nil {
 			return -1, err
 		}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -153,15 +153,6 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 			return encoding.EncodeBitArrayAscending(b, t.BitArray), nil
 		}
 		return encoding.EncodeBitArrayDescending(b, t.BitArray), nil
-	case *tree.DArray:
-		for _, datum := range t.Array {
-			var err error
-			b, err = EncodeTableKey(b, datum, dir)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return b, nil
 	case *tree.DOid:
 		if dir == encoding.Ascending {
 			return encoding.EncodeVarintAscending(b, int64(t.DInt)), nil


### PR DESCRIPTION
Row based distsql execution used the table key encoding
for datums when encoding them for operations like
distinct and aggregations. This is correct, but does
not work for types like JSONB or Arrays because these
types do not yet have valid table encodings. This PR
introduces a new `Hash` method on EncodedDatum that
uses the key encoding for indexable types, and defaults
to the value encoding for types that do not have
valid table keys. As a side effect, this PR
Fixes #44079, and allows for JSONB columns to be
aggregated and distincted.

Fixes #45216.

Release note (bug fix): Fix a bug where the distinct operation
on ARRAY[NULL] and NULL could sometimes
return an incorrect result and omit some tuples.

Release note (sql change): Allow for JSONB columns to be grouped
by and distincted on.