### PR TITLE
opt: factor limit hints into scan and lookup join costs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -751,16 +751,19 @@ group      ·            ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
-·               distributed  false             ·               ·
-·               vectorized   true              ·               ·
-group           ·            ·                 (min int)       ·
- │              aggregate 0  min(v)            ·               ·
- │              scalar       ·                 ·               ·
- └── render     ·            ·                 (v int)         ·
-      │         render 0     (v)[int]          ·               ·
-      └── scan  ·            ·                 (k int, v int)  ·
-·               table        opt_test@primary  ·               ·
-·               spans        -/3/# /5-         ·               ·
+·                    distributed  false                         ·               ·
+·                    vectorized   true                          ·               ·
+group                ·            ·                             (min int)       ·
+ │                   aggregate 0  any_not_null(v)               ·               ·
+ │                   scalar       ·                             ·               ·
+ └── render          ·            ·                             (v int)         ·
+      │              render 0     (v)[int]                      ·               ·
+      └── limit      ·            ·                             (k int, v int)  +v
+           │         count        (1)[int]                      ·               ·
+           └── scan  ·            ·                             (k int, v int)  +v
+·                    table        opt_test@v                    ·               ·
+·                    spans        /!NULL-                       ·               ·
+·                    filter       ((k)[int] != (4)[int])[bool]  ·               ·
 
 # Check that the optimization doesn't work when the argument is non-trivial (we
 # can't in general guarantee an ordering on a synthesized column).

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -148,18 +148,17 @@ filter     ·            ·          (k)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-·                distributed  false      ·          ·
-·                vectorized   true       ·          ·
-render           ·            ·          (k, w)     ·
- │               render 0     k          ·          ·
- │               render 1     w          ·          ·
- └── index-join  ·            ·          (k, v, w)  ·
-      │          table        t@primary  ·          ·
-      │          key columns  k          ·          ·
-      └── scan   ·            ·          (k, v)     ·
-·                table        t@t_v_idx  ·          ·
-·                spans        /1-/101    ·          ·
-·                limit        10         ·          ·
+·               distributed  false                    ·          ·
+·               vectorized   true                     ·          ·
+render          ·            ·                        (k, w)     ·
+ │              render 0     k                        ·          ·
+ │              render 1     w                        ·          ·
+ └── limit      ·            ·                        (k, v, w)  ·
+      │         count        10                       ·          ·
+      └── scan  ·            ·                        (k, v, w)  ·
+·               table        t@primary                ·          ·
+·               spans        ALL                      ·          ·
+·               filter       (v >= 1) AND (v <= 100)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -45,34 +45,36 @@ root            ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-·                    distributed   false                                                                        ·          ·
-·                    vectorized    false                                                                        ·          ·
-root                 ·             ·                                                                            (a, b, c)  ·
- ├── scan            ·             ·                                                                            (a, b, c)  ·
- │                   table         abc@primary                                                                  ·          ·
- │                   spans         ALL                                                                          ·          ·
- │                   filter        a = @S2                                                                      ·          ·
- ├── subquery        ·             ·                                                                            (a, b, c)  ·
- │    │              id            @S1                                                                          ·          ·
- │    │              original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·          ·
- │    │              exec mode     exists                                                                       ·          ·
- │    └── limit      ·             ·                                                                            (a, b, c)  ·
- │         │         count         1                                                                            ·          ·
- │         └── scan  ·             ·                                                                            (a, b, c)  ·
- │                   table         abc@primary                                                                  ·          ·
- │                   spans         ALL                                                                          ·          ·
- │                   filter        c = (a + 3)                                                                  ·          ·
- └── subquery        ·             ·                                                                            (a, b, c)  ·
-      │              id            @S2                                                                          ·          ·
-      │              original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·          ·
-      │              exec mode     one row                                                                      ·          ·
-      └── group      ·             ·                                                                            (max)      ·
-           │         aggregate 0   max(a)                                                                       ·          ·
-           │         scalar        ·                                                                            ·          ·
-           └── scan  ·             ·                                                                            (a)        ·
-·                    table         abc@primary                                                                  ·          ·
-·                    spans         ALL                                                                          ·          ·
-·                    filter        @S1                                                                          ·          ·
+·                            distributed   false                                                                        ·               ·
+·                            vectorized    false                                                                        ·               ·
+root                         ·             ·                                                                            (a, b, c)       ·
+ ├── scan                    ·             ·                                                                            (a, b, c)       ·
+ │                           table         abc@primary                                                                  ·               ·
+ │                           spans         ALL                                                                          ·               ·
+ │                           filter        a = @S2                                                                      ·               ·
+ ├── subquery                ·             ·                                                                            (a, b, c)       ·
+ │    │                      id            @S1                                                                          ·               ·
+ │    │                      original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
+ │    │                      exec mode     exists                                                                       ·               ·
+ │    └── limit              ·             ·                                                                            (a, b, c)       ·
+ │         │                 count         1                                                                            ·               ·
+ │         └── scan          ·             ·                                                                            (a, b, c)       ·
+ │                           table         abc@primary                                                                  ·               ·
+ │                           spans         ALL                                                                          ·               ·
+ │                           filter        c = (a + 3)                                                                  ·               ·
+ └── subquery                ·             ·                                                                            (a, b, c)       ·
+      │                      id            @S2                                                                          ·               ·
+      │                      original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
+      │                      exec mode     one row                                                                      ·               ·
+      └── group              ·             ·                                                                            (any_not_null)  ·
+           │                 aggregate 0   any_not_null(a)                                                              ·               ·
+           │                 scalar        ·                                                                            ·               ·
+           └── limit         ·             ·                                                                            (a)             -a
+                │            count         1                                                                            ·               ·
+                └── revscan  ·             ·                                                                            (a)             -a
+·                            table         abc@primary                                                                  ·               ·
+·                            spans         ALL                                                                          ·               ·
+·                            filter        @S1                                                                          ·               ·
 
 # IN expression transformed into semi-join.
 query TTTTT

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -148,7 +148,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G5: (const 10)
  ├── G6: (plus G11 G12)
  ├── G7: (project G13 G14 y)
- │    ├── [ordering: +2] [limit hint: 10.00]
+ │    ├── [ordering: +2] [limit hint: 100.00]
  │    │    ├── best: (sort G7)
  │    │    └── cost: 1119.26
  │    ├── [ordering: +5]
@@ -169,7 +169,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G11: (variable y)
  ├── G12: (const 1)
  ├── G13: (select G16 G17)
- │    ├── [ordering: +2] [limit hint: 10.00]
+ │    ├── [ordering: +2] [limit hint: 100.00]
  │    │    ├── best: (sort G13)
  │    │    └── cost: 1112.58
  │    └── []
@@ -178,7 +178,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G14: (projections G18)
  ├── G15: (eq G19 G20)
  ├── G16: (scan a)
- │    ├── [ordering: +2] [limit hint: 30.00]
+ │    ├── [ordering: +2] [limit hint: 300.00]
  │    │    ├── best: (sort G16)
  │    │    └── cost: 1259.35
  │    └── []

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -148,7 +148,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G5: (const 10)
  ├── G6: (plus G11 G12)
  ├── G7: (project G13 G14 y)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 10.00]
  │    │    ├── best: (sort G7)
  │    │    └── cost: 1119.26
  │    ├── [ordering: +5]
@@ -169,7 +169,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G11: (variable y)
  ├── G12: (const 1)
  ├── G13: (select G16 G17)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 10.00]
  │    │    ├── best: (sort G13)
  │    │    └── cost: 1112.58
  │    └── []
@@ -178,7 +178,7 @@ memo (optimized, ~18KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G14: (projections G18)
  ├── G15: (eq G19 G20)
  ├── G16: (scan a)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2] [limit hint: 30.00]
  │    │    ├── best: (sort G16)
  │    │    └── cost: 1259.35
  │    └── []

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -14,13 +14,13 @@ limit
  ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
- ├── cost: 1050.13
+ ├── cost: 21.13
  ├── prune: (2)
  ├── interesting orderings: (+1,+2)
  ├── scan t.public.abc@ab
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
  │    ├── stats: [rows=1000]
- │    ├── cost: 1050.02
+ │    ├── cost: 21.02
  │    ├── ordering: +1
  │    ├── limit hint: 10.00
  │    ├── prune: (1,2)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -107,6 +107,14 @@ const (
 	// justification for this constant.
 	lookupJoinRetrieveRowCost = 2 * seqIOCostFactor
 
+	// Input rows to a join are processed in batches of this size.
+	// See joinreader.go.
+	joinReaderBatchSize = 100.0
+
+	// In the case of a limit hint, a scan will read this multiple of the expected
+	// number of rows. See scanNode.limitHint.
+	scanSoftLimitMultiplier = 2.0
+
 	// latencyCostFactor represents the throughput impact of doing scans on an
 	// index that may be remotely located in a different locality. If latencies
 	// are higher, then overall cluster throughput will suffer somewhat, as there
@@ -174,7 +182,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		cost = c.computeIndexJoinCost(candidate.(*memo.IndexJoinExpr))
 
 	case opt.LookupJoinOp:
-		cost = c.computeLookupJoinCost(candidate.(*memo.LookupJoinExpr))
+		cost = c.computeLookupJoinCost(candidate.(*memo.LookupJoinExpr), required)
 
 	case opt.ZigzagJoinOp:
 		cost = c.computeZigzagJoinCost(candidate.(*memo.ZigzagJoinExpr))
@@ -280,6 +288,10 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 	rowCount := scan.Relational().Stats.RowCount
 	perRowCost := c.rowScanCost(scan.Table, scan.Index, scan.Cols.Len())
+
+	if required.LimitHint != 0 {
+		rowCount = math.Min(rowCount, required.LimitHint*scanSoftLimitMultiplier)
+	}
 
 	if ordering.ScanIsReverse(scan, &required.Ordering) {
 		if rowCount > 1 {
@@ -394,8 +406,22 @@ func (c *coster) computeIndexJoinCost(join *memo.IndexJoinExpr) memo.Cost {
 	return memo.Cost(leftRowCount) * perRowCost
 }
 
-func (c *coster) computeLookupJoinCost(join *memo.LookupJoinExpr) memo.Cost {
-	leftRowCount := join.Input.Relational().Stats.RowCount
+func (c *coster) computeLookupJoinCost(
+	join *memo.LookupJoinExpr, required *physical.Required,
+) memo.Cost {
+	lookupCount := join.Input.Relational().Stats.RowCount
+
+	// Lookup joins can return early if enough rows have been found. An otherwise
+	// expensive lookup join might have a lower cost if its limit hint estimates
+	// that most rows will not be needed.
+	if required.LimitHint != 0 {
+		// Estimate the number of lookups needed to output LimitHint rows.
+		expectedLookupCount := required.LimitHint * lookupCount / join.Relational().Stats.RowCount
+
+		// Round up to the nearest multiple of a batch.
+		expectedLookupCount = math.Ceil(expectedLookupCount/joinReaderBatchSize) * joinReaderBatchSize
+		lookupCount = math.Min(lookupCount, expectedLookupCount)
+	}
 
 	// The rows in the (left) input are used to probe into the (right) table.
 	// Since the matching rows in the table may not all be in the same range, this
@@ -409,7 +435,7 @@ func (c *coster) computeLookupJoinCost(join *memo.LookupJoinExpr) memo.Cost {
 		// slower.
 		perLookupCost *= 5
 	}
-	cost := memo.Cost(leftRowCount) * perLookupCost
+	cost := memo.Cost(lookupCount) * perLookupCost
 
 	// Each lookup might retrieve many rows; add the IO cost of retrieving the
 	// rows (relevant when we expect many resulting rows per lookup) and the CPU

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -99,6 +99,7 @@ func BuildChildPhysicalProps(
 		}
 
 	case opt.IndexJoinOp:
+		// For an index join, every input row results in exactly one output row.
 		childProps.LimitHint = parentProps.LimitHint
 
 	case opt.ExceptOp, opt.ExceptAllOp, opt.IntersectOp, opt.IntersectAllOp,
@@ -113,15 +114,21 @@ func BuildChildPhysicalProps(
 			childProps.LimitHint = distinctOnLimitHint(distinctCount, parentProps.LimitHint)
 		}
 
-	case opt.SelectOp:
+	case opt.SelectOp, opt.LookupJoinOp:
+		// These operations are assumed to produce a constant number of output rows
+		// for each input row, independent of already-processed rows.
 		outputRows := parent.(memo.RelExpr).Relational().Stats.RowCount
 		if outputRows == 0 || outputRows < parentProps.LimitHint {
 			break
 		}
 		if input, ok := parent.Child(nth).(memo.RelExpr); ok {
 			inputRows := input.Relational().Stats.RowCount
+			// outputRows / inputRows is roughly the number of output rows produced
+			// for each input row. Reduce the number of required input rows so that
+			// the expected number of output rows is equal to the parent limit hint.
 			childProps.LimitHint = parentProps.LimitHint * inputRows / outputRows
 		}
+
 	case opt.OrdinalityOp, opt.ProjectOp, opt.ProjectSetOp:
 		childProps.LimitHint = parentProps.LimitHint
 	}

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -112,6 +112,118 @@ inner-join (hash)
  └── filters
       └── k:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE b INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10000,
+    "distinct_count": 1000
+  }
+]'
+----
+
+# Lookup join with no limit hint.
+opt
+SELECT * FROM a JOIN b ON k=z WHERE x > 0 AND x <= 5000
+----
+inner-join (lookup a)
+ ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ ├── key columns: [6] = [1]
+ ├── lookup columns are key
+ ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(6)=1000, null(6)=0]
+ ├── cost: 71400.04
+ ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ ├── select
+ │    ├── columns: x:5!null z:6!null
+ │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    ├── cost: 10600.03
+ │    ├── scan b
+ │    │    ├── columns: x:5 z:6!null
+ │    │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    │    └── cost: 10500.02
+ │    └── filters
+ │         └── (x:5 > 0) AND (x:5 <= 5000) [outer=(5), constraints=(/5: [/1 - /5000]; tight)]
+ └── filters (true)
+
+# With the limit hint, the cost of the lookup join is reduced.
+opt
+SELECT * FROM a JOIN b ON k=z WHERE x > 0 AND x <= 5000 LIMIT 6000
+----
+limit
+ ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ ├── cardinality: [0 - 6000]
+ ├── stats: [rows=6000]
+ ├── cost: 55460.05
+ ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ ├── inner-join (lookup a)
+ │    ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ │    ├── key columns: [6] = [1]
+ │    ├── lookup columns are key
+ │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(6)=1000, null(6)=0]
+ │    ├── cost: 55400.04
+ │    ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ │    ├── limit hint: 6000.00
+ │    ├── select
+ │    │    ├── columns: x:5!null z:6!null
+ │    │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    │    ├── cost: 10600.03
+ │    │    ├── limit hint: 6000.00
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:5 z:6!null
+ │    │    │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    │    │    ├── cost: 10500.02
+ │    │    │    └── limit hint: 6000.00
+ │    │    └── filters
+ │    │         └── (x:5 > 0) AND (x:5 <= 5000) [outer=(5), constraints=(/5: [/1 - /5000]; tight)]
+ │    └── filters (true)
+ └── 6000
+
+# The limit hint for the lookup join input will be rounded up to the nearest
+# multiple of the batch size, so the cost of the lookup join here is the same
+# as the test case above.
+opt
+SELECT * FROM a JOIN b ON k=z WHERE x > 0 AND x <= 5000 LIMIT 5950
+----
+limit
+ ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ ├── cardinality: [0 - 5950]
+ ├── stats: [rows=5950]
+ ├── cost: 55459.55
+ ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ ├── inner-join (lookup a)
+ │    ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ │    ├── key columns: [6] = [1]
+ │    ├── lookup columns are key
+ │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(6)=1000, null(6)=0]
+ │    ├── cost: 55400.04
+ │    ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ │    ├── limit hint: 5950.00
+ │    ├── select
+ │    │    ├── columns: x:5!null z:6!null
+ │    │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    │    ├── cost: 10600.03
+ │    │    ├── limit hint: 6000.00
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:5 z:6!null
+ │    │    │    ├── stats: [rows=10000, distinct(5)=1000, null(5)=0, distinct(6)=1000, null(6)=0]
+ │    │    │    ├── cost: 10500.02
+ │    │    │    └── limit hint: 6000.00
+ │    │    └── filters
+ │    │         └── (x:5 > 0) AND (x:5 <= 5000) [outer=(5), constraints=(/5: [/1 - /5000]; tight)]
+ │    └── filters (true)
+ └── 5950
 
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX c_idx (c))
@@ -365,3 +477,133 @@ project
       └── filters
            ├── a:12 = 'foo' [outer=(12), constraints=(/12: [/'foo' - /'foo']; tight), fd=()-->(12)]
            └── b:13 = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [outer=(13), constraints=(/13: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(13)]
+
+exec-ddl
+DROP TABLE abcde
+----
+
+exec-ddl
+DROP TABLE wxyz
+----
+
+exec-ddl
+CREATE TABLE abcde (
+  a TEXT NOT NULL,
+  b UUID NOT NULL,
+  c UUID NOT NULL,
+  d VARCHAR(255) NOT NULL,
+  e TEXT NOT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (a, b, c),
+  UNIQUE INDEX idx_abd (a, b, d),
+  UNIQUE INDEX idx_abcd (a, b, c, d)
+)
+----
+
+exec-ddl
+ALTER TABLE abcde INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 250000,
+    "distinct_count": 1
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 250000,
+    "distinct_count": 2
+  },
+  {
+    "columns": ["d"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 250000,
+    "distinct_count": 125000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE wxyz (
+  w TEXT NOT NULL,
+  x UUID NOT NULL,
+  y UUID NOT NULL,
+  z TEXT NOT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (w, x, y),
+  CONSTRAINT "foreign" FOREIGN KEY (w, x, y) REFERENCES abcde (a, b, c)
+)
+----
+
+exec-ddl
+ALTER TABLE wxyz INJECT STATISTICS '[
+  {
+    "columns": ["w"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10000,
+    "distinct_count": 1
+  },
+  {
+    "columns": ["x"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 1
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 2500
+  }
+]'
+----
+
+# Regression test for #34811. Ensure the soft limit propagation causes us to
+# select a lookup join.
+opt
+SELECT w, x, y, z
+FROM wxyz
+INNER JOIN abcde
+ON w = a AND x = b AND y = c
+WHERE w = 'foo' AND x = '2AB23800-06B1-4E19-A3BB-DF3768B808D2'
+ORDER BY d
+LIMIT 10
+----
+project
+ ├── columns: w:1!null x:2!null y:3!null z:4!null  [hidden: d:8!null]
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 104717.922
+ ├── key: (8)
+ ├── fd: ()-->(1,2), (3)-->(4,8), (8)-->(3,4)
+ ├── ordering: +8 opt(1,2) [actual: +8]
+ └── limit
+      ├── columns: w:1!null x:2!null y:3!null z:4!null a:5!null b:6!null c:7!null d:8!null
+      ├── internal-ordering: +8 opt(1,2,5,6)
+      ├── cardinality: [0 - 10]
+      ├── stats: [rows=10]
+      ├── cost: 104717.812
+      ├── key: (7)
+      ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
+      ├── ordering: +8 opt(1,2,5,6) [actual: +8]
+      ├── inner-join (lookup wxyz)
+      │    ├── columns: w:1!null x:2!null y:3!null z:4!null a:5!null b:6!null c:7!null d:8!null
+      │    ├── key columns: [5 6 7] = [1 2 3]
+      │    ├── lookup columns are key
+      │    ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=2500, null(7)=0]
+      │    ├── cost: 104717.702
+      │    ├── key: (7)
+      │    ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
+      │    ├── ordering: +8 opt(1,2,5,6) [actual: +8]
+      │    ├── limit hint: 10.00
+      │    ├── scan abcde@idx_abd
+      │    │    ├── columns: a:5!null b:6!null c:7!null d:8!null
+      │    │    ├── constraint: /5/6/8: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
+      │    │    ├── stats: [rows=125000, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=24975.5859, null(7)=0, distinct(8)=93750, null(8)=0]
+      │    │    ├── cost: 216.01
+      │    │    ├── key: (7)
+      │    │    ├── fd: ()-->(5,6), (7)-->(8), (8)-->(7)
+      │    │    ├── ordering: +8 opt(5,6) [actual: +8]
+      │    │    └── limit hint: 100.00
+      │    └── filters
+      │         ├── w:1 = 'foo' [outer=(1), constraints=(/1: [/'foo' - /'foo']; tight), fd=()-->(1)]
+      │         └── x:2 = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [outer=(2), constraints=(/2: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(2)]
+      └── 10

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -12,6 +12,87 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(3)
 
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100
+  }
+]'
+----
+
+# The limit hint is propagated to the scan and the cost is slightly more than
+# the limit hint * 2 (the scan soft limit multiplier).
+opt
+SELECT * FROM a WHERE k > 5 AND i IN (1, 3, 5, 7, 9) LIMIT 20
+----
+limit
+ ├── columns: k:1!null i:2!null s:3 d:4!null
+ ├── cardinality: [0 - 20]
+ ├── stats: [rows=20]
+ ├── cost: 1197.56333
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── select
+ │    ├── columns: k:1!null i:2!null s:3 d:4!null
+ │    ├── stats: [rows=1666.66667, distinct(1)=1666.66667, null(1)=0, distinct(2)=5, null(2)=0]
+ │    ├── cost: 1197.35333
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 20.00
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 s:3 d:4!null
+ │    │    ├── constraint: /1: [/6 - ]
+ │    │    ├── stats: [rows=33333.3333, distinct(1)=33333.3333, null(1)=0]
+ │    │    ├── cost: 864.01
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    └── limit hint: 400.00
+ │    └── filters
+ │         └── i:2 IN (1, 3, 5, 7, 9) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
+ └── 20
+
+# The limit hint is propagated, but the cost is not multiplied by 2 (the scan
+# soft limit multiplier) since the row count is known to be less than 400 * 2.
+opt
+SELECT * FROM a WHERE k > 0 AND k <= 450 AND i IN (1, 3, 5, 7, 9) LIMIT 20
+----
+limit
+ ├── columns: k:1!null i:2!null s:3 d:4!null
+ ├── cardinality: [0 - 20]
+ ├── stats: [rows=20]
+ ├── cost: 490.73
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── select
+ │    ├── columns: k:1!null i:2!null s:3 d:4!null
+ │    ├── cardinality: [0 - 450]
+ │    ├── stats: [rows=22.5, distinct(1)=22.5, null(1)=0, distinct(2)=5, null(2)=0]
+ │    ├── cost: 490.52
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 20.00
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 s:3 d:4!null
+ │    │    ├── constraint: /1: [/1 - /450]
+ │    │    ├── cardinality: [0 - 450]
+ │    │    ├── stats: [rows=450, distinct(1)=450, null(1)=0]
+ │    │    ├── cost: 486.01
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    └── limit hint: 400.00
+ │    └── filters
+ │         └── i:2 IN (1, 3, 5, 7, 9) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
+ └── 20
+
 # Regression test for #35042. Ensure we always prefer constrained scans.
 exec-ddl
 CREATE TABLE speed_test (id INT PRIMARY KEY DEFAULT unique_rowid())

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -402,6 +402,95 @@ limit
  │         └── generate_series(1, x:1) [outer=(1), side-effects]
  └── 10
 
+# --------------------------------------------------
+# Lookup join.
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
+----
+
+exec-ddl
+CREATE TABLE b (x INT, z INT NOT NULL)
+----
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE b INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10000,
+    "distinct_count": 1000
+  }
+]'
+----
+
+# Ensure the limit hint is propagated to the lookup join input as a multiple
+# of the batch size.
+opt
+SELECT * FROM a JOIN b ON k=z WHERE x > 0 AND x <= 5000 LIMIT 6003
+----
+limit
+ ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ ├── cardinality: [0 - 6003]
+ ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ ├── inner-join (lookup a)
+ │    ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ │    ├── key columns: [6] = [1]
+ │    ├── lookup columns are key
+ │    ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ │    ├── limit hint: 6003.00
+ │    ├── select
+ │    │    ├── columns: x:5!null z:6!null
+ │    │    ├── limit hint: 6100.00
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:5 z:6!null
+ │    │    │    └── limit hint: 6100.00
+ │    │    └── filters
+ │    │         └── (x:5 > 0) AND (x:5 <= 5000) [outer=(5)]
+ │    └── filters (true)
+ └── 6003
+
+# The limit hint for the lookup join input must be at least the batch size.
+opt
+SELECT * FROM a JOIN b ON k=z WHERE x > 0 AND x <= 5000 LIMIT 3
+----
+limit
+ ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ ├── cardinality: [0 - 3]
+ ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ ├── inner-join (lookup a)
+ │    ├── columns: k:1!null i:2 s:3 d:4!null x:5!null z:6!null
+ │    ├── key columns: [6] = [1]
+ │    ├── lookup columns are key
+ │    ├── fd: (1)-->(2-4), (1)==(6), (6)==(1)
+ │    ├── limit hint: 3.00
+ │    ├── select
+ │    │    ├── columns: x:5!null z:6!null
+ │    │    ├── limit hint: 100.00
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:5 z:6!null
+ │    │    │    └── limit hint: 100.00
+ │    │    └── filters
+ │    │         └── (x:5 > 0) AND (x:5 <= 5000) [outer=(5)]
+ │    └── filters (true)
+ └── 3
+
+# --------------------------------------------------
+# Negative limits.
+# --------------------------------------------------
+
 # Regression test for #44683.
 exec-ddl
 CREATE TABLE t44683(c0 INT)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -151,7 +151,7 @@ scalar-group-by
 # This is because we know nothing about the ordering of y
 # on the index xy after a scan on xy with x>7.
 opt
-SELECT min(y) FROM xyz WHERE x>7
+SELECT min(y) FROM xyz@xy WHERE x>7
 ----
 scalar-group-by
  ├── columns: min:4
@@ -161,6 +161,7 @@ scalar-group-by
  ├── scan xyz@xy
  │    ├── columns: x:1!null y:2
  │    ├── constraint: /1/2: [/8 - ]
+ │    ├── flags: force-index=xy
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations
@@ -171,7 +172,7 @@ scalar-group-by
 # This is because we know nothing about the ordering of y
 # on the index xy after a scan on xy with x>7
 opt
-SELECT max(y) FROM xyz WHERE x>7
+SELECT max(y) FROM xyz@xy WHERE x>7
 ----
 scalar-group-by
  ├── columns: max:4
@@ -181,6 +182,7 @@ scalar-group-by
  ├── scan xyz@xy
  │    ├── columns: x:1!null y:2
  │    ├── constraint: /1/2: [/8 - ]
+ │    ├── flags: force-index=xy
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations
@@ -501,7 +503,7 @@ memo (optimized, ~5KB, required=[presentation: min:5])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: +1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,cols=(1))
- │    │    └── cost: 1050.02
+ │    │    └── cost: 2.12
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1050.02
@@ -563,7 +565,7 @@ memo (optimized, ~5KB, required=[presentation: max:5])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: -1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,rev,cols=(1))
- │    │    └── cost: 1149.68
+ │    │    └── cost: 2.14
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1050.02

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -111,12 +111,12 @@ memo (optimized, ~6KB, required=[presentation: s:4])
  ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── [limit hint: 1.00]
  │         ├── best: (scan a@s_idx,cols=(4),constrained)
- │         └── cost: 10.51
+ │         └── cost: 2.11
  ├── G3: (const 1)
  ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
  │    └── [limit hint: 100.00]
  │         ├── best: (scan a@s_idx,cols=(4))
- │         └── cost: 1050.02
+ │         └── cost: 210.02
  ├── G5: (filters G6)
  ├── G6: (eq G7 G8)
  ├── G7: (variable s)
@@ -224,29 +224,28 @@ explain
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2-4)~~>(1)
       ├── ordering: -2
-      ├── sort
+      ├── select
       │    ├── columns: a:1!null b:2 c:3 d:4
       │    ├── cardinality: [0 - 11]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
       │    ├── ordering: -2
       │    ├── limit hint: 5.00
-      │    └── select
-      │         ├── columns: a:1!null b:2 c:3 d:4
-      │         ├── cardinality: [0 - 11]
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-      │         ├── index-join abcd
-      │         │    ├── columns: a:1!null b:2 c:3 d:4
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-      │         │    └── scan abcd@b
-      │         │         ├── columns: a:1!null b:2
-      │         │         ├── flags: force-index=b
-      │         │         ├── key: (1)
-      │         │         └── fd: (1)-->(2)
-      │         └── filters
-      │              └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
+      │    ├── index-join abcd
+      │    │    ├── columns: a:1!null b:2 c:3 d:4
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      │    │    ├── ordering: -2
+      │    │    ├── limit hint: 454.55
+      │    │    └── scan abcd@b,rev
+      │    │         ├── columns: a:1!null b:2
+      │    │         ├── flags: force-index=b
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2)
+      │    │         ├── ordering: -2
+      │    │         └── limit hint: 454.55
+      │    └── filters
+      │         └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
       └── 5
 
 optsteps
@@ -372,7 +371,7 @@ ConsolidateSelectFilters
               └── 5
 ================================================================================
 GenerateIndexScans
-  Cost: 5141.10
+  Cost: 5134.91
 ================================================================================
    explain
     ├── columns: tree:5 field:6 description:7
@@ -410,29 +409,28 @@ GenerateIndexScans
   -           │         └── filters
   -           │              └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
   -           └── 5
-  +      ├── sort
+  +      ├── select
   +      │    ├── columns: a:1!null b:2 c:3 d:4
   +      │    ├── cardinality: [0 - 11]
   +      │    ├── key: (1)
   +      │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
   +      │    ├── ordering: -2
   +      │    ├── limit hint: 5.00
-  +      │    └── select
-  +      │         ├── columns: a:1!null b:2 c:3 d:4
-  +      │         ├── cardinality: [0 - 11]
-  +      │         ├── key: (1)
-  +      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-  +      │         ├── index-join abcd
-  +      │         │    ├── columns: a:1!null b:2 c:3 d:4
-  +      │         │    ├── key: (1)
-  +      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-  +      │         │    └── scan abcd@b
-  +      │         │         ├── columns: a:1!null b:2
-  +      │         │         ├── flags: force-index=b
-  +      │         │         ├── key: (1)
-  +      │         │         └── fd: (1)-->(2)
-  +      │         └── filters
-  +      │              └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  +      │    ├── index-join abcd
+  +      │    │    ├── columns: a:1!null b:2 c:3 d:4
+  +      │    │    ├── key: (1)
+  +      │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  +      │    │    ├── ordering: -2
+  +      │    │    ├── limit hint: 454.55
+  +      │    │    └── scan abcd@b,rev
+  +      │    │         ├── columns: a:1!null b:2
+  +      │    │         ├── flags: force-index=b
+  +      │    │         ├── key: (1)
+  +      │    │         ├── fd: (1)-->(2)
+  +      │    │         ├── ordering: -2
+  +      │    │         └── limit hint: 454.55
+  +      │    └── filters
+  +      │         └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
   +      └── 5
 --------------------------------------------------------------------------------
 GenerateZigzagJoins (no changes)
@@ -442,7 +440,7 @@ GenerateConstrainedScans (no changes)
 --------------------------------------------------------------------------------
 ================================================================================
 Final best expression
-  Cost: 5141.10
+  Cost: 5134.91
 ================================================================================
   explain
    ├── columns: tree:5 field:6 description:7
@@ -453,29 +451,28 @@ Final best expression
         ├── key: (1)
         ├── fd: (1)-->(2-4), (2-4)~~>(1)
         ├── ordering: -2
-        ├── sort
+        ├── select
         │    ├── columns: a:1!null b:2 c:3 d:4
         │    ├── cardinality: [0 - 11]
         │    ├── key: (1)
         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
         │    ├── ordering: -2
         │    ├── limit hint: 5.00
-        │    └── select
-        │         ├── columns: a:1!null b:2 c:3 d:4
-        │         ├── cardinality: [0 - 11]
-        │         ├── key: (1)
-        │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
-        │         ├── index-join abcd
-        │         │    ├── columns: a:1!null b:2 c:3 d:4
-        │         │    ├── key: (1)
-        │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
-        │         │    └── scan abcd@b
-        │         │         ├── columns: a:1!null b:2
-        │         │         ├── flags: force-index=b
-        │         │         ├── key: (1)
-        │         │         └── fd: (1)-->(2)
-        │         └── filters
-        │              └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
+        │    ├── index-join abcd
+        │    │    ├── columns: a:1!null b:2 c:3 d:4
+        │    │    ├── key: (1)
+        │    │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        │    │    ├── ordering: -2
+        │    │    ├── limit hint: 454.55
+        │    │    └── scan abcd@b,rev
+        │    │         ├── columns: a:1!null b:2
+        │    │         ├── flags: force-index=b
+        │    │         ├── key: (1)
+        │    │         ├── fd: (1)-->(2)
+        │    │         ├── ordering: -2
+        │    │         └── limit hint: 454.55
+        │    └── filters
+        │         └── (a:1 >= 20) AND (a:1 <= 30) [outer=(1), constraints=(/1: [/20 - /30]; tight)]
         └── 5
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -64,7 +64,7 @@ memo (optimized, ~3KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3))
  │    ├── [ordering: -1] [limit hint: 10.00]
  │    │    ├── best: (scan a,rev,cols=(1,3))
- │    │    └── cost: 1169.68
+ │    │    └── cost: 22.28
  │    └── []
  │         ├── best: (scan a@s_idx,cols=(1,3))
  │         └── cost: 1060.02


### PR DESCRIPTION
This PR is a continuation of #43415. The first commit is copied directly
from that PR, and the second commit includes a minor fix as well as a 
number of test cases.

Fixes #34811; the example query in this issue now chooses a lookup join
as desired. The coster now takes limit hints into account when costing
scans and lookup joins, and propagates limit hints through lookup joins.

Release note (sql change): The optimizer now considers the likely number
of rows an operator will need to provide, and might choose query plans
based on this. In particular, the optimizer might prefer lookup joins
over alternatives in some situations where all rows of the join will
probably not be needed.