### PR TITLE
sql: make max1row operator take error text as a parameter

### DIFF
--- a/pkg/sql/max_one_row.go
+++ b/pkg/sql/max_one_row.go
@@ -29,8 +29,9 @@ import (
 type max1RowNode struct {
 	plan planNode
 
-	nexted bool
-	values tree.Datums
+	nexted    bool
+	values    tree.Datums
+	errorText string
 }
 
 func (m *max1RowNode) startExec(runParams) error {
@@ -56,8 +57,7 @@ func (m *max1RowNode) Next(params runParams) (bool, error) {
 		var secondOk bool
 		secondOk, err = m.plan.Next(params)
 		if secondOk {
-			return false, pgerror.Newf(pgcode.CardinalityViolation,
-				"more than one row returned by a subquery used as an expression")
+			return false, pgerror.New(pgcode.CardinalityViolation, m.errorText)
 		}
 	}
 	return ok, err

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -188,7 +188,7 @@ func (f *stubFactory) ConstructLimit(
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructMax1Row(input exec.Node) (exec.Node, error) {
+func (f *stubFactory) ConstructMax1Row(input exec.Node, errorText string) (exec.Node, error) {
 	return struct{}{}, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1399,7 +1399,7 @@ func (b *Builder) buildMax1Row(max1Row *memo.Max1RowExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
-	node, err := b.factory.ConstructMax1Row(input.root)
+	node, err := b.factory.ConstructMax1Row(input.root, max1Row.ErrorText)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -267,9 +267,9 @@ type Factory interface {
 	ConstructLimit(input Node, limit, offset tree.TypedExpr) (Node, error)
 
 	// ConstructMax1Row returns a node that permits at most one row from the
-	// given input node, returning an error at runtime if the node tries to return
-	// more than one row.
-	ConstructMax1Row(input Node) (Node, error)
+	// given input node, returning an error with the given text at runtime if
+	// the node tries to return more than one row.
+	ConstructMax1Row(input Node, errorText string) (Node, error)
 
 	// ConstructProjectSet returns a node that performs a lateral cross join
 	// between the output of the given node and the functional zip of the given

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -42,7 +42,7 @@ const (
 	ExprFmtShowAll ExprFmtFlags = 0
 
 	// ExprFmtHideMiscProps does not show outer columns, row cardinality, provided
-	// orderings, or side effects in the output.
+	// orderings, side effects, or error text in the output.
 	ExprFmtHideMiscProps ExprFmtFlags = 1 << (iota - 1)
 
 	// ExprFmtHideConstraints does not show inferred constraints in the output.
@@ -299,6 +299,11 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	case *OffsetExpr:
 		if !f.HasFlags(ExprFmtHidePhysProps) && !t.Ordering.Any() {
 			tp.Childf("internal-ordering: %s", t.Ordering)
+		}
+
+	case *Max1RowExpr:
+		if !f.HasFlags(ExprFmtHideMiscProps) {
+			tp.Childf("error: \"%s\"", t.ErrorText)
 		}
 
 	// Special-case handling for set operators to show the left and right

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -227,6 +227,7 @@ project
       └── subquery [type=decimal, outer=(2,10), correlated-subquery]
            └── max1-row
                 ├── columns: sum:11(decimal)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (2,10)
                 ├── cardinality: [0 - 1]
                 ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -65,6 +65,7 @@ project
  │    │    ├── prune: (6)
  │    │    ├── max1-row
  │    │    │    ├── columns: column1:5(int)
+ │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    ├── outer: (1,2)
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
@@ -117,6 +118,7 @@ project
       │    └── interesting orderings: (+1) (-3,+4,+1)
       ├── max1-row
       │    ├── columns: v:6(int!null)
+      │    ├── error: "more than one row returned by a subquery used as an expression"
       │    ├── outer: (1)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
@@ -176,6 +178,7 @@ project
       │    └── interesting orderings: (+1) (-3,+4,+1)
       ├── max1-row
       │    ├── columns: v:6(int!null)
+      │    ├── error: "more than one row returned by a subquery used as an expression"
       │    ├── outer: (1,2)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
@@ -269,6 +272,7 @@ project
       │    │    └── interesting orderings: (+1) (-3,+4,+1)
       │    ├── max1-row
       │    │    ├── columns: u:5(int!null)
+      │    │    ├── error: "more than one row returned by a subquery used as an expression"
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -71,6 +71,7 @@ limit
  └── subquery [type=int]
       └── max1-row
            ├── columns: "?column?":5(int!null)
+           ├── error: "more than one row returned by a subquery used as an expression"
            ├── cardinality: [1 - 1]
            ├── key: ()
            ├── fd: ()-->(5)
@@ -124,6 +125,7 @@ project
       └── subquery [type=int, outer=(1,2), side-effects, correlated-subquery]
            └── max1-row
                 ├── columns: x:8(int)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
                 ├── side-effects

--- a/pkg/sql/opt/memo/testdata/logprops/max1row
+++ b/pkg/sql/opt/memo/testdata/logprops/max1row
@@ -26,6 +26,7 @@ select
            ├── subquery [type=string]
            │    └── max1-row
            │         ├── columns: v:7(string)
+           │         ├── error: "more than one row returned by a subquery used as an expression"
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
            │         ├── fd: ()-->(7)

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -41,6 +41,7 @@ offset
  └── subquery [type=int]
       └── max1-row
            ├── columns: "?column?":5(int!null)
+           ├── error: "more than one row returned by a subquery used as an expression"
            ├── cardinality: [1 - 1]
            ├── key: ()
            ├── fd: ()-->(5)
@@ -91,6 +92,7 @@ project
       └── subquery [type=int, outer=(1,2), correlated-subquery]
            └── max1-row
                 ├── columns: x:8(int)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
                 ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -66,6 +66,7 @@ select
            ├── subquery [type=int]
            │    └── max1-row
            │         ├── columns: y:9(int)
+           │         ├── error: "more than one row returned by a subquery used as an expression"
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
@@ -99,6 +100,7 @@ select
            │                   └── subquery [type=int, outer=(2), correlated-subquery]
            │                        └── max1-row
            │                             ├── columns: y:8(int)
+           │                             ├── error: "more than one row returned by a subquery used as an expression"
            │                             ├── outer: (2)
            │                             ├── cardinality: [1 - 1]
            │                             ├── key: ()
@@ -216,6 +218,7 @@ project
       └── subquery [type=int, outer=(1), correlated-subquery]
            └── max1-row
                 ├── columns: xysd.y:5(int)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1)
                 ├── cardinality: [0 - 1]
                 ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -304,6 +304,7 @@ project
                 ├── subquery [type=int]
                 │    └── max1-row
                 │         ├── columns: count_rows:8(int!null)
+                │         ├── error: "more than one row returned by a subquery used as an expression"
                 │         ├── outer: (2)
                 │         ├── cardinality: [1 - 1]
                 │         ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -116,6 +116,7 @@ select
            ├── subquery [type=tuple{int, int}]
            │    └── max1-row
            │         ├── columns: column13:13(tuple{int, int})
+           │         ├── error: "more than one row returned by a subquery used as an expression"
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -37,6 +37,7 @@ project
  │    │    └── prune: (1,2)
  │    ├── max1-row
  │    │    ├── columns: unnest:6(int)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (1,2)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── side-effects

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -73,6 +73,7 @@ project
       └── subquery [type=int, outer=(1,2), correlated-subquery]
            └── max1-row
                 ├── columns: column1:3(int)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1,2)
                 ├── cardinality: [1 - 1]
                 ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -104,6 +104,7 @@ project
       └── subquery [type=int, outer=(1), correlated-subquery]
            └── max1-row
                 ├── columns: "?column?":10(int)
+                ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1)
                 ├── cardinality: [1 - 1]
                 ├── key: ()

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1145,6 +1145,7 @@ project
  │    │    └── stats: [rows=1000]
  │    ├── max1-row
  │    │    ├── columns: "?column?":15(int!null)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (2)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── stats: [rows=1]

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -80,6 +80,7 @@ limit
  └── subquery [type=int]
       └── max1-row
            ├── columns: c:5(int!null)
+           ├── error: "more than one row returned by a subquery used as an expression"
            ├── cardinality: [1 - 1]
            ├── stats: [rows=1]
            ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -230,6 +230,7 @@ inner-join (cross)
  │              └── subquery [type=int]
  │                   └── max1-row
  │                        ├── columns: generate_series:5(int)
+ │                        ├── error: "more than one row returned by a subquery used as an expression"
  │                        ├── cardinality: [0 - 1]
  │                        ├── side-effects
  │                        ├── key: ()
@@ -3960,6 +3961,7 @@ scalar-group-by
  │    │    │    └── columns: i:2(int)
  │    │    ├── max1-row
  │    │    │    ├── columns: y:7(int!null)
+ │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    ├── outer: (2)
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
@@ -4277,6 +4279,7 @@ project
  │    │    └── fd: (1)-->(2)
  │    ├── max1-row
  │    │    ├── columns: column1:8(int)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (1,2)
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -668,6 +668,7 @@ project
       │    │    └── fd: (6)-->(7)
       │    ├── max1-row
       │    │    ├── columns: "?column?":10(int)
+      │    │    ├── error: "more than one row returned by a subquery used as an expression"
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
@@ -764,6 +765,7 @@ project
  │    │    └── key: (1)
  │    ├── max1-row
  │    │    ├── columns: b.x:4(int!null)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (1)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
@@ -818,6 +820,7 @@ project
  │    │    └── key: (1)
  │    ├── max1-row
  │    │    ├── columns: b.x:9(int!null)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (1)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
@@ -917,6 +920,7 @@ project
  │    │    │    │              ├── subquery [type=string]
  │    │    │    │              │    └── max1-row
  │    │    │    │              │         ├── columns: s:19(string)
+ │    │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │              │         ├── cardinality: [0 - 1]
  │    │    │    │              │         ├── key: ()
  │    │    │    │              │         ├── fd: ()-->(19)
@@ -930,6 +934,7 @@ project
  │    │    │    │              ├── subquery [type=string]
  │    │    │    │              │    └── max1-row
  │    │    │    │              │         ├── columns: s:19(string)
+ │    │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │              │         ├── cardinality: [0 - 1]
  │    │    │    │              │         ├── key: ()
  │    │    │    │              │         ├── fd: ()-->(19)
@@ -2725,6 +2730,7 @@ project
       │    │    └── fd: (3)-->(4)
       │    ├── max1-row
       │    │    ├── columns: k:5(int!null)
+      │    │    ├── error: "more than one row returned by a subquery used as an expression"
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
@@ -2773,6 +2779,7 @@ project
       │    │    └── fd: (3)-->(4)
       │    ├── max1-row
       │    │    ├── columns: k:5(int!null)
+      │    │    ├── error: "more than one row returned by a subquery used as an expression"
       │    │    ├── outer: (3)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -84,6 +84,7 @@ values
            ├── subquery [type=int]
            │    └── max1-row
            │         ├── columns: i:2(int)
+           │         ├── error: "more than one row returned by a subquery used as an expression"
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
            │         ├── fd: ()-->(2)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -853,6 +853,7 @@ project
       │    └── fd: (1)-->(2)
       ├── max1-row
       │    ├── columns: r:7(int)
+      │    ├── error: "more than one row returned by a subquery used as an expression"
       │    ├── outer: (1)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
@@ -3033,6 +3034,7 @@ project
  │    │    │    │         └── subquery [type=bool]
  │    │    │    │              └── max1-row
  │    │    │    │                   ├── columns: bool:4(bool!null)
+ │    │    │    │                   ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │                   ├── cardinality: [0 - 1]
  │    │    │    │                   ├── key: ()
  │    │    │    │                   ├── fd: ()-->(4)

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -173,6 +173,7 @@ project
       │    │    └── fd: (1)-->(2-4)
       │    ├── max1-row
       │    │    ├── columns: u:7(int!null)
+      │    │    ├── error: "more than one row returned by a subquery used as an expression"
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1005,6 +1005,7 @@ select
                 ├── subquery [type=int]
                 │    └── max1-row
                 │         ├── columns: "?column?":13(int)
+                │         ├── error: "more than one row returned by a subquery used as an expression"
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
                 │         ├── fd: ()-->(13)

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -133,6 +133,7 @@ project
  │    │    └── columns: w:2(int)
  │    ├── max1-row
  │    │    ├── columns: k:16(int!null)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (2)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -762,12 +762,16 @@ define Offset {
     Ordering OrderingChoice
 }
 
-# Max1Row enforces that its input must return at most one row. It is used as
-# input to the Subquery operator. See the comment above Subquery for more
-# details.
+# Max1Row enforces that its input must return at most one row. If the input
+# has more than one row, Max1Row raises an error with the specified error text.
+#
+# Max1Row is most often used as input to the Subquery operator. See the comment
+# above Subquery for more details.
 [Relational]
 define Max1Row {
     Input RelExpr
+
+    ErrorText string
 }
 
 # Ordinality adds a column to each row in its input containing a unique,

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+const multiRowSubqueryErrText = "more than one row returned by a subquery used as an expression"
+
 // subquery represents a subquery expression in an expression tree
 // after it has been type-checked and added to the memo.
 type subquery struct {
@@ -315,7 +317,7 @@ func (b *Builder) buildSingleRowSubquery(
 	// Wrap the subquery in a Max1Row operator to enforce that it should return
 	// at most one row. Max1Row may be removed by the optimizer later if it can
 	// prove statically that the subquery always returns at most one row.
-	input = b.factory.ConstructMax1Row(input)
+	input = b.factory.ConstructMax1Row(input, multiRowSubqueryErrText)
 
 	out = b.factory.ConstructSubquery(input, &subqueryPrivate)
 	return out, outScope

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -251,7 +251,7 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 				mb.outScope.appendColumnsFromScope(subqueryScope)
 				mb.outScope.expr = mb.b.factory.ConstructLeftJoinApply(
 					mb.outScope.expr,
-					mb.b.factory.ConstructMax1Row(subqueryScope.expr),
+					mb.b.factory.ConstructMax1Row(subqueryScope.expr, multiRowSubqueryErrText),
 					memo.TrueFilter,
 					memo.EmptyJoinPrivate,
 				)

--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -88,6 +88,7 @@ project
  │    │    └── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string)
  │    ├── max1-row
  │    │    ├── columns: "?column?":36(bool)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (4)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -101,6 +101,7 @@ project
  │    │         └── t.typnamespace = n.oid [type=bool, outer=(3,33), constraints=(/3: (/NULL - ]; /33: (/NULL - ]), fd=(3)==(33), (33)==(3)]
  │    ├── max1-row
  │    │    ├── columns: case:70(string!null)
+ │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    ├── outer: (25)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -464,6 +464,7 @@ project
  │    │    │    │    └── key: (1)
  │    │    │    ├── max1-row
  │    │    │    │    ├── columns: bool:6(bool!null)
+ │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │    ├── outer: (1)
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -749,10 +749,11 @@ func (ef *execFactory) ConstructLimit(
 }
 
 // ConstructMax1Row is part of the exec.Factory interface.
-func (ef *execFactory) ConstructMax1Row(input exec.Node) (exec.Node, error) {
+func (ef *execFactory) ConstructMax1Row(input exec.Node, errorText string) (exec.Node, error) {
 	plan := input.(planNode)
 	return &max1RowNode{
-		plan: plan,
+		plan:      plan,
+		errorText: errorText,
 	}, nil
 }
 


### PR DESCRIPTION
Previously, when the max1row operator found multiple input rows, it
raised an error with a literal string as text. The error text refers
to a subquery with multiple input rows, so the operator can only be
used for that case.

This commit makes the error text a parameter of the max1row operator,
so that it can be used in other contexts besides subqueries. In
particular, it will soon be used for raising an error in the duplicate
row Upsert case.

Release note: None