### PR TITLE
sql: add more detailed test for operations during a primary key change

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -403,6 +403,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				CreatedExplicitly: true,
 				EncodingType:      sqlbase.PrimaryIndexEncoding,
 				Type:              sqlbase.IndexDescriptor_FORWARD,
+				Version:           sqlbase.SecondaryIndexFamilyFormatVersion,
 			}
 
 			// If the new index is requested to be sharded, set up the index descriptor
@@ -442,6 +443,25 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 			if err := n.tableDesc.AllocateIDs(); err != nil {
 				return err
+			}
+
+			// Ensure that the new primary index stores all columns in the table. We can't
+			// use AllocateID's to fill the stored columns here because it assumes
+			// that the indexed columns are n.PrimaryIndex.ColumnIDs, but here we want
+			// to consider the indexed columns to be newPrimaryIndexDesc.ColumnIDs.
+			newPrimaryIndexDesc.StoreColumnNames, newPrimaryIndexDesc.StoreColumnIDs = nil, nil
+			for _, col := range n.tableDesc.Columns {
+				containsCol := false
+				for _, colID := range newPrimaryIndexDesc.ColumnIDs {
+					if colID == col.ID {
+						containsCol = true
+						break
+					}
+				}
+				if !containsCol {
+					newPrimaryIndexDesc.StoreColumnIDs = append(newPrimaryIndexDesc.StoreColumnIDs, col.ID)
+					newPrimaryIndexDesc.StoreColumnNames = append(newPrimaryIndexDesc.StoreColumnNames, col.Name)
+				}
 			}
 
 			if t.Interleave != nil {

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -422,11 +422,12 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 		// We're resetting the length of this slice for variable length indexes such as inverted
 		// indexes which can append entries to the end of the slice. If we don't do this, then everything
 		// EncodeSecondaryIndexes appends to secondaryIndexEntries for a row, would stay in the slice for
-		// subsequent rows and we would then have duplicates in entries on output.
+		// subsequent rows and we would then have duplicates in entries on output. Additionally, we do
+		// not want to include empty k/v pairs while backfilling.
 		buffer = buffer[:len(ib.added)]
 		if buffer, err = sqlbase.EncodeSecondaryIndexes(
 			tableDesc.TableDesc(), ib.added, ib.colIdxMap,
-			ib.rowVals, buffer); err != nil {
+			ib.rowVals, buffer, false /* includeEmpty */); err != nil {
 			return nil, nil, err
 		}
 		entries = append(entries, buffer...)

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -354,3 +354,196 @@ message LIKE 'Scan%'
 ORDER BY message
 ----
 Scan /Table/57/2/2/{0-1}
+
+# Ensure that when backfilling an index we only insert the needed k/vs.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (
+  x INT PRIMARY KEY, y INT, z INT, w INT,
+  FAMILY (y), FAMILY (x), FAMILY (z), FAMILY (w)
+);
+INSERT INTO t VALUES (1, 2, NULL, 3), (4, 5, 6, NULL), (8, 9, NULL, NULL);
+CREATE INDEX i ON t (y) STORING (z, w)
+
+query IIII rowsort
+SET TRACING=on,kv,results;
+SELECT * FROM t@i;
+SET TRACING=off
+----
+1 2 NULL 3
+4 5 6 NULL
+8 9 NULL NULL
+
+# Ensure by scanning that we fetch 2 k/v's for row (1, 2, NULL, 3),
+# 2 k/v's for row (4, 5, 6, NULL), and 1 k/v for row (8, 9, NULL, NULL).
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'fetched%'
+ORDER BY message
+----
+fetched: /t/i/2/1 -> NULL
+fetched: /t/i/2/1/w -> /3
+fetched: /t/i/5/4 -> NULL
+fetched: /t/i/5/4/z -> /6
+fetched: /t/i/9/8 -> NULL
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (
+  x INT PRIMARY KEY, y INT, z INT, w INT,
+  FAMILY (y), FAMILY (x), FAMILY (z), FAMILY (w)
+);
+INSERT INTO t VALUES (1, 2, NULL, NULL)
+
+statement ok
+BEGIN
+
+# Place i on the mutations queue in a delete only state.
+statement ok
+CREATE INDEX i ON t (y) STORING (z, w)
+
+statement ok
+SET TRACING=on,kv,results;
+UPDATE t SET z = 3 WHERE y = 2;
+SET TRACING=off
+
+# Because i is in a delete only state, we should see a delete
+# for each k/v for i for the row (1, 2, NULL, NULL).
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Del%'
+ORDER BY message
+----
+Del /Table/59/2/2/1/0
+Del /Table/59/2/2/1/2/1
+Del /Table/59/2/2/1/3/1
+
+statement ok
+COMMIT
+
+query IIII
+SELECT * FROM t@i
+----
+1 2 3 NULL
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (
+  x INT PRIMARY KEY, y INT, a INT, b INT, c INT, d INT, e INT, f INT,
+  FAMILY (x), FAMILY (y), FAMILY (a, b), FAMILY (c, d), FAMILY (e), FAMILY (f),
+  INDEX i1 (y) STORING (a, b, c, d, e, f),
+  UNIQUE INDEX i2 (y) STORING (a, b, c, d, e, f)
+);
+
+# Ensure we only insert the correct keys.
+statement ok
+SET TRACING=on,kv,results;
+INSERT INTO t VALUES (1, 2, 3, NULL, 5, 6, NULL, 8);
+SET TRACING=off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'InitPut%'
+ORDER BY message
+----
+InitPut /Table/60/2/2/1/0 -> /BYTES/
+InitPut /Table/60/2/2/1/2/1 -> /TUPLE/3:3:Int/3
+InitPut /Table/60/2/2/1/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
+InitPut /Table/60/2/2/1/5/1 -> /TUPLE/8:8:Int/8
+InitPut /Table/60/3/2/0 -> /BYTES/0x89
+InitPut /Table/60/3/2/2/1 -> /TUPLE/3:3:Int/3
+InitPut /Table/60/3/2/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
+InitPut /Table/60/3/2/5/1 -> /TUPLE/8:8:Int/8
+
+# Test some cases of the updater.
+statement ok
+SET TRACING=on,kv,results;
+UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2;
+SET TRACING=off
+
+query IIIIIIII
+SELECT * FROM t@i2
+----
+1 2 3 4 NULL NULL 7 NULL
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Put /Table/60/2/%' OR
+message LIKE 'Del /Table/60/2/%' OR
+message LIKE 'CPut /Table/60/2/%'
+----
+CPut /Table/60/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4 (replacing raw_bytes:"\000\000\000\000\n3\006" timestamp:<> , if exists)
+Del /Table/60/2/2/1/3/1
+CPut /Table/60/2/2/1/4/1 -> /TUPLE/7:7:Int/7 (expecting does not exist)
+Del /Table/60/2/2/1/5/1
+
+statement ok
+INSERT INTO t VALUES (3, 3, NULL, NULL, NULL, NULL, NULL, NULL)
+
+statement ok
+SET TRACING=on,kv,results;
+UPDATE t SET a = 10, b = 11, c = 12, d = 13, e = 14, f = 15 WHERE y = 3;
+SET TRACING=off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Put /Table/60/2/%' OR
+message LIKE 'Del /Table/60/2/%' OR
+message LIKE 'CPut /Table/60/2/%'
+----
+CPut /Table/60/2/3/3/2/1 -> /TUPLE/3:3:Int/10/1:4:Int/11 (expecting does not exist)
+CPut /Table/60/2/3/3/3/1 -> /TUPLE/5:5:Int/12/1:6:Int/13 (expecting does not exist)
+CPut /Table/60/2/3/3/4/1 -> /TUPLE/7:7:Int/14 (expecting does not exist)
+CPut /Table/60/2/3/3/5/1 -> /TUPLE/8:8:Int/15 (expecting does not exist)
+
+statement ok
+SET TRACING=on,kv,results;
+UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3;
+SET TRACING=off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Put /Table/60/2/%' OR
+message LIKE 'Del /Table/60/2/%' OR
+message LIKE 'CPut /Table/60/2/%'
+----
+Del /Table/60/2/3/3/2/1
+Del /Table/60/2/3/3/3/1
+Del /Table/60/2/3/3/4/1
+Del /Table/60/2/3/3/5/1
+
+
+statement ok
+INSERT INTO t VALUES (20, 21, 22, NULL, NULL, 25, NULL, 27);
+SET TRACING=on,kv,results;
+UPDATE t SET y = 22 WHERE y = 21;
+SET TRACING=off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+message LIKE 'Put /Table/60/2/%' OR
+message LIKE 'Del /Table/60/2/%' OR
+message LIKE 'CPut /Table/60/2/%'
+----
+Del /Table/60/2/21/20/0
+CPut /Table/60/2/22/20/0 -> /BYTES/ (expecting does not exist)
+Del /Table/60/2/21/20/2/1
+CPut /Table/60/2/22/20/2/1 -> /TUPLE/3:3:Int/22 (expecting does not exist)
+Del /Table/60/2/21/20/3/1
+CPut /Table/60/2/22/20/3/1 -> /TUPLE/6:6:Int/25 (expecting does not exist)
+Del /Table/60/2/21/20/5/1
+CPut /Table/60/2/22/20/5/1 -> /TUPLE/8:8:Int/27 (expecting does not exist)
+
+query IIIIIIII rowsort
+SELECT * FROM t@i1
+----
+1 2 3 4 NULL NULL 7 NULL
+3 3 NULL NULL NULL NULL NULL NULL
+20 22 22 NULL NULL 25 NULL 27
+
+query IIIIIIII rowsort
+SELECT * FROM t@i2
+----
+1 2 3 4 NULL NULL 7 NULL
+3 3 NULL NULL NULL NULL NULL NULL
+20 22 22 NULL NULL 25 NULL 27

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -139,8 +139,9 @@ func (rd *Deleter) DeleteRow(
 
 	// Delete the row from any secondary indices.
 	for i := range rd.Helper.Indexes {
+		// We want to include empty k/v pairs because we want to delete all k/v's for this row.
 		entries, err := sqlbase.EncodeSecondaryIndex(
-			rd.Helper.TableDesc.TableDesc(), &rd.Helper.Indexes[i], rd.FetchColIDtoRowIndex, values)
+			rd.Helper.TableDesc.TableDesc(), &rd.Helper.Indexes[i], rd.FetchColIDtoRowIndex, values, true /* includeEmpty */)
 		if err != nil {
 			return err
 		}
@@ -212,8 +213,9 @@ func (rd *Deleter) DeleteIndexRow(
 			return err
 		}
 	}
+	// We want to include empty k/v pairs because we want to delete all k/v's for this row.
 	secondaryIndexEntry, err := sqlbase.EncodeSecondaryIndex(
-		rd.Helper.TableDesc.TableDesc(), idx, rd.FetchColIDtoRowIndex, values)
+		rd.Helper.TableDesc.TableDesc(), idx, rd.FetchColIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1358,7 +1358,9 @@ func (rf *Fetcher) checkSecondaryIndexDatumEncodings(ctx context.Context) error 
 		values[i] = table.row[i].Datum
 	}
 
-	indexEntries, err := sqlbase.EncodeSecondaryIndex(table.desc.TableDesc(), table.index, table.colIdxMap, values)
+	// The below code makes incorrect checks (#45256).
+	indexEntries, err := sqlbase.EncodeSecondaryIndex(
+		table.desc.TableDesc(), table.index, table.colIdxMap, values, false /* includeEmpty */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -56,13 +56,13 @@ func newRowHelper(
 // secondaryIndexEntries are only valid until the next call to encodeIndexes or
 // encodeSecondaryIndexes.
 func (rh *rowHelper) encodeIndexes(
-	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum,
+	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum, includeEmpty bool,
 ) (primaryIndexKey []byte, secondaryIndexEntries []sqlbase.IndexEntry, err error) {
 	primaryIndexKey, err = rh.encodePrimaryIndex(colIDtoRowIndex, values)
 	if err != nil {
 		return nil, nil, err
 	}
-	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(colIDtoRowIndex, values)
+	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(colIDtoRowIndex, values, includeEmpty)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,13 +86,13 @@ func (rh *rowHelper) encodePrimaryIndex(
 // secondaryIndexEntries are only valid until the next call to encodeIndexes or
 // encodeSecondaryIndexes.
 func (rh *rowHelper) encodeSecondaryIndexes(
-	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum,
+	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum, includeEmpty bool,
 ) (secondaryIndexEntries []sqlbase.IndexEntry, err error) {
 	if len(rh.indexEntries) != len(rh.Indexes) {
 		rh.indexEntries = make([]sqlbase.IndexEntry, len(rh.Indexes))
 	}
 	rh.indexEntries, err = sqlbase.EncodeSecondaryIndexes(
-		rh.TableDesc.TableDesc(), rh.Indexes, colIDtoRowIndex, values, rh.indexEntries)
+		rh.TableDesc.TableDesc(), rh.Indexes, colIDtoRowIndex, values, rh.indexEntries, includeEmpty)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -158,7 +158,9 @@ func (ri *Inserter) InsertRow(
 		}
 	}
 
-	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(ri.InsertColIDtoRowIndex, values)
+	// We don't want to insert any empty k/v's, so set includeEmpty to false.
+	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(
+		ri.InsertColIDtoRowIndex, values, false /* includeEmpty */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -319,7 +319,7 @@ func (ru *Updater) UpdateRow(
 	}
 	var deleteOldSecondaryIndexEntries []sqlbase.IndexEntry
 	if ru.DeleteHelper != nil {
-		_, deleteOldSecondaryIndexEntries, err = ru.DeleteHelper.encodeIndexes(ru.FetchColIDtoRowIndex, oldValues)
+		_, deleteOldSecondaryIndexEntries, err = ru.DeleteHelper.encodeIndexes(ru.FetchColIDtoRowIndex, oldValues, true /* includeEmpty */)
 		if err != nil {
 			return nil, err
 		}
@@ -352,15 +352,24 @@ func (ru *Updater) UpdateRow(
 	}
 
 	for i := range ru.Helper.Indexes {
-		// TODO (rohany): include a version of sqlbase.EncodeSecondaryIndex that allocates index entries
-		//  into an argument list.
+		// We don't want to write k/v's that have empty values, so don't include empty k/v's here.
 		ru.oldIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
-			ru.Helper.TableDesc.TableDesc(), &ru.Helper.Indexes[i], ru.FetchColIDtoRowIndex, oldValues)
+			ru.Helper.TableDesc.TableDesc(),
+			&ru.Helper.Indexes[i],
+			ru.FetchColIDtoRowIndex,
+			oldValues,
+			false, /* includeEmpty */
+		)
 		if err != nil {
 			return nil, err
 		}
 		ru.newIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
-			ru.Helper.TableDesc.TableDesc(), &ru.Helper.Indexes[i], ru.FetchColIDtoRowIndex, ru.newValues)
+			ru.Helper.TableDesc.TableDesc(),
+			&ru.Helper.Indexes[i],
+			ru.FetchColIDtoRowIndex,
+			ru.newValues,
+			false, /* includeEmpty */
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -436,35 +445,103 @@ func (ru *Updater) UpdateRow(
 	for i := range ru.Helper.Indexes {
 		index := &ru.Helper.Indexes[i]
 		if index.Type == sqlbase.IndexDescriptor_FORWARD {
-			if len(ru.oldIndexEntries[i]) != len(ru.newIndexEntries[i]) {
-				panic("expected same number of index entries for old and new values")
-			}
-			for j := range ru.oldIndexEntries[i] {
-				oldEntry := &ru.oldIndexEntries[i][j]
-				newEntry := &ru.newIndexEntries[i][j]
-				var expValue *roachpb.Value
-				if !bytes.Equal(oldEntry.Key, newEntry.Key) {
-					// TODO (rohany): this check is duplicated here and above, is there a reason?
-					ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID, ru.Helper.Indexes[i].Type)
+			oldIdx, newIdx := 0, 0
+			oldEntries, newEntries := ru.oldIndexEntries[i], ru.newIndexEntries[i]
+			for oldIdx < len(oldEntries) && newIdx < len(newEntries) {
+				oldEntry, newEntry := &oldEntries[oldIdx], &newEntries[newIdx]
+				if oldEntry.Family == newEntry.Family {
+					// If the families are equal, then check if the keys have changed. If so, delete the old key.
+					// Then, issue a CPut for the new value of the key if the value has changed.
+					// Because the indexes will always have a k/v for family 0, it suffices to only
+					// add foreign key checks in this case, because we are guaranteed to enter here.
+					oldIdx++
+					newIdx++
+					var expValue *roachpb.Value
+					if !bytes.Equal(oldEntry.Key, newEntry.Key) {
+						ru.Fks.addCheckForIndex(index.ID, index.Type)
+						if traceKV {
+							log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldEntry.Key))
+						}
+						batch.Del(oldEntry.Key)
+					} else if !newEntry.Value.EqualData(oldEntry.Value) {
+						expValue = &oldEntry.Value
+					} else {
+						continue
+					}
+					if traceKV {
+						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
+						v := newEntry.Value.PrettyPrint()
+						if expValue != nil {
+							log.VEventf(ctx, 2, "CPut %s -> %v (replacing %v, if exists)", k, v, expValue)
+						} else {
+							log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+						}
+					}
+					batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, expValue)
+				} else if oldEntry.Family < newEntry.Family {
+					if oldEntry.Family == sqlbase.FamilyID(0) {
+						return nil, errors.AssertionFailedf(
+							"index entry for family 0 for table %s, index %s was not generated",
+							ru.Helper.TableDesc.Name, index.Name,
+						)
+					}
+					// In this case, the index has a k/v for a family that does not exist in
+					// the new set of k/v's for the row. So, we need to delete the old k/v.
 					if traceKV {
 						log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldEntry.Key))
 					}
 					batch.Del(oldEntry.Key)
-				} else if !newEntry.Value.EqualData(oldEntry.Value) {
-					expValue = &oldEntry.Value
+					oldIdx++
 				} else {
-					continue
+					if newEntry.Family == sqlbase.FamilyID(0) {
+						return nil, errors.AssertionFailedf(
+							"index entry for family 0 for table %s, index %s was not generated",
+							ru.Helper.TableDesc.Name, index.Name,
+						)
+					}
+					// In this case, the index now has a k/v that did not exist in the
+					// old row, so we should expect to not see a value for the new
+					// key, and put the new key in place.
+					if traceKV {
+						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
+						v := newEntry.Value.PrettyPrint()
+						log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+					}
+					batch.CPut(newEntry.Key, &newEntry.Value, nil)
+					newIdx++
+				}
+			}
+			for oldIdx < len(oldEntries) {
+				// Delete any remaining old entries that are not matched by new entries in this row.
+				oldEntry := &oldEntries[oldIdx]
+				if oldEntry.Family == sqlbase.FamilyID(0) {
+					return nil, errors.AssertionFailedf(
+						"index entry for family 0 for table %s, index %s was not generated",
+						ru.Helper.TableDesc.Name, index.Name,
+					)
+				}
+				if traceKV {
+					log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldEntry.Key))
+				}
+				batch.Del(oldEntry.Key)
+				oldIdx++
+			}
+			for newIdx < len(newEntries) {
+				// Insert any remaining new entries that are not present in the old row.
+				newEntry := &newEntries[newIdx]
+				if newEntry.Family == sqlbase.FamilyID(0) {
+					return nil, errors.AssertionFailedf(
+						"index entry for family 0 for table %s, index %s was not generated",
+						ru.Helper.TableDesc.Name, index.Name,
+					)
 				}
 				if traceKV {
 					k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
 					v := newEntry.Value.PrettyPrint()
-					if expValue != nil {
-						log.VEventf(ctx, 2, "CPut %s -> %v (replacing %v, if exists)", k, v, expValue)
-					} else {
-						log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
-					}
+					log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
 				}
-				batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, expValue)
+				batch.CPut(newEntry.Key, &newEntry.Value, nil)
+				newIdx++
 			}
 		} else {
 			// Remove all inverted index entries, and re-add them.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2562,6 +2562,168 @@ CREATE TABLE t.test (k INT NOT NULL, v INT);
 		// be using k as the primary key, we disable the UPSERT statements in the test.
 		false,
 	)
+
+	// runSchemaChangeWithOperations only performs some simple
+	// operations on the kv table. We want to also run some
+	// more operations against a table with more columns.
+	if _, err := sqlDB.Exec(`
+DROP TABLE t.test;
+CREATE TABLE t.test (
+	x INT PRIMARY KEY, y INT NOT NULL, z INT, a INT, b INT,
+	c INT, d INT, FAMILY (x), FAMILY (y), FAMILY (z),
+	FAMILY (a, b), FAMILY (c), FAMILY (d)
+);
+`); err != nil {
+		t.Fatal(err)
+	}
+	// Insert into the table.
+	inserts := make([]string, maxValue+1)
+	for i := 0; i < maxValue+1; i++ {
+		inserts[i] = fmt.Sprintf(
+			"(%d, %d, %d, %d, %d, %d, %d)",
+			i, i, i, i, i, i, i,
+		)
+	}
+	if _, err := sqlDB.Exec(
+		fmt.Sprintf(`INSERT INTO t.test VALUES %s`, strings.Join(inserts, ","))); err != nil {
+		t.Fatal(err)
+	}
+
+	notification := initBackfillNotification()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if _, err := sqlDB.Exec(`
+SET experimental_enable_primary_key_changes = true;
+ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (y)`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	// Wait until the backfill starts.
+	<-notification
+
+	// Update some rows.
+	rowsUpdated := make(map[int]struct{})
+	for i := 0; i < 10; i++ {
+		// Update a row that hasn't been updated yet.
+		for {
+			k := rand.Intn(maxValue)
+			if _, ok := rowsUpdated[k]; !ok {
+				rowsUpdated[k] = struct{}{}
+				break
+			}
+		}
+	}
+	for k := range rowsUpdated {
+		if _, err := sqlDB.Exec(`
+UPDATE t.test SET z = NULL, a = $1, b = NULL, c = NULL, d = $1 WHERE y = $2`, 2*k, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Delete some rows.
+	rowsDeleted := make(map[int]struct{})
+	for i := 0; i < 10; i++ {
+		// Delete a row that hasn't been updated.
+		for {
+			k := rand.Intn(maxValue)
+			_, updated := rowsUpdated[k]
+			_, deleted := rowsDeleted[k]
+			if !updated && !deleted {
+				rowsDeleted[k] = struct{}{}
+				break
+			}
+		}
+	}
+	for k := range rowsDeleted {
+		if _, err := sqlDB.Exec(`DELETE FROM t.test WHERE x = $1`, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Insert some rows.
+	inserts = make([]string, 10)
+	for i := 0; i < 10; i++ {
+		val := i + maxValue + 1
+		inserts[i] = fmt.Sprintf(
+			"(%d, %d, %d, %d, %d, %d, %d)",
+			val, val, val, val, val, val, val,
+		)
+	}
+	if _, err := sqlDB.Exec(
+		fmt.Sprintf(`INSERT INTO t.test VALUES %s`, strings.Join(inserts, ","))); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the pk change to complete.
+	wg.Wait()
+
+	// Ensure that the count of rows is correct along both indexes.
+	var count int
+	row := sqlDB.QueryRow(`SELECT count(*) FROM t.test@primary`)
+	if err := row.Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != maxValue+1 {
+		t.Fatalf("expected %d rows, found %d", maxValue+1, count)
+	}
+	row = sqlDB.QueryRow(`SELECT count(x) FROM t.test@test_x_key`)
+	if err := row.Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != maxValue+1 {
+		t.Fatalf("expected %d rows, found %d", maxValue+1, count)
+	}
+
+	// Verify that we cannot find our deleted rows.
+	for k := range rowsDeleted {
+		row := sqlDB.QueryRow(`SELECT count(*) FROM t.test WHERE x = $1`, k)
+		if err := row.Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("expected %d rows, found %d", 0, count)
+		}
+	}
+
+	// Verify that we can find our inserted rows.
+	for i := 0; i < 10; i++ {
+		val := i + maxValue + 1
+		row := sqlDB.QueryRow(`SELECT * FROM t.test WHERE y = $1`, val)
+		var x, y, z, a, b, c, d int
+		if err := row.Scan(&x, &y, &z, &a, &b, &c, &d); err != nil {
+			t.Fatal(err)
+		}
+		for i, v := range []int{x, y, z, a, b, c, d} {
+			if v != val {
+				t.Fatalf("expected to find %d for column %d, but found %d", val, i, v)
+			}
+		}
+	}
+
+	// Verify that our updated rows have indeed been updated.
+	for k := range rowsUpdated {
+		row := sqlDB.QueryRow(`SELECT * FROM t.test WHERE y = $1`, k)
+		var (
+			x, y, a, d int
+			z, b, c    gosql.NullInt64
+		)
+		if err := row.Scan(&x, &y, &z, &a, &b, &c, &d); err != nil {
+			t.Fatal(err)
+		}
+		require.Equal(t, k, x)
+		require.Equal(t, k, y)
+		require.Equal(t, 2*k, a)
+		require.Equal(t, 2*k, d)
+		for _, v := range []gosql.NullInt64{z, b, c} {
+			if v.Valid {
+				t.Fatalf("expected NULL but found %d", v.Int64)
+			}
+		}
+	}
 }
 
 // TestPrimaryKeyChangeKVOps tests sequences of k/v operations

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -64,7 +64,7 @@ INSERT INTO t."tEst" VALUES (10, 20);
 	// Construct the secondary index key that is currently in the
 	// database.
 	secondaryIndexKey, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values)
+		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -132,7 +132,7 @@ CREATE INDEX secondary ON t.test (v);
 	// Construct datums and secondary k/v for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(314)}
 	secondaryIndex, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values)
+		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -226,7 +226,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate the existing secondary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(1337)}
 	secondaryIndex, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values)
+		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 
 	if len(secondaryIndex) != 1 {
 		t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndex), secondaryIndex)
@@ -243,7 +243,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate a secondary index k/v that has a different value.
 	values = []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(314)}
 	secondaryIndex, err = sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values)
+		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -444,7 +444,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 	// Construct the secondary index key entry as it exists in the
 	// database.
 	secondaryIndexKey, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values)
+		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -464,7 +464,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 
 	// Construct the new secondary index key that will be inserted.
 	secondaryIndexKey, err = sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values)
+		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3306,7 +3306,7 @@ may increase either contention or retry errors, or both.`,
 					return tree.NewDBytes(tree.DBytes(res)), err
 				}
 				// We have a secondary index.
-				res, err := sqlbase.EncodeSecondaryIndex(tableDesc, indexDesc, colMap, datums)
+				res, err := sqlbase.EncodeSecondaryIndex(tableDesc, indexDesc, colMap, datums, true /* includeEmpty */)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -224,7 +224,7 @@ func TestIndexKey(t *testing.T) {
 		primaryIndexKV := client.KeyValue{Key: primaryKey, Value: &primaryValue}
 
 		secondaryIndexEntry, err := EncodeSecondaryIndex(
-			&tableDesc, &tableDesc.Indexes[0], colMap, testValues)
+			&tableDesc, &tableDesc.Indexes[0], colMap, testValues, true /* includeEmpty */)
 		if len(secondaryIndexEntry) != 1 {
 			t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndexEntry), secondaryIndexEntry)
 		}


### PR DESCRIPTION
The existing operations test did not catch various bugs
uncovered in #45347, so this test expands upon the existing
schema change operations tests with a larger test case.

Depends on #45347 to land first.

Release note: None