### PR TITLE
release-19.2: sql: fix a few issues with reporting of errors to sentry

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1336,7 +1336,7 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 			if ex.idleConn() {
 				// If we're about to close the connection, close res in order to flush
 				// now, as we won't have an opportunity to do it later.
-				res.Close(stateToTxnStatusIndicator(ex.machine.CurState()))
+				res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 				return errDrainingComplete
 			}
 		}
@@ -1395,10 +1395,10 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		if resErr == nil && ok {
 			// Depending on whether the result has the error already or not, we have
 			// to call either Close or CloseWithErr.
-			res.CloseWithErr(pe.errorCause())
+			res.CloseWithErr(ctx, pe.errorCause())
 		} else {
 			ex.recordError(ctx, resErr)
-			res.Close(stateToTxnStatusIndicator(ex.machine.CurState()))
+			res.Close(ctx, stateToTxnStatusIndicator(ex.machine.CurState()))
 		}
 	} else {
 		res.Discard()

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -86,8 +86,10 @@ type commandResult struct {
 	released bool
 }
 
+var _ sql.CommandResult = &commandResult{}
+
 // Close is part of the CommandResult interface.
-func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
+func (r *commandResult) Close(ctx context.Context, t sql.TransactionStatusIndicator) {
 	r.assertNotReleased()
 	defer r.release()
 	if r.errExpected && r.err == nil {
@@ -96,7 +98,7 @@ func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
 
 	r.conn.writerState.fi.registerCmd(r.pos)
 	if r.err != nil {
-		r.conn.bufferErr(r.err)
+		r.conn.bufferErr(ctx, r.err)
 		return
 	}
 
@@ -130,7 +132,7 @@ func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
 }
 
 // CloseWithErr is part of the CommandResult interface.
-func (r *commandResult) CloseWithErr(err error) {
+func (r *commandResult) CloseWithErr(ctx context.Context, err error) {
 	r.assertNotReleased()
 	defer r.release()
 	if r.err != nil {
@@ -138,7 +140,7 @@ func (r *commandResult) CloseWithErr(err error) {
 	}
 
 	r.conn.writerState.fi.registerCmd(r.pos)
-	r.conn.bufferErr(err)
+	r.conn.bufferErr(ctx, err)
 }
 
 // Discard is part of the CommandResult interface.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1149,10 +1149,8 @@ func (c *conn) bufferPortalSuspended() {
 	}
 }
 
-func (c *conn) bufferErr(err error) {
-	// TODO(andrei,knz): This would benefit from a context with the
-	// current connection log tags.
-	if err := writeErr(context.Background(), c.sv,
+func (c *conn) bufferErr(ctx context.Context, err error) {
+	if err := writeErr(ctx, c.sv,
 		err, &c.msgBuilder, &c.writerState.buf); err != nil {
 		panic(fmt.Sprintf("unexpected err from buffer: %s", err))
 	}


### PR DESCRIPTION
Backport 1/3 commits from #43301.

/cc @cockroachdb/release

---

**sql: use the correct context when recording an error for sentry**

Previously, context.Background() was used to record an internal error.
That context is missing the registered tags (e.g. 'statement' tag) which
results in an incomplete sentry report. Now this is fixed.

Release note: None
