### PR TITLE
storage/engine: add Pebble support for "rocksdb.min_wal_sync_interval"

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -348,6 +349,11 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 	// cfg.FS and cfg.ReadOnly later on.
 	cfg.Opts.EnsureDefaults()
 	cfg.Opts.ErrorIfNotExists = cfg.MustExist
+	if settings := cfg.Settings; settings != nil {
+		cfg.Opts.WALMinSyncInterval = func() time.Duration {
+			return minWALSyncInterval.Get(&settings.SV)
+		}
+	}
 
 	var auxDir string
 	if cfg.Dir == "" {


### PR DESCRIPTION
Hook up "rocksdb.min_wal_sync_interval" to
`pebble.Options.WALMinSyncInterval`. The Pebble support for
`WALMinSyncInterval` is currently buggy and will be fixed by
https://github.com/cockroachdb/pebble/pull/551.

Release note: None