### PR TITLE
roachpb: redefine read/write request divide, introduce locking concept

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads.go
+++ b/pkg/ccl/followerreadsccl/followerreads.go
@@ -82,7 +82,11 @@ func batchCanBeEvaluatedOnFollower(ba roachpb.BatchRequest) bool {
 // txnCanPerformFollowerRead determines if the provided transaction can perform
 // follower reads.
 func txnCanPerformFollowerRead(txn *roachpb.Transaction) bool {
-	return txn != nil && !txn.IsWriting()
+	// If the request is transactional and that transaction has acquired any
+	// locks then that request should not perform follower reads. Doing so could
+	// allow the request to miss its own writes or observe state that conflicts
+	// with its locks.
+	return txn != nil && !txn.IsLocking()
 }
 
 // canUseFollowerRead determines if a query can be sent to a follower.

--- a/pkg/ccl/followerreadsccl/followerreads.go
+++ b/pkg/ccl/followerreadsccl/followerreads.go
@@ -76,7 +76,7 @@ func evalFollowerReadOffset(clusterID uuid.UUID, st *cluster.Settings) (time.Dur
 // batchCanBeEvaluatedOnFollower determines if a batch consists exclusively of
 // requests that can be evaluated on a follower replica.
 func batchCanBeEvaluatedOnFollower(ba roachpb.BatchRequest) bool {
-	return ba.IsReadOnly() && ba.IsAllTransactional()
+	return !ba.IsLocking() && ba.IsAllTransactional()
 }
 
 // txnCanPerformFollowerRead determines if the provided transaction can perform

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -57,7 +57,7 @@ func TestTxnSnowballTrace(t *testing.T) {
 	// dump:
 	//    0.105ms      0.000ms    event:inside txn
 	//    0.275ms      0.171ms    event:client.Txn did AutoCommit. err: <nil>
-	//txn: "internal/client/txn_test.go:67 TestTxnSnowballTrace" id=<nil> key=/Min rw=false pri=0.00000000 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=0.000000000,0 orig=0.000000000,0 max=0.000000000,0 wto=false rop=false
+	//txn: "internal/client/txn_test.go:67 TestTxnSnowballTrace" id=<nil> key=/Min lock=false pri=0.00000000 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=0.000000000,0 orig=0.000000000,0 max=0.000000000,0 wto=false rop=false
 	//    0.278ms      0.173ms    event:txn complete
 	found, err := regexp.MatchString(
 		// The (?s) makes "." match \n. This makes the test resilient to other log

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -2972,7 +2972,7 @@ func TestCanSendToFollower(t *testing.T) {
 	defer func() { CanSendToFollower = old }()
 	canSend := true
 	CanSendToFollower = func(_ uuid.UUID, _ *cluster.Settings, ba roachpb.BatchRequest) bool {
-		return ba.IsReadOnly() && canSend
+		return !ba.IsLocking() && canSend
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -27,7 +27,7 @@ func DefaultDeclareKeys(
 	latchSpans, _ *spanset.SpanSet,
 ) {
 	var access spanset.SpanAccess
-	if roachpb.IsReadOnly(req) {
+	if roachpb.IsReadOnly(req) && !roachpb.IsLocking(req) {
 		access = spanset.SpanReadOnly
 	} else {
 		access = spanset.SpanReadWrite
@@ -47,7 +47,7 @@ func DefaultDeclareIsolatedKeys(
 	latchSpans, lockSpans *spanset.SpanSet,
 ) {
 	var access spanset.SpanAccess
-	if roachpb.IsReadOnly(req) {
+	if roachpb.IsReadOnly(req) && !roachpb.IsLocking(req) {
 		access = spanset.SpanReadOnly
 	} else {
 		access = spanset.SpanReadWrite

--- a/pkg/kv/kvserver/replica_application_cmd.go
+++ b/pkg/kv/kvserver/replica_application_cmd.go
@@ -130,7 +130,7 @@ func (c *replicatedCmd) CanAckBeforeApplication() bool {
 	// We don't try to ack async consensus writes before application because we
 	// know that there isn't a client waiting for the result.
 	req := c.proposal.Request
-	return req.IsTransactionWrite() && !req.AsyncConsensus
+	return req.IsIntentWrite() && !req.AsyncConsensus
 }
 
 // AckSuccess implements the apply.CheckedCommand interface.

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -69,7 +69,7 @@ func maybeStripInFlightWrites(ba *roachpb.BatchRequest) (*roachpb.BatchRequest, 
 		for _, ru := range otherReqs {
 			req := ru.GetInner()
 			switch {
-			case roachpb.IsTransactionWrite(req) && !roachpb.IsRange(req):
+			case roachpb.IsIntentWrite(req) && !roachpb.IsRange(req):
 				// Concurrent point write.
 				writes++
 			case req.Method() == roachpb.QueryIntent:
@@ -100,7 +100,7 @@ func maybeStripInFlightWrites(ba *roachpb.BatchRequest) (*roachpb.BatchRequest, 
 		req := ru.GetInner()
 		seq := req.Header().Sequence
 		switch {
-		case roachpb.IsTransactionWrite(req) && !roachpb.IsRange(req):
+		case roachpb.IsIntentWrite(req) && !roachpb.IsRange(req):
 			// Concurrent point write.
 		case req.Method() == roachpb.QueryIntent:
 			// Earlier pipelined point write that hasn't been proven yet. We

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -168,15 +168,13 @@ func evaluateBatch(
 	if baHeader.Txn != nil {
 		baHeader.Txn = baHeader.Txn.Clone()
 
-		// Check whether this transaction has been aborted, if applicable.
-		// This applies to writes that leave intents (the use of the
-		// IsTransactionWrite flag excludes operations like HeartbeatTxn),
-		// and reads that occur in a transaction that has already written
-		// (see #2231 for more about why we check for aborted transactions
-		// on reads). Note that 1PC transactions have had their
-		// transaction field cleared by this point so we do not execute
-		// this check in that case.
-		if ba.IsTransactionWrite() || baHeader.Txn.IsWriting() {
+		// Check whether this transaction has been aborted, if applicable. This
+		// applies to reads and writes once a transaction that has begun to
+		// acquire locks (see #2231 for more about why we check for aborted
+		// transactions on reads). Note that 1PC transactions have had their
+		// transaction field cleared by this point so we do not execute this
+		// check in that case.
+		if baHeader.Txn.IsLocking() {
 			// We don't check the abort span for a couple of special requests:
 			// - if the request is asking to abort the transaction, then don't check the
 			// AbortSpan; we don't want the request to be rejected if the transaction

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -55,7 +55,7 @@ func (r *Replica) canServeFollowerRead(
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
 		ba.IsAllTransactional() && // followerreadsccl.batchCanBeEvaluatedOnFollower
-		(ba.Txn == nil || !ba.Txn.IsWriting()) && // followerreadsccl.txnCanPerformFollowerRead
+		(ba.Txn == nil || !ba.Txn.IsLocking()) && // followerreadsccl.txnCanPerformFollowerRead
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) {
 
 		ts := ba.Timestamp

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -54,7 +54,7 @@ func (r *Replica) canServeFollowerRead(
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
-		ba.IsAllTransactional() && // followerreadsccl.batchCanBeEvaluatedOnFollower
+		(!ba.IsLocking() && ba.IsAllTransactional()) && // followerreadsccl.batchCanBeEvaluatedOnFollower
 		(ba.Txn == nil || !ba.Txn.IsLocking()) && // followerreadsccl.txnCanPerformFollowerRead
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) {
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -501,15 +501,15 @@ func (r *Replica) collectSpans(
 	//
 	// TODO(bdarnell): revisit as the local portion gets its appropriate
 	// use.
-	if ba.IsReadOnly() {
-		latchSpans.Reserve(spanset.SpanReadOnly, spanset.SpanGlobal, len(ba.Requests))
-	} else {
+	if ba.IsLocking() {
 		guess := len(ba.Requests)
 		if et, ok := ba.GetArg(roachpb.EndTxn); ok {
 			// EndTxn declares a global write for each of its intent spans.
 			guess += len(et.(*roachpb.EndTxnRequest).IntentSpans) - 1
 		}
 		latchSpans.Reserve(spanset.SpanReadWrite, spanset.SpanGlobal, guess)
+	} else {
+		latchSpans.Reserve(spanset.SpanReadOnly, spanset.SpanGlobal, len(ba.Requests))
 	}
 
 	// For non-local, MVCC spans we annotate them with the request timestamp

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -473,7 +473,7 @@ func (q *Queue) MaybeWaitForPush(
 	var readyCh chan struct{}                     // signaled when pusher txn should be queried
 
 	// Query the pusher if it's a valid read-write transaction.
-	if req.PusherTxn.ID != uuid.Nil && req.PusherTxn.IsWriting() {
+	if req.PusherTxn.ID != uuid.Nil && req.PusherTxn.IsLocking() {
 		// Create a context which will be canceled once this call completes.
 		// This ensures that the goroutine created to query the pusher txn
 		// is properly cleaned up.

--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -303,7 +303,7 @@ func (tc *txnCommitter) canCommitInParallel(
 	for _, ru := range ba.Requests[:len(ba.Requests)-1] {
 		req := ru.GetInner()
 		switch {
-		case roachpb.IsTransactionWrite(req):
+		case roachpb.IsIntentWrite(req):
 			if roachpb.IsRange(req) {
 				// Similar to how we can't pipeline ranged writes, we also can't
 				// commit in parallel with them. The reason for this is that the

--- a/pkg/kv/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/txn_interceptor_seq_num_allocator.go
@@ -87,7 +87,7 @@ func (s *txnSeqNumAllocator) SendLocked(
 		// Only increment the sequence number generator for requests that
 		// will leave intents or requests that will commit the transaction.
 		// This enables ba.IsCompleteTransaction to work properly.
-		if roachpb.IsTransactionWrite(req) || req.Method() == roachpb.EndTxn {
+		if roachpb.IsIntentWrite(req) || req.Method() == roachpb.EndTxn {
 			s.writeSeq++
 		}
 

--- a/pkg/roachpb/batch_test.go
+++ b/pkg/roachpb/batch_test.go
@@ -11,9 +11,11 @@
 package roachpb
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/kr/pretty"
@@ -215,58 +217,63 @@ func TestBatchRequestSummary(t *testing.T) {
 	}
 }
 
-func TestIntentSpanIterate(t *testing.T) {
-	testCases := []struct {
+func TestLockSpanIterate(t *testing.T) {
+	type testReq struct {
 		req    Request
 		resp   Response
 		span   Span
 		resume Span
-	}{
+	}
+	testReqs := []testReq{
 		{&ScanRequest{}, &ScanResponse{}, sp("a", "c"), sp("b", "c")},
 		{&ReverseScanRequest{}, &ReverseScanResponse{}, sp("d", "f"), sp("d", "e")},
-		{&DeleteRangeRequest{}, &DeleteRangeResponse{}, sp("g", "i"), sp("h", "i")},
+		{&PutRequest{}, &PutResponse{}, sp("m", ""), sp("", "")},
+		{&DeleteRangeRequest{}, &DeleteRangeResponse{}, sp("n", "p"), sp("o", "p")},
+		// TODO(nvanbenschoten): uncomment in the next commit.
+		// {&ScanRequest{KeyLocking: lock.Exclusive}, &ScanResponse{}, sp("g", "i"), sp("h", "i")},
+		// {&ReverseScanRequest{KeyLocking: lock.Exclusive}, &ReverseScanResponse{}, sp("j", "l"), sp("k", "l")},
 	}
 
-	// A batch request with a batch response with no ResumeSpan.
-	ba := BatchRequest{}
-	br := BatchResponse{}
-	for _, tc := range testCases {
-		tc.req.SetHeader(RequestHeaderFromSpan(tc.span))
-		ba.Add(tc.req)
-		br.Add(tc.resp)
-	}
+	// NB: can't import testutils for RunTrueAndFalse.
+	for _, resume := range []bool{false, true} {
+		t.Run(fmt.Sprintf("resume=%t", resume), func(t *testing.T) {
+			// A batch request with a batch response with no ResumeSpan.
+			ba := BatchRequest{}
+			br := BatchResponse{}
+			for i := range testReqs {
+				tr := &testReqs[i]
+				tr.req.SetHeader(RequestHeaderFromSpan(tr.span))
+				ba.Add(tr.req)
+				if resume {
+					tr.resp.SetHeader(ResponseHeader{ResumeSpan: &tr.resume})
+				}
+				br.Add(tr.resp)
+			}
 
-	var spans []Span
-	fn := func(span Span) {
-		spans = append(spans, span)
-	}
-	ba.IntentSpanIterate(&br, fn)
-	// Only DeleteRangeResponse is a write request.
-	if e := 1; len(spans) != e {
-		t.Fatalf("unexpected number of spans: e = %d, found = %d", e, len(spans))
-	}
-	if e := testCases[2].span; !reflect.DeepEqual(e, spans[0]) {
-		t.Fatalf("unexpected spans: e = %+v, found = %+v", e, spans[0])
-	}
+			var spans [lock.MaxDurability + 1][]Span
+			fn := func(span Span, dur lock.Durability) {
+				spans[dur] = append(spans[dur], span)
+			}
+			ba.LockSpanIterate(&br, fn)
 
-	// A batch request with a batch response with a ResumeSpan.
-	ba = BatchRequest{}
-	br = BatchResponse{}
-	for _, tc := range testCases {
-		tc.req.SetHeader(RequestHeaderFromSpan(tc.span))
-		ba.Add(tc.req)
-		tc.resp.SetHeader(ResponseHeader{ResumeSpan: &tc.resume})
-		br.Add(tc.resp)
-	}
+			toExpSpans := func(trs ...testReq) []Span {
+				exp := make([]Span, len(trs))
+				for i, tr := range trs {
+					exp[i] = tr.span
+					if resume {
+						exp[i].EndKey = tr.resume.Key
+					}
+				}
+				return exp
+			}
 
-	spans = []Span{}
-	ba.IntentSpanIterate(&br, fn)
-	// Only DeleteRangeResponse is a write request.
-	if e := 1; len(spans) != e {
-		t.Fatalf("unexpected number of spans: e = %d, found = %d", e, len(spans))
-	}
-	if e := sp("g", "h"); !reflect.DeepEqual(e, spans[0]) {
-		t.Fatalf("unexpected spans: e = %+v, found = %+v", e, spans[0])
+			// The intent writes are replicated locking request.
+			require.Equal(t, toExpSpans(testReqs[2], testReqs[3]), spans[lock.Replicated])
+
+			// The scans with KeyLocking are unreplicated locking requests.
+			require.Nil(t, nil, spans[lock.Unreplicated])
+			// require.Equal(t, toExpSpans(testReqs[4], testReqs[5]), spans[lock.Unreplicated])
+		})
 	}
 }
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1077,9 +1077,9 @@ func (t *Transaction) UpgradePriority(minPriority enginepb.TxnPriority) {
 	}
 }
 
-// IsWriting returns whether the transaction has begun writing intents.
-// This method will never return true for a read-only transaction.
-func (t *Transaction) IsWriting() bool {
+// IsLocking returns whether the transaction has begun acquiring locks.
+// This method will never return false for a writing transaction.
+func (t *Transaction) IsLocking() bool {
 	return t.Key != nil
 }
 
@@ -1091,8 +1091,8 @@ func (t Transaction) String() string {
 	if len(t.Name) > 0 {
 		fmt.Fprintf(&buf, "%q ", t.Name)
 	}
-	fmt.Fprintf(&buf, "meta={%s} rw=%t stat=%s rts=%s wto=%t max=%s",
-		t.TxnMeta, t.IsWriting(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.MaxTimestamp)
+	fmt.Fprintf(&buf, "meta={%s} lock=%t stat=%s rts=%s wto=%t max=%s",
+		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.MaxTimestamp)
 	if ni := len(t.IntentSpans); t.Status != PENDING && ni > 0 {
 		fmt.Fprintf(&buf, " int=%d", ni)
 	}
@@ -1114,8 +1114,8 @@ func (t Transaction) SafeMessage() string {
 	if len(t.Name) > 0 {
 		fmt.Fprintf(&buf, "%q ", t.Name)
 	}
-	fmt.Fprintf(&buf, "meta={%s} rw=%t stat=%s rts=%s wto=%t max=%s",
-		t.TxnMeta.SafeMessage(), t.IsWriting(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.MaxTimestamp)
+	fmt.Fprintf(&buf, "meta={%s} lock=%t stat=%s rts=%s wto=%t max=%s",
+		t.TxnMeta.SafeMessage(), t.IsLocking(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.MaxTimestamp)
 	if ni := len(t.IntentSpans); t.Status != PENDING && ni > 0 {
 		fmt.Fprintf(&buf, " int=%d", ni)
 	}

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -44,7 +44,7 @@ func TestTransactionString(t *testing.T) {
 		MaxTimestamp:  hlc.Timestamp{WallTime: 40, Logical: 41},
 	}
 	expStr := `"name" meta={id=d7aa0f5e key="foo" pri=44.58039917 epo=2 ts=0.000000020,21 min=0.000000010,11 seq=15}` +
-		` rw=true stat=COMMITTED rts=0.000000030,31 wto=false max=0.000000040,41`
+		` lock=true stat=COMMITTED rts=0.000000030,31 wto=false max=0.000000040,41`
 
 	if str := txn.String(); str != expStr {
 		t.Errorf(

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2385,20 +2385,15 @@ func mvccScanToKvs(
 	kvData := res.KVData
 	res.KVData = nil
 
-	var k MVCCKey
-	var rawBytes []byte
 	var i int
-	for _, data := range kvData {
-		for len(data) > 0 {
-			k, rawBytes, data, err = MVCCScanDecodeKeyValue(data)
-			if err != nil {
-				return MVCCScanResult{}, err
-			}
-			res.KVs[i].Key = k.Key
-			res.KVs[i].Value.RawBytes = rawBytes
-			res.KVs[i].Value.Timestamp = k.Timestamp
-			i++
-		}
+	if err := MVCCScanDecodeKeyValues(kvData, func(key MVCCKey, rawBytes []byte) error {
+		res.KVs[i].Key = key.Key
+		res.KVs[i].Value.RawBytes = rawBytes
+		res.KVs[i].Value.Timestamp = key.Timestamp
+		i++
+		return nil
+	}); err != nil {
+		return MVCCScanResult{}, err
 	}
 	return res, err
 }

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -11,7 +11,7 @@ with t=A v=abc resolve
   put  k=c
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000044,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000044,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000044,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000044,0 wto=false max=0,0
 data: "a"/0.000000044,0 -> /BYTES/abc
 data: "a/123"/0.000000044,0 -> /BYTES/abc
 data: "b"/0.000000044,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn
@@ -2,7 +2,7 @@ run ok
 txn_begin t=A ts=123
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
 
 # Write value1.
 
@@ -12,7 +12,7 @@ with t=A
   cput k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=1} ts=0.000000123,0 del=false klen=12 vlen=6
 data: "k"/0.000000123,0 -> /BYTES/v
 
@@ -25,7 +25,7 @@ with t=A
   cput k=k v=v2 cond=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=2} ts=0.000000123,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
 data: "k"/0.000000123,0 -> /BYTES/v2
 
@@ -38,7 +38,7 @@ with t=A
   cput k=k v=v3
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000123,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000123,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000123,0 min=0,0 seq=1} ts=0.000000123,0 del=false klen=12 vlen=7
 data: "k"/0.000000123,0 -> /BYTES/v3
 
@@ -86,7 +86,7 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} ts=0.000000002,0 del=false klen=12 vlen=9
 data: "c"/0.000000002,0 -> /BYTES/cput
 data: "c"/0.000000001,0 -> /BYTES/value
@@ -100,9 +100,9 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> txn_restart ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
 >> cput k=c v=cput cond=value t=A
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=9
 data: "c"/0.000000003,0 -> /BYTES/cput

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -34,7 +34,7 @@ with t=a
   cput k=k v=v2 cond=v1
 ----
 >> at end:
-txn: "a" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 data: "k"/0.000000010,1 -> /BYTES/v2
 data: "k"/0.000000010,0 -> /BYTES/v1
 error: (*roachpb.ConditionFailedError:) unexpected value: <nil>

--- a/pkg/storage/testdata/mvcc_histories/empty_key
+++ b/pkg/storage/testdata/mvcc_histories/empty_key
@@ -28,6 +28,6 @@ txn_begin t=A
 resolve_intent t=A k=
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} rw=true stat=PENDING rts=0,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=true stat=PENDING rts=0,0 wto=false max=0,0
 <no data>
 error: (*errors.fundamental:) attempted access to empty key

--- a/pkg/storage/testdata/mvcc_histories/idempotent_transactions
+++ b/pkg/storage/testdata/mvcc_histories/idempotent_transactions
@@ -7,7 +7,7 @@ with t=a k=a
   put v=first
 ----
 >> at end:
-txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} ts=0.000000011,0 del=false klen=12 vlen=10
 data: "a"/0.000000011,0 -> /BYTES/first
 
@@ -36,7 +36,7 @@ with t=a k=a
 ----
 meta: "a" -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 >> at end:
-txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000011,0 -> /BYTES/second
 
@@ -47,7 +47,7 @@ with t=a k=a
   put v=second
 ----
 >> at end:
-txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=-1} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=-1} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000011,0 -> /BYTES/second
 error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000001 with sequence 1 missing an intent with lower sequence -1
@@ -67,7 +67,7 @@ inc: current value = 1
 inc: current value = 1
 inc: current value = 1
 >> at end:
-txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000011,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=2} ts=0.000000011,0 del=false klen=12 vlen=6
@@ -89,7 +89,7 @@ inc: current value = 1
 inc: current value = 1
 inc: current value = 1
 >> at end:
-txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000011,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=3} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{2 /INT/1}}

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -16,7 +16,7 @@ with t=A
   txn_step  seq=40
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 data: "k"/0.000000011,0 -> /BYTES/c
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
@@ -46,7 +46,7 @@ get: "k" -> /BYTES/b @0,0
 get: "k" -> /BYTES/b @0,0
 get: "k" -> /BYTES/b @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # Mask a write in the middle.
 
@@ -62,7 +62,7 @@ scan: "k/10" -> /BYTES/10 @0.000000011,0
 scan: "k/30" -> /BYTES/30 @0.000000011,0
 get: "k" -> /BYTES/c @0.000000011,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # Mask all the writes.
 
@@ -76,7 +76,7 @@ with t=A
 scan: "k"-"l" -> <no data>
 get: "k" -> <no data>
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # Disjoint masks.
 
@@ -91,7 +91,7 @@ scan: "k" -> /BYTES/b @0,0
 scan: "k/20" -> /BYTES/20 @0.000000011,0
 get: "k" -> /BYTES/b @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=2
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=2
 
 # A historical read before the ignored range should retrieve the
 # historical value visible at that point.
@@ -107,7 +107,7 @@ scan: "k" -> /BYTES/a @0,0
 scan: "k/10" -> /BYTES/10 @0.000000011,0
 get: "k" -> /BYTES/a @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=12} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=12} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # A historical read with an ignored range before it should hide
 # the historical value hidden at that point.
@@ -123,7 +123,7 @@ scan: "k" -> /BYTES/b @0,0
 scan: "k/20" -> /BYTES/20 @0.000000011,0
 get: "k" -> /BYTES/b @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=22} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=22} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # A historical read with an ignored range that overlaps should hide
 # the historical value hidden at that point.
@@ -140,7 +140,7 @@ scan: "k/10" -> /BYTES/10 @0.000000011,0
 scan: "k/20" -> /BYTES/20 @0.000000011,0
 get: "k" -> /BYTES/b @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=32} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=32} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # Do an intent push by advancing the transaction timestamp, while also having
 # a range of ignored seqnums. This should permanently delete the value at seqnum
@@ -164,7 +164,7 @@ get: "k" -> /BYTES/b @0,0
 meta: "k" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000014,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 get: "k" -> /BYTES/b @0.000000014,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=32} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=32} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000014,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
@@ -189,7 +189,7 @@ scan: "k/10" -> /BYTES/10 @0.000000011,0
 scan: "k/30" -> /BYTES/30 @0.000000011,0
 get: "k" -> /BYTES/a @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 run ok
 with t=A
@@ -211,7 +211,7 @@ scan: "k/10" -> /BYTES/10 @0.000000011,0
 scan: "k/20" -> /BYTES/20 @0.000000011,0
 get: "k" -> /BYTES/b @0.000000014,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=25} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000014,0 min=0,0 seq=25} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 
 # Call mvccResolveWriteIntent with status=COMMITTED. This should fold the
 # intent while leaving the value unmodified.
@@ -228,7 +228,7 @@ with t=B
 meta: "k" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000014,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 get: "k" -> /BYTES/b @0.000000014,0
 >> at end:
-txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000020,0 wto=false max=0,0
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000020,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -254,7 +254,7 @@ with t=B
 meta: "l" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=30} ts=0.000000020,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "l" -> /BYTES/c @0.000000020,0
 >> at end:
-txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000020,0 wto=false max=0,0
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000020,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -281,7 +281,7 @@ with t=B
 meta: "l" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=30} ts=0.000000020,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "l" -> <no data>
 >> at end:
-txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=35} rw=true stat=PENDING rts=0.000000020,0 wto=false max=0,0 isn=1
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000020,0 min=0,0 seq=35} lock=true stat=PENDING rts=0.000000020,0 wto=false max=0,0 isn=1
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -299,7 +299,7 @@ with t=C
 ----
 get: "l" -> <no data>
 >> at end:
-txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000030,0 wto=false max=0,0
+txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000030,0 wto=false max=0,0
 
 
 # Put some values, then ignore all except the first, then do a commit. The
@@ -319,7 +319,7 @@ with t=C
 meta: "m" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} ts=0.000000030,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "m" -> /BYTES/c @0.000000030,0
 >> at end:
-txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000030,0 wto=false max=0,0
+txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000030,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -341,7 +341,7 @@ with t=C
 meta: "m" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} ts=0.000000030,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "m" -> /BYTES/a @0,0
 >> at end:
-txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000030,0 wto=false max=0,0 isn=1
+txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000030,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000030,0 wto=false max=0,0 isn=1
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -369,7 +369,7 @@ get: "m" -> /BYTES/a @0.000000030,0
 meta: "n" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000040,0 min=0,0 seq=30} ts=0.000000040,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "n" -> /BYTES/c @0.000000040,0
 >> at end:
-txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000040,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000040,0 wto=false max=0,0
+txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000040,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000040,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -397,7 +397,7 @@ get: "n" -> /BYTES/c @0.000000040,0
 meta: "n" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000040,0 min=0,0 seq=30} ts=0.000000045,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 get: "n" -> /BYTES/c @0.000000045,0
 >> at end:
-txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000045,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000040,0 wto=false max=0,0
+txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000045,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000040,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -425,7 +425,7 @@ meta: "n" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000040,0 min
 get: "n" -> /BYTES/c @0.000000045,0
 get: "n" -> /BYTES/c @0.000000045,0
 >> at end:
-txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000050,0 wto=false max=0,0
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000050,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -457,7 +457,7 @@ with t=E
 get: "n" -> /BYTES/c @0.000000045,0
 get: "o" -> <no data>
 >> at end:
-txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000050,0 wto=false max=0,0
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000050,0 wto=false max=0,0
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -484,7 +484,7 @@ with t=E
 get: "n" -> /BYTES/c @0.000000045,0
 get: "o" -> <no data>
 >> at end:
-txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -532,7 +532,7 @@ with t=E
 ----
 meta: "o" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} ts=0.000000050,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 >> at end:
-txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000050,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10
@@ -555,7 +555,7 @@ with t=E
 ----
 get: "o" -> <no data>
 >> at end:
-txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000055,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000055,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000050,0 wto=false max=0,0 isn=1
 data: "k"/0.000000014,0 -> /BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=7
 data: "k/10"/0.000000011,0 -> /BYTES/10

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -23,7 +23,7 @@ with t=A
   resolve_intent k=k/30
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 data: "k"/0.000000011,0 -> /BYTES/b
 data: "k/10"/0.000000011,0 -> /BYTES/10
 data: "k/20"/0.000000011,0 -> /BYTES/20
@@ -64,7 +64,7 @@ with t=A
   resolve_intent k=k/30
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 data: "k"/0.000000011,0 -> /BYTES/c
 data: "k/10"/0.000000011,0 -> /BYTES/10
 data: "k/30"/0.000000011,0 -> /BYTES/30

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
@@ -18,7 +18,7 @@ with t=A
   txn_step  seq=20
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=10} ts=0.000000011,0 del=false klen=12 vlen=6
 data: "k"/0.000000011,0 -> /BYTES/a
 data: "k"/0.000000001,0 -> /BYTES/first
@@ -64,7 +64,7 @@ with t=B
   txn_step  seq=30
 ----
 >> at end:
-txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 data: "k"/0.000000011,0 -> /BYTES/b
 data: "k"/0.000000001,0 -> /BYTES/first
@@ -112,7 +112,7 @@ with t=C
   txn_step  seq=40
 ----
 >> at end:
-txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}}
 data: "k"/0.000000011,0 -> /BYTES/c
 data: "k"/0.000000001,0 -> /BYTES/first
@@ -168,7 +168,7 @@ with t=D
   txn_step  seq=30
 ----
 >> at end:
-txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
+txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=30} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=20} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 data: "k"/0.000000011,0 -> /BYTES/b
 data: "k"/0.000000001,0 -> /BYTES/first

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -34,7 +34,7 @@ with k=k t=a ts=0,1
 inc: current value = 1
 inc: current value = 2
 >> at end:
-txn: "a" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} rw=true stat=PENDING rts=0,1 wto=false max=0,0
+txn: "a" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} lock=true stat=PENDING rts=0,1 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}}
 data: "k"/0,1 -> /INT/2
 
@@ -72,7 +72,7 @@ with t=r
   increment k=r
 ----
 >> at end:
-txn: "r" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "r" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}}
 data: "k"/0,1 -> /INT/2
 meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000003,2 del=false klen=12 vlen=6

--- a/pkg/storage/testdata/mvcc_histories/intent_history
+++ b/pkg/storage/testdata/mvcc_histories/intent_history
@@ -25,25 +25,25 @@ with t=A
   resolve_intent
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=first k=a t=A
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000002,0 del=false klen=12 vlen=10
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=second k=a t=A
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} ts=0.000000002,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000002,0 -> /BYTES/second
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step n=2 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> del k=a t=A
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} ts=0.000000002,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
 data: "a"/0.000000002,0 -> /<empty>
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step n=6 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} rw=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=first k=a t=A
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} ts=0.000000002,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}
 data: "a"/0.000000002,0 -> /BYTES/first

--- a/pkg/storage/testdata/mvcc_histories/merges
+++ b/pkg/storage/testdata/mvcc_histories/merges
@@ -36,4 +36,4 @@ with t=A
 ----
 get: "a" -> /BYTES/defghi @0,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000033,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000033,0 wto=false max=0,0

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort
@@ -8,7 +8,7 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=22 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000022,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000022,0 wto=false max=0,0
 >> put v=cde t=A k=a
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} ts=0.000000022,0 del=false klen=12 vlen=8
 data: "a"/0.000000022,0 -> /BYTES/cde

--- a/pkg/storage/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/testdata/mvcc_histories/put_after_rollback
@@ -13,7 +13,7 @@ with t=A k=k2
 get: "k2" -> /BYTES/b @0.000000001,0
 get: "k2" -> <no data>
 >> at end:
-txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
 data: "k2"/0.000000001,0 -> /BYTES/b
 
@@ -26,7 +26,7 @@ with t=A k=k3
   del
 ----
 >> at end:
-txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
 data: "k2"/0.000000001,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0
@@ -43,7 +43,7 @@ with t=A k=k4
   cput      v=c
 ----
 >> at end:
-txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=60} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
+txn: "A" meta={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=60} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
 data: "k2"/0.000000001,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0
@@ -72,7 +72,7 @@ with t=B k=k5
 meta: "k5" -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=30} ts=0.000000005,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 meta: "k5" -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=40} ts=0.000000005,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}}
 >> at end:
-txn: "B" meta={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=40} rw=true stat=PENDING rts=0.000000005,0 wto=false max=0,0 isn=1
+txn: "B" meta={id=00000000 key="k5" pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=40} lock=true stat=PENDING rts=0.000000005,0 wto=false max=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=20} ts=0.000000001,0 del=false klen=12 vlen=6
 data: "k2"/0.000000001,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000000 key="k2" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=40} ts=0.000000001,0 del=true klen=12 vlen=0

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
@@ -21,7 +21,7 @@ with t=A
 ----
 get: "k" -> /BYTES/v @0.000000001,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} ts=0.000000001,0 del=false klen=12 vlen=6
 data: "k"/0.000000001,0 -> /BYTES/v
 
@@ -31,7 +31,7 @@ with t=A
   txn_step n=4
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000001,0 min=0,0 seq=4} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000001,0 min=0,0 seq=4} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 
 
 # We're operating at a higher epoch but a lower seqnum.

--- a/pkg/storage/testdata/mvcc_histories/put_out_of_order
+++ b/pkg/storage/testdata/mvcc_histories/put_out_of_order
@@ -8,7 +8,7 @@ with t=A
   put         ts=1 k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,1 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,1 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,1 min=0,0 seq=0} ts=0.000000002,1 del=false klen=12 vlen=6
 data: "k"/0.000000002,1 -> /BYTES/v
 
@@ -20,7 +20,7 @@ with t=A
   put         ts=1 k=k v=v2
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} ts=0.000000002,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}}
 data: "k"/0.000000002,1 -> /BYTES/v2
 
@@ -40,7 +40,7 @@ with t=A
   put ts=1 k=k v=v2
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} ts=0.000000002,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}{1 /BYTES/v2}}
 data: "k"/0.000000002,1 -> /BYTES/v2
 

--- a/pkg/storage/testdata/mvcc_histories/put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/put_with_txn
@@ -10,6 +10,6 @@ get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
 >> at end:
-txn: "A" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} rw=true stat=PENDING rts=0,1 wto=false max=0,0
+txn: "A" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6
 data: "k"/0,1 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/read_after_write
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write
@@ -9,7 +9,7 @@ with t=A
     resolve_intent
 ----
 >> txn_begin ts=11 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 >> put v=abc k=a t=A
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} ts=0.000000011,0 del=false klen=12 vlen=8
 data: "a"/0.000000011,0 -> /BYTES/abc
@@ -42,7 +42,7 @@ with t=A
 ----
 get: "a" -> /BYTES/abc @0.000000011,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 
 run trace ok
 with t=A
@@ -85,5 +85,5 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=1 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 >> txn_remove t=A k=a

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -14,7 +14,7 @@ with t=A
   put k=k2 v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000010,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000010,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000010,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000010,0 wto=false max=0,0
 data: "k1"/0.000000010,0 -> /BYTES/v
 meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000010,0 min=0,0 seq=0} ts=0.000000010,0 del=false klen=12 vlen=6
 data: "k2"/0.000000010,0 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
@@ -10,7 +10,7 @@ with t=B
   put   k=a v=zzz
 ----
 >> at end:
-txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000044,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000044,0 wto=false max=0,0
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000044,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000044,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} ts=0.000000033,0 del=false klen=12 vlen=8
 data: "a"/0.000000033,0 -> /BYTES/xyz
 error: (*roachpb.WriteIntentError:) conflicting intents on "a"

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
@@ -4,7 +4,7 @@ with t=A
   put k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} rw=true stat=PENDING rts=0,1 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6
 data: "k"/0,1 -> /BYTES/v
 
@@ -18,6 +18,6 @@ with t=A
   put k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} rw=true stat=PENDING rts=0,1 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} lock=true stat=PENDING rts=0,1 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} ts=0.000000001,0 del=false klen=12 vlen=6 ih={{0 /BYTES/v}}
 data: "k"/0.000000001,0 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -20,7 +20,7 @@ with t=A
   del   k=a
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} rw=true stat=PENDING rts=0.000000033,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000033,0 wto=false max=0,0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000033,0 min=0,0 seq=0} ts=0.000000044,1 del=true klen=12 vlen=0
 data: "a"/0.000000044,1 -> /<empty>
 data: "a"/0.000000044,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/write_with_sequence
+++ b/pkg/storage/testdata/mvcc_histories/write_with_sequence
@@ -17,7 +17,7 @@ with t=t k=k
 ----
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}}
 data: "k"/0.000000001,0 -> /BYTES/v2
 error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000001 with sequence 3 missing an intent with lower sequence 1
@@ -43,7 +43,7 @@ with t=t k=k
 ----
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}}
 data: "k"/0.000000001,0 -> /BYTES/v2
 
@@ -68,7 +68,7 @@ with t=t k=k
 ----
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}}
 data: "k"/0.000000001,0 -> /BYTES/v2
 error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000003 with sequence 2 has a different value [0 0 0 0 3 118 50] after recomputing from what was written: [0 0 0 0 3 118 49]
@@ -94,7 +94,7 @@ with t=t k=k
 ----
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}}
 data: "k"/0.000000001,0 -> /BYTES/v2
 
@@ -119,7 +119,7 @@ with t=t k=k
 ----
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=3} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}}
 data: "k"/0.000000001,0 -> /BYTES/v2
 error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000005 with sequence 3 has a different value [0 0 0 0 3 118 51] after recomputing from what was written: [0 0 0 0 3 118 50]
@@ -147,7 +147,7 @@ with t=t k=k
 ----
 put: batch after write is non-empty
 >> at end:
-txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=4} rw=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "t" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=4} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
 meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=4} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}{3 /BYTES/v2}}
 data: "k"/0.000000001,0 -> /BYTES/v4
 


### PR DESCRIPTION
This PR contains a few refactors that prepare the `kv` and `storage` packages for the introduction of unreplicated locks, which is supported by the new lockTable. After this, there's jsut one change remaining to hook up unreplicated locks to `SELECT FOR UPDATE`. I was planning on making all of those changes in the same PR, but with the impending package refactor, getting this merged now seems like a good idea.

#### roachpb: redefine Transaction.IsWriting to IsLocking

This is the first of a few terminology updates. Before this change, "writing" and "locking" were synonymous so we used the concepts interchangeably. Now that we plan to introduce "read-only" requests that acquire unreplicated locks, we need to split these concepts. This commit starts this process by renaming `Transaction.IsWriting` to `Transaction.IsLocking`, which is the concept that the method was intending to talk about.

#### roachpb: redefine read/write request divide, introduce locking concept

This commit decouples the key-value layer notion of "writing" with "locking". It does so by first redefining the difference between reads and writes as a function of whether the requests go through Raft or not. Reads observe state on a leaseholder (or follower) but do not create a WriteBatch that is proposed through Raft. Writes observe state on a leaseholder and do create a WriteBatch that is proposed through Raft.

With distinction consolidated, the change then moves on to introducing the notion of "locking" at the key-value layer. Both read and write requests are able to acquire locks, though at different durability levels. Reads can only acquire unreplicated locks while writes can acquire replicated locks.

Finally, the commit renames "TransactionWrite" to "IntentWrite", which is more clear. The commit then audits situations where `IsIntentWrite` is used and replaces them with `IsLocking` where appropriate.