### PR TITLE
opt: extend WithUses and improve NeededMutationCols

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -40,6 +40,18 @@ func (b *Builder) buildMutationInput(
 		return execPlan{}, err
 	}
 
+	if p.WithID != 0 {
+		// The input might have extra columns that are used only by FK checks; make
+		// sure we don't project them away.
+		cols := inputExpr.Relational().OutputCols.Copy()
+		for _, c := range colList {
+			cols.Remove(c)
+		}
+		for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
+			colList = append(colList, c)
+		}
+	}
+
 	input, err = b.ensureColumns(input, colList, nil, inputExpr.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -662,9 +662,19 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if r.JoinSize > 1 {
 			tp.Childf("join-size: %d", r.JoinSize)
 		}
-		if len(relational.Shared.Rule.WithUses) > 0 {
-			// Go map
-			tp.Childf("cte-uses: %v", relational.Shared.Rule.WithUses)
+		if withUses := relational.Shared.Rule.WithUses; len(withUses) > 0 {
+			n := tp.Childf("cte-uses")
+			ids := make([]opt.WithID, 0, len(withUses))
+			for id := range withUses {
+				ids = append(ids, id)
+			}
+			sort.Slice(ids, func(i, j int) bool {
+				return ids[i] < ids[j]
+			})
+			for _, id := range ids {
+				info := withUses[id]
+				n.Childf("&%d: count=%d used-columns=%s", id, info.Count, info.UsedCols)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -24,7 +24,8 @@ with &1 (foo)
       ├── key: (3)
       ├── fd: (3)-->(4)
       ├── prune: (3,4)
-      └── cte-uses: map[1:1]
+      └── cte-uses
+           └── &1: count=1 used-columns=(1,2)
 
 # Side effects should be propagated up to the top-level from the Binding side
 # of a WITH.
@@ -93,7 +94,8 @@ with &1 (foo)
       ├── key: ()
       ├── fd: ()-->(3)
       ├── prune: (3)
-      ├── cte-uses: map[1:1]
+      ├── cte-uses
+      │    └── &1: count=1 used-columns=(1)
       ├── with-scan &1 (foo)
       │    ├── columns: "?column?":2(int!null)
       │    ├── mapping:
@@ -102,7 +104,8 @@ with &1 (foo)
       │    ├── key: ()
       │    ├── fd: ()-->(2)
       │    ├── prune: (2)
-      │    └── cte-uses: map[1:1]
+      │    └── cte-uses
+      │         └── &1: count=1 used-columns=(1)
       └── projections
            └── div [as="?column?":3, type=decimal, side-effects]
                 ├── const: 1 [type=int]
@@ -138,7 +141,8 @@ with &1 (foo)
       ├── key: ()
       ├── fd: ()-->(3)
       ├── prune: (3)
-      ├── cte-uses: map[1:1]
+      ├── cte-uses
+      │    └── &1: count=1 used-columns=(1)
       ├── with-scan &1 (foo)
       │    ├── columns: int8:2(int)
       │    ├── mapping:
@@ -147,7 +151,8 @@ with &1 (foo)
       │    ├── key: ()
       │    ├── fd: ()-->(2)
       │    ├── prune: (2)
-      │    └── cte-uses: map[1:1]
+      │    └── cte-uses
+      │         └── &1: count=1 used-columns=(1)
       └── projections
            └── const: 1 [as="?column?":3, type=int]
 

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -481,7 +481,7 @@
     $input:*
     $checks:*
     $mutationPrivate:* &
-        (CanPruneCols $input $needed:(NeededMutationCols $mutationPrivate))
+        (CanPruneCols $input $needed:(NeededMutationCols $mutationPrivate $checks))
 )
 =>
 ((OpName)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2870,7 +2870,8 @@ with &1 (foo)
       ├── stats: [rows=1000]
       ├── cost: 0.01
       ├── prune: (6)
-      └── cte-uses: map[1:1]
+      └── cte-uses
+           └── &1: count=1 used-columns=(2)
 
 # --------------------------------------------------
 # PruneUnionAllCols

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -31,7 +31,8 @@ with &1 (foo)
       ├── stats: [rows=2]
       ├── cost: 0.05
       ├── prune: (4)
-      ├── cte-uses: map[1:2]
+      ├── cte-uses
+      │    └── &1: count=2 used-columns=(1)
       ├── with-scan &1 (foo)
       │    ├── columns: "?column?":2(int!null)
       │    ├── mapping:
@@ -42,7 +43,8 @@ with &1 (foo)
       │    ├── key: ()
       │    ├── fd: ()-->(2)
       │    ├── prune: (2)
-      │    └── cte-uses: map[1:1]
+      │    └── cte-uses
+      │         └── &1: count=1 used-columns=(1)
       └── with-scan &1 (foo)
            ├── columns: "?column?":3(int!null)
            ├── mapping:
@@ -53,7 +55,8 @@ with &1 (foo)
            ├── key: ()
            ├── fd: ()-->(3)
            ├── prune: (3)
-           └── cte-uses: map[1:1]
+           └── cte-uses
+                └── &1: count=1 used-columns=(1)
 
 norm format=show-all expect=InlineWith
 WITH foo AS (SELECT 1) SELECT * FROM foo
@@ -279,7 +282,8 @@ with &1 (foo)
       ├── key: ()
       ├── fd: ()-->(3-6)
       ├── prune: (3-6)
-      ├── cte-uses: map[1:2]
+      ├── cte-uses
+      │    └── &1: count=2 used-columns=(1)
       ├── values
       │    ├── columns: "?column?":2(int!null)
       │    ├── cardinality: [1 - 1]
@@ -298,7 +302,9 @@ with &1 (foo)
            ├── key: ()
            ├── fd: ()-->(3-6)
            ├── prune: (3-6)
-           ├── cte-uses: map[1:2 2:2]
+           ├── cte-uses
+           │    ├── &1: count=2 used-columns=(1)
+           │    └── &2: count=2 used-columns=(2)
            ├── inner-join (cross)
            │    ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null)
            │    ├── cardinality: [1 - 1]
@@ -308,7 +314,9 @@ with &1 (foo)
            │    ├── fd: ()-->(3-5)
            │    ├── prune: (3-5)
            │    ├── join-size: 3
-           │    ├── cte-uses: map[1:1 2:2]
+           │    ├── cte-uses
+           │    │    ├── &1: count=1 used-columns=(1)
+           │    │    └── &2: count=2 used-columns=(2)
            │    ├── inner-join (cross)
            │    │    ├── columns: "?column?":3(int!null) "?column?":4(int!null)
            │    │    ├── cardinality: [1 - 1]
@@ -318,7 +326,9 @@ with &1 (foo)
            │    │    ├── fd: ()-->(3,4)
            │    │    ├── prune: (3,4)
            │    │    ├── join-size: 2
-           │    │    ├── cte-uses: map[1:1 2:1]
+           │    │    ├── cte-uses
+           │    │    │    ├── &1: count=1 used-columns=(1)
+           │    │    │    └── &2: count=1 used-columns=(2)
            │    │    ├── with-scan &1 (foo)
            │    │    │    ├── columns: "?column?":3(int!null)
            │    │    │    ├── mapping:
@@ -329,7 +339,8 @@ with &1 (foo)
            │    │    │    ├── key: ()
            │    │    │    ├── fd: ()-->(3)
            │    │    │    ├── prune: (3)
-           │    │    │    └── cte-uses: map[1:1]
+           │    │    │    └── cte-uses
+           │    │    │         └── &1: count=1 used-columns=(1)
            │    │    ├── with-scan &2 (bar)
            │    │    │    ├── columns: "?column?":4(int!null)
            │    │    │    ├── mapping:
@@ -340,7 +351,8 @@ with &1 (foo)
            │    │    │    ├── key: ()
            │    │    │    ├── fd: ()-->(4)
            │    │    │    ├── prune: (4)
-           │    │    │    └── cte-uses: map[2:1]
+           │    │    │    └── cte-uses
+           │    │    │         └── &2: count=1 used-columns=(2)
            │    │    └── filters (true)
            │    ├── with-scan &2 (bar)
            │    │    ├── columns: "?column?":5(int!null)
@@ -352,7 +364,8 @@ with &1 (foo)
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(5)
            │    │    ├── prune: (5)
-           │    │    └── cte-uses: map[2:1]
+           │    │    └── cte-uses
+           │    │         └── &2: count=1 used-columns=(2)
            │    └── filters (true)
            ├── with-scan &1 (foo)
            │    ├── columns: "?column?":6(int!null)
@@ -364,7 +377,8 @@ with &1 (foo)
            │    ├── key: ()
            │    ├── fd: ()-->(6)
            │    ├── prune: (6)
-           │    └── cte-uses: map[1:1]
+           │    └── cte-uses
+           │         └── &1: count=1 used-columns=(1)
            └── filters (true)
 
 exec-ddl
@@ -543,3 +557,120 @@ with &1 (cte)
            │    └── 10
            └── projections
                 └── 1 [as="?column?":17]
+
+# Check cte-uses when used with mutations (for FK checks).
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT REFERENCES parent(p))
+----
+
+norm format=show-all
+WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING c) SELECT c FROM cte UNION SELECT c+1 FROM cte
+----
+with &2 (cte)
+ ├── columns: c:11(int!null)
+ ├── cardinality: [1 - 2]
+ ├── side-effects, mutations
+ ├── stats: [rows=2, distinct(11)=2, null(11)=0]
+ ├── cost: 1037.7025
+ ├── key: (11)
+ ├── insert t.public.child
+ │    ├── columns: t.public.child.c:1(int!null)
+ │    ├── insert-mapping:
+ │    │    ├── column1:3 => t.public.child.c:1
+ │    │    └── column2:4 => t.public.child.p:2
+ │    ├── input binding: &1
+ │    ├── cardinality: [1 - 1]
+ │    ├── side-effects, mutations
+ │    ├── stats: [rows=1]
+ │    ├── cost: 1037.5925
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── columns: column1:3(int!null) column2:4(int!null)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── cost: 0.02
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(3,4)
+ │    │    ├── prune: (3,4)
+ │    │    └── tuple [type=tuple{int, int}]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── f-k-checks
+ │         └── f-k-checks-item: child(p) -> parent(p)
+ │              └── anti-join (hash)
+ │                   ├── columns: column2:6(int!null)
+ │                   ├── cardinality: [0 - 1]
+ │                   ├── stats: [rows=1e-10]
+ │                   ├── cost: 1037.5625
+ │                   ├── key: ()
+ │                   ├── fd: ()-->(6)
+ │                   ├── cte-uses
+ │                   │    └── &1: count=1 used-columns=(4)
+ │                   ├── with-scan &1
+ │                   │    ├── columns: column2:6(int!null)
+ │                   │    ├── mapping:
+ │                   │    │    └──  column2:4(int) => column2:6(int)
+ │                   │    ├── cardinality: [1 - 1]
+ │                   │    ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │                   │    ├── cost: 0.01
+ │                   │    ├── key: ()
+ │                   │    ├── fd: ()-->(6)
+ │                   │    ├── prune: (6)
+ │                   │    └── cte-uses
+ │                   │         └── &1: count=1 used-columns=(4)
+ │                   ├── scan t.public.parent
+ │                   │    ├── columns: t.public.parent.p:7(int!null)
+ │                   │    ├── stats: [rows=1000, distinct(7)=1000, null(7)=0]
+ │                   │    ├── cost: 1020.02
+ │                   │    ├── key: (7)
+ │                   │    ├── prune: (7)
+ │                   │    └── interesting orderings: (+7)
+ │                   └── filters
+ │                        └── eq [type=bool, outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
+ │                             ├── variable: column2:6 [type=int]
+ │                             └── variable: t.public.parent.p:7 [type=int]
+ └── union
+      ├── columns: c:11(int!null)
+      ├── left columns: c:8(int)
+      ├── right columns: "?column?":10(int)
+      ├── cardinality: [1 - 2]
+      ├── stats: [rows=2, distinct(11)=2, null(11)=0]
+      ├── cost: 0.1
+      ├── key: (11)
+      ├── with-scan &2 (cte)
+      │    ├── columns: c:8(int!null)
+      │    ├── mapping:
+      │    │    └──  t.public.child.c:1(int) => c:8(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── stats: [rows=1, distinct(8)=1, null(8)=0]
+      │    ├── cost: 0.01
+      │    ├── key: ()
+      │    ├── fd: ()-->(8)
+      │    └── prune: (8)
+      └── project
+           ├── columns: "?column?":10(int!null)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1, distinct(10)=1, null(10)=0]
+           ├── cost: 0.04
+           ├── key: ()
+           ├── fd: ()-->(10)
+           ├── prune: (10)
+           ├── with-scan &2 (cte)
+           │    ├── columns: c:9(int!null)
+           │    ├── mapping:
+           │    │    └──  t.public.child.c:1(int) => c:9(int)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1, distinct(9)=1, null(9)=0]
+           │    ├── cost: 0.01
+           │    ├── key: ()
+           │    ├── fd: ()-->(9)
+           │    └── prune: (9)
+           └── projections
+                └── plus [as="?column?":10, type=int, outer=(9)]
+                     ├── variable: c:9 [type=int]
+                     └── const: 1 [type=int]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -170,10 +170,24 @@ type Shared struct {
 	// Rule props are lazily calculated and typically only apply to a single
 	// rule. See the comment above Relational.Rule for more details.
 	Rule struct {
-		// WithUses tracks the number of times each With expression has been
-		// referenced in the given expression.
-		WithUses map[opt.WithID]int
+		// WithUses tracks information about the WithScans inside the given
+		// expression which reference WithIDs outside of that expression.
+		WithUses WithUsesMap
 	}
+}
+
+// WithUsesMap stores information about each WithScan referencing an outside
+// WithID, grouped by each WithID.
+type WithUsesMap map[opt.WithID]WithUseInfo
+
+// WithUseInfo contains information about the usage of a specific WithID.
+type WithUseInfo struct {
+	// Count is the number of WithScan operators which reference this WithID.
+	Count int
+
+	// UsedCols is the union of columns used by all WithScan operators which
+	// reference this WithID.
+	UsedCols opt.ColSet
 }
 
 // Relational properties describe the content and characteristics of relational


### PR DESCRIPTION
This change extends the WithUses rule prop to keep track of the columns actually
used by `WithScan`s.

This set is then used by NeededMutationCols to make sure we never prune mutation
input columns that are used by FK checks. Currently this never happens, but
because of fairly subtle reasons: FKs happen to require indexes on both sides,
and those indexes force the mutation operator to require values for those
columns. This won't be the case anymore with upsert FK checks, for which this
fix is required.

The new information will also be used (in a future change) to prune unused
columns of `With` itself.

Release note: None