### PR TITLE
sql: add a roachtest running tpcc and a primary key change

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -14,13 +14,13 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func registerAlterPK(r *testRegistry) {
-	const numRows = 1000000
-	const duration = 1 * time.Minute
 
-	runAlterPK := func(ctx context.Context, t *test, c *cluster) {
+	setupTest := func(ctx context.Context, t *test, c *cluster) (nodeListOption, nodeListOption) {
 		roachNodes := c.Range(1, c.spec.NodeCount-1)
 		loadNode := c.Node(c.spec.NodeCount)
 		t.Status("copying binaries")
@@ -29,6 +29,15 @@ func registerAlterPK(r *testRegistry) {
 
 		t.Status("starting cockroach nodes")
 		c.Start(ctx, t, roachNodes)
+		return roachNodes, loadNode
+	}
+
+	// runAlterPKBank runs a primary key change while the bank workload runs.
+	runAlterPKBank := func(ctx context.Context, t *test, c *cluster) {
+		const numRows = 1000000
+		const duration = 1 * time.Minute
+
+		roachNodes, loadNode := setupTest(ctx, t, c)
 
 		initDone := make(chan struct{}, 1)
 		pkChangeDone := make(chan struct{}, 1)
@@ -82,14 +91,98 @@ func registerAlterPK(r *testRegistry) {
 		})
 		m.Wait()
 	}
+
+	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
+	runAlterPKTPCC := func(ctx context.Context, t *test, c *cluster) {
+		const warehouses = 500
+		const duration = 1 * time.Minute
+
+		roachNodes, loadNode := setupTest(ctx, t, c)
+
+		cmd := fmt.Sprintf(
+			"./cockroach workload fixtures import tpcc --warehouses=%d --db=tpcc",
+			warehouses,
+		)
+		if err := c.RunE(ctx, c.Node(roachNodes[0]), cmd); err != nil {
+			t.Fatal(err)
+		}
+
+		m := newMonitor(ctx, c, roachNodes)
+		m.Go(func(ctx context.Context) error {
+			// Start running the workload.
+			runCmd := fmt.Sprintf(
+				"./workload run tpcc --warehouses=%d --split --scatter --duration=%s {pgurl%s}",
+				warehouses,
+				duration,
+				roachNodes,
+			)
+			if err := c.RunE(ctx, loadNode, runCmd); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		})
+		m.Go(func(ctx context.Context) error {
+			// Start a primary key change after some delay.
+			time.Sleep(duration / 10)
+
+			// Pick a random table to change the primary key of.
+			alterStmts := []string{
+				`ALTER TABLE warehouse ALTER PRIMARY KEY USING COLUMNS (w_id)`,
+				`ALTER TABLE district ALTER PRIMARY KEY USING COLUMNS (d_w_id, d_id)`,
+				`ALTER TABLE history ALTER PRIMARY KEY USING COLUMNS (h_w_id, rowid)`,
+				`ALTER TABLE customer ALTER PRIMARY KEY USING COLUMNS (c_w_id, c_d_id, c_id)`,
+				`ALTER TABLE "order" ALTER PRIMARY KEY USING COLUMNS (o_w_id, o_d_id, o_id DESC)`,
+				`ALTER TABLE new_order ALTER PRIMARY KEY USING COLUMNS (no_w_id, no_d_id, no_o_id)`,
+				`ALTER TABLE item ALTER PRIMARY KEY USING COLUMNS (i_id)`,
+				`ALTER TABLE stock ALTER PRIMARY KEY USING COLUMNS (s_w_id, s_i_id)`,
+				`ALTER TABLE order_line ALTER PRIMARY KEY USING COLUMNS (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`,
+			}
+
+			rand, _ := randutil.NewPseudoRand()
+			randStmt := alterStmts[rand.Intn(len(alterStmts))]
+			t.Status("Running command: ", randStmt)
+
+			db := c.Conn(ctx, roachNodes[0])
+			defer db.Close()
+			alterCmd := `SET experimental_enable_primary_key_changes = true;
+							USE tpcc;
+							%s;`
+			t.Status("beginning primary key change")
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(alterCmd, randStmt)); err != nil {
+				t.Fatal(err)
+			}
+			t.Status("primary key change finished")
+			return nil
+		})
+
+		m.Wait()
+
+		// Run the verification checks of the TPCC workload post primary key change.
+		checkCmd := fmt.Sprintf(
+			"./workload check tpcc --warehouses %d --expensive-checks {pgurl%s}",
+			warehouses,
+			c.Node(roachNodes[0]),
+		)
+		if err := c.RunE(ctx, loadNode, checkCmd); err != nil {
+			t.Fatal(err)
+		}
+	}
 	r.Add(testSpec{
-		// TODO (rohany): update this setup if we want to add more workloads to this roachtest.
-		Name:  "alterpk",
-		Owner: OwnerSQLExec,
+		Name:  "alterpk-bank",
+		Owner: OwnerSQLSchema,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4),
-		Run:        runAlterPK,
+		Run:        runAlterPKBank,
+	})
+	r.Add(testSpec{
+		Name:  "alterpk-tpcc",
+		Owner: OwnerSQLSchema,
+		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
+		// workload driver node.
+		MinVersion: "v20.1.0",
+		Cluster:    makeClusterSpec(4),
+		Run:        runAlterPKTPCC,
 	})
 }


### PR DESCRIPTION
Fixes #45608.

This PR adds a roachtest that runs TPCC along with a primary key
change on a randomly selected table within the schema.

Release note: None