### PR TITLE
ui: Extend Button component styles

### DIFF
--- a/pkg/ui/src/components/button/button.styl
+++ b/pkg/ui/src/components/button/button.styl
@@ -12,10 +12,11 @@
 
 .crl-button
   border-radius 3px
+  cursor pointer
+  width max-content
 
 .crl-button--type-flat
-  border none
-  cursor pointer
+  border solid 1px transparent
   background-color transparent
   color $colors--primary-blue-3
 
@@ -35,7 +36,6 @@
     cursor default
 
 .crl-button--type-primary
-  cursor pointer
   background-color $colors--primary-green-3
   color $colors--white
   border solid 1px $colors--primary-green-3
@@ -57,6 +57,30 @@
     pointer-events none
     cursor default
 
+
+.crl-button--type-secondary
+  background-color $colors--white
+  color $colors--primary-text
+  border solid 1px $colors--neutral-4
+
+  &:hover, &:active, &:focus
+    color $colors--primary-text
+    background $colors--neutral-1
+
+  &:active
+    border solid 1px $colors--neutral-5
+
+  &:focus
+    outline none
+    border solid 1px $colors--neutral-5
+
+  &.crl-button--disabled
+    border solid 1px $colors--neutral-4
+    background $colors--neutral-1
+    color $colors--neutral-5
+    pointer-events none
+    cursor default
+
 .crl-button--size-default
   height $line-height--larger
   min-width $line-height--larger
@@ -68,14 +92,13 @@
   min-width $line-height--medium
   padding 0 $spacing-xx-small
 
-
-
 .crl-button__container
   display flex
   flex-direction row
+  flex-wrap nowrap
 
-crl-button__icon--push-left
+.crl-button__icon--push-left
   order -1
 
-crl-button__icon--push-left
+.crl-button__icon--push-right
   order 1


### PR DESCRIPTION
- Add styles for button secondary type (according to DS)
- Add styles to prevent word wrapping inside button. Button will
have width to place its content in one line
- Fix styles for aligning button icon (left-right sides)