### PR TITLE
tree: assume Location() to be UTC if SessionData is unset

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -147,3 +147,15 @@ INSERT INTO test.order VALUES (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0,
 
 query TTTTTTTT
 EXPERIMENTAL SCRUB TABLE test.order WITH OPTIONS PHYSICAL
+
+# Test that scrubbing timestamp works as expected.
+subtest regression_44992
+
+statement ok
+CREATE TABLE t0(c0 TIMESTAMP UNIQUE); INSERT INTO t0(c0) VALUES(TIMESTAMP '1969-1-1'); INSERT INTO t0(c0) VALUES(TIMESTAMP '1969-1-2')
+
+statement ok
+EXPERIMENTAL SCRUB TABLE t0
+
+statement ok
+DROP TABLE t0

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3019,7 +3019,7 @@ func (ctx *EvalContext) SetStmtTimestamp(ts time.Time) {
 
 // GetLocation returns the session timezone.
 func (ctx *EvalContext) GetLocation() *time.Location {
-	if ctx.SessionData.DataConversion.Location == nil {
+	if ctx.SessionData == nil || ctx.SessionData.DataConversion.Location == nil {
 		return time.UTC
 	}
 	return ctx.SessionData.DataConversion.Location


### PR DESCRIPTION
Resolves #44992 .

There are cases (especially in tests) when EvalContext has an unset
SessionData, including in `checkKeyOrdering` which is used by SCRUB.
Modify the function EvalContext.Location() to take this into account.

Release note (bug fix): Fix a bug where `EXPERIMENTAL SCRUB TABLE` on a
timestamp/timestamptz key does not work.