### PR TITLE
jobs: allow jobs to create SessionBoundInternalExecutors

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -18,7 +18,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -560,6 +562,12 @@ func (j *Job) FractionCompleted() float32 {
 func (j *Job) WithTxn(txn *client.Txn) *Job {
 	j.txn = txn
 	return j
+}
+
+func (j *Job) MakeSessionBoundInternalExecutor(
+	ctx context.Context, sd *sessiondata.SessionData,
+) sqlutil.InternalExecutor {
+	return j.registry.sessionBoundInternalExecutorFactory(ctx, sd)
 }
 
 func (j *Job) runInTxn(ctx context.Context, fn func(context.Context, *client.Txn) error) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -844,6 +844,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return &ie
 		}
 
+	// We use the SessionBoundInternalExecutor from the distSQLServer.
+	s.jobRegistry.SetSessionBoundInternalExecutorFactory(
+		s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory)
+
 	for _, m := range s.pgServer.Metrics() {
 		s.registry.AddMetricStruct(m)
 	}


### PR DESCRIPTION
This PR adds a `SessionBoundInternalExecutorFactory` to the job
registry, and exposes the ability to create session bound internal
executors in jobs via a method `MakeSessionBoundInternalExecutor()` on
`Job`. This is needed for the (forthcoming) temp table cleanup job.

This diff is a subset of #45185 (at time of writing) and only contains the internal executor factory changes. I'm pulling out the changes since they're useful for schema changes as well.

Release note: None