### PR TITLE
colexec: add recursive partitioning to external hash joiner

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -208,7 +208,7 @@ func (m *MemBatch) SetSelection(b bool) {
 func (m *MemBatch) SetLength(n uint16) {
 	m.n = n
 	for _, v := range m.b {
-		if v.Type() == coltypes.Bytes {
+		if v != nil && v.Type() == coltypes.Bytes {
 			v.Bytes().UpdateOffsetsToBeNonDecreasing(uint64(n))
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -641,7 +642,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		// descriptors that the vectorized execution engine may have open at any
 		// one time. This limit is implemented as a weighted semaphore acquired
 		// before opening files.
-		VecFDSemaphore: semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", 256)),
+		VecFDSemaphore: semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", colexec.VecMaxOpenFDsLimit)),
 		DiskMonitor:    s.cfg.TempStorageConfig.Mon,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -72,6 +72,17 @@ func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Ba
 	return coldata.NewMemBatchWithSize(types, size)
 }
 
+// NewMemBatchNoCols creates a "skeleton" of new in-memory coldata.Batch. It
+// allocates memory for the selection vector but does *not* allocate any memory
+// for the column vectors - those will have to be added separately.
+func (a *Allocator) NewMemBatchNoCols(types []coltypes.T, size int) coldata.Batch {
+	estimatedMemoryUsage := selVectorSize(size)
+	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
+		execerror.VectorizedInternalPanic(err)
+	}
+	return coldata.NewMemBatchNoCols(types, size)
+}
+
 // RetainBatch adds the size of the batch to the memory account. This shouldn't
 // need to be used regularly, since most memory accounting necessary is done
 // through PerformOperation. Use this if you want to explicitly manage the

--- a/pkg/sql/colexec/constants.go
+++ b/pkg/sql/colexec/constants.go
@@ -18,3 +18,8 @@ package colexec
 // Note: if you are updating this field, please make sure to update
 // vectorize_threshold logic test accordingly.
 const DefaultVectorizeRowCountThreshold = 1000
+
+// VecMaxOpenFDsLimit specifies the maximum number of open file descriptors
+// that the vectorized engine can have (globally) for use of the temporary
+// storage.
+const VecMaxOpenFDsLimit = 256

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -13,10 +13,14 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/dustin/go-humanize"
 	"github.com/marusama/semaphore"
 )
 
@@ -25,15 +29,33 @@ import (
 type externalHashJoinerState int
 
 const (
-	// externalHJPartitioning indicates that the operator is currently reading
-	// batches from both inputs and distributing tuples to different partitions
-	// based on the hash values. Once both inputs are exhausted, the external
-	// hash joiner transitions to externalHJJoinNewPartition state.
-	externalHJPartitioning externalHashJoinerState = iota
-	// externalHJJoinNewPartition indicates that the operator is setting up the
-	// in-memory hash joiner to operate on the new partition. As the first step,
-	// the operator searches for next non-empty partition. If there are none, it
-	// transitions to externalHJFinished state.
+	// externalHJInitialPartitioning indicates that the operator is currently
+	// reading batches from both inputs and distributing tuples to different
+	// partitions based on the hash values. Once both inputs are exhausted, the
+	// external hash joiner transitions to externalHJJoinNewPartition state.
+	externalHJInitialPartitioning externalHashJoinerState = iota
+	// externalHJRecursivePartitioning indicates that the operator is recursively
+	// partitioning one of the existing partitions (that is too big to join at
+	// once). It will do so using a different hash function and will spill newly
+	// created partitions to disk. We also keep track whether repartitioning
+	// reduces the size of the partitions in question - if we see that the newly
+	// created largest partition is about the same in size as the "parent"
+	// partition (the percentage difference is less than
+	// externalHJRecursivePartitioningSizeDecreaseThreshold), it is likely that
+	// the partition consists of the tuples not distinct on the equality columns,
+	// so we fall back to using a combination of sort and merge join to process
+	// such partition. After repartitioning, the operator transitions to
+	// externalHJJoinNewPartition state.
+	// TODO(yuzefovich): implement the fallback to sort + merge join.
+	externalHJRecursivePartitioning
+	// externalHJJoinNewPartition indicates that the operator should choose a
+	// partition index and join the corresponding partitions from both sides. We
+	// will only join the partitions if the right side partition fits into memory
+	// (because in-memory hash joiner will fully buffer the right side but will
+	// process left side in the streaming fashion). If there are no partition
+	// indices that the operator can join, it transitions into
+	// externalHJRecursivePartitioning state. If there are no partition indices
+	// left at all to join, the operator transitions to externalHJFinished state.
 	externalHJJoinNewPartition
 	// externalHJJoining indicates that the operator is currently joining tuples
 	// from the corresponding partitions from both sides. An in-memory hash join
@@ -45,6 +67,20 @@ const (
 	// externalHJFinished indicates that the external hash joiner has emitted all
 	// tuples already and only zero-length batch will be emitted from now on.
 	externalHJFinished
+)
+
+const (
+	// externalHJRecursivePartitioningSizeDecreaseThreshold determines by how
+	// much the newly-created partitions in the recursive partitioning stage
+	// should be smaller than the "parent" partition in order to consider the
+	// repartitioning "successful". If this threshold is not met, then we fall
+	// back to sort + merge join (which, in a sense, serves as the base case
+	// for "recursion").
+	externalHJRecursivePartitioningSizeDecreaseThreshold = 0.05
+	// externalHJDiskQueuesMemFraction determines the fraction of the available
+	// RAM that is allocated for the in-memory cache of disk queues.
+	externalHJDiskQueuesMemFraction      = 0.5
+	externalHJFallbackToSortMergeJoinMsg = "recursive partitioning didn't sufficiently decrease the size of the partition"
 )
 
 // externalHashJoiner is an operator that performs Grace hash join algorithm
@@ -74,26 +110,45 @@ const (
 // side of the join. So, it's safe to do the join in pieces, partition by
 // partition.
 //
-// If one of the partition hash joins itself runs out of memory, we can
-// recursively apply this algorithm. The partition will be divided into
-// sub-partitions by a new hash function, spilled to disk, and so on.
-// TODO(yuzefovich): actually implement recursive partitioning.
+// If one of the partitions itself runs out of memory, we can recursively apply
+// this algorithm. The partition will be divided into sub-partitions by a new
+// hash function, spilled to disk, and so on.
 type externalHashJoiner struct {
 	twoInputNode
 	NonExplainable
 
-	state     externalHashJoinerState
-	allocator *Allocator
-	spec      hashJoinerSpec
+	closed             bool
+	state              externalHashJoinerState
+	unlimitedAllocator *Allocator
+	spec               hashJoinerSpec
+	diskQueueCfg       colcontainer.DiskQueueCfg
 
 	// Partitioning phase variables.
 	leftPartitioner  colcontainer.PartitionedQueue
 	rightPartitioner colcontainer.PartitionedQueue
 	tupleDistributor *tupleHashDistributor
-	// TODO(yuzefovich): use bitmap for this to reduce memory footprint.
-	nonEmptyPartition []bool
-	numPartitions     int
-	scratch           struct {
+	// maxNumberActivePartitions determines the maximum number of active
+	// partitions that the operator is allowed to have. This number is computed
+	// semi-dynamically and will influence the choice of numBuckets value.
+	maxNumberActivePartitions int
+	// numBuckets is the number of buckets that a partition is divided into.
+	numBuckets int
+	// partitionsToJoin is a map from partitionIdx to a utility struct. This map
+	// contains all partition indices that need to be joined.
+	partitionsToJoin map[int]*externalHJPartitionInfo
+	// partitionIdxOffset stores the first "available" partition index to use.
+	// During the partitioning step, all tuples will go into one of the buckets
+	// in [partitionIdxOffset, partitionIdxOffset + numBuckets) range.
+	partitionIdxOffset int
+	// numRepartitions tracks the number of times the external hash joiner had to
+	// recursively repartition another partition because the latter was too big
+	// to join.
+	numRepartitions int
+	// scratch and recursiveScratch are helper structs. Note that batches in
+	// scratch are fully-allocated whereas batches in recursiveScratch are
+	// simply "skeletons". The latter are intended to be used to dequeue into
+	// from colcontainer.PartitionedQueues.
+	scratch, recursiveScratch struct {
 		// Input sources can have different schemas, so when distributing tuples
 		// (i.e. copying them into scratch batch to be spilled) we might need two
 		// different batches.
@@ -103,45 +158,120 @@ type externalHashJoiner struct {
 	// Join phase variables.
 	leftInMemHashJoinerInput, rightInMemHashJoinerInput *partitionerToOperator
 	inMemHashJoiner                                     *hashJoiner
-	partitionIdxToJoin                                  int
+
+	memState struct {
+		// maxRightPartitionSizeToJoin indicates the maximum memory size of a
+		// partition on the right side that we're ok with joining without having to
+		// repartition it. We pay attention only to the right side because in-memory
+		// hash joiner will buffer the whole right input before processing the left
+		// input in a "streaming" fashion.
+		maxRightPartitionSizeToJoin int64
+	}
+
+	testingKnobs struct {
+		// numForcedRepartitions is a number of times that the external hash joiner
+		// is forced to recursively repartition (even if it is otherwise not
+		// needed) before it proceeds to actual join partitions.
+		numForcedRepartitions int
+		// repartitionForced is a (temporary) knob that indicates to the external
+		// hash joiner that the last repartition was forced artificially. If it is
+		// true, then we skip the check whether there was a reasonable decrease
+		// in size.
+		// TODO(yuzefovich): remove this once we have fallback to sort + merge
+		// join.
+		repartitionForced bool
+	}
 }
 
 var _ Operator = &externalHashJoiner{}
 
+type externalHJPartitionInfo struct {
+	rightMemSize       int64
+	rightParentMemSize int64
+}
+
+type joinSide int
+
+const (
+	leftSide joinSide = iota
+	rightSide
+)
+
+// newExternalHashJoiner returns a disk-backed hash joiner.
+// - unlimitedAllocator must have been created with a memory account derived
+// from an unlimited memory monitor. It will be used by several internal
+// components of the external hash joiner which is responsible for making sure
+// that the components stay within the memory limit.
+// - numForcedRepartitions is a number of times that the external hash joiner
+// is forced to recursively repartition (even if it is otherwise not needed).
+// This should be non-zero only in tests.
+// - diskQueuesUnlimitedAllocator is a (temporary) unlimited allocator that
+// will be used to create dummy queues and will be removed once we have actual
+// disk-backed queues.
 func newExternalHashJoiner(
-	allocator *Allocator,
+	unlimitedAllocator *Allocator,
 	spec hashJoinerSpec,
 	leftInput, rightInput Operator,
+	memoryLimit int64,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
+	numForcedRepartitions int,
 ) Operator {
 	leftPartitioner := colcontainer.NewPartitionedDiskQueue(spec.left.sourceTypes, diskQueueCfg, fdSemaphore, colcontainer.PartitionerStrategyDefault)
 	leftInMemHashJoinerInput := newPartitionerToOperator(
-		allocator, spec.left.sourceTypes, leftPartitioner, 0, /* partitionIdx */
+		unlimitedAllocator, spec.left.sourceTypes, leftPartitioner, 0, /* partitionIdx */
 	)
 	rightPartitioner := colcontainer.NewPartitionedDiskQueue(spec.right.sourceTypes, diskQueueCfg, fdSemaphore, colcontainer.PartitionerStrategyDefault)
 	rightInMemHashJoinerInput := newPartitionerToOperator(
-		allocator, spec.right.sourceTypes, rightPartitioner, 0, /* partitionIdx */
+		unlimitedAllocator, spec.right.sourceTypes, rightPartitioner, 0, /* partitionIdx */
 	)
+	diskQueuesTotalMemLimit := int(float64(memoryLimit) * externalHJDiskQueuesMemFraction)
+	// With the default limit of 256 file descriptors, this results in 16
+	// partitions. This is a hard maximum of partitions that will be used by the
+	// external hash joiner. Below we check whether we have enough RAM to support
+	// the caches of this number of partitions.
+	// TODO(yuzefovich): this number should be tuned.
+	maxNumberActivePartitions := fdSemaphore.GetLimit() / 16
+	if diskQueueCfg.BufferSizeBytes > 0 {
+		numDiskQueuesThatFit := diskQueuesTotalMemLimit / diskQueueCfg.BufferSizeBytes
+		if numDiskQueuesThatFit < maxNumberActivePartitions {
+			maxNumberActivePartitions = numDiskQueuesThatFit
+		}
+	}
+	if maxNumberActivePartitions < 4 {
+		// We need at least two buckets per side to make progress.
+		maxNumberActivePartitions = 4
+	}
 	ehj := &externalHashJoiner{
-		twoInputNode:     newTwoInputNode(leftInput, rightInput),
-		allocator:        allocator,
-		spec:             spec,
-		leftPartitioner:  leftPartitioner,
-		rightPartitioner: rightPartitioner,
-		// TODO(asubiotto): This is temporary. With the default limit of 256 file
-		//  descriptors, this results in 16 partitions (8 for the left and 8 for the
-		//  right). The total size of these partitions is ignored and might hit a
-		//  memory limit. This is temporary until recursive partitioning is merged
-		//  and is behind the experimental_on flag.
-		numPartitions:             fdSemaphore.GetLimit() / 32,
+		twoInputNode:              newTwoInputNode(leftInput, rightInput),
+		unlimitedAllocator:        unlimitedAllocator,
+		spec:                      spec,
+		diskQueueCfg:              diskQueueCfg,
+		leftPartitioner:           leftPartitioner,
+		rightPartitioner:          rightPartitioner,
+		maxNumberActivePartitions: maxNumberActivePartitions,
+		// In the initial partitioning state we will use half of available
+		// partitions to write the partitioned input from the left side and another
+		// half for the right side.
+		// TODO(yuzefovich): figure out whether we should care about
+		// hj.numBuckets being a power of two (finalizeHash step is faster if so).
+		numBuckets:                maxNumberActivePartitions / 2,
+		partitionsToJoin:          make(map[int]*externalHJPartitionInfo),
 		leftInMemHashJoinerInput:  leftInMemHashJoinerInput,
 		rightInMemHashJoinerInput: rightInMemHashJoinerInput,
 		inMemHashJoiner: newHashJoiner(
-			allocator, spec, leftInMemHashJoinerInput, rightInMemHashJoinerInput,
+			unlimitedAllocator, spec, leftInMemHashJoinerInput, rightInMemHashJoinerInput,
 		).(*hashJoiner),
 	}
-	ehj.scratch.leftBatch = allocator.NewMemBatch(spec.left.sourceTypes)
+	// To simplify the accounting, we will assume that the in-memory hash
+	// joiner's memory usage is equal to the size of the right partition to be
+	// joined (which will be fully buffered). This is an underestimate because a
+	// single batch from the left partition will be read at a time as well as an
+	// output batch will be used, but that shouldn't matter in the grand scheme
+	// of things.
+	ehj.memState.maxRightPartitionSizeToJoin = memoryLimit - int64(diskQueuesTotalMemLimit)
+	ehj.scratch.leftBatch = unlimitedAllocator.NewMemBatch(spec.left.sourceTypes)
+	ehj.recursiveScratch.leftBatch = unlimitedAllocator.NewMemBatchNoCols(spec.left.sourceTypes, 0 /* size */)
 	sameSourcesSchema := len(spec.left.sourceTypes) == len(spec.right.sourceTypes)
 	for i, leftType := range spec.left.sourceTypes {
 		if i < len(spec.right.sourceTypes) && leftType != spec.right.sourceTypes[i] {
@@ -152,9 +282,12 @@ func newExternalHashJoiner(
 		// The schemas of both sources are the same, so we can reuse the left
 		// scratch batch.
 		ehj.scratch.rightBatch = ehj.scratch.leftBatch
+		ehj.recursiveScratch.rightBatch = ehj.recursiveScratch.leftBatch
 	} else {
-		ehj.scratch.rightBatch = allocator.NewMemBatch(spec.right.sourceTypes)
+		ehj.scratch.rightBatch = unlimitedAllocator.NewMemBatch(spec.right.sourceTypes)
+		ehj.recursiveScratch.rightBatch = unlimitedAllocator.NewMemBatchNoCols(spec.right.sourceTypes, 0 /* size */)
 	}
+	ehj.testingKnobs.numForcedRepartitions = numForcedRepartitions
 	return ehj
 }
 
@@ -165,33 +298,39 @@ func (hj *externalHashJoiner) Init() {
 	// value, so in order to use a "different" hash function in the partitioning
 	// phase we use a different init hash value.
 	hj.tupleDistributor = newTupleHashDistributor(
-		defaultInitHashValue+1, hj.numPartitions,
+		defaultInitHashValue+1, hj.numBuckets,
 	)
-	hj.nonEmptyPartition = make([]bool, hj.numPartitions)
-	hj.state = externalHJPartitioning
+	hj.state = externalHJInitialPartitioning
 }
 
 func (hj *externalHashJoiner) partitionBatch(
-	ctx context.Context,
-	batch coldata.Batch,
-	scratchBatch coldata.Batch,
-	sourceSpec hashJoinerSourceSpec,
-	partitioner colcontainer.PartitionedQueue,
+	ctx context.Context, batch coldata.Batch, side joinSide, parentMemSize int64,
 ) {
-	if batch.Length() == 0 {
+	batchLen := batch.Length()
+	if batchLen == 0 {
 		return
+	}
+	scratchBatch := hj.scratch.leftBatch
+	sourceSpec := hj.spec.left
+	partitioner := hj.leftPartitioner
+	if side == rightSide {
+		scratchBatch = hj.scratch.rightBatch
+		sourceSpec = hj.spec.right
+		partitioner = hj.rightPartitioner
 	}
 	selections := hj.tupleDistributor.distribute(
 		ctx, batch, sourceSpec.sourceTypes, sourceSpec.eqCols,
 	)
-	for partitionIdx, sel := range selections {
+	for idx, sel := range selections {
+		partitionIdx := hj.partitionIdxOffset + idx
 		if len(sel) > 0 {
 			scratchBatch.ResetInternalBatch()
 			// The partitioner expects the batches without a selection vector, so we
 			// need to copy the tuples according to the selection vector into a
 			// scratch batch.
-			hj.allocator.PerformOperation(scratchBatch.ColVecs(), func() {
-				for i, colvec := range scratchBatch.ColVecs() {
+			colVecs := scratchBatch.ColVecs()
+			hj.unlimitedAllocator.PerformOperation(colVecs, func() {
+				for i, colvec := range colVecs {
 					colvec.Copy(coldata.CopySliceArgs{
 						SliceArgs: coldata.SliceArgs{
 							ColType:   sourceSpec.sourceTypes[i],
@@ -206,20 +345,45 @@ func (hj *externalHashJoiner) partitionBatch(
 			if err := partitioner.Enqueue(ctx, partitionIdx, scratchBatch); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
-			hj.nonEmptyPartition[partitionIdx] = true
+			partitionInfo, ok := hj.partitionsToJoin[partitionIdx]
+			if !ok {
+				partitionInfo = &externalHJPartitionInfo{}
+				hj.partitionsToJoin[partitionIdx] = partitionInfo
+			}
+			if side == rightSide {
+				partitionInfo.rightParentMemSize = parentMemSize
+				// We cannot use allocator's methods directly because those look at the
+				// capacities of the vectors, and in our case only first len(sel)
+				// tuples belong to the "current" batch. Also, there is no selection
+				// vector on the enqueued batch, so we don't need to worry about that.
+				curBatchMemSize := getVecsMemoryFootprint(colVecs) / int64(batchLen) * int64(len(sel))
+				partitionInfo.rightMemSize += curBatchMemSize
+			}
 		}
 	}
 }
 
 func (hj *externalHashJoiner) Next(ctx context.Context) coldata.Batch {
+StateChanged:
 	for {
 		switch hj.state {
-		case externalHJPartitioning:
+		case externalHJInitialPartitioning:
 			leftBatch := hj.inputOne.Next(ctx)
 			rightBatch := hj.inputTwo.Next(ctx)
 			if leftBatch.Length() == 0 && rightBatch.Length() == 0 {
 				// Both inputs have been partitioned and spilled, so we transition to
 				// "joining" phase. Close all the open write file descriptors.
+				//
+				// TODO(yuzefovich): this will also clear the cache once the new PR is
+				// in. This means we will reallocate a cache whenever reading from the
+				// partitions. What I think we might want to do is not close the
+				// partitions here. Instead, we move on to joining, which will switch
+				// all of these reserved file descriptors to read in the best case (no
+				// repartitioning) and reuse the cache. Only if we need to repartition
+				// should we CloseAllOpenWriteFileDescriptors of both sides. It might
+				// also be more efficient to Dequeue from the partitions you'll read
+				// from before doing that to exempt them from releasing their FDs to
+				// the semaphore.
 				if err := hj.leftPartitioner.CloseAllOpenWriteFileDescriptors(); err != nil {
 					execerror.VectorizedInternalPanic(err)
 				}
@@ -227,55 +391,163 @@ func (hj *externalHashJoiner) Next(ctx context.Context) coldata.Batch {
 					execerror.VectorizedInternalPanic(err)
 				}
 				hj.inMemHashJoiner.Init()
+				hj.partitionIdxOffset += hj.numBuckets
 				hj.state = externalHJJoinNewPartition
 				continue
 			}
-			hj.partitionBatch(ctx, leftBatch, hj.scratch.leftBatch, hj.spec.left, hj.leftPartitioner)
-			hj.partitionBatch(ctx, rightBatch, hj.scratch.rightBatch, hj.spec.right, hj.rightPartitioner)
+			hj.partitionBatch(ctx, leftBatch, leftSide, math.MaxInt64)
+			hj.partitionBatch(ctx, rightBatch, rightSide, math.MaxInt64)
+
+		case externalHJRecursivePartitioning:
+			hj.numRepartitions++
+			if log.V(2) && hj.numRepartitions%10 == 0 {
+				log.Info(ctx, fmt.Sprintf(
+					"external hash joiner is performing %d'th repartition", hj.numRepartitions,
+				))
+			}
+			// In order to use a different hash function when repartitioning, we need
+			// to increase the seed value of the tuple distributor.
+			hj.tupleDistributor.initHashValue++
+			// We're actively will be using hj.numBuckets + 1 partitions (because
+			// we're repartitioning one side at a time), so we can set hj.numBuckets
+			// higher than in the initial partitioning step.
+			// TODO(yuzefovich): figure out whether we should care about
+			// hj.numBuckets being a power of two (finalizeHash step is faster if so).
+			hj.numBuckets = hj.maxNumberActivePartitions - 1
+			hj.tupleDistributor.resetNumOutputs(hj.numBuckets)
+			for parentPartitionIdx, parentPartitionInfo := range hj.partitionsToJoin {
+				for _, side := range []joinSide{leftSide, rightSide} {
+					batch := hj.recursiveScratch.leftBatch
+					partitioner := hj.leftPartitioner
+					memSize := int64(math.MaxInt64)
+					if side == rightSide {
+						batch = hj.recursiveScratch.rightBatch
+						partitioner = hj.rightPartitioner
+						memSize = parentPartitionInfo.rightMemSize
+					}
+					for {
+						if err := partitioner.Dequeue(ctx, parentPartitionIdx, batch); err != nil {
+							execerror.VectorizedInternalPanic(err)
+						}
+						if batch.Length() == 0 {
+							break
+						}
+						hj.partitionBatch(ctx, batch, side, memSize)
+					}
+					// We're done reading from this partition, and it will never be read
+					// from again, so we can close it.
+					if err := partitioner.CloseInactiveReadPartitions(); err != nil {
+						execerror.VectorizedInternalPanic(err)
+					}
+					// We're done writing to the newly created partitions.
+					// TODO(yuzefovich): we should not release the descriptors here. The
+					// invariant should be: we're enteringexternalHJRecursivePartitioning,
+					// at that stage we have at most numBuckets*2 file descriptors open. At
+					// the top of the state transition, close all open write file
+					// descriptors, which should reduce the open descriptors to 0. Now we
+					// open the two read partitions for 2 file descriptors and whatever
+					// number of write partitions we want. This'll allow us to remove the
+					// call to CloseAllOpen... in the first state as well.
+					if err := partitioner.CloseAllOpenWriteFileDescriptors(); err != nil {
+						execerror.VectorizedInternalPanic(err)
+					}
+				}
+				if !hj.testingKnobs.repartitionForced {
+					// If the repartition was forced, then it is possible that there is
+					// no reduction in size, and we don't want to error out in such case.
+					for idx := 0; idx < hj.numBuckets; idx++ {
+						if partitionInfo, ok := hj.partitionsToJoin[hj.partitionIdxOffset+idx]; ok {
+							before, after := partitionInfo.rightParentMemSize, partitionInfo.rightMemSize
+							if before > 0 {
+								sizeDecrease := 1.0 - float64(after)/float64(before)
+								if sizeDecrease < externalHJRecursivePartitioningSizeDecreaseThreshold {
+									// TODO(yuzefovich): support this case by falling back to
+									// sort + merge join.
+									execerror.VectorizedInternalPanic(errors.Errorf(
+										"%s: before %s, after %s", externalHJFallbackToSortMergeJoinMsg,
+										humanize.Bytes(uint64(before)), humanize.Bytes(uint64(after))))
+								}
+							}
+						}
+					}
+				}
+				hj.testingKnobs.repartitionForced = false
+				// We have successfully repartitioned the partitions with index
+				// 'parentPartitionIdx' on both sides, so we delete that index from the
+				// map and proceed on joining the newly created partitions.
+				delete(hj.partitionsToJoin, parentPartitionIdx)
+				hj.partitionIdxOffset += hj.numBuckets
+				hj.state = externalHJJoinNewPartition
+				continue StateChanged
+			}
 
 		case externalHJJoinNewPartition:
-			// Find next non empty partition. Close any open read file descriptors
-			// from previous joins.
-			if err := hj.leftPartitioner.CloseAllOpenReadFileDescriptors(); err != nil {
-				execerror.VectorizedInternalPanic(err)
+			if hj.testingKnobs.numForcedRepartitions > 0 {
+				hj.testingKnobs.numForcedRepartitions--
+				hj.testingKnobs.repartitionForced = true
+				hj.state = externalHJRecursivePartitioning
+				continue
 			}
-			if err := hj.rightPartitioner.CloseAllOpenReadFileDescriptors(); err != nil {
-				execerror.VectorizedInternalPanic(err)
-			}
-			for hj.partitionIdxToJoin < hj.numPartitions &&
-				!hj.nonEmptyPartition[hj.partitionIdxToJoin] {
-				hj.partitionIdxToJoin++
-			}
-			if hj.partitionIdxToJoin == hj.numPartitions {
-				// All partitions have been processed, so we clean up the disk
-				// infrastructure and transition to finished state.
-				if err := hj.leftPartitioner.Close(); err != nil {
-					execerror.VectorizedInternalPanic(err)
+			// Find next partition that we can join without having to recursively
+			// repartition.
+			for partitionIdx, partitionInfo := range hj.partitionsToJoin {
+				if partitionInfo.rightMemSize <= hj.memState.maxRightPartitionSizeToJoin {
+					// Update the inputs to in-memory hash joiner and reset the latter.
+					hj.leftInMemHashJoinerInput.partitionIdx = partitionIdx
+					hj.rightInMemHashJoinerInput.partitionIdx = partitionIdx
+					hj.inMemHashJoiner.reset()
+					hj.state = externalHJJoining
+					delete(hj.partitionsToJoin, partitionIdx)
+					continue StateChanged
 				}
-				if err := hj.rightPartitioner.Close(); err != nil {
-					execerror.VectorizedInternalPanic(err)
-				}
+			}
+			if len(hj.partitionsToJoin) == 0 {
+				// All partitions have been processed, so we transition to finished
+				// state.
 				hj.state = externalHJFinished
 				continue
 			}
-			// Update the inputs to in-memory hash joiner and reset the latter.
-			hj.leftInMemHashJoinerInput.partitionIdx = hj.partitionIdxToJoin
-			hj.rightInMemHashJoinerInput.partitionIdx = hj.partitionIdxToJoin
-			hj.inMemHashJoiner.reset()
-			hj.state = externalHJJoining
+			// We have partitions that we cannot join without recursively
+			// repartitioning first, so we transition to the corresponding state.
+			hj.state = externalHJRecursivePartitioning
 
 		case externalHJJoining:
 			b := hj.inMemHashJoiner.Next(ctx)
 			if b.Length() == 0 {
-				hj.partitionIdxToJoin++
+				// We're done joining these partitions, so we close them and transition
+				// to joining new ones.
+				if err := hj.leftPartitioner.CloseInactiveReadPartitions(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				if err := hj.rightPartitioner.CloseInactiveReadPartitions(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
 				hj.state = externalHJJoinNewPartition
 				continue
 			}
 			return b
 		case externalHJFinished:
+			if err := hj.Close(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
 			return coldata.ZeroBatch
 		default:
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected externalHashJoinerState %d", hj.state))
 		}
 	}
+}
+
+func (hj *externalHashJoiner) Close() error {
+	if hj.closed {
+		return nil
+	}
+	var retErr error
+	if err := hj.leftPartitioner.Close(); err != nil {
+		retErr = err
+	}
+	if err := hj.rightPartitioner.Close(); err != nil && retErr == nil {
+		retErr = err
+	}
+	hj.closed = true
+	return retErr
 }

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -52,9 +52,9 @@ func TestExternalHashJoiner(t *testing.T) {
 	// which the joiner spills to disk.
 	for _, spillForced := range []bool{false, true} {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
-		t.Run(fmt.Sprintf("spillForced=%t", spillForced), func(t *testing.T) {
-			for _, tcs := range [][]joinTestCase{hjTestCases, mjTestCases} {
-				for _, tc := range tcs {
+		for _, tcs := range [][]joinTestCase{hjTestCases, mjTestCases} {
+			for _, tc := range tcs {
+				t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.description), func(t *testing.T) {
 					runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
 						spec := createSpecForHashJoiner(tc)
 						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, sources, func() {}, queueCfg)
@@ -62,9 +62,9 @@ func TestExternalHashJoiner(t *testing.T) {
 						memMonitors = append(memMonitors, monitors...)
 						return hjOp, err
 					})
-				}
+				})
 			}
-		})
+		}
 	}
 	for _, memAccount := range memAccounts {
 		memAccount.Close(ctx)

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -13,12 +13,14 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -26,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/marusama/semaphore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,6 +51,8 @@ func TestExternalHashJoiner(t *testing.T) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
+	// External hash joiner needs at least two partitions per side.
+	const maxNumberPartitions = 4
 	// Test the case in which the default memory is used as well as the case in
 	// which the joiner spills to disk.
 	for _, spillForced := range []bool{false, true} {
@@ -55,13 +60,45 @@ func TestExternalHashJoiner(t *testing.T) {
 		for _, tcs := range [][]joinTestCase{hjTestCases, mjTestCases} {
 			for _, tc := range tcs {
 				t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.description), func(t *testing.T) {
+					// Unfortunately, there is currently no better way to check that the
+					// external hash joiner does not have leftover file descriptors other
+					// than appending each semaphore used to this slice on construction.
+					// This is because some tests don't fully drain the input, making
+					// intercepting the Close() method not a useful option, since it is
+					// impossible to check between an expected case where more than 0 FDs
+					// are open (e.g. in allNullsInjection, where the joiner is not fully
+					// drained so Close must be called explicitly) and an unexpected one.
+					// These cases happen during normal execution when a limit is
+					// satisfied, but flows will call Close explicitly on Cleanup.
+					// TODO(yuzefovich): not implemented yet, currently we rely on the
+					// flow tracking open FDs and releasing any leftovers.
+					var semsToCheck []semaphore.Semaphore
+					if !tc.onExpr.Empty() {
+						// When we have ON expression, there might be other operators (like
+						// selections) on top of the external hash joiner in
+						// diskSpiller.diskBackedOp chain. This will not allow for Close()
+						// call to propagate to the external hash joiner, so we will skip
+						// allNullsInjection test for now.
+						defer func(oldValue bool) {
+							tc.skipAllNullsInjection = oldValue
+						}(tc.skipAllNullsInjection)
+						tc.skipAllNullsInjection = true
+					}
 					runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
+						sem := NewTestingSemaphore(maxNumberPartitions)
+						semsToCheck = append(semsToCheck, sem)
 						spec := createSpecForHashJoiner(tc)
-						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, sources, func() {}, queueCfg)
+						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(
+							ctx, flowCtx, spec, sources, func() {}, queueCfg,
+							2 /* numForcedPartitions */, sem,
+						)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
 						return hjOp, err
 					})
+					for i, sem := range semsToCheck {
+						require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+					}
 				})
 			}
 		}
@@ -72,6 +109,73 @@ func TestExternalHashJoiner(t *testing.T) {
 	for _, memMonitor := range memMonitors {
 		memMonitor.Stop(ctx)
 	}
+}
+
+// TestExternalHashJoinerFallbackToSortMergeJoin tests that the external hash
+// joiner falls back to using sort + merge join when repartitioning doesn't
+// decrease the size of the partition. We instantiate two sources that contain
+// the same tuple many times.
+func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+			TestingKnobs: execinfra.TestingKnobs{
+				ForceDiskSpill:   true,
+				MemoryLimitBytes: 1,
+			},
+		},
+	}
+	sourceTypes := []coltypes.T{coltypes.Int64}
+	batch := testAllocator.NewMemBatch(sourceTypes)
+	// We don't need to set the data since zero values in the columns work.
+	batch.SetLength(coldata.BatchSize())
+	nBatches := 2
+	leftSource := newFiniteBatchSource(batch, nBatches)
+	rightSource := newFiniteBatchSource(batch, nBatches)
+	spec := createSpecForHashJoiner(joinTestCase{
+		joinType:     sqlbase.JoinType_INNER,
+		leftTypes:    sourceTypes,
+		leftOutCols:  []uint32{0},
+		leftEqCols:   []uint32{0},
+		rightTypes:   sourceTypes,
+		rightOutCols: []uint32{0},
+		rightEqCols:  []uint32{0},
+	})
+	var spilled bool
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+	// External hash joiner needs at least two partitions per side.
+	const maxNumberPartitions = 4
+	hj, accounts, monitors, err := createDiskBackedHashJoiner(
+		ctx, flowCtx, spec, []Operator{leftSource, rightSource},
+		func() { spilled = true }, queueCfg, 0, /* numForcedRepartitions */
+		NewTestingSemaphore(maxNumberPartitions),
+	)
+	defer func() {
+		for _, memAccount := range accounts {
+			memAccount.Close(ctx)
+		}
+		for _, memMonitor := range monitors {
+			memMonitor.Stop(ctx)
+		}
+	}()
+	require.NoError(t, err)
+	hj.Init()
+	err = execerror.CatchVectorizedRuntimeError(func() {
+		for b := hj.Next(ctx); b.Length() > 0; b = hj.Next(ctx) {
+		}
+	})
+	require.True(t, spilled)
+	// Currently, we don't have the fallback in place, so we expect an error.
+	// TODO(yuzefovich): change this once we have the fallback.
+	require.NotNil(t, err)
+	require.True(t, strings.Contains(err.Error(), externalHJFallbackToSortMergeJoinMsg))
 }
 
 func BenchmarkExternalHashJoiner(b *testing.B) {
@@ -147,7 +251,11 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							leftSource.reset(nBatches)
 							rightSource.reset(nBatches)
-							hj, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, []Operator{leftSource, rightSource}, func() {}, queueCfg)
+							hj, accounts, monitors, err := createDiskBackedHashJoiner(
+								ctx, flowCtx, spec, []Operator{leftSource, rightSource},
+								func() {}, queueCfg, 0, /* numForcedRepartitions */
+								NewTestingSemaphore(VecMaxOpenFDsLimit),
+							)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							require.NoError(b, err)
@@ -180,23 +288,21 @@ func createDiskBackedHashJoiner(
 	inputs []Operator,
 	spillingCallbackFn func(),
 	diskQueueCfg colcontainer.DiskQueueCfg,
+	numForcedRepartitions int,
+	testingSemaphore semaphore.Semaphore,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
 	args := NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,
 		StreamingMemAccount: testMemAcc,
 		DiskQueueCfg:        diskQueueCfg,
-		// The TestingSemaphore is created with a limit since the
-		// externalHashJoiner calculates the maximum number of partitions based on
-		// this.
-		// TODO(asubiotto): Assert a maximum number of open file descriptors when
-		//  we have recursive partitioning.
-		FDSemaphore: NewTestingSemaphore(256),
+		FDSemaphore:         testingSemaphore,
 	}
 	// We will not use streaming memory account for the external hash join so
 	// that the in-memory hash join operator could hit the memory limit set on
 	// flowCtx.
 	args.TestingKnobs.SpillingCallbackFn = spillingCallbackFn
+	args.TestingKnobs.NumForcedRepartitions = numForcedRepartitions
 	result, err := NewColOperator(ctx, flowCtx, args)
 	return result.Op, result.BufferingOpMemAccounts, result.BufferingOpMemMonitors, err
 }

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -344,7 +344,7 @@ func createDiskBackedSorter(
 	// understand when to start a new partition, so we will not use
 	// the streaming memory account.
 	args.TestingKnobs.SpillingCallbackFn = spillingCallbackFn
-	args.TestingKnobs.MaxNumberPartitions = maxNumberPartitions
+	args.TestingKnobs.NumForcedRepartitions = maxNumberPartitions
 	result, err := NewColOperator(ctx, flowCtx, args)
 	return result.Op, result.BufferingOpMemAccounts, result.BufferingOpMemMonitors, err
 }

--- a/pkg/sql/colexec/hash_utils.go
+++ b/pkg/sql/colexec/hash_utils.go
@@ -155,3 +155,16 @@ func (d *tupleHashDistributor) distribute(
 	}
 	return d.selections
 }
+
+// resetNumOutputs sets up the tupleHashDistributor to distribute the tuples
+// to a different number of outputs.
+func (d *tupleHashDistributor) resetNumOutputs(numOutputs int) {
+	if cap(d.selections) >= numOutputs {
+		d.selections = d.selections[:numOutputs]
+		return
+	}
+	d.selections = d.selections[:cap(d.selections)]
+	for len(d.selections) < numOutputs {
+		d.selections = append(d.selections, make([]uint16, 0, coldata.BatchSize()))
+	}
+}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -50,8 +50,9 @@ func init() {
 
 	hjTestCases = []joinTestCase{
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "0",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			leftTuples: tuples{
 				{0},
@@ -85,8 +86,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "1",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test an empty build table.
 			leftTuples: tuples{},
@@ -111,8 +113,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "2",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			leftTuples: tuples{
 				{0},
@@ -145,8 +148,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "3",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test right outer join.
 			leftTuples: tuples{
@@ -173,8 +177,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "4",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test right outer join with non-distinct left build table with an
 			// unmatched row from the right followed by a matched one. This is a
@@ -204,8 +209,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "5",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test null handling only on probe column.
 			leftTuples: tuples{
@@ -229,8 +235,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "6",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test null handling only on build column.
 			leftTuples: tuples{
@@ -259,8 +266,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64},
+			description: "7",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
 
 			// Test null handling in output columns.
 			leftTuples: tuples{
@@ -292,8 +300,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "8",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test null handling in hash join key column.
 			leftTuples: tuples{
@@ -326,8 +335,9 @@ func init() {
 		},
 		{
 			// Test handling of multiple column non-distinct equality keys.
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			description: "9",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
 
 			leftTuples: tuples{
 				{0, 0, 1},
@@ -364,8 +374,9 @@ func init() {
 		},
 		{
 			// Test handling of duplicate equality keys that map to same buckets.
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "10",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			leftTuples: tuples{
 				{0},
@@ -410,8 +421,9 @@ func init() {
 		},
 		{
 			// Test handling of duplicate equality keys.
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "11",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			leftTuples: tuples{
 				{0},
@@ -448,8 +460,9 @@ func init() {
 		},
 		{
 			// Test handling of various output column coltypes.
-			leftTypes:  []coltypes.T{coltypes.Bool, coltypes.Int64, coltypes.Bytes, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Float64, coltypes.Int32},
+			description: "12",
+			leftTypes:   []coltypes.T{coltypes.Bool, coltypes.Int64, coltypes.Bytes, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Float64, coltypes.Int32},
 
 			leftTuples: tuples{
 				{false, 5, "a", 10},
@@ -480,8 +493,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "13",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Reverse engineering hash table hash heuristic to find key values that
 			// hash to the same bucket.
@@ -512,8 +526,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "14",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			// Test a N:1 inner join where the right side key has duplicate values.
 			leftTuples: tuples{
@@ -548,8 +563,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			description: "15",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
 
 			// Test inner join on multiple equality columns.
 			leftTuples: tuples{
@@ -584,8 +600,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64},
+			description: "16",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
 
 			// Test multiple column with values that hash to the same bucket.
 			leftTuples: tuples{
@@ -618,8 +635,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Bytes, coltypes.Bool, coltypes.Int16, coltypes.Int32, coltypes.Int64, coltypes.Bytes},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int32, coltypes.Int16, coltypes.Bool, coltypes.Bytes},
+			description: "17",
+			leftTypes:   []coltypes.T{coltypes.Bytes, coltypes.Bool, coltypes.Int16, coltypes.Int32, coltypes.Int64, coltypes.Bytes},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int32, coltypes.Int16, coltypes.Bool, coltypes.Bytes},
 
 			// Test multiple equality columns of different coltypes.
 			leftTuples: tuples{
@@ -655,8 +673,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Float64},
-			rightTypes: []coltypes.T{coltypes.Float64},
+			description: "18",
+			leftTypes:   []coltypes.T{coltypes.Float64},
+			rightTypes:  []coltypes.T{coltypes.Float64},
 
 			// Test equality columns of type float.
 			leftTuples: tuples{
@@ -687,8 +706,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			description: "19",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64, coltypes.Int64, coltypes.Int64},
 
 			// Test use right side as build table.
 			leftTuples: tuples{
@@ -718,8 +738,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Decimal},
-			rightTypes: []coltypes.T{coltypes.Decimal},
+			description: "20",
+			leftTypes:   []coltypes.T{coltypes.Decimal},
+			rightTypes:  []coltypes.T{coltypes.Decimal},
 
 			// Test coltypes.Decimal type as equality column.
 			leftTuples: tuples{
@@ -747,8 +768,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "21",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			joinType: sqlbase.JoinType_LEFT_SEMI,
 
@@ -779,8 +801,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64},
+			description: "22",
+			leftTypes:   []coltypes.T{coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64},
 
 			joinType: sqlbase.JoinType_LEFT_ANTI,
 
@@ -809,8 +832,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64},
+			description: "23",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
 
 			// Test ON expression.
 			leftTuples: tuples{
@@ -841,8 +865,9 @@ func init() {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int64},
+			description: "24",
+			leftTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:  []coltypes.T{coltypes.Int64, coltypes.Int64},
 
 			// Test ON expression.
 			leftTuples: tuples{

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1577,7 +1577,7 @@ func TestMergeJoiner(t *testing.T) {
 
 		// We use a custom verifier function so that we can get the merge join op
 		// to use a custom output batch size per test, to exercise more cases.
-		var mergeJoinVerifier verifier = func(output *opTestOutput) error {
+		var mergeJoinVerifier verifierFn = func(output *opTestOutput) error {
 			if mj, ok := output.input.(variableOutputBatchSizeInitializer); ok {
 				mj.initWithOutputBatchSize(tc.outputBatchSize)
 			} else {

--- a/pkg/sql/colexec/simple_project.go
+++ b/pkg/sql/colexec/simple_project.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 )
@@ -103,4 +104,11 @@ func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
 	d.batch.Batch = batch
 
 	return d.batch
+}
+
+func (d *simpleProjectOp) Close() error {
+	if c, ok := d.input.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -78,6 +78,9 @@ var _ bufferingInMemoryOperator = &sortChunksOp{}
 func (c *sortChunksOp) Init() {
 	c.input.init()
 	c.sorter.Init()
+	// TODO(yuzefovich): switch to calling this method on allocator. This will
+	// require plumbing unlimited allocator to work correctly in tests with
+	// memory limit of 1.
 	c.windowedBatch = coldata.NewMemBatchNoCols(c.input.inputTypes, int(coldata.BatchSize()))
 }
 

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -99,6 +99,9 @@ func (t *topKSorter) Init() {
 		typ := t.inputTypes[i]
 		t.comparators[i] = GetVecComparator(typ, 2)
 	}
+	// TODO(yuzefovich): switch to calling this method on allocator. This will
+	// require plumbing unlimited allocator to work correctly in tests with
+	// memory limit of 1.
 	t.windowedBatch = coldata.NewMemBatchNoCols(t.inputTypes, int(coldata.BatchSize()))
 }
 

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -328,7 +328,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 						forceDiskSpill: spillForced,
 					}
 					if spillForced {
-						args.maxNumberPartitions = 2 + rng.Intn(3)
+						args.numForcedRepartitions = 2 + rng.Intn(3)
 					}
 					if err := verifyColOperator(args); err != nil {
 						fmt.Printf("--- seed = %d spillForced = %t nCols = %d K = %d ---\n",
@@ -547,12 +547,13 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 									},
 								}
 								args := verifyColOperatorArgs{
-									anyOrder:       true,
-									inputTypes:     [][]types.T{lInputTypes, rInputTypes},
-									inputs:         []sqlbase.EncDatumRows{lRows, rRows},
-									outputTypes:    outputTypes,
-									pspec:          pspec,
-									forceDiskSpill: spillForced,
+									anyOrder:              true,
+									inputTypes:            [][]types.T{lInputTypes, rInputTypes},
+									inputs:                []sqlbase.EncDatumRows{lRows, rRows},
+									outputTypes:           outputTypes,
+									pspec:                 pspec,
+									forceDiskSpill:        spillForced,
+									numForcedRepartitions: 2,
 								}
 								if err := verifyColOperator(args); err != nil {
 									fmt.Printf("--- spillForced = %t join type = %s onExpr = %q"+

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1451,6 +1451,7 @@ func TestLint(t *testing.T) {
 			// - coldata.NewMemBatchWithSize
 			// - coldata.NewMemColumn
 			// - coldata.Batch.AppendCol
+			// TODO(yuzefovich): prohibit call to coldata.NewMemBatchNoCols.
 			fmt.Sprintf(`(coldata\.NewMem(Batch|BatchWithSize|Column)|\.AppendCol)\(`),
 			"--",
 			"sql/colexec",


### PR DESCRIPTION
**colexec: fix verifySelAndNullsReset test**

Previously, we would run verifySelAndNullsReset test on all of the
units. However, this test relies on the fact that the output of the
operator in question is the same which is not always the case - it is
such only if we expect the order of tuples (and batches) remain the
same. This is now fixed by checking whether the verifierType is
orderedVerifier, and only if so, we will run this test.

Additionally, this numbers all hash joiner unit tests for ease of
debugging.

Release note: None

**colexec: add recursive partitioning to external hash joiner**

This commit adds the support for recursive partitioning to external hash
joiner. The goal is that if a partition is too big to join at once (when
the right side partition exceeds the memory limit), we need to
repartition that partition according to a different hash function. We
will always try to join as many partitions as possible (and emit the
corresponding output), and then if there are any partitions that are too
big, we will repartition them, one at a time. Once that single big
partition is repartitioned, we will try joining subpartitions. If at
some point we see that there is no decrease in size (if the decrease
is less than 0.05), we will bail on such query. It is likely that in
such case we have tuples that are not distinct on equality columns, and
we need to fallback to a combination of sort + merge join (currently not
supported).

The given memory limit is divided into two parts: one half for disk
queues (i.e. partitions), and another half for the in-memory hash
joiner. The number of buckets to divide a partition into is
semi-dynamically computed to be in the range [2, 8] (i.e. we will be
using from 4 to 16 disk queues). The memory usage of the in-memory hash
joiner is approximated by the size of the right side partition.

Fixes: #44727.

Release note: None