### PR TITLE
ui: Refactor redux connect for enqueue ranges

### DIFF
--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -11,8 +11,7 @@
 import _ from "lodash";
 import React, { Fragment } from "react";
 import Helmet from "react-helmet";
-import {RouteComponentProps, withRouter} from "react-router-dom";
-import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
 
 import { enqueueRange } from "src/util/api";
 import { cockroach } from "src/js/protos";
@@ -75,10 +74,20 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
     });
   }
 
+  handleEnqueueRange = (queue: string, rangeID: number, nodeID: number, skipShouldQueue: boolean) => {
+    const req = new EnqueueRangeRequest({
+      queue: queue,
+      range_id: rangeID,
+      node_id: nodeID,
+      skip_should_queue: skipShouldQueue,
+    });
+    return enqueueRange(req);
+  }
+
   handleSubmit = (evt: React.FormEvent<any>) => {
     evt.preventDefault();
 
-    this.props.handleEnqueueRange(
+    this.handleEnqueueRange(
       this.state.queue,
       // These parseInts should succeed because <input type="number" />
       // enforces numeric input. Otherwise they're NaN.
@@ -156,7 +165,7 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
     }
 
     return (
-      <Fragment>Error running EnqueueRange: { error.message }</Fragment>
+      <Fragment>Error running EnqueueRange: {error.message}</Fragment>
     );
   }
 
@@ -233,19 +242,6 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
 }
 
 // tslint:disable-next-line:variable-name
-const EnqueueRangeConnected = withRouter(connect(
-  null,
-  {
-    handleEnqueueRange: (queue: string, rangeID: number, nodeID: number, skipShouldQueue: boolean) => {
-      const req = new EnqueueRangeRequest({
-        queue: queue,
-        range_id: rangeID,
-        node_id: nodeID,
-        skip_should_queue: skipShouldQueue,
-      });
-      return enqueueRange(req);
-    },
-  },
-)(EnqueueRange));
+const EnqueueRangeConnected = withRouter(EnqueueRange);
 
 export default EnqueueRangeConnected;


### PR DESCRIPTION
Moving `handleEnqueueRange` from Redux connect to a method in the component as the data seems useless in the state and doesn't dispatch an action.

It seems like the GPRC promise wasn't getting handled by either the [Thunk](https://github.com/reduxjs/redux-thunk) or [Saga](https://github.com/redux-saga/redux-saga) middleware and was confusing Redux as with a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instead of [an action](https://redux.js.org/basics/actions/).

I'm also increasing the request timeout time on the GPRC request to an hour to ensure completion of tasks.

fixes #44948, #42888