### PR TITLE
roachtest: point hibernate test to use new fork

### DIFF
--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -44,9 +44,9 @@ func registerHibernate(r *testRegistry) {
 
 		// TODO(rafi): Once our fork is merged into the main repo, go back to
 		// fetching the latest tag. For now, always use the
-		// `HHH-13724-cockroachdb-support` branch, where we are building the
+		// `HHH-13724-cockroachdb-dialects` branch, where we are building the
 		// dialect.
-		latestTag := "HHH-13724-cockroachdb-support"
+		latestTag := "HHH-13724-cockroachdb-dialects"
 		//t.Status("cloning hibernate and installing prerequisites")
 		//latestTag, err := repeatGetLatestTag(
 		//	ctx, c, "hibernate", "hibernate-orm", hibernateReleaseTagRegex,

--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -24,11 +24,7 @@ var hibernateBlacklists = blacklistsForVersion{
 // in the test log.
 var hibernateBlackList20_1 = blacklist{}
 
-var hibernateBlackList19_2 = blacklist{
-	"org.hibernate.jpa.test.criteria.QueryBuilderTest.testDateTimeFunctions":                           "31708",
-	"org.hibernate.jpa.test.query.NativeQueryOrdinalParametersTest.testCteNativeQueryOrdinalParameter": "38636",
-	"org.hibernate.test.hql.ASTParserLoadingTest.testStandardFunctions":                                "31708",
-}
+var hibernateBlackList19_2 = blacklist{}
 
 var hibernateBlackList19_1 = blacklist{
 	"org.hibernate.jpa.test.criteria.QueryBuilderTest.testDateTimeFunctions":                                                                               "31708",


### PR DESCRIPTION
This uses a new branch that contains the latest work for the CockroachDB
dialect.

Release note: None