### PR TITLE
sql,opt: fix typing of NULLIF expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -205,19 +205,3 @@ query B
 SELECT '' BETWEEN ''::BYTES AND '';
 ----
 true
-
-# Regression test for #44632: NULLIF should have the type of the first argument.
-query I
-SELECT NULLIF(NULL, 0) + NULLIF(NULL, 0)
-----
-NULL
-
-query I
-SELECT NULLIF(0, 0) + NULLIF(0, 0)
-----
-NULL
-
-query I
-SELECT NULLIF(0, NULL) + NULLIF(0, NULL)
-----
-0

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -205,3 +205,24 @@ query B
 SELECT '' BETWEEN ''::BYTES AND '';
 ----
 true
+
+# Regression test for #44632.
+query I
+SELECT NULLIF(NULL, 0) + NULLIF(NULL, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, 0) + NULLIF(0, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, NULL) + NULLIF(0, NULL)
+----
+0
+
+query I
+SELECT IF(true, NULL, 1) + IF(false, 1, NULL)
+----
+NULL

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -210,7 +210,7 @@ case [type=int]
  └── const: 2 [type=int]
 
 build-scalar
-if(false, null, 1)
+if(false, NULL, 1)
 ----
 case [type=int]
  ├── false [type=bool]
@@ -218,6 +218,26 @@ case [type=int]
  │    ├── true [type=bool]
  │    └── null [type=unknown]
  └── const: 1 [type=int]
+
+build-scalar
+if(true, NULL, 1)
+----
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=unknown]
+ │    ├── true [type=bool]
+ │    └── null [type=unknown]
+ └── const: 1 [type=int]
+
+build-scalar
+if(false, 1, NULL)
+----
+case [type=int]
+ ├── false [type=bool]
+ ├── when [type=int]
+ │    ├── true [type=bool]
+ │    └── const: 1 [type=int]
+ └── null [type=unknown]
 
 build-scalar
 nullif(1, 2)
@@ -229,6 +249,28 @@ case [type=int]
  │    └── null [type=unknown]
  └── const: 1 [type=int]
 
+build-scalar
+nullif(NULL, 0)
+----
+case [type=int]
+ ├── cast: INT8 [type=int]
+ │    └── null [type=unknown]
+ ├── when [type=unknown]
+ │    ├── const: 0 [type=int]
+ │    └── null [type=unknown]
+ └── cast: INT8 [type=int]
+      └── null [type=unknown]
+
+build-scalar
+nullif(0, NULL)
+----
+case [type=int]
+ ├── const: 0 [type=int]
+ ├── when [type=unknown]
+ │    ├── null [type=unknown]
+ │    └── null [type=unknown]
+ └── const: 0 [type=int]
+
 build-scalar vars=(string)
 length(@1) = 2
 ----
@@ -236,7 +278,6 @@ eq [type=bool]
  ├── function: length [type=int]
  │    └── variable: @1 [type=string]
  └── const: 2 [type=int]
-
 
 build-scalar vars=(jsonb)
 @1 @> '{"a":1}'

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1019,15 +1019,13 @@ func (expr *NotExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, e
 
 // TypeCheck implements the Expr interface.
 func (expr *NullIfExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error) {
-	typedSubExprs, _, err := TypeCheckSameTypedExprs(ctx, desired, expr.Expr1, expr.Expr2)
+	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, desired, expr.Expr1, expr.Expr2)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible NULLIF expressions")
 	}
 
 	expr.Expr1, expr.Expr2 = typedSubExprs[0], typedSubExprs[1]
-
-	// The return type of NULLIF is the type of the first expression.
-	expr.typ = typedSubExprs[0].ResolvedType()
+	expr.typ = retType
 	return expr, nil
 }
 

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -68,7 +68,6 @@ func TestTypeCheck(t *testing.T) {
 		{`NULLIF(NULL, 2)`, `NULLIF(NULL, 2:::INT8)`},
 		{`NULLIF(2, NULL)`, `NULLIF(2:::INT8, NULL)`},
 		{`NULLIF((1, 2), (1, 3))`, `NULLIF((1:::INT8, 2:::INT8), (1:::INT8, 3:::INT8))`},
-		{`NULLIF(NULL, 0) + NULLIF(NULL, 0)`, `NULL`},
 		{`COALESCE(1, 2, 3, 4, 5)`, `COALESCE(1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8)`},
 		{`COALESCE(1, 2.0)`, `COALESCE(1:::DECIMAL, 2.0:::DECIMAL)`},
 		{`COALESCE(NULL, 2)`, `COALESCE(NULL, 2:::INT8)`},


### PR DESCRIPTION
**sql: fix TypeCheck for NULLIF**
This reverts commit 4c86310.

Typing of `NULLIF` was in fact correct before. The next commit will fix
the underlying issue that commit 4c86310 was trying to fix.

**opt: fix typing of NULLIF expressions**
Prior to this commit, the `optbuilder` converted `NULLIF(expr1, expr2)` expressions
to `CASE` expressions of the form:
```
  CASE expr1 WHEN expr2 THEN NULL ELSE expr1 END;
```
However, this was a problem when `expr1` was `NULL` and `expr2` was not, because
the `CASE` expression would have a different type than the original `NULLIF`
expression, causing an internal error. The solution is to add an explicit
cast around `expr1` inside the `CASE` expression so that it can be correctly typed.

For example, `NULLIF(NULL, 0)` now gets converted to:
```
  CASE NULL::INT WHEN 0 THEN NULL ELSE NULL::INT END;
```
Notice that the `NULL` corresponding to `expr1` is now explicitly casted to `INT`,
which is the type of the original `NULLIF` expression. This allows the type
inference logic for `CASE` to identify that the type of the `CASE` expression is
also `INT`.

Release note (bug fix): Fixed an internal error that could occur when
NULLIF was called with one null argument.
