### PR TITLE
backupccl: allow appending incremental layers to backups

### DIFF
--- a/pkg/ccl/backupccl/partitioned_backup_test.go
+++ b/pkg/ccl/backupccl/partitioned_backup_test.go
@@ -93,7 +93,7 @@ func TestGetURIsByLocalityKV(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defaultURI, urisByLocality, err := getURIsByLocalityKV(tc.input)
+			defaultURI, urisByLocality, err := getURIsByLocalityKV(tc.input, "" /* appendPath */)
 			if tc.error != "" {
 				if !testutils.IsError(err, tc.error) {
 					t.Fatalf("expected error matching %q, got %q", tc.error, err)

--- a/pkg/ccl/logictestccl/testdata/logic_test/restore
+++ b/pkg/ccl/logictestccl/testdata/logic_test/restore
@@ -1,5 +1,5 @@
 # LogicTest: local
 
 # Check that we get through parsing and license check.
-statement error pq: failed to read backup descriptor: unsupported storage scheme: ""
+statement error pq: failed to open backup storage location: unsupported storage scheme: ""
 RESTORE foo FROM "bar"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1160,7 +1160,6 @@ func TestLint(t *testing.T) {
 		forbiddenImports := map[string]string{
 			"golang.org/x/net/context":                    "context",
 			"log":                                         "util/log",
-			"path":                                        "path/filepath",
 			"github.com/golang/protobuf/proto":            "github.com/gogo/protobuf/proto",
 			"github.com/satori/go.uuid":                   "util/uuid",
 			"golang.org/x/sync/singleflight":              "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
@@ -1231,10 +1230,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/util/sysutil: syscall$`),
 			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
-			stream.GrepNot(`cockroach/pkg/server/debug/pprofui: path$`),
-			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
-			stream.GrepNot(`cockroach/pkg/storage/cloud: path$`),
-			stream.GrepNot(`cockroach/pkg/ccl/workloadccl: path$`),
+
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")


### PR DESCRIPTION
This changes the behavior when running BACKUP to a destination already
containing a backup. Previously attempting to do so would result in an
error saying that the destination already contained a backup. After this
change, it will instead result in implicitly producing an _incremental
backup_ in an automatically chosen subdirectory of the specified backup.

More specifically, if the destination already contains a BACKUP, trying
to backup to it again will instead backup to a subdirectory with a date-
based name. Additionally, it will search for existing incremental
backups in any similarly created subdirectories, choosing the latest as
the basis from which it will be incremental.

The essentially turns `BACKUP TO x` into a create-or-append operation:
The first time it is run it creates a full backup in x. The next time
it discovers what is currently covered by x and adds an incremental
backup from x in x/day/time1. When run again, it creates another, this
time in x/day/time2, which is incremental from x/day/time1, etc.

`RESTORE FROM x` is modified slightly, such that if x contains such
automatically created subdirectories, it is implicitly transformed to
`RESTORE FROM x, x/day/time1, x/day/time2, ...`.

Release note (enterprise change): BACKUP can be re-run with the same destination path to automatically append an incremental backup to that path.