### PR TITLE
sql: implement a background task for temp object cleanup

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -58,6 +58,7 @@
 <tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.histogram_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>histogram collection mode</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
+<tr><td><code>sql.temp_object_cleaner.cleanup_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how often to clean up orphaned temporary objects</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing. Note that enabling this may have a non-trivial negative performance impact.</td></tr>
 <tr><td><code>sql.trace.txn.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>duration beyond which all transactions are traced (set to 0 to disable)</td></tr>

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -133,14 +132,7 @@ func (r *Reconciler) run(ctx context.Context, stopper *stop.Stopper) {
 }
 
 func (r *Reconciler) isMeta1Leaseholder(ctx context.Context, now hlc.Timestamp) (bool, error) {
-	repl, _, err := r.localStores.GetReplicaForRangeID(1)
-	if roachpb.IsRangeNotFoundError(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return repl.OwnsValidLease(now), nil
+	return r.localStores.IsMeta1Leaseholder(now)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context) {

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -70,6 +70,19 @@ func NewStores(
 	}
 }
 
+// IsMeta1Leaseholder returns whether the specified stores owns
+// the meta1 lease. Returns an error if any.
+func (ls *Stores) IsMeta1Leaseholder(now hlc.Timestamp) (bool, error) {
+	repl, _, err := ls.GetReplicaForRangeID(1)
+	if roachpb.IsRangeNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return repl.OwnsValidLease(now), nil
+}
+
 // GetStoreCount returns the number of stores this node is exporting.
 func (ls *Stores) GetStoreCount() int {
 	var count int

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -200,13 +200,14 @@ type Server struct {
 	debug            *debug.Server
 	// sessionRegistry can be queried for info on running SQL sessions. It is
 	// shared between the sql.Server and the statusServer.
-	sessionRegistry     *sql.SessionRegistry
-	jobRegistry         *jobs.Registry
-	statsRefresher      *stats.Refresher
-	replicationReporter *reports.Reporter
-	engines             Engines
-	internalMemMetrics  sql.MemoryMetrics
-	adminMemMetrics     sql.MemoryMetrics
+	sessionRegistry        *sql.SessionRegistry
+	jobRegistry            *jobs.Registry
+	statsRefresher         *stats.Refresher
+	replicationReporter    *reports.Reporter
+	temporaryObjectCleaner *sql.TemporaryObjectCleaner
+	engines                Engines
+	internalMemMetrics     sql.MemoryMetrics
+	adminMemMetrics        sql.MemoryMetrics
 	// sqlMemMetrics are used to track memory usage of sql sessions.
 	sqlMemMetrics         sql.MemoryMetrics
 	protectedtsProvider   protectedts.Provider
@@ -889,6 +890,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	s.debug = debug.NewServer(s.ClusterSettings(), s.pgServer.HBADebugFn())
 
+	s.temporaryObjectCleaner = sql.NewTemporaryObjectCleaner(
+		s.st,
+		s.db,
+		s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory,
+		s.status,
+		s.node.stores.IsMeta1Leaseholder,
+		sqlExecutorTestingKnobs,
+	)
+
 	return s, nil
 }
 
@@ -1570,6 +1580,7 @@ func (s *Server) Start(ctx context.Context) error {
 		time.NewTicker,
 	)
 	s.replicationReporter.Start(ctx, s.stopper)
+	s.temporaryObjectCleaner.Start(ctx, s.stopper)
 
 	// Cluster ID should have been determined by this point.
 	if s.rpcContext.ClusterID.Get() == uuid.Nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -655,6 +655,17 @@ type ExecutorTestingKnobs struct {
 	// optimization). This is only called when the Executor is the one doing the
 	// committing.
 	BeforeAutoCommit func(ctx context.Context, stmt string) error
+
+	// DisableTempObjectsCleanupOnSessionExit disables cleaning up temporary schemas
+	// and tables when a session is closed.
+	DisableTempObjectsCleanupOnSessionExit bool
+	// TempObjectsCleanupCh replaces the time.Ticker.C channel used for scheduling
+	// a cleanup on every temp object in the cluster. If this is set, the job
+	// will now trigger when items come into this channel.
+	TempObjectsCleanupCh chan time.Time
+	// OnTempObjectsCleanupDone will trigger when the temporary objects cleanup
+	// job is done.
+	OnTempObjectsCleanupDone func()
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -317,6 +317,9 @@ func applyOverrides(o sqlbase.InternalExecutorSessionDataOverride, sd *sessionda
 	if o.ApplicationName != "" {
 		sd.ApplicationName = o.ApplicationName
 	}
+	if o.SearchPath != nil {
+		sd.SearchPath = *o.SearchPath
+	}
 }
 
 func (ie *InternalExecutor) maybeRootSessionDataOverride(

--- a/pkg/sql/sqlbase/internal.go
+++ b/pkg/sql/sqlbase/internal.go
@@ -10,6 +10,8 @@
 
 package sqlbase
 
+import "github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+
 // InternalExecutorSessionDataOverride is used by the InternalExecutor interface
 // to allow control over some of the session data.
 type InternalExecutorSessionDataOverride struct {
@@ -19,4 +21,6 @@ type InternalExecutorSessionDataOverride struct {
 	Database string
 	// ApplicationName represents the application that the query runs under.
 	ApplicationName string
+	// SearchPath represents the namespaces to search in.
+	SearchPath *sessiondata.SearchPath
 }

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -44,6 +44,12 @@ var (
 	CreateTempViewCounter = telemetry.GetCounterOnce("sql.schema.create_temp_view")
 )
 
+var (
+	// TempObjectCleanerDeletionCounter is to be incremented every time a temporary schema
+	// has been deleted by the temporary object cleaner.
+	TempObjectCleanerDeletionCounter = telemetry.GetCounterOnce("sql.schema.temp_object_cleaner.num_cleaned")
+)
+
 // SchemaChangeCreate is to be incremented every time a CREATE
 // schema change was made.
 func SchemaChangeCreate(typ string) telemetry.Counter {

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -13,18 +13,72 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/errors"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+// TempObjectCleanupInterval is a ClusterSetting controlling how often
+// temporary objects get cleaned up.
+var TempObjectCleanupInterval = settings.RegisterPublicDurationSetting(
+	"sql.temp_object_cleaner.cleanup_interval",
+	"how often to clean up orphaned temporary objects",
+	30*time.Minute,
+)
+
+var (
+	temporaryObjectCleanerActiveCleanersMetric = metric.Metadata{
+		Name:        "sql.temp_object_cleaner.active_cleaners",
+		Help:        "number of cleaner t®asks currently running on this node",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_GAUGE,
+	}
+	temporaryObjectCleanerSchemasToDeleteMetric = metric.Metadata{
+		Name:        "sql.temp_object_cleaner.schemas_to_delete",
+		Help:        "number of schemas to be deleted by the temp object cleaner on this node",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	temporaryObjectCleanerSchemasDeletionErrorMetric = metric.Metadata{
+		Name:        "sql.temp_object_cleaner.schemas_deletion_error",
+		Help:        "number of errored schema deletions by the temp object cleaner on this node",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	temporaryObjectCleanerSchemasDeletionSuccessMetric = metric.Metadata{
+		Name:        "sql.temp_object_cleaner.schemas_deletion_success",
+		Help:        "number of successful schema deletions by the temp object cleaner on this node",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
 )
 
 func createTempSchema(params runParams, sKey sqlbase.DescriptorKey) (sqlbase.ID, error) {
@@ -60,6 +114,26 @@ func temporarySchemaName(sessionID ClusterWideID) string {
 	return fmt.Sprintf("pg_temp_%d_%d", sessionID.Hi, sessionID.Lo)
 }
 
+// temporarySchemaSessionID returns the sessionID of the given temporary schema.
+func temporarySchemaSessionID(scName string) (bool, ClusterWideID, error) {
+	if !strings.HasPrefix(scName, "pg_temp_") {
+		return false, ClusterWideID{}, nil
+	}
+	parts := strings.Split(scName, "_")
+	if len(parts) != 4 {
+		return false, ClusterWideID{}, errors.Errorf("malformed temp schema name %s", scName)
+	}
+	hi, err := strconv.ParseUint(parts[2], 10, 64)
+	if err != nil {
+		return false, ClusterWideID{}, err
+	}
+	lo, err := strconv.ParseUint(parts[3], 10, 64)
+	if err != nil {
+		return false, ClusterWideID{}, err
+	}
+	return true, ClusterWideID{uint128.Uint128{Hi: hi, Lo: lo}}, nil
+}
+
 // getTemporaryObjectNames returns all the temporary objects under the
 // temporary schema of the given dbID.
 func getTemporaryObjectNames(
@@ -81,16 +155,15 @@ func getTemporaryObjectNames(
 
 // cleanupSessionTempObjects removes all temporary objects (tables, sequences,
 // views, temporary schema) created by the session.
-func cleanupSessionTempObjects(ctx context.Context, server *Server, sessionID ClusterWideID) error {
+func cleanupSessionTempObjects(
+	ctx context.Context,
+	settings *cluster.Settings,
+	db *kv.DB,
+	ie sqlutil.InternalExecutor,
+	sessionID ClusterWideID,
+) error {
 	tempSchemaName := temporarySchemaName(sessionID)
-	sd := &sessiondata.SessionData{
-		SearchPath:    sqlbase.DefaultSearchPath.WithTemporarySchemaName(tempSchemaName),
-		User:          security.RootUser,
-		SequenceState: &sessiondata.SequenceState{},
-	}
-	ie := MakeInternalExecutor(ctx, server, MemoryMetrics{}, server.cfg.Settings)
-	ie.SetSessionData(sd)
-	return server.cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// We are going to read all database descriptor IDs, then for each database
 		// we will drop all the objects under the temporary schema.
 		dbIDs, err := GetAllDatabaseDescriptorIDs(ctx, txn)
@@ -98,7 +171,14 @@ func cleanupSessionTempObjects(ctx context.Context, server *Server, sessionID Cl
 			return err
 		}
 		for _, id := range dbIDs {
-			if err := cleanupSchemaObjects(ctx, server.cfg.Settings, ie.Exec, txn, id, tempSchemaName); err != nil {
+			if err := cleanupSchemaObjects(
+				ctx,
+				settings,
+				txn,
+				ie,
+				id,
+				tempSchemaName,
+			); err != nil {
 				return err
 			}
 			// Even if no objects were found under the temporary schema, the schema
@@ -113,24 +193,12 @@ func cleanupSessionTempObjects(ctx context.Context, server *Server, sessionID Cl
 	})
 }
 
-// TestingCleanupSchemaObjects is a wrapper around cleanupSchemaObjects, used for testing only.
-func TestingCleanupSchemaObjects(
-	ctx context.Context,
-	settings *cluster.Settings,
-	execQuery func(context.Context, string, *kv.Txn, string, ...interface{}) (int, error),
-	txn *kv.Txn,
-	dbID sqlbase.ID,
-	schemaName string,
-) error {
-	return cleanupSchemaObjects(ctx, settings, execQuery, txn, dbID, schemaName)
-}
-
 // cleanupSchemaObjects removes all objects that is located within a dbID and schema.
 func cleanupSchemaObjects(
 	ctx context.Context,
 	settings *cluster.Settings,
-	execQuery func(context.Context, string, *kv.Txn, string, ...interface{}) (int, error),
 	txn *kv.Txn,
+	ie sqlutil.InternalExecutor,
 	dbID sqlbase.ID,
 	schemaName string,
 ) error {
@@ -139,6 +207,12 @@ func cleanupSchemaObjects(
 		return err
 	}
 	a := UncachedPhysicalAccessor{}
+
+	searchPath := sqlbase.DefaultSearchPath.WithTemporarySchemaName(schemaName)
+	override := sqlbase.InternalExecutorSessionDataOverride{
+		SearchPath: &searchPath,
+		User:       security.RootUser,
+	}
 
 	// TODO(andrei): We might want to accelerate the deletion of this data.
 	var tables sqlbase.IDs
@@ -227,10 +301,11 @@ func cleanupSchemaObjects(
 								tree.Name(schema),
 								tree.Name(dTableDesc.Name),
 							)
-							_, err = execQuery(
+							_, err = ie.ExecEx(
 								ctx,
 								"delete-temp-dependent-col",
 								txn,
+								override,
 								fmt.Sprintf(
 									"ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT",
 									tbName.FQString(),
@@ -269,11 +344,219 @@ func cleanupSchemaObjects(
 				query.WriteString(tbName.FQString())
 			}
 			query.WriteString(" CASCADE")
-			_, err = execQuery(ctx, "delete-temp-"+toDelete.typeName, txn, query.String())
+			_, err = ie.ExecEx(ctx, "delete-temp-"+toDelete.typeName, txn, override, query.String())
 			if err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// isMeta1LeaseholderFunc helps us avoid an import into pkg/storage.
+type isMeta1LeaseholderFunc func(hlc.Timestamp) (bool, error)
+
+// TemporaryObjectCleaner is a background thread job that periodically
+// cleans up orphaned temporary objects by sessions which did not close
+// down cleanly.
+type TemporaryObjectCleaner struct {
+	settings                         *cluster.Settings
+	db                               *kv.DB
+	makeSessionBoundInternalExecutor sqlutil.SessionBoundInternalExecutorFactory
+	statusServer                     serverpb.StatusServer
+	isMeta1LeaseholderFunc           isMeta1LeaseholderFunc
+	testingKnobs                     ExecutorTestingKnobs
+	metrics                          *temporaryObjectCleanerMetrics
+}
+
+// temporaryObjectCleanerMetrics are the metrics for TemporaryObjectCleaner
+type temporaryObjectCleanerMetrics struct {
+	ActiveCleaners         *metric.Gauge
+	SchemasToDelete        *metric.Counter
+	SchemasDeletionError   *metric.Counter
+	SchemasDeletionSuccess *metric.Counter
+}
+
+var _ metric.Struct = (*temporaryObjectCleanerMetrics)(nil)
+
+// MetricStruct implements the metrics.Struct interface.
+func (m *temporaryObjectCleanerMetrics) MetricStruct() {}
+
+// NewTemporaryObjectCleaner initializes the TemporaryObjectCleaner with the
+// required arguments, but does not start it.
+func NewTemporaryObjectCleaner(
+	settings *cluster.Settings,
+	db *kv.DB,
+	makeSessionBoundInternalExecutor sqlutil.SessionBoundInternalExecutorFactory,
+	statusServer serverpb.StatusServer,
+	isMeta1LeaseholderFunc isMeta1LeaseholderFunc,
+	testingKnobs ExecutorTestingKnobs,
+) *TemporaryObjectCleaner {
+	return &TemporaryObjectCleaner{
+		settings:                         settings,
+		db:                               db,
+		makeSessionBoundInternalExecutor: makeSessionBoundInternalExecutor,
+		statusServer:                     statusServer,
+		isMeta1LeaseholderFunc:           isMeta1LeaseholderFunc,
+		testingKnobs:                     testingKnobs,
+		metrics:                          makeTemporaryObjectCleanerMetrics(),
+	}
+}
+
+// makeTemporaryObjectCleanerMetrics makes the metrics for the TemporaryObjectCleaner.
+func makeTemporaryObjectCleanerMetrics() *temporaryObjectCleanerMetrics {
+	return &temporaryObjectCleanerMetrics{
+		ActiveCleaners:         metric.NewGauge(temporaryObjectCleanerActiveCleanersMetric),
+		SchemasToDelete:        metric.NewCounter(temporaryObjectCleanerSchemasToDeleteMetric),
+		SchemasDeletionError:   metric.NewCounter(temporaryObjectCleanerSchemasDeletionErrorMetric),
+		SchemasDeletionSuccess: metric.NewCounter(temporaryObjectCleanerSchemasDeletionSuccessMetric),
+	}
+}
+
+// doTemporaryObjectCleanup performs the actual cleanup.
+func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(ctx context.Context) error {
+	// Wrap the retry functionality with the default arguments.
+	retryFunc := func(ctx context.Context, do func() error) error {
+		return retry.WithMaxAttempts(
+			ctx,
+			retry.Options{InitialBackoff: 1 * time.Second, MaxBackoff: 1 * time.Minute, Multiplier: 2},
+			5, // maxAttempts
+			func() error {
+				err := do()
+				if err != nil {
+					log.Warningf(ctx, "error during schema cleanup, retrying: %v", err)
+				}
+				return err
+			},
+		)
+	}
+
+	// We only want to perform the cleanup if we are holding the meta1 lease.
+	// This ensures only one server can perform the job at a time.
+	isLeaseholder, err := c.isMeta1LeaseholderFunc(c.db.Clock().Now())
+	if err != nil {
+		return err
+	}
+	if !isLeaseholder {
+		log.Infof(ctx, "skipping temporary object cleanup run as it is not the leaseholder")
+		return nil
+	}
+
+	c.metrics.ActiveCleaners.Inc(1)
+	defer c.metrics.ActiveCleaners.Dec(1)
+
+	log.Infof(ctx, "running temporary object cleanup background job")
+	txn := kv.NewTxn(ctx, c.db, 0)
+
+	// Build a set of all session IDs with temporary objects.
+	var dbIDs []sqlbase.ID
+	if err := retryFunc(ctx, func() error {
+		var err error
+		dbIDs, err = GetAllDatabaseDescriptorIDs(ctx, txn)
+		return err
+	}); err != nil {
+		return err
+	}
+	sessionIDs := make(map[ClusterWideID]struct{})
+	for _, dbID := range dbIDs {
+		var schemaNames map[sqlbase.ID]string
+		if err := retryFunc(ctx, func() error {
+			var err error
+			schemaNames, err = schema.GetForDatabase(ctx, txn, dbID)
+			return err
+		}); err != nil {
+			return err
+		}
+		for _, scName := range schemaNames {
+			isTempSchema, sessionID, err := temporarySchemaSessionID(scName)
+			if err != nil {
+				// This should not cause an error.
+				log.Warningf(ctx, "could not parse %q as temporary schema name", scName)
+				continue
+			}
+			if isTempSchema {
+				sessionIDs[sessionID] = struct{}{}
+			}
+		}
+	}
+	log.Infof(ctx, "found %d temporary schemas", len(sessionIDs))
+
+	// Get active sessions.
+	var response *serverpb.ListSessionsResponse
+	if err := retryFunc(ctx, func() error {
+		var err error
+		response, err = c.statusServer.ListSessions(
+			ctx,
+			&serverpb.ListSessionsRequest{},
+		)
+		return err
+	}); err != nil {
+		return err
+	}
+	activeSessions := make(map[uint128.Uint128]struct{})
+	for _, session := range response.Sessions {
+		activeSessions[uint128.FromBytes(session.ID)] = struct{}{}
+	}
+
+	// Clean up temporary data for inactive sessions.
+	ie := c.makeSessionBoundInternalExecutor(ctx, &sessiondata.SessionData{})
+	for sessionID := range sessionIDs {
+		if _, ok := activeSessions[sessionID.Uint128]; !ok {
+			log.Eventf(ctx, "cleaning up temporary object for session %q", sessionID)
+			c.metrics.SchemasToDelete.Inc(1)
+
+			// Reset the session data with the appropriate sessionID such that we can resolve
+			// the given schema correctly.
+			if err := retryFunc(ctx, func() error {
+				return cleanupSessionTempObjects(
+					ctx,
+					c.settings,
+					c.db,
+					ie,
+					sessionID,
+				)
+			}); err != nil {
+				// Log error but continue trying to delete the rest.
+				log.Warningf(ctx, "failed to clean temp objects under session %q: %v", sessionID, err)
+				c.metrics.SchemasDeletionError.Inc(1)
+			} else {
+				c.metrics.SchemasDeletionSuccess.Inc(1)
+				telemetry.Inc(sqltelemetry.TempObjectCleanerDeletionCounter)
+			}
+		} else {
+			log.Eventf(ctx, "not cleaning up %q as session is still active", sessionID)
+		}
+	}
+
+	log.Infof(ctx, "completed temporary object cleanup job")
+	return nil
+}
+
+// Start initializes the background thread which periodically cleans up leftover temporary objects.
+func (c *TemporaryObjectCleaner) Start(ctx context.Context, stopper *stop.Stopper) {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
+		nextTick := timeutil.Now()
+		for {
+			nextTickCh := time.After(nextTick.Sub(timeutil.Now()))
+			if c.testingKnobs.TempObjectsCleanupCh != nil {
+				nextTickCh = c.testingKnobs.TempObjectsCleanupCh
+			}
+
+			select {
+			case <-nextTickCh:
+				if err := c.doTemporaryObjectCleanup(ctx); err != nil {
+					log.Warningf(ctx, "failed to clean temp objects: %v", err)
+				}
+			case <-stopper.ShouldQuiesce():
+				return
+			case <-ctx.Done():
+				return
+			}
+			if c.testingKnobs.OnTempObjectsCleanupDone != nil {
+				c.testingKnobs.OnTempObjectsCleanupDone()
+			}
+			nextTick = nextTick.Add(TempObjectCleanupInterval.Get(&c.settings.SV))
+			log.Infof(ctx, "temporary object cleaner next scheduled to run at %s", nextTick)
+		}
+	})
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1551,6 +1551,23 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "Temporary Objects Cleanup"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Active Cleaners",
+				Metrics: []string{"sql.temp_object_cleaner.active_cleaners"},
+			},
+			{
+				Title: "Deletion Rate",
+				Metrics: []string{
+					"sql.temp_object_cleaner.schemas_to_delete",
+					"sql.temp_object_cleaner.schemas_deletion_success",
+					"sql.temp_object_cleaner.schemas_deletion_error",
+				},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "SQL"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/45666

This PR introduces a `TempObjectCleaner`, which is a background task
that runs periodically on every node, but will only be executed by the
node that has the meta1 leaseholder. This task will cleanup dangling
temporary schemas that could not have been cleaned up by the connection.
The job also comes with logging and metrics. A simple test mocking the
ticking mechanism has also been included.

Also refactored the existing temporary schema deletion to use ExecEx,
which overrides the SearchPath / User executing the deletion at a lower
layer rather than using `SetSessionExecutor`.

Release note (sql change): Introduced a temporary table cleanup job that
runs once every periodically per cluster that will remove any temporary
schemas and their related objects that did not get removed cleanly when
the connection closed. This period can be changed by the cluster setting
`sql.temp_object_cleaner.cleanup_interval`, which defaults to 30min-ly.

