### PR TITLE
colexec: fix null handling in sort chunks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -833,7 +833,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/sort.eg.go \
   pkg/sql/colexec/substring.eg.go \
   pkg/sql/colexec/sum_agg.eg.go \
-  pkg/sql/colexec/tuples_differ.eg.go \
+  pkg/sql/colexec/values_differ.eg.go \
   pkg/sql/colexec/vec_comparators.eg.go \
   pkg/sql/colexec/window_peer_grouper.eg.go
 
@@ -1531,7 +1531,7 @@ pkg/sql/colexec/selection_ops.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
 pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
 pkg/sql/colexec/substring.eg.go: pkg/sql/colexec/substring_tmpl.go
 pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
-pkg/sql/colexec/tuples_differ.eg.go: pkg/sql/colexec/tuples_differ_tmpl.go
+pkg/sql/colexec/values_differ.eg.go: pkg/sql/colexec/values_differ_tmpl.go
 pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go
 pkg/sql/colexec/window_peer_grouper.eg.go: pkg/sql/colexec/window_peer_grouper_tmpl.go
 

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -34,6 +34,6 @@ select_in.eg.go
 sort.eg.go
 substring.eg.go
 sum_agg.eg.go
-tuples_differ.eg.go
+values_differ.eg.go
 vec_comparators.eg.go
 window_peer_grouper.eg.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-func genTuplesDiffer(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/tuples_differ_tmpl.go")
+func genValuesDiffer(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/colexec/values_differ_tmpl.go")
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func genTuplesDiffer(wr io.Writer) error {
 	s = replaceManipulationFuncs(".LTyp", s)
 
 	// Now, generate the op, from the template.
-	tmpl, err := template.New("tuples_differ").Parse(s)
+	tmpl, err := template.New("values_differ").Parse(s)
 	if err != nil {
 		return err
 	}
@@ -47,5 +47,5 @@ func genTuplesDiffer(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genTuplesDiffer, "tuples_differ.eg.go")
+	registerGenerator(genValuesDiffer, "values_differ.eg.go")
 }

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -354,8 +354,8 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 	seed := rand.Int()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	nRuns := 5
-	nRows := 100
-	maxCols := 5
+	nRows := 3 / 2 * coldata.BatchSize()
+	maxCols := 3
 	maxNum := 10
 	intTyps := make([]types.T, maxCols)
 	for i := range intTyps {
@@ -409,8 +409,8 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 						forceDiskSpill: spillForced,
 					}
 					if err := verifyColOperator(args); err != nil {
-						fmt.Printf("--- seed = %d spillForced = %t nCols = %d matchLen = %d ---\n",
-							seed, spillForced, nCols, matchLen)
+						fmt.Printf("--- seed = %d spillForced = %t orderingCols = %v matchLen = %d run = %d ---\n",
+							seed, spillForced, orderingCols, matchLen, run)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
 						prettyPrintInput(rows, inputTypes, "t" /* tableName */)
 						t.Fatal(err)


### PR DESCRIPTION
Previously, `tuplesDiffer` function (which checks whether a value in one
colvec differs from a value in another colvec) didn't pay attention to
NULLs which is wrong. This could cause sortChunksOp to incorrectly find
the boundaries of the chunks. Now this is fixed, as well as
`tuples_differ` has been renamed to `values_differ` as it describes it
better. The likelihood of such occurrence is very low, and out tests
never caught this (I believe eventually it would have since we now
randomize coldata.BatchSize) due to fixed number of rows with which we
had only a single input batch.

Release note (bug fix): Previously, CockroachDB could incorrectly order
data with NULL values in the ordering columns in some edge cases, and
now this has been fixed.