### PR TITLE
release-19.2: sql,opt: fix typing of NULLIF expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -207,3 +207,24 @@ query B
 SELECT '' BETWEEN ''::BYTES AND '';
 ----
 true
+
+# Regression test for #44632.
+query I
+SELECT NULLIF(NULL, 0) + NULLIF(NULL, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, 0) + NULLIF(0, 0)
+----
+NULL
+
+query I
+SELECT NULLIF(0, NULL) + NULLIF(0, NULL)
+----
+0
+
+query I
+SELECT IF(true, NULL, 1) + IF(false, 1, NULL)
+----
+NULL

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -308,7 +308,12 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructNot(input)
 
 	case *tree.NullIfExpr:
-		input := b.buildScalar(t.Expr1.(tree.TypedExpr), inScope, nil, nil, colRefs)
+		// Ensure that the type of the first expression matches the resolved type
+		// of the NULLIF expression so that type inference will be correct in the
+		// CASE expression constructed below. For example, the type of
+		// NULLIF(NULL, 0) should be int.
+		expr1, _ := tree.ReType(t.Expr1.(tree.TypedExpr), t.ResolvedType())
+		input := b.buildScalar(expr1, inScope, nil, nil, colRefs)
 		cond := b.buildScalar(t.Expr2.(tree.TypedExpr), inScope, nil, nil, colRefs)
 		whens := memo.ScalarListExpr{b.factory.ConstructWhen(cond, memo.NullSingleton)}
 		out = b.factory.ConstructCase(input, whens, input)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -212,7 +212,7 @@ case [type=int]
  └── const: 2 [type=int]
 
 build-scalar
-if(false, null, 1)
+if(false, NULL, 1)
 ----
 case [type=int]
  ├── false [type=bool]
@@ -220,6 +220,26 @@ case [type=int]
  │    ├── true [type=bool]
  │    └── null [type=unknown]
  └── const: 1 [type=int]
+
+build-scalar
+if(true, NULL, 1)
+----
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=unknown]
+ │    ├── true [type=bool]
+ │    └── null [type=unknown]
+ └── const: 1 [type=int]
+
+build-scalar
+if(false, 1, NULL)
+----
+case [type=int]
+ ├── false [type=bool]
+ ├── when [type=int]
+ │    ├── true [type=bool]
+ │    └── const: 1 [type=int]
+ └── null [type=unknown]
 
 build-scalar
 nullif(1, 2)
@@ -231,6 +251,28 @@ case [type=int]
  │    └── null [type=unknown]
  └── const: 1 [type=int]
 
+build-scalar
+nullif(NULL, 0)
+----
+case [type=int]
+ ├── cast: INT8 [type=int]
+ │    └── null [type=unknown]
+ ├── when [type=unknown]
+ │    ├── const: 0 [type=int]
+ │    └── null [type=unknown]
+ └── cast: INT8 [type=int]
+      └── null [type=unknown]
+
+build-scalar
+nullif(0, NULL)
+----
+case [type=int]
+ ├── const: 0 [type=int]
+ ├── when [type=unknown]
+ │    ├── null [type=unknown]
+ │    └── null [type=unknown]
+ └── const: 0 [type=int]
+
 build-scalar vars=(string)
 length(@1) = 2
 ----
@@ -238,7 +280,6 @@ eq [type=bool]
  ├── function: length [type=int]
  │    └── variable: @1 [type=string]
  └── const: 2 [type=int]
-
 
 build-scalar vars=(jsonb)
 @1 @> '{"a":1}'


### PR DESCRIPTION
Backport 1/2 commits from #45354.

/cc @cockroachdb/release

---

Prior to this commit, the `optbuilder` converted `NULLIF(expr1, expr2)` expressions
to `CASE` expressions of the form:
```
  CASE expr1 WHEN expr2 THEN NULL ELSE expr1 END;
```
However, this was a problem when `expr1` was `NULL` and `expr2` was not, because
the `CASE` expression would have a different type than the original `NULLIF`
expression, causing an internal error. The solution is to add an explicit
cast around `expr1` inside the `CASE` expression so that it can be correctly typed.

For example, `NULLIF(NULL, 0)` now gets converted to:
```
  CASE NULL::INT WHEN 0 THEN NULL ELSE NULL::INT END;
```
Notice that the `NULL` corresponding to `expr1` is now explicitly casted to `INT`,
which is the type of the original `NULLIF` expression. This allows the type
inference logic for `CASE` to identify that the type of the `CASE` expression is
also `INT`.

Release note (bug fix): Fixed an internal error that could occur when
NULLIF was called with one null argument.

