### PR TITLE
colexec: fix a couple of issues with memory accounting

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -381,6 +381,12 @@ func (b *Bytes) Size() uintptr {
 		uintptr(cap(b.offsets))*sizeOfInt32
 }
 
+// ProportionalSize returns the size of the receiver in bytes that is
+// attributed to only first n out of Len() elements.
+func (b *Bytes) ProportionalSize(n int64) uintptr {
+	return FlatBytesOverhead + uintptr(len(b.data[:b.offsets[n]])) + uintptr(n)*sizeOfInt32
+}
+
 var zeroInt32Slice = make([]int32, BatchSize())
 
 // Reset resets the underlying Bytes for reuse. Note that this zeroes out the

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -33,14 +33,21 @@ type Allocator struct {
 	acc *mon.BoundAccount
 }
 
-func getVecsSize(vecs []coldata.Vec) int64 {
+func selVectorSize(capacity int) int64 {
+	return int64(capacity * sizeOfUint16)
+}
+
+func getVecMemoryFootprint(vec coldata.Vec) int64 {
+	if vec.Type() == coltypes.Bytes {
+		return int64(vec.Bytes().Size())
+	}
+	return int64(estimateBatchSizeBytes([]coltypes.T{vec.Type()}, vec.Capacity()))
+}
+
+func getVecsMemoryFootprint(vecs []coldata.Vec) int64 {
 	var size int64
 	for _, dest := range vecs {
-		if dest.Type() == coltypes.Bytes {
-			size += int64(dest.Bytes().Size())
-		} else {
-			size += int64(estimateBatchSizeBytes([]coltypes.T{dest.Type()}, dest.Capacity()))
-		}
+		size += getVecMemoryFootprint(dest)
 	}
 	return size
 }
@@ -55,15 +62,11 @@ func (a *Allocator) NewMemBatch(types []coltypes.T) coldata.Batch {
 	return a.NewMemBatchWithSize(types, int(coldata.BatchSize()))
 }
 
-func (a *Allocator) selVectorSize(capacity int) int64 {
-	return int64(capacity * sizeOfUint16)
-}
-
 // NewMemBatchWithSize allocates a new in-memory coldata.Batch with the given
 // column size.
 func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Batch {
-	estimatedStaticMemoryUsage := a.selVectorSize(size) + int64(estimateBatchSizeBytes(types, size))
-	if err := a.acc.Grow(a.ctx, estimatedStaticMemoryUsage); err != nil {
+	estimatedMemoryUsage := selVectorSize(size) + int64(estimateBatchSizeBytes(types, size))
+	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
 	return coldata.NewMemBatchWithSize(types, size)
@@ -73,24 +76,60 @@ func (a *Allocator) NewMemBatchWithSize(types []coltypes.T, size int) coldata.Ba
 // need to be used regularly, since most memory accounting necessary is done
 // through PerformOperation. Use this if you want to explicitly manage the
 // memory accounted for.
+// NOTE: when calculating memory footprint, this method looks at the capacities
+// of the vectors and does *not* pay attention to the length of the batch.
 func (a *Allocator) RetainBatch(b coldata.Batch) {
-	if err := a.acc.Grow(a.ctx, a.selVectorSize(cap(b.Selection()))+getVecsSize(b.ColVecs())); err != nil {
+	if b == coldata.ZeroBatch {
+		// coldata.ZeroBatch takes up no space but also doesn't support the change
+		// of the selection vector, so we need to handle it separately.
+		return
+	}
+	// We need to get the capacity of the internal selection vector, even if b
+	// currently doesn't use it, so we set selection to true and will reset
+	// below.
+	usesSel := b.Selection() != nil
+	b.SetSelection(true)
+	if err := a.acc.Grow(a.ctx, selVectorSize(cap(b.Selection()))+getVecsMemoryFootprint(b.ColVecs())); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
+	b.SetSelection(usesSel)
 }
 
 // ReleaseBatch releases the size of the batch from the memory account. This
 // shouldn't need to be used regularly, since all accounts are closed by
 // Flow.Cleanup. Use this if you want to explicitly manage the memory used. An
 // example of a use case is releasing a batch before writing it to disk.
+// NOTE: when calculating memory footprint, this method looks at the capacities
+// of the vectors and does *not* pay attention to the length of the batch.
 func (a *Allocator) ReleaseBatch(b coldata.Batch) {
-	a.acc.Shrink(a.ctx, a.selVectorSize(cap(b.Selection()))+getVecsSize(b.ColVecs()))
+	if b == coldata.ZeroBatch {
+		// coldata.ZeroBatch takes up no space but also doesn't support the change
+		// of the selection vector, so we need to handle it separately.
+		return
+	}
+	// We need to get the capacity of the internal selection vector, even if b
+	// currently doesn't use it, so we set selection to true and will reset
+	// below.
+	usesSel := b.Selection() != nil
+	b.SetSelection(true)
+	batchMemSize := selVectorSize(cap(b.Selection())) + getVecsMemoryFootprint(b.ColVecs())
+	if batchMemSize > a.acc.Used() {
+		// It appears to be possible that our estimation of the batch size when
+		// allocating a new batch is lower than our current estimate (maybe because
+		// we append to flat bytes), so reduce batchMemSize to clear out the
+		// account in such scenario.
+		// TODO(yuzefovich): I tried to debug to figure out why this happens to no
+		// success. See #45425.
+		batchMemSize = a.acc.Used()
+	}
+	a.acc.Shrink(a.ctx, batchMemSize)
+	b.SetSelection(usesSel)
 }
 
 // NewMemColumn returns a new coldata.Vec, initialized with a length.
 func (a *Allocator) NewMemColumn(t coltypes.T, n int) coldata.Vec {
-	estimatedStaticMemoryUsage := int64(estimateBatchSizeBytes([]coltypes.T{t}, n))
-	if err := a.acc.Grow(a.ctx, estimatedStaticMemoryUsage); err != nil {
+	estimatedMemoryUsage := int64(estimateBatchSizeBytes([]coltypes.T{t}, n))
+	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
 	return coldata.NewMemColumn(t, n)
@@ -117,8 +156,8 @@ func (a *Allocator) MaybeAddColumn(b coldata.Batch, t coltypes.T, colIdx int) {
 	for b.Width() < colIdx {
 		b.AppendCol(a.NewMemColumn(coltypes.Unhandled, 0))
 	}
-	estimatedStaticMemoryUsage := int64(estimateBatchSizeBytes([]coltypes.T{t}, int(coldata.BatchSize())))
-	if err := a.acc.Grow(a.ctx, estimatedStaticMemoryUsage); err != nil {
+	estimatedMemoryUsage := int64(estimateBatchSizeBytes([]coltypes.T{t}, int(coldata.BatchSize())))
+	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
 	col := a.NewMemColumn(t, int(coldata.BatchSize()))
@@ -134,12 +173,12 @@ func (a *Allocator) MaybeAddColumn(b coldata.Batch, t coltypes.T, colIdx int) {
 // NOTE: if some columnar vectors are not modified, they should not be included
 // in 'destVecs' to reduce the performance hit of memory accounting.
 func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
-	before := getVecsSize(destVecs)
+	before := getVecsMemoryFootprint(destVecs)
 	// To simplify the accounting, we perform the operation first and then will
 	// update the memory account. The minor "drift" in accounting that is
 	// caused by this approach is ok.
 	operation()
-	after := getVecsSize(destVecs)
+	after := getVecsMemoryFootprint(destVecs)
 
 	delta := after - before
 	if delta >= 0 {

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -798,13 +798,13 @@ func NewColOperator(
 							ctx, result.createBufferingUnlimitedMemAccount(
 								ctx, flowCtx, monitorNamePrefix,
 							))
-						standaloneAllocator := NewAllocator(
-							ctx, result.createStandaloneMemAccount(
-								ctx, flowCtx, monitorNamePrefix,
-							))
+						standaloneMemAccount := result.createStandaloneMemAccount(
+							ctx, flowCtx, monitorNamePrefix,
+						)
 						return newExternalSorter(
+							ctx,
 							unlimitedAllocator,
-							standaloneAllocator,
+							standaloneMemAccount,
 							input, inputTypes, core.Sorter.OutputOrdering,
 							execinfra.GetWorkMemLimit(flowCtx.Cfg),
 							args.TestingKnobs.MaxNumberPartitions,

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -123,7 +123,6 @@ func TestExternalSort(t *testing.T) {
 
 func TestExternalSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/45322")
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)


### PR DESCRIPTION
This commit fixes an issue of not correctly accounting for the selection
vector in `RetainBatch` / `ReleaseBatch` methods when the selection is
set to `false`.

Also, it fixes an issue with memory accounting in external sort when
we're dividing the input into partitions. Previously, we used
`RetainBatch` method to track the memory usage. However, that method
looks at the capacities of the vectors in the batch whereas in tests we
often have full-sizes vectors with the length of the batch being very
small. This caused external sorter to create a partition for every tuple
(if `batchSize` of 1 is used) which caused some tests to be extremely
slow. This is now fixed by accounting for the "portion" of the batch's
memory footprint proportional to the length of the batch.

Fixes: #45322.

Release note: None