### PR TITLE
fix compilation error

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2877,7 +2877,7 @@ func dbGetProto(
 		// Make a byte slice that is backed by result.data. This slice
 		// cannot live past the lifetime of this method, but we're only
 		// using it to unmarshal the roachpb.
-		data := cSliceToUnsafeGoBytes(result)
+		data := cSliceToUnsafeGoBytes(C.DBSlice(result))
 		err = protoutil.Unmarshal(data, msg)
 	}
 	C.free(unsafe.Pointer(result.data))


### PR DESCRIPTION
This commit fixes compilation error of rocksdb.go where currently cSliceToUnsafeGoBytes called with the wrong parameter data type (DBString instead of DBSlice) as expected, which cause compilation error:

```pkg/storage/engine/rocksdb.go:2880:32: cannot use result (type _Ctype_struct___1) as type _Ctype_struct___0 in argument to cSliceToUnsafeGoBytes```

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note: none