### PR TITLE
colexec: plan multiple window functions in the same query

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -140,6 +140,8 @@ type NewColOperatorResult struct {
 	BufferingOpMemAccounts []*mon.BoundAccount
 }
 
+const noFilterIdx = -1
+
 // isSupported checks whether we have a columnar operator equivalent to a
 // processor described by spec. Note that it doesn't perform any other checks
 // (like validity of the number of inputs).
@@ -221,37 +223,41 @@ func isSupported(spec *execinfrapb.ProcessorSpec) (bool, error) {
 		return true, nil
 
 	case core.Windower != nil:
-		if len(core.Windower.WindowFns) != 1 {
-			return false, errors.Newf("only a single window function is currently supported")
-		}
-		wf := core.Windower.WindowFns[0]
-		if wf.Frame != nil &&
-			(wf.Frame.Mode != execinfrapb.WindowerSpec_Frame_RANGE ||
-				wf.Frame.Bounds.Start.BoundType != execinfrapb.WindowerSpec_Frame_UNBOUNDED_PRECEDING ||
-				(wf.Frame.Bounds.End != nil && wf.Frame.Bounds.End.BoundType != execinfrapb.WindowerSpec_Frame_CURRENT_ROW)) {
-			return false, errors.Newf("window functions with non-default window frames are not supported")
-		}
-		if wf.Func.AggregateFunc != nil {
-			return false, errors.Newf("aggregate functions used as window functions are not supported")
-		}
-		if len(core.Windower.PartitionBy) > 0 || len(wf.Ordering.Columns) > 0 {
-			// When we have non-empty PARTITION BY and ORDER BY clauses, we will need
-			// to plan a sorter which currently doesn't support operating on interval
-			// type.
-			inputTypes, err := typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
-			if err != nil {
-				return false, err
-			}
-			for _, t := range inputTypes {
-				if t == coltypes.Interval {
-					return false, errors.WithIssueLink(errors.Errorf("window functions involving interval type not supported"),
-						errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/45392"})
+		for _, wf := range core.Windower.WindowFns {
+			if wf.Frame != nil {
+				frame, err := wf.Frame.ConvertToAST()
+				if err != nil {
+					return false, err
+				}
+				if !frame.IsDefaultFrame() {
+					return false, errors.Newf("window functions with non-default window frames are not supported")
 				}
 			}
-		}
+			if wf.FilterColIdx != noFilterIdx {
+				return false, errors.Newf("window functions with FILTER clause are not supported")
+			}
+			if wf.Func.AggregateFunc != nil {
+				return false, errors.Newf("aggregate functions used as window functions are not supported")
+			}
+			if len(core.Windower.PartitionBy) > 0 || len(wf.Ordering.Columns) > 0 {
+				// When we have non-empty PARTITION BY and ORDER BY clauses, we will need
+				// to plan a sorter which currently doesn't support operating on interval
+				// type.
+				inputTypes, err := typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
+				if err != nil {
+					return false, err
+				}
+				for _, t := range inputTypes {
+					if t == coltypes.Interval {
+						return false, errors.WithIssueLink(errors.Errorf("window functions involving interval type not supported"),
+							errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/45392"})
+					}
+				}
+			}
 
-		if _, supported := SupportedWindowFns[*wf.Func.WindowFunc]; !supported {
-			return false, errors.Newf("window function %s is not supported", wf.String())
+			if _, supported := SupportedWindowFns[*wf.Func.WindowFunc]; !supported {
+				return false, errors.Newf("window function %s is not supported", wf.String())
+			}
 		}
 		return true, nil
 
@@ -883,107 +889,112 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 1); err != nil {
 				return result, err
 			}
-			wf := core.Windower.WindowFns[0]
-			input := inputs[0]
-			var typs []coltypes.T
-			typs, err = typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
-			if err != nil {
-				return result, err
-			}
-			tempColOffset, partitionColIdx := uint32(0), columnOmitted
-			peersColIdx := columnOmitted
 			memMonitorsPrefix := "window-"
-			windowFn := *wf.Func.WindowFunc
-			if len(core.Windower.PartitionBy) > 0 {
-				// TODO(yuzefovich): add support for hashing partitioner (probably by
-				// leveraging hash routers once we can distribute). The decision about
-				// which kind of partitioner to use should come from the optimizer.
-				partitionColIdx = int(wf.OutputColIdx)
-				input, err = NewWindowSortingPartitioner(
-					NewAllocator(ctx, streamingMemAccount), input, typs,
-					core.Windower.PartitionBy, wf.Ordering.Columns, int(wf.OutputColIdx),
-					func(input Operator, inputTypes []coltypes.T, orderingCols []execinfrapb.Ordering_Column) (Operator, error) {
-						return result.createDiskBackedSort(
-							ctx, flowCtx, args, input, inputTypes,
-							execinfrapb.Ordering{Columns: orderingCols},
-							0 /* matchLen */, spec.ProcessorID,
-							&execinfrapb.PostProcessSpec{}, memMonitorsPrefix)
-					},
-				)
-				// Window partitioner will append a boolean column.
-				tempColOffset++
-				typs = append(typs, coltypes.Bool)
-			} else {
-				if len(wf.Ordering.Columns) > 0 {
-					input, err = result.createDiskBackedSort(
-						ctx, flowCtx, args, input, typs, wf.Ordering, 0, /* matchLen */
-						spec.ProcessorID, &execinfrapb.PostProcessSpec{}, memMonitorsPrefix,
+			input := inputs[0]
+			result.ColumnTypes = spec.Input[0].ColumnTypes
+			// Most supported window functions can run in auto mode because they are
+			// streaming operators and internally they might use a sorter which can
+			// fall back to disk if needed.
+			canRunInAutoMode := true
+			for _, wf := range core.Windower.WindowFns {
+				var typs []coltypes.T
+				typs, err = typeconv.FromColumnTypes(result.ColumnTypes)
+				if err != nil {
+					return result, err
+				}
+				tempColOffset, partitionColIdx := uint32(0), columnOmitted
+				peersColIdx := columnOmitted
+				windowFn := *wf.Func.WindowFunc
+				if len(core.Windower.PartitionBy) > 0 {
+					// TODO(yuzefovich): add support for hashing partitioner (probably by
+					// leveraging hash routers once we can distribute). The decision about
+					// which kind of partitioner to use should come from the optimizer.
+					partitionColIdx = int(wf.OutputColIdx)
+					input, err = NewWindowSortingPartitioner(
+						NewAllocator(ctx, streamingMemAccount), input, typs,
+						core.Windower.PartitionBy, wf.Ordering.Columns, int(wf.OutputColIdx),
+						func(input Operator, inputTypes []coltypes.T, orderingCols []execinfrapb.Ordering_Column) (Operator, error) {
+							return result.createDiskBackedSort(
+								ctx, flowCtx, args, input, inputTypes,
+								execinfrapb.Ordering{Columns: orderingCols},
+								0 /* matchLen */, spec.ProcessorID,
+								&execinfrapb.PostProcessSpec{}, memMonitorsPrefix)
+						},
 					)
+					// Window partitioner will append a boolean column.
+					tempColOffset++
+					typs = append(typs, coltypes.Bool)
+				} else {
+					if len(wf.Ordering.Columns) > 0 {
+						input, err = result.createDiskBackedSort(
+							ctx, flowCtx, args, input, typs, wf.Ordering, 0, /* matchLen */
+							spec.ProcessorID, &execinfrapb.PostProcessSpec{}, memMonitorsPrefix,
+						)
+					}
 				}
-			}
-			if err != nil {
-				return result, err
-			}
-			if windowFnNeedsPeersInfo(*wf.Func.WindowFunc) {
-				peersColIdx = int(wf.OutputColIdx + tempColOffset)
-				input, err = NewWindowPeerGrouper(
-					NewAllocator(ctx, streamingMemAccount),
-					input, typs, wf.Ordering.Columns,
-					partitionColIdx, peersColIdx,
-				)
-				// Window peer grouper will append a boolean column.
-				tempColOffset++
-				typs = append(typs, coltypes.Bool)
-			}
-
-			switch windowFn {
-			case execinfrapb.WindowerSpec_ROW_NUMBER:
-				result.Op = NewRowNumberOperator(
-					NewAllocator(ctx, streamingMemAccount), input, int(wf.OutputColIdx+tempColOffset), partitionColIdx,
-				)
-			case execinfrapb.WindowerSpec_RANK, execinfrapb.WindowerSpec_DENSE_RANK:
-				result.Op, err = NewRankOperator(
-					NewAllocator(ctx, streamingMemAccount), input, windowFn, wf.Ordering.Columns,
-					int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx,
-				)
-			case execinfrapb.WindowerSpec_PERCENT_RANK, execinfrapb.WindowerSpec_CUME_DIST:
-				memAccount := streamingMemAccount
-				if !useStreamingMemAccountForBuffering {
-					memAccount = result.createBufferingMemAccount(ctx, flowCtx, "relative-rank")
+				if err != nil {
+					return result, err
 				}
-				result.Op, err = NewRelativeRankOperator(
-					NewAllocator(ctx, memAccount), input, typs, windowFn, wf.Ordering.Columns,
-					int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx,
-				)
-			default:
-				return result, errors.AssertionFailedf("window function %s is not supported", wf.String())
-			}
-
-			if tempColOffset > 0 {
-				// We want to project out temporary columns (which have indices in the
-				// range [wf.OutputColIdx, wf.OutputColIdx+tempColOffset)).
-				projection := make([]uint32, 0, wf.OutputColIdx+tempColOffset)
-				for i := uint32(0); i < wf.OutputColIdx; i++ {
-					projection = append(projection, i)
+				if windowFnNeedsPeersInfo(*wf.Func.WindowFunc) {
+					peersColIdx = int(wf.OutputColIdx + tempColOffset)
+					input, err = NewWindowPeerGrouper(
+						NewAllocator(ctx, streamingMemAccount),
+						input, typs, wf.Ordering.Columns,
+						partitionColIdx, peersColIdx,
+					)
+					// Window peer grouper will append a boolean column.
+					tempColOffset++
+					typs = append(typs, coltypes.Bool)
 				}
-				projection = append(projection, wf.OutputColIdx+tempColOffset)
-				result.Op = NewSimpleProjectOp(result.Op, int(wf.OutputColIdx+tempColOffset), projection)
-			}
 
-			_, returnType, err := execinfrapb.GetWindowFunctionInfo(wf.Func, []types.T{}...)
-			if err != nil {
-				return result, err
+				switch windowFn {
+				case execinfrapb.WindowerSpec_ROW_NUMBER:
+					result.Op = NewRowNumberOperator(
+						NewAllocator(ctx, streamingMemAccount), input, int(wf.OutputColIdx+tempColOffset), partitionColIdx,
+					)
+				case execinfrapb.WindowerSpec_RANK, execinfrapb.WindowerSpec_DENSE_RANK:
+					result.Op, err = NewRankOperator(
+						NewAllocator(ctx, streamingMemAccount), input, windowFn, wf.Ordering.Columns,
+						int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx,
+					)
+				case execinfrapb.WindowerSpec_PERCENT_RANK, execinfrapb.WindowerSpec_CUME_DIST:
+					memAccount := streamingMemAccount
+					if !useStreamingMemAccountForBuffering {
+						memAccount = result.createBufferingMemAccount(ctx, flowCtx, memMonitorsPrefix+"relative-rank")
+					}
+					result.Op, err = NewRelativeRankOperator(
+						NewAllocator(ctx, memAccount), input, typs, windowFn, wf.Ordering.Columns,
+						int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx,
+					)
+					// Relative rank operators are buffering operators, and currently
+					// they don't support falling back to disk, so we cannot run such
+					// plan in 'auto' mode.
+					// TODO(yuzefovich): add spilling to disk for percent_rank and
+					// cume_dist.
+					canRunInAutoMode = false
+				default:
+					return result, errors.AssertionFailedf("window function %s is not supported", wf.String())
+				}
+
+				if tempColOffset > 0 {
+					// We want to project out temporary columns (which have indices in the
+					// range [wf.OutputColIdx, wf.OutputColIdx+tempColOffset)).
+					projection := make([]uint32, 0, wf.OutputColIdx+tempColOffset)
+					for i := uint32(0); i < wf.OutputColIdx; i++ {
+						projection = append(projection, i)
+					}
+					projection = append(projection, wf.OutputColIdx+tempColOffset)
+					result.Op = NewSimpleProjectOp(result.Op, int(wf.OutputColIdx+tempColOffset), projection)
+				}
+
+				_, returnType, err := execinfrapb.GetWindowFunctionInfo(wf.Func, []types.T{}...)
+				if err != nil {
+					return result, err
+				}
+				result.ColumnTypes = append(result.ColumnTypes, *returnType)
+				input = result.Op
 			}
-			result.ColumnTypes = append(spec.Input[0].ColumnTypes, *returnType)
-			if windowFn != execinfrapb.WindowerSpec_PERCENT_RANK &&
-				windowFn != execinfrapb.WindowerSpec_CUME_DIST {
-				// Window functions can run in auto mode because they are streaming
-				// operators (except for percent_rank and cume_dist) and internally
-				// they might use a sorter which can fall back to disk if needed.
-				result.CanRunInAutoMode = true
-				// TODO(yuzefovich): add spilling to disk for percent_rank and
-				// cume_dist.
-			}
+			result.CanRunInAutoMode = canRunInAutoMode
 
 		default:
 			return result, errors.Newf("unsupported processor core %q", core)

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -28,6 +28,12 @@ type windowFnTestCase struct {
 	windowerSpec execinfrapb.WindowerSpec
 }
 
+func (tc *windowFnTestCase) init() {
+	for i := range tc.windowerSpec.WindowFns {
+		tc.windowerSpec.WindowFns[i].FilterColIdx = noFilterIdx
+	}
+}
+
 func TestWindowFunctions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -244,6 +250,7 @@ func TestWindowFunctions(t *testing.T) {
 		},
 	} {
 		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, func(inputs []Operator) (Operator, error) {
+			tc.init()
 			ct := make([]types.T, len(tc.tuples[0]))
 			for i := range ct {
 				ct[i] = *types.Int

--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -13,7 +13,8 @@ INSERT INTO t VALUES
 statement ok
 SET vectorize=experimental_always
 
-# We sort the output on all queries to get deterministic results.
+# We sort the output on all queries with row_number window function to get
+# deterministic results.
 query III
 SELECT a, b, row_number() OVER (ORDER BY a, b) FROM t ORDER BY a, b
 ----
@@ -38,50 +39,83 @@ SELECT a, b, row_number() OVER (PARTITION BY a, b) FROM t ORDER BY a, b
 1 1 1
 1 2 1
 
-query III
-SELECT a, b, rank() OVER () FROM t ORDER BY a, b
+query III rowsort
+SELECT a, b, rank() OVER () FROM t
 ----
 0 1 1
 0 2 1
 1 1 1
 1 2 1
 
-query III
-SELECT a, b, rank() OVER (ORDER BY a) FROM t ORDER BY a, b
+query III rowsort
+SELECT a, b, rank() OVER (ORDER BY a) FROM t
 ----
 0 1 1
 0 2 1
 1 1 3
 1 2 3
 
-query IIII
-SELECT a, b, c, rank() OVER (PARTITION BY a ORDER BY c) FROM t ORDER BY a, b
+query IIII rowsort
+SELECT a, b, c, rank() OVER (PARTITION BY a ORDER BY c) FROM t
 ----
 0 1 0 1
 0 2 2 2
 1 1 1 1
 1 2 3 2
 
-query III
-SELECT a, b, dense_rank() OVER () FROM t ORDER BY a, b
+query III rowsort
+SELECT a, b, dense_rank() OVER () FROM t
 ----
 0 1 1
 0 2 1
 1 1 1
 1 2 1
 
-query III
-SELECT a, b, dense_rank() OVER (ORDER BY a) FROM t ORDER BY a, b
+query III rowsort
+SELECT a, b, dense_rank() OVER (ORDER BY a) FROM t
 ----
 0 1 1
 0 2 1
 1 1 2
 1 2 2
 
-query IIII
-SELECT a, b, c, dense_rank() OVER (PARTITION BY a ORDER BY c) FROM t ORDER BY a, b
+query IIII rowsort
+SELECT a, b, c, dense_rank() OVER (PARTITION BY a ORDER BY c) FROM t
 ----
 0 1 0 1
 0 2 2 2
 1 1 1 1
 1 2 3 2
+
+query IIIIRR rowsort
+SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dist() OVER w FROM t WINDOW w AS ()
+----
+0  1  1  1  0  1
+1  1  1  1  0  1
+0  2  1  1  0  1
+1  2  1  1  0  1
+
+query IIIIRR rowsort
+SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dist() OVER w FROM t WINDOW w AS (PARTITION BY a)
+----
+0  1  1  1  0  1
+0  2  1  1  0  1
+1  1  1  1  0  1
+1  2  1  1  0  1
+
+
+query IIIIRR rowsort
+SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dist() OVER w FROM t WINDOW w AS (ORDER BY a)
+----
+0  1  1  1  0                  0.5
+0  2  1  1  0                  0.5
+1  1  3  2  0.666666666666667  1
+1  2  3  2  0.666666666666667  1
+
+query IIIIRR rowsort
+SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dist() OVER w FROM t WINDOW w AS (PARTITION BY a ORDER BY b)
+----
+0  1  1  1  0  0.5
+0  2  2  2  1  1
+1  1  1  1  0  0.5
+1  2  2  2  1  1

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -554,7 +554,7 @@ func (w *windower) processPartition(
 		frameRun.Rows = partition
 		frameRun.RowIdx = 0
 
-		if !frameRun.IsDefaultFrame() {
+		if !frameRun.Frame.IsDefaultFrame() {
 			// We have a custom frame not equivalent to default one, so if we have
 			// an aggregate function, we want to reset it for each row. Not resetting
 			// is an optimization since we're not computing the result over the whole

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -197,7 +197,7 @@ func NewAggregateWindowFunc(
 func (w *aggregateWindowFunc) Compute(
 	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	if !wfr.FirstInPeerGroup() && wfr.DefaultFrameExclusion() {
+	if !wfr.FirstInPeerGroup() && wfr.Frame.DefaultFrameExclusion() {
 		return w.peerRes, nil
 	}
 
@@ -294,7 +294,7 @@ func (w *framableAggregateWindowFunc) Compute(
 	if err != nil {
 		return nil, err
 	}
-	if !wfr.FirstInPeerGroup() && wfr.DefaultFrameExclusion() {
+	if !wfr.FirstInPeerGroup() && wfr.Frame.DefaultFrameExclusion() {
 		// The concept of window framing takes precedence over the concept of
 		// peers - although we calculated the result for one of the peers of the
 		// current row, it is possible for that peer to have a different window
@@ -758,7 +758,7 @@ func (nthValueWindow) Compute(
 	var idx int
 	// Note that we do not need to check whether a filter is present because
 	// filters are only supported for aggregate functions.
-	if wfr.DefaultFrameExclusion() {
+	if wfr.Frame.DefaultFrameExclusion() {
 		// We subtract 1 because nth is counting from 1.
 		idx = frameStartIdx + nth - 1
 	} else {

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -107,7 +107,7 @@ func (w *slidingWindowFunc) Compute(
 		return nil, err
 	}
 
-	if !wfr.DefaultFrameExclusion() {
+	if !wfr.Frame.DefaultFrameExclusion() {
 		// We cannot use a sliding window approach because we have a frame
 		// exclusion clause - some rows will be in and out of the frame which
 		// breaks the necessary assumption, so we fallback to a naive quadratic
@@ -272,7 +272,7 @@ func (w *slidingWindowSumFunc) Compute(
 	if err != nil {
 		return nil, err
 	}
-	if !wfr.DefaultFrameExclusion() {
+	if !wfr.Frame.DefaultFrameExclusion() {
 		// We cannot use a sliding window approach because we have a frame
 		// exclusion clause - some rows will be in and out of the frame which
 		// breaks the necessary assumption, so we fallback to a naive quadratic


### PR DESCRIPTION
Previously, we would plan only a single window function in the query.
The planning code has been extended to support multiple ones. The check
whether `core.Windower` is supported by the vectorized engine has been
simplified (and a missing check for absence of FILTER clause has been
added).

Release note: None