### PR TITLE
changefeedccl: add support for gzip compression

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -172,7 +172,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	nodeID := ca.flowCtx.EvalCtx.NodeID
 	var err error
 	if ca.sink, err = getSink(
-		ca.spec.Feed.SinkURI, nodeID, ca.spec.Feed.Opts, ca.spec.Feed.Targets,
+		ctx, ca.spec.Feed.SinkURI, nodeID, ca.spec.Feed.Opts, ca.spec.Feed.Targets,
 		ca.flowCtx.Cfg.Settings, timestampOracle, ca.flowCtx.Cfg.ExternalStorageFromURI,
 	); err != nil {
 		err = MarkRetryableError(err)
@@ -481,7 +481,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	// but the oracle is only used when emitting row updates.
 	var nilOracle timestampLowerBoundOracle
 	if cf.sink, err = getSink(
-		cf.spec.Feed.SinkURI, nodeID, cf.spec.Feed.Opts, cf.spec.Feed.Targets,
+		ctx, cf.spec.Feed.SinkURI, nodeID, cf.spec.Feed.Opts, cf.spec.Feed.Targets,
 		cf.flowCtx.Cfg.Settings, nilOracle, cf.flowCtx.Cfg.ExternalStorageFromURI,
 	); err != nil {
 		err = MarkRetryableError(err)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -250,7 +250,7 @@ func changefeedPlanHook(
 			nodeID := p.ExtendedEvalContext().NodeID
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
-				details.SinkURI, nodeID, details.Opts, details.Targets,
+				ctx, details.SinkURI, nodeID, details.Opts, details.Targets,
 				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
 			)
 			if err != nil {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -26,6 +26,7 @@ const (
 	OptResolvedTimestamps      = `resolved`
 	OptUpdatedTimestamps       = `updated`
 	OptDiff                    = `diff`
+	OptCompression             = `compression`
 
 	OptEnvelopeKeyOnly       EnvelopeType = `key_only`
 	OptEnvelopeRow           EnvelopeType = `row`
@@ -62,4 +63,5 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptResolvedTimestamps:      sql.KVStringOptAny,
 	OptUpdatedTimestamps:       sql.KVStringOptRequireNoValue,
 	OptDiff:                    sql.KVStringOptRequireNoValue,
+	OptCompression:             sql.KVStringOptRequireValue,
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -68,6 +68,7 @@ type Sink interface {
 }
 
 func getSink(
+	ctx context.Context,
 	sinkURI string,
 	nodeID roachpb.NodeID,
 	opts map[string]string,
@@ -189,7 +190,7 @@ func getSink(
 		q = url.Values{}
 		makeSink = func() (Sink, error) {
 			return makeCloudStorageSink(
-				u.String(), nodeID, fileSize, settings,
+				ctx, u.String(), nodeID, fileSize, settings,
 				opts, timestampOracle, makeExternalStorageFromURI,
 			)
 		}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -279,6 +279,7 @@ type cloudStorageSink struct {
 var cloudStorageSinkIDAtomic int64
 
 func makeCloudStorageSink(
+	ctx context.Context,
 	baseURI string,
 	nodeID roachpb.NodeID,
 	targetMaxFileSize int64,
@@ -333,7 +334,6 @@ func makeCloudStorageSink(
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 
-	ctx := context.TODO()
 	var err error
 	if s.es, err = makeExternalStorageFromURI(ctx, baseURI); err != nil {
 		return nil, err

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -10,11 +10,13 @@ package changefeedccl
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -50,7 +52,19 @@ func cloudStorageFormatTime(ts hlc.Timestamp) string {
 
 type cloudStorageSinkFile struct {
 	cloudStorageSinkKey
-	buf bytes.Buffer
+	codec   io.WriteCloser
+	rawSize int
+	buf     bytes.Buffer
+}
+
+var _ io.Writer = &cloudStorageSinkFile{}
+
+func (f *cloudStorageSinkFile) Write(p []byte) (int, error) {
+	f.rawSize += len(p)
+	if f.codec != nil {
+		return f.codec.Write(p)
+	}
+	return f.buf.Write(p)
 }
 
 // cloudStorageSink writes changefeed output to files in a cloud storage bucket
@@ -259,6 +273,8 @@ type cloudStorageSink struct {
 	ext           string
 	recordDelimFn func(io.Writer) error
 
+	compression string
+
 	es cloud.ExternalStorage
 
 	// These are fields to track information needed to output files based on the naming
@@ -275,6 +291,8 @@ type cloudStorageSink struct {
 	dataFilePartition string
 	prevFilename      string
 }
+
+const sinkCompressionGzip = "gzip"
 
 var cloudStorageSinkIDAtomic int64
 
@@ -334,6 +352,15 @@ func makeCloudStorageSink(
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 
+	if codec, ok := opts[changefeedbase.OptCompression]; ok && codec != "" {
+		if strings.EqualFold(codec, "gzip") {
+			s.compression = sinkCompressionGzip
+			s.ext = s.ext + ".gz"
+		} else {
+			return nil, errors.Errorf(`unsupported compression codec %q`, codec)
+		}
+	}
+
 	var err error
 	if s.es, err = makeExternalStorageFromURI(ctx, baseURI); err != nil {
 		return nil, err
@@ -352,6 +379,10 @@ func (s *cloudStorageSink) getOrCreateFile(
 	f := &cloudStorageSinkFile{
 		cloudStorageSinkKey: key,
 	}
+	switch s.compression {
+	case sinkCompressionGzip:
+		f.codec = gzip.NewWriter(&f.buf)
+	}
 	s.files.ReplaceOrInsert(f)
 	return f
 }
@@ -367,10 +398,10 @@ func (s *cloudStorageSink) EmitRow(
 	file := s.getOrCreateFile(table.Name, table.Version)
 
 	// TODO(dan): Memory monitoring for this
-	if _, err := file.buf.Write(value); err != nil {
+	if _, err := file.Write(value); err != nil {
 		return err
 	}
-	if err := s.recordDelimFn(&file.buf); err != nil {
+	if err := s.recordDelimFn(file); err != nil {
 		return err
 	}
 
@@ -467,10 +498,18 @@ func (s *cloudStorageSink) Flush(ctx context.Context) error {
 
 // file should not be used after flushing.
 func (s *cloudStorageSink) flushFile(ctx context.Context, file *cloudStorageSinkFile) error {
-	if file.buf.Len() == 0 {
+	if file.rawSize == 0 {
 		// This method shouldn't be called with an empty file, but be defensive
 		// about not writing empty files anyway.
 		return nil
+	}
+
+	// If the file is written via compression codec, close the codec to ensure it
+	// has flushed to the underlying buffer.
+	if file.codec != nil {
+		if err := file.codec.Close(); err != nil {
+			return err
+		}
 	}
 
 	// We use this monotonically increasing fileID to ensure correct ordering

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -87,7 +87,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		sinkDir := `golden`
 		s, err := makeCloudStorageSink(
-			`nodelocal:///`+sinkDir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+sinkDir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `single-node`
 		s, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -188,12 +188,12 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `multi-node`
 		s1, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s2, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 2, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 2, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -222,12 +222,12 @@ func TestCloudStorageSink(t *testing.T) {
 		// this happens before checkpointing, some data is written again but
 		// this is unavoidable.
 		s1R, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s2R, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 2, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 2, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -268,14 +268,14 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `zombie`
 		s1, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s1.(*cloudStorageSink).sinkID = 7         // Force a deterministic sinkID.
 		s1.(*cloudStorageSink).jobSessionID = "a" // Force deterministic job session ID.
 		s2, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `bucketing`
 		const targetMaxFileSize = 6
 		s, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, targetMaxFileSize,
+			ctx, `nodelocal:///`+dir, 1, targetMaxFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `file-ordering`
 		s, err := makeCloudStorageSink(
-			`nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 
@@ -456,7 +456,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `ordering-among-schema-versions`
 		var targetMaxFileSize int64 = 10
-		s, err := makeCloudStorageSink(`nodelocal:///`+dir, 1, targetMaxFileSize, settings,
+		s, err := makeCloudStorageSink(ctx, `nodelocal:///`+dir, 1, targetMaxFileSize, settings,
 			opts, timestampOracle, externalStorageFromURI)
 		require.NoError(t, err)
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -9,6 +9,8 @@
 package changefeedccl
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/blobs"
@@ -38,6 +41,19 @@ func TestCloudStorageSink(t *testing.T) {
 	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()
 
+	gzipDecompress := func(t *testing.T, compressed []byte) []byte {
+		r, err := gzip.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		decompressed, err := ioutil.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return decompressed
+	}
+
 	// slurpDir returns the contents of every file under root (relative to the
 	// temp dir created above), sorted by the name of the file.
 	slurpDir := func(t *testing.T, root string) []string {
@@ -53,6 +69,9 @@ func TestCloudStorageSink(t *testing.T) {
 			if err != nil {
 				return err
 			}
+			if strings.HasSuffix(path, ".gz") {
+				file = gzipDecompress(t, file)
+			}
 			files = append(files, string(file))
 			return nil
 		}
@@ -67,9 +86,10 @@ func TestCloudStorageSink(t *testing.T) {
 	settings := cluster.MakeTestingClusterSettings()
 	settings.ExternalIODir = dir
 	opts := map[string]string{
-		changefeedbase.OptFormat:     string(changefeedbase.OptFormatJSON),
-		changefeedbase.OptEnvelope:   string(changefeedbase.OptEnvelopeWrapped),
-		changefeedbase.OptKeyInValue: ``,
+		changefeedbase.OptFormat:      string(changefeedbase.OptFormatJSON),
+		changefeedbase.OptEnvelope:    string(changefeedbase.OptEnvelopeWrapped),
+		changefeedbase.OptKeyInValue:  ``,
+		changefeedbase.OptCompression: ``, // NB: overridden in single-node subtest.
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
 	e, err := makeJSONEncoder(opts)
@@ -107,77 +127,88 @@ func TestCloudStorageSink(t *testing.T) {
 		require.Equal(t, `{"resolved":"5.0000000000"}`, string(resolvedFile))
 	})
 	t.Run(`single-node`, func(t *testing.T) {
-		t1 := &sqlbase.TableDescriptor{Name: `t1`}
-		t2 := &sqlbase.TableDescriptor{Name: `t2`}
+		before := opts[changefeedbase.OptCompression]
+		// Compression codecs include buffering that interferes with other tests,
+		// e.g. the bucketing test that configures very small flush sizes.
+		defer func() {
+			opts[changefeedbase.OptCompression] = before
+		}()
+		for _, compression := range []string{"", "gzip"} {
+			opts[changefeedbase.OptCompression] = compression
+			t.Run("compress="+compression, func(t *testing.T) {
+				t1 := &sqlbase.TableDescriptor{Name: `t1`}
+				t2 := &sqlbase.TableDescriptor{Name: `t2`}
 
-		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
-		sf := span.MakeFrontier(testSpan)
-		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
-		dir := `single-node`
-		s, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI,
-		)
-		require.NoError(t, err)
-		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
+				testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+				sf := span.MakeFrontier(testSpan)
+				timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
+				dir := `single-node` + compression
+				s, err := makeCloudStorageSink(
+					ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+					settings, opts, timestampOracle, externalStorageFromURI,
+				)
+				require.NoError(t, err)
+				s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
-		// Empty flush emits no files.
-		require.NoError(t, s.Flush(ctx))
-		require.Equal(t, []string(nil), slurpDir(t, dir))
+				// Empty flush emits no files.
+				require.NoError(t, s.Flush(ctx))
+				require.Equal(t, []string(nil), slurpDir(t, dir))
 
-		// Emitting rows and flushing should write them out in one file per table. Note
-		// the ordering among these two files is non deterministic as either of them could
-		// be flushed first (and thus be assigned fileID 0).
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1)))
-		require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3)))
-		require.NoError(t, s.Flush(ctx))
-		expected := []string{
-			"v1\nv2\n",
-			"w1\n",
+				// Emitting rows and flushing should write them out in one file per table. Note
+				// the ordering among these two files is non deterministic as either of them could
+				// be flushed first (and thus be assigned fileID 0).
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1)))
+				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3)))
+				require.NoError(t, s.Flush(ctx))
+				expected := []string{
+					"v1\nv2\n",
+					"w1\n",
+				}
+				actual := slurpDir(t, dir)
+				sort.Strings(actual)
+				require.Equal(t, expected, actual)
+
+				// Flushing with no new emits writes nothing new.
+				require.NoError(t, s.Flush(ctx))
+				actual = slurpDir(t, dir)
+				sort.Strings(actual)
+				require.Equal(t, expected, actual)
+
+				// Without a flush, nothing new shows up.
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3)))
+				actual = slurpDir(t, dir)
+				sort.Strings(actual)
+				require.Equal(t, expected, actual)
+
+				// Note that since we haven't forwarded `testSpan` yet, all files initiated until
+				// this point must have the same `frontier` timestamp. Since fileID increases
+				// monotonically, the last file emitted should be ordered as such.
+				require.NoError(t, s.Flush(ctx))
+				require.Equal(t, []string{
+					"v3\n",
+				}, slurpDir(t, dir)[2:])
+
+				// Data from different versions of a table is put in different files, so that we
+				// can guarantee that all rows in any given file have the same schema.
+				// We also advance `testSpan` and `Flush` to make sure these new rows are read
+				// after the rows emitted above.
+				require.True(t, sf.Forward(testSpan, ts(4)))
+				require.NoError(t, s.Flush(ctx))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4)))
+				t1.Version = 2
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5)))
+				require.NoError(t, s.Flush(ctx))
+				expected = []string{
+					"v4\n",
+					"v5\n",
+				}
+				actual = slurpDir(t, dir)
+				actual = actual[len(actual)-2:]
+				sort.Strings(actual)
+				require.Equal(t, expected, actual)
+			})
 		}
-		actual := slurpDir(t, dir)
-		sort.Strings(actual)
-		require.Equal(t, expected, actual)
-
-		// Flushing with no new emits writes nothing new.
-		require.NoError(t, s.Flush(ctx))
-		actual = slurpDir(t, dir)
-		sort.Strings(actual)
-		require.Equal(t, expected, actual)
-
-		// Without a flush, nothing new shows up.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3)))
-		actual = slurpDir(t, dir)
-		sort.Strings(actual)
-		require.Equal(t, expected, actual)
-
-		// Note that since we haven't forwarded `testSpan` yet, all files initiated until
-		// this point must have the same `frontier` timestamp. Since fileID increases
-		// monotonically, the last file emitted should be ordered as such.
-		require.NoError(t, s.Flush(ctx))
-		require.Equal(t, []string{
-			"v3\n",
-		}, slurpDir(t, dir)[2:])
-
-		// Data from different versions of a table is put in different files, so that we
-		// can guarantee that all rows in any given file have the same schema.
-		// We also advance `testSpan` and `Flush` to make sure these new rows are read
-		// after the rows emitted above.
-		require.True(t, sf.Forward(testSpan, ts(4)))
-		require.NoError(t, s.Flush(ctx))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4)))
-		t1.Version = 2
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5)))
-		require.NoError(t, s.Flush(ctx))
-		expected = []string{
-			"v4\n",
-			"v5\n",
-		}
-		actual = slurpDir(t, dir)
-		actual = actual[len(actual)-2:]
-		sort.Strings(actual)
-		require.Equal(t, expected, actual)
 	})
 
 	t.Run(`multi-node`, func(t *testing.T) {


### PR DESCRIPTION
This adds support for requesting data files written to cloud storage sinks
be compressed using gzip.

Fixes #43103.

Release note (enterprise change): CDC to cloud-storage sinks now supports optional gzip compression.
