### PR TITLE
sql: ensure that GRANT/REVOKE can only propagate allowed privs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -142,3 +142,19 @@ user testuser
 
 statement ok
 DROP DATABASE a CASCADE
+
+user root
+
+statement ok
+CREATE DATABASE d45697
+
+statement ok
+GRANT CREATE,GRANT ON DATABASE d45697 TO testuser
+
+user testuser
+
+statement ok
+GRANT CREATE ON DATABASE d45697 TO bar
+
+statement error user testuser does not have DROP privilege on database d45697
+GRANT DROP ON DATABASE d45697 TO bar

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -169,10 +169,16 @@ REVOKE SELECT ON t FROM testuser
 user testuser
 
 statement ok
-GRANT ALL ON t TO bar
+GRANT INSERT ON t TO bar
 
 statement ok
-REVOKE ALL ON t FROM bar
+REVOKE INSERT ON t FROM bar
+
+statement error user testuser does not have ALL privilege on relation t
+GRANT ALL ON t TO bar
+
+statement error user testuser does not have SELECT privilege on relation t
+GRANT SELECT ON t TO bar
 
 statement ok
 INSERT INTO t VALUES (1, 1), (2, 2)

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -107,16 +107,23 @@ SELECT * FROM privatedb.privatetable
 statement error user testuser does not have INSERT privilege on relation publictable
 INSERT INTO publicdb.publictable VALUES (1)
 
-# Give ourselves more permissions.
+user root
+
 statement ok
 GRANT INSERT ON publicdb.publictable TO public
+
+user testuser
 
 statement ok
 INSERT INTO publicdb.publictable VALUES (1)
 
+user root
+
 # Revoke public access.
 statement ok
 REVOKE ALL ON publicdb.publictable FROM public
+
+user testuser
 
 statement error user testuser does not have SELECT privilege on relation publictable
 SELECT * FROM publicdb.publictable

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -184,16 +184,17 @@ SELECT * FROM (SELECT * FROM generate_series(1, 2)) a FOR UPDATE
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v int)
 
-statement ok
-GRANT GRANT on t to testuser
-
 user testuser
 
 statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
 
+user root
+
 statement ok
 GRANT SELECT ON t TO testuser
+
+user testuser
 
 statement ok
 SELECT * FROM t
@@ -204,8 +205,12 @@ SELECT * FROM t FOR UPDATE
 statement error pgcode 42501 user testuser does not have UPDATE privilege on relation t
 SELECT * FROM t FOR SHARE
 
+user root
+
 statement ok
 GRANT UPDATE ON t TO testuser
+
+user testuser
 
 statement ok
 SELECT * FROM t FOR UPDATE

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -419,20 +419,19 @@ ALTER DATABASE system RENAME TO not_system
 statement error user root does not have DROP privilege on database system
 DROP DATABASE system
 
-# Users cannot exceed allowed privileges on system objects.
-statement error user testuser must not have ALL privileges on system object with ID=.*
+statement error user root does not have ALL privilege on database system
 GRANT ALL ON DATABASE system TO testuser
 
-statement error user testuser must not have INSERT privileges on system object with ID=.*
+statement error user root does not have INSERT privilege on database system
 GRANT GRANT, SELECT, INSERT ON DATABASE system TO testuser
 
 statement ok
 GRANT GRANT, SELECT ON DATABASE system TO testuser
 
-statement error user testuser must not have ALL privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation namespace
 GRANT ALL ON system.namespace TO testuser
 
-statement error user testuser must not have INSERT privileges on system object with ID=.*
+statement error user root does not have INSERT privilege on relation namespace
 GRANT GRANT, SELECT, INSERT ON system.namespace TO testuser
 
 statement ok
@@ -442,19 +441,19 @@ statement ok
 GRANT SELECT ON system.descriptor TO testuser
 
 # Superusers must have exactly the allowed privileges.
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have ALL privilege on database system
 GRANT ALL ON DATABASE system TO root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have DELETE privilege on database system
 GRANT DELETE, INSERT ON DATABASE system TO root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation namespace
 GRANT ALL ON system.namespace TO root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have DELETE privilege on relation descriptor
 GRANT DELETE, INSERT ON system.descriptor TO root
 
-statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation descriptor
 GRANT ALL ON system.descriptor TO root
 
 statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
@@ -463,23 +462,32 @@ REVOKE GRANT ON DATABASE system FROM root
 statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 REVOKE GRANT ON system.namespace FROM root
 
-statement error user root does not have privileges
+statement error user root does not have ALL privilege on relation namespace
 REVOKE ALL ON system.namespace FROM root
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have privileges over system object with ID=.*
+REVOKE GRANT,SELECT ON system.namespace FROM root
+
+statement error user root does not have ALL privilege on database system
 GRANT ALL ON DATABASE system TO admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have DELETE privilege on database system
 GRANT DELETE, INSERT ON DATABASE system TO admin
 
 statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+REVOKE GRANT ON DATABASE system FROM admin
+
+statement error user root does not have ALL privilege on relation namespace
 GRANT ALL ON system.namespace TO admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have DELETE privilege on relation descriptor
 GRANT DELETE, INSERT ON system.descriptor TO admin
 
-statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation descriptor
 GRANT ALL ON system.descriptor TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+REVOKE GRANT ON system.descriptor FROM admin
 
 statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
 REVOKE GRANT ON DATABASE system FROM admin
@@ -487,31 +495,34 @@ REVOKE GRANT ON DATABASE system FROM admin
 statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
 REVOKE GRANT ON system.namespace FROM admin
 
-statement error user admin does not have privileges
+statement error user root does not have ALL privilege on relation namespace
 REVOKE ALL ON system.namespace FROM admin
+
+statement error user admin does not have privileges over system object with ID=.*
+REVOKE GRANT,SELECT ON system.namespace FROM admin
 
 # Some tables (we test system.lease here) used to allow multiple privilege sets for
 # backwards compatibility, and superusers were allowed very wide privileges.
 # We make sure this is no longer the case.
-statement error user testuser must not have ALL privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation lease
 GRANT ALL ON system.lease TO testuser
 
-statement error user root must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+statement error user root does not have CREATE privilege on relation lease
 GRANT CREATE on system.lease to root
 
-statement error user admin must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+statement error user root does not have CREATE privilege on relation lease
 GRANT CREATE on system.lease to admin
 
-statement error user testuser must not have CREATE privileges on system object with ID=.*
+statement error user root does not have CREATE privilege on relation lease
 GRANT CREATE on system.lease to testuser
 
-statement error user root must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation lease
 GRANT ALL ON system.lease TO root
 
-statement error user admin must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation lease
 GRANT ALL ON system.lease TO admin
 
-statement error user testuser must not have ALL privileges on system object with ID=.*
+statement error user root does not have ALL privilege on relation lease
 GRANT ALL ON system.lease TO testuser
 
 # NB: the "order by" is necessary or this test is flaky under DistSQL.

--- a/pkg/sql/sqlbase/privilege.go
+++ b/pkg/sql/sqlbase/privilege.go
@@ -271,7 +271,7 @@ func (p PrivilegeDescriptor) validateRequiredSuperuser(
 ) error {
 	superPriv, ok := p.findUser(user)
 	if !ok {
-		return fmt.Errorf("user %s does not have privileges", user)
+		return fmt.Errorf("user %s does not have privileges over system object with ID=%d", user, id)
 	}
 
 	// The super users must match the allowed privilege set exactly.


### PR DESCRIPTION
Fixes #45211.

Previously, a user with the GRANT bit on a descriptor was, in effect,
super-user on that descriptor - they could use the GRANT bit
to grant themselves and anyone else very other privilege bits.

This was a mis-design; the idea of GRANT is to only propagate
bits that the user already have on the privilege.
This patch fixes it.

Release note (security update): The GRANT bit on database/table
descriptors was previously, effectively but unintendedly, an "admin"
bit: it could be used to grant any other bit to any user, even to the
requesting user. This has been changed to become more like a
capability-based system: the GRANT bit can only propagate other
privileges that the requesting user already has. Note that
the pseudo-privilege `ALL` includes GRANT, so `GRANT ALL` in effect
preserves the previous behavior: it grants GRANT and every over
privileges, so all privileges can be re-granted transitively.

Release note (backward-incompatible change): The GRANT and REVOKE
statements now require that the requesting user already have the
target privileges themselves. For example, `GRANT SELECT ON t TO foo`
requires that the requesting user already have SELECT on `t`.