### PR TITLE
ui: Refactor redux connect for enqueue ranges

### DIFF
--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -11,7 +11,7 @@
 import React, { Fragment } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import moment from 'moment';
+import moment from "moment";
 
 import { enqueueRange } from "src/util/api";
 import { cockroach } from "src/js/protos";

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -11,8 +11,7 @@
 import _ from "lodash";
 import React, { Fragment } from "react";
 import Helmet from "react-helmet";
-import {RouteComponentProps, withRouter} from "react-router-dom";
-import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
 
 import { enqueueRange } from "src/util/api";
 import { cockroach } from "src/js/protos";
@@ -75,10 +74,20 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
     });
   }
 
+  handleEnqueueRange = (queue: string, rangeID: number, nodeID: number, skipShouldQueue: boolean) => {
+    const req = new EnqueueRangeRequest({
+      queue: queue,
+      range_id: rangeID,
+      node_id: nodeID,
+      skip_should_queue: skipShouldQueue,
+    });
+    return enqueueRange(req);
+  }
+
   handleSubmit = (evt: React.FormEvent<any>) => {
     evt.preventDefault();
 
-    this.props.handleEnqueueRange(
+    this.handleEnqueueRange(
       this.state.queue,
       // These parseInts should succeed because <input type="number" />
       // enforces numeric input. Otherwise they're NaN.
@@ -156,7 +165,7 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
     }
 
     return (
-      <Fragment>Error running EnqueueRange: { error.message }</Fragment>
+      <Fragment>Error running EnqueueRange: {error.message}</Fragment>
     );
   }
 
@@ -233,19 +242,6 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
 }
 
 // tslint:disable-next-line:variable-name
-const EnqueueRangeConnected = withRouter(connect(
-  null,
-  {
-    handleEnqueueRange: (queue: string, rangeID: number, nodeID: number, skipShouldQueue: boolean) => {
-      const req = new EnqueueRangeRequest({
-        queue: queue,
-        range_id: rangeID,
-        node_id: nodeID,
-        skip_should_queue: skipShouldQueue,
-      });
-      return enqueueRange(req);
-    },
-  },
-)(EnqueueRange));
+const EnqueueRangeConnected = withRouter(EnqueueRange);
 
 export default EnqueueRangeConnected;

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -12,6 +12,7 @@ import _ from "lodash";
 import React, { Fragment } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import moment from 'moment';
 
 import { enqueueRange } from "src/util/api";
 import { cockroach } from "src/js/protos";
@@ -81,7 +82,7 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
       node_id: nodeID,
       skip_should_queue: skipShouldQueue,
     });
-    return enqueueRange(req);
+    return enqueueRange(req, moment.duration({ hours: 1 }));
   }
 
   handleSubmit = (evt: React.FormEvent<any>) => {

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2018 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import _ from "lodash";
 import React, { Fragment } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -92,8 +91,8 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
       this.state.queue,
       // These parseInts should succeed because <input type="number" />
       // enforces numeric input. Otherwise they're NaN.
-      _.parseInt(this.state.rangeID),
-      _.parseInt(this.state.nodeID),
+      parseInt(this.state.rangeID, 10),
+      parseInt(this.state.nodeID, 10),
       this.state.skipShouldQueue,
     ).then(
       response => {
@@ -242,7 +241,6 @@ export class EnqueueRange extends React.Component<EnqueueRangeProps & RouteCompo
   }
 }
 
-// tslint:disable-next-line:variable-name
 const EnqueueRangeConnected = withRouter(EnqueueRange);
 
 export default EnqueueRangeConnected;

--- a/pkg/ui/tslint.json
+++ b/pkg/ui/tslint.json
@@ -54,10 +54,13 @@
     "no-require-imports": false,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
-    "trailing-comma": [true, {
-      "multiline": "always",
-      "singleline": "never"
-    }],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never"
+      }
+    ],
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-use-before-declare": false,
@@ -105,7 +108,8 @@
     ],
     "variable-name": [
       true,
-      "allow-leading-underscore"
+      "allow-leading-underscore",
+      "allow-pascal-case"
     ],
     "whitespace": [
       true,
@@ -128,13 +132,17 @@
     "eofline": true,
     "forin": true,
     "import-spacing": true,
-    "indent":  {
-      "options": ["spaces"]
+    "indent": {
+      "options": [
+        "spaces"
+      ]
     },
     "jsdoc-format": true,
     "label-position": true,
     "max-line-length": {
-      "options": [120]
+      "options": [
+        120
+      ]
     },
     "new-parens": true,
     "no-arg": true,
@@ -167,7 +175,9 @@
       ]
     },
     "one-variable-per-declaration": {
-      "options": ["ignore-for-loop"]
+      "options": [
+        "ignore-for-loop"
+      ]
     },
     "quotemark": {
       "options": [
@@ -177,7 +187,9 @@
     },
     "radix": true,
     "semicolon": {
-      "options": ["always"]
+      "options": [
+        "always"
+      ]
     },
     "space-before-function-paren": {
       "options": {
@@ -195,7 +207,9 @@
       }
     },
     "triple-equals": {
-      "options": ["allow-null-check"]
+      "options": [
+        "allow-null-check"
+      ]
     },
     "use-isnan": true,
     "variable-name": {


### PR DESCRIPTION
Moving `handleEnqueueRange` from Redux connect to a method in the component as the data seems useless in the state and doesn't dispatch an action.

It seems like the GPRC promise wasn't getting handled by either the [Thunk](https://github.com/reduxjs/redux-thunk) or [Saga](https://github.com/redux-saga/redux-saga) middleware and was confusing Redux as with a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instead of [an action](https://redux.js.org/basics/actions/).

I'm also increasing the request timeout time on the GPRC request to an hour to ensure completion of tasks.

fixes #44948, #42888