### PR TITLE
job: subtle bug in CANCEL JOB when the job is reverting

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -28,22 +28,22 @@ func ResetConstructors() func() {
 
 // FakeResumer calls optional callbacks during the job lifecycle.
 type FakeResumer struct {
-	OnResume     func() error
-	FailOrCancel func() error
+	OnResume     func(context.Context) error
+	FailOrCancel func(context.Context) error
 	Success      func() error
 	Terminal     func()
 }
 
-func (d FakeResumer) Resume(_ context.Context, _ interface{}, _ chan<- tree.Datums) error {
+func (d FakeResumer) Resume(ctx context.Context, _ interface{}, _ chan<- tree.Datums) error {
 	if d.OnResume != nil {
-		return d.OnResume()
+		return d.OnResume(ctx)
 	}
 	return nil
 }
 
-func (d FakeResumer) OnFailOrCancel(_ context.Context, _ interface{}) error {
+func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
 	if d.FailOrCancel != nil {
-		return d.FailOrCancel()
+		return d.FailOrCancel(ctx)
 	}
 	return nil
 }

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -160,7 +160,6 @@ type registryTestSuite struct {
 	failOrCancelCh      chan error
 	resumeCheckCh       chan struct{}
 	failOrCancelCheckCh chan struct{}
-	termCh              chan struct{}
 	// Instead of a ch for success, use a variable because it can retry since it
 	// is in a transaction.
 	successErr error
@@ -181,11 +180,10 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 	rts.failOrCancelCh = make(chan error)
 	rts.resumeCheckCh = make(chan struct{})
 	rts.failOrCancelCheckCh = make(chan struct{})
-	rts.termCh = make(chan struct{})
 
 	jobs.RegisterConstructor(jobspb.TypeImport, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
-			OnResume: func() error {
+			OnResume: func(ctx context.Context) error {
 				t.Log("Starting resume")
 				rts.mu.Lock()
 				rts.mu.a.ResumeStart = true
@@ -199,6 +197,11 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				for {
 					<-rts.resumeCheckCh
 					select {
+					case <-ctx.Done():
+						rts.mu.Lock()
+						rts.mu.a.ResumeExit--
+						rts.mu.Unlock()
+						return ctx.Err()
 					case err := <-rts.resumeCh:
 						return err
 					case <-rts.progressCh:
@@ -210,7 +213,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				}
 			},
 
-			FailOrCancel: func() error {
+			FailOrCancel: func(ctx context.Context) error {
 				t.Log("Starting FailOrCancel")
 				rts.mu.Lock()
 				rts.mu.a.OnFailOrCancelStart = true
@@ -222,7 +225,15 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 					t.Log("Exiting OnFailOrCancel")
 				}()
 				<-rts.failOrCancelCheckCh
-				return <-rts.failOrCancelCh
+				select {
+				case <-ctx.Done():
+					rts.mu.Lock()
+					rts.mu.a.OnFailOrCancelExit--
+					rts.mu.Unlock()
+					return ctx.Err()
+				case err := <-rts.failOrCancelCh:
+					return err
+				}
 			},
 
 			Success: func() error {
@@ -241,7 +252,6 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				rts.mu.Lock()
 				rts.mu.a.Terminal++
 				rts.mu.Unlock()
-				<-rts.termCh
 				t.Log("Exiting terminal")
 			},
 		}
@@ -254,7 +264,6 @@ func (rts *registryTestSuite) tearDown() {
 	close(rts.resumeCheckCh)
 	close(rts.failOrCancelCh)
 	close(rts.failOrCancelCheckCh)
-	close(rts.termCh)
 	close(rts.done)
 	rts.s.Stopper().Stop(rts.ctx)
 	jobs.DefaultAdoptInterval = rts.oldInterval
@@ -296,19 +305,21 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
+
 		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
 		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -316,73 +327,210 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
+
 		j, err := rts.registry.CreateJobWithTxn(rts.ctx, rts.mockJob, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
 		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCheckCh <- struct{}{}
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
-	t.Run("pause", func(t *testing.T) {
+	t.Run("pause running", func(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
-		job, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
-		rts.job = job
+		rts.job = j
+
 		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
 		rts.check(t, jobs.StatusRunning)
-		rts.sqlDB.Exec(t, "PAUSE JOB $1", *job.ID())
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
 		rts.check(t, jobs.StatusPaused)
-		rts.sqlDB.Exec(t, "PAUSE JOB $1", *job.ID())
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
 		rts.check(t, jobs.StatusPaused)
-		rts.sqlDB.Exec(t, "RESUME JOB $1", *job.ID())
-		rts.resumeCheckCh <- struct{}{}
-		rts.resumeCh <- nil
-		rts.mu.e.ResumeExit++
-		rts.resumeCheckCh <- struct{}{}
-		rts.resumeCh <- nil
-		rts.mu.e.ResumeExit++
+
+		rts.sqlDB.Exec(t, "RESUME JOB $1", *j.ID())
+		rts.check(t, jobs.StatusRunning)
+
 		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+		rts.resumeCh <- nil
+		rts.mu.e.ResumeExit++
+
 		rts.mu.e.Success = true
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
-	t.Run("cancel", func(t *testing.T) {
+	t.Run("pause reverting", func(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
-		job, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
-		rts.job = job
+		rts.job = j
+
 		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
 		rts.check(t, jobs.StatusRunning)
-		rts.sqlDB.Exec(t, "CANCEL JOB $1", *job.ID())
+
+		// Make Resume fail.
+		rts.resumeCh <- errors.New("resume failed")
+		rts.mu.e.ResumeExit++
 		rts.mu.e.OnFailOrCancelStart = true
 		rts.failOrCancelCheckCh <- struct{}{}
-		// Test for Reverting status.
 		rts.check(t, jobs.StatusReverting)
-		rts.mu.e.OnFailOrCancelExit++
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
+		rts.check(t, jobs.StatusPaused)
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
+		rts.check(t, jobs.StatusPaused)
+
+		rts.sqlDB.Exec(t, "RESUME JOB $1", *j.ID())
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
 		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit++
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
-		// Test for Canceled status.
+		rts.check(t, jobs.StatusFailed)
+	})
+
+	t.Run("cancel running", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
+		rts.sqlDB.Exec(t, "CANCEL JOB $1", *j.ID())
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.check(t, jobs.StatusReverting)
+
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit++
+		rts.mu.e.Terminal++
+
 		rts.check(t, jobs.StatusCanceled)
+	})
+
+	t.Run("cancel reverting", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
+		rts.sqlDB.Exec(t, "CANCEL JOB $1", *j.ID())
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.check(t, jobs.StatusReverting)
+
+		rts.sqlDB.ExpectErr(t, "status reverting cannot be requested to be canceled", "CANCEL JOB $1", *j.ID())
+		rts.check(t, jobs.StatusReverting)
+	})
+
+	t.Run("cancel pause running", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
+		rts.check(t, jobs.StatusPaused)
+
+		rts.sqlDB.Exec(t, "CANCEL JOB $1", *j.ID())
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit++
+		rts.mu.e.Terminal++
+		rts.check(t, jobs.StatusCanceled)
+	})
+
+	t.Run("cancel pause reverting", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+
+		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
+		// Make Resume fail.
+		rts.resumeCh <- errors.New("resume failed")
+		rts.mu.e.ResumeExit++
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
+		rts.sqlDB.Exec(t, "PAUSE JOB $1", *j.ID())
+		rts.check(t, jobs.StatusPaused)
+
+		rts.sqlDB.ExpectErr(t, "paused and has non-nil FinalResumeError resume", "CANCEL JOB $1", *j.ID())
+		rts.check(t, jobs.StatusPaused)
+
+		rts.sqlDB.Exec(t, "RESUME JOB $1", *j.ID())
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit++
+		rts.mu.e.Terminal++
+		rts.check(t, jobs.StatusFailed)
 	})
 
 	// Verify that pause and cancel in a rollback do nothing.
@@ -395,9 +543,11 @@ func TestRegistryLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 		rts.job = job
+
 		rts.mu.e.ResumeStart = true
 		rts.resumeCheckCh <- struct{}{}
 		rts.check(t, jobs.StatusRunning)
+
 		// Rollback a CANCEL.
 		{
 			txn, err := rts.outerDB.Begin()
@@ -448,14 +598,8 @@ func TestRegistryLifecycle(t *testing.T) {
 			if err := txn.Commit(); err != nil {
 				t.Fatal(err)
 			}
-			// Test for a paused error message.
-			if err := job.CheckStatus(rts.ctx); !testutils.IsError(err, "cannot update progress on pause") {
-				t.Fatalf("unexpected %v", err)
-			}
+			rts.check(t, jobs.StatusPaused)
 		}
-		rts.progressCh <- struct{}{}
-		rts.mu.e.ResumeExit++
-		rts.check(t, jobs.StatusPaused)
 		// Rollback a RESUME.
 		{
 			txn, err := rts.outerDB.Begin()
@@ -493,7 +637,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -501,22 +644,26 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
+
 		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
 		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCheckCh <- struct{}{}
 		rts.resumeCh <- errors.New("resume failed")
 		rts.mu.e.ResumeExit++
 		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
+		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
 		rts.mu.e.Terminal++
-		rts.failOrCancelCheckCh <- struct{}{}
-		rts.failOrCancelCh <- nil
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -525,24 +672,28 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
-		rts.successErr = errors.New("resume failed")
+
+		// Make marking success fail.
+		rts.successErr = errors.New("marking success failed")
 		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
 		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
+
 		rts.mu.e.Success = true
 		rts.mu.e.OnFailOrCancelStart = true
-		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 		rts.failOrCancelCheckCh <- struct{}{}
 		rts.failOrCancelCh <- nil
-		rts.termCh <- struct{}{}
+		rts.mu.e.OnFailOrCancelExit++
+		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -552,19 +703,24 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
+
+		// Make marking success fail.
 		rts.successErr = errors.New("resume failed")
 		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
 		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
 		rts.mu.e.OnFailOrCancelStart = true
+
 		// The job is now in state reverting and will never resume again because
 		// OnFailOrCancel also fails.
 		rts.check(t, jobs.StatusReverting)
@@ -580,26 +736,30 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()
+
+		// Make marking success fail.
 		rts.successErr = errors.New("resume failed")
 		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
 		}
 		rts.job = j
+
 		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
 		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
 		rts.resumeCh <- errors.New("resume failed")
 		rts.mu.e.ResumeExit++
 		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
 		// The job is now in state reverting and will never resume again.
 		rts.check(t, jobs.StatusReverting)
-		rts.failOrCancelCheckCh <- struct{}{}
+
 		// But let it fail.
 		rts.mu.e.OnFailOrCancelExit++
 		rts.failOrCancelCh <- errors.New("resume failed")
 		rts.mu.e.Terminal++
-		rts.termCh <- struct{}{}
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -674,9 +834,13 @@ func TestJobLifecycle(t *testing.T) {
 
 	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
-			OnResume: func() error {
-				<-done
-				return nil
+			OnResume: func(ctx context.Context) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-done:
+					return nil
+				}
 			},
 		}
 	})
@@ -1561,9 +1725,13 @@ func TestShowJobWhenComplete(t *testing.T) {
 	jobs.RegisterConstructor(
 		jobspb.TypeImport, func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 			return jobs.FakeResumer{
-				OnResume: func() error {
-					<-done
-					return nil
+				OnResume: func(ctx context.Context) error {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-done:
+						return nil
+					}
 				},
 			}
 		})
@@ -1715,7 +1883,7 @@ func TestJobInTxn(t *testing.T) {
 	)
 	jobs.RegisterConstructor(jobspb.TypeBackup, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
-			OnResume: func() error {
+			OnResume: func(ctx context.Context) error {
 				t.Logf("Resuming job: %+v", job.Payload())
 				return nil
 			},
@@ -1750,7 +1918,7 @@ func TestJobInTxn(t *testing.T) {
 	)
 	jobs.RegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
-			OnResume: func() error {
+			OnResume: func(_ context.Context) error {
 				return errors.New("RESTORE failed")
 			},
 		}


### PR DESCRIPTION
Previously, trying to cancel a job on a node that was not running it
will not work. Also, if reverting job was resumed it was not passed
the failure from Resume.

This PR fixes this by adding a similar if case for checking if
a job is CancelRequested in the adopt loop. This also makes the code
more readable. Also added a specific error to indicate job was cancelled
by user to be able to distinguishing if we are reverting a failed or
cancelled job. Before this we were relying on the absence of error for
that and this was error prone.
    
Release note (bug fix): in some rare cases a job was not cancellable
when in state Reverting.
