### PR TITLE
storage/concurrency: pool concurrency manager memory allocations

### DIFF
--- a/pkg/storage/concurrency/concurrency_control.go
+++ b/pkg/storage/concurrency/concurrency_control.go
@@ -449,7 +449,8 @@ type lockTable interface {
 	ScanAndEnqueue(Request, lockTableGuard) lockTableGuard
 
 	// Dequeue removes the request from its lock wait-queues. It should be
-	// called when the request is finished, whether it evaluated or not.
+	// called when the request is finished, whether it evaluated or not. The
+	// guard should not be used after being dequeued.
 	//
 	// This method does not release any locks. This method must be called on the
 	// last guard returned from ScanAndEnqueue for the request, even if one of

--- a/pkg/storage/concurrency/lock_table.go
+++ b/pkg/storage/concurrency/lock_table.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -288,6 +289,43 @@ type lockTableGuardImpl struct {
 
 var _ lockTableGuard = &lockTableGuardImpl{}
 
+// Used to avoid allocations.
+var lockTableGuardImplPool = sync.Pool{
+	New: func() interface{} {
+		g := new(lockTableGuardImpl)
+		g.mu.signal = make(chan struct{}, 1)
+		g.mu.locks = make(map[*lockState]struct{})
+		return g
+	},
+}
+
+// newLockTableGuardImpl returns a new lockTableGuardImpl. The struct will
+// contain pre-allocated mu.signal and mu.locks fields, so it shouldn't be
+// overwritten blindly.
+func newLockTableGuardImpl() *lockTableGuardImpl {
+	return lockTableGuardImplPool.Get().(*lockTableGuardImpl)
+}
+
+// releaseLockTableGuardImpl releases the guard back into the object pool.
+func releaseLockTableGuardImpl(g *lockTableGuardImpl) {
+	// Preserve the signal channel and locks map fields in the pooled
+	// object. Drain the signal channel and assert that the map is empty.
+	// The map should have been cleared by lockState.requestDone.
+	signal, locks := g.mu.signal, g.mu.locks
+	select {
+	case <-signal:
+	default:
+	}
+	if len(locks) != 0 {
+		panic("lockTableGuardImpl.mu.locks not empty after Dequeue")
+	}
+
+	*g = lockTableGuardImpl{}
+	g.mu.signal = signal
+	g.mu.locks = locks
+	lockTableGuardImplPool.Put(g)
+}
+
 func (g *lockTableGuardImpl) ShouldWait() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -425,6 +463,12 @@ type lockHolderInfo struct {
 }
 
 // Per lock state in lockTableImpl.
+//
+// NOTE: we can't easily pool lockState objects without some form of reference
+// counting because they are used as elements in a copy-on-write btree and may
+// still be referenced by clones of the tree even when deleted from the primary.
+// However, other objects referenced by lockState can be pooled as long as they
+// are removed from all lockStates that reference them first.
 type lockState struct {
 	id     uint64 // needed for implementing util/interval/generic type contract
 	endKey []byte // used in btree iteration and tests
@@ -1479,27 +1523,28 @@ func (l *lockState) lockIsFree() (gc bool) {
 	return false
 }
 
+func (t *treeMu) nextLockSeqNum() uint64 {
+	t.lockIDSeqNum++
+	return t.lockIDSeqNum
+}
+
 // ScanAndEnqueue implements the lockTable interface.
 func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTableGuard {
 	var g *lockTableGuardImpl
 	if guard == nil {
-		seqNum := atomic.AddUint64(&t.seqNum, 1)
-		g = &lockTableGuardImpl{
-			seqNum:  seqNum,
-			spans:   req.LockSpans,
-			readTS:  req.Timestamp,
-			writeTS: req.Timestamp,
-			sa:      spanset.NumSpanAccess - 1,
-			index:   -1,
-		}
+		g = newLockTableGuardImpl()
+		g.seqNum = atomic.AddUint64(&t.seqNum, 1)
+		g.spans = req.LockSpans
+		g.readTS = req.Timestamp
+		g.writeTS = req.Timestamp
+		g.sa = spanset.NumSpanAccess - 1
+		g.index = -1
 		if req.Txn != nil {
 			g.txn = &req.Txn.TxnMeta
 			g.readTS = req.Txn.ReadTimestamp
 			g.readTS.Forward(req.Txn.MaxTimestamp)
 			g.writeTS = req.Txn.WriteTimestamp
 		}
-		g.mu.signal = make(chan struct{}, 1)
-		g.mu.locks = make(map[*lockState]struct{})
 	} else {
 		g = guard.(*lockTableGuardImpl)
 		g.key = nil
@@ -1533,6 +1578,8 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTa
 // Dequeue implements the lockTable interface.
 func (t *lockTableImpl) Dequeue(guard lockTableGuard) {
 	g := guard.(*lockTableGuardImpl)
+	defer releaseLockTableGuardImpl(g)
+
 	var candidateLocks []*lockState
 	g.mu.Lock()
 	for l := range g.mu.locks {
@@ -1574,8 +1621,7 @@ func (t *lockTableImpl) AddDiscoveredLock(intent *roachpb.Intent, guard lockTabl
 	iter := tree.MakeIter()
 	iter.FirstOverlap(&lockState{key: key})
 	if !iter.Valid() {
-		l = &lockState{id: tree.lockIDSeqNum, key: key, ss: ss}
-		tree.lockIDSeqNum++
+		l = &lockState{id: tree.nextLockSeqNum(), key: key, ss: ss}
 		l.queuedWriters.Init()
 		l.waitingReaders.Init()
 		tree.Set(l)
@@ -1612,7 +1658,7 @@ func (t *lockTableImpl) AcquireLock(
 			// Don't remember uncontended replicated locks.
 			return nil
 		}
-		l = &lockState{id: tree.lockIDSeqNum, key: key, ss: ss}
+		l = &lockState{id: tree.nextLockSeqNum(), key: key, ss: ss}
 		tree.lockIDSeqNum++
 		l.queuedWriters.Init()
 		l.waitingReaders.Init()

--- a/pkg/storage/concurrency/lock_table_test.go
+++ b/pkg/storage/concurrency/lock_table_test.go
@@ -1044,6 +1044,7 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 			return
 		}
 	}
+	env.lt.Dequeue(g)
 	env.lm.Release(lg)
 	if len(item.locksToAcquire) == 0 {
 		doneCh <- nil


### PR DESCRIPTION
#### storage/concurrency: pool lockTableGuardImpl allocations
    
```
name                                           old time/op    new time/op    delta
LockTable/groups=1,outstanding=1,read=0/-16      14.6µs ± 3%    14.2µs ± 2%   -2.62%  (p=0.095 n=5+5)
LockTable/groups=1,outstanding=1,read=1/-16      12.7µs ± 3%    12.3µs ± 3%   -3.12%  (p=0.095 n=5+5)
LockTable/groups=1,outstanding=1,read=2/-16      10.8µs ± 2%    10.4µs ± 3%   -3.94%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=3/-16      9.24µs ± 3%    8.79µs ± 1%   -4.81%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=4/-16      5.68µs ± 2%    5.18µs ± 1%   -8.85%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=5/-16      5.70µs ± 1%    5.26µs ± 1%   -7.72%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=0/-16      22.9µs ± 5%    22.2µs ± 3%   -3.12%  (p=0.056 n=5+5)
LockTable/groups=1,outstanding=2,read=1/-16      20.6µs ± 8%    19.8µs ± 3%     ~     (p=0.310 n=5+5)
LockTable/groups=1,outstanding=2,read=2/-16      17.5µs ± 3%    16.8µs ± 5%   -3.91%  (p=0.056 n=5+5)
LockTable/groups=1,outstanding=2,read=3/-16      14.1µs ± 7%    13.3µs ± 4%   -5.84%  (p=0.032 n=5+5)
LockTable/groups=1,outstanding=2,read=4/-16      3.42µs ± 3%    3.19µs ± 4%   -6.69%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=5/-16      3.50µs ± 3%    3.24µs ± 1%   -7.63%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=0/-16      24.0µs ± 7%    22.2µs ± 5%   -7.56%  (p=0.016 n=5+5)
LockTable/groups=1,outstanding=4,read=1/-16      20.7µs ± 4%    20.5µs ± 5%     ~     (p=0.421 n=5+5)
LockTable/groups=1,outstanding=4,read=2/-16      19.0µs ± 5%    18.2µs ± 4%   -3.83%  (p=0.095 n=5+5)
LockTable/groups=1,outstanding=4,read=3/-16      14.7µs ± 5%    14.4µs ± 5%     ~     (p=0.421 n=5+5)
LockTable/groups=1,outstanding=4,read=4/-16      1.95µs ± 8%    1.78µs ± 6%   -9.00%  (p=0.016 n=5+5)
LockTable/groups=1,outstanding=4,read=5/-16      1.93µs ± 6%    1.70µs ± 7%  -12.01%  (p=0.016 n=5+5)
LockTable/groups=1,outstanding=8,read=0/-16      26.0µs ± 4%    25.5µs ± 4%     ~     (p=0.222 n=5+5)
LockTable/groups=1,outstanding=8,read=1/-16      23.8µs ± 4%    23.6µs ± 5%     ~     (p=0.841 n=5+5)
LockTable/groups=1,outstanding=8,read=2/-16      21.2µs ± 3%    21.2µs ± 3%     ~     (p=1.000 n=5+5)
LockTable/groups=1,outstanding=8,read=3/-16      17.5µs ± 5%    17.1µs ± 4%   -2.24%  (p=0.095 n=5+5)
LockTable/groups=1,outstanding=8,read=4/-16      1.55µs ± 2%    1.37µs ± 2%  -11.26%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=5/-16      1.52µs ± 4%    1.37µs ± 2%   -9.90%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=0/-16     34.2µs ± 7%    34.3µs ± 4%     ~     (p=1.000 n=5+5)
LockTable/groups=1,outstanding=16,read=1/-16     31.5µs ± 4%    31.0µs ± 5%     ~     (p=0.421 n=5+5)
LockTable/groups=1,outstanding=16,read=2/-16     28.8µs ± 4%    29.0µs ± 3%     ~     (p=0.690 n=5+5)
LockTable/groups=1,outstanding=16,read=3/-16     23.4µs ± 5%    23.3µs ± 4%     ~     (p=1.000 n=5+5)
LockTable/groups=1,outstanding=16,read=4/-16     1.42µs ± 4%    1.25µs ± 5%  -11.62%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=5/-16     1.36µs ± 4%    1.24µs ± 5%   -9.46%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=0/-16     24.9µs ± 4%    24.9µs ± 4%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=1,read=1/-16     20.4µs ± 1%    20.0µs ± 4%   -2.00%  (p=0.032 n=5+5)
LockTable/groups=16,outstanding=1,read=2/-16     12.6µs ± 6%    12.7µs ± 6%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=1,read=3/-16     9.75µs ± 5%    9.70µs ± 3%     ~     (p=0.690 n=5+5)
LockTable/groups=16,outstanding=1,read=4/-16     1.29µs ± 5%    1.14µs ± 2%  -11.76%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=5/-16     1.28µs ± 4%    1.14µs ± 5%  -11.29%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=0/-16     29.5µs ± 3%    29.7µs ± 4%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=2,read=1/-16     23.2µs ± 7%    24.2µs ± 7%     ~     (p=0.421 n=5+5)
LockTable/groups=16,outstanding=2,read=2/-16     15.3µs ± 7%    15.5µs ±11%     ~     (p=0.548 n=5+5)
LockTable/groups=16,outstanding=2,read=3/-16     12.2µs ± 4%    11.8µs ± 2%   -3.39%  (p=0.056 n=5+5)
LockTable/groups=16,outstanding=2,read=4/-16     1.31µs ± 3%    1.15µs ± 4%  -12.65%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=5/-16     1.29µs ± 2%    1.12µs ± 3%  -12.75%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=0/-16     32.3µs ± 3%    31.4µs ± 7%     ~     (p=0.421 n=5+5)
LockTable/groups=16,outstanding=4,read=1/-16     25.5µs ±10%    27.5µs ± 4%     ~     (p=0.151 n=5+5)
LockTable/groups=16,outstanding=4,read=2/-16     20.2µs ± 4%    19.6µs ± 5%     ~     (p=0.222 n=5+5)
LockTable/groups=16,outstanding=4,read=3/-16     16.2µs ± 4%    16.2µs ± 3%     ~     (p=0.548 n=5+5)
LockTable/groups=16,outstanding=4,read=4/-16     1.31µs ± 2%    1.14µs ± 3%  -12.92%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=5/-16     1.28µs ± 2%    1.15µs ± 1%  -10.56%  (p=0.016 n=5+4)
LockTable/groups=16,outstanding=8,read=0/-16     33.7µs ± 4%    33.8µs ± 5%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=8,read=1/-16     28.1µs ± 5%    27.8µs ± 5%     ~     (p=0.841 n=5+5)
LockTable/groups=16,outstanding=8,read=2/-16     21.8µs ± 5%    21.7µs ± 7%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=8,read=3/-16     19.4µs ± 2%    19.4µs ± 5%     ~     (p=0.841 n=5+5)
LockTable/groups=16,outstanding=8,read=4/-16     1.30µs ± 1%    1.18µs ± 3%   -9.14%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=5/-16     1.32µs ± 2%    1.16µs ± 2%  -12.07%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=0/-16    32.6µs ± 7%    32.5µs ± 6%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=16,read=1/-16    26.3µs ± 5%    26.7µs ± 5%     ~     (p=0.690 n=5+5)
LockTable/groups=16,outstanding=16,read=2/-16    25.5µs ± 4%    25.4µs ± 5%     ~     (p=1.000 n=5+5)
LockTable/groups=16,outstanding=16,read=3/-16    23.3µs ± 6%    24.1µs ± 5%     ~     (p=0.310 n=5+5)
LockTable/groups=16,outstanding=16,read=4/-16    1.37µs ± 3%    1.24µs ± 4%   -9.64%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=5/-16    1.36µs ± 4%    1.24µs ± 2%   -8.87%  (p=0.008 n=5+5)

name                                           old alloc/op   new alloc/op   delta
LockTable/groups=1,outstanding=1,read=0/-16      4.16kB ± 0%    3.73kB ± 0%  -10.31%  (p=0.000 n=5+4)
LockTable/groups=1,outstanding=1,read=1/-16      3.68kB ± 0%    3.25kB ± 0%  -11.69%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=2/-16      3.20kB ± 0%    2.77kB ± 0%  -13.48%  (p=0.000 n=5+4)
LockTable/groups=1,outstanding=1,read=3/-16      2.71kB ± 0%    2.28kB ± 0%  -15.87%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=4/-16      1.33kB ± 0%    0.90kB ± 0%  -32.44%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=5/-16      1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=0/-16      5.21kB ± 0%    4.70kB ± 0%   -9.71%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=1/-16      4.72kB ± 0%    4.21kB ± 0%  -10.75%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=2/-16      4.23kB ± 0%    3.72kB ± 0%  -12.06%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=3/-16      3.45kB ± 0%    2.94kB ± 0%  -14.73%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=4/-16      1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.000 n=5+4)
LockTable/groups=1,outstanding=2,read=5/-16      1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.079 n=4+5)
LockTable/groups=1,outstanding=4,read=0/-16      5.27kB ± 0%    4.77kB ± 0%   -9.57%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=1/-16      4.80kB ± 0%    4.29kB ± 0%  -10.60%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=2/-16      4.31kB ± 0%    3.81kB ± 0%  -11.72%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=3/-16      3.51kB ± 0%    3.01kB ± 0%  -14.44%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=4/-16      1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.079 n=4+5)
LockTable/groups=1,outstanding=4,read=5/-16      1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=0/-16      5.35kB ± 0%    4.85kB ± 0%   -9.38%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=1/-16      4.88kB ± 0%    4.37kB ± 0%  -10.35%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=2/-16      4.39kB ± 0%    3.88kB ± 0%  -11.50%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=3/-16      3.58kB ± 0%    3.07kB ± 0%  -14.14%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=4/-16      1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=5/-16      1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=0/-16     5.54kB ± 1%    5.03kB ± 0%   -9.24%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=1/-16     5.14kB ± 0%    4.63kB ± 1%   -9.80%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=2/-16     4.73kB ± 0%    4.23kB ± 1%  -10.60%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=3/-16     4.03kB ± 1%    3.51kB ± 0%  -13.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=4/-16     1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=5/-16     1.33kB ± 0%    0.90kB ± 0%  -32.46%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=0/-16     4.90kB ± 0%    4.46kB ± 0%   -8.92%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=1/-16     4.06kB ± 0%    3.63kB ± 0%  -10.56%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=2/-16     3.48kB ± 0%    3.05kB ± 0%  -12.32%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=3/-16     2.99kB ± 0%    2.56kB ± 0%  -14.35%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=4/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=5/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=0/-16     5.68kB ± 0%    5.18kB ± 0%   -8.87%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=1/-16     5.12kB ± 0%    4.62kB ± 0%   -9.82%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=2/-16     3.78kB ± 0%    3.32kB ± 0%  -12.17%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=3/-16     3.18kB ± 0%    2.72kB ± 0%  -14.27%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=4/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=5/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=0/-16     6.12kB ± 0%    5.62kB ± 0%   -8.24%  (p=0.016 n=5+4)
LockTable/groups=16,outstanding=4,read=1/-16     5.36kB ± 0%    4.86kB ± 0%   -9.45%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=2/-16     4.14kB ± 0%    3.64kB ± 0%  -12.02%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=3/-16     3.43kB ± 0%    2.94kB ± 0%  -14.33%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=4/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=5/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=0/-16     6.11kB ± 1%    5.61kB ± 1%   -8.28%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=1/-16     5.39kB ± 0%    4.88kB ± 0%   -9.47%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=2/-16     4.17kB ± 0%    3.67kB ± 0%  -12.02%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=3/-16     3.50kB ± 0%    3.00kB ± 0%  -14.34%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=4/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=5/-16     1.33kB ± 0%    0.90kB ± 0%  -32.41%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=0/-16    5.71kB ± 0%    5.20kB ± 1%   -8.93%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=1/-16    5.27kB ± 0%    4.75kB ± 0%   -9.78%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=2/-16    4.24kB ± 0%    3.73kB ± 0%  -12.02%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=3/-16    3.63kB ± 0%    3.13kB ± 0%  -13.80%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=4/-16    1.33kB ± 0%    0.90kB ± 0%  -32.48%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=5/-16    1.33kB ± 0%    0.90kB ± 0%  -32.48%  (p=0.008 n=5+5)

name                                           old allocs/op  new allocs/op  delta
LockTable/groups=1,outstanding=1,read=0/-16        21.0 ± 0%      18.0 ± 0%  -14.29%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=1/-16        17.0 ± 0%      14.0 ± 0%  -17.65%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=2/-16        13.0 ± 0%      10.0 ± 0%  -23.08%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=3/-16        9.00 ± 0%      6.00 ± 0%  -33.33%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=4/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=1,read=5/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=0/-16        24.0 ± 0%      20.0 ± 0%  -16.67%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=1/-16        20.0 ± 0%      16.0 ± 0%  -20.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=2/-16        16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=3/-16        11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=4/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=2,read=5/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=0/-16        24.0 ± 0%      21.0 ± 0%  -12.50%  (p=0.000 n=5+4)
LockTable/groups=1,outstanding=4,read=1/-16        21.0 ± 0%      17.0 ± 0%  -19.05%  (p=0.079 n=4+5)
LockTable/groups=1,outstanding=4,read=2/-16        16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=3/-16        11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=4/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=4,read=5/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=0/-16        25.0 ± 0%      21.0 ± 0%  -16.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=1/-16        21.0 ± 0%      17.0 ± 0%  -19.05%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=2/-16        17.0 ± 0%      13.0 ± 0%  -23.53%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=3/-16        12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=4/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=8,read=5/-16        4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=0/-16       25.0 ± 0%      21.0 ± 0%  -16.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=1/-16       22.0 ± 0%      18.0 ± 0%  -18.18%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=2/-16       18.0 ± 0%      14.0 ± 0%  -22.22%  (p=0.000 n=5+4)
LockTable/groups=1,outstanding=16,read=3/-16       14.0 ± 0%      10.0 ± 0%  -28.57%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=4/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=1,outstanding=16,read=5/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=0/-16       23.0 ± 0%      20.0 ± 0%  -13.04%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=1/-16       18.0 ± 0%      15.0 ± 0%  -16.67%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=2/-16       14.0 ± 0%      11.0 ± 0%  -21.43%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=3/-16       10.0 ± 0%       7.0 ± 0%  -30.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=4/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=1,read=5/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=0/-16       27.0 ± 0%      23.0 ± 0%  -14.81%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=1/-16       22.0 ± 0%      18.0 ± 0%  -18.18%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=2/-16       15.0 ± 0%      11.0 ± 0%  -26.67%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=3/-16       10.0 ± 0%       7.0 ± 0%  -30.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=4/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=2,read=5/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=0/-16       28.0 ± 0%      24.0 ± 0%  -14.29%  (p=0.000 n=5+4)
LockTable/groups=16,outstanding=4,read=1/-16       23.0 ± 0%      19.0 ± 0%  -17.39%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=2/-16       16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=3/-16       11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=4/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=4,read=5/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=0/-16       27.6 ± 2%      23.6 ± 3%  -14.49%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=1/-16       23.0 ± 0%      19.0 ± 0%  -17.39%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=2/-16       15.0 ± 0%      11.0 ± 0%  -26.67%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=3/-16       11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=4/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=8,read=5/-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=0/-16      24.0 ± 0%      19.6 ± 3%  -18.33%  (p=0.000 n=4+5)
LockTable/groups=16,outstanding=16,read=1/-16      21.0 ± 0%      17.0 ± 0%  -19.05%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=2/-16      15.0 ± 0%      11.0 ± 0%  -26.67%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=3/-16      11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=4/-16      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
LockTable/groups=16,outstanding=16,read=5/-16      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
```

#### storage/concurrency: pool concurrency Guard allocations
    
```
name                          old time/op    new time/op    delta
KV/Scan/Native/rows=1-16        57.1µs ± 1%    56.9µs ± 2%    ~     (p=0.548 n=5+5)
KV/Scan/Native/rows=10-16       61.4µs ± 1%    61.2µs ± 1%    ~     (p=0.690 n=5+5)
KV/Scan/Native/rows=100-16      89.8µs ± 2%    88.8µs ± 1%    ~     (p=0.151 n=5+5)
KV/Scan/Native/rows=1000-16      364µs ± 1%     359µs ± 2%    ~     (p=0.095 n=5+5)
KV/Scan/Native/rows=10000-16    2.98ms ± 1%    2.97ms ± 2%    ~     (p=1.000 n=5+5)

name                          old alloc/op   new alloc/op   delta
KV/Scan/Native/rows=1-16        8.02kB ± 0%    7.90kB ± 0%  -1.50%  (p=0.008 n=5+5)
KV/Scan/Native/rows=10-16       9.18kB ± 0%    9.09kB ± 1%  -1.00%  (p=0.008 n=5+5)
KV/Scan/Native/rows=100-16      21.1kB ± 0%    21.0kB ± 0%  -0.47%  (p=0.016 n=5+5)
KV/Scan/Native/rows=1000-16      148kB ± 0%     148kB ± 0%    ~     (p=0.151 n=5+5)
KV/Scan/Native/rows=10000-16    1.34MB ± 0%    1.34MB ± 0%    ~     (p=1.000 n=5+5)

name                          old allocs/op  new allocs/op  delta
KV/Scan/Native/rows=1-16          70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
KV/Scan/Native/rows=10-16         70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
KV/Scan/Native/rows=100-16        70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
KV/Scan/Native/rows=1000-16       72.0 ± 0%      71.0 ± 0%  -1.39%  (p=0.008 n=5+5)
KV/Scan/Native/rows=10000-16      90.0 ± 0%      88.8 ± 1%  -1.33%  (p=0.016 n=4+5)
```
