### PR TITLE
sqlbase: plumb DummyPrivilegedAccessor to relevant initializers

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -302,12 +302,13 @@ func (ds *ServerImpl) setupFlow(
 			Mon:         &monitor,
 			// Most processors will override this Context with their own context in
 			// ProcessorBase. StartInternal().
-			Context:          ctx,
-			Planner:          &sqlbase.DummyEvalPlanner{},
-			SessionAccessor:  &sqlbase.DummySessionAccessor{},
-			Sequence:         &sqlbase.DummySequenceOperators{},
-			InternalExecutor: ie,
-			Txn:              leafTxn,
+			Context:            ctx,
+			Planner:            &sqlbase.DummyEvalPlanner{},
+			SessionAccessor:    &sqlbase.DummySessionAccessor{},
+			PrivilegedAccessor: &sqlbase.DummyPrivilegedAccessor{},
+			Sequence:           &sqlbase.DummySequenceOperators{},
+			InternalExecutor:   ie,
+			Txn:                leafTxn,
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2431,10 +2431,11 @@ func createSchemaChangeEvalCtx(
 			InternalExecutor: ieFactory(ctx, sd),
 			// TODO(andrei): This is wrong (just like on the main code path on
 			// setupFlow). Each processor should override Ctx with its own context.
-			Context:         ctx,
-			Sequence:        &sqlbase.DummySequenceOperators{},
-			Planner:         &sqlbase.DummyEvalPlanner{},
-			SessionAccessor: &sqlbase.DummySessionAccessor{},
+			Context:            ctx,
+			Sequence:           &sqlbase.DummySequenceOperators{},
+			Planner:            &sqlbase.DummyEvalPlanner{},
+			SessionAccessor:    &sqlbase.DummySessionAccessor{},
+			PrivilegedAccessor: &sqlbase.DummyPrivilegedAccessor{},
 		},
 	}
 	// The backfill is going to use the current timestamp for the various

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3534,10 +3534,6 @@ may increase either contention or retry errors, or both.`,
 			Types:      tree.ArgTypes{{"parent_id", types.Int}, {"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if ctx.PrivilegedAccessor == nil {
-					return nil, errors.AssertionFailedf("PrivilegedAccessor not set")
-				}
-
 				parentID := tree.MustBeDInt(args[0])
 				name := tree.MustBeDString(args[1])
 				id, found, err := ctx.PrivilegedAccessor.LookupNamespaceID(
@@ -3565,10 +3561,6 @@ may increase either contention or retry errors, or both.`,
 			Types:      tree.ArgTypes{{"namespace_id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if ctx.PrivilegedAccessor == nil {
-					return nil, errors.AssertionFailedf("PrivilegedAccessor not set")
-				}
-
 				id := tree.MustBeDInt(args[0])
 				bytes, found, err := ctx.PrivilegedAccessor.LookupZoneConfigByNamespaceID(
 					ctx.Context,

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -110,6 +110,28 @@ func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error
 	return nil, errors.WithStack(errEvalPlanner)
 }
 
+// DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
+type DummyPrivilegedAccessor struct{}
+
+var _ tree.PrivilegedAccessor = &DummyPrivilegedAccessor{}
+
+var errEvalPrivileged = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,
+	"cannot evaluate privileged expressions in this context")
+
+// LookupNamespaceID is part of the tree.PrivilegedAccessor interface.
+func (ep *DummyPrivilegedAccessor) LookupNamespaceID(
+	ctx context.Context, parentID int64, name string,
+) (tree.DInt, bool, error) {
+	return 0, false, errors.WithStack(errEvalPrivileged)
+}
+
+// LookupZoneConfigByNamespaceID is part of the tree.PrivilegedAccessor interface.
+func (ep *DummyPrivilegedAccessor) LookupZoneConfigByNamespaceID(
+	ctx context.Context, id int64,
+) (tree.DBytes, bool, error) {
+	return "", false, errors.WithStack(errEvalPrivileged)
+}
+
 // DummySessionAccessor implements the tree.EvalSessionAccessor interface by returning errors.
 type DummySessionAccessor struct{}
 


### PR DESCRIPTION
Refs: #45408

No functional change but a help with debugging, initialize
PrivilegedAccessor with a dummy one much like we do with
SessionAccessor.

Release note: None