### PR TITLE
libroach: add directory sync to SafeWriteStringToFile

### DIFF
--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -151,6 +151,7 @@ class DataKeyManager : public KeyManager {
   // These do not change after initialization. env_ is thread safe.
   rocksdb::Env* env_;
   std::shared_ptr<rocksdb::Logger> logger_;
+  std::unique_ptr<rocksdb::Directory> registry_dir_;
   std::string registry_path_;
   int64_t rotation_period_;
   bool read_only_;

--- a/c-deps/libroach/file_registry.h
+++ b/c-deps/libroach/file_registry.h
@@ -93,6 +93,8 @@ class FileRegistry {
   const bool read_only_;
   const std::string registry_path_;
 
+  std::unique_ptr<rocksdb::Directory> registry_dir_;
+
   // Write 'reg' to the registry file, and swap with registry_ if successful. mu_ is held.
   rocksdb::Status PersistRegistryLocked(std::unique_ptr<enginepb::FileRegistry> reg);
 

--- a/c-deps/libroach/file_registry_test.cc
+++ b/c-deps/libroach/file_registry_test.cc
@@ -36,11 +36,12 @@ TEST(FileRegistry, TransformPath) {
       {"/mnt/otherdevice/myfile", "/mnt/otherdevice/myfile", ""},
   };
 
+  std::unique_ptr<rocksdb::Env> env(rocksdb::NewMemEnv(rocksdb::Env::Default()));
   int test_num = 0;
   for (auto t : test_cases) {
     SCOPED_TRACE(fmt::StringPrintf("Testing #%d", test_num++));
 
-    FileRegistry reg(nullptr, t.db_dir, false /* read-only */);
+    FileRegistry reg(env.get(), t.db_dir, false /* read-only */);
     auto out = reg.TransformPath(t.input);
     EXPECT_EQ(t.output, out);
   }

--- a/c-deps/libroach/utils.cc
+++ b/c-deps/libroach/utils.cc
@@ -12,8 +12,8 @@
 
 static const std::string kTempFileNameSuffix = ".crdbtmp";
 
-rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename,
-                                      const std::string& contents) {
+rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, rocksdb::Directory* dir,
+                                      const std::string& filename, const std::string& contents) {
   std::string tmpname = filename + kTempFileNameSuffix;
   auto status = rocksdb::WriteStringToFile(env, contents, tmpname, true /* should_sync */);
   if (status.ok()) {
@@ -21,8 +21,9 @@ rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& file
   }
   if (!status.ok()) {
     env->DeleteFile(tmpname);
+    return status;
   }
-  return status;
+  return dir->Fsync();
 }
 
 std::string PathAppend(const std::string& path1, const std::string& path2) {

--- a/c-deps/libroach/utils.h
+++ b/c-deps/libroach/utils.h
@@ -15,9 +15,10 @@
 #include <string>
 
 // Write 'contents' to a temporary file, sync, rename to 'filename'.
-// On non-OK status, the original file has not been touched.
-rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename,
-                                      const std::string& contents);
+// On non-OK status, either the original or new file will be readable,
+// and not some intermediate corrupted state.
+rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, rocksdb::Directory* dir,
+                                      const std::string& filename, const std::string& contents);
 
 // PathAppend takes two path components and returns the new path
 // with a separator if not already present.


### PR DESCRIPTION
This method is used for persisting the file and key
registeries, which are in the db dir. Existing dir
syncs in RocksDB are probably insufficient to make up
for the lack of db dir sync -- a WAL file could be
created and synced in the WAL dir.

Fixes #37978

Release note: None