### PR TITLE
sql: update error message for primary key change on an interleave parent

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -405,7 +406,31 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			// Disable primary key changes on tables that are interleaved parents.
 			if len(n.tableDesc.PrimaryIndex.InterleavedBy) != 0 {
-				return errors.New("cannot change the primary key of an interleaved parent")
+				var sb strings.Builder
+				sb.WriteString("[")
+				comma := ", "
+				for i := range n.tableDesc.PrimaryIndex.InterleavedBy {
+					interleave := &n.tableDesc.PrimaryIndex.InterleavedBy[i]
+					if i != 0 {
+						sb.WriteString(comma)
+					}
+					childTable, err := params.p.Tables().getTableVersionByID(
+						params.ctx,
+						params.p.Txn(),
+						interleave.Table,
+						tree.ObjectLookupFlags{},
+					)
+					if err != nil {
+						return err
+					}
+					sb.WriteString(childTable.Name)
+				}
+				sb.WriteString("]")
+				return errors.Newf(
+					"cannot change primary key of table %s because table(s) %s are interleaved into it",
+					n.tableDesc.Name,
+					sb.String(),
+				)
 			}
 
 			nameExists := func(name string) bool {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -130,7 +130,13 @@ SELECT * FROM child WHERE x >= 1 AND x < 5 AND y >= 2 AND y <= 6
 1 2 3
 4 5 6
 
-statement error pq: cannot change the primary key of an interleaved parent
+statement error pq: cannot change primary key of table parent because table\(s\) \[child\] are interleaved into it
+ALTER TABLE parent ALTER PRIMARY KEY USING COLUMNS (x)
+
+statement ok
+CREATE TABLE child2 (x INT, y INT, z INT, PRIMARY KEY (x, y, z)) INTERLEAVE IN PARENT parent (x, y)
+
+statement error pq: cannot change primary key of table parent because table\(s\) \[child, child2\] are interleaved into it
 ALTER TABLE parent ALTER PRIMARY KEY USING COLUMNS (x)
 
 statement error pq: unimplemented: "parent" is interleaved by table "child"


### PR DESCRIPTION
Fixes #45537.

This PR updates the error message when trying to perform a primary
key change on an interleaved parent to include the name of the
table as well as the names of the interleaved children.

Release note: None