### PR TITLE
release-19.2: sql: allow inverted indexes on mixed-case cols

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1135,7 +1135,7 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 			col := idx.ColumnNames[0]
 			row, err := evalCtx.InternalExecutor.QueryRow(ctx, "verify-inverted-idx-count", txn,
 				fmt.Sprintf(
-					`SELECT coalesce(sum_int(crdb_internal.json_num_index_entries(%s)), 0) FROM [%d AS t]`,
+					`SELECT coalesce(sum_int(crdb_internal.json_num_index_entries(%q)), 0) FROM [%d AS t]`,
 					col, tableDesc.ID,
 				),
 			)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -26,10 +26,11 @@ statement ok
 CREATE TABLE c (
   id INT PRIMARY KEY,
   foo JSON,
-  bar JSON,
+  "bAr" JSON,
+  "qUuX" JSON,
   INVERTED INDEX (foo),
-  INVERTED INDEX (bar),
-  FAMILY "primary" (id, foo, bar)
+  INVERTED INDEX ("bAr"),
+  FAMILY "primary" (id, foo, "bAr", "qUuX")
 )
 
 query TT
@@ -38,12 +39,18 @@ SHOW CREATE TABLE c
 c  CREATE TABLE c (
    id INT8 NOT NULL,
    foo JSONB NULL,
-   bar JSONB NULL,
+   "bAr" JSONB NULL,
+   "qUuX" JSONB NULL,
    CONSTRAINT "primary" PRIMARY KEY (id ASC),
    INVERTED INDEX c_foo_idx (foo),
-   INVERTED INDEX c_bar_idx (bar),
-   FAMILY "primary" (id, foo, bar)
+   INVERTED INDEX "c_bAr_idx" ("bAr"),
+   FAMILY "primary" (id, foo, "bAr", "qUuX")
 )
+
+# Regression test for #42944: make sure that mixed-case columns can be
+# inverted indexed.
+statement ok
+CREATE INVERTED INDEX ON c("qUuX")
 
 statement error indexing more than one column with an inverted index is not supported
 CREATE TABLE d (


### PR DESCRIPTION
Backport 1/1 commits from #45621.

/cc @cockroachdb/release

---

Closes #42944.

Previously, a bug prevented creation of inverted indexes on columns with
mixed-case identifiers. Now, the bug is fixed.

Release note (bug fix): it is now possible to create inverted indexes on
columns whose names are mixed-case.
