### PR TITLE
ui: Filter out internal statements for default All filter

### DIFF
--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -311,6 +311,7 @@ export const selectStatements = createSelector(
     }
     let statements = flattenStatementStats(state.data.statements);
     const app = getMatchParamByName(props.match, appAttr);
+    const isInternal = (statement: ExecutionStatistics) => statement.app.startsWith(state.data.internal_app_name_prefix);
 
     if (app) {
       let criteria = app;
@@ -322,8 +323,10 @@ export const selectStatements = createSelector(
       }
 
       statements = statements.filter(
-        (statement: ExecutionStatistics) => (showInternal && statement.app.startsWith(state.data.internal_app_name_prefix)) || statement.app === criteria,
+        (statement: ExecutionStatistics) => (showInternal && isInternal(statement)) || statement.app === criteria,
       );
+    } else {
+      statements = statements.filter((statement: ExecutionStatistics) => !isInternal(statement));
     }
 
     const statsByStatementAndImplicitTxn: { [statement: string]: StatementsSummaryData } = {};


### PR DESCRIPTION
Resolves: #45107

Release justification: bug fixes and low-risk updates to new functionality

Before, Statements list displayed both internal and APP statements
by default.
Now, internal statements are filtered out by default.