### PR TITLE
storage/engine: adjust default rocksdb.min_wal_sync_interval to 0.5ms

### DIFF
--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -60,7 +60,7 @@ import "C"
 var minWALSyncInterval = settings.RegisterDurationSetting(
 	"rocksdb.min_wal_sync_interval",
 	"minimum duration between syncs of the RocksDB WAL",
-	0*time.Millisecond,
+	100*time.Microsecond,
 )
 
 var rocksdbConcurrency = envutil.EnvOrDefaultInt(


### PR DESCRIPTION
Release note (performance improvement): Adjust the default value of
"rocksdb.min_wal_sync_interval" to 0.5ms which significantly reduces the
number of disk write operations while have a negligible impact on
latency. This is particularly important in cloud deployments where
virtualized storage may have IOPS limitations.