### PR TITLE
colexec: improve unordered distinct performance

### DIFF
--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -101,14 +101,18 @@ func TestDistinct(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
-			func(input []Operator) (Operator, error) {
-				return NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
-			})
-		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier,
-			func(input []Operator) (Operator, error) {
-				return NewUnorderedDistinct(testAllocator, input[0], tc.distinctCols, tc.colTypes), nil
-			})
+		t.Run("ordered", func(t *testing.T) {
+			runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
+				func(input []Operator) (Operator, error) {
+					return NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
+				})
+		})
+		t.Run("unordered", func(t *testing.T) {
+			runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier,
+				func(input []Operator) (Operator, error) {
+					return NewUnorderedDistinct(testAllocator, input[0], tc.distinctCols, tc.colTypes), nil
+				})
+		})
 	}
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -44,6 +44,10 @@ func genHashTable(wr io.Writer) error {
 		s,
 		`{{template "checkColBody" buildDict "Global" .Global "UseSel" .UseSel "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9}}`)
 
+	checkBody := makeFunctionRegex("_CHECK_BODY", 1)
+	s = checkBody.ReplaceAllString(s,
+		`{{template "checkBody" buildDict "Global" . "IsHashTableInFullMode" $1}}`)
+
 	s = replaceManipulationFuncs(".Global.LTyp", s)
 
 	tmpl, err := template.New("hashtable").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -232,6 +232,7 @@ func (hj *hashJoiner) Init() {
 		hj.spec.right.eqCols,
 		hj.spec.right.outCols,
 		false, /* allowNullEquality */
+		hashTableFullMode,
 	)
 
 	hj.exportBufferedState.rightWindowedBatch = hj.allocator.NewMemBatchWithSize(hj.spec.right.sourceTypes, 0 /* size */)

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -33,6 +33,7 @@ func NewUnorderedDistinct(
 		distinctCols,
 		outCols,
 		true, /* allowNullEquality */
+		hashTableDistinctMode,
 	)
 
 	return &unorderedDistinct{
@@ -77,7 +78,7 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 	if !op.buildFinished {
 		op.buildFinished = true
 		op.ht.build(ctx, op.input)
-		op.ht.findSameTuples(ctx)
+		op.ht.findTupleGroups(ctx)
 	}
 
 	// The selection vector needs to be populated before any batching can be


### PR DESCRIPTION
Improve unordered distinct operator performance by skipping populating the `same` array in hash table. 

Performance comparison: 

```
name                                                      old time/op    new time/op     delta
UnorderedDistinct/numCols=1/nulls=false/numBatches=1-8      64.1µs ± 0%     45.3µs ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=false/numBatches=16-8     1.23ms ± 0%     0.90ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=false/numBatches=256-8    46.5ms ± 0%     25.4ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=1-8        115µs ± 0%       73µs ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=16-8      2.00ms ± 0%     1.33ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=256-8     92.1ms ± 0%     50.6ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=false/numBatches=16-8     1.79ms ± 0%     1.38ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=false/numBatches=256-8    83.1ms ± 0%     40.7ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=true/numBatches=1-8        169µs ± 0%      124µs ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=true/numBatches=16-8      3.19ms ± 0%     2.36ms ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=true/numBatches=256-8      116ms ± 0%      115ms ± 0%   ~     (p=1.000 n=1+1)

name                                                      old speed      new speed       delta
UnorderedDistinct/numCols=1/nulls=false/numBatches=1-8     128MB/s ± 0%    181MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=false/numBatches=16-8    107MB/s ± 0%    145MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=false/numBatches=256-8  45.1MB/s ± 0%   82.6MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=1-8     71.5MB/s ± 0%  112.1MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=16-8    65.6MB/s ± 0%   98.9MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=1/nulls=true/numBatches=256-8   22.8MB/s ± 0%   41.5MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=false/numBatches=16-8    146MB/s ± 0%    190MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=false/numBatches=256-8  50.5MB/s ± 0%  103.1MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=true/numBatches=1-8     97.2MB/s ± 0%  131.6MB/s ± 0%   ~     (p=1.000 n=1+1)
UnorderedDistinct/numCols=2/nulls=true/numBatches=16-8    82.0MB/s ± 0%  111.2MB/s ± 0%   ~     (p=1.000 n=1+1)
```

Improves #44404 

Release note: None