### PR TITLE
opt: remove conflicting input rows in ON CONFLICT DO NOTHING case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1143,3 +1143,46 @@ DROP TABLE source
 
 statement ok
 DROP TABLE target
+
+# ------------------------------------------------------------------------------
+# DO NOTHING with duplicate inputs.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE target (x INT PRIMARY KEY, y INT, z INT, UNIQUE (y, z))
+
+statement ok
+CREATE TABLE source (a INT, b INT, c INT)
+
+# Ensure that duplicates are removed from the input at runtime. NULL values are
+# never considered to be duplicates.
+statement ok
+INSERT INTO source
+VALUES
+    (1, 1, 2),
+    (1, 2, 1),
+    (1, 2, 2),
+    (2, 3, 3),
+    (4, 1, NULL),
+    (5, 1, NULL),
+    (6, NULL, NULL),
+    (7, NULL, NULL),
+    (3, 3, 3)
+
+statement ok
+INSERT INTO target SELECT * FROM source ON CONFLICT DO NOTHING
+
+query III rowsort
+SELECT * FROM target
+----
+1  1     2
+2  3     3
+4  1     NULL
+5  1     NULL
+6  NULL  NULL
+7  NULL  NULL
+
+statement ok
+DROP TABLE source
+
+statement ok
+DROP TABLE target

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -88,7 +88,7 @@ type Table interface {
 	WritableIndexCount() int
 
 	// DeletableIndexCount returns the number of public, write-only, and
-	// delete-onlyindexes defined on this table. DeletableIndexCount is always
+	// delete-only indexes defined on this table. DeletableIndexCount is always
 	// >= WritableIndexCount.
 	DeletableIndexCount() int
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1010,12 +1010,16 @@ func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
 	}
 	ep := execPlan{outputCols: input.outputCols}
 
-	// If this is UpsertDistinctOn, then treat NULL values as distinct and raise
-	// an error if any distinct grouping has more than one row.
+	// If this is UpsertDistinctOn, then treat NULL values as distinct.
 	var nullsAreDistinct bool
-	var errorOnDup string
 	if distinct.Op() == opt.UpsertDistinctOnOp {
 		nullsAreDistinct = true
+	}
+
+	// If duplicate input rows are not allowed, raise an error at runtime if
+	// duplicates are detected.
+	var errorOnDup string
+	if private.ErrorOnDup {
 		errorOnDup = sqlbase.DuplicateUpsertErrText
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -107,7 +107,7 @@ count                                         ·                      ·
                 └── distinct                  ·                      ·
                      │                        distinct on            k
                      │                        nulls are distinct     ·
-                     │                        error on dups          ·
+                     │                        error on duplicate     ·
                      └── render               ·                      ·
                           │                   render 0               CAST(NULL AS INT8)
                           │                   render 1               k
@@ -505,7 +505,7 @@ count                                 ·                      ·                
                      └── distinct     ·                      ·                                            (column1, column2, column3)                        ·
                           │           distinct on            column2, column3                             ·                                                  ·
                           │           nulls are distinct     ·                                            ·                                                  ·
-                          │           error on dups          ·                                            ·                                                  ·
+                          │           error on duplicate     ·                                            ·                                                  ·
                           └── values  ·                      ·                                            (column1, column2, column3)                        ·
 ·                                     size                   3 columns, 2 rows                            ·                                                  ·
 ·                                     row 0, expr 0          2                                            ·                                                  ·
@@ -561,7 +561,7 @@ count                               ·                      ·                  
                      └── distinct   ·                      ·                                      (x, y, z)                        ·
                           │         distinct on            y, z                                   ·                                ·
                           │         nulls are distinct     ·                                      ·                                ·
-                          │         error on dups          ·                                      ·                                ·
+                          │         error on duplicate     ·                                      ·                                ·
                           │         order key              y, z                                   ·                                ·
                           └── scan  ·                      ·                                      (x, y, z)                        +y,+z
 ·                                   table                  source@source_y_z_idx                  ·                                ·

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -293,6 +293,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if !f.HasFlags(ExprFmtHidePhysProps) && !private.Ordering.Any() {
 			tp.Childf("internal-ordering: %s", private.Ordering)
 		}
+		if !f.HasFlags(ExprFmtHideMiscProps) && private.ErrorOnDup {
+			tp.Childf("error-on-dup")
+		}
 
 	case *LimitExpr:
 		if !f.HasFlags(ExprFmtHidePhysProps) && !t.Ordering.Any() {

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -163,7 +163,7 @@ func ExtractJoinEqualityColumns(
 ) (leftEq opt.ColList, rightEq opt.ColList) {
 	for i := range on {
 		condition := on[i].Condition
-		ok, left, right := isJoinEquality(leftCols, rightCols, condition)
+		ok, left, right := ExtractJoinEquality(leftCols, rightCols, condition)
 		if !ok {
 			continue
 		}
@@ -193,7 +193,7 @@ func ExtractJoinEqualityFilters(leftCols, rightCols opt.ColSet, on FiltersExpr) 
 	var newFilters FiltersExpr
 	for i := range on {
 		condition := on[i].Condition
-		ok, _, _ := isJoinEquality(leftCols, rightCols, condition)
+		ok, _, _ := ExtractJoinEquality(leftCols, rightCols, condition)
 		if ok {
 			if newFilters != nil {
 				newFilters = append(newFilters, on[i])
@@ -222,7 +222,11 @@ func isVarEquality(condition opt.ScalarExpr) (leftVar, rightVar *VariableExpr, o
 	return nil, nil, false
 }
 
-func isJoinEquality(
+// ExtractJoinEquality returns true if the given condition is a simple equality
+// condition with two variables (e.g. a=b), where one of the variables (returned
+// as "left") is in the set of leftCols and the other (returned as "right") is
+// in the set of rightCols.
+func ExtractJoinEquality(
 	leftCols, rightCols opt.ColSet, condition opt.ScalarExpr,
 ) (ok bool, left, right opt.ColumnID) {
 	lvar, rvar, ok := isVarEquality(condition)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -84,6 +84,7 @@ project
            │    │    │    ├── upsert-distinct-on
            │    │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null)
            │    │    │    │    ├── grouping columns: y:6(int!null) column9:9(int!null)
+           │    │    │    │    ├── error-on-dup
            │    │    │    │    ├── cardinality: [0 - 1]
            │    │    │    │    ├── side-effects
            │    │    │    │    ├── key: ()
@@ -207,7 +208,7 @@ project
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── side-effects, mutations
  ├── key: (1)
- ├── fd: (1)-->(2,3), (2)-->(3)
+ ├── fd: (1)-->(2,3), (2)-->(3), (2,3)~~>(1)
  ├── prune: (1-3)
  └── insert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
@@ -218,165 +219,200 @@ project
       │    └── column8:8 => rowid:4
       ├── side-effects, mutations
       ├── key: (1)
-      ├── fd: (1)-->(2-4), (2)-->(3)
-      └── project
+      ├── fd: (1)-->(2-4), (2)-->(3), (4)~~>(1-3), (2,3)~~>(1,4)
+      └── upsert-distinct-on
            ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           ├── grouping columns: y:6(int) column9:9(int)
            ├── side-effects
            ├── key: (5)
-           ├── fd: (5)-->(6,8), (6)-->(9)
-           ├── prune: (5,6,8,9)
-           ├── interesting orderings: (+5) (+6)
-           └── select
-                ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-                ├── side-effects
-                ├── key: (5)
-                ├── fd: ()-->(18-21), (5)-->(6,8), (6)-->(9)
-                ├── prune: (5,8,18)
-                ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
-                ├── left-join (hash)
-                │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-                │    ├── side-effects
-                │    ├── key: (5,21)
-                │    ├── fd: (5)-->(6,8), (6)-->(9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
-                │    ├── prune: (5,8,18,21)
-                │    ├── reject-nulls: (18-21)
-                │    ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
-                │    ├── project
-                │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-                │    │    ├── side-effects
-                │    │    ├── key: (5)
-                │    │    ├── fd: (5)-->(6,8), (6)-->(9)
-                │    │    ├── prune: (5,6,8,9)
-                │    │    ├── interesting orderings: (+5) (+6)
-                │    │    └── select
-                │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-                │    │         ├── side-effects
-                │    │         ├── key: (5)
-                │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9)
-                │    │         ├── prune: (6,8,9,15-17)
-                │    │         ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
-                │    │         ├── left-join (hash)
-                │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-                │    │         │    ├── side-effects
-                │    │         │    ├── key: (5,17)
-                │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
-                │    │         │    ├── prune: (6,8,9,15-17)
-                │    │         │    ├── reject-nulls: (14-17)
-                │    │         │    ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
-                │    │         │    ├── project
-                │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-                │    │         │    │    ├── side-effects
-                │    │         │    │    ├── key: (5)
-                │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
-                │    │         │    │    ├── prune: (5,6,8,9)
-                │    │         │    │    ├── interesting orderings: (+5) (+6)
-                │    │         │    │    └── select
-                │    │         │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-                │    │         │    │         ├── side-effects
-                │    │         │    │         ├── key: (5)
-                │    │         │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
-                │    │         │    │         ├── prune: (5,6,9-12)
-                │    │         │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-                │    │         │    │         ├── left-join (hash)
-                │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-                │    │         │    │         │    ├── side-effects
-                │    │         │    │         │    ├── key: (5,13)
-                │    │         │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-                │    │         │    │         │    ├── prune: (5,6,9-12)
-                │    │         │    │         │    ├── reject-nulls: (10-13)
-                │    │         │    │         │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-                │    │         │    │         │    ├── project
-                │    │         │    │         │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
-                │    │         │    │         │    │    ├── side-effects
-                │    │         │    │         │    │    ├── key: (5)
-                │    │         │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
-                │    │         │    │         │    │    ├── prune: (5,6,8,9)
-                │    │         │    │         │    │    ├── interesting orderings: (+5) (+6)
-                │    │         │    │         │    │    ├── project
-                │    │         │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
-                │    │         │    │         │    │    │    ├── side-effects
-                │    │         │    │         │    │    │    ├── key: (5)
-                │    │         │    │         │    │    │    ├── fd: (5)-->(6,8)
-                │    │         │    │         │    │    │    ├── prune: (5,6,8)
-                │    │         │    │         │    │    │    ├── interesting orderings: (+5) (+6)
-                │    │         │    │         │    │    │    ├── project
-                │    │         │    │         │    │    │    │    ├── columns: x:5(int!null) y:6(int)
-                │    │         │    │         │    │    │    │    ├── key: (5)
-                │    │         │    │         │    │    │    │    ├── fd: (5)-->(6)
-                │    │         │    │         │    │    │    │    ├── prune: (5,6)
-                │    │         │    │         │    │    │    │    ├── interesting orderings: (+5) (+6)
-                │    │         │    │         │    │    │    │    └── scan xyz
-                │    │         │    │         │    │    │    │         ├── columns: x:5(int!null) y:6(int) z:7(int)
-                │    │         │    │         │    │    │    │         ├── key: (5)
-                │    │         │    │         │    │    │    │         ├── fd: (5)-->(6,7), (6,7)~~>(5)
-                │    │         │    │         │    │    │    │         ├── prune: (5-7)
-                │    │         │    │         │    │    │    │         └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
-                │    │         │    │         │    │    │    └── projections
-                │    │         │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
-                │    │         │    │         │    │    └── projections
-                │    │         │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
-                │    │         │    │         │    │              ├── variable: y:6 [type=int]
-                │    │         │    │         │    │              └── const: 1 [type=int]
-                │    │         │    │         │    ├── scan abc
-                │    │         │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
-                │    │         │    │         │    │    ├── computed column expressions
-                │    │         │    │         │    │    │    └── c:12
-                │    │         │    │         │    │    │         └── plus [type=int]
-                │    │         │    │         │    │    │              ├── variable: b:11 [type=int]
-                │    │         │    │         │    │    │              └── const: 1 [type=int]
-                │    │         │    │         │    │    ├── key: (13)
-                │    │         │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-                │    │         │    │         │    │    ├── prune: (10-13)
-                │    │         │    │         │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
-                │    │         │    │         │    └── filters
-                │    │         │    │         │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
-                │    │         │    │         │              ├── variable: column8:8 [type=int]
-                │    │         │    │         │              └── variable: rowid:13 [type=int]
-                │    │         │    │         └── filters
-                │    │         │    │              └── is [type=bool, outer=(13), constraints=(/13: [/NULL - /NULL]; tight), fd=()-->(13)]
-                │    │         │    │                   ├── variable: rowid:13 [type=int]
-                │    │         │    │                   └── null [type=unknown]
-                │    │         │    ├── scan abc
-                │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
-                │    │         │    │    ├── computed column expressions
-                │    │         │    │    │    └── c:16
-                │    │         │    │    │         └── plus [type=int]
-                │    │         │    │    │              ├── variable: b:15 [type=int]
-                │    │         │    │    │              └── const: 1 [type=int]
-                │    │         │    │    ├── key: (17)
-                │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
-                │    │         │    │    ├── prune: (14-17)
-                │    │         │    │    └── interesting orderings: (+17) (+14) (+15,+16,+17)
-                │    │         │    └── filters
-                │    │         │         └── eq [type=bool, outer=(5,14), constraints=(/5: (/NULL - ]; /14: (/NULL - ]), fd=(5)==(14), (14)==(5)]
-                │    │         │              ├── variable: x:5 [type=int]
-                │    │         │              └── variable: a:14 [type=int]
-                │    │         └── filters
-                │    │              └── is [type=bool, outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
-                │    │                   ├── variable: a:14 [type=int]
-                │    │                   └── null [type=unknown]
-                │    ├── scan abc
-                │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
-                │    │    ├── computed column expressions
-                │    │    │    └── c:20
-                │    │    │         └── plus [type=int]
-                │    │    │              ├── variable: b:19 [type=int]
-                │    │    │              └── const: 1 [type=int]
-                │    │    ├── key: (21)
-                │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
-                │    │    ├── prune: (18-21)
-                │    │    └── interesting orderings: (+21) (+18) (+19,+20,+21)
-                │    └── filters
-                │         ├── eq [type=bool, outer=(6,19), constraints=(/6: (/NULL - ]; /19: (/NULL - ]), fd=(6)==(19), (19)==(6)]
-                │         │    ├── variable: y:6 [type=int]
-                │         │    └── variable: b:19 [type=int]
-                │         └── eq [type=bool, outer=(9,20), constraints=(/9: (/NULL - ]; /20: (/NULL - ]), fd=(9)==(20), (20)==(9)]
-                │              ├── variable: column9:9 [type=int]
-                │              └── variable: c:20 [type=int]
-                └── filters
-                     └── is [type=bool, outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
-                          ├── variable: rowid:21 [type=int]
-                          └── null [type=unknown]
+           ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (6,9)~~>(5,8)
+           ├── project
+           │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    ├── side-effects
+           │    ├── key: (5)
+           │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
+           │    ├── prune: (5,6,8,9)
+           │    └── select
+           │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
+           │         ├── side-effects
+           │         ├── key: (5)
+           │         ├── fd: ()-->(18-21), (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
+           │         ├── prune: (18)
+           │         ├── interesting orderings: (+21) (+18) (+19,+20,+21)
+           │         ├── left-join (hash)
+           │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
+           │         │    ├── side-effects
+           │         │    ├── key: (5,21)
+           │         │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
+           │         │    ├── prune: (18,21)
+           │         │    ├── reject-nulls: (18-21)
+           │         │    ├── interesting orderings: (+21) (+18) (+19,+20,+21)
+           │         │    ├── upsert-distinct-on
+           │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │         │    │    ├── grouping columns: x:5(int!null)
+           │         │    │    ├── side-effects
+           │         │    │    ├── key: (5)
+           │         │    │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
+           │         │    │    ├── project
+           │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │         │    │    │    ├── side-effects
+           │         │    │    │    ├── key: (5)
+           │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
+           │         │    │    │    ├── prune: (5,6,8,9)
+           │         │    │    │    └── select
+           │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
+           │         │    │    │         ├── side-effects
+           │         │    │    │         ├── key: (5)
+           │         │    │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
+           │         │    │    │         ├── prune: (15-17)
+           │         │    │    │         ├── interesting orderings: (+17) (+14) (+15,+16,+17)
+           │         │    │    │         ├── left-join (hash)
+           │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
+           │         │    │    │         │    ├── side-effects
+           │         │    │    │         │    ├── key: (5,17)
+           │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
+           │         │    │    │         │    ├── prune: (15-17)
+           │         │    │    │         │    ├── reject-nulls: (14-17)
+           │         │    │    │         │    ├── interesting orderings: (+17) (+14) (+15,+16,+17)
+           │         │    │    │         │    ├── upsert-distinct-on
+           │         │    │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │         │    │    │         │    │    ├── grouping columns: column8:8(int)
+           │         │    │    │         │    │    ├── side-effects
+           │         │    │    │         │    │    ├── key: (5)
+           │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
+           │         │    │    │         │    │    ├── project
+           │         │    │    │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │         │    │    │         │    │    │    ├── side-effects
+           │         │    │    │         │    │    │    ├── key: (5)
+           │         │    │    │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │         │    │    │         │    │    │    ├── prune: (5,6,8,9)
+           │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
+           │         │    │    │         │    │    │    └── select
+           │         │    │    │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │         │    │    │         │    │    │         ├── side-effects
+           │         │    │    │         │    │    │         ├── key: (5)
+           │         │    │    │         │    │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
+           │         │    │    │         │    │    │         ├── prune: (5,6,9-12)
+           │         │    │    │         │    │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
+           │         │    │    │         │    │    │         ├── left-join (hash)
+           │         │    │    │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │         │    │    │         │    │    │         │    ├── side-effects
+           │         │    │    │         │    │    │         │    ├── key: (5,13)
+           │         │    │    │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │         │    │    │         │    │    │         │    ├── prune: (5,6,9-12)
+           │         │    │    │         │    │    │         │    ├── reject-nulls: (10-13)
+           │         │    │    │         │    │    │         │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
+           │         │    │    │         │    │    │         │    ├── project
+           │         │    │    │         │    │    │         │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
+           │         │    │    │         │    │    │         │    │    ├── side-effects
+           │         │    │    │         │    │    │         │    │    ├── key: (5)
+           │         │    │    │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │         │    │    │         │    │    │         │    │    ├── prune: (5,6,8,9)
+           │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+5) (+6)
+           │         │    │    │         │    │    │         │    │    ├── project
+           │         │    │    │         │    │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
+           │         │    │    │         │    │    │         │    │    │    ├── side-effects
+           │         │    │    │         │    │    │         │    │    │    ├── key: (5)
+           │         │    │    │         │    │    │         │    │    │    ├── fd: (5)-->(6,8)
+           │         │    │    │         │    │    │         │    │    │    ├── prune: (5,6,8)
+           │         │    │    │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
+           │         │    │    │         │    │    │         │    │    │    ├── project
+           │         │    │    │         │    │    │         │    │    │    │    ├── columns: x:5(int!null) y:6(int)
+           │         │    │    │         │    │    │         │    │    │    │    ├── key: (5)
+           │         │    │    │         │    │    │         │    │    │    │    ├── fd: (5)-->(6)
+           │         │    │    │         │    │    │         │    │    │    │    ├── prune: (5,6)
+           │         │    │    │         │    │    │         │    │    │    │    ├── interesting orderings: (+5) (+6)
+           │         │    │    │         │    │    │         │    │    │    │    └── scan xyz
+           │         │    │    │         │    │    │         │    │    │    │         ├── columns: x:5(int!null) y:6(int) z:7(int)
+           │         │    │    │         │    │    │         │    │    │    │         ├── key: (5)
+           │         │    │    │         │    │    │         │    │    │    │         ├── fd: (5)-->(6,7), (6,7)~~>(5)
+           │         │    │    │         │    │    │         │    │    │    │         ├── prune: (5-7)
+           │         │    │    │         │    │    │         │    │    │    │         └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
+           │         │    │    │         │    │    │         │    │    │    └── projections
+           │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
+           │         │    │    │         │    │    │         │    │    └── projections
+           │         │    │    │         │    │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
+           │         │    │    │         │    │    │         │    │              ├── variable: y:6 [type=int]
+           │         │    │    │         │    │    │         │    │              └── const: 1 [type=int]
+           │         │    │    │         │    │    │         │    ├── scan abc
+           │         │    │    │         │    │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+           │         │    │    │         │    │    │         │    │    ├── computed column expressions
+           │         │    │    │         │    │    │         │    │    │    └── c:12
+           │         │    │    │         │    │    │         │    │    │         └── plus [type=int]
+           │         │    │    │         │    │    │         │    │    │              ├── variable: b:11 [type=int]
+           │         │    │    │         │    │    │         │    │    │              └── const: 1 [type=int]
+           │         │    │    │         │    │    │         │    │    ├── key: (13)
+           │         │    │    │         │    │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │         │    │    │         │    │    │         │    │    ├── prune: (10-13)
+           │         │    │    │         │    │    │         │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
+           │         │    │    │         │    │    │         │    └── filters
+           │         │    │    │         │    │    │         │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
+           │         │    │    │         │    │    │         │              ├── variable: column8:8 [type=int]
+           │         │    │    │         │    │    │         │              └── variable: rowid:13 [type=int]
+           │         │    │    │         │    │    │         └── filters
+           │         │    │    │         │    │    │              └── is [type=bool, outer=(13), constraints=(/13: [/NULL - /NULL]; tight), fd=()-->(13)]
+           │         │    │    │         │    │    │                   ├── variable: rowid:13 [type=int]
+           │         │    │    │         │    │    │                   └── null [type=unknown]
+           │         │    │    │         │    │    └── aggregations
+           │         │    │    │         │    │         ├── first-agg [as=x:5, type=int, outer=(5)]
+           │         │    │    │         │    │         │    └── variable: x:5 [type=int]
+           │         │    │    │         │    │         ├── first-agg [as=y:6, type=int, outer=(6)]
+           │         │    │    │         │    │         │    └── variable: y:6 [type=int]
+           │         │    │    │         │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
+           │         │    │    │         │    │              └── variable: column9:9 [type=int]
+           │         │    │    │         │    ├── scan abc
+           │         │    │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
+           │         │    │    │         │    │    ├── computed column expressions
+           │         │    │    │         │    │    │    └── c:16
+           │         │    │    │         │    │    │         └── plus [type=int]
+           │         │    │    │         │    │    │              ├── variable: b:15 [type=int]
+           │         │    │    │         │    │    │              └── const: 1 [type=int]
+           │         │    │    │         │    │    ├── key: (17)
+           │         │    │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
+           │         │    │    │         │    │    ├── prune: (14-17)
+           │         │    │    │         │    │    └── interesting orderings: (+17) (+14) (+15,+16,+17)
+           │         │    │    │         │    └── filters
+           │         │    │    │         │         └── eq [type=bool, outer=(5,14), constraints=(/5: (/NULL - ]; /14: (/NULL - ]), fd=(5)==(14), (14)==(5)]
+           │         │    │    │         │              ├── variable: x:5 [type=int]
+           │         │    │    │         │              └── variable: a:14 [type=int]
+           │         │    │    │         └── filters
+           │         │    │    │              └── is [type=bool, outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
+           │         │    │    │                   ├── variable: a:14 [type=int]
+           │         │    │    │                   └── null [type=unknown]
+           │         │    │    └── aggregations
+           │         │    │         ├── first-agg [as=y:6, type=int, outer=(6)]
+           │         │    │         │    └── variable: y:6 [type=int]
+           │         │    │         ├── first-agg [as=column8:8, type=int, outer=(8)]
+           │         │    │         │    └── variable: column8:8 [type=int]
+           │         │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
+           │         │    │              └── variable: column9:9 [type=int]
+           │         │    ├── scan abc
+           │         │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
+           │         │    │    ├── computed column expressions
+           │         │    │    │    └── c:20
+           │         │    │    │         └── plus [type=int]
+           │         │    │    │              ├── variable: b:19 [type=int]
+           │         │    │    │              └── const: 1 [type=int]
+           │         │    │    ├── key: (21)
+           │         │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
+           │         │    │    ├── prune: (18-21)
+           │         │    │    └── interesting orderings: (+21) (+18) (+19,+20,+21)
+           │         │    └── filters
+           │         │         ├── eq [type=bool, outer=(6,19), constraints=(/6: (/NULL - ]; /19: (/NULL - ]), fd=(6)==(19), (19)==(6)]
+           │         │         │    ├── variable: y:6 [type=int]
+           │         │         │    └── variable: b:19 [type=int]
+           │         │         └── eq [type=bool, outer=(9,20), constraints=(/9: (/NULL - ]; /20: (/NULL - ]), fd=(9)==(20), (20)==(9)]
+           │         │              ├── variable: column9:9 [type=int]
+           │         │              └── variable: c:20 [type=int]
+           │         └── filters
+           │              └── is [type=bool, outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
+           │                   ├── variable: rowid:21 [type=int]
+           │                   └── null [type=unknown]
+           └── aggregations
+                ├── first-agg [as=x:5, type=int, outer=(5)]
+                │    └── variable: x:5 [type=int]
+                └── first-agg [as=column8:8, type=int, outer=(8)]
+                     └── variable: column8:8 [type=int]
 
 # UPSERT case.
 build
@@ -436,6 +472,7 @@ project
  │         │    │    ├── upsert-distinct-on
  │         │    │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null)
  │         │    │    │    ├── grouping columns: column7:7(int)
+ │         │    │    │    ├── error-on-dup
  │         │    │    │    ├── cardinality: [1 - 2]
  │         │    │    │    ├── side-effects
  │         │    │    │    ├── lax-key: (7)
@@ -580,6 +617,7 @@ upsert abc
       │    │    │    ├── upsert-distinct-on
       │    │    │    │    ├── columns: y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null)
       │    │    │    │    ├── grouping columns: y:6(int!null)
+      │    │    │    │    ├── error-on-dup
       │    │    │    │    ├── side-effects
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: ()-->(8,10), (6)-->(8-10)

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -40,6 +40,41 @@ CREATE TABLE uv (
 )
 ----
 
+# Table with multi-column key.
+exec-ddl
+CREATE TABLE mno (
+    m INT PRIMARY KEY,
+    n INT,
+    o INT,
+    UNIQUE (n, o)
+)
+----
+
+exec-ddl
+ALTER TABLE mno INJECT STATISTICS '[
+  {
+    "columns": ["m"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["n"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 100,
+    "null_count": 10
+  },
+  {
+    "columns": ["o"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 1900,
+    "null_count": 100
+  }
+]'
+----
+
 # Statistics should be derived from input columns and transferred to RETURNING
 # columns.
 build
@@ -86,13 +121,14 @@ with &1
  │         │    ├── fd: ()-->(8,12), (5)~~>(4), (9)-->(10,11)
  │         │    ├── left-join (hash)
  │         │    │    ├── columns: a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float)
- │         │    │    ├── stats: [rows=9.94974874, distinct(9)=6.31184239, null(9)=0]
+ │         │    │    ├── stats: [rows=9.94974874, distinct(9)=9.94974874, null(9)=0]
  │         │    │    ├── lax-key: (5,9)
  │         │    │    ├── fd: ()-->(8), (5)~~>(4), (9)-->(10,11)
  │         │    │    ├── upsert-distinct-on
  │         │    │    │    ├── columns: a:4(int!null) b:5(string) column8:8(float)
  │         │    │    │    ├── grouping columns: b:5(string)
- │         │    │    │    ├── stats: [rows=9.94974874, distinct(4)=6.31184239, null(4)=0, distinct(5)=6.31184239, null(5)=0]
+ │         │    │    │    ├── error-on-dup
+ │         │    │    │    ├── stats: [rows=9.94974874, distinct(4)=6.31184239, null(4)=0, distinct(5)=9.94974874, null(5)=0]
  │         │    │    │    ├── lax-key: (5)
  │         │    │    │    ├── fd: ()-->(8), (5)~~>(4,8)
  │         │    │    │    ├── project
@@ -215,26 +251,27 @@ upsert uv
  └── project
       ├── columns: upsert_u:11(int) upsert_v:12(int) z:6(int) column7:7(int) u:8(int) v:9(int) column10:10(int!null)
       ├── side-effects
-      ├── stats: [rows=1009.08174]
+      ├── stats: [rows=1000]
       ├── lax-key: (6,8)
       ├── fd: ()-->(10), (6)~~>(7), (8)-->(9), (9)~~>(8), (7,8)-->(11), (6,8)-->(12), (6,8)~~>(7,11)
       ├── project
       │    ├── columns: column10:10(int!null) z:6(int) column7:7(int) u:8(int) v:9(int)
       │    ├── side-effects
-      │    ├── stats: [rows=1009.08174]
+      │    ├── stats: [rows=1000]
       │    ├── lax-key: (6,8)
       │    ├── fd: ()-->(10), (6)~~>(7), (8)-->(9), (9)~~>(8)
       │    ├── left-join (hash)
       │    │    ├── columns: z:6(int) column7:7(int) u:8(int) v:9(int)
       │    │    ├── side-effects
-      │    │    ├── stats: [rows=1009.08174, distinct(9)=100, null(9)=10.0908174]
+      │    │    ├── stats: [rows=1000, distinct(9)=991, null(9)=10]
       │    │    ├── lax-key: (6,8)
       │    │    ├── fd: (6)~~>(7), (8)-->(9), (9)~~>(8)
       │    │    ├── upsert-distinct-on
       │    │    │    ├── columns: z:6(int) column7:7(int)
       │    │    │    ├── grouping columns: z:6(int)
+      │    │    │    ├── error-on-dup
       │    │    │    ├── side-effects
-      │    │    │    ├── stats: [rows=1000, distinct(6)=100, null(6)=10]
+      │    │    │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=10]
       │    │    │    ├── lax-key: (6)
       │    │    │    ├── fd: (6)~~>(7)
       │    │    │    ├── project
@@ -268,3 +305,72 @@ upsert uv
       └── projections
            ├── CASE WHEN u:8 IS NULL THEN column7:7 ELSE u:8 END [as=upsert_u:11, type=int, outer=(7,8)]
            └── CASE WHEN u:8 IS NULL THEN z:6 ELSE column10:10 END [as=upsert_v:12, type=int, outer=(6,8,10)]
+
+# Multiple conflict columns.
+# TODO(andyk): The null counts for the left join are surprisingly high. It's due
+# to the stats code deciding that the left join will only return a tiny number
+# of matches, which then implies all non-matches are NULL (due to null extending
+# behavior of left join). This will get better once we improve multi-column
+# stats.
+build
+INSERT INTO mno
+SELECT * FROM mno
+ON CONFLICT (n, o) DO UPDATE SET o = 5
+----
+upsert mno
+ ├── columns: <none>
+ ├── canary column: 7
+ ├── fetch columns: m:7(int) n:8(int) o:9(int)
+ ├── insert-mapping:
+ │    ├── m:4 => m:1
+ │    ├── n:5 => n:2
+ │    └── o:6 => o:3
+ ├── update-mapping:
+ │    └── upsert_o:13 => o:3
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── stats: [rows=0]
+ └── project
+      ├── columns: upsert_m:11(int) upsert_n:12(int) upsert_o:13(int) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int) column10:10(int!null)
+      ├── stats: [rows=2000]
+      ├── key: (4,7)
+      ├── fd: ()-->(10), (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7), (4,7)-->(11), (5,7,8)-->(12), (6,7)-->(13)
+      ├── project
+      │    ├── columns: column10:10(int!null) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int)
+      │    ├── stats: [rows=2000]
+      │    ├── key: (4,7)
+      │    ├── fd: ()-->(10), (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7)
+      │    ├── left-join (hash)
+      │    │    ├── columns: m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int)
+      │    │    ├── stats: [rows=2000, distinct(8)=21.0526316, null(8)=1988.94737, distinct(9)=21.0526316, null(9)=2000]
+      │    │    ├── key: (4,7)
+      │    │    ├── fd: (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7)
+      │    │    ├── upsert-distinct-on
+      │    │    │    ├── columns: m:4(int!null) n:5(int) o:6(int)
+      │    │    │    ├── grouping columns: n:5(int) o:6(int)
+      │    │    │    ├── error-on-dup
+      │    │    │    ├── stats: [rows=2000, distinct(4)=1981, null(4)=0, distinct(5)=100, null(5)=10, distinct(6)=1900, null(6)=100]
+      │    │    │    ├── key: (4)
+      │    │    │    ├── fd: (4)-->(5,6), (5,6)~~>(4)
+      │    │    │    ├── scan mno
+      │    │    │    │    ├── columns: m:4(int!null) n:5(int) o:6(int)
+      │    │    │    │    ├── stats: [rows=2000, distinct(5)=100, null(5)=10, distinct(6)=1900, null(6)=100, distinct(5,6)=1981, null(5,6)=20]
+      │    │    │    │    ├── key: (4)
+      │    │    │    │    └── fd: (4)-->(5,6), (5,6)~~>(4)
+      │    │    │    └── aggregations
+      │    │    │         └── first-agg [as=m:4, type=int, outer=(4)]
+      │    │    │              └── m:4 [type=int]
+      │    │    ├── scan mno
+      │    │    │    ├── columns: m:7(int!null) n:8(int) o:9(int)
+      │    │    │    ├── stats: [rows=2000, distinct(8)=100, null(8)=10, distinct(9)=1900, null(9)=100]
+      │    │    │    ├── key: (7)
+      │    │    │    └── fd: (7)-->(8,9), (8,9)~~>(7)
+      │    │    └── filters
+      │    │         ├── n:5 = n:8 [type=bool, outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
+      │    │         └── o:6 = o:9 [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
+      │    └── projections
+      │         └── 5 [as=column10:10, type=int]
+      └── projections
+           ├── CASE WHEN m:7 IS NULL THEN m:4 ELSE m:7 END [as=upsert_m:11, type=int, outer=(4,7)]
+           ├── CASE WHEN m:7 IS NULL THEN n:5 ELSE n:8 END [as=upsert_n:12, type=int, outer=(5,7,8)]
+           └── CASE WHEN m:7 IS NULL THEN o:6 ELSE column10:10 END [as=upsert_o:13, type=int, outer=(6,7,10)]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1897,7 +1897,7 @@ func (c *CustomFuncs) MakeArrayAggCol(typ *types.T) opt.ColumnID {
 }
 
 // MakeOrderedGrouping constructs a new GroupingPrivate using the given
-// grouping columns and OrderingChoice private.
+// grouping columns and OrderingChoice private. The ErrorOnDup will be false.
 func (c *CustomFuncs) MakeOrderedGrouping(
 	groupingCols opt.ColSet, ordering physical.OrderingChoice,
 ) *memo.GroupingPrivate {

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -627,7 +627,7 @@ func (c *CustomFuncs) EnsureAggsCanIgnoreNulls(
 }
 
 // MakeGrouping constructs a new unordered GroupingPrivate using the given
-// grouping columns.
+// grouping columns. ErrorOnDup is false.
 func (c *CustomFuncs) MakeGrouping(groupingCols opt.ColSet) *memo.GroupingPrivate {
 	return &memo.GroupingPrivate{GroupingCols: groupingCols}
 }
@@ -646,10 +646,9 @@ func (c *CustomFuncs) ExtractGroupingOrdering(
 func (c *CustomFuncs) AddColsToGrouping(
 	private *memo.GroupingPrivate, groupingCols opt.ColSet,
 ) *memo.GroupingPrivate {
-	return &memo.GroupingPrivate{
-		GroupingCols: private.GroupingCols.Union(groupingCols),
-		Ordering:     private.Ordering,
-	}
+	p := *private
+	p.GroupingCols = private.GroupingCols.Union(groupingCols)
+	return &p
 }
 
 // AddColsToPartition unions the given set of columns with a window private's

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -295,6 +295,7 @@ upsert nullablecols
       │    ├── upsert-distinct-on
       │    │    ├── columns: i:6!null
       │    │    ├── grouping columns: i:6!null
+      │    │    ├── error-on-dup
       │    │    ├── key: (6)
       │    │    └── select
       │    │         ├── columns: k:5!null i:6!null
@@ -557,6 +558,7 @@ upsert xy
       │    ├── upsert-distinct-on
       │    │    ├── columns: y:4 column5:5
       │    │    ├── grouping columns: y:4
+      │    │    ├── error-on-dup
       │    │    ├── lax-key: (4)
       │    │    ├── fd: ()-->(4,5)
       │    │    ├── project
@@ -608,6 +610,7 @@ upsert abc
       ├── upsert-distinct-on
       │    ├── columns: b:5!null "?column?":7!null "?column?":8!null
       │    ├── grouping columns: b:5!null
+      │    ├── error-on-dup
       │    ├── key: (5)
       │    ├── fd: ()-->(7,8)
       │    ├── project
@@ -660,6 +663,7 @@ upsert abc
       │    ├── upsert-distinct-on
       │    │    ├── columns: b:5!null c:6!null "?column?":7
       │    │    ├── grouping columns: c:6!null "?column?":7
+      │    │    ├── error-on-dup
       │    │    ├── lax-key: (6,7)
       │    │    ├── fd: ()-->(5,7)
       │    │    ├── project
@@ -1173,16 +1177,50 @@ values
 # Eliminate DistinctOn when Values operator is below Project, Select, and
 # LeftJoin operators.
 norm expect=EliminateDistinctOnValues
-SELECT DISTINCT ON (x) *, x+1
+SELECT DISTINCT ON (x, y, z) *, x+1
+FROM (VALUES (1, 2, 3), (4, 5, 6)) t(x, y, z)
+LEFT JOIN (SELECT a, b, c FROM abc)
+ON a=x AND b=y AND c=z
+WHERE x > 100 OR b > 100
+----
+project
+ ├── columns: x:1!null y:2!null z:3!null a:4 b:5 c:6 "?column?":7!null
+ ├── fd: (1)-->(7)
+ ├── select
+ │    ├── columns: column1:1!null column2:2!null column3:3!null a:4 b:5 c:6
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:1!null column2:2!null column3:3!null a:4 b:5 c:6
+ │    │    ├── cardinality: [2 - ]
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1!null column2:2!null column3:3!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── (1, 2, 3)
+ │    │    │    └── (4, 5, 6)
+ │    │    ├── scan abc
+ │    │    │    ├── columns: a:4!null b:5!null c:6!null
+ │    │    │    └── key: (4-6)
+ │    │    └── filters
+ │    │         ├── a:4 = column1:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    │         ├── b:5 = column2:2 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+ │    │         └── c:6 = column3:3 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │    └── filters
+ │         └── (column1:1 > 100) OR (b:5 > 100) [outer=(1,5)]
+ └── projections
+      └── column1:1 + 1 [as="?column?":7, outer=(1)]
+
+# Right input of left join does not have a key, so left side may have dups.
+norm expect-not=EliminateDistinctOnValues
+SELECT DISTINCT ON (x) *
 FROM (VALUES (1), (2)) t(x)
 LEFT JOIN (SELECT a FROM abc)
 ON a=x
-WHERE x IS NOT NULL
 ----
-project
- ├── columns: x:1!null a:2 "?column?":5!null
- ├── cardinality: [2 - ]
- ├── fd: (1)-->(5)
+distinct-on
+ ├── columns: x:1!null a:2
+ ├── grouping columns: column1:1!null
+ ├── cardinality: [1 - ]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
  ├── left-join (hash)
  │    ├── columns: column1:1!null a:2
  │    ├── cardinality: [2 - ]
@@ -1195,8 +1233,45 @@ project
  │    │    └── columns: a:2!null
  │    └── filters
  │         └── a:2 = column1:1 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
- └── projections
-      └── column1:1 + 1 [as="?column?":5, outer=(1)]
+ └── aggregations
+      └── first-agg [as=a:2, outer=(2)]
+           └── a:2
+
+# Left join does not join on all columns of the right input's key, so dups are
+# possible.
+norm expect-not=EliminateDistinctOnValues
+SELECT DISTINCT ON (x, y) *
+FROM (VALUES (1, 2), (3, 4)) t(x, y)
+LEFT JOIN (SELECT * FROM abc)
+ON x=a AND y=c
+----
+distinct-on
+ ├── columns: x:1!null y:2!null a:3 b:4 c:5
+ ├── grouping columns: column1:1!null column2:2!null
+ ├── cardinality: [1 - ]
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3-5)
+ ├── left-join (hash)
+ │    ├── columns: column1:1!null column2:2!null a:3 b:4 c:5
+ │    ├── cardinality: [2 - ]
+ │    ├── values
+ │    │    ├── columns: column1:1!null column2:2!null
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── (1, 2)
+ │    │    └── (3, 4)
+ │    ├── scan abc
+ │    │    ├── columns: a:3!null b:4!null c:5!null
+ │    │    └── key: (3-5)
+ │    └── filters
+ │         ├── column1:1 = a:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │         └── column2:2 = c:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+ └── aggregations
+      ├── first-agg [as=a:3, outer=(3)]
+      │    └── a:3
+      ├── first-agg [as=b:4, outer=(4)]
+      │    └── b:4
+      └── first-agg [as=c:5, outer=(5)]
+           └── c:5
 
 # Grouping columns are not passthrough Project columns.
 norm expect-not=EliminateDistinctOnValues
@@ -1441,6 +1516,7 @@ upsert a
       │    ├── upsert-distinct-on
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       │    │    ├── grouping columns: column2:7!null column3:8!null
+      │    │    ├── error-on-dup
       │    │    ├── cardinality: [1 - 3]
       │    │    ├── key: (7,8)
       │    │    ├── fd: ()-->(9,10), (7,8)-->(6,9,10)
@@ -1473,3 +1549,333 @@ upsert a
       │         └── column2:7 = s:14 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
       └── projections
            └── CASE WHEN k:11 IS NULL THEN column9:9 ELSE 1.0 END [as=upsert_f:19, outer=(9,11)]
+
+# DO NOTHING case where all distinct ops can be removed.
+norm expect=EliminateDistinctOnValues
+INSERT INTO a (k, s, i, f) VALUES (1, 'foo', 1, 1.0), (2, 'bar', 2, 2.0), (3, 'foo', 2, 1.0)
+ON CONFLICT DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => k:1
+ │    ├── column3:8 => i:2
+ │    ├── column4:9 => f:3
+ │    ├── column2:7 => s:4
+ │    └── column10:10 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10
+      ├── fd: ()-->(10)
+      └── select
+           ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+           ├── fd: ()-->(10,11,19,22)
+           ├── left-join (hash)
+           │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+           │    ├── fd: ()-->(10,11,19)
+           │    ├── select
+           │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+           │    │    ├── fd: ()-->(10,11,19)
+           │    │    ├── left-join (hash)
+           │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+           │    │    │    ├── fd: ()-->(10,11)
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    ├── fd: ()-->(10,11)
+           │    │    │    │    ├── left-join (hash)
+           │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    │    ├── cardinality: [3 - ]
+           │    │    │    │    │    ├── fd: ()-->(10)
+           │    │    │    │    │    ├── project
+           │    │    │    │    │    │    ├── columns: column10:10 column1:6!null column2:7!null column3:8!null column4:9!null
+           │    │    │    │    │    │    ├── cardinality: [3 - 3]
+           │    │    │    │    │    │    ├── fd: ()-->(10)
+           │    │    │    │    │    │    ├── values
+           │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+           │    │    │    │    │    │    │    ├── cardinality: [3 - 3]
+           │    │    │    │    │    │    │    ├── (1, 'foo', 1, 1.0)
+           │    │    │    │    │    │    │    ├── (2, 'bar', 2, 2.0)
+           │    │    │    │    │    │    │    └── (3, 'foo', 2, 1.0)
+           │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column10:10]
+           │    │    │    │    │    ├── scan a
+           │    │    │    │    │    │    ├── columns: k:11!null
+           │    │    │    │    │    │    └── key: (11)
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── column1:6 = k:11 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
+           │    │    │    │    └── filters
+           │    │    │    │         └── k:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
+           │    │    │    ├── scan a
+           │    │    │    │    ├── columns: i:17!null s:19!null
+           │    │    │    │    └── key: (17,19)
+           │    │    │    └── filters
+           │    │    │         ├── column2:7 = s:19 [outer=(7,19), constraints=(/7: (/NULL - ]; /19: (/NULL - ]), fd=(7)==(19), (19)==(7)]
+           │    │    │         └── column3:8 = i:17 [outer=(8,17), constraints=(/8: (/NULL - ]; /17: (/NULL - ]), fd=(8)==(17), (17)==(8)]
+           │    │    └── filters
+           │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
+           │    ├── scan a
+           │    │    ├── columns: i:22!null f:23
+           │    │    └── lax-key: (22,23)
+           │    └── filters
+           │         ├── column4:9 = f:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
+           │         └── column3:8 = i:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
+           └── filters
+                └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+
+# DO NOTHING case where one distinct op can be removed (k), but two others
+# can't: (s, i) and (f, i).
+norm expect=EliminateDistinctOnValues
+INSERT INTO a (k, s, f) VALUES (1, 'foo', 1.0), (2, 'bar', 2.0), (3, 'foo', 1.0)
+ON CONFLICT DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => k:1
+ │    ├── column9:9 => i:2
+ │    ├── column3:8 => f:3
+ │    ├── column2:7 => s:4
+ │    └── column10:10 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── upsert-distinct-on
+      ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
+      ├── grouping columns: column3:8!null column9:9
+      ├── lax-key: (8,9)
+      ├── fd: ()-->(9,10), (7,9)~~>(6,8), (8,9)~~>(6,7,10)
+      ├── select
+      │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
+      │    ├── lax-key: (7,9,22,23)
+      │    ├── fd: ()-->(9,10,22), (7,9)~~>(6,8)
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
+      │    │    ├── lax-key: (7,9,22,23)
+      │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8)
+      │    │    ├── upsert-distinct-on
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
+      │    │    │    ├── grouping columns: column2:7!null column9:9
+      │    │    │    ├── lax-key: (7,9)
+      │    │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8,10)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19
+      │    │    │    │    ├── fd: ()-->(9-11,19)
+      │    │    │    │    ├── left-join (hash)
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19
+      │    │    │    │    │    ├── fd: ()-->(9-11)
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11
+      │    │    │    │    │    │    ├── fd: ()-->(9-11)
+      │    │    │    │    │    │    ├── left-join (hash)
+      │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11
+      │    │    │    │    │    │    │    ├── cardinality: [3 - ]
+      │    │    │    │    │    │    │    ├── fd: ()-->(9,10)
+      │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    ├── columns: column9:9 column10:10 column1:6!null column2:7!null column3:8!null
+      │    │    │    │    │    │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(9,10)
+      │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    │    │    │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    │    │    │    │    │    │    ├── (1, 'foo', 1.0)
+      │    │    │    │    │    │    │    │    │    ├── (2, 'bar', 2.0)
+      │    │    │    │    │    │    │    │    │    └── (3, 'foo', 1.0)
+      │    │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │    │         ├── CAST(NULL AS INT8) [as=column9:9]
+      │    │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column10:10]
+      │    │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    │    │    ├── columns: k:11!null
+      │    │    │    │    │    │    │    │    └── key: (11)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── column1:6 = k:11 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── k:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
+      │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    ├── columns: i:17!null s:19!null
+      │    │    │    │    │    │    └── key: (17,19)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── column2:7 = s:19 [outer=(7,19), constraints=(/7: (/NULL - ]; /19: (/NULL - ]), fd=(7)==(19), (19)==(7)]
+      │    │    │    │    │         └── column9:9 = i:17 [outer=(9,17), constraints=(/9: (/NULL - ]; /17: (/NULL - ]), fd=(9)==(17), (17)==(9)]
+      │    │    │    │    └── filters
+      │    │    │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column1:6, outer=(6)]
+      │    │    │         │    └── column1:6
+      │    │    │         ├── first-agg [as=column3:8, outer=(8)]
+      │    │    │         │    └── column3:8
+      │    │    │         └── first-agg [as=column10:10, outer=(10)]
+      │    │    │              └── column10:10
+      │    │    ├── scan a
+      │    │    │    ├── columns: i:22!null f:23
+      │    │    │    └── lax-key: (22,23)
+      │    │    └── filters
+      │    │         ├── column3:8 = f:23 [outer=(8,23), constraints=(/8: (/NULL - ]; /23: (/NULL - ]), fd=(8)==(23), (23)==(8)]
+      │    │         └── column9:9 = i:22 [outer=(9,22), constraints=(/9: (/NULL - ]; /22: (/NULL - ]), fd=(9)==(22), (22)==(9)]
+      │    └── filters
+      │         └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+      └── aggregations
+           ├── first-agg [as=column1:6, outer=(6)]
+           │    └── column1:6
+           ├── first-agg [as=column2:7, outer=(7)]
+           │    └── column2:7
+           └── first-agg [as=column10:10, outer=(10)]
+                └── column10:10
+
+# DO NOTHING case where innermost distinct op cannot be removed (because it
+# groups on a non-constant column). Ensure that outer distinct ops can still be
+# removed.
+norm
+INSERT INTO a (k, s, i, f) VALUES (unique_rowid(), 'foo', 1, 1.0), (unique_rowid(), 'bar', 2, 2.0)
+ON CONFLICT DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => k:1
+ │    ├── column3:8 => i:2
+ │    ├── column4:9 => f:3
+ │    ├── column2:7 => s:4
+ │    └── column10:10 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
+      ├── side-effects
+      ├── fd: ()-->(10), (6)~~>(7-9)
+      └── select
+           ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
+           ├── side-effects
+           ├── lax-key: (6,17,19,22,23)
+           ├── fd: ()-->(10,19,22), (6)~~>(7-9)
+           ├── left-join (hash)
+           │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
+           │    ├── side-effects
+           │    ├── lax-key: (6,17,19,22,23)
+           │    ├── fd: ()-->(10,19), (6)~~>(7-9)
+           │    ├── select
+           │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
+           │    │    ├── side-effects
+           │    │    ├── lax-key: (6,17,19)
+           │    │    ├── fd: ()-->(10,19), (6)~~>(7-9)
+           │    │    ├── left-join (hash)
+           │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
+           │    │    │    ├── side-effects
+           │    │    │    ├── lax-key: (6,17,19)
+           │    │    │    ├── fd: ()-->(10), (6)~~>(7-9)
+           │    │    │    ├── upsert-distinct-on
+           │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
+           │    │    │    │    ├── grouping columns: column1:6
+           │    │    │    │    ├── side-effects
+           │    │    │    │    ├── lax-key: (6)
+           │    │    │    │    ├── fd: ()-->(10), (6)~~>(7-10)
+           │    │    │    │    ├── select
+           │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    ├── fd: ()-->(10,11)
+           │    │    │    │    │    ├── left-join (hash)
+           │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    │    │    ├── cardinality: [2 - ]
+           │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    ├── fd: ()-->(10)
+           │    │    │    │    │    │    ├── project
+           │    │    │    │    │    │    │    ├── columns: column10:10 column1:6 column2:7!null column3:8!null column4:9!null
+           │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+           │    │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    │    ├── fd: ()-->(10)
+           │    │    │    │    │    │    │    ├── values
+           │    │    │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null
+           │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+           │    │    │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
+           │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
+           │    │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column10:10]
+           │    │    │    │    │    │    ├── scan a
+           │    │    │    │    │    │    │    ├── columns: k:11!null
+           │    │    │    │    │    │    │    └── key: (11)
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── column1:6 = k:11 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── k:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
+           │    │    │    │    └── aggregations
+           │    │    │    │         ├── first-agg [as=column2:7, outer=(7)]
+           │    │    │    │         │    └── column2:7
+           │    │    │    │         ├── first-agg [as=column3:8, outer=(8)]
+           │    │    │    │         │    └── column3:8
+           │    │    │    │         ├── first-agg [as=column4:9, outer=(9)]
+           │    │    │    │         │    └── column4:9
+           │    │    │    │         └── first-agg [as=column10:10, outer=(10)]
+           │    │    │    │              └── column10:10
+           │    │    │    ├── scan a
+           │    │    │    │    ├── columns: i:17!null s:19!null
+           │    │    │    │    └── key: (17,19)
+           │    │    │    └── filters
+           │    │    │         ├── column2:7 = s:19 [outer=(7,19), constraints=(/7: (/NULL - ]; /19: (/NULL - ]), fd=(7)==(19), (19)==(7)]
+           │    │    │         └── column3:8 = i:17 [outer=(8,17), constraints=(/8: (/NULL - ]; /17: (/NULL - ]), fd=(8)==(17), (17)==(8)]
+           │    │    └── filters
+           │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
+           │    ├── scan a
+           │    │    ├── columns: i:22!null f:23
+           │    │    └── lax-key: (22,23)
+           │    └── filters
+           │         ├── column4:9 = f:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
+           │         └── column3:8 = i:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
+           └── filters
+                └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+
+# DO NOTHING case with explicit conflict columns (only add upsert-distinct-on
+# for one index).
+norm expect-not=EliminateDistinctOnValues
+INSERT INTO a (k, s, i) SELECT i, 'foo', i FROM a
+ON CONFLICT (s, i) DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── i:7 => k:1
+ │    ├── i:7 => i:2
+ │    ├── column12:12 => f:3
+ │    ├── "?column?":11 => s:4
+ │    └── column13:13 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── upsert-distinct-on
+      ├── columns: i:7!null "?column?":11!null column12:12 column13:13
+      ├── grouping columns: i:7!null
+      ├── key: (7)
+      ├── fd: ()-->(11-13)
+      ├── select
+      │    ├── columns: i:7!null "?column?":11!null column12:12 column13:13 i:15 s:17
+      │    ├── fd: ()-->(11-13,17)
+      │    ├── left-join (hash)
+      │    │    ├── columns: i:7!null "?column?":11!null column12:12 column13:13 i:15 s:17
+      │    │    ├── fd: ()-->(11-13)
+      │    │    ├── project
+      │    │    │    ├── columns: column12:12 column13:13 "?column?":11!null i:7!null
+      │    │    │    ├── fd: ()-->(11-13)
+      │    │    │    ├── scan a
+      │    │    │    │    └── columns: i:7!null
+      │    │    │    └── projections
+      │    │    │         ├── CAST(NULL AS FLOAT8) [as=column12:12]
+      │    │    │         ├── CAST(NULL AS JSONB) [as=column13:13]
+      │    │    │         └── 'foo' [as="?column?":11]
+      │    │    ├── select
+      │    │    │    ├── columns: i:15!null s:17!null
+      │    │    │    ├── key: (15)
+      │    │    │    ├── fd: ()-->(17)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: i:15!null s:17!null
+      │    │    │    │    └── key: (15,17)
+      │    │    │    └── filters
+      │    │    │         └── s:17 = 'foo' [outer=(17), constraints=(/17: [/'foo' - /'foo']; tight), fd=()-->(17)]
+      │    │    └── filters
+      │    │         └── i:7 = i:15 [outer=(7,15), constraints=(/7: (/NULL - ]; /15: (/NULL - ]), fd=(7)==(15), (15)==(7)]
+      │    └── filters
+      │         └── s:17 IS NULL [outer=(17), constraints=(/17: [/NULL - /NULL]; tight), fd=()-->(17)]
+      └── aggregations
+           ├── first-agg [as=column12:12, outer=(12)]
+           │    └── column12:12
+           ├── first-agg [as=column13:13, outer=(13)]
+           │    └── column13:13
+           └── const-agg [as="?column?":11, outer=(11)]
+                └── "?column?":11

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2628,6 +2628,7 @@ project
            │    ├── upsert-distinct-on
            │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13
            │    │    ├── grouping columns: column13:13
+           │    │    ├── error-on-dup
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── side-effects
            │    │    ├── key: ()

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -527,6 +527,10 @@ define GroupingPrivate {
     # columns. Exploration rules can create versions of the operator with
     # orderings that contain grouping columns.
     Ordering OrderingChoice
+
+    # ErrorOnDup, if true, triggers an error if any aggregation group contains
+    # more than one row. This can only be true for the UpsertDistinctOn operator.
+    ErrorOnDup bool
 }
 
 # ScalarGroupBy computes aggregate functions over the complete set of input

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -281,8 +281,9 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	if fromClausePresent {
 		var pkCols opt.ColSet
 
-		// We need to ensure that the join has a maximum of one row for every row in the
-		// table and we ensure this by constructing a distinct on the primary key columns.
+		// We need to ensure that the join has a maximum of one row for every row
+		// in the table and we ensure this by constructing a distinct on the primary
+		// key columns.
 		primaryIndex := mb.tab.Index(cat.PrimaryIndex)
 		for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
 			pkCol := mb.outScope.cols[primaryIndex.Column(i).Ordinal]
@@ -295,7 +296,8 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		}
 
 		if !pkCols.Empty() {
-			mb.outScope = mb.b.buildDistinctOn(pkCols, mb.outScope, false /* forUpsert */)
+			mb.outScope = mb.b.buildDistinctOn(
+				pkCols, mb.outScope, false /* nullsAreDistinct */, false /* errorOnDup */)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -952,7 +952,12 @@ func (b *Builder) buildSelectClause(
 		if projectionsScope.distinctOnCols.Empty() {
 			outScope.expr = b.constructDistinct(outScope)
 		} else {
-			outScope = b.buildDistinctOn(projectionsScope.distinctOnCols, outScope, false /* forUpsert */)
+			outScope = b.buildDistinctOn(
+				projectionsScope.distinctOnCols,
+				outScope,
+				false, /* nullsAreDistinct */
+				false, /* errorOnDup */
+			)
 		}
 	}
 	return outScope

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -41,22 +41,28 @@ insert child
  │    ├── column1:3 => c:1
  │    └── column2:4 => child.p:2
  ├── input binding: &1
- ├── project
+ ├── upsert-distinct-on
  │    ├── columns: column1:3!null column2:4!null
- │    └── select
- │         ├── columns: column1:3!null column2:4!null c:5 child.p:6
- │         ├── left-join (hash)
- │         │    ├── columns: column1:3!null column2:4!null c:5 child.p:6
- │         │    ├── values
- │         │    │    ├── columns: column1:3!null column2:4!null
- │         │    │    ├── (100, 1)
- │         │    │    └── (200, 1)
- │         │    ├── scan child
- │         │    │    └── columns: c:5!null child.p:6!null
- │         │    └── filters
- │         │         └── column1:3 = c:5
- │         └── filters
- │              └── c:5 IS NULL
+ │    ├── grouping columns: column1:3!null
+ │    ├── project
+ │    │    ├── columns: column1:3!null column2:4!null
+ │    │    └── select
+ │    │         ├── columns: column1:3!null column2:4!null c:5 child.p:6
+ │    │         ├── left-join (hash)
+ │    │         │    ├── columns: column1:3!null column2:4!null c:5 child.p:6
+ │    │         │    ├── values
+ │    │         │    │    ├── columns: column1:3!null column2:4!null
+ │    │         │    │    ├── (100, 1)
+ │    │         │    │    └── (200, 1)
+ │    │         │    ├── scan child
+ │    │         │    │    └── columns: c:5!null child.p:6!null
+ │    │         │    └── filters
+ │    │         │         └── column1:3 = c:5
+ │    │         └── filters
+ │    │              └── c:5 IS NULL
+ │    └── aggregations
+ │         └── first-agg [as=column2:4]
+ │              └── column2:4
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -532,48 +532,68 @@ insert xyz
  │    ├── column1:4 => x:1
  │    ├── column2:5 => y:2
  │    └── column3:6 => z:3
- └── project
+ └── upsert-distinct-on
       ├── columns: column1:4!null column2:5!null column3:6!null
-      └── select
-           ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
-           ├── left-join (hash)
-           │    ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
-           │    ├── project
-           │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-           │    │    └── select
-           │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
-           │    │         ├── left-join (hash)
-           │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
-           │    │         │    ├── project
-           │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-           │    │         │    │    └── select
-           │    │         │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-           │    │         │    │         ├── left-join (hash)
-           │    │         │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-           │    │         │    │         │    ├── values
-           │    │         │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-           │    │         │    │         │    │    ├── (1, 2, 3)
-           │    │         │    │         │    │    └── (4, 5, 6)
-           │    │         │    │         │    ├── scan xyz
-           │    │         │    │         │    │    └── columns: x:7!null y:8 z:9
-           │    │         │    │         │    └── filters
-           │    │         │    │         │         └── column1:4 = x:7
-           │    │         │    │         └── filters
-           │    │         │    │              └── x:7 IS NULL
-           │    │         │    ├── scan xyz
-           │    │         │    │    └── columns: x:10!null y:11 z:12
-           │    │         │    └── filters
-           │    │         │         ├── column2:5 = y:11
-           │    │         │         └── column3:6 = z:12
-           │    │         └── filters
-           │    │              └── x:10 IS NULL
-           │    ├── scan xyz
-           │    │    └── columns: x:13!null y:14 z:15
-           │    └── filters
-           │         ├── column3:6 = z:15
-           │         └── column2:5 = y:14
-           └── filters
-                └── x:13 IS NULL
+      ├── grouping columns: column2:5!null column3:6!null
+      ├── project
+      │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    └── select
+      │         ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │         ├── left-join (hash)
+      │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │         │    ├── upsert-distinct-on
+      │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    ├── grouping columns: column2:5!null column3:6!null
+      │         │    │    ├── project
+      │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    │    └── select
+      │         │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │         │    │    │         ├── left-join (hash)
+      │         │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │         │    │    │         │    ├── upsert-distinct-on
+      │         │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    │         │    │    ├── grouping columns: column1:4!null
+      │         │    │    │         │    │    ├── project
+      │         │    │    │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    │         │    │    │    └── select
+      │         │    │    │         │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │         │    │    │         │    │    │         ├── left-join (hash)
+      │         │    │    │         │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │         │    │    │         │    │    │         │    ├── values
+      │         │    │    │         │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    │         │    │    │         │    │    ├── (1, 2, 3)
+      │         │    │    │         │    │    │         │    │    └── (4, 5, 6)
+      │         │    │    │         │    │    │         │    ├── scan xyz
+      │         │    │    │         │    │    │         │    │    └── columns: x:7!null y:8 z:9
+      │         │    │    │         │    │    │         │    └── filters
+      │         │    │    │         │    │    │         │         └── column1:4 = x:7
+      │         │    │    │         │    │    │         └── filters
+      │         │    │    │         │    │    │              └── x:7 IS NULL
+      │         │    │    │         │    │    └── aggregations
+      │         │    │    │         │    │         ├── first-agg [as=column2:5]
+      │         │    │    │         │    │         │    └── column2:5
+      │         │    │    │         │    │         └── first-agg [as=column3:6]
+      │         │    │    │         │    │              └── column3:6
+      │         │    │    │         │    ├── scan xyz
+      │         │    │    │         │    │    └── columns: x:10!null y:11 z:12
+      │         │    │    │         │    └── filters
+      │         │    │    │         │         ├── column2:5 = y:11
+      │         │    │    │         │         └── column3:6 = z:12
+      │         │    │    │         └── filters
+      │         │    │    │              └── x:10 IS NULL
+      │         │    │    └── aggregations
+      │         │    │         └── first-agg [as=column1:4]
+      │         │    │              └── column1:4
+      │         │    ├── scan xyz
+      │         │    │    └── columns: x:13!null y:14 z:15
+      │         │    └── filters
+      │         │         ├── column3:6 = z:15
+      │         │         └── column2:5 = y:14
+      │         └── filters
+      │              └── x:13 IS NULL
+      └── aggregations
+           └── first-agg [as=column1:4]
+                └── column1:4
 
 # Conflict columns are explicitly specified.
 build
@@ -587,23 +607,29 @@ insert xyz
  │    ├── column1:4 => x:1
  │    ├── column2:5 => y:2
  │    └── column3:6 => z:3
- └── project
+ └── upsert-distinct-on
       ├── columns: column1:4!null column2:5!null column3:6!null
-      └── select
-           ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-           ├── left-join (hash)
-           │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-           │    ├── values
-           │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-           │    │    ├── (1, 2, 3)
-           │    │    └── (4, 5, 6)
-           │    ├── scan xyz
-           │    │    └── columns: x:7!null y:8 z:9
-           │    └── filters
-           │         ├── column2:5 = y:8
-           │         └── column3:6 = z:9
-           └── filters
-                └── x:7 IS NULL
+      ├── grouping columns: column2:5!null column3:6!null
+      ├── project
+      │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    └── select
+      │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │         ├── left-join (hash)
+      │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │         │    ├── values
+      │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │         │    │    ├── (1, 2, 3)
+      │         │    │    └── (4, 5, 6)
+      │         │    ├── scan xyz
+      │         │    │    └── columns: x:7!null y:8 z:9
+      │         │    └── filters
+      │         │         ├── column2:5 = y:8
+      │         │         └── column3:6 = z:9
+      │         └── filters
+      │              └── x:7 IS NULL
+      └── aggregations
+           └── first-agg [as=column1:4]
+                └── column1:4
 
 # ------------------------------------------------------------------------------
 # Test excluded columns.
@@ -1367,35 +1393,45 @@ insert checks
  ├── check columns: check1:13 check2:14
  └── project
       ├── columns: check1:13 check2:14!null column1:5!null column2:6!null column7:7 column8:8
-      ├── project
+      ├── upsert-distinct-on
       │    ├── columns: column1:5!null column2:6!null column7:7 column8:8
-      │    └── select
-      │         ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
-      │         ├── left-join (hash)
-      │         │    ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
-      │         │    ├── project
-      │         │    │    ├── columns: column8:8 column1:5!null column2:6!null column7:7
-      │         │    │    ├── project
-      │         │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
-      │         │    │    │    ├── values
-      │         │    │    │    │    ├── columns: column1:5!null column2:6!null
-      │         │    │    │    │    └── (1, 2)
-      │         │    │    │    └── projections
-      │         │    │    │         └── NULL::INT8 [as=column7:7]
-      │         │    │    └── projections
-      │         │    │         └── column7:7 + 1 [as=column8:8]
-      │         │    ├── scan checks
-      │         │    │    ├── columns: a:9!null b:10 c:11 d:12
-      │         │    │    ├── check constraint expressions
-      │         │    │    │    ├── b:10 < d:12
-      │         │    │    │    └── a:9 > 0
-      │         │    │    └── computed column expressions
-      │         │    │         └── d:12
-      │         │    │              └── c:11 + 1
-      │         │    └── filters
-      │         │         └── column1:5 = a:9
-      │         └── filters
-      │              └── a:9 IS NULL
+      │    ├── grouping columns: column1:5!null
+      │    ├── project
+      │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8
+      │    │    └── select
+      │    │         ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
+      │    │         ├── left-join (hash)
+      │    │         │    ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
+      │    │         │    ├── project
+      │    │         │    │    ├── columns: column8:8 column1:5!null column2:6!null column7:7
+      │    │         │    │    ├── project
+      │    │         │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
+      │    │         │    │    │    ├── values
+      │    │         │    │    │    │    ├── columns: column1:5!null column2:6!null
+      │    │         │    │    │    │    └── (1, 2)
+      │    │         │    │    │    └── projections
+      │    │         │    │    │         └── NULL::INT8 [as=column7:7]
+      │    │         │    │    └── projections
+      │    │         │    │         └── column7:7 + 1 [as=column8:8]
+      │    │         │    ├── scan checks
+      │    │         │    │    ├── columns: a:9!null b:10 c:11 d:12
+      │    │         │    │    ├── check constraint expressions
+      │    │         │    │    │    ├── b:10 < d:12
+      │    │         │    │    │    └── a:9 > 0
+      │    │         │    │    └── computed column expressions
+      │    │         │    │         └── d:12
+      │    │         │    │              └── c:11 + 1
+      │    │         │    └── filters
+      │    │         │         └── column1:5 = a:9
+      │    │         └── filters
+      │    │              └── a:9 IS NULL
+      │    └── aggregations
+      │         ├── first-agg [as=column2:6]
+      │         │    └── column2:6
+      │         ├── first-agg [as=column7:7]
+      │         │    └── column7:7
+      │         └── first-agg [as=column8:8]
+      │              └── column8:8
       └── projections
            ├── column2:6 < column8:8 [as=check1:13]
            └── column1:5 > 0 [as=check2:14]

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2190,37 +2190,31 @@ func (c *CustomFuncs) GenerateStreamingGroupBy(
 		// equivalent).
 		newOrd.Simplify(&input.Relational().FuncDeps)
 
+		newPrivate := *private
+		newPrivate.Ordering = newOrd
+
 		switch op {
 		case opt.GroupByOp:
 			newExpr := memo.GroupByExpr{
-				Input:        input,
-				Aggregations: aggs,
-				GroupingPrivate: memo.GroupingPrivate{
-					GroupingCols: private.GroupingCols,
-					Ordering:     newOrd,
-				},
+				Input:           input,
+				Aggregations:    aggs,
+				GroupingPrivate: newPrivate,
 			}
 			c.e.mem.AddGroupByToGroup(&newExpr, grp)
 
 		case opt.DistinctOnOp:
 			newExpr := memo.DistinctOnExpr{
-				Input:        input,
-				Aggregations: aggs,
-				GroupingPrivate: memo.GroupingPrivate{
-					GroupingCols: private.GroupingCols,
-					Ordering:     newOrd,
-				},
+				Input:           input,
+				Aggregations:    aggs,
+				GroupingPrivate: newPrivate,
 			}
 			c.e.mem.AddDistinctOnToGroup(&newExpr, grp)
 
 		case opt.UpsertDistinctOnOp:
 			newExpr := memo.UpsertDistinctOnExpr{
-				Input:        input,
-				Aggregations: aggs,
-				GroupingPrivate: memo.GroupingPrivate{
-					GroupingCols: private.GroupingCols,
-					Ordering:     newOrd,
-				},
+				Input:           input,
+				Aggregations:    aggs,
+				GroupingPrivate: newPrivate,
 			}
 			c.e.mem.AddUpsertDistinctOnToGroup(&newExpr, grp)
 		}

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1794,6 +1794,7 @@ sort
       │         │    │    ├── columns: x:4!null y:5!null z:6!null
       │         │    │    ├── grouping columns: x:4!null y:5!null z:6!null
       │         │    │    ├── internal-ordering: +5,+6
+      │         │    │    ├── error-on-dup
       │         │    │    ├── cardinality: [0 - 2]
       │         │    │    ├── key: (4-6)
       │         │    │    └── limit

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1431,7 +1431,7 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
 memo
 SELECT DISTINCT u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2-4)) (distinct-on G2 G3 cols=(2-4),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2-4),ordering=+4,+3,+2) (distinct-on G2 G3 cols=(2-4),ordering=+3,+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2-4),ordering=+2,+3,+4)
@@ -1578,7 +1578,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, v, w
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2),ordering=+3,+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+3,+4 opt(2))

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -386,7 +386,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 				v.observer.attr(name, "nulls are distinct", "")
 			}
 			if n.errorOnDup != "" {
-				v.observer.attr(name, "error on dups", "")
+				v.observer.attr(name, "error on duplicate", "")
 			}
 		}
 


### PR DESCRIPTION
Previously, the INSERT..ON CONFLICT DO NOTHING statement raised an error
if its input contained rows which conflicted with one another. For example:

  CREATE TABLE t (x INT PRIMARY KEY)
  INSERT INTO t (x) VALUES (1), (1) ON CONFLICT DO NOTHING

This raised a unique key conflict error rather than doing nothing.

This commit fixes that by wrapping the input in one or more UpsertDistinctOn
operators - one for each unique key in the target table. This ensures that
any duplicates which might cause a conflict are removed from the input.

Fixes #37880
Fixes #44434

Release note (sql change): Duplicate rows in the input to an INSERT..ON
CONFLICT DO NOTHING statement will now be ignored rather than triggering
an error.