### PR TITLE
storage/engine: add missing cast from DBString to DBSlice

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2877,7 +2877,7 @@ func dbGetProto(
 		// Make a byte slice that is backed by result.data. This slice
 		// cannot live past the lifetime of this method, but we're only
 		// using it to unmarshal the roachpb.
-		data := cSliceToUnsafeGoBytes(result)
+		data := cSliceToUnsafeGoBytes(C.DBSlice{data: result.data, len: result.len})
 		err = protoutil.Unmarshal(data, msg)
 	}
 	C.free(unsafe.Pointer(result.data))


### PR DESCRIPTION
go1.14 complains about passing a `DBString` to
`cSliceToUnsafeGoBytes`. I'm not sure why go1.13 doesn't complain.
Casting the `DBString` parameter to a `DBSlice` avoids the issue.

Release note: None