### PR TITLE
jobs: missing descIDs in job payload should not prevent jobs from GC

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -476,6 +476,12 @@ func (r *Registry) isOrphaned(ctx context.Context, payload *jobspb.Payload) (boo
 			pendingMutations = hasAnyMutations || hasDropJob
 			return nil
 		}); err != nil {
+			if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+				// Treat missing table descriptors as no longer relevant for the
+				// job payload. See
+				// https://github.com/cockroachdb/cockroach/45399.
+				continue
+			}
 			return false, err
 		}
 		if pendingMutations {

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -265,7 +265,10 @@ CREATE DATABASE IF NOT EXISTS t; CREATE TABLE IF NOT EXISTS t.to_be_mutated AS S
 			Lease:       &jobspb.Lease{NodeID: 1, Epoch: 1},
 			// register a mutation on the table so that jobs that reference
 			// the table are not considered orphaned
-			DescriptorIDs:  []sqlbase.ID{descriptorID},
+			DescriptorIDs: []sqlbase.ID{
+				descriptorID,
+				sqlbase.InvalidID, // invalid id to test handling of missing descriptors.
+			},
 			Details:        jobspb.WrapPayloadDetails(jobspb.SchemaChangeDetails{}),
 			StartedMicros:  timeutil.ToUnixMicros(created),
 			FinishedMicros: timeutil.ToUnixMicros(finished),


### PR DESCRIPTION
Touches https://github.com/cockroachlabs/support/issues/365.

Release note (bug fix): When considering if a job should be orphaned we
use to take the conservative approach when a descriptor ID pointing to
non-existent descriptor was found. This causes jobs to hang forever and
be garbage collected. We now disregard these IDs when considering if a
job has still work to do.