### PR TITLE
sql: fix error message when renaming databases with dependent sequences

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -124,7 +124,7 @@ SHOW TABLES FROM u
 ----
 kv
 
-statement error cannot rename database because view "t.public.v" depends on table "kv"
+statement error cannot rename database because relation "t.public.v" depends on relation "u.public.kv"
 ALTER DATABASE u RENAME TO v
 
 statement ok
@@ -136,7 +136,7 @@ ALTER DATABASE u RENAME TO v
 statement ok
 CREATE VIEW v.v AS SELECT k,v FROM v.kv
 
-statement error cannot rename database because view "v" depends on table "kv"
+statement error cannot rename database because relation "v.public.v" depends on relation "v.public.kv"
 ALTER DATABASE v RENAME TO u
 
 # Check that the default databases can be renamed like any other.
@@ -171,3 +171,19 @@ postgres
 system
 t
 v
+
+# Test dependent sequences on different databases upon renames
+# return the appropriate error message.
+subtest regression_45411
+
+statement ok
+CREATE DATABASE db1; CREATE SEQUENCE db1.seq
+
+statement ok
+CREATE DATABASE db2; CREATE TABLE db2.tbl (a int DEFAULT nextval('db1.seq'))
+
+statement error cannot rename database because relation "db2.public.tbl" depends on relation "db1.public.seq"
+ALTER DATABASE db1 RENAME TO db3
+
+statement ok
+DROP DATABASE db2 CASCADE; DROP DATABASE db1 CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -94,7 +94,7 @@ DROP DATABASE bob
 statement ok
 CREATE TEMP VIEW a_view AS SELECT a FROM bob.pg_temp.a
 
-statement error cannot rename database because view "defaultdb.pg_temp_.*.a_view" depends on table "a"
+statement error cannot rename database because relation "defaultdb.pg_temp_.*.a_view" depends on relation "bob.pg_temp_.*.a"
 ALTER DATABASE bob RENAME TO alice
 
 statement ok

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -73,7 +73,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{0}
 }
 
 type ForeignKeyReference_Action int32
@@ -118,7 +118,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{0, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -158,7 +158,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{0, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -195,7 +195,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{7, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{7, 0}
 }
 
 // The type of the index.
@@ -232,7 +232,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{7, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{7, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -275,7 +275,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{8, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{8, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -340,7 +340,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{10, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{10, 0}
 }
 
 // Direction of mutation.
@@ -383,7 +383,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{10, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{10, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -434,7 +434,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -471,7 +471,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 1}
 }
 
 type ForeignKeyReference struct {
@@ -493,7 +493,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -555,7 +555,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -602,7 +602,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{2}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -658,7 +658,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{3}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -704,7 +704,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{4}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -748,7 +748,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{4, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{5}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{5}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -848,7 +848,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{6}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{6}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -891,7 +891,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{6, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{6, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -936,7 +936,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{6, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{6, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1079,7 +1079,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{7}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{7}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1130,7 +1130,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{8}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{8}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1173,7 +1173,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{9}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{9}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1228,7 +1228,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{10}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{10}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1515,8 +1515,8 @@ type TableDescriptor struct {
 	// The IDs of all relations that this depends on.
 	// Only ever populated if this descriptor is for a view.
 	DependsOn []ID `protobuf:"varint,25,rep,name=dependsOn,casttype=ID" json:"dependsOn,omitempty"`
-	// All references to this table/view from other views in the system, tracked
-	// down to the column/index so that we can restrict changes to them while
+	// All references to this table/view from other views and sequences in the system,
+	// tracked down to the column/index so that we can restrict changes to them while
 	// they're still being referred to.
 	DependedOnBy []TableDescriptor_Reference `protobuf:"bytes,26,rep,name=dependedOnBy" json:"dependedOnBy"`
 	// Mutation jobs queued for execution in a FIFO order. Remains synchronized
@@ -1576,7 +1576,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1875,7 +1875,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1916,7 +1916,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 1}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2022,7 +2022,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 2}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2062,7 +2062,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 3}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2099,7 +2099,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 4}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2142,7 +2142,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 5}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2182,7 +2182,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 5, 0}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 5, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2222,7 +2222,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 6}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2259,7 +2259,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{11, 7}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{11, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2298,7 +2298,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{12}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{12}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2356,7 +2356,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_f235a9afe25f0869, []int{13}
+	return fileDescriptor_structured_40508478fa7fa1e8, []int{13}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -12084,10 +12084,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_f235a9afe25f0869)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_40508478fa7fa1e8)
 }
 
-var fileDescriptor_structured_f235a9afe25f0869 = []byte{
+var fileDescriptor_structured_40508478fa7fa1e8 = []byte{
 	// 3727 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5a, 0x4b, 0x6f, 0x23, 0x57,
 	0x76, 0x56, 0xf1, 0xcd, 0x53, 0x24, 0x55, 0xbc, 0x52, 0xb7, 0x69, 0xb9, 0x47, 0x54, 0xb3, 0xdd,

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -804,8 +804,8 @@ message TableDescriptor {
              (gogoproto.casttype) = "ColumnID"];
   }
 
-  // All references to this table/view from other views in the system, tracked
-  // down to the column/index so that we can restrict changes to them while
+  // All references to this table/view from other views and sequences in the system,
+  // tracked down to the column/index so that we can restrict changes to them while
   // they're still being referred to.
   repeated Reference dependedOnBy = 26 [(gogoproto.nullable) = false,
            (gogoproto.customname) = "DependedOnBy"];


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/cockroach/issues/45411

Release note (bug fix): Previously, renaming a database with dependent
views returned a misleading error message that implies it was a
dependent view on a dependent table. This PR renames the error message
generically to `cannot rename relation ... as it depends on relation
...` instead.