### PR TITLE
Makefile: pass GOTESTFLAGS=-json to `make testlogic`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1670,7 +1670,7 @@ $(testbins): bin/%: bin/%.d | bin/prereqs $(SUBMODULES_TARGET)
 	@echo go test -c $($*-package)
 	bin/prereqs -bin-name=$* -test $($*-package) > $@.d.tmp
 	mv -f $@.d.tmp $@.d
-	$(xgo) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o $@ $($*-package)
+	$(xgo) test $(GOTESTFLAGS) $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o $@ $($*-package)
 
 bin/prereqs: ./pkg/cmd/prereqs/*.go | bin/.submodules-initialized
 	@echo go install -v ./pkg/cmd/prereqs


### PR DESCRIPTION
testlogic has some arcane magic, which of course broke things: it wasn't
picking up the GOTESTFLAGS variable, which ultimately means that TC was
expecting JSON output but wasn't getting it. This commit fixes it.

Release note: None