### PR TITLE
lint: stop running roachvet in lintshort

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1483,6 +1483,9 @@ func TestLint(t *testing.T) {
 	// RoachVet includes all of the passes of `go vet` plus first-party additions.
 	// See pkg/cmd/roachvet.
 	t.Run("TestRoachVet", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("short flag")
+		}
 		// The -printfuncs functionality is interesting and
 		// under-documented. It checks two things:
 		//


### PR DESCRIPTION
roachvet is a beast of a checker including all of govet and some additional
checks. This requires analyzing and checking every package. It turns out
that it's quite slow. After marking this as short the `make lintshort` took
18s on my machine. I'll run it in the old mode and report back on how long
it took.

Fixes #44817.

Release note: None