### PR TITLE
sql/opt/exec: re-ignore batches to meta/schema ranges in autocommit test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -33,7 +33,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -54,7 +54,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -78,7 +78,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -102,7 +102,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -123,7 +123,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -147,7 +147,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -184,7 +184,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -205,7 +205,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -229,7 +229,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -253,7 +253,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -274,7 +274,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -298,7 +298,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -335,7 +335,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -360,7 +360,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -385,7 +385,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -407,7 +407,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -432,7 +432,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -470,7 +470,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -491,7 +491,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -515,7 +515,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -539,7 +539,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message     LIKE '%sending batch%'
+WHERE message     LIKE '%r29: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
@@ -561,7 +561,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -586,7 +586,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -636,7 +636,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -659,7 +659,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -684,7 +684,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -715,7 +715,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
@@ -740,7 +740,7 @@ SET TRACING=OFF
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-WHERE message       LIKE '%sending batch%'
+WHERE message       LIKE '%r29: sending batch%'
   AND message   NOT LIKE '%PushTxn%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'


### PR DESCRIPTION
Copy of #45175, which was reverted by #44232.

This commit restricts the trace events that the test listens to down
to just those that occur on the SQL table that the test is actively
manipulating. This should deflake #43043.