### PR TITLE
storage/batcheval: declare intent resolution at txn MinTimestamp

### DIFF
--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -13,7 +13,6 @@ package batcheval
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -31,7 +30,7 @@ func declareKeysDeleteRange(
 	args := req.(*roachpb.DeleteRangeRequest)
 	access := spanset.SpanReadWrite
 
-	if args.Inline || keys.IsLocal(req.Header().Span().Key) {
+	if args.Inline {
 		spans.AddNonMVCC(access, req.Header().Span())
 	} else {
 		spans.AddMVCC(access, req.Header().Span(), header.Timestamp)

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -81,11 +81,7 @@ func declareKeysEndTxn(
 		// purpose of acquiring latches. The parts in our Range will
 		// be resolved eagerly.
 		for _, span := range et.IntentSpans {
-			if keys.IsLocal(span.Key) {
-				spans.AddNonMVCC(spanset.SpanReadWrite, span)
-			} else {
-				spans.AddMVCC(spanset.SpanReadWrite, span, header.Timestamp)
-			}
+			spans.AddMVCC(spanset.SpanReadWrite, span, header.Timestamp)
 		}
 
 		if et.InternalCommitTrigger != nil {

--- a/pkg/storage/batcheval/cmd_put.go
+++ b/pkg/storage/batcheval/cmd_put.go
@@ -13,7 +13,6 @@ package batcheval
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -31,7 +30,7 @@ func declareKeysPut(
 	args := req.(*roachpb.PutRequest)
 	access := spanset.SpanReadWrite
 
-	if args.Inline || keys.IsLocal(req.Header().Span().Key) {
+	if args.Inline {
 		spans.AddNonMVCC(access, req.Header().Span())
 	} else {
 		spans.AddMVCC(access, req.Header().Span(), header.Timestamp)

--- a/pkg/storage/batcheval/declare.go
+++ b/pkg/storage/batcheval/declare.go
@@ -29,12 +29,7 @@ func DefaultDeclareKeys(
 	} else {
 		access = spanset.SpanReadWrite
 	}
-
-	if keys.IsLocal(req.Header().Span().Key) {
-		spans.AddNonMVCC(access, req.Header().Span())
-	} else {
-		spans.AddMVCC(access, req.Header().Span(), header.Timestamp)
-	}
+	spans.AddMVCC(access, req.Header().Span(), header.Timestamp)
 }
 
 // DeclareKeysForBatch adds all keys that the batch with the provided header

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -451,6 +451,7 @@ func TestGCQueueProcess(t *testing.T) {
 				// Overwrite the timestamps set by newTransaction().
 				txn.ReadTimestamp = datum.ts
 				txn.WriteTimestamp = datum.ts
+				txn.MinTimestamp = datum.ts
 				txn.DeprecatedOrigTimestamp = datum.ts
 				assignSeqNumsForReqs(txn, &dArgs)
 			}
@@ -468,6 +469,7 @@ func TestGCQueueProcess(t *testing.T) {
 				// Overwrite the timestamps set by newTransaction().
 				txn.ReadTimestamp = datum.ts
 				txn.WriteTimestamp = datum.ts
+				txn.MinTimestamp = datum.ts
 				txn.DeprecatedOrigTimestamp = datum.ts
 				assignSeqNumsForReqs(txn, &pArgs)
 			}

--- a/pkg/storage/spanset/spanset.go
+++ b/pkg/storage/spanset/spanset.go
@@ -127,6 +127,7 @@ func (s *SpanSet) AddMVCC(access SpanAccess, span roachpb.Span, timestamp hlc.Ti
 	scope := SpanGlobal
 	if keys.IsLocal(span.Key) {
 		scope = SpanLocal
+		timestamp = hlc.Timestamp{}
 	}
 
 	s.spans[access][scope] = append(s.spans[access][scope], Span{Span: span, Timestamp: timestamp})


### PR DESCRIPTION
This prevents the hazard described in:
https://github.com/cockroachdb/cockroach/blob/5f63ac527becd4aae5cfbdaa76b7de28e07b8767/pkg/storage/concurrency/concurrency_control.go#L480

I've been trying to (starting with #45085) clean up `spanset.Batch` to the point where it would have been able to detect this unlatched key access, but getting that all the way over the fence is a little tricky due to:
- `GCRequest` span declaration - should this even latch?
- transactional `Put` span declaration - does this need to declare a write span all the way back to txn.MinTimestamp because it might move an existing intent forward?
- `spanset.Iterator` semantics and its interaction with `pebbleMVCCScanner` - what can the `spanset.Iterator` even assert here, given that the scanner itself is determining whether to ignore values or not.

Unfortunately, without a rework, the current attempt at asserting correct timestamp access in `spanset.Batch` is hopelessly broken. Not only does the verification not encode the correct rules for declared timestamps (e.g. a write at time 10 should permit writing at any time >= 10), but the timestamp it works with isn't even the correct timestamp. It compares the declared span timestamps against the batch header timestamp, which completely misses the point. It should be comparing the declared span timestamps against the timestamps of actual uses of the `spanset.Batch` so that we're actually asserting that the batch is being used correctly.

I'd like to fix all of this, but not here.