### PR TITLE
colexec: add distinct mode to hashTable

### DIFF
--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -157,56 +157,64 @@ func BenchmarkDistinct(b *testing.B) {
 	}
 	distinctNames := []string{"Unordered", "PartiallyOrdered", "Ordered"}
 	orderedColsFraction := []float64{0, 0.5, 1.0}
-	for _, newTupleProbability := range []float64{0.001, 0.01, 0.1} {
-		for _, nBatches := range []int{1 << 2, 1 << 6} {
-			for _, nCols := range []int{2, 4} {
-				typs := make([]coltypes.T, nCols)
-				for i := range typs {
-					typs[i] = coltypes.Int64
-				}
-				batch := testAllocator.NewMemBatch(typs)
-				batch.SetLength(coldata.BatchSize())
-				distinctCols := []uint32{0, 1, 2, 3}[:nCols]
-				// We have the following equation:
-				//   newTupleProbability = 1 - (1 - newValueProbability) ^ nCols,
-				// so applying some manipulations we get:
-				//   newValueProbability = 1 - (1 - newTupleProbability) ^ (1 / nCols).
-				newValueProbability := 1.0 - math.Pow(1-newTupleProbability, 1.0/float64(nCols))
-				for i := range distinctCols {
-					col := batch.ColVec(i).Int64()
-					col[0] = 0
-					for j := 1; j < coldata.BatchSize(); j++ {
-						col[j] = col[j-1]
-						if rng.Float64() < newValueProbability {
-							col[j]++
+	for _, hasNulls := range []bool{false, true} {
+		for _, newTupleProbability := range []float64{0.001, 0.01, 0.1} {
+			for _, nBatches := range []int{1 << 2, 1 << 6} {
+				for _, nCols := range []int{2, 4} {
+					typs := make([]coltypes.T, nCols)
+					for i := range typs {
+						typs[i] = coltypes.Int64
+					}
+					batch := testAllocator.NewMemBatch(typs)
+					batch.SetLength(coldata.BatchSize())
+					distinctCols := []uint32{0, 1, 2, 3}[:nCols]
+					// We have the following equation:
+					//   newTupleProbability = 1 - (1 - newValueProbability) ^ nCols,
+					// so applying some manipulations we get:
+					//   newValueProbability = 1 - (1 - newTupleProbability) ^ (1 / nCols).
+					newValueProbability := 1.0 - math.Pow(1-newTupleProbability, 1.0/float64(nCols))
+					for i := range distinctCols {
+						col := batch.ColVec(i).Int64()
+						col[0] = 0
+						for j := 1; j < coldata.BatchSize(); j++ {
+							col[j] = col[j-1]
+							if rng.Float64() < newValueProbability {
+								col[j]++
+							}
+						}
+						nulls := batch.ColVec(i).Nulls()
+						if hasNulls {
+							nulls.SetNull(0)
+						} else {
+							nulls.UnsetNulls()
 						}
 					}
-				}
-				for distinctIdx, distinctConstructor := range distinctConstructors {
-					numOrderedCols := int(float64(nCols) * orderedColsFraction[distinctIdx])
-					b.Run(
-						fmt.Sprintf("%s/newTupleProbability=%.3f/rows=%d/cols=%d/ordCols=%d",
-							distinctNames[distinctIdx], newTupleProbability,
-							nBatches*coldata.BatchSize(), nCols, numOrderedCols,
-						),
-						func(b *testing.B) {
-							b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
-							b.ResetTimer()
-							for n := 0; n < b.N; n++ {
-								// Note that the source will be ordered on all nCols so that the
-								// number of distinct tuples doesn't vary between different
-								// distinct operator variations.
-								source := newFiniteChunksSource(batch, nBatches, nCols)
-								distinct, err := distinctConstructor(testAllocator, source, distinctCols, numOrderedCols, typs)
-								if err != nil {
-									b.Fatal(err)
+					for distinctIdx, distinctConstructor := range distinctConstructors {
+						numOrderedCols := int(float64(nCols) * orderedColsFraction[distinctIdx])
+						b.Run(
+							fmt.Sprintf("%s/hasNulls=%v/newTupleProbability=%.3f/rows=%d/cols=%d/ordCols=%d",
+								distinctNames[distinctIdx], hasNulls, newTupleProbability,
+								nBatches*coldata.BatchSize(), nCols, numOrderedCols,
+							),
+							func(b *testing.B) {
+								b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+								b.ResetTimer()
+								for n := 0; n < b.N; n++ {
+									// Note that the source will be ordered on all nCols so that the
+									// number of distinct tuples doesn't vary between different
+									// distinct operator variations.
+									source := newFiniteChunksSource(batch, nBatches, nCols)
+									distinct, err := distinctConstructor(testAllocator, source, distinctCols, numOrderedCols, typs)
+									if err != nil {
+										b.Fatal(err)
+									}
+									distinct.Init()
+									for b := distinct.Next(ctx); b.Length() > 0; b = distinct.Next(ctx) {
+									}
 								}
-								distinct.Init()
-								for b := distinct.Next(ctx); b.Length() > 0; b = distinct.Next(ctx) {
-								}
-							}
-							b.StopTimer()
-						})
+								b.StopTimer()
+							})
+					}
 				}
 			}
 		}

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -36,17 +36,26 @@ func genHashTable(wr io.Writer) error {
 	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
 	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))
 
-	checkCol := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 7)
-	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "UseSel" $7}}`)
-
-	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 9)
+	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 12)
 	s = checkColBody.ReplaceAllString(
 		s,
-		`{{template "checkColBody" buildDict "Global" .Global "UseSel" .UseSel "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9}}`)
+		`{{template "checkColBody" buildDict "Global" .Global "UseProbeSel" .UseProbeSel "UseBuildSel" .UseBuildSel "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9 "SelectDistinct" $10}}`)
 
-	checkBody := makeFunctionRegex("_CHECK_BODY", 1)
+	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 8)
+	s = checkColWithNulls.ReplaceAllString(s,
+		`{{template "checkColWithNulls" buildDict "Global" . "UseProbeSel" $7 "UseBuildSel" $8}}`)
+
+	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 8)
+	s = checkColForDistinctWithNulls.ReplaceAllString(s,
+		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $7 "UseBuildSel" $8}}`)
+
+	checkBody := makeFunctionRegex("_CHECK_BODY", 3)
 	s = checkBody.ReplaceAllString(s,
-		`{{template "checkBody" buildDict "Global" . "IsHashTableInFullMode" $1}}`)
+		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $3}}`)
+
+	updateSelBody := makeFunctionRegex("_UPDATE_SEL_BODY", 4)
+	s = updateSelBody.ReplaceAllString(s,
+		`{{template "updateSelBody" buildDict "Global" . "UseSel" $4}}`)
 
 	s = replaceManipulationFuncs(".Global.LTyp", s)
 

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -31,12 +31,12 @@ func _COLLECT_PROBE_OUTER(
 ) int { // */}}
 	// {{define "collectProbeOuter" -}}
 	// Early bounds checks.
-	_ = hj.ht.headID[batchSize-1]
+	_ = hj.ht.probeScratch.headID[batchSize-1]
 	// {{if .UseSel}}
 	_ = sel[batchSize-1]
 	// {{end}}
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.headID[i]
+		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
 			if nResults >= hj.outputBatchSize {
@@ -61,7 +61,7 @@ func _COLLECT_PROBE_OUTER(
 			hj.probeState.probeIdx[nResults] = i
 			// {{end}}
 			currentID = hj.ht.same[currentID]
-			hj.ht.headID[i] = currentID
+			hj.ht.probeScratch.headID[i] = currentID
 			nResults++
 
 			if currentID == 0 {
@@ -80,12 +80,12 @@ func _COLLECT_PROBE_NO_OUTER(
 ) int { // */}}
 	// {{define "collectProbeNoOuter" -}}
 	// Early bounds checks.
-	_ = hj.ht.headID[batchSize-1]
+	_ = hj.ht.probeScratch.headID[batchSize-1]
 	// {{if .UseSel}}
 	_ = sel[batchSize-1]
 	// {{end}}
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.headID[i]
+		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
 			if nResults >= hj.outputBatchSize {
 				hj.probeState.prevBatch = batch
@@ -100,7 +100,7 @@ func _COLLECT_PROBE_NO_OUTER(
 			hj.probeState.probeIdx[nResults] = i
 			// {{end}}
 			currentID = hj.ht.same[currentID]
-			hj.ht.headID[i] = currentID
+			hj.ht.probeScratch.headID[i] = currentID
 			nResults++
 		}
 	}
@@ -115,12 +115,12 @@ func _COLLECT_LEFT_ANTI(
 ) int { // */}}
 	// {{define "collectLeftAnti" -}}
 	// Early bounds checks.
-	_ = hj.ht.headID[batchSize-1]
+	_ = hj.ht.probeScratch.headID[batchSize-1]
 	// {{if .UseSel}}
 	_ = sel[batchSize-1]
 	// {{end}}
 	for i := int(0); i < batchSize; i++ {
-		currentID := hj.ht.headID[i]
+		currentID := hj.ht.probeScratch.headID[i]
 		if currentID == 0 {
 			// currentID of 0 indicates that ith probing row didn't have a match, so
 			// we include it into the output.
@@ -141,7 +141,7 @@ func _COLLECT_LEFT_ANTI(
 func _DISTINCT_COLLECT_PROBE_OUTER(hj *hashJoiner, batchSize int, _USE_SEL bool) { // */}}
 	// {{define "distinctCollectProbeOuter" -}}
 	// Early bounds checks.
-	_ = hj.ht.groupID[batchSize-1]
+	_ = hj.ht.probeScratch.groupID[batchSize-1]
 	_ = hj.probeState.probeRowUnmatched[batchSize-1]
 	_ = hj.probeState.buildIdx[batchSize-1]
 	_ = hj.probeState.probeIdx[batchSize-1]
@@ -150,7 +150,7 @@ func _DISTINCT_COLLECT_PROBE_OUTER(hj *hashJoiner, batchSize int, _USE_SEL bool)
 	// {{end}}
 	for i := int(0); i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		id := hj.ht.groupID[i]
+		id := hj.ht.probeScratch.groupID[i]
 		rowUnmatched := id == 0
 		hj.probeState.probeRowUnmatched[i] = rowUnmatched
 		if !rowUnmatched {
@@ -169,16 +169,16 @@ func _DISTINCT_COLLECT_PROBE_OUTER(hj *hashJoiner, batchSize int, _USE_SEL bool)
 func _DISTINCT_COLLECT_PROBE_NO_OUTER(hj *hashJoiner, batchSize int, nResults int, _USE_SEL bool) { // */}}
 	// {{define "distinctCollectProbeNoOuter" -}}
 	// Early bounds checks.
-	_ = hj.ht.groupID[batchSize-1]
+	_ = hj.ht.probeScratch.groupID[batchSize-1]
 	_ = hj.probeState.buildIdx[batchSize-1]
 	_ = hj.probeState.probeIdx[batchSize-1]
 	// {{if .UseSel}}
 	_ = sel[batchSize-1]
 	// {{end}}
 	for i := int(0); i < batchSize; i++ {
-		if hj.ht.groupID[i] != 0 {
+		if hj.ht.probeScratch.groupID[i] != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			hj.probeState.buildIdx[nResults] = int(hj.ht.groupID[i] - 1)
+			hj.probeState.buildIdx[nResults] = int(hj.ht.probeScratch.groupID[i] - 1)
 			// {{if .UseSel}}
 			hj.probeState.probeIdx[nResults] = sel[i]
 			// {{else}}

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -24,9 +24,7 @@ import (
 	"fmt"
 	"math"
 
-	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	// */}}
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	// {{/*
@@ -68,32 +66,42 @@ func _CHECK_COL_BODY(
 	_PROBE_HAS_NULLS bool,
 	_BUILD_HAS_NULLS bool,
 	_ALLOW_NULL_EQUALITY bool,
+	_SELECT_DISTINCT bool,
+	_USE_PROBE_SEL bool,
+	_USE_BUILD_SEL bool,
 ) { // */}}
 	// {{define "checkColBody" -}}
 	probeIsNull := false
 	buildIsNull := false
 	// Early bounds check.
-	_ = ht.toCheck[nToCheck-1]
+	_ = ht.probeScratch.toCheck[nToCheck-1]
 	for i := uint64(0); i < nToCheck; i++ {
 		// keyID of 0 is reserved to represent the end of the next chain.
 
-		toCheck := ht.toCheck[i]
-		if keyID := ht.groupID[toCheck]; keyID != 0 {
+		toCheck := ht.probeScratch.toCheck[i]
+		keyID := ht.probeScratch.groupID[toCheck]
+		if keyID != 0 {
 			// the build table key (calculated using keys[keyID - 1] = key) is
 			// compared to the corresponding probe table to determine if a match is
 			// found.
 
-			// {{if .UseSel}}
-			selIdx := sel[toCheck]
+			// {{if .UseProbeSel}}
+			probeIdx := probeSel[toCheck]
 			// {{else}}
-			selIdx := int(toCheck)
+			probeIdx := int(toCheck)
 			// {{end}}
 			/* {{if .ProbeHasNulls }} */
-			probeIsNull = probeVec.Nulls().NullAt(selIdx)
+			probeIsNull = probeVec.Nulls().NullAt(probeIdx)
 			/* {{end}} */
 
+			// {{if .UseBuildSel}}
+			buildIdx := buildSel[keyID-1]
+			// {{else}}
+			buildIdx := int(keyID - 1)
+			// {{end}}
+
 			/* {{if .BuildHasNulls }} */
-			buildIsNull = buildVec.Nulls().NullAt(int(keyID - 1))
+			buildIsNull = buildVec.Nulls().NullAt(buildIdx)
 			/* {{end}} */
 
 			/* {{if .AllowNullEquality}} */
@@ -107,23 +115,30 @@ func _CHECK_COL_BODY(
 				// next value to check. This behavior is special in case of allowing
 				// null equality because we don't want to reset the groupID of the
 				// current probing tuple.
-				ht.differs[toCheck] = true
+				ht.probeScratch.differs[toCheck] = true
 				continue
 			}
 			/* {{end}} */
 			if probeIsNull {
-				ht.groupID[toCheck] = 0
+				ht.probeScratch.groupID[toCheck] = 0
 			} else if buildIsNull {
-				ht.differs[toCheck] = true
+				ht.probeScratch.differs[toCheck] = true
 			} else {
-				probeVal := execgen.UNSAFEGET(probeKeys, selIdx)
-				buildVal := execgen.UNSAFEGET(buildKeys, int(keyID-1))
+				probeVal := execgen.UNSAFEGET(probeKeys, probeIdx)
+				buildVal := execgen.UNSAFEGET(buildKeys, buildIdx)
 				var unique bool
 				_ASSIGN_NE(unique, probeVal, buildVal)
 
-				ht.differs[toCheck] = ht.differs[toCheck] || unique
+				ht.probeScratch.differs[toCheck] = ht.probeScratch.differs[toCheck] || unique
 			}
 		}
+
+		// {{if .SelectDistinct}}
+		if keyID == 0 {
+			ht.probeScratch.distinct[toCheck] = true
+		}
+		// {{end}}
+
 	}
 	// {{end}}
 	// {{/*
@@ -134,7 +149,8 @@ func _CHECK_COL_WITH_NULLS(
 	probeVec, buildVec coldata.Vec,
 	probeKeys, buildKeys []interface{},
 	nToCheck uint64,
-	_USE_SEL bool,
+	_USE_PROBE_SEL bool,
+	_USE_BUILD_SEL bool,
 ) { // */}}
 	// {{define "checkColWithNulls" -}}
 	if probeVec.MaybeHasNulls() {
@@ -142,25 +158,23 @@ func _CHECK_COL_WITH_NULLS(
 			if ht.allowNullEquality {
 				// The allowNullEquality flag only matters if both vectors have nulls.
 				// This lets us avoid writing all 2^3 conditional branches.
-				_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true, true)
+				_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true, true, false, _USE_PROBE_SEL, _USE_BUILD_SEL)
 			} else {
-				_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true, false)
+				_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true, false, false, _USE_PROBE_SEL, _USE_BUILD_SEL)
 			}
 		} else {
-			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, false, false)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, false, false, false, _USE_PROBE_SEL, _USE_BUILD_SEL)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, true, false)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, true, false, false, _USE_PROBE_SEL, _USE_BUILD_SEL)
 		} else {
-			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, false, false)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, false, false, false, _USE_PROBE_SEL, _USE_BUILD_SEL)
 		}
 	}
 	// {{end}}
 	// {{/*
-}
-
-// */}}
+} // */}}
 
 // checkCol determines if the current key column in the groupID buckets matches
 // the specified equality column key. If there is a match, then the key is added
@@ -168,8 +182,14 @@ func _CHECK_COL_WITH_NULLS(
 // hashTable disallows null equality, then if any element in the key is null,
 // there is no match.
 func (ht *hashTable) checkCol(
-	probeType, buildType coltypes.T, keyColIdx int, nToCheck uint64, sel []int,
+	probeVec, buildVec coldata.Vec,
+	probeType, buildType coltypes.T,
+	keyColIdx int,
+	nToCheck uint64,
+	probeSel []int,
+	buildSel []int,
 ) {
+
 	// In order to inline the templated code of overloads, we need to have a
 	// `decimalScratch` local variable of type `decimalOverloadScratch`.
 	decimalScratch := ht.decimalScratch
@@ -179,25 +199,21 @@ func (ht *hashTable) checkCol(
 		switch buildType {
 		// {{range $rTyp, $overload := $rTypToOverload}}
 		case _BUILD_TYPE:
-			probeVec := ht.keys[keyColIdx]
-			buildVec := ht.vals.ColVec(int(ht.keyCols[keyColIdx]))
 			probeKeys := probeVec._ProbeType()
 			buildKeys := buildVec._BuildType()
 
-			if sel != nil {
-				_CHECK_COL_WITH_NULLS(
-					ht,
-					probeVec, buildVec,
-					probeKeys, buildKeys,
-					nToCheck,
-					true)
+			if probeSel != nil {
+				if buildSel != nil {
+					_CHECK_COL_WITH_NULLS(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true)
+				} else {
+					_CHECK_COL_WITH_NULLS(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, false)
+				}
 			} else {
-				_CHECK_COL_WITH_NULLS(
-					ht,
-					probeVec, buildVec,
-					probeKeys, buildKeys,
-					nToCheck,
-					false)
+				if buildSel != nil {
+					_CHECK_COL_WITH_NULLS(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, true)
+				} else {
+					_CHECK_COL_WITH_NULLS(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, false)
+				}
 			}
 			// {{end}}
 		default:
@@ -210,19 +226,82 @@ func (ht *hashTable) checkCol(
 }
 
 // {{/*
-func _CHECK_BODY(_IS_HASHTABLE_IN_FULL_MODE bool) { // */}}
+func _CHECK_COL_FOR_DISTINCT_WITH_NULLS(
+	ht *hashTable,
+	probeVec, buildVec coldata.Vec,
+	probeType coltypes.T,
+	nToCheck uint16,
+	probeSel []uint16,
+	_USE_PROBE_SEL bool,
+	_USE_BUILD_SEL bool,
+) { // */}}
+	// {{define "checkColForDistinctWithNulls" -}}
+	if probeVec.MaybeHasNulls() {
+		if buildVec.MaybeHasNulls() {
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, true, true, true, _USE_PROBE_SEL, _USE_BUILD_SEL)
+		} else {
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, true, false, true, true, _USE_PROBE_SEL, _USE_BUILD_SEL)
+		}
+	} else {
+		if buildVec.MaybeHasNulls() {
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, true, true, true, _USE_PROBE_SEL, _USE_BUILD_SEL)
+		} else {
+			_CHECK_COL_BODY(ht, probeVec, buildVec, probeKeys, buildKeys, nToCheck, false, false, true, true, _USE_PROBE_SEL, _USE_BUILD_SEL)
+		}
+	}
+
+	// {{end}}
+	// {{/*
+} // */}}
+
+func (ht *hashTable) checkColForDistinctTuples(
+	probeVec, buildVec coldata.Vec, probeType coltypes.T, nToCheck uint64, probeSel []int,
+) {
+	switch probeType {
+	// {{/*
+	// index directive allows the template to index into indexable types such as
+	// slices or maps. Following code is semantically equivalent to the Go code
+	// snippet below:
+	//
+	//  for lTyp, rTypeToOverload := range .Global {
+	//    overload := rTypeOverload[lTyp]
+	//	  ...
+	//  }
+	//
+	// */}}
+	// {{range $lTyp, $rTypToOverload := .}}
+	// {{with $overload := index $rTypToOverload $lTyp}}
+	case _PROBE_TYPE:
+		probeKeys := probeVec._ProbeType()
+		buildKeys := buildVec._ProbeType()
+
+		if probeSel != nil {
+			_CHECK_COL_FOR_DISTINCT_WITH_NULLS(ht, probeVec, buildVec, probeType, nToCheck, probeSel, true, false)
+		} else {
+			_CHECK_COL_FOR_DISTINCT_WITH_NULLS(ht, probeVec, buildVec, probeType, nToCheck, probeSel, false, false)
+		}
+		// {{end}}
+		// {{end}}
+	default:
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", probeType))
+	}
+}
+
+// {{/*
+func _CHECK_BODY(ht *hashTable, nDiffers uint64, _SELECT_SAME_TUPLES bool) { // */}}
 	// {{define "checkBody" -}}
 	for i := uint64(0); i < nToCheck; i++ {
-		if !ht.differs[ht.toCheck[i]] {
+		if !ht.probeScratch.differs[ht.probeScratch.toCheck[i]] {
 			// If the current key matches with the probe key, we want to update headID
 			// with the current key if it has not been set yet.
-			keyID := ht.groupID[ht.toCheck[i]]
-			if ht.headID[ht.toCheck[i]] == 0 {
-				ht.headID[ht.toCheck[i]] = keyID
+			keyID := ht.probeScratch.groupID[ht.probeScratch.toCheck[i]]
+			if ht.probeScratch.headID[ht.probeScratch.toCheck[i]] == 0 {
+				ht.probeScratch.headID[ht.probeScratch.toCheck[i]] = keyID
 			}
 
-			// {{if .IsHashTableInFullMode}}
-			firstID := ht.headID[ht.toCheck[i]]
+			// {{if .SelectSameTuples}}
+
+			firstID := ht.probeScratch.headID[ht.probeScratch.toCheck[i]]
 
 			if !ht.visited[keyID] {
 				// We can then add this keyID into the same array at the end of the
@@ -231,7 +310,7 @@ func _CHECK_BODY(_IS_HASHTABLE_IN_FULL_MODE bool) { // */}}
 				// differs at this position to be true. This way, the prober will
 				// continue probing for this key until it reaches the end of the next
 				// chain.
-				ht.differs[ht.toCheck[i]] = true
+				ht.probeScratch.differs[ht.probeScratch.toCheck[i]] = true
 				ht.visited[keyID] = true
 
 				if firstID != keyID {
@@ -239,13 +318,14 @@ func _CHECK_BODY(_IS_HASHTABLE_IN_FULL_MODE bool) { // */}}
 					ht.same[firstID] = keyID
 				}
 			}
+
 			// {{end}}
 		}
 
-		if ht.differs[ht.toCheck[i]] {
+		if ht.probeScratch.differs[ht.probeScratch.toCheck[i]] {
 			// Continue probing in this next chain for the probe key.
-			ht.differs[ht.toCheck[i]] = false
-			ht.toCheck[nDiffers] = ht.toCheck[i]
+			ht.probeScratch.differs[ht.probeScratch.toCheck[i]] = false
+			ht.probeScratch.toCheck[nDiffers] = ht.probeScratch.toCheck[i]
 			nDiffers++
 		}
 	}
@@ -254,6 +334,39 @@ func _CHECK_BODY(_IS_HASHTABLE_IN_FULL_MODE bool) { // */}}
 	// {{/*
 } // */}}
 
+// checkBuildForDistinct finds all tuples in probeVecs that are not present in
+// buffered tuples stored in ht.vals. It stores the probeVecs's distinct tuples'
+// keyIDs in headID buffer.
+// NOTE: It assumes that probeVecs does not contain any duplicates itself.
+// NOTE: It assumes that probSel has already being populated and it is not
+//       nil.
+func (ht *hashTable) checkBuildForDistinct(
+	probeVecs []coldata.Vec, nToCheck uint64, probeSel []int,
+) uint64 {
+	if probeSel == nil {
+		execerror.VectorizedInternalPanic("invalid selection vector")
+	}
+	copy(ht.probeScratch.distinct, zeroBoolColumn)
+
+	ht.checkColsForDistinctTuples(probeVecs, nToCheck, probeSel)
+
+	nDiffers := uint64(0)
+	for i := uint64(0); i < nToCheck; i++ {
+		if ht.probeScratch.distinct[ht.probeScratch.toCheck[i]] {
+			ht.probeScratch.distinct[ht.probeScratch.toCheck[i]] = false
+			// Calculated using the convention: keyID = keys.indexOf(key) + 1.
+			ht.probeScratch.headID[ht.probeScratch.toCheck[i]] = ht.probeScratch.toCheck[i] + 1
+		} else if ht.probeScratch.differs[ht.probeScratch.toCheck[i]] {
+			// Continue probing in this next chain for the probe key.
+			ht.probeScratch.differs[ht.probeScratch.toCheck[i]] = false
+			ht.probeScratch.toCheck[nDiffers] = ht.probeScratch.toCheck[i]
+			nDiffers++
+		}
+	}
+
+	return nDiffers
+}
+
 // check performs an equality check between the current key in the groupID bucket
 // and the probe key at that index. If there is a match, the hashTable's same
 // array is updated to lazily populate the linked list of identical build
@@ -261,17 +374,108 @@ func _CHECK_BODY(_IS_HASHTABLE_IN_FULL_MODE bool) { // */}}
 // key is removed from toCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of toCheck is returned by this function.
-func (ht *hashTable) check(probeKeyTypes []coltypes.T, nToCheck uint64, sel []int) uint64 {
-	ht.checkCols(probeKeyTypes, nToCheck, sel)
-	nDiffers := uint64(0)
+func (ht *hashTable) check(
+	probeVecs []coldata.Vec,
+	probeKeyTypes []coltypes.T,
+	buildKeyCols []uint32,
+	nToCheck uint64,
+	probeSel []int,
+) uint64 {
+	ht.checkCols(probeVecs, ht.vals.ColVecs(), probeKeyTypes, buildKeyCols, nToCheck, probeSel, nil /* buildSel */)
 
-	switch ht.mode {
-	case hashTableFullMode:
-		_CHECK_BODY(true)
-	case hashTableDistinctMode:
-		_CHECK_BODY(false)
-	default:
-		execerror.VectorizedInternalPanic("hashTable in unhandled state")
+	nDiffers := uint64(0)
+	_CHECK_BODY(ht, nDiffers, true)
+
+	return nDiffers
+}
+
+// checkProbeForDistinct performs a column by column check for duplicated tuples
+// in the probe table.
+func (ht *hashTable) checkProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
+	for i := range ht.keyCols {
+		ht.checkCol(vecs[i], vecs[i], ht.keyTypes[i], ht.keyTypes[i], i, nToCheck, sel, sel)
+	}
+
+	nDiffers := uint64(0)
+	_CHECK_BODY(ht, nDiffers, false)
+
+	return nDiffers
+}
+
+// {{/*
+func _UPDATE_SEL_BODY(ht *hashTable, b coldata.Batch, sel []int, _USE_SEL bool) { // */}}
+	// {{define "updateSelBody" -}}
+
+	// Reuse the buffer allocated for distinct.
+	visited := ht.probeScratch.distinct
+	copy(visited, zeroBoolColumn)
+
+	for i := 0; i < b.Length(); i++ {
+		if ht.probeScratch.headID[i] != 0 {
+			if hasVisited := visited[ht.probeScratch.headID[i]-1]; !hasVisited {
+				// {{if .UseSel}}
+				sel[distinctCount] = sel[ht.probeScratch.headID[i]-1]
+				// {{else}}
+				sel[distinctCount] = int(ht.probeScratch.headID[i] - 1)
+				// {{end}}
+				visited[ht.probeScratch.headID[i]-1] = true
+
+				// Compacting and deduplicating hash buffer.
+				ht.probeScratch.hashBuffer[distinctCount] = ht.probeScratch.hashBuffer[i]
+				distinctCount++
+			}
+		}
+		ht.probeScratch.headID[i] = 0
+		ht.probeScratch.differs[i] = false
+	}
+
+	// {{end}}
+	// {{/*
+} // */}}
+
+// updateSel updates the selection vector in the given batch using the headID
+// buffer. For each nonzero keyID in headID, it will be translated to the actual
+// key index using the convention keyID = keys.indexOf(key) + 1. If the input
+// batch's selection vector is nil, the key index will be directly used to
+// populate the selection vector. Otherwise, the selection vector's value at the
+// key index will be used. The duplicated keyIDs will be discarded. The
+// hashBuffer will also compact and discard hash values of duplicated keys.
+func (ht *hashTable) updateSel(b coldata.Batch) {
+	distinctCount := 0
+
+	if sel := b.Selection(); sel != nil {
+		_UPDATE_SEL_BODY(ht, b, sel, true)
+	} else {
+		b.SetSelection(true)
+		sel = b.Selection()
+		_UPDATE_SEL_BODY(ht, b, sel, false)
+	}
+
+	b.SetLength(distinctCount)
+}
+
+// distinctCheck determines if the current key in the groupID bucket matches the
+// equality column key. If there is a match, then the key is removed from
+// toCheck. If the bucket has reached the end, the key is rejected. The toCheck
+// list is reconstructed to only hold the indices of the eqCol keys that have
+// not been found. The new length of toCheck is returned by this function.
+func (ht *hashTable) distinctCheck(
+	probeKeyTypes []coltypes.T, nToCheck uint64, probeSel []int,
+) uint64 {
+	probeVecs := ht.probeScratch.keys
+	buildVecs := ht.vals.ColVecs()
+	buildKeyCols := ht.keyCols
+	var buildSel []int
+	ht.checkCols(probeVecs, buildVecs, probeKeyTypes, buildKeyCols, nToCheck, probeSel, buildSel)
+
+	// Select the indices that differ and put them into toCheck.
+	nDiffers := uint64(0)
+	for i := uint64(0); i < nToCheck; i++ {
+		if ht.probeScratch.differs[ht.probeScratch.toCheck[i]] {
+			ht.probeScratch.differs[ht.probeScratch.toCheck[i]] = false
+			ht.probeScratch.toCheck[nDiffers] = ht.probeScratch.toCheck[i]
+			nDiffers++
+		}
 	}
 
 	return nDiffers

--- a/pkg/sql/colexec/partially_ordered_distinct.go
+++ b/pkg/sql/colexec/partially_ordered_distinct.go
@@ -121,7 +121,7 @@ func newChunkerOperator(
 	return &chunkerOperator{
 		input:         input,
 		inputTypes:    inputTypes,
-		windowedBatch: allocator.NewMemBatchWithSize(inputTypes, 0),
+		windowedBatch: allocator.NewMemBatchNoCols(inputTypes, coldata.BatchSize()),
 	}
 }
 


### PR DESCRIPTION
Previously hashTable will buffer all tuples before building `head` and
`same` vector.
Now hashTable supports distinct mode where it only buffers
the distinct tuples from upstream operator. This removes the need of traversing
through the `head` and `same` vectors. Instead, now user of the hashTable
can directly build hashTable in distinct mode and copy the buffered tuples.

Closes #44404

Release note: None