### PR TITLE
sql: inverted index fixes

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -423,7 +423,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 		// indexes which can append entries to the end of the slice. If we don't do this, then everything
 		// EncodeSecondaryIndexes appends to secondaryIndexEntries for a row, would stay in the slice for
 		// subsequent rows and we would then have duplicates in entries on output.
-		buffer = buffer[:len(ib.added)]
+		buffer = buffer[:0]
 		if buffer, err = sqlbase.EncodeSecondaryIndexes(
 			tableDesc.TableDesc(), ib.added, ib.colIdxMap,
 			ib.rowVals, buffer); err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3,11 +3,51 @@
 statement ok
 CREATE TABLE d (
   a INT PRIMARY KEY,
-  b JSONB
+  b JSONB,
+  FAMILY (a,b)
 )
 
 statement ok
 CREATE INVERTED INDEX foo_inv ON d(b)
+
+query T kvtrace
+INSERT INTO d VALUES(0, '{"a": "b"}')
+----
+CPut /Table/53/1/0/0 -> /TUPLE/
+InitPut /Table/53/2/"a"/"b"/0/0 -> /BYTES/
+
+# Make sure duplicate values don't get inserted.
+query T kvtrace
+INSERT INTO d VALUES(1, '[7,0,7]')
+----
+CPut /Table/53/1/1/0 -> /TUPLE/
+InitPut /Table/53/2/Arr/0/1/0 -> /BYTES/
+InitPut /Table/53/2/Arr/7/1/0 -> /BYTES/
+
+# Make sure duplicate values don't get deleted either.
+query T kvtrace
+DELETE FROM d WHERE a=1
+----
+Scan /Table/53/1/1{-/#}
+Del /Table/53/2/Arr/0/1/0
+Del /Table/53/2/Arr/7/1/0
+Del /Table/53/1/1/0
+
+query T kvtrace
+INSERT INTO d VALUES(2, '[{"a": "b"}, 3, {"a": "b"}]')
+----
+CPut /Table/53/1/2/0 -> /TUPLE/
+InitPut /Table/53/2/Arr/3/2/0 -> /BYTES/
+InitPut /Table/53/2/Arr/"a"/"b"/2/0 -> /BYTES/
+
+query T kvtrace
+INSERT INTO d VALUES(3, '[{"a": [0,1,0]}, 3, {"a": "b"}]')
+----
+CPut /Table/53/1/3/0 -> /TUPLE/
+InitPut /Table/53/2/Arr/3/3/0 -> /BYTES/
+InitPut /Table/53/2/Arr/"a"/"b"/3/0 -> /BYTES/
+InitPut /Table/53/2/Arr/"a"/Arr/0/3/0 -> /BYTES/
+InitPut /Table/53/2/Arr/"a"/Arr/1/3/0 -> /BYTES/
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -49,6 +49,35 @@ InitPut /Table/53/2/Arr/"a"/"b"/3/0 -> /BYTES/
 InitPut /Table/53/2/Arr/"a"/Arr/0/3/0 -> /BYTES/
 InitPut /Table/53/2/Arr/"a"/Arr/1/3/0 -> /BYTES/
 
+# Make sure that inserting NULL doesn't make an index entry.
+query T kvtrace
+INSERT INTO d VALUES(4, NULL)
+----
+CPut /Table/53/1/4/0 -> /TUPLE/
+
+# Update away from null.
+query T kvtrace
+UPDATE d SET b='[1]' WHERE a=4
+----
+Scan /Table/53/1/4{-/#}
+Put /Table/53/1/4/0 -> /TUPLE/
+InitPut /Table/53/2/Arr/1/4/0 -> /BYTES/
+
+# Update back to null.
+query T kvtrace
+UPDATE d SET b=NULL WHERE a=4
+----
+Scan /Table/53/1/4{-/#}
+Put /Table/53/1/4/0 -> /TUPLE/
+Del /Table/53/2/Arr/1/4/0
+
+# Deleting a null shouldn't remove anything from the inv idx.
+query T kvtrace
+DELETE FROM d WHERE a=4
+----
+Scan /Table/53/1/4{-/#}
+Del /Table/53/1/4/0
+
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -186,6 +215,7 @@ index-join  ·            ·                            (a, b)  ·
 ·           table        d@foo_inv                    ·       ·
 ·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
+# Make sure that querying for NULL equality doesn't use the inverted index.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -88,11 +88,11 @@ func (rh *rowHelper) encodePrimaryIndex(
 func (rh *rowHelper) encodeSecondaryIndexes(
 	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum,
 ) (secondaryIndexEntries []sqlbase.IndexEntry, err error) {
-	if len(rh.indexEntries) != len(rh.Indexes) {
-		rh.indexEntries = make([]sqlbase.IndexEntry, len(rh.Indexes))
+	if cap(rh.indexEntries) < len(rh.Indexes) {
+		rh.indexEntries = make([]sqlbase.IndexEntry, 0, len(rh.Indexes))
 	}
 	rh.indexEntries, err = sqlbase.EncodeSecondaryIndexes(
-		rh.TableDesc.TableDesc(), rh.Indexes, colIDtoRowIndex, values, rh.indexEntries)
+		rh.TableDesc.TableDesc(), rh.Indexes, colIDtoRowIndex, values, rh.indexEntries[:0])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -379,6 +379,12 @@ func (ru *Updater) UpdateRow(
 		if ru.Fks.checker != nil {
 			ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIndex.ID, ru.Helper.TableDesc.PrimaryIndex.Type)
 			for i := range ru.Helper.Indexes {
+				if ru.Helper.Indexes[i].Type == sqlbase.IndexDescriptor_INVERTED {
+					// We ignore FK existence checks for inverted indexes.
+					//
+					// TODO(knz): verify that this is indeed correct.
+					continue
+				}
 				// * We always will have at least 1 entry in the index, so indexing 0 is safe.
 				// * The only difference between column family 0 vs other families encodings is
 				//   just the family key ending of the key, so if index[0] is different, the other

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3612,7 +3612,7 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				arg := args[0]
 				if arg == tree.DNull {
-					return tree.NewDInt(tree.DInt(1)), nil
+					return tree.DZero, nil
 				}
 				n, err := json.NumInvertedIndexEntries(tree.MustBeDJSON(arg).JSON)
 				if err != nil {

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -305,6 +305,10 @@ func (s *Builder) encodeConstraintKey(
 			if err != nil {
 				return nil, false, err
 			}
+			if len(keys) == 0 {
+				err := errors.AssertionFailedf("trying to use null key in index lookup")
+				return nil, false, err
+			}
 			if len(keys) > 1 {
 				err := errors.AssertionFailedf("trying to use multiple keys in index lookup")
 				return nil, false, err

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -831,8 +831,7 @@ func (a byID) Less(i, j int) bool { return a[i].id < a[j].id }
 
 // EncodeInvertedIndexKeys creates a list of inverted index keys by
 // concatenating keyPrefix with the encodings of the column in the
-// index. Returns the key and whether any of the encoded values were
-// NULLs.
+// index.
 func EncodeInvertedIndexKeys(
 	tableDesc *TableDescriptor,
 	index *IndexDescriptor,
@@ -1194,22 +1193,18 @@ func EncodeSecondaryIndexes(
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
 ) ([]IndexEntry, error) {
-	if len(secondaryIndexEntries) != len(indexes) {
-		panic("Length of secondaryIndexEntries is not equal to the number of indexes.")
+	if len(secondaryIndexEntries) > 0 {
+		panic("Length of secondaryIndexEntries was non-zero")
 	}
 	for i := range indexes {
 		entries, err := EncodeSecondaryIndex(tableDesc, &indexes[i], colMap, values)
 		if err != nil {
 			return secondaryIndexEntries, err
 		}
-		secondaryIndexEntries[i] = entries[0]
-
-		// This is specifically for inverted indexes which can have more than one entry
-		// associated with them, or secondary indexes which store columns from
-		// multiple column families.
-		if len(entries) > 1 {
-			secondaryIndexEntries = append(secondaryIndexEntries, entries[1:]...)
-		}
+		// Normally, each index will have exactly one entry. However, inverted
+		// indexes can have 0 or >1 entries, as well as secondary indexes which
+		// store columns from multiple column families.
+		secondaryIndexEntries = append(secondaryIndexEntries, entries...)
 	}
 	return secondaryIndexEntries, nil
 }

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -857,9 +857,11 @@ func EncodeInvertedIndexKeys(
 // concatenates it with `inKey`and returns a list of buffers per
 // path. The encoded values is guaranteed to be lexicographically
 // sortable, but not guaranteed to be round-trippable during decoding.
+// A (SQL) NULL input Datum produces no keys, because inverted indexes
+// cannot and do not need to satisfy the predicate col IS NULL.
 func EncodeInvertedIndexTableKeys(val tree.Datum, inKey []byte) (key [][]byte, err error) {
 	if val == tree.DNull {
-		return [][]byte{encoding.EncodeNullAscending(inKey)}, nil
+		return nil, nil
 	}
 	switch t := tree.UnwrapDatum(nil, val).(type) {
 	case *tree.DJSON:

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/unique"
 )
 
 func eachPair(a, b JSON, f func(a, b JSON)) {
@@ -1274,6 +1275,11 @@ func TestEncodeJSONInvertedIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// Make sure that the expected encoding slice is sorted, as well as the
+		// output of the function under test, because the function under test can
+		// reorder the keys it's returning if there are arrays inside.
+		enc = unique.UniquifyByteSlices(enc)
+		c.expEnc = unique.UniquifyByteSlices(c.expEnc)
 		for j, path := range enc {
 			if !bytes.Equal(path, c.expEnc[j]) {
 				t.Errorf("unexpected encoding mismatch for %v. expected [%#v], got [%#v]",

--- a/pkg/util/unique/unique.go
+++ b/pkg/util/unique/unique.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package unique
+
+import (
+	"bytes"
+	"sort"
+)
+
+// UniquifyByteSlices takes as input a slice of slices of bytes, and
+// deduplicates them using a sort and unique. The output will not contain any
+// duplicates but it will be sorted.
+func UniquifyByteSlices(slices [][]byte) [][]byte {
+	if len(slices) == 0 {
+		return slices
+	}
+	// First sort:
+	sort.Slice(slices, func(i int, j int) bool {
+		return bytes.Compare(slices[i], slices[j]) < 0
+	})
+	// Then distinct: (wouldn't it be nice if Go had generics?)
+	lastUniqueIdx := 0
+	for i := 1; i < len(slices); i++ {
+		if !bytes.Equal(slices[i], slices[lastUniqueIdx]) {
+			// We found a unique entry, at index i. The last unique entry in the array
+			// was at lastUniqueIdx, so set the entry after that one to our new unique
+			// entry, and bump lastUniqueIdx for the next loop iteration.
+			lastUniqueIdx++
+			slices[lastUniqueIdx] = slices[i]
+		}
+	}
+	slices = slices[:lastUniqueIdx+1]
+	return slices
+}

--- a/pkg/util/unique/unique_test.go
+++ b/pkg/util/unique/unique_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package unique
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestUniquifyByteSlices(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{"foo", "foo"},
+			expected: []string{"foo"},
+		},
+		{
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			input:    []string{"", ""},
+			expected: []string{""},
+		},
+		{
+			input:    []string{"foo"},
+			expected: []string{"foo"},
+		},
+		{
+			input:    []string{"foo", "bar", "foo"},
+			expected: []string{"bar", "foo"},
+		},
+		{
+			input:    []string{"foo", "bar"},
+			expected: []string{"bar", "foo"},
+		},
+		{
+			input:    []string{"bar", "bar", "foo"},
+			expected: []string{"bar", "foo"},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			input := make([][]byte, len(tt.input))
+			expected := make([][]byte, len(tt.expected))
+			for i := range tt.input {
+				input[i] = []byte(tt.input[i])
+			}
+			for i := range tt.expected {
+				expected[i] = []byte(tt.expected[i])
+			}
+			if got := UniquifyByteSlices(input); !reflect.DeepEqual(got, expected) {
+				t.Errorf("UniquifyByteSlices() = %v, expected %v", got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is based on #45563, and split out from #45157.

Closes #45154.
Closes #32468.

Miscellaneous fixes for inverted indexes.

1. Don't produce duplicate keys for inverted indexes.
2. Permit rows to not emit any keys for a particular index, which is required to allow not having any inverted index entries for NULL (or empty container).
3. Don't produce keys for NULL entries in inverted indexes