### PR TITLE
storage/concurrency: support idempotent lock acquisition

### DIFF
--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -47,7 +47,7 @@ new-locktable maxlocks=<int>
 
   Creates a lockTable.
 
-new-txn txn=<name> ts=<int>[,<int>] epoch=<int>
+new-txn txn=<name> ts=<int>[,<int>] epoch=<int> [seq=<int>]
 ----
 
  Creates a TxnMeta.
@@ -148,6 +148,10 @@ func TestLockTableBasic(t *testing.T) {
 				ts := scanTimestamp(t, d)
 				var epoch int
 				d.ScanArgs(t, "epoch", &epoch)
+				var seq int
+				if d.HasArg("seq") {
+					d.ScanArgs(t, "seq", &seq)
+				}
 				txnMeta, ok := txnsByName[txnName]
 				var id uuid.UUID
 				if ok {
@@ -158,6 +162,7 @@ func TestLockTableBasic(t *testing.T) {
 				txnsByName[txnName] = &enginepb.TxnMeta{
 					ID:             id,
 					Epoch:          enginepb.TxnEpoch(epoch),
+					Sequence:       enginepb.TxnSeq(seq),
 					WriteTimestamp: ts,
 				}
 				return ""

--- a/pkg/storage/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/storage/concurrency/testdata/lock_table/acquire_idempotency
@@ -1,0 +1,195 @@
+# -------------------------------------------------------------
+# In this test we acquire the same lock multiple times at different
+# transaction sequence numbers. The test cases correspond closely
+# to those in TestReplicaTxnIdempotency.
+# -------------------------------------------------------------
+
+new-lock-table maxlocks=10000
+----
+
+# -------------------------------------------------------------
+# Acquire locks with sequence numbers 1, 2, and 4
+# -------------------------------------------------------------
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=1
+----
+
+new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1
+local: num=0
+
+dequeue r=req1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1
+local: num=0
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=2
+----
+
+new-request r=req2 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req2
+----
+start-waiting: false
+
+acquire r=req2 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2
+local: num=0
+
+dequeue r=req2
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2
+local: num=0
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=4
+----
+
+new-request r=req3 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req3
+----
+start-waiting: false
+
+acquire r=req3 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+dequeue r=req3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Re-Acquire lock with sequence number 4
+# -------------------------------------------------------------
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=4
+----
+
+new-request r=req3 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req3
+----
+start-waiting: false
+
+acquire r=req3 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+dequeue r=req3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Re-Acquire lock with sequence number 2
+# -------------------------------------------------------------
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=2
+----
+
+new-request r=req4 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req4
+----
+start-waiting: false
+
+acquire r=req4 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+dequeue r=req4
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Try to acquire lock with sequence number 3. Should throw an
+# error because this sequence does not already exist in the
+# lock's sequence history.
+# -------------------------------------------------------------
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=3
+----
+
+new-request r=req5 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req5
+----
+start-waiting: false
+
+acquire r=req5 k=a durability=u
+----
+missing lock at sequence: 3 not in [1 2 4]
+
+dequeue r=req5
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Acquire lock with sequence numbers 5
+# -------------------------------------------------------------
+
+new-txn txn=txn1 ts=10,1 epoch=0 seq=5
+----
+
+new-request r=req6 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req6
+----
+start-waiting: false
+
+acquire r=req6 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5
+local: num=0
+
+dequeue r=req6
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5
+local: num=0


### PR DESCRIPTION
This commit updates lockTableImpl to support idempotent acquisition
of locks at previous sequence numbers. The storage layer expects this
to work, as is tested in TestReplicaTxnIdempotency.

The commit also fixes a bug where we were forgetting to add to the
sequence slice when updating an existing lock in acquireLock.