### PR TITLE
colexec: plan disk-backed sorter for window functions' use

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -1,4 +1,4 @@
-# LogicTest: local-vec
+# LogicTest: local-vec fakedist-vec
 
 statement ok
 CREATE TABLE t (a INT, b INT, c INT PRIMARY KEY)


### PR DESCRIPTION
Previously, an in-memory sorter was used by the window functions. This
commit extracts the planning logic for instantiating disk-backed sorter
and reuses it in the window functions' use case.

Release note: None