### PR TITLE
colexec: miscellaneous HashRouter fixes

### DIFF
--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -55,11 +55,14 @@ func (a *Allocator) NewMemBatch(types []coltypes.T) coldata.Batch {
 	return a.NewMemBatchWithSize(types, int(coldata.BatchSize()))
 }
 
+func (a *Allocator) selVectorSize(capacity int) int64 {
+	return int64(capacity * sizeOfUint16)
+}
+
 // NewMemBatchWithSize allocates a new in-memory coldata.Batch with the given
 // column size.
 func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Batch {
-	selVectorSize := size * sizeOfUint16
-	estimatedStaticMemoryUsage := int64(estimateBatchSizeBytes(types, size) + selVectorSize)
+	estimatedStaticMemoryUsage := a.selVectorSize(size) + int64(estimateBatchSizeBytes(types, size))
 	if err := a.acc.Grow(a.ctx, estimatedStaticMemoryUsage); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
@@ -71,7 +74,7 @@ func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Ba
 // through PerformOperation. Use this if you want to explicitly manage the
 // memory accounted for.
 func (a *Allocator) RetainBatch(b coldata.Batch) {
-	if err := a.acc.Grow(a.ctx, getVecsSize(b.ColVecs())); err != nil {
+	if err := a.acc.Grow(a.ctx, a.selVectorSize(cap(b.Selection()))+getVecsSize(b.ColVecs())); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
 }
@@ -81,7 +84,7 @@ func (a *Allocator) RetainBatch(b coldata.Batch) {
 // Flow.Cleanup. Use this if you want to explicitly manage the memory used. An
 // example of a use case is releasing a batch before writing it to disk.
 func (a *Allocator) ReleaseBatch(b coldata.Batch) {
-	a.acc.Shrink(a.ctx, getVecsSize(b.ColVecs()))
+	a.acc.Shrink(a.ctx, a.selVectorSize(cap(b.Selection()))+getVecsSize(b.ColVecs()))
 }
 
 // NewMemColumn returns a new coldata.Vec, initialized with a length.

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -735,6 +735,11 @@ func TestHashRouterOneOutput(t *testing.T) {
 				t.Fatal(err)
 			}
 			wg.Wait()
+			// Expect no metadata, this should be a successful run.
+			unexpectedMetadata := r.DrainMeta(ctx)
+			if len(unexpectedMetadata) != 0 {
+				t.Fatalf("unexpected metadata when draining HashRouter: %+v", unexpectedMetadata)
+			}
 			if !mtc.skipExpSpillCheck {
 				// If len(sel) == 0, no items will have been enqueued so override an
 				// expected spill if this is the case.
@@ -864,6 +869,11 @@ func TestHashRouterRandom(t *testing.T) {
 				// likely due to a cancellation bug.
 				wg.Wait()
 				if !cancel {
+					// Expect no metadata, this should be a successful run.
+					unexpectedMetadata := r.DrainMeta(ctx)
+					if len(unexpectedMetadata) != 0 {
+						t.Fatalf("unexpected metadata when draining HashRouter: %+v", unexpectedMetadata)
+					}
 					// Only do output verification if no cancellation happened.
 					if actualTotal := atomic.LoadUint64(&results); actualTotal != uint64(len(data)) {
 						t.Fatalf("unexpected number of results %d, expected %d", actualTotal, len(data))

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -11,12 +11,14 @@
 package colexec
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // spillingQueue is a Queue that uses a fixed-size in-memory circular buffer
@@ -167,6 +169,7 @@ func (q *spillingQueue) maybeSpillToDisk() error {
 	if q.diskQueue != nil {
 		return nil
 	}
+	log.VEvent(context.TODO(), 1, "spilled to disk")
 	diskQueue, err := colcontainer.NewDiskQueue(q.typs, q.diskQueueCfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit fixes several bugs and discomforts related to the HashRouter
observed when running tpch queries.
1) RetainBatch and ReleaseBatch weren't accounting for the selection vector,
   resulting in a slight memory leak.
2) HashRouter disk spilling infrastructure was not being cleaned up on
   successful termination.
3) HashRouter memory monitor names were not unique, they now contain the output
   StreamIDs. Example: hash-router-[1,2,3]-unlimited.
4) A big memory accounting leak was happening when returning an in-memory
   pending batch. This batch is a staging area that is flushed to disk when
   full, but returned if a read occurs before that. The batch was being
   returned without changing the memory account. Since batches are unsafe for
   reuse, the HashRouter should call ReleaseBatch in this case.
5) Tests would ignore if Run returned an error, resulting in hard-to-decipher
   failures where no output was returned. Run is now checked for errors before
   verifying the output.

Release note: None (bug fixes related to vectorize=experimental_on)