### PR TITLE
bors: Increase build timeout to 4 hours

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -7,6 +7,8 @@ pr_status = [
 block_labels = [
   "do-not-merge"
 ]
+# Set to 4 hours
+timeout_sec = 14400
 
 [committer]
 name = "craig[bot]"


### PR DESCRIPTION
The `testrace` build phase is pushing past two hours.  This is a quick fix to
ensure that PR's aren't getting unnecessarily blocked while fixing slow
`testrace`.

Closes: https://github.com/cockroachdb/dev-inf/issues/45

Release note: None