### PR TITLE
storage/concurrency: move TestConcurrencyManagerBasic into test pkg

### DIFF
--- a/pkg/storage/concurrency/concurrency_control.go
+++ b/pkg/storage/concurrency/concurrency_control.go
@@ -273,6 +273,13 @@ type RangeStateListener interface {
 // MetricExporter is concerned with providing observability into the state of
 // the concurrency manager. It is one of the roles of Manager.
 type MetricExporter interface {
+	// LatchMetrics returns information about the state of the latchManager.
+	LatchMetrics() (global, local storagepb.LatchManagerInfo)
+
+	// LockTableDebug returns a debug string representing the state of the
+	// lockTable.
+	LockTableDebug() string
+
 	// TODO(nvanbenschoten): fill out this interface to provide observability
 	// into the state of the concurrency manager.
 	// LatchMetrics()
@@ -509,6 +516,9 @@ type lockTable interface {
 
 	// Clear removes all locks and lock wait-queues from the lockTable.
 	Clear()
+
+	// String returns a debug string representing the state of the lockTable.
+	String() string
 }
 
 // lockTableGuard is a handle to a request as it waits on conflicting locks in a

--- a/pkg/storage/concurrency/concurrency_manager.go
+++ b/pkg/storage/concurrency/concurrency_manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -337,6 +338,16 @@ func (m *managerImpl) OnSplit() {
 func (m *managerImpl) OnMerge() {
 	m.lt.Clear()
 	m.twq.Clear(true /* disable */)
+}
+
+// LatchMetrics implements the MetricExporter interface.
+func (m *managerImpl) LatchMetrics() (global, local storagepb.LatchManagerInfo) {
+	return m.lm.Info()
+}
+
+// LockTableDebug implements the MetricExporter interface.
+func (m *managerImpl) LockTableDebug() string {
+	return m.lt.String()
 }
 
 // ContainsKey implements the txnwait.ReplicaInterface interface.

--- a/pkg/storage/concurrency/datadriven_util_test.go
+++ b/pkg/storage/concurrency/datadriven_util_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package concurrency
+package concurrency_test
 
 import (
 	"strconv"
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -51,42 +50,6 @@ func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
 	}
 	ts.Logical = int32(tsL)
 	return ts
-}
-
-func getSpan(t *testing.T, d *datadriven.TestData, str string) roachpb.Span {
-	parts := strings.Split(str, ",")
-	span := roachpb.Span{Key: roachpb.Key(parts[0])}
-	if len(parts) > 2 {
-		d.Fatalf(t, "incorrect span format: %s", str)
-	} else if len(parts) == 2 {
-		span.EndKey = roachpb.Key(parts[1])
-	}
-	return span
-}
-
-func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.SpanSet {
-	spans := &spanset.SpanSet{}
-	var spansStr string
-	d.ScanArgs(t, "spans", &spansStr)
-	parts := strings.Split(spansStr, "+")
-	for _, p := range parts {
-		if len(p) < 2 || p[1] != '@' {
-			d.Fatalf(t, "incorrect span with access format: %s", p)
-		}
-		c := p[0]
-		p = p[2:]
-		var sa spanset.SpanAccess
-		switch c {
-		case 'r':
-			sa = spanset.SpanReadOnly
-		case 'w':
-			sa = spanset.SpanReadWrite
-		default:
-			d.Fatalf(t, "incorrect span access: %c", c)
-		}
-		spans.AddMVCC(sa, getSpan(t, d, p), ts)
-	}
-	return spans
 }
 
 func scanSingleRequest(t *testing.T, d *datadriven.TestData, line string) roachpb.Request {

--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -368,6 +370,72 @@ func TestLockTableBasic(t *testing.T) {
 			}
 		})
 	})
+}
+
+func nextUUID(counter *uint128.Uint128) uuid.UUID {
+	*counter = counter.Add(1)
+	return uuid.FromUint128(*counter)
+}
+
+func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
+	var ts hlc.Timestamp
+	var tsS string
+	d.ScanArgs(t, "ts", &tsS)
+	parts := strings.Split(tsS, ",")
+
+	// Find the wall time part.
+	tsW, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		d.Fatalf(t, "%v", err)
+	}
+	ts.WallTime = tsW
+
+	// Find the logical part, if there is one.
+	var tsL int64
+	if len(parts) > 1 {
+		tsL, err = strconv.ParseInt(parts[1], 10, 32)
+		if err != nil {
+			d.Fatalf(t, "%v", err)
+		}
+	}
+	ts.Logical = int32(tsL)
+	return ts
+}
+
+func getSpan(t *testing.T, d *datadriven.TestData, str string) roachpb.Span {
+	parts := strings.Split(str, ",")
+	span := roachpb.Span{Key: roachpb.Key(parts[0])}
+	if len(parts) > 2 {
+		d.Fatalf(t, "incorrect span format: %s", str)
+	} else if len(parts) == 2 {
+		span.EndKey = roachpb.Key(parts[1])
+	}
+	return span
+}
+
+func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.SpanSet {
+	spans := &spanset.SpanSet{}
+	var spansStr string
+	d.ScanArgs(t, "spans", &spansStr)
+	parts := strings.Split(spansStr, "+")
+	for _, p := range parts {
+		if len(p) < 2 || p[1] != '@' {
+			d.Fatalf(t, "incorrect span with access format: %s", p)
+		}
+		c := p[0]
+		p = p[2:]
+		var sa spanset.SpanAccess
+		switch c {
+		case 'r':
+			sa = spanset.SpanReadOnly
+		case 'w':
+			sa = spanset.SpanReadWrite
+		default:
+			d.Fatalf(t, "incorrect span access: %c", c)
+		}
+		spans.AddMVCC(sa, getSpan(t, d, p), ts)
+	}
+	return spans
 }
 
 type workItem struct {

--- a/pkg/storage/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/basic
@@ -106,7 +106,7 @@ sequence req=req3
 [1] sequence req3: scanning lock table for conflicting locks
 [1] sequence req3: waiting in lock wait-queues
 [1] sequence req3: pushing txn 00000000-0000-0000-0000-000000000002
-[1] sequence req3: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+[1] sequence req3: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
@@ -175,7 +175,7 @@ sequence req=req5
 [1] sequence req5: scanning lock table for conflicting locks
 [1] sequence req5: waiting in lock wait-queues
 [1] sequence req5: pushing txn 00000000-0000-0000-0000-000000000002
-[1] sequence req5: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+[1] sequence req5: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 new-request name=req6 txn=none ts=16,1
   scan key=c endkey=z
@@ -220,7 +220,7 @@ finish req=req6
 [3] sequence req7: scanning lock table for conflicting locks
 [3] sequence req7: waiting in lock wait-queues
 [3] sequence req7: pushing txn 00000000-0000-0000-0000-000000000002
-[3] sequence req7: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+[3] sequence req7: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
@@ -38,7 +38,7 @@ sequence req=req1
 [2] sequence req1: scanning lock table for conflicting locks
 [2] sequence req1: waiting in lock wait-queues
 [2] sequence req1: pushing txn 00000000-0000-0000-0000-000000000001
-[2] sequence req1: blocked on sync.Cond.Wait in concurrency.(*cluster).PushTransaction
+[2] sequence req1: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=aborted
 ----


### PR DESCRIPTION
This not only ensures that we're testing the external interface of
concurrency.Manager, but it also ensures that we don't hit cyclic
dependency issues in later commits.