### PR TITLE
 backupccl: allow picking a backup with AS OF SYSTEM time

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2378,27 +2378,50 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 
 		// fullBackup covers up to ts[2], inc to ts[5], inc2 to > ts[8].
 		sqlDB.ExpectErr(
-			t, "incompatible RESTORE timestamp",
+			t, "invalid RESTORE timestamp",
 			fmt.Sprintf(`RESTORE data.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='err'`, ts[3]),
 			fullBackup,
 		)
 
 		for _, i := range ts {
-			sqlDB.ExpectErr(
-				t, "incompatible RESTORE timestamp",
-				fmt.Sprintf(`RESTORE data.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
-				latestBackup,
-			)
 
-			sqlDB.ExpectErr(
-				t, "incompatible RESTORE timestamp",
-				fmt.Sprintf(`RESTORE data.* FROM $1, $2, $3 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
-				latestBackup, incLatestBackup, inc2LatestBackup,
-			)
+			if i == ts[2] {
+				// latestBackup is _at_ ts2 so that is the time, and the only time, at
+				// which restoring it is allowed.
+				sqlDB.Exec(
+					t, fmt.Sprintf(`RESTORE data.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
+					latestBackup,
+				)
+				sqlDB.Exec(t, `DROP DATABASE err; CREATE DATABASE err`)
+			} else {
+				sqlDB.ExpectErr(
+					t, "invalid RESTORE timestamp",
+					fmt.Sprintf(`RESTORE data.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
+					latestBackup,
+				)
+			}
+
+			if i == ts[2] || i == ts[5] {
+				// latestBackup is _at_ ts2 and incLatestBackup is at ts5, so either of
+				// those are valid for the chain (latest,incLatest,inc2Latest). In fact
+				// there's a third time -- that of inc2Latest, that is valid as well but
+				// it isn't fixed when created above so we know it / test for it.
+				sqlDB.Exec(
+					t, fmt.Sprintf(`RESTORE data.* FROM $1, $2, $3 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
+					latestBackup, incLatestBackup, inc2LatestBackup,
+				)
+				sqlDB.Exec(t, `DROP DATABASE err; CREATE DATABASE err`)
+			} else {
+				sqlDB.ExpectErr(
+					t, "invalid RESTORE timestamp",
+					fmt.Sprintf(`RESTORE data.* FROM $1, $2, $3 AS OF SYSTEM TIME %s WITH into_db='err'`, i),
+					latestBackup, incLatestBackup, inc2LatestBackup,
+				)
+			}
 		}
 
 		sqlDB.ExpectErr(
-			t, "incompatible RESTORE timestamp",
+			t, "invalid RESTORE timestamp",
 			fmt.Sprintf(`RESTORE data.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='err'`, after),
 			latestBackup,
 		)


### PR DESCRIPTION
This change extends the support for picking, via AS OF SYSTEM TIME, any
backup in the chain provided to RESTORE as the target to RESTORE to.

For revision-history backups, this already works: one can specify any
point in time covered anywhere in the chain, as long as the backup
covering that time has revision history. For non-revision-history
backups however, the only way to restore to a particular backup, say 'c'
from the chain ('a', 'b', 'c', 'd'), was to explicitly say `RESTORE FROM
a, b, c` and elide the rest of the chain from the RESTORE command.

In practice, when dealing with large numbers of incremental backups, is
is often easier to simply maintain the full list of backups and paste it
in its entirety than try to manage it by hand and specify a prefix.
Furthermore, with "appeandable" backups that automatically create and
discover the list of incremental layers implicitly rather than
specifying it by hand, there's not an option of specifying a prefix.

This change thus allows specifying the timestamp of a backup in the
chain provided to RESTORE by using AS OF SYSTEM TIME even if that backup
was *not* created with revision history to effectively truncate the
chain to that point, e.g. making it possible to say
`RESTORE FROM a, b, c, d AS OF SYSTEM TIME <ts of c>`.

Release note (enterprise change): RESTORE allows using AS OF SYSTEM TIME to pick a target backup from a larger list of incremental backups.