### PR TITLE
colexec: make sorts and joins actually spill to disk

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -55,7 +55,7 @@ type ArrowBatchConverter struct {
 func NewArrowBatchConverter(typs []coltypes.T) (*ArrowBatchConverter, error) {
 	for _, t := range typs {
 		if _, supported := supportedTypes[t]; !supported {
-			return nil, errors.Errorf("unsupported type %v", t.String())
+			return nil, errors.Errorf("arrowbatchconverter unsupported type %v", t.String())
 		}
 	}
 	c := &ArrowBatchConverter{typs: typs}

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -143,10 +143,8 @@ func (w *diskQueueWriter) numBytesBuffered() int {
 // writes the same amount of buffer space.
 // NOTE: We could reuse the memory used to buffer uncompressed writes to buffer
 // uncompressed reads, but this would only work with the limitation that all
-// writes happen before all reads.
-// TODO(asubiotto): The improvement mentioned above might be worth it once we
-//  ensure that we only use DiskQueues for the write-everything, read-everything
-//  pattern.
+// writes happen before all reads, which is not the case for the
+// colexec.HashRouter.
 type diskQueue struct {
 	// dirName is the directory in cfg.Path that holds this queue's files.
 	dirName string
@@ -194,6 +192,9 @@ type Queue interface {
 	// to. If an error is returned, the batch and boolean returned are
 	// meaningless.
 	Dequeue(coldata.Batch) (bool, error)
+	// CloseRead closes the read file descriptor. If Dequeued, the file may be
+	// reopened.
+	CloseRead() error
 	// Close closes any resources associated with the Queue.
 	Close() error
 }
@@ -268,6 +269,16 @@ func NewDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) (Queue, error) {
 	return d, d.rotateFile()
 }
 
+func (d *diskQueue) CloseRead() error {
+	if d.readFile != nil {
+		if err := d.readFile.Close(); err != nil {
+			return err
+		}
+		d.readFile = nil
+	}
+	return nil
+}
+
 func (d *diskQueue) Close() error {
 	if d.serializer != nil {
 		if err := d.writeFooterAndFlush(); err != nil {
@@ -287,12 +298,9 @@ func (d *diskQueue) Close() error {
 		}
 		d.writeFile = nil
 	}
-	if d.readFile != nil {
-		if err := d.readFile.Close(); err != nil {
-			return err
-		}
-		d.readFile = nil
-		// The readFile will be removed below in DeleteDirAndFiles.
+	// The readFile will be removed below in DeleteDirAndFiles.
+	if err := d.CloseRead(); err != nil {
+		return err
 	}
 	if err := d.cfg.FS.DeleteDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
 		return err
@@ -366,6 +374,10 @@ func (d *diskQueue) writeFooterAndFlush() error {
 
 func (d *diskQueue) Enqueue(b coldata.Batch) error {
 	if b.Length() == 0 {
+		if d.done {
+			// Already done.
+			return nil
+		}
 		if err := d.writeFooterAndFlush(); err != nil {
 			return err
 		}
@@ -421,7 +433,7 @@ func (d *diskQueue) maybeInitDeserializer() (bool, error) {
 		// writer has rotated to a new file.
 		if fileToRead.finishedWriting {
 			// Close and remove current file.
-			if err := d.readFile.Close(); err != nil {
+			if err := d.CloseRead(); err != nil {
 				return false, err
 			}
 			if err := d.cfg.FS.DeleteFile(d.files[d.readFileIdx].name); err != nil {

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -292,9 +292,9 @@ func (d *diskQueue) Close() error {
 			return err
 		}
 		d.readFile = nil
-		// The readFile will be removed below in RemoveAll.
+		// The readFile will be removed below in DeleteDirAndFiles.
 	}
-	if err := d.cfg.FS.DeleteDir(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
+	if err := d.cfg.FS.DeleteDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -11,75 +11,343 @@
 package colcontainer
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/errors"
+	"github.com/marusama/semaphore"
 )
 
 // PartitionedQueue is the abstraction for on-disk storage.
 type PartitionedQueue interface {
 	// Enqueue adds the batch to the end of the partitionIdx'th partition. If a
-	// partition at that index does not exist, a new one is created.
-	Enqueue(partitionIdx int, batch coldata.Batch) error
+	// partition at that index does not exist, a new one is created. Existing
+	// partitions may not be Enqueued to after calling
+	// CloseAllOpenWriteFileDescriptors.
+	Enqueue(ctx context.Context, partitionIdx int, batch coldata.Batch) error
 	// Dequeue removes and returns the batch from the front of the
 	// partitionIdx'th partition. If the partition is empty, or no partition at
-	// that index was Enqueued to, a zero-length batch is returned.
-	Dequeue(partitionIdx int, batch coldata.Batch) error
+	// that index was Enqueued to, a zero-length batch is returned. Note that
+	// it is illegal to call Enqueue on a partition after Dequeue.
+	Dequeue(ctx context.Context, partitionIdx int, batch coldata.Batch) error
+	// CloseAllOpenWriteFileDescriptors notifies the PartitionedQueue that it can
+	// close all open write file descriptors. After this point, only new
+	// partitions may be Enqueued to.
+	CloseAllOpenWriteFileDescriptors() error
+	// CloseAllOpenReadFileDescriptors closes the open read file descriptors
+	// belonging to partitions. These partitions may still be Dequeued from,
+	// although this will trigger files to be reopened.
+	CloseAllOpenReadFileDescriptors() error
+	// CloseInactiveReadPartitions closes all partitions that have been Dequeued
+	// from and have either been temporarily closed through
+	// CloseAllOpenReadFileDescriptors or have returned a coldata.ZeroBatch from
+	// Dequeue. This close removes the underlying files.
+	CloseInactiveReadPartitions() error
 	// Close closes all partitions created.
 	Close() error
 }
 
+// partitionState is the state a partition is in.
+type partitionState int
+
+const (
+	// partitionStateWriting is the initial state of a partition. A partition will
+	// always transition to partitionStateClosedForWriting next.
+	partitionStateWriting partitionState = iota
+	// partitionStateClosedForWriting is the state a partition is in when it is
+	// closed for writing. The next possible state is for reads to happen, and
+	// thus a transition to partitionStateReading. Note that if a partition is
+	// in this state when entering a method of PartitionedDiskQueue, it is always
+	// true that the file descriptor for this partition has been released.
+	partitionStateClosedForWriting
+	// partitionStateReading is the state a partition is in when Dequeue has been
+	// called. It is always the case that this partition has been closed for
+	// writing and may not transition back to partitionStateWriting or
+	// partitionStateClosedForWriting. The read file descriptor for this partition
+	// may be closed in this state, although it will be reacquired on the next
+	// read.
+	partitionStateReading
+	// partitionStateClosedForReading is the state a partition is in when a
+	// partition was in partitionStateReading and CloseAllOpenReadFileDescriptors
+	// was called. If Dequeued, this partition will reacquire a file descriptor
+	// and transition back to partitionStateReading.
+	partitionStateClosedForReading
+	// partitionStatePermanentlyClosed is the state a partition is in when its
+	// underlying DiskQueue has been Closed.
+	partitionStatePermanentlyClosed
+)
+
+// partition is a simple wrapper over a Queue used by the PartitionedDiskQueue.
+type partition struct {
+	Queue
+	state partitionState
+}
+
+// PartitionerStrategy describes a strategy used by the PartitionedQueue during
+// its operation.
+type PartitionerStrategy int
+
+const (
+	// PartitionerStrategyDefault is a partitioner strategy in which the
+	// PartitionedQueue will keep all partitions open for writing.
+	// Note that this uses up as many file descriptors as partitions.
+	PartitionerStrategyDefault PartitionerStrategy = iota
+	// PartitionerStrategyCloseOnNewPartition is a partitioner strategy that
+	// closes an open partition for writing if a new partition is created. This
+	// ensures that the total number of file descriptors remains at 1. However,
+	// note that closed partitions may never be written to again, only read.
+	PartitionerStrategyCloseOnNewPartition
+)
+
+// PartitionedDiskQueue is a PartitionedQueue whose partitions are on-disk.
 type PartitionedDiskQueue struct {
-	typs []coltypes.T
-	cfg  DiskQueueCfg
+	typs     []coltypes.T
+	strategy PartitionerStrategy
+	cfg      DiskQueueCfg
 
 	partitionIdxToIndex map[int]int
-	partitions          []Queue
+	partitions          []partition
+
+	// lastEnqueuedPartitionIdx is the index of the last enqueued partition. Set
+	// to -1 during initialization.
+	lastEnqueuedPartitionIdx int
+
+	numOpenFDs  int
+	fdSemaphore semaphore.Semaphore
 }
 
 // NewPartitionedDiskQueue creates a PartitionedDiskQueue whose partitions are
 // all on-disk queues. Note that diskQueues will be lazily created when
 // enqueueing to a new partition. Each new partition will use
 // cfg.BufferSizeBytes, so memory usage may increase in an unbounded fashion if
-// used unmethodically.
-func NewPartitionedDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) *PartitionedDiskQueue {
+// used unmethodically. The file descriptors are acquired through fdSemaphore.
+// Note that actual file descriptors open may be less than, but never more than
+// the number acquired through the semaphore.
+func NewPartitionedDiskQueue(
+	typs []coltypes.T,
+	cfg DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
+	partitionerStrategy PartitionerStrategy,
+) *PartitionedDiskQueue {
 	return &PartitionedDiskQueue{
-		typs:                typs,
-		cfg:                 cfg,
-		partitionIdxToIndex: make(map[int]int),
-		partitions:          make([]Queue, 0),
+		typs:                     typs,
+		strategy:                 partitionerStrategy,
+		cfg:                      cfg,
+		partitionIdxToIndex:      make(map[int]int),
+		partitions:               make([]partition, 0),
+		lastEnqueuedPartitionIdx: -1,
+		fdSemaphore:              fdSemaphore,
 	}
 }
 
-func (p *PartitionedDiskQueue) Enqueue(partitionIdx int, batch coldata.Batch) error {
+type closeWritePartitionArgument int
+
+const (
+	retainFD closeWritePartitionArgument = iota
+	releaseFD
+)
+
+// closeWritePartition enqueues a coldata.ZeroBatch to a partition at index
+// idx, resulting in it closing its write file descriptor. This partition may
+// still be read from, but never written to again. Note that releaseFDOption
+// should always be retainFD if a new file is opened in the same scope, to avoid
+// having to re-enter the semaphore. The argument should only be releaseFD if
+// reopening a different file in a different scope.
+func (p *PartitionedDiskQueue) closeWritePartition(
+	idx int, releaseFDOption closeWritePartitionArgument,
+) error {
+	if p.partitions[idx].state != partitionStateWriting {
+		execerror.VectorizedInternalPanic(fmt.Sprintf("illegal state change from %d to partitionStateClosedForWriting, only partitionStateWriting allowed", p.partitions[idx].state))
+	}
+	if err := p.partitions[idx].Enqueue(coldata.ZeroBatch); err != nil {
+		return err
+	}
+	if releaseFDOption == releaseFD {
+		p.fdSemaphore.Release(1)
+		p.numOpenFDs--
+	}
+	p.partitions[idx].state = partitionStateClosedForWriting
+	return nil
+}
+
+func (p *PartitionedDiskQueue) closeReadPartition(idx int) error {
+	if p.partitions[idx].state != partitionStateReading {
+		execerror.VectorizedInternalPanic(fmt.Sprintf("illegal state change from %d to partitionStateClosedForReading, only partitionStateReading allowed", p.partitions[idx].state))
+	}
+	if err := p.partitions[idx].CloseRead(); err != nil {
+		return err
+	}
+	p.fdSemaphore.Release(1)
+	p.numOpenFDs--
+	p.partitions[idx].state = partitionStateClosedForReading
+	return nil
+}
+
+func (p *PartitionedDiskQueue) acquireNewFD(ctx context.Context) error {
+	if err := p.fdSemaphore.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	p.numOpenFDs++
+	return nil
+}
+
+// Enqueue enqueues a batch at partition partitionIdx.
+func (p *PartitionedDiskQueue) Enqueue(
+	ctx context.Context, partitionIdx int, batch coldata.Batch,
+) error {
 	idx, ok := p.partitionIdxToIndex[partitionIdx]
 	if !ok {
+		needToAcquireFD := true
+		if p.strategy == PartitionerStrategyCloseOnNewPartition && p.lastEnqueuedPartitionIdx != -1 {
+			idxToClose, found := p.partitionIdxToIndex[p.lastEnqueuedPartitionIdx]
+			if !found {
+				// This would be unexpected.
+				return errors.New("PartitionerStrategyCloseOnNewPartition unable to find last Enqueued partition")
+			}
+			if p.partitions[idxToClose].state == partitionStateWriting {
+				// Close the last enqueued partition. No need to release or acquire a new
+				// file descriptor, since the acquired FD will represent the new
+				// partition's FD opened in Enqueue below.
+				if err := p.closeWritePartition(idxToClose, retainFD); err != nil {
+					return err
+				}
+				needToAcquireFD = false
+			} else {
+				// The partition that was last enqueued to is not open for writing, so
+				// we need to acquire a new FD for this new partition.
+				needToAcquireFD = true
+			}
+		}
+
+		if needToAcquireFD {
+			// Acquire only one file descriptor. This will represent the write file
+			// descriptor. When we start Dequeueing from this partition, this will
+			// represent the read file descriptor.
+			if err := p.acquireNewFD(ctx); err != nil {
+				return err
+			}
+		}
 		// Partition has not been created yet.
 		q, err := NewDiskQueue(p.typs, p.cfg)
 		if err != nil {
 			return err
 		}
 		idx = len(p.partitions)
-		p.partitions = append(p.partitions, q)
+		p.partitions = append(p.partitions, partition{Queue: q})
 		p.partitionIdxToIndex[partitionIdx] = idx
 	}
+	if state := p.partitions[idx].state; state != partitionStateWriting {
+		if state == partitionStatePermanentlyClosed {
+			return errors.Errorf("partition at index %d permanently closed, cannot Enqueue", partitionIdx)
+		}
+		return errors.New("Enqueue illegally called after Dequeue or CloseAllOpenWriteFileDescriptors")
+	}
+	p.lastEnqueuedPartitionIdx = partitionIdx
 	return p.partitions[idx].Enqueue(batch)
 }
 
-func (p *PartitionedDiskQueue) Dequeue(partitionIdx int, batch coldata.Batch) error {
+// Dequeue dequeues a batch from partition partitionIdx, returns a
+// coldata.ZeroBatch if that partition does not exist. If the partition exists
+// and a coldata.ZeroBatch is returned, that partition is closed.
+func (p *PartitionedDiskQueue) Dequeue(
+	ctx context.Context, partitionIdx int, batch coldata.Batch,
+) error {
 	idx, ok := p.partitionIdxToIndex[partitionIdx]
 	if !ok {
 		batch.SetLength(0)
 		return nil
 	}
+	switch state := p.partitions[idx].state; state {
+	case partitionStateWriting:
+		// Close this partition for writing. However, we keep a file descriptor
+		// acquired for the read file descriptor opened for Dequeue.
+		if err := p.closeWritePartition(idx, retainFD); err != nil {
+			return err
+		}
+		p.partitions[idx].state = partitionStateReading
+	case partitionStateClosedForWriting, partitionStateClosedForReading:
+		// There will never be a file descriptor acquired for a partition in this
+		// state, so acquire it.
+		if err := p.acquireNewFD(ctx); err != nil {
+			return err
+		}
+		p.partitions[idx].state = partitionStateReading
+	case partitionStateReading:
+	// Do nothing.
+	case partitionStatePermanentlyClosed:
+		return errors.Errorf("partition at index %d permanently closed, cannot Dequeue", partitionIdx)
+	default:
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled state %d", state))
+	}
 	notEmpty, err := p.partitions[idx].Dequeue(batch)
 	if err != nil {
 		return err
 	}
+	if batch.Length() == 0 {
+		// Queue is finished, release the acquired file descriptor.
+		if err := p.closeReadPartition(idx); err != nil {
+			return err
+		}
+	}
 	if !notEmpty {
-		// The queue was empty.
-		batch.SetLength(0)
+		// This should never happen. It simply means that there was no batch to
+		// Dequeue but more batches will be added in the future (i.e. a zero batch
+		// was never enqueued). Since we require partitions to be closed for writing
+		// before reading, this state is unexpected.
+		execerror.VectorizedInternalPanic("DiskQueue unexpectedly returned that more data will be added")
 	}
 	return nil
+}
+
+// CloseAllOpenWriteFileDescriptors closes all open write file descriptors
+// belonging to partitions that are being Enqueued to. Once this method is
+// called, existing partitions may not be enqueued to again.
+func (p *PartitionedDiskQueue) CloseAllOpenWriteFileDescriptors() error {
+	for i, q := range p.partitions {
+		if q.state != partitionStateWriting {
+			continue
+		}
+		// closeWritePartition will Release the file descriptor.
+		if err := p.closeWritePartition(i, releaseFD); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CloseAllOpenReadFileDescriptors closes all open read file descriptors
+// belonging to partitions that are being Dequeued from. If Dequeue is called
+// on a closed partition, it will be reopened.
+func (p *PartitionedDiskQueue) CloseAllOpenReadFileDescriptors() error {
+	for i, q := range p.partitions {
+		if q.state != partitionStateReading {
+			continue
+		}
+		// closeReadPartition will Release the file descriptor.
+		if err := p.closeReadPartition(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CloseInactiveReadPartitions closes all partitions that were Dequeued from
+// and either Dequeued a coldata.ZeroBatch or were closed through
+// CloseAllOpenReadFileDescriptors. This method call Closes the underlying
+// DiskQueue to remove its files, so a partition may never be used again.
+func (p *PartitionedDiskQueue) CloseInactiveReadPartitions() error {
+	var lastErr error
+	for i, q := range p.partitions {
+		if q.state != partitionStateClosedForReading {
+			continue
+		}
+		lastErr = q.Close()
+		p.partitions[i].state = partitionStatePermanentlyClosed
+	}
+	return lastErr
 }
 
 // Close closes all the PartitionedDiskQueue's partitions. If an error is
@@ -87,8 +355,17 @@ func (p *PartitionedDiskQueue) Dequeue(partitionIdx int, batch coldata.Batch) er
 // anyway and return the last error encountered.
 func (p *PartitionedDiskQueue) Close() error {
 	var lastErr error
-	for _, q := range p.partitions {
+	for i, q := range p.partitions {
+		if q.state == partitionStatePermanentlyClosed {
+			// Already closed.
+			continue
+		}
 		lastErr = q.Close()
+		p.partitions[i].state = partitionStatePermanentlyClosed
+	}
+	if p.numOpenFDs != 0 {
+		p.fdSemaphore.Release(p.numOpenFDs)
+		p.numOpenFDs = 0
 	}
 	return lastErr
 }

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -1,0 +1,94 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colcontainer
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// PartitionedQueue is the abstraction for on-disk storage.
+type PartitionedQueue interface {
+	// Enqueue adds the batch to the end of the partitionIdx'th partition. If a
+	// partition at that index does not exist, a new one is created.
+	Enqueue(partitionIdx int, batch coldata.Batch) error
+	// Dequeue removes and returns the batch from the front of the
+	// partitionIdx'th partition. If the partition is empty, or no partition at
+	// that index was Enqueued to, a zero-length batch is returned.
+	Dequeue(partitionIdx int, batch coldata.Batch) error
+	// Close closes all partitions created.
+	Close() error
+}
+
+type PartitionedDiskQueue struct {
+	typs []coltypes.T
+	cfg  DiskQueueCfg
+
+	partitionIdxToIndex map[int]int
+	partitions          []Queue
+}
+
+// NewPartitionedDiskQueue creates a PartitionedDiskQueue whose partitions are
+// all on-disk queues. Note that diskQueues will be lazily created when
+// enqueueing to a new partition. Each new partition will use
+// cfg.BufferSizeBytes, so memory usage may increase in an unbounded fashion if
+// used unmethodically.
+func NewPartitionedDiskQueue(typs []coltypes.T, cfg DiskQueueCfg) *PartitionedDiskQueue {
+	return &PartitionedDiskQueue{
+		typs:                typs,
+		cfg:                 cfg,
+		partitionIdxToIndex: make(map[int]int),
+		partitions:          make([]Queue, 0),
+	}
+}
+
+func (p *PartitionedDiskQueue) Enqueue(partitionIdx int, batch coldata.Batch) error {
+	idx, ok := p.partitionIdxToIndex[partitionIdx]
+	if !ok {
+		// Partition has not been created yet.
+		q, err := NewDiskQueue(p.typs, p.cfg)
+		if err != nil {
+			return err
+		}
+		idx = len(p.partitions)
+		p.partitions = append(p.partitions, q)
+		p.partitionIdxToIndex[partitionIdx] = idx
+	}
+	return p.partitions[idx].Enqueue(batch)
+}
+
+func (p *PartitionedDiskQueue) Dequeue(partitionIdx int, batch coldata.Batch) error {
+	idx, ok := p.partitionIdxToIndex[partitionIdx]
+	if !ok {
+		batch.SetLength(0)
+		return nil
+	}
+	notEmpty, err := p.partitions[idx].Dequeue(batch)
+	if err != nil {
+		return err
+	}
+	if !notEmpty {
+		// The queue was empty.
+		batch.SetLength(0)
+	}
+	return nil
+}
+
+// Close closes all the PartitionedDiskQueue's partitions. If an error is
+// encountered, the PartitionedDiskQueue will attempt to close all partitions
+// anyway and return the last error encountered.
+func (p *PartitionedDiskQueue) Close() error {
+	var lastErr error
+	for _, q := range p.partitions {
+		lastErr = q.Close()
+	}
+	return lastErr
+}

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -132,6 +132,12 @@ func NewPartitionedDiskQueue(
 	fdSemaphore semaphore.Semaphore,
 	partitionerStrategy PartitionerStrategy,
 ) *PartitionedDiskQueue {
+	if len(typs) == 0 {
+		// DiskQueues cannot serialize zero length schemas, so catch this error
+		// early.
+		// TODO(asubiotto): We could support this, but not sure we need to.
+		execerror.VectorizedInternalPanic("zero length schema unsupported")
+	}
 	return &PartitionedDiskQueue{
 		typs:                     typs,
 		strategy:                 partitionerStrategy,

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -1,0 +1,314 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colcontainer_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/fs"
+	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/marusama/semaphore"
+	"github.com/stretchr/testify/require"
+)
+
+type fdCountingFSFile struct {
+	fs.File
+	onCloseCb func()
+}
+
+func (f *fdCountingFSFile) Close() error {
+	if err := f.File.Close(); err != nil {
+		return err
+	}
+	f.onCloseCb()
+	return nil
+}
+
+type fdCountingFS struct {
+	fs.FS
+	writeFDs int
+	readFDs  int
+}
+
+// assertOpenFDs is a helper function that checks that sem has the correct count
+// of open file descriptors, and the fs' open file descriptors match up with the
+// given expected number.
+func (f *fdCountingFS) assertOpenFDs(
+	t *testing.T, sem semaphore.Semaphore, expectedWriteFDs, expectedReadFDs int,
+) {
+	t.Helper()
+	require.Equal(t, expectedWriteFDs+expectedReadFDs, sem.GetCount())
+	require.Equal(t, expectedWriteFDs, f.writeFDs)
+	require.Equal(t, expectedReadFDs, f.readFDs)
+}
+
+func (f *fdCountingFS) CreateFile(name string) (fs.File, error) {
+	file, err := f.FS.CreateFile(name)
+	if err != nil {
+		return nil, err
+	}
+	f.writeFDs++
+	return &fdCountingFSFile{File: file, onCloseCb: func() { f.writeFDs-- }}, nil
+}
+
+func (f *fdCountingFS) CreateFileWithSync(name string, bytesPerSync int) (fs.File, error) {
+	file, err := f.FS.CreateFileWithSync(name, bytesPerSync)
+	if err != nil {
+		return nil, err
+	}
+	f.writeFDs++
+	return &fdCountingFSFile{File: file, onCloseCb: func() { f.writeFDs-- }}, nil
+}
+
+func (f *fdCountingFS) OpenFile(name string) (fs.File, error) {
+	file, err := f.FS.OpenFile(name)
+	if err != nil {
+		return nil, err
+	}
+	f.readFDs++
+	return &fdCountingFSFile{File: file, onCloseCb: func() { f.readFDs-- }}, nil
+}
+
+// TestPartitionedDiskQueue tests interesting scenarios that are different from
+// the simulated external algorithms below and don't make sense to add to that
+// test.
+func TestPartitionedDiskQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var (
+		ctx   = context.Background()
+		typs  = []coltypes.T{coltypes.Int64}
+		batch = testAllocator.NewMemBatch(typs)
+		sem   = &colexec.TestingSemaphore{}
+	)
+	batch.SetLength(coldata.BatchSize())
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	countingFS := &fdCountingFS{FS: queueCfg.FS}
+	queueCfg.FS = countingFS
+
+	t.Run("ReopenReadPartition", func(t *testing.T) {
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault)
+
+		countingFS.assertOpenFDs(t, sem, 0, 0)
+		require.NoError(t, p.Enqueue(ctx, 0, batch))
+		countingFS.assertOpenFDs(t, sem, 1, 0)
+		require.NoError(t, p.Enqueue(ctx, 0, batch))
+		countingFS.assertOpenFDs(t, sem, 1, 0)
+		require.NoError(t, p.Dequeue(ctx, 0, batch))
+		require.True(t, batch.Length() != 0)
+		countingFS.assertOpenFDs(t, sem, 0, 1)
+		// There is still one batch to dequeue. Close all read files.
+		require.NoError(t, p.CloseAllOpenReadFileDescriptors())
+		countingFS.assertOpenFDs(t, sem, 0, 0)
+		require.NoError(t, p.Dequeue(ctx, 0, batch))
+		require.True(t, batch.Length() != 0)
+		// Here we do a manual check, since this is the case in which the semaphore
+		// will report an extra file open (the read happens from the in-memory
+		// buffer, not disk).
+		require.Equal(t, 1, sem.GetCount())
+		require.Equal(t, 0, countingFS.writeFDs+countingFS.readFDs)
+
+		// However, now the partition should be empty if Dequeued from again.
+		require.NoError(t, p.Dequeue(ctx, 0, batch))
+		require.True(t, batch.Length() == 0)
+		// And the file descriptor should be automatically closed.
+		countingFS.assertOpenFDs(t, sem, 0, 0)
+
+		require.NoError(t, p.Close())
+		countingFS.assertOpenFDs(t, sem, 0, 0)
+	})
+
+}
+
+func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var (
+		ctx    = context.Background()
+		typs   = []coltypes.T{coltypes.Int64}
+		batch  = testAllocator.NewMemBatch(typs)
+		rng, _ = randutil.NewPseudoRand()
+		// maxPartitions is in [1, 10]. The maximum partitions on a single level.
+		maxPartitions = 1 + rng.Intn(10)
+		// numRepartitions is in [1, 5].
+		numRepartitions = 1 + rng.Intn(5)
+	)
+	batch.SetLength(coldata.BatchSize())
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	// Wrap the FS with an FS that counts the file descriptors, to assert that
+	// they line up with the semaphore's count.
+	countingFS := &fdCountingFS{FS: queueCfg.FS}
+	queueCfg.FS = countingFS
+
+	// Sort simulates the use of a PartitionedDiskQueue during an external sort.
+	t.Run(fmt.Sprintf("Sort/maxPartitions=%d/numRepartitions=%d", maxPartitions, numRepartitions), func(t *testing.T) {
+		// Creating a new testing semaphore will assert that no more than
+		// maxPartitions+1 are created. The +1 is the file descriptor of the
+		// new partition being written to when closedForWrites from maxPartitions
+		// and writing the merged result to a single new partition.
+		sem := colexec.NewTestingSemaphore(maxPartitions + 1)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyCloseOnNewPartition)
+
+		// Define sortRepartition to be able to call this helper function
+		// recursively.
+		var sortRepartition func(int, int)
+		sortRepartition = func(curPartitionIdx, numRepartitionsLeft int) {
+			if numRepartitionsLeft == 0 {
+				return
+			}
+
+			firstPartitionIdx := curPartitionIdx
+			// Create maxPartitions partitions.
+			for ; curPartitionIdx < firstPartitionIdx+maxPartitions; curPartitionIdx++ {
+				require.NoError(t, p.Enqueue(ctx, curPartitionIdx, batch))
+				// Assert that there is only one write file descriptor open at a time.
+				countingFS.assertOpenFDs(t, sem, 1, 0)
+			}
+
+			// Make sure that an Enqueue attempt on a previously closed partition
+			// fails.
+			if maxPartitions > 1 {
+				require.Error(t, p.Enqueue(ctx, firstPartitionIdx, batch))
+			}
+
+			// Closing all open read descriptors will still leave us with one
+			// write descriptor, since we only ever wrote.
+			require.NoError(t, p.CloseAllOpenReadFileDescriptors())
+			countingFS.assertOpenFDs(t, sem, 1, 0)
+			// Closing all write descriptors will close all descriptors.
+			require.NoError(t, p.CloseAllOpenWriteFileDescriptors())
+			countingFS.assertOpenFDs(t, sem, 0, 0)
+
+			// Now, we simulate a repartition. Open all partitions for reads.
+			for readPartitionIdx := firstPartitionIdx; readPartitionIdx < firstPartitionIdx+maxPartitions; readPartitionIdx++ {
+				require.NoError(t, p.Dequeue(ctx, readPartitionIdx, batch))
+				// Make sure the number of file descriptors increases and all of these
+				// files are read file descriptors.
+				countingFS.assertOpenFDs(t, sem, 0, (readPartitionIdx-firstPartitionIdx)+1)
+			}
+
+			// Now, we simulate a write of the merged partitions.
+			curPartitionIdx++
+			require.NoError(t, p.Enqueue(ctx, curPartitionIdx, batch))
+			// All file descriptors should still be open in addition to the new write
+			// file descriptor.
+			countingFS.assertOpenFDs(t, sem, 1, maxPartitions)
+
+			// Simulate closing all read partitions.
+			require.NoError(t, p.CloseAllOpenReadFileDescriptors())
+			// Only the write file descriptor should remain open. Note that this
+			// file descriptor should be closed on the next new partition, i.e. the
+			// next iteration (if any, otherwise p.Close should close it) of this loop.
+			countingFS.assertOpenFDs(t, sem, 1, 0)
+			// Call CloseInactiveReadPartitions to reclaim space.
+			require.NoError(t, p.CloseInactiveReadPartitions())
+			// Try to enqueue to a partition that was just closed.
+			require.Error(t, p.Enqueue(ctx, firstPartitionIdx, batch))
+			countingFS.assertOpenFDs(t, sem, 1, 0)
+
+			numRepartitionsLeft--
+			sortRepartition(curPartitionIdx, numRepartitionsLeft)
+		}
+
+		sortRepartition(0, numRepartitions)
+		require.NoError(t, p.Close())
+		countingFS.assertOpenFDs(t, sem, 0, 0)
+	})
+
+	t.Run(fmt.Sprintf("HashJoin/maxPartitions=%d/numRepartitions=%d", maxPartitions, numRepartitions), func(t *testing.T) {
+		// Double maxPartitions to get an even number, half for the left input, half
+		// for the right input. We'll consider the even index the left side and the
+		// next partition index the right side.
+		maxPartitions *= 2
+
+		// The limit for a hash join is maxPartitions + 2. maxPartitions is the
+		// number of partitions partitioned to and 2 represents the file descriptors
+		// for the left and right side in the case of a repartition.
+		sem := colexec.NewTestingSemaphore(maxPartitions + 2)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault)
+
+		// joinRepartition will perform the partitioning that happens during a hash
+		// join. expectedRepartitionReadFDs are the read file descriptors that are
+		// expected to be open during a repartitioning step. 0 in the first call,
+		// 2 otherwise (left + right side).
+		var joinRepartition func(int, int, int, int)
+		joinRepartition = func(curPartitionIdx, readPartitionIdx, numRepartitionsLeft, expectedRepartitionReadFDs int) {
+			if numRepartitionsLeft == 0 {
+				return
+			}
+
+			firstPartitionIdx := curPartitionIdx
+			// Partitioning phase.
+			partitionIdxs := make([]int, maxPartitions)
+			for i := 0; i < maxPartitions; i, curPartitionIdx = i+1, curPartitionIdx+1 {
+				partitionIdxs[i] = curPartitionIdx
+			}
+			// Since we set these partitions randomly, simulate that.
+			rng.Shuffle(len(partitionIdxs), func(i, j int) {
+				partitionIdxs[i], partitionIdxs[j] = partitionIdxs[j], partitionIdxs[i]
+			})
+
+			for i, idx := range partitionIdxs {
+				require.NoError(t, p.Enqueue(ctx, idx, batch))
+				// Assert that the open file descriptors keep increasing, this is the
+				// default partitioner strategy behavior.
+				countingFS.assertOpenFDs(t, sem, i+1, expectedRepartitionReadFDs)
+			}
+
+			// The input has been partitioned. All file descriptors should be closed.
+			require.NoError(t, p.CloseAllOpenWriteFileDescriptors())
+			countingFS.assertOpenFDs(t, sem, 0, expectedRepartitionReadFDs)
+			require.NoError(t, p.CloseAllOpenReadFileDescriptors())
+			countingFS.assertOpenFDs(t, sem, 0, 0)
+			require.NoError(t, p.CloseInactiveReadPartitions())
+			countingFS.assertOpenFDs(t, sem, 0, 0)
+			// Now that we closed (read: deleted) the partitions read to repartition,
+			// it should be illegal to enqueue to that index.
+			if expectedRepartitionReadFDs > 0 {
+				require.Error(t, p.Dequeue(ctx, readPartitionIdx, batch))
+			}
+
+			// Now we simulate that one partition has been found to be too large. Read
+			// the first two partitions (left + right side) and assert that these file
+			// descriptors are open.
+			require.NoError(t, p.Dequeue(ctx, firstPartitionIdx, batch))
+			// We shouldn't have Dequeued an empty batch.
+			require.True(t, batch.Length() != 0)
+			require.NoError(t, p.Dequeue(ctx, firstPartitionIdx+1, batch))
+			// We shouldn't have Dequeued an empty batch.
+			require.True(t, batch.Length() != 0)
+			countingFS.assertOpenFDs(t, sem, 0, 2)
+
+			// Increment curPartitionIdx to the next available slot.
+			curPartitionIdx++
+
+			// Now we repartition these two partitions.
+			numRepartitionsLeft--
+			joinRepartition(curPartitionIdx, firstPartitionIdx, numRepartitionsLeft, 2)
+		}
+
+		joinRepartition(0, 0, numRepartitions, 0)
+	})
+}

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -224,6 +225,13 @@ func (d *diskSpillerBase) Next(ctx context.Context) coldata.Batch {
 		execerror.VectorizedInternalPanic(err)
 	}
 	return batch
+}
+
+func (d *diskSpillerBase) Close() error {
+	if c, ok := d.diskBackedOp.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 func (d *diskSpillerBase) ChildCount(verbose bool) int {

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
+	"github.com/marusama/semaphore"
 )
 
 func checkNumIn(inputs []Operator, numIn int) error {
@@ -95,6 +96,7 @@ type NewColOperatorArgs struct {
 	StreamingMemAccount  *mon.BoundAccount
 	ProcessorConstructor execinfra.ProcessorConstructor
 	DiskQueueCfg         colcontainer.DiskQueueCfg
+	FDSemaphore          semaphore.Semaphore
 	TestingKnobs         struct {
 		// UseStreamingMemAccountForBuffering specifies whether to use
 		// StreamingMemAccount when creating buffering operators and should only be
@@ -556,7 +558,7 @@ func NewColOperator(
 					inputs[0], inputs[1], inMemoryHashJoiner.(bufferingInMemoryOperator),
 					hashJoinerMemMonitorName,
 					func(inputOne, inputTwo Operator) Operator {
-						monitorNamePrefix := "external-hash-joiner-"
+						monitorNamePrefix := "external-hash-joiner"
 						allocator := NewAllocator(
 							// Pass in the default limit explicitly since we don't want to
 							// use the default memory limit of 1 if ForceDiskSpill is true, to
@@ -565,11 +567,7 @@ func NewColOperator(
 							ctx, result.createBufferingMemAccountWithLimit(
 								ctx, flowCtx, monitorNamePrefix, execinfra.GetWorkMemLimit(flowCtx.Cfg),
 							))
-						return newExternalHashJoiner(
-							allocator, hjSpec,
-							inputOne, inputTwo,
-							args.DiskQueueCfg,
-						)
+						return newExternalHashJoiner(allocator, hjSpec, inputOne, inputTwo, args.DiskQueueCfg, args.FDSemaphore)
 					},
 					args.TestingKnobs.SpillingCallbackFn,
 				)
@@ -780,6 +778,7 @@ func NewColOperator(
 							execinfra.GetWorkMemLimit(flowCtx.Cfg),
 							args.TestingKnobs.MaxNumberPartitions,
 							args.DiskQueueCfg,
+							args.FDSemaphore,
 						)
 					},
 					args.TestingKnobs.SpillingCallbackFn,

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -121,11 +121,17 @@ type NewColOperatorArgs struct {
 // NewColOperatorResult is a helper struct that encompasses all of the return
 // values of NewColOperator call.
 type NewColOperatorResult struct {
-	Op                     Operator
-	ColumnTypes            []types.T
-	InternalMemUsage       int
-	MetadataSources        []execinfrapb.MetadataSource
-	IsStreaming            bool
+	Op               Operator
+	ColumnTypes      []types.T
+	InternalMemUsage int
+	MetadataSources  []execinfrapb.MetadataSource
+	IsStreaming      bool
+	// CanRunInAutoMode returns whether the result can be run in auto mode if
+	// IsStreaming is false. This applies to operators that can spill to disk, but
+	// also operators such as the hash aggregator that buffer, but not
+	// proportionally to the input size (in the hash aggregator's case, it is the
+	// number of distinct groups).
+	CanRunInAutoMode       bool
 	BufferingOpMemMonitors []*mon.BytesMonitor
 	BufferingOpMemAccounts []*mon.BoundAccount
 }
@@ -192,6 +198,15 @@ func isSupported(spec *execinfrapb.ProcessorSpec) (bool, error) {
 		return true, nil
 
 	case core.Sorter != nil:
+		inputTypes, err := typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return false, err
+		}
+		for _, t := range inputTypes {
+			if t == coltypes.Interval {
+				return false, errors.WithIssueLink(errors.Errorf("sort on interval type not supported"), errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/45392"})
+			}
+		}
 		return true, nil
 
 	case core.Windower != nil:
@@ -645,8 +660,13 @@ func NewColOperator(
 
 			mergeJoinerMemAccount := streamingMemAccount
 			if !result.IsStreaming && !useStreamingMemAccountForBuffering {
-				// Whether the merge joiner is streaming is already set above.
-				mergeJoinerMemAccount = result.createBufferingMemAccount(ctx, flowCtx, "merge-joiner")
+				// If the merge joiner is buffering, create an unlimited buffering
+				// account for now.
+				// TODO(asubiotto): Once we support spilling to disk in the merge
+				//  joiner, make this a limited account. Done this way so that we can
+				//  still run plans that include a merge join with a low memory limit
+				//  to test disk spilling of other components for the time being.
+				mergeJoinerMemAccount = result.createBufferingUnlimitedMemAccount(ctx, flowCtx, "merge-joiner")
 			}
 			result.Op, err = NewMergeJoinOp(
 				NewAllocator(ctx, mergeJoinerMemAccount),
@@ -692,6 +712,11 @@ func NewColOperator(
 			inputTypes, err = typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
 			if err != nil {
 				return result, err
+			}
+			for _, t := range inputTypes {
+				if t == coltypes.Interval {
+					execerror.VectorizedInternalPanic("attempted to create a sort on interval type after isSupported check")
+				}
 			}
 			orderingCols := core.Sorter.OutputOrdering.Columns
 			matchLen := core.Sorter.OrderingMatchLen
@@ -785,6 +810,10 @@ func NewColOperator(
 				)
 			}
 			result.ColumnTypes = spec.Input[0].ColumnTypes
+			// A sorter can run in auto mode because it falls back to disk if there
+			// is not enough memory available.
+			// TODO(asubiotto): Currently disabled
+			// result.CanRunInAutoMode = true
 
 		case core.Windower != nil:
 			if err := checkNumIn(inputs, 1); err != nil {

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/marusama/semaphore"
 )
 
 // externalHashJoinerState indicates the current state of the external hash
@@ -45,10 +46,6 @@ const (
 	// tuples already and only zero-length batch will be emitted from now on.
 	externalHJFinished
 )
-
-// TODO(yuzefovich): make this tunable. Ideally, we would calculate this number
-// based on the cardinality of inputs.
-const externalHJNumPartitions = 4 << 10 /* 4096 */
 
 // externalHashJoiner is an operator that performs Grace hash join algorithm
 // and can spill to disk. The high level view is that it partitions the left
@@ -116,22 +113,28 @@ func newExternalHashJoiner(
 	spec hashJoinerSpec,
 	leftInput, rightInput Operator,
 	diskQueueCfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 ) Operator {
-	leftPartitioner := colcontainer.NewPartitionedDiskQueue(spec.left.sourceTypes, diskQueueCfg)
+	leftPartitioner := colcontainer.NewPartitionedDiskQueue(spec.left.sourceTypes, diskQueueCfg, fdSemaphore, colcontainer.PartitionerStrategyDefault)
 	leftInMemHashJoinerInput := newPartitionerToOperator(
 		allocator, spec.left.sourceTypes, leftPartitioner, 0, /* partitionIdx */
 	)
-	rightPartitioner := colcontainer.NewPartitionedDiskQueue(spec.right.sourceTypes, diskQueueCfg)
+	rightPartitioner := colcontainer.NewPartitionedDiskQueue(spec.right.sourceTypes, diskQueueCfg, fdSemaphore, colcontainer.PartitionerStrategyDefault)
 	rightInMemHashJoinerInput := newPartitionerToOperator(
 		allocator, spec.right.sourceTypes, rightPartitioner, 0, /* partitionIdx */
 	)
 	ehj := &externalHashJoiner{
-		twoInputNode:              newTwoInputNode(leftInput, rightInput),
-		allocator:                 allocator,
-		spec:                      spec,
-		leftPartitioner:           leftPartitioner,
-		rightPartitioner:          rightPartitioner,
-		numPartitions:             externalHJNumPartitions,
+		twoInputNode:     newTwoInputNode(leftInput, rightInput),
+		allocator:        allocator,
+		spec:             spec,
+		leftPartitioner:  leftPartitioner,
+		rightPartitioner: rightPartitioner,
+		// TODO(asubiotto): This is temporary. With the default limit of 256 file
+		//  descriptors, this results in 16 partitions (8 for the left and 8 for the
+		//  right). The total size of these partitions is ignored and might hit a
+		//  memory limit. This is temporary until recursive partitioning is merged
+		//  and is behind the experimental_on flag.
+		numPartitions:             fdSemaphore.GetLimit() / 32,
 		leftInMemHashJoinerInput:  leftInMemHashJoinerInput,
 		rightInMemHashJoinerInput: rightInMemHashJoinerInput,
 		inMemHashJoiner: newHashJoiner(
@@ -200,7 +203,7 @@ func (hj *externalHashJoiner) partitionBatch(
 				}
 				scratchBatch.SetLength(uint16(len(sel)))
 			})
-			if err := partitioner.Enqueue(partitionIdx, scratchBatch); err != nil {
+			if err := partitioner.Enqueue(ctx, partitionIdx, scratchBatch); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			hj.nonEmptyPartition[partitionIdx] = true
@@ -216,7 +219,13 @@ func (hj *externalHashJoiner) Next(ctx context.Context) coldata.Batch {
 			rightBatch := hj.inputTwo.Next(ctx)
 			if leftBatch.Length() == 0 && rightBatch.Length() == 0 {
 				// Both inputs have been partitioned and spilled, so we transition to
-				// "joining" phase.
+				// "joining" phase. Close all the open write file descriptors.
+				if err := hj.leftPartitioner.CloseAllOpenWriteFileDescriptors(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				if err := hj.rightPartitioner.CloseAllOpenWriteFileDescriptors(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
 				hj.inMemHashJoiner.Init()
 				hj.state = externalHJJoinNewPartition
 				continue
@@ -225,7 +234,14 @@ func (hj *externalHashJoiner) Next(ctx context.Context) coldata.Batch {
 			hj.partitionBatch(ctx, rightBatch, hj.scratch.rightBatch, hj.spec.right, hj.rightPartitioner)
 
 		case externalHJJoinNewPartition:
-			// Find next non empty partition.
+			// Find next non empty partition. Close any open read file descriptors
+			// from previous joins.
+			if err := hj.leftPartitioner.CloseAllOpenReadFileDescriptors(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			if err := hj.rightPartitioner.CloseAllOpenReadFileDescriptors(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
 			for hj.partitionIdxToJoin < hj.numPartitions &&
 				!hj.nonEmptyPartition[hj.partitionIdxToJoin] {
 				hj.partitionIdxToJoin++

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -186,6 +186,12 @@ func createDiskBackedHashJoiner(
 		Inputs:              inputs,
 		StreamingMemAccount: testMemAcc,
 		DiskQueueCfg:        diskQueueCfg,
+		// The TestingSemaphore is created with a limit since the
+		// externalHashJoiner calculates the maximum number of partitions based on
+		// this.
+		// TODO(asubiotto): Assert a maximum number of open file descriptors when
+		//  we have recursive partitioning.
+		FDSemaphore: NewTestingSemaphore(256),
 	}
 	// We will not use streaming memory account for the external hash join so
 	// that the in-memory hash join operator could hit the memory limit set on

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
@@ -39,6 +41,9 @@ func TestExternalHashJoiner(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 	}
 
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
 	var (
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
@@ -52,9 +57,7 @@ func TestExternalHashJoiner(t *testing.T) {
 				for _, tc := range tcs {
 					runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
 						spec := createSpecForHashJoiner(tc)
-						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(
-							ctx, flowCtx, spec, sources, func() {},
-						)
+						hjOp, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, sources, func() {}, queueCfg)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
 						return hjOp, err
@@ -112,6 +115,8 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 				vec.Nulls().UnsetNulls()
 			}
 		}
+		queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
+		defer cleanup()
 		leftSource := newFiniteBatchSource(batch, 0)
 		rightSource := newFiniteBatchSource(batch, 0)
 		for _, fullOuter := range []bool{false, true} {
@@ -142,9 +147,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							leftSource.reset(nBatches)
 							rightSource.reset(nBatches)
-							hj, accounts, monitors, err := createDiskBackedHashJoiner(
-								ctx, flowCtx, spec, []Operator{leftSource, rightSource}, func() {},
-							)
+							hj, accounts, monitors, err := createDiskBackedHashJoiner(ctx, flowCtx, spec, []Operator{leftSource, rightSource}, func() {}, queueCfg)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							require.NoError(b, err)
@@ -176,11 +179,13 @@ func createDiskBackedHashJoiner(
 	spec *execinfrapb.ProcessorSpec,
 	inputs []Operator,
 	spillingCallbackFn func(),
+	diskQueueCfg colcontainer.DiskQueueCfg,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
 	args := NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,
 		StreamingMemAccount: testMemAcc,
+		DiskQueueCfg:        diskQueueCfg,
 	}
 	// We will not use streaming memory account for the external hash join so
 	// that the in-memory hash join operator could hit the memory limit set on

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/marusama/semaphore"
 )
 
 // externalSorterState indicates the current state of the external sorter.
@@ -33,13 +34,13 @@ const (
 	// externalSorterSpillPartition indicates that the next batch we read should
 	// be added to the last partition so far. A zero-length batch in this state
 	// indicates that the end of the partition has been reached and we should
-	// transition to starting a new partition.
+	// transition to starting a new partition. If maxNumberPartitions is reached
+	// in this state, the sorter will transition to externalSorterRepeatedMerging
+	// to reduce the number of partitions.
 	externalSorterSpillPartition
-	// externalSorterRepeatedMerging indicates that we need to merge several
-	// partitions into one and spill that new partition to disk. The number of
-	// partitions that we can merge at a time is determined by
-	// maxNumberPartitions. This procedure will be repeated until only one
-	// partition is left, and we transition to externalSorterNewPartition state.
+	// externalSorterRepeatedMerging indicates that we need to merge
+	// maxNumberPartitions into one and spill that new partition to disk. When
+	// finished, the sorter will transition to externalSorterNewPartition.
 	externalSorterRepeatedMerging
 	// externalSorterFinalMerging indicates that we have fully consumed the input
 	// and can merge all of the partitions in one step. We then transition to
@@ -103,10 +104,10 @@ type externalSorter struct {
 	OneInputNode
 	NonExplainable
 
+	closed             bool
 	unlimitedAllocator *Allocator
 	memoryLimit        int64
 	state              externalSorterState
-	inputDone          bool
 	inputTypes         []coltypes.T
 	ordering           execinfrapb.Ordering
 	inMemSorter        resettableOperator
@@ -148,6 +149,7 @@ func newExternalSorter(
 	memoryLimit int64,
 	maxNumberPartitions int,
 	cfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 ) Operator {
 	inputPartitioner := newInputPartitioningOperator(standaloneAllocator, input, memoryLimit)
 	inMemSorter, err := newSorter(
@@ -178,7 +180,7 @@ func newExternalSorter(
 		unlimitedAllocator:  unlimitedAllocator,
 		memoryLimit:         memoryLimit,
 		inMemSorter:         inMemSorter,
-		partitioner:         colcontainer.NewPartitionedDiskQueue(inputTypes, cfg),
+		partitioner:         colcontainer.NewPartitionedDiskQueue(inputTypes, cfg, fdSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition),
 		inputTypes:          inputTypes,
 		ordering:            ordering,
 		maxNumberPartitions: maxNumberPartitions,
@@ -196,14 +198,15 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 		case externalSorterNewPartition:
 			b := s.input.Next(ctx)
 			if b.Length() == 0 {
-				// The input has been fully exhausted, so we transition to "merging
-				// partitions" state.
-				s.inputDone = true
-				s.state = externalSorterRepeatedMerging
+				// The input has been fully exhausted, and it is always the case that
+				// the number of partitions is less than the maximum number since
+				// externalSorterSpillPartition will check and re-merge if not.
+				// Proceed to the final merging state.
+				s.state = externalSorterFinalMerging
 				continue
 			}
 			newPartitionIdx := s.firstPartitionIdx + s.numPartitions
-			if err := s.partitioner.Enqueue(newPartitionIdx, b); err != nil {
+			if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			s.state = externalSorterSpillPartition
@@ -226,43 +229,31 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.state = externalSorterNewPartition
 				continue
 			}
-			if err := s.partitioner.Enqueue(curPartitionIdx, b); err != nil {
+			if err := s.partitioner.Enqueue(ctx, curPartitionIdx, b); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			continue
 		case externalSorterRepeatedMerging:
-			if s.numPartitions < 2 {
-				if s.inputDone {
-					s.state = externalSorterFinalMerging
-				} else {
-					s.state = externalSorterNewPartition
-				}
-				continue
-			}
-			numPartitionsToMerge := s.maxNumberPartitions
-			if numPartitionsToMerge > s.numPartitions {
-				numPartitionsToMerge = s.numPartitions
-			}
-			if numPartitionsToMerge == s.numPartitions && s.inputDone {
-				// The input has been fully consumed and we can merge all of the
-				// remaining partitions, so we transition to "final merging" state.
-				s.state = externalSorterFinalMerging
-				continue
-			}
 			// We will merge all partitions in range [s.firstPartitionIdx,
-			// s.firstPartitionIdx+numPartitionsToMerge) and will spill all the
-			// resulting batches into a new partition with the next available
-			// index.
-			merger := s.createMergerForPartitions(s.firstPartitionIdx, numPartitionsToMerge)
+			// s.firstPartitionIdx+s.numPartitions) and will spill all the resulting
+			// batches into a new partition with the next available index.
+			merger := s.createMergerForPartitions(s.firstPartitionIdx, s.numPartitions)
 			merger.Init()
 			newPartitionIdx := s.firstPartitionIdx + s.numPartitions
 			for b := merger.Next(ctx); b.Length() > 0; b = merger.Next(ctx) {
-				if err := s.partitioner.Enqueue(newPartitionIdx, b); err != nil {
+				if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
 					execerror.VectorizedInternalPanic(err)
 				}
 			}
-			s.firstPartitionIdx += numPartitionsToMerge
-			s.numPartitions -= numPartitionsToMerge - 1
+			// Reclaim disk space by closing the inactive read partitions. Since the
+			// merger must have exhausted all inputs, this is all the partitions just
+			// read from.
+			if err := s.partitioner.CloseInactiveReadPartitions(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			s.firstPartitionIdx += s.numPartitions
+			s.numPartitions = 1
+			s.state = externalSorterNewPartition
 			continue
 		case externalSorterFinalMerging:
 			if s.numPartitions == 0 {
@@ -286,7 +277,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			}
 			return b
 		case externalSorterFinished:
-			if err := s.partitioner.Close(); err != nil {
+			if err := s.Close(); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			return coldata.ZeroBatch
@@ -294,6 +285,14 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected externalSorterState %d", s.state))
 		}
 	}
+}
+
+func (s *externalSorter) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.partitioner.Close()
 }
 
 // createMergerForPartitions creates an ordered synchronizer that will merge
@@ -384,8 +383,8 @@ var _ Operator = &partitionerToOperator{}
 
 func (p *partitionerToOperator) Init() {}
 
-func (p *partitionerToOperator) Next(context.Context) coldata.Batch {
-	if err := p.partitioner.Dequeue(p.partitionIdx, p.batch); err != nil {
+func (p *partitionerToOperator) Next(ctx context.Context) coldata.Batch {
+	if err := p.partitioner.Dequeue(ctx, p.partitionIdx, p.batch); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
 	return p.batch

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/marusama/semaphore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,20 +68,47 @@ func TestExternalSort(t *testing.T) {
 		for _, tcs := range [][]sortTestCase{sortAllTestCases, topKSortTestCases, sortChunksTestCases} {
 			for _, tc := range tcs {
 				t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.description), func(t *testing.T) {
+					// Unfortunately, there is currently no better way to check that a
+					// sorter does not have leftover file descriptors other than appending
+					// each semaphore used to this slice on construction. This is because
+					// some tests don't fully drain the input, making intercepting the
+					// sorter.Close() method not a useful option, since it is impossible
+					// to check between an expected case where more than 0 FDs are open
+					// (e.g. in verifySelAndNullResets, where the sorter is not fully
+					// drained so Close must be called explicitly) and an unexpected one.
+					// These cases happen during normal execution when a limit is
+					// satisfied, but flows will call Close explicitly on Cleanup.
+					// TODO(asubiotto): Not implemented yet, currently we rely on the
+					//  flow tracking open FDs and releasing any leftovers.
+					var semsToCheck []semaphore.Semaphore
 					runTests(
 						t,
 						[]tuples{tc.tuples},
 						tc.expected,
 						orderedVerifier,
 						func(input []Operator) (Operator, error) {
+							// A sorter should never exceed maxNumberPartitions+1, even during
+							// repartitioning. A panic will happen if a sorter requests more
+							// than this number of file descriptors.
+							sem := NewTestingSemaphore(maxNumberPartitions + 1)
+							// If a limit is satisfied before the sorter is drained of all its
+							// tuples, the sorter will not close its partitioner. During a
+							// flow this will happen in Cleanup, since there is no way to tell
+							// an operator that Next won't be called again.
+							if tc.k == 0 || int(tc.k) >= len(tc.tuples) {
+								semsToCheck = append(semsToCheck, sem)
+							}
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, tc.logTypes, tc.ordCols, tc.matchLen, tc.k, func() {},
-								maxNumberPartitions, queueCfg,
+								maxNumberPartitions, queueCfg, sem,
 							)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							return sorter, err
 						})
+					for i, sem := range semsToCheck {
+						require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+					}
 				})
 			}
 		}
@@ -125,10 +153,19 @@ func TestExternalSortRandomized(t *testing.T) {
 	const maxNumberPartitions = 2
 	// Interesting disk spilling scenarios:
 	// 1) The sorter is forced to spill to disk as soon as possible.
-	// 2) The memory limit is set to mon.DefaultPoolAllocationSize, this will
+	// 2) The memory limit is dynamically set to repartition twice, this will also
 	//    allow the in-memory sorter to spool several batches before hitting the
 	//    memory limit.
-	for _, tk := range []execinfra.TestingKnobs{{ForceDiskSpill: true}, {MemoryLimitBytes: mon.DefaultPoolAllocationSize}} {
+	colTyps, err := typeconv.FromColumnTypes(logTypes)
+	require.NoError(t, err)
+	// memoryToSort is the total amount of memory that will be sorted in this
+	// test.
+	memoryToSort := (nTups / int(coldata.BatchSize())) * estimateBatchSizeBytes(colTyps, int(coldata.BatchSize()))
+	// partitionSize will be the memory limit passed in to tests with a memory
+	// limit. With a maximum number of partitions of 2 this will result in
+	// repartitioning twice.
+	partitionSize := int64(memoryToSort / 4)
+	for _, tk := range []execinfra.TestingKnobs{{ForceDiskSpill: true}, {MemoryLimitBytes: partitionSize}} {
 		flowCtx.Cfg.TestingKnobs = tk
 		for nCols := 1; nCols <= maxCols; nCols++ {
 			for nOrderingCols := 1; nOrderingCols <= nCols; nOrderingCols++ {
@@ -138,6 +175,19 @@ func TestExternalSortRandomized(t *testing.T) {
 				}
 				name := fmt.Sprintf("%s/nCols=%d/nOrderingCols=%d", namePrefix, nCols, nOrderingCols)
 				t.Run(name, func(t *testing.T) {
+					// Unfortunately, there is currently no better way to check that a
+					// sorter does not have leftover file descriptors other than appending
+					// each semaphore used to this slice on construction. This is because
+					// some tests don't fully drain the input, making intercepting the
+					// sorter.Close() method not a useful option, since it is impossible
+					// to check between an expected case where more than 0 FDs are open
+					// (e.g. in verifySelAndNullResets, where the sorter is not fully
+					// drained so Close must be called explicitly) and an unexpected one.
+					// These cases happen during normal execution when a limit is
+					// satisfied, but flows will call Close explicitly on Cleanup.
+					// TODO(asubiotto): Not implemented yet, currently we rely on the
+					//  flow tracking open FDs and releasing any leftovers.
+					var semsToCheck []semaphore.Semaphore
 					tups, expected, ordCols := generateRandomDataForTestSort(rng, nTups, nCols, nOrderingCols)
 					runTests(
 						t,
@@ -145,15 +195,19 @@ func TestExternalSortRandomized(t *testing.T) {
 						expected,
 						orderedVerifier,
 						func(input []Operator) (Operator, error) {
+							sem := NewTestingSemaphore(maxNumberPartitions + 1)
+							semsToCheck = append(semsToCheck, sem)
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, logTypes[:nCols], ordCols,
 								0 /* matchLen */, 0 /* k */, func() {},
-								maxNumberPartitions, queueCfg,
-							)
+								maxNumberPartitions, queueCfg, sem)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							return sorter, err
 						})
+					for i, sem := range semsToCheck {
+						require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+					}
 				})
 			}
 		}
@@ -223,7 +277,7 @@ func BenchmarkExternalSort(b *testing.B) {
 						sorter, accounts, monitors, err := createDiskBackedSorter(
 							ctx, flowCtx, []Operator{source}, logTypes, ordCols,
 							0 /* matchLen */, 0 /* k */, func() { spilled = true },
-							64 /* maxNumberPartitions */, queueCfg,
+							64 /* maxNumberPartitions */, queueCfg, &TestingSemaphore{},
 						)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
@@ -265,6 +319,7 @@ func createDiskBackedSorter(
 	spillingCallbackFn func(),
 	maxNumberPartitions int,
 	diskQueueCfg colcontainer.DiskQueueCfg,
+	testingSemaphore semaphore.Semaphore,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
 	sorterSpec := &execinfrapb.SorterSpec{
 		OutputOrdering:   execinfrapb.Ordering{Columns: ordCols},
@@ -284,6 +339,7 @@ func createDiskBackedSorter(
 		Inputs:              input,
 		StreamingMemAccount: testMemAcc,
 		DiskQueueCfg:        diskQueueCfg,
+		FDSemaphore:         testingSemaphore,
 	}
 	// External sorter relies on different memory accounts to
 	// understand when to start a new partition, so we will not use

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -41,6 +43,9 @@ func TestExternalSort(t *testing.T) {
 			Settings: st,
 		},
 	}
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
 
 	var (
 		memAccounts []*mon.BoundAccount
@@ -70,7 +75,7 @@ func TestExternalSort(t *testing.T) {
 						func(input []Operator) (Operator, error) {
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, tc.logTypes, tc.ordCols, tc.matchLen, tc.k, func() {},
-								maxNumberPartitions,
+								maxNumberPartitions, queueCfg,
 							)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
@@ -110,6 +115,9 @@ func TestExternalSortRandomized(t *testing.T) {
 		logTypes[i] = *types.Int
 	}
 
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
 	var (
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
@@ -140,7 +148,7 @@ func TestExternalSortRandomized(t *testing.T) {
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, logTypes[:nCols], ordCols,
 								0 /* matchLen */, 0 /* k */, func() {},
-								maxNumberPartitions,
+								maxNumberPartitions, queueCfg,
 							)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
@@ -175,6 +183,9 @@ func BenchmarkExternalSort(b *testing.B) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
+	defer cleanup()
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
@@ -212,7 +223,7 @@ func BenchmarkExternalSort(b *testing.B) {
 						sorter, accounts, monitors, err := createDiskBackedSorter(
 							ctx, flowCtx, []Operator{source}, logTypes, ordCols,
 							0 /* matchLen */, 0 /* k */, func() { spilled = true },
-							64, /* maxNumberPartitions */
+							64 /* maxNumberPartitions */, queueCfg,
 						)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
@@ -253,6 +264,7 @@ func createDiskBackedSorter(
 	k uint16,
 	spillingCallbackFn func(),
 	maxNumberPartitions int,
+	diskQueueCfg colcontainer.DiskQueueCfg,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
 	sorterSpec := &execinfrapb.SorterSpec{
 		OutputOrdering:   execinfrapb.Ordering{Columns: ordCols},
@@ -271,6 +283,7 @@ func createDiskBackedSorter(
 		Spec:                spec,
 		Inputs:              input,
 		StreamingMemAccount: testMemAcc,
+		DiskQueueCfg:        diskQueueCfg,
 	}
 	// External sorter relies on different memory accounts to
 	// understand when to start a new partition, so we will not use

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"reflect"
@@ -272,6 +273,12 @@ func runTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
+		if c, ok := originalOp.(io.Closer); ok {
+			require.NoError(t, c.Close())
+		}
+		if c, ok := opWithNulls.(io.Closer); ok {
+			require.NoError(t, c.Close())
+		}
 	})
 }
 
@@ -372,6 +379,11 @@ func runTestsWithoutAllNullsInjection(
 				} else {
 					assert.False(t, maybeHasNulls(b))
 				}
+			}
+			if c, ok := op.(io.Closer); ok {
+				// Some operators need an explicit Close if not drained completely of
+				// input.
+				assert.NoError(t, c.Close())
 			}
 		}
 	})

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -846,6 +846,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			Inputs:               inputs,
 			StreamingMemAccount:  s.newStreamingMemAccount(flowCtx),
 			ProcessorConstructor: rowexec.NewProcessor,
+			DiskQueueCfg:         s.diskQueueCfg,
 		}
 		result, err := colexec.NewColOperator(ctx, flowCtx, args)
 		// Even when err is non-nil, it is possible that the buffering memory

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -33,20 +33,62 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/marusama/semaphore"
 	opentracing "github.com/opentracing/opentracing-go"
 )
+
+// countingSemaphore is a semaphore that keeps track of the semaphore count from
+// its perspective.
+type countingSemaphore struct {
+	semaphore.Semaphore
+	globalCount *metric.Gauge
+	count       int64
+}
+
+func (s *countingSemaphore) Acquire(ctx context.Context, n int) error {
+	if err := s.Semaphore.Acquire(ctx, n); err != nil {
+		return err
+	}
+	atomic.AddInt64(&s.count, int64(n))
+	s.globalCount.Inc(int64(n))
+	return nil
+}
+
+func (s *countingSemaphore) TryAcquire(n int) bool {
+	success := s.Semaphore.TryAcquire(n)
+	if !success {
+		return false
+	}
+	atomic.AddInt64(&s.count, int64(n))
+	s.globalCount.Inc(int64(n))
+	return success
+}
+
+func (s *countingSemaphore) Release(n int) int {
+	atomic.AddInt64(&s.count, int64(-n))
+	s.globalCount.Dec(int64(n))
+	return s.Semaphore.Release(n)
+}
 
 type vectorizedFlow struct {
 	*flowinfra.FlowBase
 	// operatorConcurrency is set if any operators are executed in parallel.
 	operatorConcurrency bool
+
+	// countingSemaphore is a wrapper over a semaphore.Semaphore that keeps track
+	// of the number of resources held in a semaphore.Semaphore requested from the
+	// context of this flow so that these can be released unconditionally upon
+	// Cleanup.
+	countingSemaphore *countingSemaphore
 
 	// streamingMemAccounts are the memory accounts that are tracking the static
 	// memory usage of the whole vectorized flow as well as all dynamic memory of
@@ -123,6 +165,7 @@ func (f *vectorizedFlow) Setup(
 				// The temporary storage directory has already been created.
 				return
 			}
+			log.VEventf(ctx, 2, "flow %s spilled to disk, stack trace: %s", f.ID, util.GetSmallTrace(2))
 			if err := f.Cfg.TempFS.CreateDir(f.tempStorage.path); err != nil {
 				execerror.VectorizedInternalPanic(errors.Errorf("unable to create temporary storage directory: %v", err))
 			}
@@ -131,6 +174,7 @@ func (f *vectorizedFlow) Setup(
 	if err := diskQueueCfg.EnsureDefaults(); err != nil {
 		return ctx, err
 	}
+	f.countingSemaphore = &countingSemaphore{Semaphore: f.Cfg.VecFDSemaphore, globalCount: f.Cfg.Metrics.VecOpenFDs}
 	creator := newVectorizedFlowCreator(
 		helper,
 		vectorizedRemoteComponentCreator{},
@@ -140,6 +184,7 @@ func (f *vectorizedFlow) Setup(
 		f.GetFlowCtx().Cfg.NodeDialer,
 		f.GetID(),
 		diskQueueCfg,
+		f.countingSemaphore,
 	)
 	if f.testingKnobs.onSetupFlow != nil {
 		f.testingKnobs.onSetupFlow(creator)
@@ -244,6 +289,10 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 				err,
 			)
 		}
+	}
+	// Release any leftover temporary storage file descriptors from this flow.
+	if unreleased := atomic.LoadInt64(&f.countingSemaphore.count); unreleased > 0 {
+		f.countingSemaphore.Release(int(unreleased))
 	}
 	f.FlowBase.Cleanup(ctx)
 	f.Release()
@@ -400,6 +449,7 @@ type vectorizedFlowCreator struct {
 	bufferingMemAccounts []*mon.BoundAccount
 
 	diskQueueCfg colcontainer.DiskQueueCfg
+	fdSemaphore  semaphore.Semaphore
 }
 
 func newVectorizedFlowCreator(
@@ -411,6 +461,7 @@ func newVectorizedFlowCreator(
 	nodeDialer *nodedialer.Dialer,
 	flowID execinfrapb.FlowID,
 	diskQueueCfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 ) *vectorizedFlowCreator {
 	return &vectorizedFlowCreator{
 		flowCreatorHelper:              helper,
@@ -424,6 +475,7 @@ func newVectorizedFlowCreator(
 		nodeDialer:                     nodeDialer,
 		flowID:                         flowID,
 		diskQueueCfg:                   diskQueueCfg,
+		fdSemaphore:                    fdSemaphore,
 	}
 }
 
@@ -530,7 +582,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
 		limit = 1
 	}
-	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg)
+	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg, s.fdSemaphore)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
 		logtags.AddTag(ctx, "hashRouterID", mmName)
 		router.Run(ctx)
@@ -847,6 +899,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			StreamingMemAccount:  s.newStreamingMemAccount(flowCtx),
 			ProcessorConstructor: rowexec.NewProcessor,
 			DiskQueueCfg:         s.diskQueueCfg,
+			FDSemaphore:          s.fdSemaphore,
 		}
 		result, err := colexec.NewColOperator(ctx, flowCtx, args)
 		// Even when err is non-nil, it is possible that the buffering memory
@@ -1083,10 +1136,7 @@ func SupportsVectorized(
 	if output == nil {
 		output = &execinfra.RowChannel{}
 	}
-	creator := newVectorizedFlowCreator(
-		newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false,
-		nil, output, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
-	)
+	creator := newVectorizedFlowCreator(newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, nil, output, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
 	// We create an unlimited memory account because we're interested whether the
 	// flow is supported via the vectorized engine in general (without paying
 	// attention to the memory since it is node-dependent in the distributed

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -913,9 +913,13 @@ func (s *vectorizedFlowCreator) setupFlow(
 		if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.EnableVectorizedInvariantsChecker {
 			result.Op = colexec.NewInvariantsChecker(result.Op, len(result.ColumnTypes))
 		}
-		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto &&
+		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.Vectorize192Auto &&
 			!result.IsStreaming {
-			return nil, errors.Errorf("non-streaming operator encountered when vectorize=auto")
+			return nil, errors.Errorf("non-streaming operator encountered when vectorize=192auto")
+		}
+		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto &&
+			(!result.IsStreaming && !result.CanRunInAutoMode) {
+			return nil, errors.Errorf("non-streaming operator encountered that is not marked as green for vectorize=auto")
 		}
 		// We created a streaming memory account when calling NewColOperator above,
 		// so there is definitely at least one memory account, and it doesn't
@@ -936,11 +940,14 @@ func (s *vectorizedFlowCreator) setupFlow(
 			op = vsc
 		}
 
-		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto &&
+		if (flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.Vectorize192Auto ||
+			flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto) &&
 			pspec.Output[0].Type == execinfrapb.OutputRouterSpec_BY_HASH {
-			// exec.HashRouter can do unlimited buffering, and it is present in the
-			// flow, so we don't want to run such a flow via the vectorized engine
-			// when vectorize=auto.
+			// colexec.HashRouter is not supported when vectorize=192auto since it can
+			// buffer an unlimited number of tuples, even though it falls back to
+			// disk. vectorize=auto does support this.
+			// TODO(asubiotto): Currently unsupported with vectorize=auto as well,
+			//  will be enabled in a future PR.
 			return nil, errors.Errorf("hash router encountered when vectorize=auto")
 		}
 		opOutputTypes, err := typeconv.FromColumnTypes(result.ColumnTypes)
@@ -1136,7 +1143,7 @@ func SupportsVectorized(
 	if output == nil {
 		output = &execinfra.RowChannel{}
 	}
-	creator := newVectorizedFlowCreator(newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, nil, output, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
+	creator := newVectorizedFlowCreator(newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, nil, output, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, flowCtx.Cfg.VecFDSemaphore)
 	// We create an unlimited memory account because we're interested whether the
 	// flow is supported via the vectorized engine in general (without paying
 	// attention to the memory since it is node-dependent in the distributed

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -164,7 +164,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					defer acc.Close(ctxRemote)
 					allocators[i] = colexec.NewAllocator(ctxRemote, &acc)
 				}
-				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg)
+				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg, &colexec.TestingSemaphore{})
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -221,6 +221,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					Spec:                tc.spec,
 					Inputs:              inputs,
 					StreamingMemAccount: &acc,
+					FDSemaphore:         colexec.NewTestingSemaphore(256),
 				}
 				// The disk spilling infrastructure relies on different memory
 				// accounts, so if the spilling is supported, we do *not* want to use

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -210,7 +210,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: roachpb.NodeID(1)}}
 	var wg sync.WaitGroup
-	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{})
+	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
 	defer func() {
@@ -248,6 +248,8 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 					Cfg: &execinfra.ServerConfig{
 						TempFS:          ngn,
 						TempStoragePath: baseDirName,
+						VecFDSemaphore:  &colexec.TestingSemaphore{},
+						Metrics:         &execinfra.DistSQLMetrics{},
 					},
 					EvalCtx: &evalCtx,
 					NodeID:  roachpb.NodeID(1),

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -258,6 +258,16 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 	}
 }
 
+// ensureSerializableTypes swaps out any types whose serialization that we don't
+// currently support in the vectorized engine with Ints.
+func ensureSerializableTypes(inputTypes []types.T) {
+	for i, t := range inputTypes {
+		if t.Family() == types.IntervalFamily {
+			inputTypes[i] = *types.Int
+		}
+	}
+}
+
 func TestSorterAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	st := cluster.MakeTestingClusterSettings()
@@ -286,6 +296,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 					)
 					if rng.Float64() < randTypesProbability {
 						inputTypes = generateRandomSupportedTypes(rng, nCols)
+						ensureSerializableTypes(inputTypes)
 						rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -360,6 +371,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 					)
 					if rng.Float64() < randTypesProbability {
 						inputTypes = generateRandomSupportedTypes(rng, nCols)
+						ensureSerializableTypes(inputTypes)
 						rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -469,6 +481,7 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 								)
 								if rng.Float64() < randTypesProbability {
 									lInputTypes = generateRandomSupportedTypes(rng, nCols)
+									ensureSerializableTypes(lInputTypes)
 									lEqCols = generateEqualityColumns(rng, nCols, nEqCols)
 									rInputTypes = append(rInputTypes[:0], lInputTypes...)
 									rEqCols = append(rEqCols[:0], lEqCols...)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -58,7 +59,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := engine.NewTempEngine(ctx, engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, tempFS, err := engine.NewTempEngine(ctx, engine.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
 	if err != nil {
 		return err
 	}
@@ -114,6 +115,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		Inputs:               columnarizers,
 		StreamingMemAccount:  &acc,
 		ProcessorConstructor: rowexec.NewProcessor,
+		DiskQueueCfg:         colcontainer.DiskQueueCfg{FS: tempFS},
 	}
 	var spilled bool
 	if args.forceDiskSpill {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -116,6 +116,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		StreamingMemAccount:  &acc,
 		ProcessorConstructor: rowexec.NewProcessor,
 		DiskQueueCfg:         colcontainer.DiskQueueCfg{FS: tempFS},
+		FDSemaphore:          colexec.NewTestingSemaphore(256),
 	}
 	var spilled bool
 	if args.forceDiskSpill {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -168,9 +168,10 @@ func (dsp *DistSQLPlanner) setupFlows(
 					ctx, &execinfra.FlowCtx{
 						EvalCtx: &evalCtx.EvalContext,
 						Cfg: &execinfra.ServerConfig{
-							DiskMonitor: &mon.BytesMonitor{},
-							Settings:    dsp.st,
-							ClusterID:   &dsp.rpcCtx.ClusterID,
+							DiskMonitor:    &mon.BytesMonitor{},
+							Settings:       dsp.st,
+							ClusterID:      &dsp.rpcCtx.ClusterID,
+							VecFDSemaphore: dsp.distSQLSrv.VecFDSemaphore,
 						},
 						NodeID: -1,
 					}, spec.Processors, fuseOpt, recv,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -147,7 +147,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	}
 
 	if evalCtx.SessionData.VectorizeMode != sessiondata.VectorizeOff {
-		if !vectorizeThresholdMet && evalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto {
+		if !vectorizeThresholdMet && (evalCtx.SessionData.VectorizeMode == sessiondata.Vectorize192Auto || evalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto) {
 			// Vectorization is not justified for this flow because the expected
 			// amount of data is too small and the overhead of pre-allocating data
 			// structures needed for the vectorized engine is expected to dominate

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -197,6 +197,7 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 	"auto",
 	map[int64]string{
 		int64(sessiondata.VectorizeOff):            "off",
+		int64(sessiondata.Vectorize192Auto):        "192auto",
 		int64(sessiondata.VectorizeAuto):           "auto",
 		int64(sessiondata.VectorizeExperimentalOn): "experimental_on",
 	},

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -27,6 +27,7 @@ type DistSQLMetrics struct {
 	QueueWaitHist *metric.Histogram
 	MaxBytesHist  *metric.Histogram
 	CurBytesCount *metric.Gauge
+	VecOpenFDs    *metric.Gauge
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -83,6 +84,12 @@ var (
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaVecOpenFDs = metric.Metadata{
+		Name:        "sql.distsql.vec.openfds",
+		Help:        "Current number of open file descriptors used by vectorized external storage",
+		Measurement: "Files",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // See pkg/sql/mem_metrics.go
@@ -100,6 +107,7 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		QueueWaitHist: metric.NewLatency(metaQueueWaitHist, histogramWindow),
 		MaxBytesHist:  metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
 		CurBytesCount: metric.NewGauge(metaMemCurBytes),
+		VecOpenFDs:    metric.NewGauge(metaVecOpenFDs),
 	}
 }
 

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/marusama/semaphore"
 )
 
 // Version identifies the distsql protocol version.
@@ -132,6 +133,10 @@ type ServerConfig struct {
 	// TempFS is used by the vectorized execution engine to store columns when the
 	// working set is larger than can be stored in memory.
 	TempFS fs.FS
+
+	// VecFDSemaphore is a weighted semaphore that restricts the number of open
+	// file descriptors in the vectorized engine.
+	VecFDSemaphore semaphore.Semaphore
 
 	// BulkAdder is used by some processors to bulk-ingest data as SSTs.
 	BulkAdder storagebase.BulkAdderFactory

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -230,7 +230,7 @@ func (p *planner) populateExplain(
 		isVec = true
 		if ctxSessionData.VectorizeMode == sessiondata.VectorizeOff {
 			isVec = false
-		} else if !vectorizedThresholdMet && ctxSessionData.VectorizeMode == sessiondata.VectorizeAuto {
+		} else if !vectorizedThresholdMet && (ctxSessionData.VectorizeMode == sessiondata.Vectorize192Auto || ctxSessionData.VectorizeMode == sessiondata.VectorizeAuto) {
 			isVec = false
 		} else {
 			thisNodeID := distSQLPlanner.nodeDesc.NodeID

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -121,8 +121,9 @@ func makeFlowCtx(planCtx *PlanningCtx, plan PhysicalPlan, params runParams) *exe
 		NodeID:  planCtx.EvalContext().NodeID,
 		EvalCtx: planCtx.EvalContext(),
 		Cfg: &execinfra.ServerConfig{
-			Settings:    params.p.execCfg.Settings,
-			DiskMonitor: &mon.BytesMonitor{},
+			Settings:       params.p.execCfg.Settings,
+			DiskMonitor:    &mon.BytesMonitor{},
+			VecFDSemaphore: params.p.execCfg.DistSQLSrv.VecFDSemaphore,
 		},
 	}
 	return flowCtx

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -559,6 +559,7 @@ var (
 		"fakedist",
 		"fakedist-vec-off",
 		"fakedist-vec",
+		"fakedist-vec-disk",
 		"fakedist-metadata",
 		"fakedist-disk",
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -559,7 +559,7 @@ var (
 		"fakedist",
 		"fakedist-vec-off",
 		"fakedist-vec",
-		"fakedist-vec-disk",
+		// TODO(asubiotto): Add "fakedist-vec-disk" to the default configs.
 		"fakedist-metadata",
 		"fakedist-disk",
 	}

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -1,4 +1,6 @@
-# LogicTest: local-vec fakedist-vec-disk
+# LogicTest: local-vec
+
+# TODO(asubiotto): Add fakedist-vec-disk configuration to this file.
 
 # Test that the exec HashJoiner follows SQL NULL semantics for ON predicate
 # equivalence.

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -1,4 +1,4 @@
-# LogicTest: local-vec
+# LogicTest: local-vec fakedist-vec-disk
 
 # Test that the exec HashJoiner follows SQL NULL semantics for ON predicate
 # equivalence.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec
+# LogicTest: local local-vec fakedist-vec-disk
 
 # Disable automatic stats.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,4 +1,6 @@
-# LogicTest: local local-vec fakedist-vec-disk
+# LogicTest: local local-vec
+
+# TODO(asubiotto): Add fakedist-vec-disk configuration to this file.
 
 # Disable automatic stats.
 statement ok
@@ -29,7 +31,7 @@ SELECT pk FROM t40574 WHERE (col0 > 9 AND (col1 <= 6.38 OR col0 =5) AND (col0 = 
 ----
 
 # OR expression as projection.
-query IB
+query IB rowsort
 SELECT b, b = 0 OR b = 2 FROM a WHERE b < 4
 ----
 0  true
@@ -38,14 +40,14 @@ SELECT b, b = 0 OR b = 2 FROM a WHERE b < 4
 3  false
 
 # OR expression as selection.
-query I
+query I rowsort
 SELECT b FROM a WHERE b = 0 OR b = 2
 ----
 0
 2
 
 # Check that the right side of an OR isn't evaluated if the left side is true.
-query I
+query I rowsort
 SELECT b FROM a WHERE b = 0 OR 1/b = 1
 ----
 0
@@ -138,7 +140,7 @@ SELECT a, b FROM a WHERE a * 2 < b LIMIT 5
 4  9
 
 # Simple projection.
-query I
+query I rowsort
 SELECT b + 1 FROM a WHERE b < 3
 ----
 1
@@ -163,7 +165,7 @@ NULL 1    NULL
 1    1    2
 
 # Multiple step projection.
-query III
+query III rowsort
 SELECT a, b, (a + 1) * (b + 2) FROM a WHERE a < 3
 ----
 0  0  2
@@ -198,7 +200,7 @@ SELECT 5, a FROM a LIMIT 3
 
 # Filter on a boolean column.
 
-query BI
+query BI rowsort
 SELECT * FROM bools WHERE b
 ----
 true 0
@@ -287,7 +289,7 @@ statement ok
 RESET vectorize
 
 # AND expressions.
-query IIBB
+query IIBB rowsort
 SELECT a, b, a < 2 AND b > 0 AND a * b != 3, a < 2 AND b < 2 FROM a WHERE a < 2 AND b > 0 AND a * b != 3
 ----
 0  1  true  true
@@ -303,7 +305,7 @@ INSERT INTO b VALUES
   (0, 'b'),
   (1, 'b')
 
-query IT
+query IT rowsort
 SELECT sum_int(a), b from b group by b
 ----
 1 a
@@ -346,7 +348,7 @@ statement ok
 SET vectorize = experimental_always
 
 # Simple lookup join.
-query I
+query I rowsort
 SELECT c.a FROM c JOIN d ON d.b = c.b
 ----
 1
@@ -381,7 +383,7 @@ SELECT * FROM a WITH ORDINALITY WHERE a > 1 LIMIT 6
 # Ensure that lookup joins properly get their postprocessing to select needed
 # columns.
 
-query I
+query I rowsort
 SELECT c.a FROM c INNER LOOKUP JOIN c@sec AS s ON c.b=s.b
 ----
 1
@@ -458,31 +460,6 @@ SELECT x, x LIKE '%', x NOT LIKE '%', x LIKE 'ab%', x NOT LIKE 'ab%', x LIKE '%b
 NULL  NULL  NULL   NULL   NULL   NULL   NULL   NULL   NULL
 abc   true  false  true   false  true   false  true   false
 xyz   true  false  false  true   false  true   false  true
-
-# Test that vectorized stats are collected correctly.
-statement ok
-SET vectorize = experimental_on
-
-statement ok
-SET distsql = on
-
-statement ok
-SET vectorize_row_count_threshold = 0
-
-query T
-SELECT url FROM [EXPLAIN ANALYZE SELECT a FROM a]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkMFO4zAQhu_7FNZ_2pW8kHACn1pBkCKFtjQ9AFUObjIqkdzY2BNEVeXdUeIe4IDEcb75Zux_TghvBgplVmS3G9F7I-7XywexzZ5WxTxfiPliXjy_ZOLvXV5uysfinzirOoq6gkRnG1roAwWoLVJUEs7bmkKwfkSnScibD6hEou1czyOuJGrrCeoEbtkQFDZ6Z2hNuiF_mUCiIdatmdY63x60P840JEqnu6DEf0gse1ZilkJip7l-pSBsz26EV5Dg3pmvKElGM5Chmtv3lo9KJBc31yNjbYzg9kBKJAHVIBGnzj8NrPcElQ7y92nWFJztAn0L8tPmZKgkqNlTvFiwva9p5W09PRPL5TQ3gYYCx24ai7yLraEa_nwGAAD__86elhA=
-
-query T
-SELECT url FROM [EXPLAIN ANALYZE SELECT c.a FROM c JOIN d ON d.b = c.b]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJykkk-P0zAQxe98itGcQDIl6dESUisoUlYhWdoegFUOrj1aDK4dPA50VeW7o_wRtEigRRz95r2Z-Y18Rv7qUOJuU25e7aGLDt5s67dwt3l_W66LCtbVuvzwcQNPXxe7_e5d-Qxmq16oyarhpi4qMFBXYBYHeAl6cWhQoA-GKnUkRnmHOTYC2xg0MYc4SOfRUJgTykyg9W2XBrkRqEMklGdMNjlCiXt1cLQlZSi-yFCgoaSsG9sy6ZVGgbtWeZbwHAXWXZKwysVqiQIPKulPxBC61A56jgJT17oLabAxOdLJfrPpQUK2yIYpnJRzkOyRJGSMTS9wisxbclL3hDLvxeNJboL1M0h-DdJGe1TxYWVQYBnCl66Fz8F6CF7CSDJj_R8TnUh3yQb_i0tgDN8ZIikz5665ByBDJ7hw5T_FR95o-S832hK3wTNd3edPnbO-EUjmnqYfxaGLmm5j0OOY6VmPuVEwxGmq5tOj8FNpWPAynP81vPwt3PRPfgQAAP__vR0M5w==
-
-query T
-SELECT url FROM [EXPLAIN ANALYZE SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy8klFr2zAUhd_3Ky73qWVaartvgkLC5g2XxO6cPGwrflCku1SgWJ4kj5aQ_z4sF9aUbCVj9M06Op-kc6536H8Y5LjM5_n7FfTOwMe6WsBt_uVmPitKmJWz-ddvOZx9KJar5ef5OTxa5USMVglFWeY1LPL6Uw7XVVGCgqqMhitQk3WDDFurqBRb8shvMcWGYeesJO-tG6RdNBTqHnnCULddHwa5YSitI-Q7DDoYQo4rsTZUk1DkLhJkqCgIbeKxndNb4R6mEhkuO9F6Du-QYdUHDtMUGa5FkHfkwfahG8RBC31nnkgZMvRkSAb9U4cHDskkGa7xQRgDQW-JQ-Kx2TMckcdn-iA2hDzds3-Lkh6Poo5FyV4lSvbHKL8T9K11ihypg9c3A_mS5UgfC3Ibura6JXeRHfZh6Hs4m6Zvz6-c3tyNn_9rtHRPsg_ati93cnnKeGvynW09Pe_m6MnJUAipDY0Fe9s7STfOynjNuKwiFwVFPoy72bgo2rgV_7-ncHoCnD2Hs7_Clwdwsm_2b34FAAD__9y3YyI=
 
 statement ok
 RESET optimizer; RESET vectorize; RESET distsql; RESET vectorize_row_count_threshold
@@ -615,13 +592,13 @@ CREATE TABLE builtin_test (x STRING, y INT)
 statement ok
 INSERT INTO builtin_test VALUES ('Hello', 3), ('There', 2)
 
-query T
+query T rowsort
 SELECT substring(x, 1, y) FROM builtin_test
 ----
 Hel
 Th
 
-query T
+query T rowsort
 SELECT substring(x, 1, abs(y)) FROM builtin_test
 ----
 Hel
@@ -638,7 +615,7 @@ SELECT substring(x, -1::INT2, 3::INT4) FROM builtin_test
 H
 T
 
-query I
+query I rowsort
 SELECT abs(y) FROM builtin_test
 ----
 3
@@ -699,39 +676,6 @@ SELECT min(x) FROM t38959_2 WHERE (y, z) = (2, 3.0)
 
 statement ok
 SET tracing=off
-
-# Making sure that colBatchScan operator can parallelize scans.
-# This test is similar to that in testplannerlogic/select
-statement ok
-CREATE TABLE tpar (
-    a INT PRIMARY KEY, item STRING, price FLOAT, FAMILY (a, item, price),
-    UNIQUE INDEX item (item), UNIQUE INDEX p (price)
-)
-
-statement ok
-ALTER TABLE tpar SPLIT AT VALUES(5)
-
-# Run a select to prime the range cache to simplify the trace below.
-statement ok
-SELECT * FROM tpar
-
-# Make sure that the scan actually gets parallelized.
-statement ok
-SET tracing = on; SELECT * FROM tpar WHERE a = 0 OR a = 10; SET tracing = off
-
-# The span "sending partial batch" means that the scan was parallelized.
-# Note that table ID here is hardcoded, so if a new table is created before
-# tpar, this query will need an adjustment.
-query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN 
-    ('querying next range at /Table/73/1/0',
-     'querying next range at /Table/73/1/10',
-     '=== SPAN START: kv.DistSender: sending partial batch ==='
-    )
-----
-querying next range at /Table/73/1/0
-=== SPAN START: kv.DistSender: sending partial batch ===
-querying next range at /Table/73/1/10
 
 # Test for #38858 -- handle aggregates correctly on an empty table.
 statement ok
@@ -1098,7 +1042,7 @@ SELECT * FROM t44304 WHERE CASE WHEN t44304.c0 > 0 THEN NULL END
 statement ok
 CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL)
 
-query TB
+query TB rowsort
 SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
 ----
 ·  true

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -1,0 +1,93 @@
+# LogicTest: local local-vec
+
+statement ok
+CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b))
+
+statement ok
+CREATE TABLE c (a INT, b INT, c INT, d INT, PRIMARY KEY (a, c), INDEX sec (b))
+
+statement ok
+CREATE TABLE d (a INT, b INT, PRIMARY KEY (b, a))
+
+statement ok
+INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)
+
+statement ok
+INSERT INTO c VALUES (1, 1, 1, 0), (2, 1, 2, 0)
+
+statement ok
+ALTER TABLE c INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+statement ok
+INSERT INTO d VALUES (1, 1), (1, 2)
+
+# Test that vectorized stats are collected correctly.
+statement ok
+SET vectorize = experimental_on
+
+statement ok
+SET distsql = on
+
+statement ok
+SET vectorize_row_count_threshold = 0
+
+query T
+SELECT url FROM [EXPLAIN ANALYZE SELECT a FROM a]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkMFO4zAQhu_7FNZ_2pW8kHACn1pBkCKFtjQ9AFUObjIqkdzY2BNEVeXdUeIe4IDEcb75Zux_TghvBgplVmS3G9F7I-7XywexzZ5WxTxfiPliXjy_ZOLvXV5uysfinzirOoq6gkRnG1roAwWoLVJUEs7bmkKwfkSnScibD6hEou1czyOuJGrrCeoEbtkQFDZ6Z2hNuiF_mUCiIdatmdY63x60P840JEqnu6DEf0gse1ZilkJip7l-pSBsz26EV5Dg3pmvKElGM5Chmtv3lo9KJBc31yNjbYzg9kBKJAHVIBGnzj8NrPcElQ7y92nWFJztAn0L8tPmZKgkqNlTvFiwva9p5W09PRPL5TQ3gYYCx24ai7yLraEa_nwGAAD__86elhA=
+
+query T
+SELECT url FROM [EXPLAIN ANALYZE SELECT c.a FROM c JOIN d ON d.b = c.b]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJykkk-P0zAQxe98itGcQDIl6dESUisoUlYhWdoegFUOrj1aDK4dPA50VeW7o_wRtEigRRz95r2Z-Y18Rv7qUOJuU25e7aGLDt5s67dwt3l_W66LCtbVuvzwcQNPXxe7_e5d-Qxmq16oyarhpi4qMFBXYBYHeAl6cWhQoA-GKnUkRnmHOTYC2xg0MYc4SOfRUJgTykyg9W2XBrkRqEMklGdMNjlCiXt1cLQlZSi-yFCgoaSsG9sy6ZVGgbtWeZbwHAXWXZKwysVqiQIPKulPxBC61A56jgJT17oLabAxOdLJfrPpQUK2yIYpnJRzkOyRJGSMTS9wisxbclL3hDLvxeNJboL1M0h-DdJGe1TxYWVQYBnCl66Fz8F6CF7CSDJj_R8TnUh3yQb_i0tgDN8ZIikz5665ByBDJ7hw5T_FR95o-S832hK3wTNd3edPnbO-EUjmnqYfxaGLmm5j0OOY6VmPuVEwxGmq5tOj8FNpWPAynP81vPwt3PRPfgQAAP__vR0M5w==
+
+query T
+SELECT url FROM [EXPLAIN ANALYZE SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJy8klFr2zAUhd_3Ky73qWVaartvgkLC5g2XxO6cPGwrflCku1SgWJ4kj5aQ_z4sF9aUbCVj9M06Op-kc6536H8Y5LjM5_n7FfTOwMe6WsBt_uVmPitKmJWz-ddvOZx9KJar5ef5OTxa5USMVglFWeY1LPL6Uw7XVVGCgqqMhitQk3WDDFurqBRb8shvMcWGYeesJO-tG6RdNBTqHnnCULddHwa5YSitI-Q7DDoYQo4rsTZUk1DkLhJkqCgIbeKxndNb4R6mEhkuO9F6Du-QYdUHDtMUGa5FkHfkwfahG8RBC31nnkgZMvRkSAb9U4cHDskkGa7xQRgDQW-JQ-Kx2TMckcdn-iA2hDzds3-Lkh6Poo5FyV4lSvbHKL8T9K11ihypg9c3A_mS5UgfC3Ibura6JXeRHfZh6Hs4m6Zvz6-c3tyNn_9rtHRPsg_ati93cnnKeGvynW09Pe_m6MnJUAipDY0Fe9s7STfOynjNuKwiFwVFPoy72bgo2rgV_7-ncHoCnD2Hs7_Clwdwsm_2b34FAAD__9y3YyI=
+
+statement ok
+RESET vectorize; RESET distsql; RESET vectorize_row_count_threshold
+
+statement ok
+SET tracing=off
+
+# Making sure that colBatchScan operator can parallelize scans.
+# This test is similar to that in testplannerlogic/select
+statement ok
+CREATE TABLE tpar (
+    a INT PRIMARY KEY, item STRING, price FLOAT, FAMILY (a, item, price),
+    UNIQUE INDEX item (item), UNIQUE INDEX p (price)
+)
+
+statement ok
+ALTER TABLE tpar SPLIT AT VALUES(5)
+
+# Run a select to prime the range cache to simplify the trace below.
+statement ok
+SELECT * FROM tpar
+
+# Make sure that the scan actually gets parallelized.
+statement ok
+SET tracing = on; SELECT * FROM tpar WHERE a = 0 OR a = 10; SET tracing = off
+
+# The span "sending partial batch" means that the scan was parallelized.
+# Note that table ID here is hardcoded, so if a new table is created before
+# tpar, this query will need an adjustment.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN
+    ('querying next range at /Table/56/1/0',
+     'querying next range at /Table/56/1/10',
+     '=== SPAN START: kv.DistSender: sending partial batch ==='
+    )
+----
+querying next range at /Table/56/1/0
+=== SPAN START: kv.DistSender: sending partial batch ===
+querying next range at /Table/56/1/10

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -254,27 +254,40 @@ func DistSQLExecModeFromString(val string) (_ DistSQLExecMode, ok bool) {
 
 // VectorizeExecMode controls if an when the Executor executes queries using the
 // columnar execution engine.
+// WARNING: When adding a VectorizeExecMode, note that nodes at previous
+// versions might interpret the integer value differently. To avoid this, only
+// append to the list or bump the minimum required distsql version (maybe also
+// take advantage of that to reorder the list as you see fit).
 type VectorizeExecMode int64
 
 const (
 	// VectorizeOff means that columnar execution is disabled.
 	VectorizeOff VectorizeExecMode = iota
-	// VectorizeAuto means that that any supported queries that use only
+	// Vectorize192Auto means that that any supported queries that use only
 	// streaming operators (i.e. those that do not require any buffering) will be
 	// run using the columnar execution.
-	VectorizeAuto
+	// TODO(asubiotto): This was the auto setting for 19.2 and is kept around as
+	//  an escape hatch. Remove in 20.2.
+	Vectorize192Auto
 	// VectorizeExperimentalOn means that any supported queries will be run using
 	// the columnar execution on.
 	VectorizeExperimentalOn
 	// VectorizeExperimentalAlways means that we attempt to vectorize all
 	// queries; unsupported queries will fail. Mostly used for testing.
 	VectorizeExperimentalAlways
+	// VectorizeAuto means that any supported queries that use only streaming
+	// operators or buffering operators that can spill to disk or are marked as
+	// buffering an amount not proportional to the input size will be run using
+	// columnar execution.
+	VectorizeAuto
 )
 
 func (m VectorizeExecMode) String() string {
 	switch m {
 	case VectorizeOff:
 		return "off"
+	case Vectorize192Auto:
+		return "192auto"
 	case VectorizeAuto:
 		return "auto"
 	case VectorizeExperimentalOn:
@@ -293,6 +306,8 @@ func VectorizeExecModeFromString(val string) (VectorizeExecMode, bool) {
 	switch strings.ToUpper(val) {
 	case "OFF":
 		m = VectorizeOff
+	case "192AUTO":
+		m = Vectorize192Auto
 	case "AUTO":
 		m = VectorizeAuto
 	case "EXPERIMENTAL_ON":

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -421,10 +421,6 @@ type Engine interface {
 	ReadFile(filename string) ([]byte, error)
 	// WriteFile writes data to a file in this RocksDB's env.
 	WriteFile(filename string, data []byte) error
-	// DeleteDirAndFiles deletes the directory and any files it contains but
-	// not subdirectories from this RocksDB's env. If dir does not exist,
-	// DeleteDirAndFiles returns nil (no error).
-	DeleteDirAndFiles(dir string) error
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine/fs/fs.go
+++ b/pkg/storage/engine/fs/fs.go
@@ -59,6 +59,11 @@ type FS interface {
 	// DeleteDir removes the named dir.
 	DeleteDir(name string) error
 
+	// DeleteDirAndFiles deletes the directory and any files it contains but
+	// not subdirectories. If dir does not exist, DeleteDirAndFiles returns nil
+	// (no error).
+	DeleteDirAndFiles(dir string) error
+
 	// ListDir returns a listing of the given directory. The names returned are
 	// relative to the directory.
 	ListDir(name string) ([]string, error)

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -42,13 +42,13 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 		path = inMemDirName
 		cleanup = ngn.Close
 	} else {
-		ngn, err := engine.NewDefaultEngine(0 /* cacheSize */, base.StorageConfig{})
+		tempPath, dirCleanup := testutils.TempDir(t)
+		path = tempPath
+		ngn, err := engine.NewDefaultEngine(0 /* cacheSize */, base.StorageConfig{Dir: tempPath})
 		if err != nil {
 			t.Fatal(err)
 		}
 		testingFS = ngn.(fs.FS)
-		tempPath, dirCleanup := testutils.TempDir(t)
-		path = tempPath
 		cleanup = func() {
 			ngn.Close()
 			dirCleanup()

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1413,6 +1413,7 @@ func TestLint(t *testing.T) {
 			"--",
 			"sql/colexec",
 			"sql/colflow",
+			"sql/colcontainer",
 			":!sql/colexec/execerror/error.go",
 			":!sql/colexec/execpb/stats.pb.go",
 			":!sql/colflow/vectorized_panic_propagation_test.go",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1395,6 +1395,10 @@ var charts = []sectionDescription{
 				Title:   "Total Queries",
 				Metrics: []string{"sql.distsql.queries.total"},
 			},
+			{
+				Title:   "Vectorized Temporary Storage Open File Descriptors",
+				Metrics: []string{"sql.distsql.vec.openfds"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Refer to commits for more details. The big changes here are that sorts and joins now use `DiskQueue`s and a file descriptor limit has been put in place using a weighted semaphore.

Closes #42407 
Closes #44807 