### PR TITLE
sql: ensure that a table can be created with a column named rowid

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -438,7 +438,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// Make a new index that is suitable to be a primary index.
-			name := generateUniqueConstraintName(
+			name := sqlbase.GenerateUniqueConstraintName(
 				"new_primary_key",
 				nameExists,
 			)
@@ -592,11 +592,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 			for _, idx := range indexesToRewrite {
 				// Clone the index that we want to rewrite.
 				newIndex := protoutil.Clone(idx).(*sqlbase.IndexDescriptor)
-				name := newIndex.Name + "_rewrite_for_primary_key_change"
-				for try := 1; nameExists(name); try++ {
-					name = fmt.Sprintf("%s#%d", name, try)
-				}
-				newIndex.Name = name
+				basename := newIndex.Name + "_rewrite_for_primary_key_change"
+				newIndex.Name = sqlbase.GenerateUniqueConstraintName(basename, nameExists)
 				if err := addIndexMutationWithSpecificPrimaryKey(n.tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
 					return err
 				}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -634,7 +634,7 @@ func ResolveFK(
 	}
 	constraintName := string(d.Name)
 	if constraintName == "" {
-		constraintName = generateUniqueConstraintName(
+		constraintName = sqlbase.GenerateUniqueConstraintName(
 			fmt.Sprintf("fk_%s_ref_%s", string(d.FromCols[0]), target.Name),
 			func(p string) bool {
 				_, ok := constraintInfo[p]
@@ -751,18 +751,6 @@ func ResolveFK(
 	}
 
 	return nil
-}
-
-// generateUniqueConstraintName attempts to generate a unique constraint name
-// with the given prefix.
-// It will first try prefix by itself, then it will subsequently try
-// adding numeric digits at the end, starting from 1.
-func generateUniqueConstraintName(prefix string, nameExistsFunc func(name string) bool) string {
-	name := prefix
-	for i := 1; nameExistsFunc(name); i++ {
-		name = fmt.Sprintf("%s_%d", prefix, i)
-	}
-	return name
 }
 
 // Adds an index to a table descriptor (that is in the process of being created)

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -580,6 +580,31 @@ SELECT * FROM t@i
 ----
 1 2 3
 
+# Ensure we don't rewrite default primary index even if its name isn't rowid.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (rowid INT NOT NULL);
+
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE t (
+   rowid INT8 NOT NULL,
+   FAMILY "primary" (rowid, rowid_1)
+)
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (rowid)
+
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE t (
+   rowid INT8 NOT NULL,
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+   FAMILY "primary" (rowid, rowid_1)
+)
+
 # Regression for old primary key not using PrimaryIndexEncoding as its encoding type.
 subtest encoding_bug
 
@@ -688,4 +713,3 @@ SELECT job_id FROM [SHOW JOBS] WHERE
 description = 'CLEANUP JOB for ''ALTER TABLE test.public.t ALTER PRIMARY KEY USING COLUMNS (y)''' AND
 status = 'running'
 ----
-

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -44,3 +44,30 @@ set require_explicit_primary_keys=true
 
 statement error pq: no primary key specified for table t \(require_explicit_primary_keys = true\)
 CREATE TABLE t (x INT, y INT)
+
+# Regression for #45496.
+statement ok
+reset require_explicit_primary_keys;
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (rowid INT, rowid_1 INT, FAMILY (rowid, rowid_1))
+
+query T rowsort
+SELECT column_name FROM [SHOW COLUMNS FROM t]
+----
+rowid
+rowid_1
+rowid_2
+
+query TT
+SELECT index_name, column_name FROM [SHOW INDEXES FROM t]
+----
+primary rowid_2
+
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE t (
+   rowid INT8 NULL,
+   rowid_1 INT8 NULL,
+   FAMILY fam_0_rowid_rowid_1_rowid_2 (rowid, rowid_1, rowid_2)
+)

--- a/pkg/sql/logictest/testdata/logic_test/no_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/no_primary_key
@@ -1,8 +1,3 @@
-query error duplicate column name: "rowid"
-CREATE TABLE t (
-  rowid INT
-)
-
 statement ok
 CREATE TABLE t (
   a INT,

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1244,9 +1244,13 @@ func (desc *MutableTableDescriptor) AllocateIDs() error {
 func (desc *MutableTableDescriptor) ensurePrimaryKey() error {
 	if len(desc.PrimaryIndex.ColumnNames) == 0 && desc.IsPhysicalTable() {
 		// Ensure a Primary Key exists.
+		nameExists := func(name string) bool {
+			_, _, err := desc.FindColumnByName(tree.Name(name))
+			return err == nil
+		}
 		s := "unique_rowid()"
 		col := &ColumnDescriptor{
-			Name:        "rowid",
+			Name:        GenerateUniqueConstraintName("rowid", nameExists),
 			Type:        *types.Int,
 			DefaultExpr: &s,
 			Hidden:      true,
@@ -2910,7 +2914,7 @@ func (desc *TableDescriptor) IsPrimaryIndexDefaultRowID() bool {
 		// Should never be in this case.
 		panic(err)
 	}
-	return col.Hidden && col.Name == "rowid"
+	return col.Hidden
 }
 
 // MakeMutationComplete updates the descriptor upon completion of a mutation.
@@ -4047,4 +4051,16 @@ func (ddk DeprecatedDatabaseKey) Key() roachpb.Key {
 // Name implements DescriptorKey interface.
 func (ddk DeprecatedDatabaseKey) Name() string {
 	return ddk.name
+}
+
+// GenerateUniqueConstraintName attempts to generate a unique constraint name
+// with the given prefix.
+// It will first try prefix by itself, then it will subsequently try
+// adding numeric digits at the end, starting from 1.
+func GenerateUniqueConstraintName(prefix string, nameExistsFunc func(name string) bool) string {
+	name := prefix
+	for i := 1; nameExistsFunc(name); i++ {
+		name = fmt.Sprintf("%s_%d", prefix, i)
+	}
+	return name
 }


### PR DESCRIPTION
Fixes #45496.

This PR also fixes a small bug in how indexes can be
renamed in the primary key change.

Release note (bug fix): This PR fixes a bug where a table without
a primary key and a column named "rowid" would throw an error
when being created.