### PR TITLE
storage: check AdminVerifyProtectedTimestamp key ranges

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2425,8 +2425,7 @@ func (r *Replica) adminScatter(
 func (r *Replica) adminVerifyProtectedTimestamp(
 	ctx context.Context, args roachpb.AdminVerifyProtectedTimestampRequest,
 ) (resp roachpb.AdminVerifyProtectedTimestampResponse, err error) {
-	resp.Verified, err = r.protectedTimestampRecordApplies(ctx, args.Protected,
-		args.RecordAliveAt, args.RecordID)
+	resp.Verified, err = r.protectedTimestampRecordApplies(ctx, &args)
 	if err == nil && !resp.Verified {
 		resp.FailedRanges = append(resp.FailedRanges, *r.Desc())
 	}


### PR DESCRIPTION
Before this commit we'd never ensure that an
AdminVerifyProtectedTimestampRequest had the proper key boundaries for the
range processing the request. This problem was revealed by test flakes which
occur when the a range splits and the request to verify a span is sent to the
LHS which does not contain that span leading to a verification failure.

Given I needed all of the fields of the request in the underlying helper
function, it seemed reasonable to change the signatures to just take the
request.

Release note: None