### PR TITLE
ui: standardize the display of node names in node lists

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -128,8 +128,8 @@ const getStatusDescription = (status: LivenessStatus) => {
 const NodeNameColumn: React.FC<{ record: NodeStatusRow | DecommissionedNodeStatusRow }> = ({ record }) => {
   return (
     <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
-      <Text textType={TextTypes.BodyStrong}>{`N${record.nodeId} `}</Text>
       <Text>{record.nodeName}</Text>
+      <Text textType={TextTypes.BodyStrong}>{` (n${record.nodeId})`}</Text>
     </Link>
   );
 };

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -85,7 +85,7 @@ export function makeStatementsColumns(statements: AggregateStatistics[], selecte
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
   return (
     <Link to={ `/node/${props.nodeId}` }>
-      <div className="node-name-tooltip__info-icon">N{props.nodeId} {props.nodeNames[props.nodeId]}</div>
+      <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
     </Link>
   );
 }


### PR DESCRIPTION
Standardize the display of node names in node lists. The nodes overview
list was displaying nodes as `N<id> <ip-address>` while graphs display
`<ip-address> (n<id>)`. Standardize on the latter format. A similar
problem existed on the statement details page which was displaying
`N<id> <ip-address> (n<id>)`. The node id was being displayed twice!

Release note: None