### PR TITLE
sql: prevent arbitrary writes to system.comments

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1428,10 +1429,11 @@ func injectTableStats(
 func (p *planner) removeColumnComment(
 	ctx context.Context, tableID sqlbase.ID, columnID sqlbase.ColumnID,
 ) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
 		"delete-column-comment",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=$3",
 		keys.ColumnCommentType,
 		tableID,

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -14,8 +14,10 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 type commentOnTableNode struct {
@@ -42,10 +44,11 @@ func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (p
 
 func (n *commentOnTableNode) startExec(params runParams) error {
 	if n.n.Comment != nil {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
 			params.ctx,
 			"set-table-comment",
 			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"UPSERT INTO system.comments VALUES ($1, $2, 0, $3)",
 			keys.TableCommentType,
 			n.tableDesc.ID,
@@ -54,10 +57,11 @@ func (n *commentOnTableNode) startExec(params runParams) error {
 			return err
 		}
 	} else {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
 			params.ctx,
 			"delete-table-comment",
 			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
 			keys.TableCommentType,
 			n.tableDesc.ID)

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -259,10 +260,11 @@ func (p *planner) accumulateDependentTables(
 }
 
 func (p *planner) removeDbComment(ctx context.Context, dbID sqlbase.ID) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
 		"delete-db-comment",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
 		keys.DatabaseCommentType,
 		dbID)

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -594,10 +595,11 @@ func removeMatchingReferences(
 func (p *planner) removeTableComment(
 	ctx context.Context, tableDesc *sqlbase.MutableTableDescriptor,
 ) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
 		"delete-table-comment",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
 		keys.TableCommentType,
 		tableDesc.ID)
@@ -605,10 +607,11 @@ func (p *planner) removeTableComment(
 		return err
 	}
 
-	_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+	_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
 		"delete-comment",
 		p.txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2",
 		keys.ColumnCommentType,
 		tableDesc.ID)

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -161,6 +161,7 @@ SET DATABASE = ''
 query TTTTT colnames,rowsort
 SELECT * FROM [SHOW GRANTS]
  WHERE schema_name NOT IN ('crdb_internal', 'pg_catalog', 'information_schema')
+ORDER BY 1,2,3
 ----
 database_name  schema_name  table_name                       grantee    privilege_type
 system         public       namespace_deprecated             admin      GRANT
@@ -296,11 +297,7 @@ system         public       comments                         admin      GRANT
 system         public       comments                         admin      INSERT
 system         public       comments                         admin      SELECT
 system         public       comments                         admin      UPDATE
-system         public       comments                         public     DELETE
-system         public       comments                         public     GRANT
-system         public       comments                         public     INSERT
 system         public       comments                         public     SELECT
-system         public       comments                         public     UPDATE
 system         public       comments                         root       DELETE
 system         public       comments                         root       GRANT
 system         public       comments                         root       INSERT
@@ -358,6 +355,16 @@ system         public       protected_ts_records             admin      GRANT
 system         public       protected_ts_records             admin      SELECT
 system         public       protected_ts_records             root       GRANT
 system         public       protected_ts_records             root       SELECT
+system         public       role_options                     admin      DELETE
+system         public       role_options                     admin      GRANT
+system         public       role_options                     admin      INSERT
+system         public       role_options                     admin      SELECT
+system         public       role_options                     admin      UPDATE
+system         public       role_options                     root       DELETE
+system         public       role_options                     root       GRANT
+system         public       role_options                     root       INSERT
+system         public       role_options                     root       SELECT
+system         public       role_options                     root       UPDATE
 system         public       statement_bundle_chunks          admin      DELETE
 system         public       statement_bundle_chunks          admin      GRANT
 system         public       statement_bundle_chunks          admin      INSERT
@@ -388,16 +395,6 @@ system         public       statement_diagnostics            root       GRANT
 system         public       statement_diagnostics            root       INSERT
 system         public       statement_diagnostics            root       SELECT
 system         public       statement_diagnostics            root       UPDATE
-system         public       role_options                     admin      DELETE
-system         public       role_options                     admin      GRANT
-system         public       role_options                     admin      INSERT
-system         public       role_options                     admin      SELECT
-system         public       role_options                     admin      UPDATE
-system         public       role_options                     root       DELETE
-system         public       role_options                     root       GRANT
-system         public       role_options                     root       INSERT
-system         public       role_options                     root       SELECT
-system         public       role_options                     root       UPDATE
 a              public       NULL                             admin      ALL
 a              public       NULL                             readwrite  ALL
 a              public       NULL                             root       ALL

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -619,7 +619,7 @@ system         public              web_sessions                       BASE TABLE
 system         public              table_statistics                   BASE TABLE   YES                 1
 system         public              locations                          BASE TABLE   YES                 1
 system         public              role_members                       BASE TABLE   YES                 1
-system         public              comments                           BASE TABLE   YES                 1
+system         public              comments                           BASE TABLE   YES                 5
 system         public              replication_constraint_stats       BASE TABLE   YES                 1
 system         public              replication_critical_localities    BASE TABLE   YES                 1
 system         public              replication_stats                  BASE TABLE   YES                 1
@@ -636,7 +636,9 @@ statement ok
 ALTER TABLE other_db.xyz ADD COLUMN j INT
 
 query TTI colnames
-SELECT TABLE_CATALOG, TABLE_NAME, VERSION FROM "".information_schema.tables WHERE version > 1 AND TABLE_SCHEMA = 'public' ORDER BY 1,2
+SELECT table_catalog, table_name, version
+  FROM "".information_schema.tables
+ WHERE table_catalog != 'system' AND version > 1 AND table_schema = 'public' ORDER BY 1,2
 ----
 table_catalog  table_name  version
 other_db       xyz         6
@@ -1603,11 +1605,7 @@ NULL     admin    system         public              comments                   
 NULL     admin    system         public              comments                           INSERT          NULL          NO
 NULL     admin    system         public              comments                           SELECT          NULL          YES
 NULL     admin    system         public              comments                           UPDATE          NULL          NO
-NULL     public   system         public              comments                           DELETE          NULL          NO
-NULL     public   system         public              comments                           GRANT           NULL          NO
-NULL     public   system         public              comments                           INSERT          NULL          NO
 NULL     public   system         public              comments                           SELECT          NULL          YES
-NULL     public   system         public              comments                           UPDATE          NULL          NO
 NULL     root     system         public              comments                           DELETE          NULL          NO
 NULL     root     system         public              comments                           GRANT           NULL          NO
 NULL     root     system         public              comments                           INSERT          NULL          NO
@@ -2076,11 +2074,7 @@ NULL     admin    system         public              comments                   
 NULL     admin    system         public              comments                           INSERT          NULL          NO
 NULL     admin    system         public              comments                           SELECT          NULL          YES
 NULL     admin    system         public              comments                           UPDATE          NULL          NO
-NULL     public   system         public              comments                           DELETE          NULL          NO
-NULL     public   system         public              comments                           GRANT           NULL          NO
-NULL     public   system         public              comments                           INSERT          NULL          NO
 NULL     public   system         public              comments                           SELECT          NULL          YES
-NULL     public   system         public              comments                           UPDATE          NULL          NO
 NULL     root     system         public              comments                           DELETE          NULL          NO
 NULL     root     system         public              comments                           GRANT           NULL          NO
 NULL     root     system         public              comments                           INSERT          NULL          NO

--- a/pkg/sql/logictest/testdata/logic_test/privileges_comments
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_comments
@@ -1,0 +1,82 @@
+# Disable automatic stats to avoid flakiness.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
+subtest regression45707
+
+user root
+
+statement ok
+CREATE DATABASE d45707; CREATE TABLE d45707.t45707(x INT);
+  GRANT SELECT ON DATABASE d45707 TO testuser;
+  GRANT SELECT ON d45707.t45707 TO testuser
+
+statement ok
+COMMENT ON DATABASE d45707 IS 'd45707';
+COMMENT ON TABLE d45707.t45707 IS 't45707';
+COMMENT ON COLUMN d45707.t45707.x IS 'x45707';
+COMMENT ON INDEX d45707.t45707@primary IS 'p45707'
+
+user testuser
+
+statement ok
+SET DATABASE = d45707
+
+# Verify the user cannot modify the comments
+
+statement error user testuser does not have CREATE privilege on database d45707
+COMMENT ON DATABASE d45707 IS 'd45707'
+
+statement error user testuser does not have CREATE privilege on relation t45707
+COMMENT ON TABLE d45707.t45707 IS 't45707'
+
+statement error user testuser does not have CREATE privilege on relation t45707
+COMMENT ON COLUMN d45707.t45707.x IS 'x45707'
+
+statement error user testuser does not have CREATE privilege on relation t45707
+COMMENT ON INDEX d45707.t45707@primary IS 'p45707'
+
+# Verify that the user can view the comments
+
+query T
+SELECT shobj_description(oid, 'pg_database')
+  FROM pg_database
+ WHERE datname = 'd45707'
+----
+d45707
+
+query T
+SELECT col_description(attrelid, attnum)
+  FROM pg_attribute
+ WHERE attrelid = 't45707'::regclass AND attname = 'x'
+----
+x45707
+
+query T
+SELECT obj_description('t45707'::REGCLASS)
+----
+t45707
+
+query T
+SELECT obj_description(indexrelid)
+  FROM pg_index
+ WHERE indrelid = 't45707'::REGCLASS
+   AND indisprimary
+----
+p45707
+
+# Verify that the user can modify the comments.
+
+user root
+
+statement ok
+GRANT ALL ON DATABASE d45707 TO testuser;
+  GRANT ALL ON TABLE d45707.t45707 TO testuser
+
+user testuser
+
+statement ok
+COMMENT ON DATABASE d45707 IS 'd45707_2';
+COMMENT ON TABLE d45707.t45707 IS 't45707_2';
+COMMENT ON COLUMN d45707.t45707.x IS 'x45707_2';
+COMMENT ON INDEX d45707.t45707@primary IS 'p45707_2'

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -186,11 +186,7 @@ system  public  comments                         admin   GRANT
 system  public  comments                         admin   INSERT
 system  public  comments                         admin   SELECT
 system  public  comments                         admin   UPDATE
-system  public  comments                         public  DELETE
-system  public  comments                         public  GRANT
-system  public  comments                         public  INSERT
 system  public  comments                         public  SELECT
-system  public  comments                         public  UPDATE
 system  public  comments                         root    DELETE
 system  public  comments                         root    GRANT
 system  public  comments                         root    INSERT

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -1554,6 +1554,7 @@ func IsReservedID(id ID) bool {
 
 // newCommentPrivilegeDescriptor returns a privilege descriptor for comment table
 func newCommentPrivilegeDescriptor(priv privilege.List) *PrivilegeDescriptor {
+	selectPriv := privilege.List{privilege.SELECT}
 	return &PrivilegeDescriptor{
 		Users: []UserPrivileges{
 			{
@@ -1562,7 +1563,7 @@ func newCommentPrivilegeDescriptor(priv privilege.List) *PrivilegeDescriptor {
 			},
 			{
 				User:       PublicRole,
-				Privileges: priv.ToBitField(),
+				Privileges: selectPriv.ToBitField(),
 			},
 			{
 				User:       security.RootUser,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -466,10 +466,11 @@ func reassignColumnComment(
 	}
 
 	if comment != nil {
-		_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+		_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 			ctx,
 			"set-column-comment",
 			p.txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"UPSERT INTO system.comments VALUES ($1, $2, $3, $4)",
 			keys.ColumnCommentType,
 			newID,
@@ -479,10 +480,11 @@ func reassignColumnComment(
 			return err
 		}
 
-		_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
+		_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 			ctx,
 			"delete-column-comment",
 			p.txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=$3",
 			keys.ColumnCommentType,
 			oldID,


### PR DESCRIPTION
Fixes #45707.

Previously, the GRANT, UPDATE, DELETE and INSERT privileges
were granted to `public`, i.e. everyone, on `system.comments`.

This was unintended - only users with permissions on an object
should be able to modify that object's comments.

This patch fixes it.

Release note (security update): Any user could previously modify any
database/table/view/index comment via direct SQL updates to
`system.comments`. This was unintended and a form of privilege
escalation, and is now prevented. The privileges required for the
COMMENT statement and `pg_description`, `col_description()`,
`obj_description()` and `shobj_description()` are operating as
in PostgreSQL and unaffected by this change: all users can *view* any
comments on any object (bypassing other privileges), but modifying
comments require write privilege on the target object.