### PR TITLE
storage/concurrency: release reqs from same txn as discovered lock

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -42,7 +42,7 @@ import (
 Test needs to handle caller constraints wrt latches being held. The datadriven
 test uses the following format:
 
-new-locktable maxlocks=<int>
+new-lock-table maxlocks=<int>
 ----
 
   Creates a lockTable.

--- a/pkg/storage/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/storage/concurrency/testdata/lock_table/add_discovered
@@ -1,0 +1,136 @@
+# -------------------------------------------------------------
+# In this test we create a lock wait-queue for a key. We then
+# have the head of the queue discover an existing lock on the
+# key. The lock is part of the same transaction as one of the
+# queued writes. The writer should stop waiting on the lock.
+#
+# NOTE: this test is somewhat synthetic and it's not clear that
+# there's currently a way to trigger this behavior if all lock
+# acquisitions are observed sequentially when starting from an
+# empty lock-table, given the current policy on how wait-queues
+# form in the lock-table. Still, this is worth handling correctly
+# in case this ever changes.
+#
+# Setup: txn1 acquires lock
+#        txn2 and txn3 enter wait-queue
+#        txn1 releases lock, txn2 becomes reservation holder
+#
+# Test:  discover lock from txn3
+#        txn3 should exit wait-queue
+# -------------------------------------------------------------
+
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-txn txn=txn3 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10,1 spans=w@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+dequeue r=req1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+local: num=0
+
+new-request r=req2 txn=txn2 ts=10,1 spans=w@a
+----
+
+new-request r=req3 txn=txn3 ts=10,1 spans=w@a
+----
+
+scan r=req2
+----
+start-waiting: true
+
+scan r=req3
+----
+start-waiting: true
+
+release txn=txn1 span=a
+----
+global: num=1
+ lock: "a"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,1
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 3
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn2 ts=10,1 key="a" held=false guard-access=write
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+add-discovered r=req2 k=a txn=txn3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,1
+   queued writers:
+    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+local: num=0
+
+scan r=req2
+----
+start-waiting: true
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn3 ts=10,1 key="a" held=true guard-access=write
+
+guard-state r=req3
+----
+new: state=doneWaiting
+
+dequeue r=req3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,1
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 2
+local: num=0
+
+release txn=txn3 span=a
+----
+global: num=1
+ lock: "a"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,1
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+dequeue r=req2
+----
+global: num=0
+local: num=0


### PR DESCRIPTION
This commit updates the AddDiscoveredLock state transition in lockTableImpl to release all waiting writers that are part of the same transaction as a discovered lock.

This caused issues in #45482, where we saw txn deadlocks in the `pkg/sql/tests.Bank` benchmark. This issue was triggered because we were forgetting to inform the lockTable of a lock acquisition in a subtle case. That is now fixed and it's not clear that we can actually hit the bug here anymore given the current policy on how wait-queues form in the lock-table. Regardless, this is worth handling correctly in case things ever change.