### PR TITLE
ui: Stick application header top of the screen

### DIFF
--- a/pkg/ui/src/views/app/components/NotFound/index.tsx
+++ b/pkg/ui/src/views/app/components/NotFound/index.tsx
@@ -13,7 +13,7 @@ import React from "react";
 function NotFound() {
   return (
     <div className="section">
-      <h1 className="base-heading page-title">Page Not Found</h1>
+      <h1 className="base-heading">Page Not Found</h1>
     </div>
   );
 }

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -12,6 +12,7 @@
 
 $side-panel-width = 140px
 $top-bar-height = 50px
+$container-top-offset = 120px
 
 .layout-panel
   display flex
@@ -22,6 +23,7 @@ $top-bar-height = 50px
   max-width 100vw
   min-height 100vh
   max-height 100vh
+  overflow hidden
 
 .layout-panel__header
   height $top-bar-height
@@ -44,6 +46,8 @@ $top-bar-height = 50px
   display flex
   flex-direction row
   flex 1
+  overflow hidden
+  height "calc(100% - %s)" % $container-top-offset
 
 .layout-panel__content
   width "calc(100% - %s)" % $side-panel-width

--- a/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
+++ b/pkg/ui/src/views/app/containers/layout/layoutPanel.styl
@@ -12,7 +12,6 @@
 
 $side-panel-width = 140px
 $top-bar-height = 50px
-$container-top-offset = 120px
 
 .layout-panel
   display flex
@@ -23,7 +22,6 @@ $container-top-offset = 120px
   max-width 100vw
   min-height 100vh
   max-height 100vh
-  overflow hidden
 
 .layout-panel__header
   height $top-bar-height
@@ -46,12 +44,11 @@ $container-top-offset = 120px
   display flex
   flex-direction row
   flex 1
-  overflow hidden
-  height "calc(100% - %s)" % $container-top-offset
 
 .layout-panel__content
   width "calc(100% - %s)" % $side-panel-width
   overflow auto
+  margin $spacing-large 0 0
 
 .layout-panel__sidebar
   min-width $side-panel-width

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -25,8 +25,7 @@
   padding-top 0
 
 .cluster-page
-  height 100vh
-  max-height 100vh
+  height 100%
   display flex
   flex-direction column
   overflow hidden

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -25,7 +25,8 @@
   padding-top 0
 
 .cluster-page
-  height 100%
+  height 100vh
+  max-height 100vh
   display flex
   flex-direction column
   overflow hidden

--- a/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
@@ -168,7 +168,7 @@ export class DataDistributionPage extends React.Component<DataDistributionPagePr
       <div>
         <Helmet title="Data Distribution" />
         <section className="section">
-          <h1 className="base-heading page-title">Data Distribution</h1>
+          <h1 className="base-heading">Data Distribution</h1>
         </section>
         <section className="section">
           <Loading

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -140,7 +140,7 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
     return <div>
       <Helmet title="Events" />
       <section className="section section--heading">
-        <h1 className="base-heading page-title">Events</h1>
+        <h1 className="base-heading">Events</h1>
       </section>
       <section className="section l-columns">
         <div className="l-columns__left events-table">

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -207,7 +207,7 @@ export class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     return (
       <div>
         <Helmet title={title} />
-        <section className="section"><h1 className="base-heading page-title">{ title }</h1></section>
+        <section className="section"><h1 className="base-heading">{ title }</h1></section>
         <PageConfig>
           <PageConfigItem>
             <Dropdown

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -93,7 +93,7 @@ class DatabaseTablesList extends React.Component<DatabaseListProps> {
 
     return <div>
       <Helmet title="Tables | Databases" />
-      <section className="section"><h1 className="base-heading page-title">Databases</h1></section>
+      <section className="section"><h1 className="base-heading">Databases</h1></section>
       <DatabaseListNav selected="tables" onChange={this.handleOnNavigationListChange}/>
       <div className="section databases">
         {
@@ -124,7 +124,7 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps> {
 
     return <div>
       <Helmet title="Grants | Databases" />
-      <section className="section"><h1 className="base-heading page-title">Databases</h1></section>
+      <section className="section"><h1 className="base-heading">Databases</h1></section>
       <DatabaseListNav selected="grants" onChange={this.handleOnNavigationListChange}/>
       <div className="section databases">
         {

--- a/pkg/ui/src/views/devtools/containers/raft/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raft/index.tsx
@@ -21,7 +21,7 @@ export default class Layout extends React.Component<{}, {}> {
     // `nav-container's styling. Should those styles apply only to `nav`?
     return <div>
       <Helmet title="Raft | Debug" />
-      <section className="section"><h1 className="base-heading page-title">Raft</h1></section>
+      <section className="section"><h1 className="base-heading">Raft</h1></section>
       <div className="nav-container">
         <ul className="nav">
           <li className="normal">

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -117,7 +117,7 @@ export class JobsTable extends React.Component<JobsTableProps> {
       <div className="jobs-page">
         <Helmet title="Jobs" />
         <section className="section">
-          <h1 className="base-heading page-title">
+          <h1 className="base-heading">
             Jobs
           </h1>
         </section>

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -193,7 +193,7 @@ export class Certificates extends React.Component<CertificatesProps, {}> {
     return (
       <div className="section">
         <Helmet title="Certificates | Debug" />
-        <h1 className="base-heading page-title">Certificates</h1>
+        <h1 className="base-heading">Certificates</h1>
 
         <section className="section">
           <Loading

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -261,7 +261,7 @@ export class CustomChart extends React.Component<CustomChartProps & RouteCompone
     return (
       <>
         <Helmet title="Custom Chart | Debug" />
-        <section className="section"><h1 className="base-heading page-title">Custom Chart</h1></section>
+        <section className="section"><h1 className="base-heading">Custom Chart</h1></section>
         <PageConfig>
           <PageConfigItem>
             <TimeScaleDropdown />

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -83,7 +83,7 @@ export default function Debug() {
   return (
     <div className="section">
       <Helmet title="Debug" />
-      <h1 className="base-heading page-title">Advanced Debugging</h1>
+      <h1 className="base-heading">Advanced Debugging</h1>
       <div className="debug-header">
         <InfoBox>
           <p>

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -102,7 +102,7 @@ export class Localities extends React.Component<LocalitiesProps, {}> {
     return (
       <div>
         <Helmet title="Localities | Debug" />
-        <section className="section"><h1 className="base-heading page-title">Localities</h1></section>
+        <section className="section"><h1 className="base-heading">Localities</h1></section>
         <Loading
           loading={ !this.props.localityStatus.data || !this.props.locationStatus.data }
           error={ [this.props.localityStatus.lastError, this.props.locationStatus.lastError] }

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -368,7 +368,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
       <Fragment>
         <Helmet title="Network Diagnostics | Debug" />
         <div className="section">
-          <h1 className="base-heading page-title">Network Diagnostics</h1>
+          <h1 className="base-heading">Network Diagnostics</h1>
         </div>
         <Loading
           loading={!contentAvailable(nodesSummary)}

--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -45,7 +45,7 @@ const detailTimeFormat = "Y/MM/DD HH:mm:ss";
 
 const loading = (
   <div className="section">
-    <h1 className="base-heading page-title">Node Diagnostics</h1>
+    <h1 className="base-heading">Node Diagnostics</h1>
     <h2 className="base-heading">Loading cluster status...</h2>
   </div>
 );
@@ -334,7 +334,7 @@ export class Nodes extends React.Component<NodesProps, {}> {
     if (_.isEmpty(orderedNodeIDs)) {
       return (
         <section className="section">
-          <h1 className="base-heading page-title">Node Diagnostics</h1>
+          <h1 className="base-heading">Node Diagnostics</h1>
           <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
           <h2 className="base-heading">No nodes match the filters</h2>
         </section>
@@ -344,7 +344,7 @@ export class Nodes extends React.Component<NodesProps, {}> {
     return (
       <section className="section">
         <Helmet title="Node Diagnostics | Debug" />
-        <h1 className="base-heading page-title">Node Diagnostics</h1>
+        <h1 className="base-heading">Node Diagnostics</h1>
         <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
         <h2 className="base-heading">Nodes</h2>
         <table className="nodes-table">

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -196,7 +196,7 @@ export class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     return (
       <div className="section">
         <Helmet title="Problem Ranges | Debug" />
-        <h1 className="base-heading page-title">Problem Ranges Report</h1>
+        <h1 className="base-heading">Problem Ranges Report</h1>
         <Loading
           loading={isLoading(this.props.problemRanges)}
           error={this.props.problemRanges && this.props.problemRanges.lastError}

--- a/pkg/ui/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/src/views/reports/containers/range/index.tsx
@@ -54,7 +54,7 @@ function ErrorPage(props: {
 }) {
   return (
     <div className="section">
-      <h1 className="base-heading page-title">Range Report for r{props.rangeID}</h1>
+      <h1 className="base-heading">Range Report for r{props.rangeID}</h1>
       <h2 className="base-heading">{props.errorText}</h2>
       <ConnectionsTable range={props.range} />
     </div>
@@ -180,7 +180,7 @@ export class Range extends React.Component<RangeProps, {}> {
     return (
       <div className="section">
         <Helmet title={ `r${responseRangeID.toString()} Range | Debug` } />
-        <h1 className="base-heading page-title">Range Report for r{responseRangeID.toString()}</h1>
+        <h1 className="base-heading">Range Report for r{responseRangeID.toString()}</h1>
         <RangeTable infos={infos} replicas={replicas} />
         <LeaseTable info={_.head(infos)} />
         <ConnectionsTable range={range} />

--- a/pkg/ui/src/views/reports/containers/redux/index.tsx
+++ b/pkg/ui/src/views/reports/containers/redux/index.tsx
@@ -43,7 +43,7 @@ export class ReduxDebug extends React.Component<ReduxDebugProps, ReduxDebugState
     return (
       <div>
         <Helmet title="Redux State | Debug" />
-        <section className="section"><h1 className="base-heading page-title">Redux State</h1></section>
+        <section className="section"><h1 className="base-heading">Redux State</h1></section>
         <section className="section">
           <CopyToClipboard text={ text } onCopy={() => this.setState({ copied: true})}>
             <span className={spanClass}>

--- a/pkg/ui/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/src/views/reports/containers/settings/index.tsx
@@ -81,7 +81,7 @@ export class Settings extends React.Component<SettingsProps, {}> {
     return (
       <div className="section">
         <Helmet title="Cluster Settings | Debug" />
-        <h1 className="base-heading page-title">Cluster Settings</h1>
+        <h1 className="base-heading">Cluster Settings</h1>
         <Loading
           loading={!this.props.settings.data}
           error={this.props.settings.lastError}

--- a/pkg/ui/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/src/views/reports/containers/stores/index.tsx
@@ -107,7 +107,7 @@ export class Stores extends React.Component<StoresProps, {}> {
     return (
       <div className="section">
         <Helmet title="Stores | Debug" />
-        <h1 className="base-heading page-title">Stores</h1>
+        <h1 className="base-heading">Stores</h1>
         <h2 className="base-heading">{header} stores</h2>
         <Loading
           loading={this.props.loading}

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -229,7 +229,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
         <Helmet title={ app ? `${app} App | Statements` : "Statements"} />
 
         <section className="section">
-          <h1 className="base-heading page-title">Statements</h1>
+          <h1 className="base-heading">Statements</h1>
         </section>
 
         <Loading

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -28,9 +28,6 @@ h1.base-heading
   letter-spacing 5px
   text-transform uppercase
 
-h1.page-title
-  margin-top 32px
-
 h2.base-heading
   padding 12px 0
   font-size 20px


### PR DESCRIPTION
- Application bar should not be scrolled out from screen and this
required to disable scrollbars on top elements and enable scrolling for
content section. It allows headers and left panel to remain on their positions
during scrolling.