### PR TITLE
kv,quotapool,stopper: make the DistSender async concurrency limit configurable

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -190,7 +191,7 @@ type DistSender struct {
 	rpcContext       *rpc.Context
 	nodeDialer       *nodedialer.Dialer
 	rpcRetryOptions  retry.Options
-	asyncSenderSem   chan struct{}
+	asyncSenderSem   *quotapool.IntPool
 	// clusterID is used to verify access to enterprise features.
 	// It is copied out of the rpcContext at construction time and used in
 	// testing.
@@ -282,7 +283,8 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	}
 	ds.clusterID = &cfg.RPCContext.ClusterID
 	ds.nodeDialer = cfg.NodeDialer
-	ds.asyncSenderSem = make(chan struct{}, defaultSenderConcurrency)
+	ds.asyncSenderSem = quotapool.NewIntPool("dist sender concurrency", defaultSenderConcurrency)
+	ds.rpcContext.Stopper.AddCloser(ds.asyncSenderSem.Closer("stopper"))
 	ds.rangeIteratorGen = func() *RangeIterator { return NewRangeIterator(ds) }
 
 	if g != nil {

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -92,6 +93,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 			Clock:      s.Clock(),
 			RPCContext: s.RPCContext(),
 			NodeDialer: nodedialer.New(s.RPCContext(), gossip.AddressResolver(s.(*server.TestServer).Gossip())),
+			Settings:   cluster.MakeTestingClusterSettings(),
 		},
 		s.(*server.TestServer).Gossip(),
 	)
@@ -961,6 +963,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 						Clock:      clock,
 						RPCContext: s.RPCContext(),
 						NodeDialer: nodedialer.New(s.RPCContext(), gossip.AddressResolver(s.(*server.TestServer).Gossip())),
+						Settings:   cluster.MakeTestingClusterSettings(),
 					},
 					s.(*server.TestServer).Gossip(),
 				)
@@ -1166,6 +1169,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 			Clock:      s.Clock(),
 			RPCContext: s.RPCContext(),
 			NodeDialer: nodedialer.New(s.RPCContext(), gossip.AddressResolver(s.(*server.TestServer).Gossip())),
+			Settings:   cluster.MakeTestingClusterSettings(),
 		}, s.(*server.TestServer).Gossip(),
 	)
 	for _, key := range []string{"c"} {

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -353,6 +353,7 @@ func TestSendRPCOrder(t *testing.T) {
 		},
 		RangeDescriptorDB: mockRangeDescriptorDBForDescs(descriptor),
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -521,6 +522,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 		},
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -592,6 +594,7 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 		},
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	v := roachpb.MakeValueFromString("value")
@@ -672,6 +675,7 @@ func TestBackoffOnNotLeaseHolderErrorDuringTransfer(t *testing.T) {
 			InitialBackoff: time.Microsecond,
 			MaxBackoff:     time.Microsecond,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	for i, c := range []struct {
 		leaseSequences []roachpb.LeaseSequence
@@ -758,6 +762,7 @@ func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
 				},
 			}),
 		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -819,6 +824,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 			return []roachpb.RangeDescriptor{testUserRangeDescriptor}, nil, err
 		}),
 		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	put := roachpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
@@ -884,6 +890,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 		},
 		RangeDescriptorDB: rDB,
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
 	ds := NewDistSender(cfg, g).withMetaRecursion()
@@ -1004,6 +1011,7 @@ func TestEvictCacheOnError(t *testing.T) {
 			},
 			RangeDescriptorDB: defaultMockRangeDescriptorDB,
 			NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+			Settings:          cluster.MakeTestingClusterSettings(),
 		}
 		ds := NewDistSender(cfg, g)
 		ds.leaseHolderCache.Update(context.TODO(), 1, leaseHolder.StoreID)
@@ -1072,6 +1080,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 		},
 		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	key := roachpb.Key("a")
@@ -1172,6 +1181,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1267,6 +1277,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1290,6 +1301,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
 		RPCContext: n.RPCContext,
 		NodeDialer: nodedialer.New(n.RPCContext, gossip.AddressResolver(n.Nodes[0].Gossip)),
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}, n.Nodes[0].Gossip)
 	if _, err := ds.FirstRange(); err == nil {
 		t.Errorf("expected not to find first range descriptor")
@@ -1383,6 +1395,7 @@ func TestSendRPCRetry(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1469,6 +1482,7 @@ func TestSendRPCRangeNotFoundError(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds = NewDistSender(cfg, g)
 	get := roachpb.NewGet(roachpb.Key("b"))
@@ -1497,6 +1511,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
 		RPCContext: rpcContext,
 		Clock:      clock,
+		Settings:   cluster.MakeTestingClusterSettings(),
 	}, g)
 	g.NodeID.Reset(5)
 	if err := g.SetNodeDescriptor(newNodeDesc(5)); err != nil {
@@ -1577,6 +1592,7 @@ func TestMultiRangeGapReverse(t *testing.T) {
 				sender,
 			),
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -1686,6 +1702,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 			}
 			return []roachpb.RangeDescriptor{mergedRange}, nil, nil
 		}),
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1729,6 +1746,7 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 			}
 			return []roachpb.RangeDescriptor{testUserRangeDescriptor}, nil, nil
 		}),
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	rScan := &roachpb.ReverseScanRequest{
@@ -1755,6 +1773,7 @@ func TestClockUpdateOnResponse(t *testing.T) {
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 
@@ -1889,6 +1908,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(sendStub),
 		},
 		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 
@@ -2016,6 +2036,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(sendStub),
 		},
 		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 
@@ -2205,6 +2226,7 @@ func TestMultiRangeWithEndTxn(t *testing.T) {
 				TransportFactory: adaptSimpleTransport(testFn),
 			},
 			RangeDescriptorDB: descDB,
+			Settings:          cluster.MakeTestingClusterSettings(),
 		}
 		ds := NewDistSender(cfg, g)
 		ds.DisableParallelBatches()
@@ -2339,6 +2361,7 @@ func TestParallelCommitSplitFromQueryIntents(t *testing.T) {
 					TransportFactory: adaptSimpleTransport(testFn),
 				},
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
+				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 			ds := NewDistSender(cfg, g)
 			ds.DisableParallelBatches()
@@ -2454,6 +2477,7 @@ func TestParallelCommitsDetectIntentMissingCause(t *testing.T) {
 					TransportFactory: adaptSimpleTransport(testFn),
 				},
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
+				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 			ds := NewDistSender(cfg, g)
 
@@ -2531,6 +2555,7 @@ func TestCountRanges(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(stubRPCSendFn),
 		},
 		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 
@@ -2623,6 +2648,7 @@ func TestGatewayNodeID(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 	var ba roachpb.BatchRequest
@@ -2774,6 +2800,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 					TransportFactory: adaptSimpleTransport(testFn),
 				},
 				RangeDescriptorDB: descDB,
+				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 			ds := NewDistSender(cfg, g)
 
@@ -2902,6 +2929,7 @@ func TestErrorIndexAlignment(t *testing.T) {
 					TransportFactory: adaptSimpleTransport(testFn),
 				},
 				RangeDescriptorDB: descDB,
+				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 			ds := NewDistSender(cfg, g)
 			ds.DisableParallelBatches()
@@ -2985,6 +3013,7 @@ func TestCanSendToFollower(t *testing.T) {
 			InitialBackoff: time.Microsecond,
 			MaxBackoff:     time.Microsecond,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	for i, c := range []struct {
 		canSendToFollower bool
@@ -3186,6 +3215,7 @@ func TestEvictMetaRange(t *testing.T) {
 				TransportFactory: adaptSimpleTransport(testFn),
 			},
 			NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+			Settings:   cluster.MakeTestingClusterSettings(),
 		}
 		ds := NewDistSender(cfg, g)
 
@@ -3297,6 +3327,7 @@ func TestConnectionClass(t *testing.T) {
 			MaxRetries: 1,
 		},
 		RangeDescriptorDB: rDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg, g)
 
@@ -3428,6 +3459,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 		RPCRetryOptions: &retry.Options{
 			MaxRetries: 1,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ds = NewDistSender(cfg, g)
 

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -63,6 +64,7 @@ func TestRangeIterForward(t *testing.T) {
 		Clock:             clock,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}, g)
 
 	ctx := context.Background()
@@ -97,6 +99,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 		Clock:             clock,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}, g)
 
 	ctx := context.Background()
@@ -134,6 +137,7 @@ func TestRangeIterReverse(t *testing.T) {
 		Clock:             clock,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}, g)
 
 	ctx := context.Background()
@@ -168,6 +172,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 		Clock:             clock,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
 	}, g)
 
 	ctx := context.Background()

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -275,6 +276,7 @@ func sendBatch(
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: transportFactory,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}, nil)
 	return ds.sendToReplicas(
 		ctx,

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -231,6 +231,7 @@ func TestTxnCoordSenderCondenseIntentSpans(t *testing.T) {
 				TransportFactory: adaptSimpleTransport(sendFn),
 			},
 			RangeDescriptorDB: descDB,
+			Settings:          cluster.MakeTestingClusterSettings(),
 		},
 		s.Gossip,
 	)

--- a/pkg/util/quotapool/bench_test.go
+++ b/pkg/util/quotapool/bench_test.go
@@ -73,7 +73,7 @@ func BenchmarkConcurrentChannelSemaphore(b *testing.B) {
 // BenchmarkIntQuotaPoolFunc benchmarks the common case where we have sufficient
 // quota available in the pool and we repeatedly acquire and release quota.
 func BenchmarkIntPoolFunc(b *testing.B) {
-	qp := quotapool.NewIntPool("test", 1, quotapool.LogSlowAcquisition)
+	qp := quotapool.NewIntPool("test", 1, logSlowAcquisition)
 	ctx := context.Background()
 	toAcquire := intRequest(1)
 	for n := 0; n < b.N; n++ {
@@ -122,7 +122,7 @@ func (s concurrentBenchSpec) benchmarkChannelSem(b *testing.B) {
 }
 
 func (s concurrentBenchSpec) benchmarkIntPool(b *testing.B) {
-	qp := quotapool.NewIntPool("test", s.quota, quotapool.LogSlowAcquisition)
+	qp := quotapool.NewIntPool("test", s.quota, logSlowAcquisition)
 	g, ctx := errgroup.WithContext(context.Background())
 	runWorker := func(workerNum int) {
 		g.Go(func() error {

--- a/pkg/util/quotapool/bench_test.go
+++ b/pkg/util/quotapool/bench_test.go
@@ -1,0 +1,173 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool_test
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"golang.org/x/sync/errgroup"
+)
+
+// BenchmarkIntQuotaPool benchmarks the common case where we have sufficient
+// quota available in the pool and we repeatedly acquire and release quota.
+func BenchmarkIntPool(b *testing.B) {
+	qp := quotapool.NewIntPool("test", 1)
+	ctx := context.Background()
+	for n := 0; n < b.N; n++ {
+		alloc, err := qp.Acquire(ctx, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+		alloc.Release()
+	}
+	qp.Close("")
+}
+
+func BenchmarkChannelSemaphore(b *testing.B) {
+	sem := make(chan struct{}, 1)
+	ctx := context.Background()
+	for n := 0; n < b.N; n++ {
+		select {
+		case <-ctx.Done():
+		case sem <- struct{}{}:
+		}
+		select {
+		case <-ctx.Done():
+		case <-sem:
+		}
+	}
+	close(sem)
+}
+
+// BenchmarkConcurrentIntPool benchmarks concurrent workers in a variety
+// of ratios between adequate and inadequate quota to concurrently serve all
+// workers with the IntPool.
+func BenchmarkConcurrentIntPool(b *testing.B) {
+	for _, s := range concurrentBenchSpecs {
+		b.Run(s.String(), s.benchmarkIntPool)
+	}
+}
+
+// BenchmarkConcurrentChannelSem benchmarks concurrent workers in a variety
+// of ratios between adequate and inadequate quota to concurrently serve all
+// workers with a channel-based semaphore to compare the performance against
+// the IntPool.
+func BenchmarkConcurrentChannelSemaphore(b *testing.B) {
+	for _, s := range concurrentBenchSpecs {
+		b.Run(s.String(), s.benchmarkChannelSem)
+	}
+}
+
+// BenchmarkIntQuotaPoolFunc benchmarks the common case where we have sufficient
+// quota available in the pool and we repeatedly acquire and release quota.
+func BenchmarkIntPoolFunc(b *testing.B) {
+	qp := quotapool.NewIntPool("test", 1, quotapool.LogSlowAcquisition)
+	ctx := context.Background()
+	toAcquire := intRequest(1)
+	for n := 0; n < b.N; n++ {
+		alloc, err := qp.AcquireFunc(ctx, toAcquire.acquire)
+		if err != nil {
+			b.Fatal(err)
+		} else if acquired := alloc.Acquired(); acquired != 1 {
+			b.Fatalf("expected to acquire %d, got %d", 1, acquired)
+		}
+		alloc.Release()
+	}
+	qp.Close("")
+}
+
+type concurrentBenchSpec struct {
+	workers int
+	quota   uint64
+}
+
+func (s concurrentBenchSpec) benchmarkChannelSem(b *testing.B) {
+	sem := make(chan struct{}, s.quota)
+	g, ctx := errgroup.WithContext(context.Background())
+	runWorker := func(workerNum int) {
+		g.Go(func() error {
+			for i := workerNum; i < b.N; i += s.workers {
+				select {
+				case <-ctx.Done():
+				case sem <- struct{}{}:
+				}
+				runtime.Gosched()
+				select {
+				case <-ctx.Done():
+				case <-sem:
+				}
+			}
+			return nil
+		})
+	}
+	for i := 0; i < s.workers; i++ {
+		runWorker(i)
+	}
+	if err := g.Wait(); err != nil {
+		b.Fatal(err)
+	}
+	close(sem)
+}
+
+func (s concurrentBenchSpec) benchmarkIntPool(b *testing.B) {
+	qp := quotapool.NewIntPool("test", s.quota, quotapool.LogSlowAcquisition)
+	g, ctx := errgroup.WithContext(context.Background())
+	runWorker := func(workerNum int) {
+		g.Go(func() error {
+			for i := workerNum; i < b.N; i += s.workers {
+				alloc, err := qp.Acquire(ctx, 1)
+				if err != nil {
+					b.Fatal(err)
+				}
+				runtime.Gosched()
+				alloc.Release()
+			}
+			return nil
+		})
+	}
+	for i := 0; i < s.workers; i++ {
+		runWorker(i)
+	}
+	if err := g.Wait(); err != nil {
+		b.Fatal(err)
+	}
+	qp.Close("")
+}
+
+func (s concurrentBenchSpec) String() string {
+	return fmt.Sprintf("workers=%d,quota=%d", s.workers, s.quota)
+}
+
+var concurrentBenchSpecs = []concurrentBenchSpec{
+	{1, 1},
+	{2, 2},
+	{8, 4},
+	{128, 4},
+	{512, 128},
+	{512, 513},
+	{512, 511},
+	{1024, 4},
+	{1024, 4096},
+}
+
+// intRequest is a wrapper to create a IntRequestFunc from an int64.
+type intRequest uint64
+
+func (ir intRequest) acquire(_ context.Context, pi quotapool.PoolInfo) (took uint64, err error) {
+	if uint64(ir) < pi.Available {
+		return 0, quotapool.ErrNotEnoughQuota
+	}
+	return uint64(ir), nil
+}

--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -48,10 +47,8 @@ func OnSlowAcquisition(threshold time.Duration, f SlowAcquisitionFunc) Option {
 	})
 }
 
-// LogSlowAcquisition is an Option to log slow acquisitions.
-var LogSlowAcquisition = OnSlowAcquisition(base.SlowRequestThreshold, logSlowAcquire)
-
-func logSlowAcquire(ctx context.Context, poolName string, r Request, start time.Time) func() {
+// LogSlowAcquisition is a SlowAcquisitionFunc.
+func LogSlowAcquisition(ctx context.Context, poolName string, r Request, start time.Time) func() {
 	log.Warningf(ctx, "have been waiting %s attempting to acquire %s quota",
 		timeutil.Since(start), poolName)
 	return func() {

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -13,6 +13,7 @@ package quotapool
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -37,7 +38,10 @@ type IntPool struct {
 
 // IntAlloc is an allocated quantity which should be released.
 type IntAlloc struct {
-	alloc uint64
+	// alloc may be negative when used as the current quota for an IntPool or when
+	// lowering the capacity (see UpdateCapacity). Allocs acquired by clients of
+	// this package will never be negative.
+	alloc int64
 	p     *IntPool
 }
 
@@ -49,7 +53,7 @@ func (ia *IntAlloc) Release() {
 
 // Acquired returns the quantity that this alloc has acquired.
 func (ia *IntAlloc) Acquired() uint64 {
-	return ia.alloc
+	return uint64(ia.alloc)
 }
 
 // Merge adds the acquired resources in other to ia. Other may not be used after
@@ -59,7 +63,7 @@ func (ia *IntAlloc) Merge(other *IntAlloc) {
 	if ia.p != other.p {
 		panic("cannot merge IntAllocs from two different pools")
 	}
-	ia.alloc = min(ia.p.Capacity(), ia.alloc+other.alloc)
+	ia.alloc = min(int64(ia.p.Capacity()), ia.alloc+other.alloc)
 	ia.p.putIntAlloc(other)
 }
 
@@ -69,7 +73,7 @@ func (ia *IntAlloc) Merge(other *IntAlloc) {
 // AcquireFunc() requests will be woken up with an updated Capacity, and Alloc()
 // requests will be trimmed accordingly.
 func (ia *IntAlloc) Freeze() {
-	ia.p.decCapacity(ia.alloc)
+	ia.p.decCapacity(uint64(ia.alloc))
 }
 
 // String formats an IntAlloc as a string.
@@ -77,7 +81,7 @@ func (ia *IntAlloc) String() string {
 	if ia == nil {
 		return strconv.Itoa(0)
 	}
-	return strconv.FormatUint(ia.alloc, 10)
+	return strconv.FormatInt(ia.alloc, 10)
 }
 
 // from returns true if this IntAlloc is from p.
@@ -96,12 +100,17 @@ func (ia *intAlloc) Merge(other Resource) {
 
 // NewIntPool creates a new named IntPool.
 //
-// capacity is the amount of quota initially available.
+// capacity is the amount of quota initially available. The maximum capacity
+// is math.MaxInt64. If the capacity argument exceeds that value, this function
+// will panic.
 func NewIntPool(name string, capacity uint64, options ...Option) *IntPool {
+	if capacity > math.MaxInt64 {
+		panic(errors.Errorf("capacity %d exceeds max capacity %d", capacity, math.MaxInt64))
+	}
 	p := IntPool{
 		capacity: capacity,
 	}
-	p.qp = New(name, (*intAlloc)(p.newIntAlloc(capacity)), options...)
+	p.qp = New(name, (*intAlloc)(p.newIntAlloc(int64(capacity))), options...)
 	return &p
 }
 
@@ -131,7 +140,12 @@ func (p *IntPool) TryAcquire(ctx context.Context, v uint64) (*IntAlloc, error) {
 func (p *IntPool) acquireMaybeWait(ctx context.Context, v uint64, wait bool) (*IntAlloc, error) {
 	// Special case acquisitions of size 0.
 	if v == 0 {
-		return p.newIntAlloc(v), nil
+		return p.newIntAlloc(0), nil
+	}
+	// The maximum capacity is math.MaxInt64 so we can always truncate requests
+	// to that value.
+	if v > math.MaxInt64 {
+		v = math.MaxInt64
 	}
 	r := p.newIntRequest(v)
 	defer p.putIntRequest(r)
@@ -144,7 +158,7 @@ func (p *IntPool) acquireMaybeWait(ctx context.Context, v uint64, wait bool) (*I
 	if err := p.qp.Acquire(ctx, req); err != nil {
 		return nil, err
 	}
-	return p.newIntAlloc(r.want), nil
+	return p.newIntAlloc(int64(r.want)), nil
 }
 
 // Release will release allocs back to their pool. Allocs which are from p are
@@ -249,7 +263,9 @@ func (p *IntPool) acquireFuncMaybeWait(
 		}
 		return nil, r.err
 	}
-	return p.newIntAlloc(r.took), nil
+	// NB: We know that r.took must be less than math.MaxInt64 because capacity
+	// cannot exceed that value and took cannot exceed capacity.
+	return p.newIntAlloc(int64(r.took)), nil
 }
 
 // Len returns the current length of the queue for this IntPool.
@@ -262,7 +278,7 @@ func (p *IntPool) Len() int {
 func (p *IntPool) ApproximateQuota() (q uint64) {
 	p.qp.ApproximateQuota(func(r Resource) {
 		if ia, ok := r.(*intAlloc); ok {
-			q = ia.alloc
+			q = uint64(max(0, ia.alloc))
 		}
 	})
 	return q
@@ -296,7 +312,7 @@ var intAllocSyncPool = sync.Pool{
 	New: func() interface{} { return new(IntAlloc) },
 }
 
-func (p *IntPool) newIntAlloc(v uint64) *IntAlloc {
+func (p *IntPool) newIntAlloc(v int64) *IntAlloc {
 	ia := intAllocSyncPool.Get().(*IntAlloc)
 	*ia = IntAlloc{p: p, alloc: v}
 	return ia
@@ -363,11 +379,12 @@ type intRequest struct {
 
 func (r *intRequest) Acquire(ctx context.Context, v Resource) (fulfilled bool, extra Resource) {
 	ia := v.(*intAlloc)
-	r.want = min(r.want, ia.p.Capacity())
-	if ia.alloc < r.want {
+	want := min(int64(r.want), int64(ia.p.Capacity()))
+	if ia.alloc < want {
 		return false, nil
 	}
-	ia.alloc -= r.want
+	r.want = uint64(want)
+	ia.alloc -= want
 	return true, ia
 }
 
@@ -396,7 +413,7 @@ type intFuncRequest struct {
 func (r *intFuncRequest) Acquire(ctx context.Context, v Resource) (fulfilled bool, extra Resource) {
 	ia := v.(*intAlloc)
 	pi := PoolInfo{
-		Available: ia.alloc,
+		Available: uint64(max(0, ia.alloc)),
 		Capacity:  ia.p.Capacity(),
 	}
 	took, err := r.f(ctx, pi)
@@ -411,16 +428,23 @@ func (r *intFuncRequest) Acquire(ctx context.Context, v Resource) (fulfilled boo
 		// Take the request out of the queue and put all the quota back.
 		return true, ia
 	}
-	if took > ia.alloc {
+	if took > math.MaxInt64 || int64(took) > ia.alloc {
 		panic(errors.Errorf("took %d quota > %d allocated", took, ia.alloc))
 	}
 	r.took = took
-	ia.alloc -= took
+	ia.alloc -= int64(took)
 	return true, ia
 }
 
-func min(a, b uint64) (v uint64) {
+func min(a, b int64) (v int64) {
 	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int64) (v int64) {
+	if a > b {
 		return a
 	}
 	return b

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 // IntPool manages allocating integer units of quota to clients.
@@ -189,6 +189,17 @@ type IntRequestFunc func(ctx context.Context, p PoolInfo) (took uint64, err erro
 // again once there's new resources.
 var ErrNotEnoughQuota = fmt.Errorf("not enough quota available")
 
+// HasErrClosed returns true if this error is or contains an ErrClosed error.
+func HasErrClosed(err error) bool {
+	_, hasErrClosed := errors.If(err, func(err error) (unwrapped interface{}, ok bool) {
+		if _, hasErrClosed := err.(*ErrClosed); hasErrClosed {
+			return err, hasErrClosed
+		}
+		return nil, false
+	})
+	return hasErrClosed
+}
+
 // PoolInfo represents the information that the IntRequestFunc gets about the current quota pool conditions.
 type PoolInfo struct {
 	// Available is the amount of quota available to be consumed. This is the
@@ -263,6 +274,22 @@ func (p *IntPool) ApproximateQuota() (q uint64) {
 // Safe for concurrent use.
 func (p *IntPool) Close(reason string) {
 	p.qp.Close(reason)
+}
+
+// IntPoolCloser implements stop.Closer.
+type IntPoolCloser struct {
+	reason string
+	p      *IntPool
+}
+
+// Close makes the IntPoolCloser a stop.Closer.
+func (ipc IntPoolCloser) Close() {
+	ipc.p.Close(ipc.reason)
+}
+
+// Closer returns a struct which implements stop.Closer.
+func (p *IntPool) Closer(reason string) IntPoolCloser {
+	return IntPoolCloser{p: p, reason: reason}
 }
 
 var intAllocSyncPool = sync.Pool{

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -119,13 +119,29 @@ func NewIntPool(name string, capacity uint64, options ...Option) *IntPool {
 //
 // Safe for concurrent use.
 func (p *IntPool) Acquire(ctx context.Context, v uint64) (*IntAlloc, error) {
+	return p.acquireMaybeWait(ctx, v, true /* wait */)
+}
+
+// TryAcquire is like Acquire but if there is insufficient quota to acquire
+// immediately the method will return ErrNotEnoughQuota.
+func (p *IntPool) TryAcquire(ctx context.Context, v uint64) (*IntAlloc, error) {
+	return p.acquireMaybeWait(ctx, v, false /* wait */)
+}
+
+func (p *IntPool) acquireMaybeWait(ctx context.Context, v uint64, wait bool) (*IntAlloc, error) {
 	// Special case acquisitions of size 0.
 	if v == 0 {
 		return p.newIntAlloc(v), nil
 	}
 	r := p.newIntRequest(v)
 	defer p.putIntRequest(r)
-	if err := p.qp.Acquire(ctx, r); err != nil {
+	var req Request
+	if wait {
+		req = r
+	} else {
+		req = (*intRequestNoWait)(r)
+	}
+	if err := p.qp.Acquire(ctx, req); err != nil {
 		return nil, err
 	}
 	return p.newIntAlloc(r.want), nil
@@ -191,9 +207,28 @@ type PoolInfo struct {
 // AcquireFunc acquires a quantity of quota determined by a function which is
 // called with a quantity of available quota.
 func (p *IntPool) AcquireFunc(ctx context.Context, f IntRequestFunc) (*IntAlloc, error) {
+	return p.acquireFuncMaybeWait(ctx, f, true /* wait */)
+}
+
+// TryAcquireFunc is like AcquireFunc but if insufficient quota exists the
+// method will return ErrNotEnoughQuota rather than waiting for quota to become
+// available.
+func (p *IntPool) TryAcquireFunc(ctx context.Context, f IntRequestFunc) (*IntAlloc, error) {
+	return p.acquireFuncMaybeWait(ctx, f, false /* wait */)
+}
+
+func (p *IntPool) acquireFuncMaybeWait(
+	ctx context.Context, f IntRequestFunc, wait bool,
+) (*IntAlloc, error) {
 	r := p.newIntFuncRequest(f)
 	defer p.putIntFuncRequest(r)
-	err := p.qp.Acquire(ctx, r)
+	var req Request
+	if wait {
+		req = r
+	} else {
+		req = (*intFuncRequestNoWait)(r)
+	}
+	err := p.qp.Acquire(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -309,6 +344,18 @@ func (r *intRequest) Acquire(ctx context.Context, v Resource) (fulfilled bool, e
 	return true, ia
 }
 
+func (r *intRequest) ShouldWait() bool { return true }
+
+type intRequestNoWait intRequest
+
+func (r *intRequestNoWait) Acquire(
+	ctx context.Context, v Resource,
+) (fulfilled bool, extra Resource) {
+	return (*intRequest)(r).Acquire(ctx, v)
+}
+
+func (r *intRequestNoWait) ShouldWait() bool { return false }
+
 // intFuncRequest is used to acquire a quantity from the pool which is not
 // known ahead of time.
 type intFuncRequest struct {
@@ -351,3 +398,15 @@ func min(a, b uint64) (v uint64) {
 	}
 	return b
 }
+
+func (r *intFuncRequest) ShouldWait() bool { return true }
+
+type intFuncRequestNoWait intFuncRequest
+
+func (r *intFuncRequestNoWait) Acquire(
+	ctx context.Context, v Resource,
+) (fulfilled bool, extra Resource) {
+	return (*intFuncRequest)(r).Acquire(ctx, v)
+}
+
+func (r *intFuncRequestNoWait) ShouldWait() bool { return false }

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -34,6 +35,9 @@ type IntPool struct {
 	// The capacity is originally set when the IntPool is constructed, and then it
 	// can be decreased by IntAlloc.Freeze().
 	capacity uint64
+
+	// updateCapacityMu synchronizes accesses to the capacity.
+	updateCapacityMu syncutil.Mutex
 }
 
 // IntAlloc is an allocated quantity which should be released.
@@ -68,12 +72,23 @@ func (ia *IntAlloc) Merge(other *IntAlloc) {
 }
 
 // Freeze informs the quota pool that this allocation will never be Release()ed.
-// Releasing it later is illegal.
+// Releasing it later is illegal and will lead to panics.
+//
+// Using Freeze and UpdateCapacity on the same pool may require explicit
+// coordination. It is illegal to freeze allocated capacity which is no longer
+// available - specifically it is illegal to make the capacity of an IntPool
+// negative. Imagine the case where the capacity of an IntPool is initially 10.
+// An allocation of 10 is acquired. Then, while it is held, the pool's capacity
+// is updated to be 9. Then the outstanding allocation is frozen. This would
+// make the total capacity of the IntPool negative which is not allowed and will
+// lead to a panic. In general it's a bad idea to freeze allocated quota from a
+// pool which will ever have its capacity decreased.
 //
 // AcquireFunc() requests will be woken up with an updated Capacity, and Alloc()
 // requests will be trimmed accordingly.
 func (ia *IntAlloc) Freeze() {
 	ia.p.decCapacity(uint64(ia.alloc))
+	ia.p = nil // ensure that future uses of this alloc will panic
 }
 
 // String formats an IntAlloc as a string.
@@ -104,9 +119,7 @@ func (ia *intAlloc) Merge(other Resource) {
 // is math.MaxInt64. If the capacity argument exceeds that value, this function
 // will panic.
 func NewIntPool(name string, capacity uint64, options ...Option) *IntPool {
-	if capacity > math.MaxInt64 {
-		panic(errors.Errorf("capacity %d exceeds max capacity %d", capacity, math.MaxInt64))
-	}
+	assertCapacityIsValid(capacity)
 	p := IntPool{
 		capacity: capacity,
 	}
@@ -362,14 +375,64 @@ func (p *IntPool) Capacity() uint64 {
 	return atomic.LoadUint64(&p.capacity)
 }
 
+// UpdateCapacity sets the capacity to newCapacity. If the current capacity
+// is higher than the new capacity, currently running requests will not be
+// affected. When the capacity is increased, new quota will be added. The total
+// quantity of outstanding quota will never exceed the maximum value of the
+// capacity which existed when any outstanding quota was acquired.
+func (p *IntPool) UpdateCapacity(newCapacity uint64) {
+	assertCapacityIsValid(newCapacity)
+
+	// Synchronize updates so that we never lose any quota. If we did not
+	// synchronize then a rapid succession of increases and decreases could have
+	// their associated updates to the current quota re-ordered.
+	//
+	// Imagine the capacity moves through:
+	//   100, 1, 100, 1, 100
+	// It would lead to the following intAllocs being released:
+	//   -99, 99, -99, 99
+	// If was reordered to:
+	//   99, 99, -99, -99
+	// Then we'd effectively ignore the additions at the beginning because they
+	// would push the alloc above the capacity and then we'd make the
+	// corresponding subtractions, leading to a final state of -98 even though
+	// we'd like it to be 1.
+	p.updateCapacityMu.Lock()
+	defer p.updateCapacityMu.Unlock()
+
+	// NB: if we're going to be lowering the capacity, we need to remove the
+	// quota from the pool before we update the capacity value. Imagine the case
+	// where there's a concurrent release of quota back into the pool. If it sees
+	// the newer capacity but the old quota value, it would push the value above
+	// the new capacity and thus get truncated. This is a bummer. We prevent this
+	// by subtracting from the quota pool (perhaps pushing it into negative
+	// territory), before we change the capacity.
+	oldCapacity := atomic.LoadUint64(&p.capacity)
+	delta := int64(newCapacity) - int64(oldCapacity)
+	if delta < 0 {
+		p.newIntAlloc(delta).Release()
+		delta = 0 // we still want to release after the update to wake goroutines
+	}
+	atomic.SwapUint64(&p.capacity, newCapacity)
+	p.newIntAlloc(delta).Release()
+}
+
 // decCapacity decrements the capacity by c.
 func (p *IntPool) decCapacity(c uint64) {
-	// This is how you decrement from a uint64.
-	atomic.AddUint64(&p.capacity, ^(c - 1))
+	p.updateCapacityMu.Lock()
+	defer p.updateCapacityMu.Unlock()
+
+	oldCapacity := p.Capacity()
+	if int64(oldCapacity)-int64(c) < 0 {
+		panic("cannot freeze quota which is no longer part of the pool")
+	}
+	newCapacity := oldCapacity - c
+	atomic.SwapUint64(&p.capacity, newCapacity)
+
 	// Wake up the request at the front of the queue. The decrement above may race
 	// with an ongoing request (which is why it's an atomic access), but in any
 	// case that request is evaluated again.
-	p.qp.Add(&intAlloc{alloc: 0, p: p})
+	p.newIntAlloc(0).Release()
 }
 
 // intRequest is used to acquire a quantity from the quota known ahead of time.
@@ -461,3 +524,10 @@ func (r *intFuncRequestNoWait) Acquire(
 }
 
 func (r *intFuncRequestNoWait) ShouldWait() bool { return false }
+
+// assertCapacityIsValid panics if capacity exceeds math.MaxInt64.
+func assertCapacityIsValid(capacity uint64) {
+	if capacity > math.MaxInt64 {
+		panic(errors.Errorf("capacity %d exceeds max capacity %d", capacity, math.MaxInt64))
+	}
+}

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -13,7 +13,6 @@ package quotapool_test
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -24,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 // TestQuotaPoolBasic tests the minimal expected behavior of the quota pool
@@ -407,134 +405,6 @@ func TestQuotaPoolCapacityDecrease(t *testing.T) {
 	}
 }
 
-// BenchmarkIntQuotaPool benchmarks the common case where we have sufficient
-// quota available in the pool and we repeatedly acquire and release quota.
-func BenchmarkIntQuotaPool(b *testing.B) {
-	qp := quotapool.NewIntPool("test", 1)
-	ctx := context.Background()
-	for n := 0; n < b.N; n++ {
-		alloc, err := qp.Acquire(ctx, 1)
-		if err != nil {
-			b.Fatal(err)
-		}
-		alloc.Release()
-	}
-	qp.Close("")
-}
-
-func BenchmarkChannelSemaphore(b *testing.B) {
-	sem := make(chan struct{}, 1)
-	ctx := context.Background()
-	for n := 0; n < b.N; n++ {
-		select {
-		case <-ctx.Done():
-		case sem <- struct{}{}:
-		}
-		select {
-		case <-ctx.Done():
-		case <-sem:
-		}
-	}
-	close(sem)
-}
-
-type concurrentBenchSpec struct {
-	workers int
-	quota   uint64
-}
-
-func (s concurrentBenchSpec) benchmarkChannelSem(b *testing.B) {
-	sem := make(chan struct{}, s.quota)
-	g, ctx := errgroup.WithContext(context.Background())
-	runWorker := func(workerNum int) {
-		g.Go(func() error {
-			for i := workerNum; i < b.N; i += s.workers {
-				select {
-				case <-ctx.Done():
-				case sem <- struct{}{}:
-				}
-				runtime.Gosched()
-				select {
-				case <-ctx.Done():
-				case <-sem:
-				}
-			}
-			return nil
-		})
-	}
-	for i := 0; i < s.workers; i++ {
-		runWorker(i)
-	}
-	if err := g.Wait(); err != nil {
-		b.Fatal(err)
-	}
-	close(sem)
-}
-
-func (s concurrentBenchSpec) benchmarkIntPool(b *testing.B) {
-	qp := quotapool.NewIntPool("test", s.quota, quotapool.LogSlowAcquisition)
-	g, ctx := errgroup.WithContext(context.Background())
-	runWorker := func(workerNum int) {
-		g.Go(func() error {
-			for i := workerNum; i < b.N; i += s.workers {
-				alloc, err := qp.Acquire(ctx, 1)
-				if err != nil {
-					b.Fatal(err)
-				}
-				runtime.Gosched()
-				alloc.Release()
-			}
-			return nil
-		})
-	}
-	for i := 0; i < s.workers; i++ {
-		runWorker(i)
-	}
-	if err := g.Wait(); err != nil {
-		b.Fatal(err)
-	}
-	qp.Close("")
-}
-
-func (s concurrentBenchSpec) String() string {
-	return fmt.Sprintf("workers=%d,quota=%d", s.workers, s.quota)
-}
-
-var concurrentBenchSpecs = []concurrentBenchSpec{
-	{1, 1},
-	{2, 2},
-	{8, 4},
-	{128, 4},
-	{512, 128},
-	{512, 513},
-	{512, 511},
-	{1024, 4},
-	{1024, 4096},
-}
-
-// BenchmarkConcurrentIntPool benchmarks concurrent workers in a variety
-// of ratios between adequate and inadequate quota to concurrently serve all
-// workers with the IntPool.
-func BenchmarkConcurrentIntPool(b *testing.B) {
-	// test returns the arguments to b.Run for a given number of workers and
-	// quantity of quota.
-	for _, s := range concurrentBenchSpecs {
-		b.Run(s.String(), s.benchmarkIntPool)
-	}
-}
-
-// BenchmarkConcurrentChannelSem benchmarks concurrent workers in a variety
-// of ratios between adequate and inadequate quota to concurrently serve all
-// workers with a channel-based semaphore to compare the performance against
-// the IntPool.
-func BenchmarkConcurrentChannelSemaphore(b *testing.B) {
-	// test returns the arguments to b.Run for a given number of workers and
-	// quantity of quota.
-	for _, s := range concurrentBenchSpecs {
-		b.Run(s.String(), s.benchmarkChannelSem)
-	}
-}
-
 // TestIntpoolRelease tests the Release method of intpool to ensure that it releases
 // what is expected and behaves as documented.
 func TestIntpoolRelease(t *testing.T) {
@@ -688,32 +558,4 @@ func TestLen(t *testing.T) {
 	alloc.Release()
 	<-allocCh
 	assert.Equal(t, 0, qp.Len())
-}
-
-// BenchmarkIntQuotaPoolFunc benchmarks the common case where we have sufficient
-// quota available in the pool and we repeatedly acquire and release quota.
-func BenchmarkIntQuotaPoolFunc(b *testing.B) {
-	qp := quotapool.NewIntPool("test", 1, quotapool.LogSlowAcquisition)
-	ctx := context.Background()
-	toAcquire := intRequest(1)
-	for n := 0; n < b.N; n++ {
-		alloc, err := qp.AcquireFunc(ctx, toAcquire.acquire)
-		if err != nil {
-			b.Fatal(err)
-		} else if acquired := alloc.Acquired(); acquired != 1 {
-			b.Fatalf("expected to acquire %d, got %d", 1, acquired)
-		}
-		alloc.Release()
-	}
-	qp.Close("")
-}
-
-// intRequest is a wrapper to create a IntRequestFunc from an int64.
-type intRequest uint64
-
-func (ir intRequest) acquire(_ context.Context, pi quotapool.PoolInfo) (took uint64, err error) {
-	if uint64(ir) < pi.Available {
-		return 0, quotapool.ErrNotEnoughQuota
-	}
-	return uint64(ir), nil
 }

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
@@ -24,6 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// logSlowAcquisition is an Option to log slow acquisitions.
+var logSlowAcquisition = quotapool.OnSlowAcquisition(base.SlowRequestThreshold, quotapool.LogSlowAcquisition)
 
 // TestQuotaPoolBasic tests the minimal expected behavior of the quota pool
 // with different sized quota pool and a varying number of goroutines, each
@@ -561,7 +565,7 @@ func TestIntpoolRelease(t *testing.T) {
 func TestLen(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	qp := quotapool.NewIntPool("test", 1, quotapool.LogSlowAcquisition)
+	qp := quotapool.NewIntPool("test", 1, logSlowAcquisition)
 	ctx := context.Background()
 	allocCh := make(chan *quotapool.IntAlloc)
 	doAcquire := func(ctx context.Context) {


### PR DESCRIPTION
This PR has the high level goal of making the DistSender concurrency limit configuable. To achieve this goal it changes `stop.Stopper.RunLimitedAsyncTask` to take a quotapool rather than a raw channel to act as the semaphore. It additionally extends the quotapool to both have a non-blocking `Try` variant and to have a resizable capacity. It then adopts this quotapool in place of the old channels. The first commit adds benchmarking to demonstrate that the cost of switching to a quotapool isn't too high. 