### PR TITLE
ui: Handle Email signup alert message close

### DIFF
--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -56,6 +56,7 @@ export interface Alert extends AlertInfo {
   showAsAlert?: boolean;
   autoClose?: boolean;
   closable?: boolean;
+  autoCloseTimeout?: number;
 }
 
 const localSettingsSelector = (state: AdminUIState) => state.localSettings;
@@ -261,6 +262,7 @@ export const emailSubscriptionAlertSelector = createSelector(
       title: "You successfully signed up for CockroachDB release notes",
       text: "You will receive emails about CockroachDB releases and best practices. You can unsubscribe from these emails anytime.",
       showAsAlert: true,
+      autoClose: true,
       dismiss: (dispatch: Dispatch<Action, AdminUIState>) => {
         dispatch(emailSubscriptionAlertLocalSetting.set(false));
         return Promise.resolve();

--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -260,9 +260,9 @@ export const emailSubscriptionAlertSelector = createSelector(
     return {
       level: AlertLevel.SUCCESS,
       title: "You successfully signed up for CockroachDB release notes",
-      text: "You will receive emails about CockroachDB releases and best practices. You can unsubscribe from these emails anytime.",
       showAsAlert: true,
       autoClose: true,
+      closable: false,
       dismiss: (dispatch: Dispatch<Action, AdminUIState>) => {
         dispatch(emailSubscriptionAlertLocalSetting.set(false));
         return Promise.resolve();

--- a/pkg/ui/src/views/dashboard/emailSubscription.tsx
+++ b/pkg/ui/src/views/dashboard/emailSubscription.tsx
@@ -18,6 +18,7 @@ import { clusterIdSelector } from "src/redux/nodes";
 import { LocalSetting } from "src/redux/localsettings";
 
 import "./emailSubscription.styl";
+import { emailSubscriptionAlertLocalSetting } from "oss/src/redux/alerts";
 
 type EmailSubscriptionProps = MapDispatchToProps & MapStateToProps;
 
@@ -27,7 +28,12 @@ class EmailSubscription extends React.Component<EmailSubscriptionProps> {
   }
 
   handlePanelHide = () => {
+    this.props.dismissAlertMessage();
     this.props.hidePanel();
+  }
+
+  componentWillUnmount() {
+    this.props.dismissAlertMessage();
   }
 
   render() {
@@ -68,11 +74,13 @@ const hidePanelLocalSetting = new LocalSetting<AdminUIState, boolean>(
 interface MapDispatchToProps {
   signUpForEmailSubscription: (clusterId: string, email: string) => void;
   hidePanel: () => void;
+  dismissAlertMessage: () => void;
 }
 
 const mapDispatchToProps = {
   signUpForEmailSubscription,
   hidePanel: () => hidePanelLocalSetting.set(true),
+  dismissAlertMessage: () => emailSubscriptionAlertLocalSetting.set(false),
 };
 
 interface MapStateToProps {

--- a/pkg/ui/src/views/shared/components/alertMessage/alertMessage.tsx
+++ b/pkg/ui/src/views/shared/components/alertMessage/alertMessage.tsx
@@ -17,6 +17,7 @@ import "./alertMessage.styl";
 
 interface AlertMessageProps extends AlertInfo {
   autoClose: boolean;
+  autoCloseTimeout: number;
   closable: boolean;
   dismiss(): void;
 }
@@ -56,14 +57,15 @@ const getIconType = (alertLevel: AlertLevel): string => {
 export class AlertMessage extends React.Component<AlertMessageProps> {
   static defaultProps = {
     closable: true,
+    autoCloseTimeout: 6000,
   };
 
   timeoutHandler: number;
 
   componentDidMount() {
-    const { autoClose, dismiss } = this.props;
+    const { autoClose, dismiss, autoCloseTimeout } = this.props;
     if (autoClose) {
-      this.timeoutHandler = setTimeout(dismiss, 6000);
+      this.timeoutHandler = setTimeout(dismiss, autoCloseTimeout);
     }
   }
 


### PR DESCRIPTION
Resolves: #45457

- Auto close alert after 6 seconds;
- Close alert when Email Subscription form is unmounted;
- Close alert whet Email Subscription form is closed explicitly;

Release justification: bug fixes and low-risk updates to new functionality