### PR TITLE
sql: introduce sending NOTICE commands through pgwire

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1160,7 +1160,7 @@
   revision = "634a59d12406abc51545000deab7cf43ebc32378"
 
 [[projects]]
-  digest = "1:9ff22c26414baf7deaf74f2a788fe7b97666048bcbe346c52cfe823442abbdfb"
+  digest = "1:e8501d7fa801be523f103178ced935b37778925c7338f0f94e50c14a4d450f4a"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -1168,8 +1168,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "99274577be97ac9b1d95a2d61d566dc9b7cc6a54"
-  version = "v1.3.0"
+  revision = "9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be"
 
 [[projects]]
   digest = "1:078d0b47a888546a9f8810d64f76792f70b2fa564ad2bbe6dddd002c032ce7cf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -129,6 +129,11 @@ ignored = [
   name = "github.com/cockroachdb/pebble"
   branch = "master"
 
+# github.com/lib/pq has a newer revision that has notices, which we want
+[[override]]
+  name = "github.com/lib/pq"
+  revision = "9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be"
+
 # github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
 # version of thrift than is currently present in a release.
 [[override]]

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -50,6 +50,7 @@
 <tr><td><code>sql.metrics.statement_details.plan_collection.period</code></td><td>duration</td><td><code>5m0s</code></td><td>the time until a new logical plan is collected</td></tr>
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.metrics.transaction_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-application transaction statistics</td></tr>
+<tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
 <tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -95,7 +95,8 @@ func (f *formattedError) Error() string {
 	}
 	fmt.Fprintln(&buf, message)
 
-	if code != "" {
+	// Avoid printing the code for NOTICE, as the code is always 00000.
+	if severity != "NOTICE" && code != "" {
 		// In contrast to `psql` we print the code even when printing
 		// non-verbosely, because we want to promote users reporting codes
 		// when interacting with support.

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -1,0 +1,21 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+# This test ensures notices are being sent as expected.
+
+spawn $argv demo --empty
+eexpect root@
+
+start_test "Test creating a view without TEMP set on a TEMP TABLE notifies it will become a TEMP VIEW."
+send "SET experimental_enable_temp_tables = true; CREATE TEMP TABLE temp_view_test_tbl(a int); CREATE VIEW temp_view_test AS SELECT a FROM temp_view_test_tbl;\r"
+eexpect "NOTICE: view \"temp_view_test\" will be a temporary view"
+end_test
+
+start_test "Check dropping an index prints a message about GC TTL."
+send "CREATE TABLE drop_index_test(a int); CREATE INDEX drop_index_test_index ON drop_index_test(a); DROP INDEX drop_index_test_index;\r"
+eexpect "NOTICE: index \"drop_index_test_index\" will be dropped asynchronously and will be complete after the GC TTL"
+end_test
+
+send "\\q\r"
+eexpect eof

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2054,6 +2054,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	ex.initEvalCtx(ctx, &p.extendedEvalCtx, p)
 
 	p.sessionDataMutator = ex.dataMutator
+	p.noticeSender = noopNoticeSender
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 
 	p.queryCacheSession.Init()

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -685,6 +685,10 @@ type RestrictedCommandResult interface {
 	// This gets flushed only when the CommandResult is closed.
 	AppendParamStatusUpdate(string, string)
 
+	// AppendNotice appends a notice to the result.
+	// This gets flushed only when the CommandResult is closed.
+	AppendNotice(noticeErr error)
+
 	// SetColumns informs the client about the schema of the result. The columns
 	// can be nil.
 	//
@@ -869,6 +873,11 @@ func (r *bufferedCommandResult) SetColumns(_ context.Context, cols sqlbase.Resul
 
 // AppendParamStatusUpdate is part of the RestrictedCommandResult interface.
 func (r *bufferedCommandResult) AppendParamStatusUpdate(key string, val string) {
+	panic("unimplemented")
+}
+
+// AppendNotice is part of the RestrictedCommandResult interface.
+func (r *bufferedCommandResult) AppendNotice(noticeErr error) {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -475,6 +475,10 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID); err != nil {
 		return err
 	}
+	p.noticeSender.AppendNotice(pgerror.Noticef(
+		"index %q will be dropped asynchronously and will be complete after the GC TTL",
+		idxName.String(),
+	))
 	// Record index drop in the event log. This is an auditable log event
 	// and is recorded in the same transaction as the table descriptor
 	// update.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1816,6 +1816,19 @@ var _ paramStatusUpdater = (*noopParamStatusUpdater)(nil)
 
 func (noopParamStatusUpdater) AppendParamStatusUpdate(string, string) {}
 
+// noticeSender is a subset of RestrictedCommandResult which allows sending
+// notices.
+type noticeSender interface {
+	AppendNotice(error)
+}
+
+// noopNoticeSender implements noticeSender by performing a no-op.
+type noopNoticeSenderImpl struct{}
+
+var noopNoticeSender noticeSender = &noopNoticeSenderImpl{}
+
+func (noopNoticeSenderImpl) AppendNotice(error) {}
+
 // sessionDataMutator is the interface used by sessionVars to change the session
 // state. It mostly mutates the Session's SessionData, but not exclusively (e.g.
 // see curTxnReadOnly).

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -98,6 +98,13 @@ func Newf(code string, format string, args ...interface{}) error {
 	return err
 }
 
+// Noticef generates a Notice with a format string.
+func Noticef(format string, args ...interface{}) error {
+	err := errors.NewWithDepthf(1, format, args...)
+	err = WithCandidateCode(err, pgcode.SuccessfulCompletion)
+	return err
+}
+
 // DangerousStatementf creates a new error for "rejected dangerous
 // statements".
 func DangerousStatementf(format string, args ...interface{}) error {

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -44,6 +44,7 @@ const (
 	ServerMsgDataRow              ServerMessageType = 'D'
 	ServerMsgEmptyQuery           ServerMessageType = 'I'
 	ServerMsgErrorResponse        ServerMessageType = 'E'
+	ServerMsgNoticeResponse       ServerMessageType = 'N'
 	ServerMsgNoData               ServerMessageType = 'n'
 	ServerMsgParameterDescription ServerMessageType = 't'
 	ServerMsgParameterStatus      ServerMessageType = 'S'

--- a/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
@@ -16,6 +16,7 @@ func _() {
 	_ = x[ServerMsgDataRow-68]
 	_ = x[ServerMsgEmptyQuery-73]
 	_ = x[ServerMsgErrorResponse-69]
+	_ = x[ServerMsgNoticeResponse-78]
 	_ = x[ServerMsgNoData-110]
 	_ = x[ServerMsgParameterDescription-116]
 	_ = x[ServerMsgParameterStatus-83]
@@ -30,17 +31,18 @@ const (
 	_ServerMessageType_name_1 = "ServerMsgCommandCompleteServerMsgDataRowServerMsgErrorResponse"
 	_ServerMessageType_name_2 = "ServerMsgCopyInResponse"
 	_ServerMessageType_name_3 = "ServerMsgEmptyQuery"
-	_ServerMessageType_name_4 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
-	_ServerMessageType_name_5 = "ServerMsgReady"
-	_ServerMessageType_name_6 = "ServerMsgNoData"
-	_ServerMessageType_name_7 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
+	_ServerMessageType_name_4 = "ServerMsgNoticeResponse"
+	_ServerMessageType_name_5 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
+	_ServerMessageType_name_6 = "ServerMsgReady"
+	_ServerMessageType_name_7 = "ServerMsgNoData"
+	_ServerMessageType_name_8 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
 )
 
 var (
 	_ServerMessageType_index_0 = [...]uint8{0, 22, 43, 65}
 	_ServerMessageType_index_1 = [...]uint8{0, 24, 40, 62}
-	_ServerMessageType_index_4 = [...]uint8{0, 13, 37, 60}
-	_ServerMessageType_index_7 = [...]uint8{0, 24, 53}
+	_ServerMessageType_index_5 = [...]uint8{0, 13, 37, 60}
+	_ServerMessageType_index_8 = [...]uint8{0, 24, 53}
 )
 
 func (i ServerMessageType) String() string {
@@ -55,16 +57,18 @@ func (i ServerMessageType) String() string {
 		return _ServerMessageType_name_2
 	case i == 73:
 		return _ServerMessageType_name_3
+	case i == 78:
+		return _ServerMessageType_name_4
 	case 82 <= i && i <= 84:
 		i -= 82
-		return _ServerMessageType_name_4[_ServerMessageType_index_4[i]:_ServerMessageType_index_4[i+1]]
+		return _ServerMessageType_name_5[_ServerMessageType_index_5[i]:_ServerMessageType_index_5[i+1]]
 	case i == 90:
-		return _ServerMessageType_name_5
-	case i == 110:
 		return _ServerMessageType_name_6
+	case i == 110:
+		return _ServerMessageType_name_7
 	case 115 <= i && i <= 116:
 		i -= 115
-		return _ServerMessageType_name_7[_ServerMessageType_index_7[i]:_ServerMessageType_index_7[i+1]]
+		return _ServerMessageType_name_8[_ServerMessageType_index_8[i]:_ServerMessageType_index_8[i+1]]
 	default:
 		return "ServerMessageType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -1,0 +1,78 @@
+# Test notices work as expected by creating a VIEW on a TEMP TABLE.
+
+send
+Parse {"Query": "SET experimental_enable_temp_tables = true"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE TEMP TABLE a (a int)"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE VIEW a_view AS SELECT a FROM a"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Severity":"NOTICE","Code":"00000","Message":"view \"a_view\" will be a temporary view","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"create_view.go","Line":65,"Routine":"startExec","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"CREATE VIEW"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Disable notices and assert now it is not sent.
+send
+Parse {"Query": "SET CLUSTER SETTING sql.notices.enabled = false"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SET CLUSTER SETTING"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE VIEW a_view_notice_disabled AS SELECT a FROM a"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CREATE VIEW"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -186,6 +186,9 @@ type planner struct {
 	// data structures that can be reused between queries (for efficiency).
 	optPlanningCtx optPlanningCtx
 
+	// noticeSender allows the sending of notices.
+	noticeSender noticeSender
+
 	queryCacheSession querycache.Session
 }
 


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/34749

In this PR, we thread NOTICEs to be sent through pgwire via the
RestrictedCommandResult. This is further attached to the planner
so that it can be used.

We further add the capability to disable notices (in case it causes
incompatibility with client drivers) by having the cluster setting
`sql.notices.enabled` (this is true by default).

Added a basic pgwire test, and added a tcl test for ensuring notices
will be printed as expected.

I will add more notices after this PR is in, this PR however
consolidates the proof of concept.

`lib/pq` is also bumped in the `vendor` directory to allow for notices
to work on the cockroach cli.

Release note (cli change): NOTICE commands can now be sent by cockroach
servers using the Postgres client/server protocol. We add notices for
two basic cases:
* Creating a VIEW on a TEMP TABLE without using `TEMP VIEW` implicitly
makes the VIEW temporary. This now sets a notice, as per postgres.
* DROP INDEX now prints information that indexes are not dropped
immediately and instead dropped after GC TTL.

These notices will print when using the cockroach cli.

These notices can be disabled using the cluster setting
`sql.notices.enabled = false`.