### PR TITLE
sql: attempt to account for memory in crdb_internal.jobs

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -471,6 +471,32 @@ CREATE TABLE crdb_internal.jobs (
 			return err
 		}
 
+		// Attempt to account for the memory of the retrieved rows and the data
+		// we're going to unmarshal and keep bufferred in RAM.
+		//
+		// TODO(ajwerner): This is a pretty terrible hack. Instead the internal
+		// executor should be hooked into the memory monitor associated with this
+		// conn executor. If we did that we would still want to account for the
+		// unmarshaling. Additionally, it's probably a good idea to paginate this
+		// and other virtual table queries but that's a bigger task.
+		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount()
+		defer ba.Close(ctx)
+		for _, r := range rows {
+			var rowSize int64
+			for field, d := range r {
+				// NB: Add the datum size twice to count the fact that we already allocated
+				// it once and we're about to
+				datumSize := int64(d.Size())
+				if field == 3 || field == 4 {
+					datumSize *= 2
+				}
+				rowSize += datumSize
+			}
+			if err := ba.Grow(ctx, rowSize); err != nil {
+				return err
+			}
+		}
+
 		for _, r := range rows {
 			id, status, created, payloadBytes, progressBytes := r[0], r[1], r[2], r[3], r[4]
 


### PR DESCRIPTION
This is a stop-gap PR to do _some_ memory accounting during the
execution of `crdb_internal.jobs`. It turns out that with hundreds of
databases and hours backups per database, one can easily get to 100k jobs
which are roughly 2-3Kb each. Given the total lack of memory monitoring here,
this situation can lead to OOMs.

Ideally we'd track the memory usage by the internal executor. That's a
bigger change left for later. Also ideally we'd paginate the output.

Related to but certainly does not solve #44166.

Release note: None