### PR TITLE
vendor: bump pebble to ac12b8c4710711ab357d5e1470388038ccd80868

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dc54789e0f16728ed007c85d9db76bcbe4ecafb08ceda930cc1deea2197a0609"
+  digest = "1:1a59b2fe33f59e254d0b8a3a29ee321798bbaa1f31800a40b784206585ea56df"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -498,7 +498,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "488fb5bfea764c8ba7f77b279d4faf6724939839"
+  revision = "ac12b8c4710711ab357d5e1470388038ccd80868"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
* internal/cache: remove "weak" values
* internal/cache: move weak cache blocks out of the Go heap
* internal/rangedel: replace iterator with base.InternalIterator
* tool: enhance db check
* internal/iterator: Add fmt.Stringer to InternalIterator
* db: add level to levelIter
* build: add go1.14.x build

Release note: None