### PR TITLE
Makefile: speed up `buildshort` and introduce `cleanshort` target

### DIFF
--- a/docs/generated/sql/README
+++ b/docs/generated/sql/README
@@ -3,7 +3,7 @@ using `docgen`.
 
 These files are copied to the `docs` repository where they are included in pages
 that document SQL. This happens periodically to ensure they stay up-to-date, for
-instance during the the release process, but it is also strongly encouraged to
+instance during the release process, but it is also strongly encouraged to
 open a docs PR with the updated generated files following any PR that changes
 them, so that the relevant context is still fresh in everyone's mind in case any
 questions come up.

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -25,9 +25,9 @@ this directory. This will run `yarn install` to install our Node dependencies,
 run the tests, and compile the assets. Asset compilation happens in two steps.
 First, [Webpack](https://webpack.github.io) runs the TypeScript compiler and CSS
 preprocessor to assemble assets into the `dist` directory. Then, we package
-those assets into `embedded.go` using
+those assets into `bindata.go` using
 [go-bindata](https://github.com/kevinburke/go-bindata). When you later run `make
-build` in the parent directory, `embedded.go` is linked into the `cockroach`
+build` in the parent directory, `bindata.go` is linked into the `cockroach`
 binary so that it can serve the admin UI when you run `cockroach start`.
 
 ## Developing


### PR DESCRIPTION
Makefile: speed up `buildshort` and introduce `cleanshort` target

I took some time to investigate where all time was going every \`make
buildshort\` invocation, and here are a few changes to tighten it up a
bit. Here's what my workflow tends to look like:

```sh
$ make clean       # Used gratuitously, like `clear`. Probably shouldn't.
$ make buildshort  # To check if everything compiles.
$ make buildshort  # As I'm iterating on things, to keep checking things.
```

Almost all of my changes are exclusively go code, and as far as
generated code goes, it's only ever protobuf generated code. Others may
also use `make generate` to regenerate code (including execgen, optgen,
etc.), but I assume the workflow is roughly the same for all. I also
assume protobufs are changed far more often than `execgen` or `optgen`
code.

To speed things up for most folks, this PR aims to make the common
sequences of "iteratively compile crdb" and "clean up some stuff and
compile crdb" faster than it was before. It does so by doing the
following:

1. Not tagging `build.utcTime` on every `buildshort` invocation, which
   lets us make much better use of the go build cache.

```sh
$ make clean; time make buildshort       # Fresh builds before
  156.40 real       553.84 user       380.26 sys
$ make clean; time make buildshort       # Fresh builds after
  121.04 real       384.52 user       278.03 sys

$ make buildshort; time make buildshort  # No-op builds before
  27.44 real        21.91 user        32.50 sys
$ make buildshort; time make buildshort  # No-op builds after
  4.79 real         3.21 user        30.79 sys
```

2. Not rebuilding the settings HTML page or the docgen page for
   `buildshort`. Given we're not building the UI, I think this is fine
   (and shaves a few seconds)

3. Introducing a `cleanshort` target, which leaves the go build cache
and C++ artifacts intact. It should suffice for most folks editing
`.proto` files and regular go code. `{exec,opt}gen` and storage folks
may still need to fall back to `make {clean,generate}`, but nobody else.

```sh
$ make clean; time make buildshort        # Fresh build; nuking most things.
  121.04 real       384.52 user       278.03 sys

$ make cleanshort; time make buildshort   # Fresh-ish build; nuking only go protos.
  31.10 real        29.04 user        36.76 sys
```

---

We also add a loud warning if `ccache` is not present on the
maintainer's system, as it really should be.

```sh
$ make clean; time make build   # Without ccache
409.45 real      3251.96 user       598.34 sys

$ make clean; time make build   # With ccache
156.40 real       553.84 user       380.26 sys
```

Release note: None
