### PR TITLE
util/log: make SecondaryLogger a Closer and do the right thing

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -789,6 +789,10 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 
 	ctx := context.Background()
 
+	if err := checkTzDatabaseAvailability(ctx); err != nil {
+		return err
+	}
+
 	c, err := setupTransientCluster(ctx, cmd, gen)
 	defer c.cleanup()
 	if err != nil {
@@ -834,8 +838,6 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 #
 `, c.s.AdminURL())
 	}
-
-	checkTzDatabaseAvailability(ctx)
 
 	conn := makeSQLConn(c.connURL)
 	defer conn.Close()

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -52,10 +53,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
@@ -583,7 +584,9 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	// Until/unless CockroachDB embeds its own tz database, we want
 	// an early sanity check. It's better to inform the user early
 	// than to get surprising errors during SQL queries.
-	checkTzDatabaseAvailability(ctx)
+	if err := checkTzDatabaseAvailability(ctx); err != nil {
+		return errors.Wrap(err, "failed to initialize node")
+	}
 
 	// ReadyFn will be called when the server has started listening on
 	// its network sockets, but perhaps before it has done bootstrapping
@@ -1041,13 +1044,33 @@ func clientFlagsRPC() string {
 	return strings.Join(flags, " ")
 }
 
-func checkTzDatabaseAvailability(ctx context.Context) {
+func checkTzDatabaseAvailability(ctx context.Context) error {
 	if _, err := timeutil.LoadLocation("America/New_York"); err != nil {
-		log.Shout(ctx, log.Severity_ERROR,
-			"unable to load named time zones, time zone support will be degraded.\n"+
-				"Hint: check that the time zone database is installed on your system, or\n"+
+		log.Errorf(ctx, "timeutil.LoadLocation: %v", err)
+		reportedErr := errors.WithHint(
+			errors.WithIssueLink(
+				errors.New("unable to load named timezones"),
+				errors.IssueLink{IssueURL: unimplemented.MakeURL(36864)}),
+			"Check that the time zone database is installed on your system, or\n"+
 				"set the ZONEINFO environment variable to a Go time zone .zip archive.")
+
+		if envutil.EnvOrDefaultBool("COCKROACH_INCONSISTENT_TIME_ZONES", false) {
+			// The user tells us they really know what they want.
+			reportedErr := &formattedError{err: reportedErr}
+			log.Shout(ctx, log.Severity_WARNING, reportedErr.Error())
+		} else {
+			// Prevent a successful start.
+			//
+			// In the past, we were simply using log.Shout to emit an error,
+			// informing the user that startup could continue with degraded
+			// behavior.  However, usage demonstrated that users typically do
+			// not see the error and instead run into silently incorrect SQL
+			// results. To avoid this situation altogether, it's better to
+			// stop early.
+			return reportedErr
+		}
 	}
+	return nil
 }
 
 func reportConfiguration(ctx context.Context) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -772,6 +772,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			internalExecutor,
 		),
 
+		// Note: don't forget to add the secondary loggers as closers
+		// on the Stopper, below.
+
 		ExecLogger: log.NewSecondaryLogger(
 			loggerCtx, nil /* dirName */, "sql-exec",
 			true /* enableGc */, false /*forceSyncWrites*/, true, /* enableMsgCount */
@@ -790,6 +793,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		QueryCache:                 querycache.New(s.cfg.SQLQueryCacheSize),
 		ProtectedTimestampProvider: s.protectedtsProvider,
 	}
+
+	s.stopper.AddCloser(execCfg.ExecLogger)
+	s.stopper.AddCloser(execCfg.AuditLogger)
+	s.stopper.AddCloser(execCfg.SlowQueryLogger)
 
 	if sqlSchemaChangerTestingKnobs := s.cfg.TestingKnobs.SQLSchemaChanger; sqlSchemaChangerTestingKnobs != nil {
 		execCfg.SchemaChangerTestingKnobs = sqlSchemaChangerTestingKnobs.(*sql.SchemaChangerTestingKnobs)

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -329,10 +329,12 @@ var pebbleLog *log.SecondaryLogger
 
 // InitPebbleLogger initializes the logger to use for Pebble log messages. If
 // not called, WARNING, ERROR, and FATAL logs will be output to the normal
-// CockroachDB log.
-func InitPebbleLogger(ctx context.Context) {
+// CockroachDB log. The caller is responsible for ensuring the
+// Close() method is eventually called on the new logger.
+func InitPebbleLogger(ctx context.Context) *log.SecondaryLogger {
 	pebbleLog = log.NewSecondaryLogger(ctx, nil, "pebble",
 		true /* enableGC */, false /* forceSyncWrites */, false /* enableMsgCount */)
+	return pebbleLog
 }
 
 type pebbleLogger struct {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -84,10 +84,12 @@ var rocksdbLogger *log.SecondaryLogger
 
 // InitRocksDBLogger initializes the logger to use for RocksDB log messages. If
 // not called, WARNING, ERROR, and FATAL logs will be output to the normal
-// CockroachDB log.
-func InitRocksDBLogger(ctx context.Context) {
+// CockroachDB log. The caller is responsible for ensuring the
+// Close() method is eventually called on the new logger.
+func InitRocksDBLogger(ctx context.Context) *log.SecondaryLogger {
 	rocksdbLogger = log.NewSecondaryLogger(ctx, nil, "rocksdb",
 		true /* enableGC */, false /* forceSyncWrites */, false /* enableMsgCount */)
+	return rocksdbLogger
 }
 
 //export rocksDBLog

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -77,7 +77,7 @@ func unimplementedInternal(
 	// Create the issue link.
 	link := errors.IssueLink{Detail: detail}
 	if issue > 0 {
-		link.IssueURL = makeURL(issue)
+		link.IssueURL = MakeURL(issue)
 	}
 
 	// Instantiate the base error.
@@ -108,6 +108,7 @@ func unimplementedInternal(
 	return err
 }
 
-func makeURL(issue int) string {
+// MakeURL produces a URL to a CockroachDB issue.
+func MakeURL(issue int) string {
 	return fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", issue)
 }

--- a/pkg/util/errorutil/unimplemented/unimplemented_test.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented_test.go
@@ -50,7 +50,7 @@ func TestUnimplemented(t *testing.T) {
 				}
 				if test.expIssue != 0 {
 					ref := fmt.Sprintf("%s\nSee: %s",
-						errors.UnimplementedErrorHint, makeURL(test.expIssue))
+						errors.UnimplementedErrorHint, MakeURL(test.expIssue))
 					if hint == ref {
 						found |= 2
 					}
@@ -79,7 +79,7 @@ func TestUnimplemented(t *testing.T) {
 				}
 
 				if test.expIssue != 0 {
-					url := makeURL(test.expIssue)
+					url := MakeURL(test.expIssue)
 					if links[0].IssueURL != url {
 						t.Errorf("expected link url %q, got %q", url, links[0].IssueURL)
 					}

--- a/pkg/util/log/log_gc_test.go
+++ b/pkg/util/log/log_gc_test.go
@@ -54,6 +54,7 @@ func TestSecondaryGC(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	l := NewSecondaryLogger(ctx, &tmpDirName, "woo", false /*enableGc*/, false /*syncWrites*/, true /*msgCount*/)
+	defer l.Close()
 
 	testLogGC(t, &l.logger, l.Logf)
 }

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -35,6 +35,7 @@ func TestSecondaryLog(t *testing.T) {
 
 	// Make a new logger, in the same directory.
 	l := NewSecondaryLogger(ctx, &mainLog.logDir, "woo", true, false, true)
+	defer l.Close()
 
 	// Interleave some messages.
 	Infof(context.Background(), "test1")
@@ -88,6 +89,7 @@ func TestRedirectStderrWithSecondaryLoggersActive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	l := NewSecondaryLogger(ctx, &mainLog.logDir, "woo", true, false, true)
+	defer l.Close()
 
 	// Log something on the secondary logger.
 	l.Logf(context.Background(), "test456")
@@ -125,6 +127,7 @@ func TestListLogFilesIncludeSecondaryLogs(t *testing.T) {
 
 	// Make a new logger, in the same directory.
 	l := NewSecondaryLogger(ctx, &mainLog.logDir, "woo", true, false, true)
+	defer l.Close()
 
 	// Emit some logging and ensure the files gets created.
 	l.Logf(ctx, "story time")


### PR DESCRIPTION
Fixes #45641.

Previously, secondary loggers would leak in the global registry.
A previous patch of mine tried to improve the situation by
asynchronously de-registering loggers, but that was not good enough.
This patch fixes that by adding a `Close()` method to do the job.

Release note: None