### PR TITLE
ui: Add "roundtrip" clarification for tooltip values on Network latency metrics

### DIFF
--- a/pkg/ui/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/latency/index.tsx
@@ -232,7 +232,7 @@ const getLatencyCell = ({ latency, identityB, identityA }: { latency: number; id
                 <p className="Chip--tooltip__nodes--item-description">{identityA.locality}</p>
               </div>
             </div>
-            <p className={`color--${type}`}>{`${latency.toFixed(2)}ms`}</p>
+            <p className={`color--${type}`}>{`${latency.toFixed(2)}ms roundtrip`}</p>
           </div>
         )}>
           <div>


### PR DESCRIPTION
Resolves: #45221

Change tooltip text to clarify what values mean. 

Release justification: bug fixes and low-risk updates to new functionality