### PR TITLE
pgwire/hba: preserve the original configuration line

### DIFF
--- a/pkg/sql/pgwire/hba/hba.go
+++ b/pkg/sql/pgwire/hba/hba.go
@@ -21,6 +21,7 @@ package hba
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -50,6 +51,11 @@ type Entry struct {
 	MethodFn     interface{}
 	Options      [][2]string
 	OptionQuotes []bool
+	// Input is the original configuration line in the HBA configuration string.
+	// This is used for auditing purposes.
+	Input string
+	// Generated is true if the entry was expanded from another.
+	Generated bool
 }
 
 // ConnType represents the type of connection matched by a rule.
@@ -93,6 +99,15 @@ func (c Conf) String() string {
 		return "# (empty configuration)\n"
 	}
 	var sb strings.Builder
+	sb.WriteString("# Original configuration:\n")
+	for _, e := range c.Entries {
+		if e.Generated {
+			continue
+		}
+		fmt.Fprintf(&sb, "# %s\n", e.Input)
+	}
+	sb.WriteString("#\n# Interpreted configuration:\n")
+
 	table := tablewriter.NewWriter(&sb)
 	table.SetAutoWrapText(false)
 	table.SetReflowDuringAutoWrap(false)
@@ -138,6 +153,14 @@ func (h Entry) GetOption(name string) string {
 		}
 	}
 	return val
+}
+
+// Equivalent returns true iff the entry is equivalent to another,
+// excluding the original syntax.
+func (h Entry) Equivalent(other Entry) bool {
+	h.Input = ""
+	other.Input = ""
+	return reflect.DeepEqual(h, other)
 }
 
 // GetOptions returns all values of option name.
@@ -343,6 +366,9 @@ outer:
 		for userIdx, iu := range allUsers {
 			entry.User = allUsers[userIdx : userIdx+1]
 			entry.User[0].Value = tree.Name(iu.Value).Normalize()
+			if userIdx > 0 {
+				entry.Generated = true
+			}
 			entries = append(entries, entry)
 		}
 	}

--- a/pkg/sql/pgwire/hba/parser.go
+++ b/pkg/sql/pgwire/hba/parser.go
@@ -33,8 +33,13 @@ import (
 type scannedInput struct {
 	// The list of lines is a triple-nested list structure.  Each line is a list of
 	// fields, and each field is a List of tokens.
-	lines   [][][]String
+	lines   []hbaLine
 	linenos []int
+}
+
+type hbaLine struct {
+	input  string
+	tokens [][]String
 }
 
 // Parse parses the provided HBA configuration.
@@ -61,9 +66,11 @@ func Parse(input string) (*Conf, error) {
 // parseHbaLine parses one line of HBA configuration.
 //
 // Inspired from pg's src/backend/libpq/hba.c, parse_hba_line().
-func parseHbaLine(line [][]String) (entry Entry, err error) {
+func parseHbaLine(inputLine hbaLine) (entry Entry, err error) {
 	fieldIdx := 0
 
+	entry.Input = inputLine.input
+	line := inputLine.tokens
 	// Read the connection type.
 	if len(line[fieldIdx]) > 1 {
 		return entry, errors.WithHint(

--- a/pkg/sql/pgwire/hba/scanner.go
+++ b/pkg/sql/pgwire/hba/scanner.go
@@ -165,7 +165,8 @@ func tokenize(input string) (res scannedInput, err error) {
 	inputLines := strings.Split(input, "\n")
 
 	for lineIdx, lineS := range inputLines {
-		var currentLine [][]String
+		var currentLine hbaLine
+		currentLine.input = strings.TrimSpace(lineS)
 		for remaining := lineS; remaining != ""; {
 			var currentField []String
 			remaining, currentField, err = nextFieldExpand(remaining)
@@ -173,10 +174,10 @@ func tokenize(input string) (res scannedInput, err error) {
 				return res, errors.Wrapf(err, "line %d", lineIdx+1)
 			}
 			if len(currentField) > 0 {
-				currentLine = append(currentLine, currentField)
+				currentLine.tokens = append(currentLine.tokens, currentField)
 			}
 		}
-		if len(currentLine) > 0 {
+		if len(currentLine.tokens) > 0 {
 			res.lines = append(res.lines, currentLine)
 			res.linenos = append(res.linenos, lineIdx+1)
 		}

--- a/pkg/sql/pgwire/hba/testdata/normalization
+++ b/pkg/sql/pgwire/hba/testdata/normalization
@@ -16,6 +16,10 @@ subtest unicode_normalization
 hba
 host all Ὀδυσσεύς all cert-password
 ----
+# Original configuration:
+# host all Ὀδυσσεύς all cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
 host   all      ὀδυσσεύς all     cert-password
 
@@ -27,6 +31,11 @@ hba
 host some foo all cert-password
 host some,more bar all cert-password
 ----
+# Original configuration:
+# host some foo all cert-password
+# host some,more bar all cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      foo  all     cert-password
 host   all      bar  all     cert-password
@@ -38,6 +47,10 @@ subtest quoted_all_host
 hba
 host all all "all" cert-password
 ----
+# Original configuration:
+# host all all "all" cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      all  "all"   cert-password
 
@@ -49,6 +62,11 @@ hba
 host all a,all,b all cert-password
 host all a,"all",b all cert-password
 ----
+# Original configuration:
+# host all a,all,b all cert-password
+# host all a,"all",b all cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER  ADDRESS METHOD        OPTIONS
 host   all      all   all     cert-password
 host   all      a     all     cert-password
@@ -62,6 +80,10 @@ subtest rule_expansion
 hba
 host all a,b,c all cert-password
 ----
+# Original configuration:
+# host all a,b,c all cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      a    all     cert-password
 host   all      b    all     cert-password

--- a/pkg/sql/pgwire/hba/testdata/parse
+++ b/pkg/sql/pgwire/hba/testdata/parse
@@ -51,18 +51,30 @@ subtest quoted_columns
 line
 "local" a b c
 ----
+# Original configuration:
+# "local" a b c
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 local  a        b            c
 
 line
 local a b "method"
 ----
+# Original configuration:
+# local a b "method"
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD   OPTIONS
 local  a        b            "method"
 
 line
 host all all all gss k=v " someopt = withspaces "
 ----
+# Original configuration:
+# host all all all gss k=v " someopt = withspaces "
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   all      all  all     gss    k=v " someopt = withspaces "
 
@@ -73,30 +85,50 @@ subtest keyword_all
 line
 host all b c d
 ----
+# Original configuration:
+# host all b c d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   all      b    c       d
 
 line
 host "all" b c d
 ----
+# Original configuration:
+# host "all" b c d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   "all"    b    c       d
 
 line
 host a all c d
 ----
+# Original configuration:
+# host a all c d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   a        all  c       d
 
 line
 host a "all" c d
 ----
+# Original configuration:
+# host a "all" c d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER  ADDRESS METHOD OPTIONS
 host   a        "all" c       d
 
 line
 host a b all d
 ----
+# Original configuration:
+# host a b all d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   a        b    all     d
 
@@ -127,6 +159,10 @@ error: multiple values specified for host address
 line
 local a b 1.1.1.1
 ----
+# Original configuration:
+# local a b 1.1.1.1
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD  OPTIONS
 local  a        b            1.1.1.1
 
@@ -134,6 +170,10 @@ local  a        b            1.1.1.1
 line
 host a b 0.0.0.0/0 d
 ----
+# Original configuration:
+# host a b 0.0.0.0/0 d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS   METHOD OPTIONS
 host   a        b    0.0.0.0/0 d
 
@@ -145,18 +185,30 @@ unknown directive: parse
 line
 host a b ::1/0 d
 ----
+# Original configuration:
+# host a b ::1/0 d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   a        b    ::/0    d
 
 line
 host a b 2.3.4.5/8 d
 ----
+# Original configuration:
+# host a b 2.3.4.5/8 d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS   METHOD OPTIONS
 host   a        b    2.0.0.0/8 d
 
 line
 host all all fe80::7a31:c1ff:0000:0000/96 cert
 ----
+# Original configuration:
+# host all all fe80::7a31:c1ff:0000:0000/96 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS                METHOD OPTIONS
 host   all      all  fe80::7a31:c1ff:0:0/96 cert
 
@@ -169,12 +221,20 @@ error: multiple values specified for netmask
 line
 host a b 2.3.4.5 255.255.0.0 d
 ----
+# Original configuration:
+# host a b 2.3.4.5 255.255.0.0 d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS    METHOD OPTIONS
 host   a        b    2.3.0.0/16 d
 
 line
 host a b fe80:7a31:c1ff:: ffff:fff0:: d
 ----
+# Original configuration:
+# host a b fe80:7a31:c1ff:: ffff:fff0:: d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS        METHOD OPTIONS
 host   a        b    fe80:7a30::/28 d
 
@@ -191,6 +251,10 @@ error: invalid IP mask "8.0.0.8": address is not a mask
 line
 host a b myhost d
 ----
+# Original configuration:
+# host a b myhost d
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   a        b    myhost  d
 
@@ -222,6 +286,13 @@ host a,b,c d,e,f all trust
 host all testuser,"all" 0.0.0.0/0 cert
 ----
 # String render check:
+# Original configuration:
+# host a,b,c all all trust
+# host all a,b,c all trust
+# host a,b,c d,e,f all trust
+# host all testuser,"all" 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER           ADDRESS   METHOD OPTIONS
 host   a,b,c    all            all       trust
 host   all      a,b,c          all       trust
@@ -245,6 +316,8 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host a,b,c all all trust",
+            Generated:    false,
         },
         {
             ConnType: 6,
@@ -261,6 +334,8 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host all a,b,c all trust",
+            Generated:    false,
         },
         {
             ConnType: 6,
@@ -279,6 +354,8 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host a,b,c d,e,f all trust",
+            Generated:    false,
         },
         {
             ConnType: 6,
@@ -297,6 +374,8 @@ host   all      testuser,"all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host all testuser,\"all\" 0.0.0.0/0 cert",
+            Generated:    false,
         },
     },
 }
@@ -306,6 +385,10 @@ multiline
 host "all","test space",something some,"us ers" all cert
 ----
 # String render check:
+# Original configuration:
+# host "all","test space",something some,"us ers" all cert
+#
+# Interpreted configuration:
 # TYPE DATABASE                     USER          ADDRESS METHOD OPTIONS
 host   "all","test space",something some,"us ers" all     cert
 # Detail:
@@ -327,6 +410,8 @@ host   "all","test space",something some,"us ers" all     cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host \"all\",\"test space\",something some,\"us ers\" all cert",
+            Generated:    false,
         },
     },
 }
@@ -358,6 +443,10 @@ multiline
 host all all all gss k=v " someopt = withspaces "
 ----
 # String render check:
+# Original configuration:
+# host all all all gss k=v " someopt = withspaces "
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD OPTIONS
 host   all      all  all     gss    k=v " someopt = withspaces "
 # Detail:
@@ -379,6 +468,8 @@ host   all      all  all     gss    k=v " someopt = withspaces "
                 {" someopt ", " withspaces "},
             },
             OptionQuotes: {false, true},
+            Input:        "host all all all gss k=v \" someopt = withspaces \"",
+            Generated:    false,
         },
     },
 }
@@ -425,6 +516,11 @@ host all all root cert-password ignored=value
 host all all all gss krb_realm=other include_realm=0 krb_realm=te-st12.COM
 ----
 # String render check:
+# Original configuration:
+# host all all root cert-password ignored=value
+# host all all all gss krb_realm=other include_realm=0 krb_realm=te-st12.COM
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      all  root    cert-password ignored=value
 host   all      all  all     gss           krb_realm=other include_realm=0 krb_realm=te-st12.COM
@@ -446,6 +542,8 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
                 {"ignored", "value"},
             },
             OptionQuotes: {false},
+            Input:        "host all all root cert-password ignored=value",
+            Generated:    false,
         },
         {
             ConnType: 6,
@@ -464,6 +562,8 @@ host   all      all  all     gss           krb_realm=other include_realm=0 krb_r
                 {"krb_realm", "te-st12.COM"},
             },
             OptionQuotes: {false, false, false},
+            Input:        "host all all all gss krb_realm=other include_realm=0 krb_realm=te-st12.COM",
+            Generated:    false,
         },
     },
 }
@@ -477,6 +577,11 @@ host db all 0.0.0.0/0 cert
 host "all" "all" 0.0.0.0/0 cert
 ----
 # String render check:
+# Original configuration:
+# host db all 0.0.0.0/0 cert
+# host "all" "all" 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER  ADDRESS   METHOD OPTIONS
 host   db       all   0.0.0.0/0 cert
 host   "all"    "all" 0.0.0.0/0 cert
@@ -499,6 +604,8 @@ host   "all"    "all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host db all 0.0.0.0/0 cert",
+            Generated:    false,
         },
         {
             ConnType: 6,
@@ -516,6 +623,8 @@ host   "all"    "all" 0.0.0.0/0 cert
             MethodFn:     nil,
             Options:      nil,
             OptionQuotes: nil,
+            Input:        "host \"all\" \"all\" 0.0.0.0/0 cert",
+            Generated:    false,
         },
     },
 }

--- a/pkg/sql/pgwire/hba/testdata/scan
+++ b/pkg/sql/pgwire/hba/testdata/scan
@@ -190,8 +190,11 @@ a
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
+            input:  "a",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
             },
         },
     },
@@ -208,8 +211,11 @@ file
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
+            input:  "a",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
             },
         },
     },
@@ -226,8 +232,11 @@ file
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
+            input:  "a",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
             },
         },
     },
@@ -244,14 +253,17 @@ a b c
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
-            },
-            {
-                {Value:"b", Quoted:false},
-            },
-            {
-                {Value:"c", Quoted:false},
+            input:  "a b c",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
+                {
+                    {Value:"b", Quoted:false},
+                },
+                {
+                    {Value:"c", Quoted:false},
+                },
             },
         },
     },
@@ -265,22 +277,28 @@ d e
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
-            },
-            {
-                {Value:"b", Quoted:false},
-            },
-            {
-                {Value:"c", Quoted:false},
+            input:  "a b c",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
+                {
+                    {Value:"b", Quoted:false},
+                },
+                {
+                    {Value:"c", Quoted:false},
+                },
             },
         },
         {
-            {
-                {Value:"d", Quoted:false},
-            },
-            {
-                {Value:"e", Quoted:false},
+            input:  "d e",
+            tokens: {
+                {
+                    {Value:"d", Quoted:false},
+                },
+                {
+                    {Value:"e", Quoted:false},
+                },
             },
         },
     },
@@ -299,19 +317,25 @@ file
 hba.scannedInput{
     lines: {
         {
-            {
-                {Value:"a", Quoted:false},
-            },
-            {
-                {Value:"b", Quoted:false},
+            input:  "a  b # c d e",
+            tokens: {
+                {
+                    {Value:"a", Quoted:false},
+                },
+                {
+                    {Value:"b", Quoted:false},
+                },
             },
         },
         {
-            {
-                {Value:"d", Quoted:false},
-            },
-            {
-                {Value:"e", Quoted:false},
+            input:  "d  e # b c",
+            tokens: {
+                {
+                    {Value:"d", Quoted:false},
+                },
+                {
+                    {Value:"e", Quoted:false},
+                },
             },
         },
     },

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -220,7 +219,7 @@ func ParseAndNormalize(val string) (*hba.Conf, error) {
 		return conf, err
 	}
 
-	if len(conf.Entries) == 0 || !reflect.DeepEqual(conf.Entries[0], rootEntry) {
+	if len(conf.Entries) == 0 || !conf.Entries[0].Equivalent(rootEntry) {
 		entries := make([]hba.Entry, 1, len(conf.Entries)+1)
 		entries[0] = rootEntry
 		entries = append(entries, conf.Entries...)
@@ -248,6 +247,7 @@ var rootEntry = hba.Entry{
 	User:     []hba.String{{Value: security.RootUser, Quoted: false}},
 	Address:  hba.AnyAddr{},
 	Method:   hba.String{Value: "cert-password"},
+	Input:    "host  all root all cert-password # CockroachDB mandatory rule",
 }
 
 // DefaultHBAConfig is used when the stored HBA configuration string
@@ -255,8 +255,8 @@ var rootEntry = hba.Entry{
 var DefaultHBAConfig = func() *hba.Conf {
 	loadDefaultMethods()
 	conf, err := ParseAndNormalize(`
-host      all all  all cert-password
-local     all all      password
+host  all all  all cert-password # built-in CockroachDB default
+local all all      password      # built-in CockroachDB default
 `)
 	if err != nil {
 		panic(err)

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -20,6 +20,12 @@ config secure
 set_hba
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host  all all  all cert-password # built-in CockroachDB default
+# local all all      password      # built-in CockroachDB default
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      root all     cert-password
 host   all      all  all     cert-password

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -15,6 +15,12 @@ host  all all  all cert-password
 local all all      password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password
+# host  all all  all cert-password
+# local all all      password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      root all     cert-password
 host   all      all  all     cert-password

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -11,6 +11,11 @@ set_hba
 host all all 0.0.0.0/32 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all all 0.0.0.0/32 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS    METHOD        OPTIONS
 host   all      root all        cert-password
 host   all      all  0.0.0.0/32 cert
@@ -41,6 +46,11 @@ set_hba
 host all all 127.0.0.0/8 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all all 127.0.0.0/8 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS     METHOD        OPTIONS
 host   all      root all         cert-password
 host   all      all  127.0.0.0/8 cert

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -22,6 +22,11 @@ set_hba
 host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all root 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
 host   all      root all       cert-password
 host   all      root 0.0.0.0/0 cert
@@ -51,6 +56,11 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
 host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 cert
@@ -78,6 +88,11 @@ set_hba
 host all "a","b","testuser" 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all "a","b","testuser" 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER       ADDRESS   METHOD        OPTIONS
 host   all      root       all       cert-password
 host   all      "a"        0.0.0.0/0 cert
@@ -97,6 +112,12 @@ host all testuser 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser 0.0.0.0/0 cert
+# host all passworduser 0.0.0.0/0 cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
 host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert
@@ -125,6 +146,11 @@ set_hba
 host all testuser,passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser,passworduser 0.0.0.0/0 cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
 host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert-password
@@ -161,6 +187,12 @@ host all testuser,all 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser,all 0.0.0.0/0 cert
+# host all passworduser 0.0.0.0/0 password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
 host   all      root         all       cert-password
 host   all      all          0.0.0.0/0 cert
@@ -183,6 +215,12 @@ host all testuser,"all" 0.0.0.0/0 cert
 host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser,"all" 0.0.0.0/0 cert
+# host all passworduser 0.0.0.0/0 password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
 host   all      root         all       cert-password
 host   all      testuser     0.0.0.0/0 cert

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -19,6 +19,11 @@ set_hba
 host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all root 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
 host   all      root all       cert-password
 host   all      root 0.0.0.0/0 cert

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -18,6 +18,11 @@ set_hba
 host all root 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all root 0.0.0.0/0 password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
 host   all      root all       cert-password
 host   all      root 0.0.0.0/0 password
@@ -45,6 +50,11 @@ set_hba
 host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser 0.0.0.0/0 cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
 host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 cert
@@ -61,6 +71,11 @@ set_hba
 host all testuser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser 0.0.0.0/0 password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
 host   all      root     all       cert-password
 host   all      testuser 0.0.0.0/0 password

--- a/pkg/sql/pgwire/testdata/auth/trust_reject
+++ b/pkg/sql/pgwire/testdata/auth/trust_reject
@@ -15,6 +15,12 @@ host all testuser all reject
 host all all all cert-password
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testuser all reject
+# host all all all cert-password
+#
+# Interpreted configuration:
 # TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
 host   all      root     all     cert-password
 host   all      testuser all     reject
@@ -42,6 +48,12 @@ host all nocert all trust
 host all all all cert
 ----
 # Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all nocert all trust
+# host all all all cert
+#
+# Interpreted configuration:
 # TYPE DATABASE USER   ADDRESS METHOD        OPTIONS
 host   all      root   all     cert-password
 host   all      nocert all     trust


### PR DESCRIPTION
Needed for #45193.

Previously the original HBA configuration text was discarded during
parsing and normalization.

This patch changes the code to retain the original text. This is
useful to preserve any explanatory comments a user may have placed at
the end of each line. This will be also necessary/useful for
authentication logging.

Release note: None