### PR TITLE
importccl: Improve delimited import performance.

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -142,7 +142,8 @@ func makeInputConverter(
 			kvCh, spec.Format.Csv, spec.WalltimeNanos, int(spec.ReaderParallelism),
 			singleTable, singleTableTargetCols, evalCtx), nil
 	case roachpb.IOFileFormat_MysqlOutfile:
-		return newMysqloutfileReader(ctx, kvCh, spec.Format.MysqlOut, singleTable, evalCtx)
+		return newMysqloutfileReader(
+			spec.Format.MysqlOut, kvCh, spec.WalltimeNanos, int(spec.ReaderParallelism), singleTable, evalCtx)
 	case roachpb.IOFileFormat_Mysqldump:
 		return newMysqldumpReader(ctx, kvCh, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_PgCopy:

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -2410,7 +2411,7 @@ var _ importRowProducer = &csvBenchmarkStream{}
 // BenchmarkConvertRecord-16    	  500000	      2365 ns/op	  50.73 MB/s	    3606 B/op	     101 allocs/op
 // BenchmarkConvertRecord-16    	  500000	      2376 ns/op	  50.49 MB/s	    3606 B/op	     101 allocs/op
 // BenchmarkConvertRecord-16    	  500000	      2390 ns/op	  50.20 MB/s	    3606 B/op	     101 allocs/op
-func BenchmarkConvertRecord(b *testing.B) {
+func BenchmarkCSVConvertRecord(b *testing.B) {
 	ctx := context.TODO()
 
 	tpchLineItemDataRows := [][]string{
@@ -2490,6 +2491,105 @@ func BenchmarkConvertRecord(b *testing.B) {
 	require.NoError(b, runParallelImport(ctx, importCtx, &importFileContext{}, producer, consumer))
 	close(kvCh)
 	b.ReportAllocs()
+}
+
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/cockroachdb/cockroach/pkg/ccl/importccl
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14411 ns/op	   8.33 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     15090 ns/op	   7.95 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14575 ns/op	   8.23 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14677 ns/op	   8.18 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14554 ns/op	   8.24 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14598 ns/op	   8.22 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14493 ns/op	   8.28 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14501 ns/op	   8.27 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14712 ns/op	   8.16 MB/s
+// BenchmarkDelimitedConvertRecord-16    	  100000	     14491 ns/op	   8.28 MB/s
+func BenchmarkDelimitedConvertRecord(b *testing.B) {
+	ctx := context.TODO()
+
+	tpchLineItemDataRows := [][]string{
+		{"1", "155190", "7706", "1", "17", "21168.23", "0.04", "0.02", "N", "O", "1996-03-13", "1996-02-12", "1996-03-22", "DELIVER IN PERSON", "TRUCK", "egular courts above the"},
+		{"1", "67310", "7311", "2", "36", "45983.16", "0.09", "0.06", "N", "O", "1996-04-12", "1996-02-28", "1996-04-20", "TAKE BACK RETURN", "MAIL", "ly final dependencies: slyly bold "},
+		{"1", "63700", "3701", "3", "8", "13309.60", "0.10", "0.02", "N", "O", "1996-01-29", "1996-03-05", "1996-01-31", "TAKE BACK RETURN", "REG AIR", "riously. regular, express dep"},
+		{"1", "2132", "4633", "4", "28", "28955.64", "0.09", "0.06", "N", "O", "1996-04-21", "1996-03-30", "1996-05-16", "NONE", "AIR", "lites. fluffily even de"},
+		{"1", "24027", "1534", "5", "24", "22824.48", "0.10", "0.04", "N", "O", "1996-03-30", "1996-03-14", "1996-04-01", "NONE", "FOB", " pending foxes. slyly re"},
+		{"1", "15635", "638", "6", "32", "49620.16", "0.07", "0.02", "N", "O", "1996-01-30", "1996-02-07", "1996-02-03", "DELIVER IN PERSON", "MAIL", "arefully slyly ex"},
+		{"2", "106170", "1191", "1", "38", "44694.46", "0.00", "0.05", "N", "O", "1997-01-28", "1997-01-14", "1997-02-02", "TAKE BACK RETURN", "RAIL", "ven requests. deposits breach a"},
+		{"3", "4297", "1798", "1", "45", "54058.05", "0.06", "0.00", "R", "F", "1994-02-02", "1994-01-04", "1994-02-23", "NONE", "AIR", "ongside of the furiously brave acco"},
+		{"3", "19036", "6540", "2", "49", "46796.47", "0.10", "0.00", "R", "F", "1993-11-09", "1993-12-20", "1993-11-24", "TAKE BACK RETURN", "RAIL", " unusual accounts. eve"},
+		{"3", "128449", "3474", "3", "27", "39890.88", "0.06", "0.07", "A", "F", "1994-01-16", "1993-11-22", "1994-01-23", "DELIVER IN PERSON", "SHIP", "nal foxes wake."},
+	}
+	b.SetBytes(120) // Raw input size. With 8 indexes, expect more on output side.
+
+	stmt, err := parser.ParseOne(`CREATE TABLE lineitem (
+		l_orderkey      INT8 NOT NULL,
+		l_partkey       INT8 NOT NULL,
+		l_suppkey       INT8 NOT NULL,
+		l_linenumber    INT8 NOT NULL,
+		l_quantity      DECIMAL(15,2) NOT NULL,
+		l_extendedprice DECIMAL(15,2) NOT NULL,
+		l_discount      DECIMAL(15,2) NOT NULL,
+		l_tax           DECIMAL(15,2) NOT NULL,
+		l_returnflag    CHAR(1) NOT NULL,
+		l_linestatus    CHAR(1) NOT NULL,
+		l_shipdate      DATE NOT NULL,
+		l_commitdate    DATE NOT NULL,
+		l_receiptdate   DATE NOT NULL,
+		l_shipinstruct  CHAR(25) NOT NULL,
+		l_shipmode      CHAR(10) NOT NULL,
+		l_comment       VARCHAR(44) NOT NULL,
+		PRIMARY KEY     (l_orderkey, l_linenumber),
+		INDEX l_ok      (l_orderkey ASC),
+		INDEX l_pk      (l_partkey ASC),
+		INDEX l_sk      (l_suppkey ASC),
+		INDEX l_sd      (l_shipdate ASC),
+		INDEX l_cd      (l_commitdate ASC),
+		INDEX l_rd      (l_receiptdate ASC),
+		INDEX l_pk_sk   (l_partkey ASC, l_suppkey ASC),
+		INDEX l_sk_pk   (l_suppkey ASC, l_partkey ASC)
+	)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	create := stmt.AST.(*tree.CreateTable)
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	tableDesc, err := MakeSimpleTableDescriptor(ctx, st, create, sqlbase.ID(100), sqlbase.ID(100), NoFKs, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	kvCh := make(chan row.KVBatch)
+	// no-op drain kvs channel.
+	go func() {
+		for range kvCh {
+		}
+	}()
+
+	descr := tableDesc.TableDesc()
+	cols := make(tree.NameList, len(descr.Columns))
+	for i, col := range descr.Columns {
+		cols[i] = tree.Name(col.Name)
+	}
+	r, err := newMysqloutfileReader(ctx, kvCh, roachpb.MySQLOutfileOptions{
+		RowSeparator:   '\n',
+		FieldSeparator: '\t',
+	}, descr, &evalCtx)
+	require.NoError(b, err)
+
+	producer := &csvBenchmarkStream{
+		n:    b.N,
+		pos:  0,
+		data: tpchLineItemDataRows,
+	}
+
+	delimited := &fileReader{Reader: producer}
+	b.ResetTimer()
+	require.NoError(b, r.readFile(ctx, delimited, 0, "benchmark", 0, nil))
+	close(kvCh)
 }
 
 // TestImportControlJob tests that PAUSE JOB, RESUME JOB, and CANCEL JOB

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -11,39 +11,42 @@ package importccl
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type mysqloutfileReader struct {
-	conv row.DatumRowConverter
-	opts roachpb.MySQLOutfileOptions
+	importCtx *parallelImportContext
+	opts      roachpb.MySQLOutfileOptions
 }
 
 var _ inputConverter = &mysqloutfileReader{}
 
 func newMysqloutfileReader(
-	ctx context.Context,
-	kvCh chan row.KVBatch,
 	opts roachpb.MySQLOutfileOptions,
+	kvCh chan row.KVBatch,
+	walltime int64,
+	parallelism int,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*mysqloutfileReader, error) {
-	conv, err := row.NewDatumRowConverter(ctx, tableDesc, nil /* targetColNames */, evalCtx, kvCh)
-	if err != nil {
-		return nil, err
-	}
 	return &mysqloutfileReader{
-		conv: *conv,
+		importCtx: &parallelImportContext{
+			walltime:   walltime,
+			numWorkers: parallelism,
+			evalCtx:    evalCtx,
+			tableDesc:  tableDesc,
+			kvCh:       kvCh,
+		},
 		opts: opts,
 	}, nil
 }
@@ -61,23 +64,111 @@ func (d *mysqloutfileReader) readFiles(
 	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage)
 }
 
-func (d *mysqloutfileReader) readFile(
-	ctx context.Context,
-	input *fileReader,
-	inputIdx int32,
-	inputName string,
-	resumePos int64,
-	rejected chan string,
-) error {
-	d.conv.KvBatch.Source = inputIdx
-	d.conv.FractionFn = input.ReadFraction
-	var count int64 = 1
-	d.conv.CompletedRowFn = func() int64 {
-		return count
-	}
+type delimitedProducer struct {
+	importCtx *parallelImportContext
+	opts      *roachpb.MySQLOutfileOptions
+	input     *fileReader
+	reader    *bufio.Reader
+	row       []rune
+	err       error
+	eof       bool
+}
 
-	var row []tree.Datum
-	var savedRow []rune
+var _ importRowProducer = &delimitedProducer{}
+
+// Scan implements importRowProducer
+func (d *delimitedProducer) Scan() bool {
+	d.row = nil
+	var r rune
+	var w int
+	nextLiteral := false
+	fieldEnclosed := false
+
+	for {
+		r, w, d.err = d.reader.ReadRune()
+		if d.err == io.EOF {
+			d.eof = true
+			d.err = nil
+		}
+
+		if d.eof {
+			if d.row != nil {
+				return true
+			}
+			if nextLiteral {
+				d.err = io.ErrUnexpectedEOF
+			}
+			return false
+		}
+
+		if d.err != nil {
+			return false
+		}
+
+		if r == unicode.ReplacementChar && w == 1 {
+			if d.err = d.reader.UnreadRune(); d.err != nil {
+				return false
+			}
+			var raw byte
+			raw, d.err = d.reader.ReadByte()
+			if d.err != nil {
+				return false
+			}
+			r = rune(raw)
+		}
+
+		if r == d.opts.RowSeparator && !nextLiteral && !fieldEnclosed {
+			return true
+		}
+
+		d.row = append(d.row, r)
+
+		if d.opts.HasEscape {
+			nextLiteral = !nextLiteral && r == d.opts.Escape
+		}
+
+		if d.opts.Enclose != roachpb.MySQLOutfileOptions_Never && r == d.opts.Encloser {
+			// We only care about well formed, enclosed fields (i.e. ones that start with
+			// enclose rune.  If we see enclose character anywhere else, then we either
+			// close the opened enclosing, or we treat this as an invalid enclosing,
+			// and let FillDatums below take care of reporting and handling any errors.
+			fieldEnclosed = len(d.row) == 1
+		}
+	}
+}
+
+// Err implements importRowProducer
+func (d *delimitedProducer) Err() error {
+	return d.err
+}
+
+// Skip implements importRowProducer
+func (d *delimitedProducer) Skip() error {
+	return nil // no-op
+}
+
+// Row implements importRowProducer
+func (d *delimitedProducer) Row() (interface{}, error) {
+	return d.row, d.err
+}
+
+// Progress implements importRowProducer
+func (d *delimitedProducer) Progress() float32 {
+	return d.input.ReadFraction()
+}
+
+type delimitedConsumer struct {
+	opts *roachpb.MySQLOutfileOptions
+}
+
+var _ importRowConsumer = &delimitedConsumer{}
+
+// FillDatums implements importRowConsumer
+func (d *delimitedConsumer) FillDatums(
+	input interface{}, rowNum int64, conv *row.DatumRowConverter,
+) error {
+	data := input.([]rune)
+
 	// The current field being read needs to be a list to be able to undo
 	// field enclosures at end of field.
 	var fieldParts []rune
@@ -96,27 +187,22 @@ func (d *mysqloutfileReader) readFile(
 	// That means if an end of field or line is next we should honor it.
 	var gotEncloser bool
 
-	// If we are in the middle of processing a row that has errors in it.
-	// That means that we are going to try to guess where the row ends
-	// save it to be retried.
-	var gotOffendingRow bool
-
 	var gotNull bool
 
-	reader := bufio.NewReaderSize(input, 1024*64)
+	var datumIdx int
+
 	addField := func() error {
 		defer func() {
 			fieldParts = fieldParts[:0]
 			readingField = false
 			gotEncloser = false
 		}()
-		// Don't even try to add fields when we are in a bad row.
-		if gotOffendingRow {
-			return nil
-		}
 		if nextLiteral {
-			return makeRowErr(inputName, count, pgcode.Syntax, "unmatched literal")
+			return newImportRowError(errors.New("unmatched literal"), string(data), rowNum)
 		}
+
+		var datum tree.Datum
+
 		// If previous symbol was field encloser it should be
 		// dropped as it only marks end of field. Otherwise
 		// throw an error since we don;t expect unmatched encloser.
@@ -128,128 +214,51 @@ func (d *mysqloutfileReader) readFile(
 			} else {
 				// Unexpected since we did not see one at start of field.
 				gotEncloser = false
-				return makeRowErr(inputName, count, pgcode.Syntax,
-					"unmatched field enclosure at end of field")
+				return newImportRowError(errors.New("unmatched field enclosure at end of field"),
+					string(data), rowNum)
 			}
 		} else if readingField {
-			return makeRowErr(inputName, count, pgcode.Syntax,
-				"unmatched field enclosure at start of field")
+			return newImportRowError(errors.New("unmatched field enclosure at start of field"),
+				string(data), rowNum)
 		}
 		field := string(fieldParts)
-		if len(row) >= len(d.conv.VisibleCols) {
-			return makeRowErr(inputName, count, pgcode.Syntax,
-				"too many columns, got %d expected %d: %#v", len(row)+1, len(d.conv.VisibleCols), row)
+		if datumIdx >= len(conv.VisibleCols) {
+			return newImportRowError(
+				fmt.Errorf("too many columns, got %d expected %d", datumIdx+1, len(conv.VisibleCols)),
+				string(data), rowNum)
 		}
+
 		if gotNull {
 			gotNull = false
 			if len(field) != 0 {
-				return makeRowErr(inputName, count, pgcode.Syntax,
-					"unexpected data after null encoding: %v", row)
+				return newImportRowError(fmt.Errorf("unexpected data after null encoding: %q", field),
+					string(data), rowNum)
 			}
-			row = append(row, tree.DNull)
+			datum = tree.DNull
 		} else if (!d.opts.HasEscape && field == "NULL") || d.opts.NullEncoding != nil && field == *d.opts.NullEncoding {
-			row = append(row, tree.DNull)
+			datum = tree.DNull
 		} else {
 			// This uses ParseDatumStringAsWithRawBytes instead of ParseDatumStringAs since mysql emits
 			// raw byte strings that do not use the same escaping as our ParseBytes
 			// function expects, and the difference between ParseStringAs and
 			// ParseDatumStringAs is whether or not it attempts to parse bytes.
-			datum, err := sqlbase.ParseDatumStringAsWithRawBytes(d.conv.VisibleColTypes[len(row)], field, d.conv.EvalCtx)
+			var err error
+			datum, err = sqlbase.ParseDatumStringAsWithRawBytes(conv.VisibleColTypes[datumIdx], field, conv.EvalCtx)
 			if err != nil {
-				col := d.conv.VisibleCols[len(row)]
-				return wrapRowErr(err, inputName, count, pgcode.Syntax,
-					"parse %q as %s", col.Name, col.Type.SQLString())
+				col := conv.VisibleCols[datumIdx]
+				return newImportRowError(
+					fmt.Errorf("error %s while parse %q as %s", err, col.Name, col.Type.SQLString()),
+					string(data), rowNum)
 			}
-			row = append(row, datum)
 		}
-		return nil
-	}
-	addRow := func() error {
-		defer func() {
-			if gotOffendingRow && rejected != nil {
-				rejected <- string(savedRow)
-			}
-			savedRow = savedRow[:0]
-			gotOffendingRow = false
-			row = row[:0]
-			fieldParts = fieldParts[:0]
-		}()
-		if gotOffendingRow {
-			return nil
-		}
-		if err := addField(); err != nil {
-			gotOffendingRow = true
-			return err
-		}
-		if len(row) != len(d.conv.VisibleCols) {
-			gotOffendingRow = true
-			return makeRowErr(inputName, count, pgcode.Syntax,
-				"unexpected number of columns, expected %d got %d: %#v", len(d.conv.VisibleCols), len(row), row)
-		}
-		if count <= resumePos {
-			return nil
-		}
-		copy(d.conv.Datums, row)
-		if err := d.conv.Row(ctx, inputIdx, count); err != nil {
-			gotOffendingRow = true
-			return wrapRowErr(err, inputName, count, pgcode.Uncategorized, "")
-		}
-		count++
+		conv.Datums[datumIdx] = datum
+		datumIdx++
 		return nil
 	}
 
-	for i := uint32(0); i < d.opts.Skip; {
-		c, _, err := reader.ReadRune()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if c == d.opts.RowSeparator {
-			i++
-		}
-	}
-	var c rune
-	var finished bool
 	// Main parsing loop body, returns true to indicate unrecoverable error.
 	// We are being conservative and treating most errors as unrecoverable for now.
-	loop := func() (bool, error) {
-		var err error
-		var w int
-		c, w, err = reader.ReadRune()
-		finished = err == io.EOF
-
-		// First check that if we're done and everything looks good.
-		if finished {
-			if len(savedRow) > 0 || (rejected != nil && gotOffendingRow) {
-				// flush the last row.
-				if err := addRow(); err != nil {
-					return false, err
-				}
-			}
-			return true, nil
-		}
-		savedRow = append(savedRow, c)
-
-		if err != nil {
-			// error on ReadRune that is not io.EOF, we should fail hard.
-			return true, err
-		}
-
-		if c == unicode.ReplacementChar && w == 1 {
-			if err := reader.UnreadRune(); err != nil {
-				return true, err
-			}
-			raw, err := reader.ReadByte()
-			if err != nil {
-				return true, err
-			}
-			fieldParts = append(fieldParts, rune(raw))
-			gotEncloser = false
-			return false, nil
-		}
-
+	for _, c := range data {
 		// Do we need to check for escaping?
 		if d.opts.HasEscape {
 			if nextLiteral {
@@ -270,39 +279,29 @@ func (d *mysqloutfileReader) readFile(
 					fieldParts = append(fieldParts, rune(byte(26)))
 				case 'N':
 					if gotNull {
-						gotNull = false
-						gotOffendingRow = true
-						return false, makeRowErr(inputName, count, pgcode.Syntax, "unexpected null encoding")
+						return newImportRowError(errors.New("unexpected null encoding"), string(data), rowNum)
 					}
 					gotNull = true
 				default:
 					fieldParts = append(fieldParts, c)
 				}
 				gotEncloser = false
-				return false, nil
+				continue
 			}
 
 			if c == d.opts.Escape {
 				nextLiteral = true
 				gotEncloser = false
-				return false, nil
+				continue
 			}
 		}
 
 		// Are we done with the field, or even the whole row?
-		if (!readingField || gotEncloser) &&
-			(c == d.opts.FieldSeparator || c == d.opts.RowSeparator) {
-			if c == d.opts.RowSeparator {
-				if err := addRow(); err != nil {
-					return false, err
-				}
-			} else {
-				if err := addField(); err != nil {
-					gotOffendingRow = true
-					return false, err
-				}
+		if (!readingField || gotEncloser) && c == d.opts.FieldSeparator {
+			if err := addField(); err != nil {
+				return err
 			}
-			return false, nil
+			continue
 		}
 
 		if gotEncloser {
@@ -316,32 +315,51 @@ func (d *mysqloutfileReader) readFile(
 		if d.opts.Enclose != roachpb.MySQLOutfileOptions_Never && c == d.opts.Encloser {
 			if !readingField && len(fieldParts) == 0 {
 				readingField = true
-				return false, nil
+				continue
 			}
 			gotEncloser = true
 		}
-
 		fieldParts = append(fieldParts, c)
-		return false, nil
 	}
-	for {
-		br, err := loop()
-		if br {
-			if err != nil {
-				return err
-			}
-			break
-		}
-		if err != nil {
-			if rejected != nil {
-				log.Error(ctx, err)
-			} else {
-				return err
-			}
-		}
-		if finished {
-			break
-		}
+
+	if err := addField(); err != nil {
+		return err
 	}
-	return d.conv.SendBatch(ctx)
+
+	if datumIdx != len(conv.VisibleCols) {
+		return newImportRowError(fmt.Errorf(
+			"unexpected number of columns, expected %d got %d", len(conv.VisibleCols), datumIdx),
+			string(data), rowNum)
+	}
+
+	return nil
+}
+
+func (d *mysqloutfileReader) readFile(
+	ctx context.Context,
+	input *fileReader,
+	inputIdx int32,
+	inputName string,
+	resumePos int64,
+	rejected chan string,
+) error {
+	producer := &delimitedProducer{
+		importCtx: d.importCtx,
+		opts:      &d.opts,
+		input:     input,
+		reader:    bufio.NewReaderSize(input, 64*1024),
+	}
+	consumer := &delimitedConsumer{opts: &d.opts}
+
+	if resumePos < int64(d.opts.Skip) {
+		resumePos = int64(d.opts.Skip)
+	}
+
+	fileCtx := &importFileContext{
+		source:   inputIdx,
+		skip:     resumePos,
+		rejected: rejected,
+	}
+
+	return runParallelImport(ctx, d.importCtx, fileCtx, producer, consumer)
 }


### PR DESCRIPTION
Parallelize mysql delimited import code to improve
it's throughput by around ~5x.

Release notes (performance): Improve delimited import throughput.