### PR TITLE
changefeedccl: add options to control initial scan behavior

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -231,8 +231,8 @@ func createBenchmarkChangefeed(
 
 	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), details, buf.Get)
 	sf := span.MakeFrontier(spans...)
-	tickFn := emitEntries(
-		s.ClusterSettings(), details, sf, encoder, sink, rowsFn, TestingKnobs{}, metrics)
+	tickFn := emitEntries(s.ClusterSettings(), details, hlc.Timestamp{}, sf,
+		encoder, sink, rowsFn, TestingKnobs{}, metrics)
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() { _ = kvfeed.Run(ctx, kvfeedCfg) }()

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -222,6 +222,7 @@ func kvsToRows(
 func emitEntries(
 	settings *cluster.Settings,
 	details jobspb.ChangefeedDetails,
+	cursor hlc.Timestamp,
 	sf *span.Frontier,
 	encoder Encoder,
 	sink Sink,
@@ -237,7 +238,7 @@ func emitEntries(
 		// it's forwarded before.
 		// TODO(dan): This should be an assertion once we're confident this can never
 		// happen under any circumstance.
-		if row.updated.LessEq(sf.Frontier()) {
+		if row.updated.LessEq(sf.Frontier()) && !row.updated.Equal(cursor) {
 			log.Errorf(ctx, "cdc ux violation: detected timestamp %s that is less than "+
 				"or equal to the local frontier %s.", cloudStorageFormatTime(row.updated),
 				cloudStorageFormatTime(sf.Frontier()))

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -365,6 +365,15 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 		}
 	}
 	{
+		_, withInitialScan := details.Opts[changefeedbase.OptInitialScan]
+		_, noInitialScan := details.Opts[changefeedbase.OptNoInitialScan]
+		if withInitialScan && noInitialScan {
+			return jobspb.ChangefeedDetails{}, errors.Errorf(
+				`cannot specify both %s and %s`, changefeedbase.OptInitialScan,
+				changefeedbase.OptNoInitialScan)
+		}
+	}
+	{
 		const opt = changefeedbase.OptEnvelope
 		switch v := changefeedbase.EnvelopeType(details.Opts[opt]); v {
 		case changefeedbase.OptEnvelopeRow, changefeedbase.OptEnvelopeDeprecatedRow:

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -57,6 +57,16 @@ const (
 	// the user could continue.
 	OptSchemaChangePolicyStop SchemaChangePolicy = `stop`
 
+	// OptInitialScan enables an initial scan. This is the default when no
+	// cursor is specified, leading to an initial scan at the statement time of
+	// the creation of the changeffed. If used in conjunction with a cursor,
+	// an initial scan will be performed at the cursor timestamp.
+	OptInitialScan = `initial_scan`
+	// OptInitialScan enables an initial scan. This is the default when a
+	// cursor is specified. This option is useful to create a changefeed which
+	// subscribes only to new messages.
+	OptNoInitialScan = `no_initial_scan`
+
 	OptEnvelopeKeyOnly       EnvelopeType = `key_only`
 	OptEnvelopeRow           EnvelopeType = `row`
 	OptEnvelopeDeprecatedRow EnvelopeType = `deprecated_row`
@@ -95,4 +105,6 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptCompression:             sql.KVStringOptRequireValue,
 	OptSchemaChangeEvents:      sql.KVStringOptRequireValue,
 	OptSchemaChangePolicy:      sql.KVStringOptRequireValue,
+	OptInitialScan:             sql.KVStringOptRequireNoValue,
+	OptNoInitialScan:           sql.KVStringOptRequireNoValue,
 }


### PR DESCRIPTION
This PR adds two new options to control whether or not an initial scan will
occur at the start time of a changefeed. Today the initial scan occurs if
no cursor is specified. This is frustrating because sometimes users would
like an initial scan from a point in time (#41006). In other cases users
would like to create a changefeed from the present and would not like the
initial scan (#44970).

Fixes #41006
Fixes #42023
Fixes #44970

Release note (enterprise change): Two new `CHANGEFEED` options `initial_scan`
and `no_initial_scan` have been added. The initial scan used to occur only if
no cursor had been specified (indicating the desire to start the `CHANGEFEED`
from `now()`). The new options allow clients to override this default behavior
and create changefeeds from the present without an initial scan or from a
point in time with one. It is illegal to specify both options simultaneously.