### PR TITLE
roleccl: enable GRANT/REVOKE for roles without a license

### DIFF
--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -79,11 +79,11 @@ func grantRolePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "GRANT <role>",
-		); err != nil {
-			return err
-		}
+		// Note: we do not check the license for GRANT <role>, only for
+		// CREATE/DROP <role>. This is because we want to allow
+		// non-licensed users to add/remove users from the admin role, so
+		// they can grant administrative privileges to user accounts that
+		// are not superusers like "root".
 
 		hasAdminRole, err := p.HasAdminRole(ctx)
 		if err != nil {
@@ -233,11 +233,11 @@ func revokeRolePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "REVOKE <role>",
-		); err != nil {
-			return err
-		}
+		// Note: we do not check the license for REVOKE <role>, only for
+		// CREATE/DROP <role>. This is because we want to allow
+		// non-licensed users to add/remove users from the admin role, so
+		// they can grant administrative privileges to user accounts that
+		// are not superusers like "root".
 
 		hasAdminRole, err := p.HasAdminRole(ctx)
 		if err != nil {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2357,4 +2357,4 @@ func (s *adminServer) hasAdminRole(ctx context.Context, sessionUser string) (boo
 	return bool(dbDatum), nil
 }
 
-var errInsufficientPrivilege = errors.New("this operation requires admin privilege")
+var errInsufficientPrivilege = status.Error(codes.PermissionDenied, "this operation requires admin privilege")


### PR DESCRIPTION
Fixes #45275.
This was discussed (and agreed upon) with @nstewart and @piyush-singh.

Release note (security update): Non-licensed users are now
able to add more principals to the special superuser role/group
`admin`. (Creation of additional roles is still a licensed feature.)

Release note (sql change): It is now possible to use `GRANT` and
`REVOKE` to add users to the `admin` role without a valid
license. This change aims to enable use of the admin UI and other
privileged features without a license.