### PR TITLE
colexec: fix simpleProjectOp in some cases

### DIFF
--- a/pkg/sql/colexec/simple_project_test.go
+++ b/pkg/sql/colexec/simple_project_test.go
@@ -11,6 +11,7 @@
 package colexec
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -78,4 +79,39 @@ func TestSimpleProjectOp(t *testing.T) {
 		projectOp := NewSimpleProjectOp(input, len(typs), []uint32{0, 1})
 		require.IsType(t, input, projectOp)
 	})
+}
+
+// TestSimpleProjectOpWithUnorderedSynchronizer sets up the following
+// structure:
+//
+//  input 1 --
+//            | --> unordered synchronizer --> simpleProjectOp --> constInt64Op
+//  input 2 --
+//
+// and makes sure that the output is as expected. The idea is to test
+// simpleProjectOp in case when it receives multiple "different internally"
+// batches. See #45686 for detailed discussion.
+func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	inputTypes := []coltypes.T{coltypes.Bytes, coltypes.Float64}
+	constVal := int64(42)
+	var wg sync.WaitGroup
+	inputTuples := []tuples{
+		{{"a", 1.0}, {"aa", 10.0}},
+		{{"b", 2.0}, {"bb", 20.0}},
+	}
+	expected := tuples{
+		{"a", constVal},
+		{"aa", constVal},
+		{"b", constVal},
+		{"bb", constVal},
+	}
+	runTestsWithoutAllNullsInjection(t, inputTuples, [][]coltypes.T{inputTypes, inputTypes}, expected,
+		unorderedVerifier, func(inputs []Operator) (Operator, error) {
+			var input Operator
+			input = NewParallelUnorderedSynchronizer(inputs, inputTypes, &wg)
+			input = NewSimpleProjectOp(input, len(inputTypes), []uint32{0})
+			return NewConstOp(testAllocator, input, coltypes.Int64, constVal, 1)
+		})
+	wg.Wait()
 }

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -453,8 +453,6 @@ func runTestsWithoutAllNullsInjection(
 func runTestsWithFn(
 	t *testing.T, tups []tuples, typs [][]coltypes.T, test func(t *testing.T, inputs []Operator),
 ) {
-	rng, _ := randutil.NewPseudoRand()
-
 	// Run tests over batchSizes of 1, (sometimes) a batch size that is small but
 	// greater than 1, and a full coldata.BatchSize().
 	batchSizes := make([]int, 0, 3)
@@ -475,6 +473,7 @@ func runTestsWithFn(
 						if typs != nil {
 							inputTypes = typs[i]
 						}
+						rng, _ := randutil.NewPseudoRand()
 						inputSources[i] = newOpTestSelInput(rng, batchSize, tup, inputTypes)
 					}
 				} else {


### PR DESCRIPTION
`simpleProjectOp` doesn't work well together with unordered
synchronizers (and possibly other components that can return
`coldata.Batch`es that point to different regions of memory). The
problem is that `simpleProjectOp` adds a `projectingBatch` wrapper on
top its input batch, but if "different internally" batches come in, the
wrapper is not updated/reset. Now this is fixed by tracking different
input batches and having a separate `projectingBatch` for them.

Fixes: #45686.

Release note (bug fix): Previously, an internal error could occur in
CockroachDB when executing queries via the vectorized engine in queries
that contained unordered synchronizers, and now this has been fixed.