### PR TITLE
roachtest: fix copy/bank roachtest to deal with smaller ranges

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -127,8 +127,8 @@ func registerCopy(r *testRegistry) {
 			}
 			rc := rangeCount()
 			t.l.Printf("range count after copy = %d\n", rc)
-			highExp := (rows * rowEstimate) / (rangeMinBytes * 2)
-			lowExp := (rows * rowEstimate) / (rangeMaxBytes)
+			highExp := (rows * rowEstimate) / rangeMinBytes
+			lowExp := (rows * rowEstimate) / rangeMaxBytes
 			if rc > highExp || rc < lowExp {
 				return errors.Errorf("expected range count for table between %d and %d, found %d",
 					lowExp, highExp, rc)


### PR DESCRIPTION
In #45451 we made the expected number of ranges reflect the current
zone config. The problem with this change is that it used a factor of
2x the minimum range size to estimate the upper bound on number of ranges.

There was no principled reason to make this assumption. We should instead
just assert that the ranges are larger than the minimum range size on average.

Release note: None