### PR TITLE
colexec: skip TestExternalSortRandomized

### DIFF
--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -90,6 +90,7 @@ func TestExternalSort(t *testing.T) {
 
 func TestExternalSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/45322")
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)


### PR DESCRIPTION
This is making the build red due to excessive repartitioning. A fix is
incoming.

Release note: None