### PR TITLE
storage/concurrency: push reservation holders to detect deadlocks

### DIFF
--- a/pkg/storage/concurrency/concurrency_control.go
+++ b/pkg/storage/concurrency/concurrency_control.go
@@ -561,7 +561,7 @@ type lockTableGuard interface {
 	// have an initial notification. Note that notifications are collapsed if
 	// not retrieved, since it is not necessary for the waiter to see every
 	// state transition.
-	NewStateChan() <-chan struct{}
+	NewStateChan() chan struct{}
 
 	// CurState returns the latest waiting state.
 	CurState() waitingState

--- a/pkg/storage/concurrency/concurrency_manager_test.go
+++ b/pkg/storage/concurrency/concurrency_manager_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -333,7 +332,7 @@ type cluster struct {
 	m         concurrency.Manager
 
 	// Definitions.
-	txnCounter     uint128.Uint128
+	txnCounter     uint32
 	txnsByName     map[string]*roachpb.Transaction
 	requestsByName map[string]concurrency.Request
 
@@ -380,7 +379,7 @@ func (c *cluster) makeConfig() concurrency.Config {
 func (c *cluster) PushTransaction(
 	ctx context.Context, pushee *enginepb.TxnMeta, h roachpb.Header, pushType roachpb.PushTxnType,
 ) (roachpb.Transaction, *roachpb.Error) {
-	log.Eventf(ctx, "pushing txn %s", pushee.ID)
+	log.Eventf(ctx, "pushing txn %s", pushee.ID.Short())
 	pusheeRecord, err := c.getTxnRecord(pushee.ID)
 	if err != nil {
 		return roachpb.Transaction{}, roachpb.NewError(err)
@@ -410,7 +409,7 @@ func (c *cluster) PushTransaction(
 func (c *cluster) ResolveIntent(
 	ctx context.Context, intent roachpb.LockUpdate, _ intentresolver.ResolveOptions,
 ) *roachpb.Error {
-	log.Eventf(ctx, "resolving intent %s for txn %s with %s status", intent.Key, intent.Txn.ID, intent.Status)
+	log.Eventf(ctx, "resolving intent %s for txn %s with %s status", intent.Key, intent.Txn.ID.Short(), intent.Status)
 	c.m.OnLockUpdated(ctx, &intent)
 	return nil
 }

--- a/pkg/storage/concurrency/concurrency_manager_test.go
+++ b/pkg/storage/concurrency/concurrency_manager_test.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -188,7 +187,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 						log.Event(ctx, "sequencing complete, returned no guard")
 					}
 				})
-				return mon.waitAndCollect(t)
+				return c.waitAndCollect(t, mon)
 
 			case "finish":
 				var reqName string
@@ -206,7 +205,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					delete(c.guardsByReqName, reqName)
 					c.mu.Unlock()
 				})
-				return mon.waitAndCollect(t)
+				return c.waitAndCollect(t, mon)
 
 			case "handle-write-intent-error":
 				var reqName string
@@ -234,7 +233,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					log.Eventf(ctx, "handling %v", err)
 					guard = m.HandleWriterIntentError(ctx, guard, err)
 				})
-				return mon.waitAndCollect(t)
+				return c.waitAndCollect(t, mon)
 
 			case "on-lock-acquired":
 				var txnName string
@@ -253,7 +252,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					up := roachpb.MakeLockUpdateWithDur(txn, span, lock.Unreplicated)
 					m.OnLockAcquired(ctx, &up)
 				})
-				return mon.waitAndCollect(t)
+				return c.waitAndCollect(t, mon)
 
 			case "on-txn-updated":
 				var txnName string
@@ -291,7 +290,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 						d.Fatalf(t, err.Error())
 					}
 				})
-				return mon.waitAndCollect(t)
+				return c.waitAndCollect(t, mon)
 
 			case "debug-latch-manager":
 				global, local := m.LatchMetrics()
@@ -311,6 +310,10 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				mon.resetSeqNums()
 				if err := c.reset(); err != nil {
 					d.Fatalf(t, "could not reset cluster: %v", err)
+				}
+				// Reset request and txn namespace?
+				if d.HasArg("namespace") {
+					c.resetNamespace()
 				}
 				return ""
 
@@ -340,14 +343,20 @@ type cluster struct {
 	mu              syncutil.Mutex
 	guardsByReqName map[string]*concurrency.Guard
 	txnRecords      map[uuid.UUID]*txnRecord
+	txnPushes       map[uuid.UUID]*txnPush
 }
 
 type txnRecord struct {
 	mu               syncutil.Mutex
-	cond             sync.Cond
+	sig              chan struct{}
 	txn              *roachpb.Transaction // immutable, modify fields below
 	updatedStatus    roachpb.TransactionStatus
 	updatedTimestamp hlc.Timestamp
+}
+
+type txnPush struct {
+	ctx            context.Context
+	pusher, pushee uuid.UUID
 }
 
 func newCluster() *cluster {
@@ -359,13 +368,14 @@ func newCluster() *cluster {
 		requestsByName:  make(map[string]concurrency.Request),
 		guardsByReqName: make(map[string]*concurrency.Guard),
 		txnRecords:      make(map[uuid.UUID]*txnRecord),
+		txnPushes:       make(map[uuid.UUID]*txnPush),
 	}
 }
 
 func (c *cluster) makeConfig() concurrency.Config {
 	st := clustersettings.MakeTestingClusterSettings()
-	concurrency.LockTableLivenessPushDelay.Override(&st.SV, 1*time.Millisecond)
-	concurrency.LockTableDeadlockDetectionPushDelay.Override(&st.SV, 1*time.Millisecond)
+	concurrency.LockTableLivenessPushDelay.Override(&st.SV, 0*time.Millisecond)
+	concurrency.LockTableDeadlockDetectionPushDelay.Override(&st.SV, 0*time.Millisecond)
 	return concurrency.Config{
 		NodeDesc:       c.nodeDesc,
 		RangeDesc:      c.rangeDesc,
@@ -384,11 +394,23 @@ func (c *cluster) PushTransaction(
 	if err != nil {
 		return roachpb.Transaction{}, roachpb.NewError(err)
 	}
-	// Wait for the transaction to be pushed.
-	pusheeRecord.mu.Lock()
-	defer pusheeRecord.mu.Unlock()
+	var pusherRecord *txnRecord
+	if h.Txn != nil {
+		pusherID := h.Txn.ID
+		pusherRecord, err = c.getTxnRecord(pusherID)
+		if err != nil {
+			return roachpb.Transaction{}, roachpb.NewError(err)
+		}
+
+		push, err := c.registerPush(ctx, pusherID, pushee.ID)
+		if err != nil {
+			return roachpb.Transaction{}, roachpb.NewError(err)
+		}
+		defer c.unregisterPush(push)
+	}
 	for {
-		pusheeTxn := pusheeRecord.asTxnLocked()
+		// Is the pushee pushed?
+		pusheeTxn, pusheeRecordSig := pusheeRecord.asTxn()
 		var pushed bool
 		switch pushType {
 		case roachpb.PUSH_TIMESTAMP:
@@ -401,7 +423,24 @@ func (c *cluster) PushTransaction(
 		if pushed {
 			return pusheeTxn, nil
 		}
-		pusheeRecord.cond.Wait()
+		// Or the pusher aborted?
+		var pusherRecordSig chan struct{}
+		if pusherRecord != nil {
+			var pusherTxn roachpb.Transaction
+			pusherTxn, pusherRecordSig = pusherRecord.asTxn()
+			if pusherTxn.Status == roachpb.ABORTED {
+				log.Eventf(ctx, "detected pusher aborted")
+				err := roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_PUSHER_ABORTED)
+				return roachpb.Transaction{}, roachpb.NewError(err)
+			}
+		}
+		// Wait until either record is updated.
+		select {
+		case <-pusheeRecordSig:
+		case <-pusherRecordSig:
+		case <-ctx.Done():
+			return roachpb.Transaction{}, roachpb.NewError(ctx.Err())
+		}
 	}
 }
 
@@ -424,8 +463,7 @@ func (c *cluster) registerTxn(name string, txn *roachpb.Transaction) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.txnsByName[name] = txn
-	r := &txnRecord{txn: txn}
-	r.cond.L = &r.mu
+	r := &txnRecord{txn: txn, sig: make(chan struct{})}
 	c.txnRecords[txn.ID] = r
 }
 
@@ -452,17 +490,89 @@ func (c *cluster) updateTxnRecord(
 	defer r.mu.Unlock()
 	r.updatedStatus = status
 	r.updatedTimestamp = ts
-	r.cond.Broadcast()
+	// Notify all listeners. This is a poor man's composable cond var.
+	close(r.sig)
+	r.sig = make(chan struct{})
 	return nil
 }
 
-func (r *txnRecord) asTxnLocked() roachpb.Transaction {
+func (r *txnRecord) asTxn() (roachpb.Transaction, chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	txn := *r.txn
 	if r.updatedStatus > txn.Status {
 		txn.Status = r.updatedStatus
 	}
 	txn.WriteTimestamp.Forward(r.updatedTimestamp)
-	return txn
+	return txn, r.sig
+}
+
+func (c *cluster) registerPush(ctx context.Context, pusher, pushee uuid.UUID) (*txnPush, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.txnPushes[pusher]; ok {
+		return nil, errors.Errorf("txn %v already pushing", pusher)
+	}
+	p := &txnPush{
+		ctx:    ctx,
+		pusher: pusher,
+		pushee: pushee,
+	}
+	c.txnPushes[pusher] = p
+	return p, nil
+}
+
+func (c *cluster) unregisterPush(push *txnPush) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.txnPushes, push.pusher)
+}
+
+// detectDeadlocks looks at all in-flight transaction pushes and determines
+// whether any are blocked due to dependency cycles within transactions. If so,
+// the method logs an event on the contexts of each of the members of the cycle.
+func (c *cluster) detectDeadlocks() {
+	// This cycle detection algorithm it not particularly efficient - at worst
+	// it runs in O(n ^ 2) time. However, it's simple and effective at assigning
+	// each member of each cycle a unique view of the cycle that it's a part of.
+	// This works because we currently only allow a transaction to push a single
+	// other transaction at a time.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var chain []uuid.UUID
+	seen := make(map[uuid.UUID]struct{})
+	for orig, origPush := range c.txnPushes {
+		pusher := orig
+		chain = append(chain[:0], orig)
+		for id := range seen {
+			delete(seen, id)
+		}
+		seen[pusher] = struct{}{}
+		for {
+			push, ok := c.txnPushes[pusher]
+			if !ok {
+				break
+			}
+			pusher = push.pushee
+			chain = append(chain, pusher)
+			if _, ok := seen[pusher]; ok {
+				// Cycle detected!
+				if pusher == orig {
+					// The cycle we were looking for (i.e. starting at orig).
+					var chainBuf strings.Builder
+					for i, id := range chain {
+						if i > 0 {
+							chainBuf.WriteString("->")
+						}
+						chainBuf.WriteString(id.Short())
+					}
+					log.Eventf(origPush.ctx, "dependency cycle detected %s", chainBuf.String())
+				}
+				break
+			}
+			seen[pusher] = struct{}{}
+		}
+	}
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests
@@ -494,6 +604,17 @@ func (c *cluster) reset() error {
 	return nil
 }
 
+// resetNamespace resets the entire cluster namespace, clearing both request
+// definitions and transaction definitions.
+func (c *cluster) resetNamespace() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.txnCounter = 0
+	c.txnsByName = make(map[string]*roachpb.Transaction)
+	c.requestsByName = make(map[string]concurrency.Request)
+	c.txnRecords = make(map[uuid.UUID]*txnRecord)
+}
+
 // collectSpans collects the declared spans for a set of requests.
 // Its logic mirrors that in Replica.collectSpans.
 func (c *cluster) collectSpans(
@@ -518,6 +639,12 @@ func (c *cluster) collectSpans(
 		}
 	}
 	return latchSpans, lockSpans
+}
+
+func (c *cluster) waitAndCollect(t *testing.T, m *monitor) string {
+	m.waitForAsyncGoroutinesToStall(t)
+	c.detectDeadlocks()
+	return m.collectRecordings()
 }
 
 // monitor tracks a set of running goroutines as they execute and captures
@@ -587,11 +714,6 @@ func (m *monitor) numMonitored() int {
 
 func (m *monitor) resetSeqNums() {
 	m.seq = 0
-}
-
-func (m *monitor) waitAndCollect(t *testing.T) string {
-	m.waitForAsyncGoroutinesToStall(t)
-	return m.collectRecordings()
 }
 
 func (m *monitor) collectRecordings() string {

--- a/pkg/storage/concurrency/datadriven_util_test.go
+++ b/pkg/storage/concurrency/datadriven_util_test.go
@@ -22,9 +22,10 @@ import (
 	"github.com/cockroachdb/datadriven"
 )
 
-func nextUUID(counter *uint128.Uint128) uuid.UUID {
-	*counter = counter.Add(1)
-	return uuid.FromUint128(*counter)
+func nextUUID(counter *uint32) uuid.UUID {
+	*counter = *counter + 1
+	hi := uint64(*counter) << 32
+	return uuid.FromUint128(uint128.Uint128{Hi: hi})
 }
 
 func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {

--- a/pkg/storage/concurrency/lock_table.go
+++ b/pkg/storage/concurrency/lock_table.go
@@ -294,7 +294,7 @@ func (g *lockTableGuardImpl) ShouldWait() bool {
 	return g.mu.startWait
 }
 
-func (g *lockTableGuardImpl) NewStateChan() <-chan struct{} {
+func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.mu.signal

--- a/pkg/storage/concurrency/lock_table_waiter_test.go
+++ b/pkg/storage/concurrency/lock_table_waiter_test.go
@@ -49,8 +49,8 @@ type mockLockTableGuard struct {
 	stateObserved chan struct{}
 }
 
-func (g *mockLockTableGuard) ShouldWait() bool              { return true }
-func (g *mockLockTableGuard) NewStateChan() <-chan struct{} { return g.signal }
+func (g *mockLockTableGuard) ShouldWait() bool            { return true }
+func (g *mockLockTableGuard) NewStateChan() chan struct{} { return g.signal }
 func (g *mockLockTableGuard) CurState() waitingState {
 	s := g.state
 	if g.stateObserved != nil {
@@ -111,25 +111,7 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 		})
 
 		t.Run("waitSelf", func(t *testing.T) {
-			w, _, g := setupLockTableWaiterTest()
-			defer w.stopper.Stop(ctx)
-
-			// Set up an observer channel to detect when the current
-			// waiting state is observed.
-			g.state = waitingState{stateKind: waitSelf}
-			g.stateObserved = make(chan struct{})
-			go func() {
-				g.notify()
-				<-g.stateObserved
-				g.notify()
-				<-g.stateObserved
-				g.state = waitingState{stateKind: doneWaiting}
-				g.notify()
-				<-g.stateObserved
-			}()
-
-			err := w.WaitOn(ctx, makeReq(), g)
-			require.Nil(t, err)
+			testWaitNoopUntilDone(t, waitSelf, makeReq)
 		})
 
 		t.Run("doneWaiting", func(t *testing.T) {
@@ -187,26 +169,7 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 	t.Run("state", func(t *testing.T) {
 		t.Run("waitFor", func(t *testing.T) {
 			t.Log("waitFor does not cause non-transactional requests to push")
-
-			w, _, g := setupLockTableWaiterTest()
-			defer w.stopper.Stop(ctx)
-
-			// Set up an observer channel to detect when the current
-			// waiting state is observed.
-			g.state = waitingState{stateKind: waitFor}
-			g.stateObserved = make(chan struct{})
-			go func() {
-				g.notify()
-				<-g.stateObserved
-				g.notify()
-				<-g.stateObserved
-				g.state = waitingState{stateKind: doneWaiting}
-				g.notify()
-				<-g.stateObserved
-			}()
-
-			err := w.WaitOn(ctx, makeReq(), g)
-			require.Nil(t, err)
+			testWaitNoopUntilDone(t, waitFor, makeReq)
 		})
 
 		t.Run("waitForDistinguished", func(t *testing.T) {
@@ -268,6 +231,7 @@ func testWaitPush(t *testing.T, k stateKind, makeReq func() Request, expPushTS h
 			defer w.stopper.Stop(ctx)
 			pusheeTxn := makeTxnProto("pushee")
 
+			req := makeReq()
 			g.state = waitingState{
 				stateKind:   k,
 				txn:         &pusheeTxn.TxnMeta,
@@ -282,69 +246,93 @@ func testWaitPush(t *testing.T, k stateKind, makeReq func() Request, expPushTS h
 			}
 			g.notify()
 
-			req := makeReq()
-			if lockHeld {
-				// We expect the holder to be pushed.
-				ir.pushTxn = func(
-					_ context.Context,
-					pusheeArg *enginepb.TxnMeta,
-					h roachpb.Header,
-					pushType roachpb.PushTxnType,
-				) (roachpb.Transaction, *Error) {
-					require.Equal(t, &pusheeTxn.TxnMeta, pusheeArg)
-					require.Equal(t, req.Txn, h.Txn)
-					require.Equal(t, expPushTS, h.Timestamp)
-					if waitAsWrite {
-						require.Equal(t, roachpb.PUSH_ABORT, pushType)
-					} else {
-						require.Equal(t, roachpb.PUSH_TIMESTAMP, pushType)
-					}
+			// waitElsewhere does not cause a push if the lock is not held.
+			// It returns immediately.
+			if k == waitElsewhere && !lockHeld {
+				err := w.WaitOn(ctx, req, g)
+				require.Nil(t, err)
+				return
+			}
 
-					resp := roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
+			// Non-transactional requests do not push reservations, only locks.
+			// They wait for doneWaiting.
+			if req.Txn == nil && !lockHeld {
+				defer notifyUntilDone(t, g)()
+				err := w.WaitOn(ctx, req, g)
+				require.Nil(t, err)
+				return
+			}
 
-					// If the lock is held, we'll try to resolve it now that
-					// we know the holder is ABORTED. Otherwide, immediately
-					// tell the request to stop waiting.
-					if lockHeld {
-						ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
-							require.Equal(t, keyA, intent.Key)
-							require.Equal(t, pusheeTxn.ID, intent.Txn.ID)
-							require.Equal(t, roachpb.ABORTED, intent.Status)
-							g.state = waitingState{stateKind: doneWaiting}
-							g.notify()
-							return nil
-						}
-					} else {
+			ir.pushTxn = func(
+				_ context.Context,
+				pusheeArg *enginepb.TxnMeta,
+				h roachpb.Header,
+				pushType roachpb.PushTxnType,
+			) (roachpb.Transaction, *Error) {
+				require.Equal(t, &pusheeTxn.TxnMeta, pusheeArg)
+				require.Equal(t, req.Txn, h.Txn)
+				require.Equal(t, expPushTS, h.Timestamp)
+				if waitAsWrite || !lockHeld {
+					require.Equal(t, roachpb.PUSH_ABORT, pushType)
+				} else {
+					require.Equal(t, roachpb.PUSH_TIMESTAMP, pushType)
+				}
+
+				resp := roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
+
+				// If the lock is held, we'll try to resolve it now that
+				// we know the holder is ABORTED. Otherwide, immediately
+				// tell the request to stop waiting.
+				if lockHeld {
+					ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
+						require.Equal(t, keyA, intent.Key)
+						require.Equal(t, pusheeTxn.ID, intent.Txn.ID)
+						require.Equal(t, roachpb.ABORTED, intent.Status)
 						g.state = waitingState{stateKind: doneWaiting}
 						g.notify()
+						return nil
 					}
-					return resp, nil
+				} else {
+					g.state = waitingState{stateKind: doneWaiting}
+					g.notify()
 				}
-			} else {
-				switch k {
-				case waitFor, waitForDistinguished:
-					// We don't expect the holder to be pushed. Set up an observer
-					// channel to detect when the current waiting state is observed.
-					g.stateObserved = make(chan struct{})
-					go func() {
-						<-g.stateObserved
-						g.notify()
-						<-g.stateObserved
-						g.state = waitingState{stateKind: doneWaiting}
-						g.notify()
-						<-g.stateObserved
-					}()
-				case waitElsewhere:
-					// Expect an immediate return.
-				default:
-					t.Fatalf("unexpected state: %v", k)
-				}
+				return resp, nil
 			}
 
 			err := w.WaitOn(ctx, req, g)
 			require.Nil(t, err)
 		})
 	})
+}
+
+func testWaitNoopUntilDone(t *testing.T, k stateKind, makeReq func() Request) {
+	ctx := context.Background()
+	w, _, g := setupLockTableWaiterTest()
+	defer w.stopper.Stop(ctx)
+
+	g.state = waitingState{stateKind: k}
+	g.notify()
+	defer notifyUntilDone(t, g)()
+
+	err := w.WaitOn(ctx, makeReq(), g)
+	require.Nil(t, err)
+}
+
+func notifyUntilDone(t *testing.T, g *mockLockTableGuard) func() {
+	// Set up an observer channel to detect when the current
+	// waiting state is observed.
+	g.stateObserved = make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		<-g.stateObserved
+		g.notify()
+		<-g.stateObserved
+		g.state = waitingState{stateKind: doneWaiting}
+		g.notify()
+		<-g.stateObserved
+		close(done)
+	}()
+	return func() { <-done }
 }
 
 // TestLockTableWaiterIntentResolverError tests that the lockTableWaiter

--- a/pkg/storage/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/basic
@@ -106,7 +106,7 @@ sequence req=req3
 [1] sequence req3: scanning lock table for conflicting locks
 [1] sequence req3: waiting in lock wait-queues
 [1] sequence req3: pushing txn 00000002
-[1] sequence req3: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
+[1] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
@@ -175,7 +175,7 @@ sequence req=req5
 [1] sequence req5: scanning lock table for conflicting locks
 [1] sequence req5: waiting in lock wait-queues
 [1] sequence req5: pushing txn 00000002
-[1] sequence req5: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
+[1] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 new-request name=req6 txn=none ts=16,1
   scan key=c endkey=z
@@ -220,7 +220,7 @@ finish req=req6
 [3] sequence req7: scanning lock table for conflicting locks
 [3] sequence req7: waiting in lock wait-queues
 [3] sequence req7: pushing txn 00000002
-[3] sequence req7: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
+[3] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/basic
@@ -58,7 +58,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000012,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1
 local: num=0
 
 finish req=req2
@@ -69,7 +69,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000012,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1
 local: num=0
 
 reset
@@ -105,13 +105,13 @@ sequence req=req3
 [1] sequence req3: acquiring latches
 [1] sequence req3: scanning lock table for conflicting locks
 [1] sequence req3: waiting in lock wait-queues
-[1] sequence req3: pushing txn 00000000-0000-0000-0000-000000000002
+[1] sequence req3: pushing txn 00000002
 [1] sequence req3: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[1] sequence req3: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with COMMITTED status
+[1] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
 [1] sequence req3: acquiring latches
 [1] sequence req3: scanning lock table for conflicting locks
 [1] sequence req3: sequencing complete, returned guard
@@ -174,7 +174,7 @@ sequence req=req5
 [1] sequence req5: acquiring latches
 [1] sequence req5: scanning lock table for conflicting locks
 [1] sequence req5: waiting in lock wait-queues
-[1] sequence req5: pushing txn 00000000-0000-0000-0000-000000000002
+[1] sequence req5: pushing txn 00000002
 [1] sequence req5: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 new-request name=req6 txn=none ts=16,1
@@ -192,7 +192,7 @@ sequence req=req6
 on-txn-updated txn=txn2 status=pending ts=18,1
 ----
 [-] update txn: increasing timestamp of txn2
-[1] sequence req5: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with PENDING status
+[1] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
 [1] sequence req5: acquiring latches
 [1] sequence req5: scanning lock table for conflicting locks
 [1] sequence req5: sequencing complete, returned guard
@@ -219,13 +219,13 @@ finish req=req6
 [-] finish req6: finishing request
 [3] sequence req7: scanning lock table for conflicting locks
 [3] sequence req7: waiting in lock wait-queues
-[3] sequence req7: pushing txn 00000000-0000-0000-0000-000000000002
+[3] sequence req7: pushing txn 00000002
 [3] sequence req7: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[3] sequence req7: resolving intent "k" for txn 00000000-0000-0000-0000-000000000002 with COMMITTED status
+[3] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
 [3] sequence req7: acquiring latches
 [3] sequence req7: scanning lock table for conflicting locks
 [3] sequence req7: sequencing complete, returned guard

--- a/pkg/storage/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/deadlocks
@@ -1,0 +1,627 @@
+# -------------------------------------------------------------
+# Deadlock due to lock ordering.
+#
+# Setup: txn1, txn2, txn3 acquire locks a, b, c
+#
+# Test:  txn1, txn2, txn3 read b, c, a 
+#        txn1 is aborted to break deadlock
+#        txn3 proceeds and commits
+#        txn2 proceeds and commits
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-request name=req1w txn=txn1 ts=10,1
+  put key=a value=v
+----
+
+new-request name=req2w txn=txn2 ts=10,1
+  put key=b value=v
+----
+
+new-request name=req3w txn=txn3 ts=10,1
+  put key=c value=v
+----
+
+sequence req=req1w
+----
+[1] sequence req1w: sequencing request
+[1] sequence req1w: acquiring latches
+[1] sequence req1w: scanning lock table for conflicting locks
+[1] sequence req1w: sequencing complete, returned guard
+
+sequence req=req2w
+----
+[2] sequence req2w: sequencing request
+[2] sequence req2w: acquiring latches
+[2] sequence req2w: scanning lock table for conflicting locks
+[2] sequence req2w: sequencing complete, returned guard
+
+sequence req=req3w
+----
+[3] sequence req3w: sequencing request
+[3] sequence req3w: acquiring latches
+[3] sequence req3w: scanning lock table for conflicting locks
+[3] sequence req3w: sequencing complete, returned guard
+
+on-lock-acquired txn=txn1 key=a
+----
+[-] acquire lock: txn1 @ a
+
+on-lock-acquired txn=txn2 key=b
+----
+[-] acquire lock: txn2 @ b
+
+on-lock-acquired txn=txn3 key=c
+----
+[-] acquire lock: txn3 @ c
+
+finish req=req1w
+----
+[-] finish req1w: finishing request
+
+finish req=req2w
+----
+[-] finish req2w: finishing request
+
+finish req=req3w
+----
+[-] finish req3w: finishing request
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+new-request name=req1r txn=txn1 ts=10,1
+  get key=b
+----
+
+new-request name=req2r txn=txn2 ts=10,1
+  get key=c
+----
+
+new-request name=req3r txn=txn3 ts=10,1
+  get key=a
+----
+
+sequence req=req1r
+----
+[4] sequence req1r: sequencing request
+[4] sequence req1r: acquiring latches
+[4] sequence req1r: scanning lock table for conflicting locks
+[4] sequence req1r: waiting in lock wait-queues
+[4] sequence req1r: pushing txn 00000002
+[4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req2r
+----
+[5] sequence req2r: sequencing request
+[5] sequence req2r: acquiring latches
+[5] sequence req2r: scanning lock table for conflicting locks
+[5] sequence req2r: waiting in lock wait-queues
+[5] sequence req2r: pushing txn 00000003
+[5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req3r
+----
+[4] sequence req1r: dependency cycle detected 00000001->00000002->00000003->00000001
+[5] sequence req2r: dependency cycle detected 00000002->00000003->00000001->00000002
+[6] sequence req3r: sequencing request
+[6] sequence req3r: acquiring latches
+[6] sequence req3r: scanning lock table for conflicting locks
+[6] sequence req3r: waiting in lock wait-queues
+[6] sequence req3r: pushing txn 00000001
+[6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
+[6] sequence req3r: dependency cycle detected 00000003->00000001->00000002->00000003
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+   waiting readers:
+    req: 6, txn: 00000003-0000-0000-0000-000000000000
+   distinguished req: 6
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+   waiting readers:
+    req: 4, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 4
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+   waiting readers:
+    req: 5, txn: 00000002-0000-0000-0000-000000000000
+   distinguished req: 5
+local: num=0
+
+# Break the deadlock by aborting txn1.
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[4] sequence req1r: detected pusher aborted
+[4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
+[6] sequence req3r: acquiring latches
+[6] sequence req3r: scanning lock table for conflicting locks
+[6] sequence req3r: sequencing complete, returned guard
+
+# Txn3 can proceed and eventually commit.
+finish req=req3r
+----
+[-] finish req3r: finishing request
+
+on-txn-updated txn=txn3 status=committed
+----
+[-] update txn: committing txn3
+[5] sequence req2r: resolving intent "c" for txn 00000003 with COMMITTED status
+[5] sequence req2r: acquiring latches
+[5] sequence req2r: scanning lock table for conflicting locks
+[5] sequence req2r: sequencing complete, returned guard
+
+# Txn2 can proceed and eventually commit.
+finish req=req2r
+----
+[-] finish req2r: finishing request
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# More complex deadlock due to lock ordering where not all of the
+# members of the deadlock are distinguished waiters.
+#
+# Setup: txn1, txn2, txn3 acquire locks a, b, c
+#
+# Test:  txn4 writes a
+#        txn1, txn2, txn3 write b, c, a 
+#        txn1 is aborted to break deadlock
+#        txn3 proceeds and commits
+#        txn2 proceeds and commits
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-txn name=txn4 ts=10,1 epoch=0
+----
+
+new-request name=req1w txn=txn1 ts=10,1
+  put key=a value=v
+----
+
+new-request name=req2w txn=txn2 ts=10,1
+  put key=b value=v
+----
+
+new-request name=req3w txn=txn3 ts=10,1
+  put key=c value=v
+----
+
+sequence req=req1w
+----
+[1] sequence req1w: sequencing request
+[1] sequence req1w: acquiring latches
+[1] sequence req1w: scanning lock table for conflicting locks
+[1] sequence req1w: sequencing complete, returned guard
+
+sequence req=req2w
+----
+[2] sequence req2w: sequencing request
+[2] sequence req2w: acquiring latches
+[2] sequence req2w: scanning lock table for conflicting locks
+[2] sequence req2w: sequencing complete, returned guard
+
+sequence req=req3w
+----
+[3] sequence req3w: sequencing request
+[3] sequence req3w: acquiring latches
+[3] sequence req3w: scanning lock table for conflicting locks
+[3] sequence req3w: sequencing complete, returned guard
+
+on-lock-acquired txn=txn1 key=a
+----
+[-] acquire lock: txn1 @ a
+
+on-lock-acquired txn=txn2 key=b
+----
+[-] acquire lock: txn2 @ b
+
+on-lock-acquired txn=txn3 key=c
+----
+[-] acquire lock: txn3 @ c
+
+finish req=req1w
+----
+[-] finish req1w: finishing request
+
+finish req=req2w
+----
+[-] finish req2w: finishing request
+
+finish req=req3w
+----
+[-] finish req3w: finishing request
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+new-request name=req4w txn=txn4 ts=10,1
+  put key=a value=v2
+----
+
+new-request name=req1w2 txn=txn1 ts=10,1
+  put key=b value=v2
+----
+
+new-request name=req2w2 txn=txn2 ts=10,1
+  put key=c value=v2
+----
+
+new-request name=req3w2 txn=txn3 ts=10,1
+  put key=a value=v2
+----
+
+sequence req=req4w
+----
+[4] sequence req4w: sequencing request
+[4] sequence req4w: acquiring latches
+[4] sequence req4w: scanning lock table for conflicting locks
+[4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: pushing txn 00000001
+[4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req1w2
+----
+[5] sequence req1w2: sequencing request
+[5] sequence req1w2: acquiring latches
+[5] sequence req1w2: scanning lock table for conflicting locks
+[5] sequence req1w2: waiting in lock wait-queues
+[5] sequence req1w2: pushing txn 00000002
+[5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req2w2
+----
+[6] sequence req2w2: sequencing request
+[6] sequence req2w2: acquiring latches
+[6] sequence req2w2: scanning lock table for conflicting locks
+[6] sequence req2w2: waiting in lock wait-queues
+[6] sequence req2w2: pushing txn 00000003
+[6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req3w2
+----
+[5] sequence req1w2: dependency cycle detected 00000001->00000002->00000003->00000001
+[6] sequence req2w2: dependency cycle detected 00000002->00000003->00000001->00000002
+[7] sequence req3w2: sequencing request
+[7] sequence req3w2: acquiring latches
+[7] sequence req3w2: scanning lock table for conflicting locks
+[7] sequence req3w2: waiting in lock wait-queues
+[7] sequence req3w2: pushing txn 00000001
+[7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+[7] sequence req3w2: dependency cycle detected 00000003->00000001->00000002->00000003
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 10, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 13, txn: 00000003-0000-0000-0000-000000000000
+   distinguished req: 10
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 11, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 11
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
+   distinguished req: 12
+local: num=0
+
+# Break the deadlock by aborting txn1.
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[4] sequence req4w: resolving intent "a" for txn 00000001 with ABORTED status
+[4] sequence req4w: acquiring latches
+[4] sequence req4w: scanning lock table for conflicting locks
+[4] sequence req4w: sequencing complete, returned guard
+[5] sequence req1w2: detected pusher aborted
+[5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
+[7] sequence req3w2: pushing txn 00000004
+[7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Txn4 can proceed.
+finish req=req4w
+----
+[-] finish req4w: finishing request
+[7] sequence req3w2: acquiring latches
+[7] sequence req3w2: scanning lock table for conflicting locks
+[7] sequence req3w2: sequencing complete, returned guard
+
+# Txn3 can proceed and eventually commit.
+finish req=req3w2
+----
+[-] finish req3w2: finishing request
+
+on-txn-updated txn=txn3 status=committed
+----
+[-] update txn: committing txn3
+[6] sequence req2w2: resolving intent "c" for txn 00000003 with COMMITTED status
+[6] sequence req2w2: acquiring latches
+[6] sequence req2w2: scanning lock table for conflicting locks
+[6] sequence req2w2: sequencing complete, returned guard
+
+# Txn2 can proceed and eventually commit.
+finish req=req2w2
+----
+[-] finish req2w2: finishing request
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# Deadlock due to request ordering.
+#
+# Setup: txn1, txn2, txn3 acquire locks a, b, c
+#        txn4 writes to b and c
+#        txn2 commits
+#        txn4 acquires reservation for b and blocks on c
+#
+# Test:  txn1 writes to b
+#        txn3 writes to a
+#        txn4 is aborted to break deadlock
+#        txn1 proceeds and commits
+#        txn3 proceeds and commits
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-txn name=txn4 ts=10,1 epoch=0
+----
+
+new-request name=req1w txn=txn1 ts=10,1
+  put key=a value=v
+----
+
+new-request name=req2w txn=txn2 ts=10,1
+  put key=b value=v
+----
+
+new-request name=req3w txn=txn3 ts=10,1
+  put key=c value=v
+----
+
+sequence req=req1w
+----
+[1] sequence req1w: sequencing request
+[1] sequence req1w: acquiring latches
+[1] sequence req1w: scanning lock table for conflicting locks
+[1] sequence req1w: sequencing complete, returned guard
+
+sequence req=req2w
+----
+[2] sequence req2w: sequencing request
+[2] sequence req2w: acquiring latches
+[2] sequence req2w: scanning lock table for conflicting locks
+[2] sequence req2w: sequencing complete, returned guard
+
+sequence req=req3w
+----
+[3] sequence req3w: sequencing request
+[3] sequence req3w: acquiring latches
+[3] sequence req3w: scanning lock table for conflicting locks
+[3] sequence req3w: sequencing complete, returned guard
+
+on-lock-acquired txn=txn1 key=a
+----
+[-] acquire lock: txn1 @ a
+
+on-lock-acquired txn=txn2 key=b
+----
+[-] acquire lock: txn2 @ b
+
+on-lock-acquired txn=txn3 key=c
+----
+[-] acquire lock: txn3 @ c
+
+finish req=req1w
+----
+[-] finish req1w: finishing request
+
+finish req=req2w
+----
+[-] finish req2w: finishing request
+
+finish req=req3w
+----
+[-] finish req3w: finishing request
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+local: num=0
+
+new-request name=req4w txn=txn4 ts=10,1
+  put key=b value=v2
+  put key=c value=v2
+----
+
+sequence req=req4w
+----
+[4] sequence req4w: sequencing request
+[4] sequence req4w: acquiring latches
+[4] sequence req4w: scanning lock table for conflicting locks
+[4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: pushing txn 00000002
+[4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+[4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
+[4] sequence req4w: pushing txn 00000003
+[4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "b"
+  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
+   distinguished req: 17
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+new-request name=req1w2 txn=txn1 ts=10,1
+  put key=b value=v2
+----
+
+new-request name=req3w2 txn=txn3 ts=10,1
+  put key=a value=v2
+----
+
+sequence req=req1w2
+----
+[5] sequence req1w2: sequencing request
+[5] sequence req1w2: acquiring latches
+[5] sequence req1w2: scanning lock table for conflicting locks
+[5] sequence req1w2: waiting in lock wait-queues
+[5] sequence req1w2: pushing txn 00000004
+[5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req3w2
+----
+[4] sequence req4w: dependency cycle detected 00000004->00000003->00000001->00000004
+[5] sequence req1w2: dependency cycle detected 00000001->00000004->00000003->00000001
+[6] sequence req3w2: sequencing request
+[6] sequence req3w2: acquiring latches
+[6] sequence req3w2: scanning lock table for conflicting locks
+[6] sequence req3w2: waiting in lock wait-queues
+[6] sequence req3w2: pushing txn 00000001
+[6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
+[6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 19, txn: 00000003-0000-0000-0000-000000000000
+   distinguished req: 19
+ lock: "b"
+  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 18, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 18
+ lock: "c"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+   queued writers:
+    active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
+   distinguished req: 17
+local: num=0
+
+# Break the deadlock by aborting txn4.
+on-txn-updated txn=txn4 status=aborted
+----
+[-] update txn: aborting txn4
+[4] sequence req4w: detected pusher aborted
+[4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[5] sequence req1w2: acquiring latches
+[5] sequence req1w2: scanning lock table for conflicting locks
+[5] sequence req1w2: sequencing complete, returned guard
+
+# Txn1 can proceed and eventually commit.
+finish req=req1w2
+----
+[-] finish req1w2: finishing request
+
+on-txn-updated txn=txn1 status=committed
+----
+[-] update txn: committing txn1
+[6] sequence req3w2: resolving intent "a" for txn 00000001 with COMMITTED status
+[6] sequence req3w2: acquiring latches
+[6] sequence req3w2: scanning lock table for conflicting locks
+[6] sequence req3w2: sequencing complete, returned guard
+
+# Txn3 can proceed and eventually commit.
+finish req=req3w2
+----
+[-] finish req3w2: finishing request
+
+on-txn-updated txn=txn3 status=committed
+----
+[-] update txn: committing txn3
+
+reset namespace
+----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
@@ -38,7 +38,7 @@ sequence req=req1
 [2] sequence req1: scanning lock table for conflicting locks
 [2] sequence req1: waiting in lock wait-queues
 [2] sequence req1: pushing txn 00000001
-[2] sequence req1: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
+[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=aborted
 ----

--- a/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/storage/concurrency/testdata/concurrency_manager/discovered_lock
@@ -28,7 +28,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
 local: num=0
 
 sequence req=req1
@@ -37,13 +37,13 @@ sequence req=req1
 [2] sequence req1: acquiring latches
 [2] sequence req1: scanning lock table for conflicting locks
 [2] sequence req1: waiting in lock wait-queues
-[2] sequence req1: pushing txn 00000000-0000-0000-0000-000000000001
+[2] sequence req1: pushing txn 00000001
 [2] sequence req1: blocked on sync.Cond.Wait in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
-[2] sequence req1: resolving intent "k" for txn 00000000-0000-0000-0000-000000000001 with ABORTED status
+[2] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
 [2] sequence req1: acquiring latches
 [2] sequence req1: scanning lock table for conflicting locks
 [2] sequence req1: sequencing complete, returned guard


### PR DESCRIPTION
This is a partial reversion of #45420.

It turns out that there are cases where a reservation holder is a link in a dependency cycle. This can happen when a reservation holder txn is holding on to one reservation while blocking on a lock on another key. If any txns queued up behind the reservation did not push _someone_, they wouldn't detect the deadlock.

```
     range A      .     range B
                  .
       txnB       .       txnC              txnA
        |         .        |  ^________      |
        v         .        v            \    v
 [lock X: (txnA)] .  [lock Y: (txnB)]  [res Z: (txnC)]
```

It turns out that this segment of the dependency cycle is always local to a single concurrency manager, so it could potentially forward the push through the reservation links to shorten the cycle and prevent non-lock holders from ever being the victim of a deadlock abort. This is tricky though, so for now, we just push.

To address the issue that motivated #45420, we perform this form of push asynchronously while continuing to listen to state transitions in the lockTable. If the pusher is unblocked (see #45420 for an example of when that can happen), it simply cancels the push and proceeds with navigating the lockTable.

This PR also adds a set of datadriven deadlock tests to the concurrency manager test suite: [`testdata/concurrency_manager/deadlocks`](https://github.com/cockroachdb/cockroach/pull/45567/files#diff-5934754d5a8f1086698cdbab628ee1b5). These tests construct deadlocks due to lock ordering and request ordering and demonstrate how the deadlocks are resolved.