### PR TITLE
vendor: bump pebble to 56d49062dcfe15a52e4e7bca6323b05080803855

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ac0d4fa5a39d687b7d902bb04c8af0fe766822ee5190ff7a89e7104e117e4732"
+  digest = "1:259c51e11fe48d9347196c832e5b4e16a81f415053627897bcc339a9a2d07bf0"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -497,7 +497,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "67f7d138c7c3592ae13d422f7cc6cc438a99a745"
+  revision = "56d49062dcfe15a52e4e7bca6323b05080803855"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -563,7 +563,9 @@ func TestBatchProto(t *testing.T) {
 				t.Errorf("expected %v; got %v", &val, getVal)
 			}
 			// Before commit, proto will not be available via engine.
+			fmt.Printf("before\n")
 			if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
+				fmt.Printf("after\n")
 				t.Fatalf("expected GetProto to fail ok=%t: %+v", ok, err)
 			}
 			// Commit and verify the proto can be read directly from the engine.

--- a/pkg/storage/gc/gc_iterator_test.go
+++ b/pkg/storage/gc/gc_iterator_test.go
@@ -123,11 +123,13 @@ func TestGCIterator(t *testing.T) {
 	makeTest := func(tc testCase) func(t *testing.T) {
 		return func(t *testing.T) {
 			eng := engine.NewDefaultInMem()
+			defer eng.Close()
 			ds := makeLiteralDataDistribution(tc.data...)
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
 			it := makeGCIterator(&desc, snap)
+			defer it.close()
 			expectations := tc.expectations
 			for i, ex := range expectations {
 				t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/storage/gc/gc_random_test.go
+++ b/pkg/storage/gc/gc_random_test.go
@@ -88,6 +88,8 @@ func TestRunNewVsOld(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%v@%v,ttl=%v", tc.ds, tc.now, tc.ttl), func(t *testing.T) {
 			eng := engine.NewDefaultInMem()
+			defer eng.Close()
+
 			tc.ds.dist(N, rng).setupTest(t, eng, *tc.ds.desc())
 			snap := eng.NewSnapshot()
 


### PR DESCRIPTION
* db: enable concurrent Ln->Ln+1 compactions
* db: rework compaction picking
* db: remove compaction queue
* db: rework concurrent compaction heuristics
* sstable: replace Properties.ValueOffsets with Loaded map
* db: fix DB.Get to not return freed memory

Adapt to the new `Reader.Get` API. Hook into the
`COCKROACH_ROCKSDB_CONCURRENCY` env var for controlling Pebble
compaction concurrency.

Release note: None