### PR TITLE
opt:tuple IN (subquery) cannot be converted to lookup semi-join (#43198)

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -445,7 +445,7 @@ $left
 #
 # TODO(andyk): Add other join types.
 [HoistJoinProjectRight, Normalize]
-(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
     $left:*
     $right:(Project $input:* $projections:[])
     $on:*
@@ -466,7 +466,7 @@ $left
 # HoistJoinProjectLeft is the same as HoistJoinProjectRight, but for the left
 # input of the join.
 [HoistJoinProjectLeft, Normalize]
-(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
     $left:(Project $input:* $projections:[])
     $right:*
     $on:*
@@ -532,6 +532,28 @@ $left
     $private
 )
 
+#ConvertProjectionsToFiltersLeft
+[ConvertProjectionsToFiltersLeft, Normalize]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
+    $left:(Project)
+    $right:*
+    $on: * & (CanExtractTupleEqualityLeft $left $right $on)
+    $private:*
+)
+=>
+(ExtractTupleEqualityLeft (OpName) $left $right $on $private)
+
+#ConvertProjectionsToFiltersRight
+[ConvertProjectionsToFiltersRight, Normalize]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
+    $left: *
+    $right:(Project)
+    $on: * & (CanExtractTupleEqualityRight $left $right $on )
+    $private:*
+)
+=>
+(ExtractTupleEqualityRight (OpName) $left $right $on $private)
+
 # ExtractJoinEqualities finds equality conditions such that one side only
 # depends on left columns and the other only on right columns and pushes the
 # expressions down into Project operators. The result is a join that has an
@@ -582,3 +604,5 @@ $left
     (SortFilters $on)
     $private
 )
+
+

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2823,3 +2823,73 @@ full-join (cross)
  │    └── fd: (3)-->(4)
  └── filters
       └── (substring('', ')') = '') = (u:3 > 0) [outer=(3)]
+
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  PRIMARY KEY (a,b)
+)
+----
+
+
+exec-ddl
+CREATE TABLE cd (
+  c INT,
+  d INT
+)
+----
+
+exec-ddl
+ALTER TABLE cd INJECT STATISTICS '[
+    {
+        "columns": [ "c" ],
+        "created_at": "2019-12-13 16:17:43.033228+00:00",
+        "distinct_count": 4,
+        "row_count": 4
+    }
+]'
+----
+
+norm
+SELECT a,b FROM ab, cd WHERE a=c AND b=d
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null)
+ └── inner-join (lookup ab)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
+      ├── key columns: [3 4] = [1 2]
+      ├── lookup columns are key
+      ├── fd: (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+      ├── scan cd
+      │    └── columns: c:3(int) d:4(int)
+      └── filters (true)
+
+
+norm
+SELECT * FROM ab WHERE (a, b) IN (SELECT c, d FROM cd)
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ └── semi-join (hash)
+      ├── columns: a:1(int!null) b:2(int!null) column7:7(tuple{int, int}!null)
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(7)
+      ├── project
+      │    ├── columns: column7:7(tuple{int, int}!null) a:1(int!null) b:2(int!null)
+      │    ├── key: (1,2)
+      │    ├── fd: (1,2)-->(7)
+      │    ├── scan ab
+      │    │    ├── columns: a:1(int!null) b:2(int!null)
+      │    │    └── key: (1,2)
+      │    └── projections
+      │         └── (a, b) [type=tuple{int, int}, outer=(1,2)]
+      ├── project
+      │    ├── columns: column6:6(tuple{int, int})
+      │    ├── scan cd
+      │    │    └── columns: c:3(int) d:4(int)
+      │    └── projections
+      │         └── (c, d) [type=tuple{int, int}, outer=(3,4)]
+      └── filters
+           └── column7 = column6 [type=bool, outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]


### PR DESCRIPTION
WIP for https://github.com/cockroachdb/cockroach/issues/43198 

Detects joins filtering on tuple equality on projected variables, and tries to split the tuple out into multiple equalities and hoist the project up above the join