### PR TITLE
storage/concurrency: don't push reservation transactions

### DIFF
--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -900,7 +900,7 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 	const numActiveTxns = 8
 	var activeTxns [numActiveTxns]*enginepb.TxnMeta
 	var items []workloadItem
-	const numRequests = 20000
+	const numRequests = 1000
 	for i := 0; i < numRequests; i++ {
 		var txnMeta *enginepb.TxnMeta
 		var ts hlc.Timestamp
@@ -968,7 +968,7 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 	for _, c := range concurrency {
 		t.Run(fmt.Sprintf("concurrency %d", c), func(t *testing.T) {
 			exec := newWorkLoadExecutor(items, c)
-			if err := exec.execute(false, 2000); err != nil {
+			if err := exec.execute(false, 200); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
This commit updates the lockTableWaiter to no longer push reservation transactions. The waiter now only pushes the holders of conflicting locks that are held by other transactions.

This is because a transaction push will block until the pushee transaction has either committed or aborted. It is therefore not appropriate for cases where there is still a chance for the pusher to make progress without the pushee completing first. This is not true when the waiter is waiting on a held lock - the lock must be released before the waiter may proceed. However, it is true when the waiter is waiting on a reservation - the reservation holder may release the reservation without acquiring a lock, allowing the waiter to proceed without conflict.

This was the cause of deadlocks in some of the experiments I was running. The exact sequence I was running into was that:
1. key K had a lock wait-queue
2. txn A acquired a reservation for key K
3. txn B queued behind txn A, becoming the distinguished waiter
4. txn B began pushing txn A
5. txn A hit a WriteTooOld error and did not acquire a lock
6. txn A exited the lock wait-queue
7. txn A handled the WriteTooOld error, returned to key K, and queued behind txn B
8. txn B waited on txn A indefinitely in the txnWaitQueue
9. deadlock!