### PR TITLE
ui: remove mention of RocksDB, now that Pebble may be in use

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -124,7 +124,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Compaction Queue"
       sources={storeSources}
-      tooltip={`The completed (or estimated) bytes of storage that were (or could be) reclaimed by forcing RocksDB compactions.`}
+      tooltip={`The completed (or estimated) bytes of storage that were (or could be) reclaimed by forcing compactions.`}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
         <Metric name="cr.store.compactor.suggestionbytes.compacted" title="Bytes compacted / sec" nonNegativeRate />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -129,11 +129,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="RocksDB Read Amplification"
+      title="Read Amplification"
       sources={storeSources}
       tooltip={
-        `RocksDB read amplification statistic; measures the average number of real read operations
-           executed per logical read operation ${tooltipSelection}.`
+        `The average number of real read operations executed per logical read operation ${tooltipSelection}.`
       }
     >
       <Axis label="factor">
@@ -142,9 +141,9 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="RocksDB SSTables"
+      title="SSTables"
       sources={storeSources}
-      tooltip={`The number of RocksDB SSTables in use ${tooltipSelection}.`}
+      tooltip={`The number of SSTables in use ${tooltipSelection}.`}
     >
       <Axis label="sstables">
         <Metric name="cr.store.rocksdb.num-sstables" title="SSTables" />
@@ -166,10 +165,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="RocksDB Compactions/Flushes"
+      title="Compactions/Flushes"
       sources={storeSources}
       tooltip={
-        `The number of RocksDB compactions and memtable flushes, per second ${tooltipSelection}.`
+        `The number of compactions and memtable flushes per second ${tooltipSelection}.`
       }
     >
       <Axis label="count">


### PR DESCRIPTION
It is no longer guaranteed that all or any nodes in a cluster are
running RocksDB. So remove mention of RocksDB from various graphs.

Release note (admin ui change): Remove mention of RocksDB from the Read
Amplification, SSTables, Compactions/Flushes, and Compaction Queue
graphs.