### PR TITLE
sql: fix usages of ActiveVersionOrEmpty in {create, alter}_table.go

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -346,8 +346,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 		case *tree.AlterTableAlterPrimaryKey:
 			// Make sure that all nodes in the cluster are able to perform primary key changes before proceeding.
-			version := params.p.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
-			if !version.IsActive(clusterversion.VersionPrimaryKeyChanges) {
+			if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionPrimaryKeyChanges) {
 				return pgerror.Newf(pgcode.FeatureNotSupported,
 					"all nodes are not the correct version for primary key changes")
 			}
@@ -358,7 +357,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			if t.Sharded != nil {
-				if !version.IsActive(clusterversion.VersionHashShardedIndexes) {
+				if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionHashShardedIndexes) {
 					return invalidClusterForShardedIndexError
 				}
 				if !params.p.EvalContext().SessionData.HashShardedIndexesEnabled {


### PR DESCRIPTION
Fixes #45519.

This PR removes an incorrect usage of ActiveVersionOrEmpty in
alter_table.go, and updates a comment in create_table.go detailing its
usage.

Release note: None