### PR TITLE
sql: support star-expanding label-less tuples + numeric tuple indexing

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1546,6 +1546,7 @@ d_expr ::=
 	| 'PLACEHOLDER'
 	| '(' a_expr ')' '.' '*'
 	| '(' a_expr ')' '.' unrestricted_name
+	| '(' a_expr ')' '.' '@' 'ICONST'
 	| '(' a_expr ')'
 	| func_expr
 	| select_with_parens

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -60,7 +60,7 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 25
+const Version execinfrapb.DistSQLVersion = 26
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1083,8 +1083,12 @@ unnest
 (1,2)
 (3,4)
 
-query error pq: type tuple{int, int} is not composite
+query II colnames
 SELECT (unnest(ARRAY[(1,2),(3,4)])).*
+----
+?column?  ?column?
+1         1
+3         3
 
 query T colnames
 SELECT * FROM unnest(ARRAY[(1,2),(3,4)])

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -825,8 +825,17 @@ SELECT ((unnest(ARRAY[1,2], ARRAY[1,2]))).unnest;
 query error pq: type tuple{int, int, int} is not composite
 SELECT ((1,2,3)).x FROM tb
 
-query error pq: type tuple{int, int, int} is not composite
+query I colnames
+SELECT ((1,2,3)).@2 FROM tb
+----
+?column?
+2
+
+query III colnames
 SELECT ((1,2,3)).* FROM tb
+----
+?column?  ?column?  ?column?
+1         2         3
 
 # Accessing all the columns
 

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -348,6 +348,7 @@ func (b *Builder) buildColumnAccess(
 	}
 	childTyp := colAccess.Input.DataType()
 	colIdx := int(colAccess.Idx)
+	// Find a label if there is one. It's OK if there isn't.
 	lbl := ""
 	if childTyp.TupleLabels() != nil {
 		lbl = childTyp.TupleLabels()[colIdx]

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -313,8 +313,7 @@ func (c *CustomFuncs) FoldColumnAccess(input opt.ScalarExpr, idx memo.TupleOrdin
 	if memo.CanExtractConstDatum(input) {
 		datum := memo.ExtractConstDatum(input)
 
-		colName := input.DataType().TupleLabels()[idx]
-		texpr := tree.NewTypedColumnAccessExpr(datum, colName, int(idx))
+		texpr := tree.NewTypedColumnAccessExpr(datum, "" /* by-index access */, int(idx))
 		result, err := texpr.Eval(c.f.evalCtx)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType())

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -584,9 +584,28 @@ project
       └── (((x:1, n:2) AS x, n)).x [as=x:3]
 
 build
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).@2
+----
+project
+ ├── columns: "?column?":3
+ ├── project-set
+ │    ├── columns: x:1 n:2
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── information_schema._pg_expandarray(ARRAY['c','b','a'])
+ └── projections
+      └── (((x:1, n:2) AS x, n)).n [as="?column?":3]
+
+build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
 ----
 error (42804): could not identify column "other" in tuple{string AS x, int AS n}
+
+build
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).@4
+----
+error (42601): tuple column 4 does not exist
 
 build
 SELECT temp.n from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -665,6 +665,7 @@ func TestParse(t *testing.T) {
 		{`SELECT (() AS a)`},
 		{`SELECT ((() AS a)).a`},
 		{`SELECT ((() AS a)).*`},
+		{`SELECT ((() AS a)).@1`},
 		{`SELECT (TABLE a)`},
 		{`SELECT 0x1`},
 		{`SELECT 'Deutsch' COLLATE de`},
@@ -1057,10 +1058,12 @@ func TestParse(t *testing.T) {
 		{`DELETE FROM [123 AS t]@idx`},
 
 		{`SELECT (1 + 2).*`},
+		{`SELECT (1 + 2).@1`},
 		{`SELECT (1 + 2).col`},
 		{`SELECT (abc.def).col`},
 		{`SELECT (i.keys).col`},
 		{`SELECT (i.keys).*`},
+		{`SELECT (i.keys).@1`},
 		{`SELECT (ARRAY['a', 'b', 'c']).name`},
 
 		{`SELECT 1 FOR UPDATE`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8372,6 +8372,12 @@ d_expr:
   {
     $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), ColName: $5 }
   }
+| '(' a_expr ')' '.' '@' ICONST
+  {
+    idx, err := $6.numVal().AsInt32()
+    if err != nil || idx <= 0 { return setErr(sqllex, err) }
+    $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), ByIndex: true, ColIndex: int(idx-1)}
+  }
 | '(' a_expr ')'
   {
     $$.val = &tree.ParenExpr{Expr: $2.expr()}

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -101,3 +101,5 @@
 - Version: 25 (MinAcceptedVersion: 24)
     - Add locking strength and wait policy fields to TableReader, JoinReader,
       IndexSkipTableReader, and InterleavedReaderJoiner spec.
+- Version: 26 (MinAcceptedVersion: 24)
+    - Add the numeric tuple field accessor and the ByIndex field to ColumnAccessExpr.

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -152,6 +152,7 @@ func TestTypeCheck(t *testing.T) {
 		{`((ROW (1) AS a)).a`, `1:::INT8`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},
 		{`((('1', 2) AS a, b)).b`, `2:::INT8`},
+		{`((('1', 2) AS a, b)).@2`, `2:::INT8`},
 		{`(pg_get_keywords()).word`, `(pg_get_keywords()).word`},
 		{
 			`(information_schema._pg_expandarray(ARRAY[1,3])).x`,


### PR DESCRIPTION
Requested by @RaduBerinde  / @ajwerner .

Previously, it was impossible to use `(t).*` to expand a single
tuple-typed column into multiple projections if the tuple was not
labeled to start with.

This limitation was caused by another limitation, that it was not
possible to refer to a single column in a tuple if the tuple was not
already labeled.

This patch addresses both limitations.

Release note (sql change): CockroachDB now supports expanding all
columns of a tuple using the `.*` notation, for example `SELECT (t).*
FROM (SELECT (1,'b',2.3) AS t)`. This is a CockroachDB-specific extension.

Release note (sql change): CockroachDB now supports accessing the Nth
column in a column with tuple type using the syntax `(...).@N`, for
example `SELECT (t).@2 FROM (SELECT (1,'b',2.3) AS t)`. This is a
CockroachDB-specific extension.