### PR TITLE
tree: improve type checking for mixed-type arrays

### DIFF
--- a/pkg/sql/sem/tree/testdata/eval/array
+++ b/pkg/sql/sem/tree/testdata/eval/array
@@ -258,3 +258,23 @@ eval
 ARRAY[1,NULL] <@ ARRAY[1,NULL]
 ----
 false
+
+eval
+ARRAY[1] IS DISTINCT FROM NULL
+----
+true
+
+eval
+NULL IS DISTINCT FROM ARRAY[1]
+----
+true
+
+eval
+'foo' COLLATE en IS DISTINCT FROM NULL
+----
+true
+
+eval
+NULL IS DISTINCT FROM 'foo' COLLATE en
+----
+true

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1713,10 +1713,14 @@ func typeCheckComparisonOp(
 	}
 	leftReturn := leftExpr.ResolvedType()
 	rightReturn := rightExpr.ResolvedType()
+	leftFamily := leftReturn.Family()
+	rightFamily := rightReturn.Family()
 
 	// Return early if at least one overload is possible, NULL is an argument,
 	// and none of the overloads accept NULL.
-	if leftReturn.Family() == types.UnknownFamily || rightReturn.Family() == types.UnknownFamily {
+	nullComparison := false
+	if leftFamily == types.UnknownFamily || rightFamily == types.UnknownFamily {
+		nullComparison = true
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
@@ -1731,13 +1735,23 @@ func typeCheckComparisonOp(
 		}
 	}
 
+	leftIsGeneric := leftFamily == types.CollatedStringFamily || leftFamily == types.ArrayFamily
+	rightIsGeneric := rightFamily == types.CollatedStringFamily || rightFamily == types.ArrayFamily
+	genericComparison := leftIsGeneric && rightIsGeneric
+
+	typeMismatch := false
+	if genericComparison && !nullComparison {
+		// A generic comparison (one between two generic types, like arrays) is not
+		// well-typed if the two input types are not equivalent, unless one of the
+		// sides is NULL.
+		typeMismatch = !leftReturn.Equivalent(rightReturn)
+	}
+
 	// Throw a typing error if overload resolution found either no compatible candidates
 	// or if it found an ambiguity.
-	collationMismatch :=
-		leftReturn.Family() == types.CollatedStringFamily && !leftReturn.Equivalent(rightReturn)
-	if len(fns) != 1 || collationMismatch {
+	if len(fns) != 1 || typeMismatch {
 		sig := fmt.Sprintf(compSignatureFmt, leftReturn, op, rightReturn)
-		if len(fns) == 0 || collationMismatch {
+		if len(fns) == 0 || typeMismatch {
 			return nil, nil, nil, false,
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sig)
 		}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -244,6 +244,10 @@ func TestTypeCheckError(t *testing.T) {
 		{`3:::int[]`, `incompatible type annotation for 3 as int[], found type: int`},
 		{`B'1001'::decimal`, `invalid cast: varbit -> decimal`},
 		{`101.3::bit`, `invalid cast: decimal -> bit`},
+		{`ARRAY[1] = ARRAY['foo']`, `could not parse "foo" as type int`},
+		{`ARRAY[1]::int[] = ARRAY[1.0]::decimal[]`, `unsupported comparison operator: <int[]> = <decimal[]>`},
+		{`ARRAY[1] @> ARRAY['foo']`, `unsupported comparison operator: <int[]> @> <string[]>`},
+		{`ARRAY[1]::int[] @> ARRAY[1.0]::decimal[]`, `unsupported comparison operator: <int[]> @> <decimal[]>`},
 		{
 			`((1,2) AS a)`,
 			`mismatch in tuple definition: 2 expressions, 1 labels`,


### PR DESCRIPTION
Previously, certain binary operators involving two arrays with different
element types would fail at runtime, not at type-check time. This led to
the following oddity:

```
root@127.0.0.1:61739/defaultdb> create table z (a int[]);
CREATE TABLE

root@127.0.0.1:61739/defaultdb> select * from z where a @> array['foo'];
  a
-----
(0 rows)

root@127.0.0.1:61739/defaultdb> insert into z values(array[1]);
INSERT 1

root@127.0.0.1:61739/defaultdb> select * from z where a @> array['foo'];
ERROR: cannot compare arrays with different element types
SQLSTATE: 42804
```

It also was a potential source of bugs, since letting operators type
check that will never be allowed later can cause issues in SQL operators
like zigzag join that expect values to be comparable when the type
checker claims that they are.

This commit adds a simple rule that bans any cross-element-type array
operators, identically to the way that collated strings are
incomparable if they're of different collations.

Release note (sql change): operators on two arrays with different
element types now fail at type-check time instead of evaluation time.