### PR TITLE
release-19.2: roleccl: enable GRANT/REVOKE for roles without a license

### DIFF
--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -78,11 +78,11 @@ func grantRolePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "GRANT <role>",
-		); err != nil {
-			return err
-		}
+		// Note: we do not check the license for GRANT <role>, only for
+		// CREATE/DROP <role>. This is because we want to allow
+		// non-licensed users to add/remove users from the admin role, so
+		// they can grant administrative privileges to user accounts that
+		// are not superusers like "root".
 
 		if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
 			return err
@@ -223,11 +223,11 @@ func revokeRolePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "REVOKE <role>",
-		); err != nil {
-			return err
-		}
+		// Note: we do not check the license for REVOKE <role>, only for
+		// CREATE/DROP <role>. This is because we want to allow
+		// non-licensed users to add/remove users from the admin role, so
+		// they can grant administrative privileges to user accounts that
+		// are not superusers like "root".
 
 		if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
 			return err


### PR DESCRIPTION
Backport 1/2 commits from #45325.

/cc @cockroachdb/release

---

Fixes #45275.
This was discussed (and agreed upon) with @nstewart and @piyush-singh.
