### PR TITLE
ui: Update nodes list with new badges

### DIFF
--- a/pkg/ui/src/components/badge/badge.styl
+++ b/pkg/ui/src/components/badge/badge.styl
@@ -34,7 +34,7 @@
 .badge--status-success
   color $colors--primary-green-3
   background-color $colors--primary-green-1
-  background rgba(180, 241, 170, 0.5);
+  border-radius 3px
 
 .badge--status-danger
   color $colors--functional-red-4

--- a/pkg/ui/src/components/badge/badge.tsx
+++ b/pkg/ui/src/components/badge/badge.tsx
@@ -16,7 +16,7 @@ import "./badge.styl";
 export type BadgeStatus = "success" | "danger" | "default" | "info" | "warning";
 
 export interface BadgeProps {
-  text: string;
+  text: React.ReactNode;
   size?: "small" | "medium" | "large";
   status?: BadgeStatus;
   tag?: boolean; // TODO (koorosh): Tag behavior isn't implemented yet.

--- a/pkg/ui/src/util/switchExhaustiveCheck.ts
+++ b/pkg/ui/src/util/switchExhaustiveCheck.ts
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// `switchExhaustiveCheck` function ensures that all switch cases are defined,
+// and default case will never occur.
+export const switchExhaustiveCheck = (value: never): never => {
+  throw new Error(`Unreachable point with value: ${value} `);
+};

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -276,34 +276,34 @@ export class NodeList extends React.Component<LiveNodeListProps> {
     {
       key: "status",
       render: (_text, record) => {
-        let status: string;
+        let badgeText: string;
         let tooltipText: string;
-        const badgeStatus = getBadgeTypeByNodeStatus(record.status);
+        const badgeType = getBadgeTypeByNodeStatus(record.status);
 
         switch (record.status) {
           case AggregatedNodeStatus.DEAD:
-            status = "warning";
+            badgeText = "warning";
             break;
           case AggregatedNodeStatus.LIVE:
           case AggregatedNodeStatus.WARNING:
-            status = AggregatedNodeStatus[record.status];
+            badgeText = AggregatedNodeStatus[record.status];
             break;
           case LivenessStatus.UNKNOWN:
           case LivenessStatus.UNAVAILABLE:
-            status = "suspect";
+            badgeText = "suspect";
             tooltipText = getStatusDescription(record.status);
             break;
           default:
-            status = LivenessStatus[record.status];
+            badgeText = LivenessStatus[record.status];
             tooltipText = getStatusDescription(record.status);
             break;
         }
         return (
           <Badge
-            status={badgeStatus}
+            status={badgeType}
             text={
               <Tooltip title={tooltipText}>
-                {status}
+                {badgeText}
               </Tooltip>
             }
           />

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -33,6 +33,7 @@ import { Percentage } from "src/util/format";
 import { FixLong } from "src/util/fixLong";
 import { getNodeLocalityTiers } from "src/util/localities";
 import { LocalityTier } from "src/redux/localities";
+import { switchExhaustiveCheck } from "src/util/switchExhaustiveCheck";
 
 import TableSection from "./tableSection";
 import "./nodes.styl";
@@ -146,7 +147,7 @@ const getBadgeTypeByNodeStatus = (status: LivenessStatus | AggregatedNodeStatus)
     case AggregatedNodeStatus.DEAD:
       return "danger";
     default:
-      return undefined;
+      return switchExhaustiveCheck(status);
   }
 };
 

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -369,16 +369,17 @@ class DecommissionedNodeList extends React.Component<DecommissionedNodeListProps
       key: "status",
       title: "status",
       render: (_text, record) => {
-        const status = _.capitalize(LivenessStatus[record.status]);
+        const badgeText = _.capitalize(LivenessStatus[record.status]);
         const tooltipText = getStatusDescription(record.status);
         return (
-          <Text
-            className={`status-column status-column--color-${status.toLowerCase()}`}
-            textType={TextTypes.Body}>
-            <Tooltip title={tooltipText}>
-              {status}
-            </Tooltip>
-          </Text>
+          <Badge
+            status="default"
+            text={
+              <Tooltip title={tooltipText}>
+                {badgeText}
+              </Tooltip>
+            }
+          />
         );
       },
     },


### PR DESCRIPTION
Resolves: #45478

Before, Badge component could accept string text as
input and it limited this component to provide more
specific content.

Now, this change allows to wrap Badge text with Tooltip
component and provide it as a text. It is necessary to add
tooltip on badges text and don't break styles and components
consistency.

Color codings for nodes and locality groups are different with
specific conditions that's why mapper functions were added to
map locality/node statuses to badges colors and badges text.

Release justification: bug fixes and low-risk updates to new functionality

<img width="1415" alt="Screenshot 2020-03-19 at 14 46 12" src="https://user-images.githubusercontent.com/3106437/77070675-573ff480-69f3-11ea-9cf8-7447bf0d9c40.png">
