### PR TITLE
storage/engine: remove unused GetTickersAndHistograms function from Pebble

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -270,8 +270,7 @@ func TestStatusEngineStatsJson(t *testing.T) {
 	}
 
 	if engineStats.Stats[0].EngineType == enginepb.EngineTypePebble {
-		// TODO(hueypark): enable when Pebble.GetTickersAndHistograms is
-		// implemented.
+		// Pebble does not have RocksDB style TickersAnd Histogram.
 		return
 	}
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -349,10 +349,6 @@ type Engine interface {
 	GetCompactionStats() string
 	// GetStats retrieves stats from the engine.
 	GetStats() (*Stats, error)
-	// GetTickersAndHistograms retrieves maps of all RocksDB tickers and histograms.
-	// It differs from `GetStats` by getting _every_ ticker and histogram, and by not
-	// getting anything else (DB properties, for example).
-	GetTickersAndHistograms() (*enginepb.TickersAndHistograms, error)
 	// GetEncryptionRegistries returns the file and key registries when encryption is enabled
 	// on the store.
 	GetEncryptionRegistries() (*EncryptionRegistries, error)

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -564,12 +564,6 @@ func (p *Pebble) GetCompactionStats() string {
 	return "\n" + p.db.Metrics().String()
 }
 
-// GetTickersAndHistograms implements the Engine interface.
-func (p *Pebble) GetTickersAndHistograms() (*enginepb.TickersAndHistograms, error) {
-	// TODO(hueypark): Implement this.
-	return nil, nil
-}
-
 // GetProto implements the Engine interface.
 func (p *Pebble) GetProto(
 	key MVCCKey, msg protoutil.Message,

--- a/pkg/storage/engine/tee.go
+++ b/pkg/storage/engine/tee.go
@@ -261,11 +261,6 @@ func (t *TeeEngine) GetStats() (*Stats, error) {
 	return t.eng2.GetStats()
 }
 
-// GetTickersAndHistograms implements the Engine interface.
-func (t *TeeEngine) GetTickersAndHistograms() (*enginepb.TickersAndHistograms, error) {
-	return t.eng1.GetTickersAndHistograms()
-}
-
 // GetEncryptionRegistries implements the Engine interface.
 func (t *TeeEngine) GetEncryptionRegistries() (*EncryptionRegistries, error) {
 	return t.eng1.GetEncryptionRegistries()


### PR DESCRIPTION
See #42479

Release note: None