### PR TITLE
ui: event details tooltip position

### DIFF
--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -65,7 +65,7 @@ export class EventRow extends React.Component<EventRowProps, {}> {
     const e = getEventInfo(event);
     return <tr>
       <td>
-        <ToolTipWrapper text={ e.content }>
+        <ToolTipWrapper placement="left" text={ e.content }>
           <div className="events__message">{e.content}</div>
         </ToolTipWrapper>
       </td>

--- a/pkg/ui/src/views/shared/components/toolTip/index.tsx
+++ b/pkg/ui/src/views/shared/components/toolTip/index.tsx
@@ -10,8 +10,12 @@
 
 import { Tooltip } from "antd";
 import React from "react";
+import { AbstractTooltipProps } from "antd/es/tooltip";
+import classNames from "classnames";
 
-interface ToolTipWrapperProps {
+import "./tooltip.styl";
+
+interface ToolTipWrapperProps extends AbstractTooltipProps {
   text: React.ReactNode;
   short?: boolean;
   children?: React.ReactNode;
@@ -26,13 +30,17 @@ interface ToolTipWrapperProps {
  * contents.
  */
 
-export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, {}> {
-  render() {
-    const { text, children } = this.props;
-    return (
-      <Tooltip title={ text } placement="bottom" overlayClassName="tooltip__preset--white">
-        {children}
-      </Tooltip>
-    );
-  }
-}
+// tslint:disable-next-line: variable-name
+export const ToolTipWrapper = (props: ToolTipWrapperProps) => {
+  const { text, children, placement } = props;
+  const overlayClassName = classNames("tooltip__preset--white", `tooltip__preset--placement-${placement}`);
+  return (
+    <Tooltip title={ text } placement="bottom" overlayClassName={overlayClassName} {...props}>
+      {children}
+    </Tooltip>
+  );
+};
+
+ToolTipWrapper.defaultProps = {
+  placement: "bottom",
+};

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~src/components/core/index.styl'
+
+.ant-tooltip.tooltip__preset--white
+  max-width 500px
+  .ant-tooltip-content
+    position relative
+    &:after, &:before
+      content ''
+      display block;
+      position absolute;
+      width 0
+      height 0
+      border-style solid
+    &:after
+      border-width 10px
+    &:before
+      border-width 10px
+  .ant-tooltip-arrow
+    &:before
+      background-color transparent
+  .ant-tooltip-inner
+    padding 10px
+    border-radius 3px
+    border solid 1px $colors--neutral-2
+    box-shadow 0 4px 4px 0 rgba(0, 0, 0, 0.15)
+    background rgba($colors--neutral-0, .98)
+    font-family Lato-Regular
+    text-align left
+    color #5F6C87
+
+.tooltip__preset--placement-bottom
+  .ant-tooltip-content
+    &:after, &:before
+      transform translate(-50%, 0)
+      left 50%
+    &:after
+      top -19px
+      border-color transparent transparent $colors--neutral-0 transparent
+    &:before
+      top -21px
+      border-color transparent transparent $colors--neutral-2 transparent
+
+.tooltip__preset--placement-left
+  .ant-tooltip-content
+    &:after, &:before
+      top 50%
+      transform translate(0, -50%)
+    &:after
+      right -16px
+      border-color transparent transparent transparent $colors--neutral-0
+    &:before
+      right -18px
+      border-color transparent transparent transparent $colors--neutral-2

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -371,39 +371,6 @@
         .ant-pagination-item-link
           color #b8bbbc
 
-.tooltip__preset--white
-  max-width 500px
-  .ant-tooltip-content
-    position relative
-    &:after, &:before
-      content ''
-      display block;
-      position absolute;
-      width 0
-      height 0
-      transform translate(-50%, 0)
-      left 50%
-      border-style solid
-    &:after
-      top -19px
-      border-color transparent transparent #fff transparent
-      border-width 10px
-    &:before
-      top -21px
-      border-color transparent transparent $popover-border-color transparent
-      border-width 10px
-  .ant-tooltip-arrow
-    &:before
-      background-color transparent
-  .ant-tooltip-inner
-    padding 10px
-    border-radius 3px
-    border solid 1px $popover-border-color
-    box-shadow 0 4px 4px 0 rgba(0, 0, 0, 0.15)
-    background rgba(255, 255, 255, .98)
-    font-family Lato-Regular
-    text-align left
-    color $body-color
 .drawer--preset-black
   display flex
   align-items center


### PR DESCRIPTION
Updated popup position from bottom to left, thereby fixed hide the text of the next event and prevent hovering over the next event.

Resolves: #44899

Release note (ui): none