### PR TITLE
colexec: wrap unsupported post process specs and ON expressions

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -140,6 +140,38 @@ type NewColOperatorResult struct {
 	BufferingOpMemAccounts []*mon.BoundAccount
 }
 
+// resetToState resets r to the state specified in arg. arg may be a shallow
+// copy made at a given point in time.
+func (r *NewColOperatorResult) resetToState(ctx context.Context, arg NewColOperatorResult) {
+	// MetadataSources are left untouched since there is no need to do any
+	// cleaning there.
+
+	// Close BoundAccounts that are not present in arg.BufferingOpMemAccounts.
+	accs := make(map[*mon.BoundAccount]struct{})
+	for _, a := range arg.BufferingOpMemAccounts {
+		accs[a] = struct{}{}
+	}
+	for _, a := range r.BufferingOpMemAccounts {
+		if _, ok := accs[a]; !ok {
+			a.Close(ctx)
+		}
+	}
+	// Stop BytesMonitors that are not present in arg.BufferingOpMemMonitors.
+	mons := make(map[*mon.BytesMonitor]struct{})
+	for _, m := range arg.BufferingOpMemMonitors {
+		mons[m] = struct{}{}
+	}
+
+	for _, m := range r.BufferingOpMemMonitors {
+		if _, ok := mons[m]; !ok {
+			m.Stop(ctx)
+		}
+	}
+
+	// Shallow copy over the rest.
+	*r = arg
+}
+
 const noFilterIdx = -1
 
 // isSupported checks whether we have a columnar operator equivalent to a
@@ -193,9 +225,8 @@ func isSupported(spec *execinfrapb.ProcessorSpec) (bool, error) {
 		return true, nil
 
 	case core.HashJoiner != nil:
-		if !core.HashJoiner.OnExpr.Empty() &&
-			core.HashJoiner.Type != sqlbase.JoinType_INNER {
-			return false, errors.Newf("can't plan non-inner hash join with on expressions")
+		if !core.HashJoiner.OnExpr.Empty() && core.HashJoiner.Type != sqlbase.InnerJoin {
+			return false, errors.Newf("can't plan vectorized non-inner hash joins with ON expressions")
 		}
 		return true, nil
 
@@ -365,6 +396,68 @@ func (r *NewColOperatorResult) createDiskBackedSort(
 	), nil
 }
 
+// createAndWrapRowSource takes a processor spec, creating the row source and
+// wrapping it using wrapRowSources. Note that the post process spec is included
+// in the processor creation, so make sure to clear it if it will be inspected
+// again. NewColOperatorResult is updated with the new OutputTypes and the
+// resulting Columnarizer if there is no error. The result is also annotated as
+// streaming because the resulting operator is not a buffering operator (even if
+// it is a buffering processor). This is not a problem for memory accounting
+// because each processor does that on its own, so the used memory will be
+// accounted for.
+func (r *NewColOperatorResult) createAndWrapRowSource(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	inputs []Operator,
+	inputTypes [][]types.T,
+	streamingMemAccount *mon.BoundAccount,
+	spec *execinfrapb.ProcessorSpec,
+	processorConstructor execinfra.ProcessorConstructor,
+) error {
+	c, err := wrapRowSources(
+		ctx,
+		flowCtx,
+		inputs,
+		inputTypes,
+		streamingMemAccount,
+		func(inputs []execinfra.RowSource) (execinfra.RowSource, error) {
+			// We provide a slice with a single nil as 'outputs' parameter because
+			// all processors expect a single output. Passing nil is ok here
+			// because when wrapping the processor, the materializer will be its
+			// output, and it will be set up in wrapRowSources.
+			proc, err := processorConstructor(
+				ctx, flowCtx, spec.ProcessorID, &spec.Core, &spec.Post, inputs,
+				[]execinfra.RowReceiver{nil}, /* outputs */
+				nil,                          /* localProcessors */
+			)
+			if err != nil {
+				return nil, err
+			}
+			var (
+				rs execinfra.RowSource
+				ok bool
+			)
+			if rs, ok = proc.(execinfra.RowSource); !ok {
+				return nil, errors.Newf(
+					"processor %s is not an execinfra.RowSource", spec.Core.String(),
+				)
+			}
+			r.ColumnTypes = rs.OutputTypes()
+			return rs, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+	// We say that the wrapped processor is "streaming" because it is not a
+	// buffering operator (even if it is a buffering processor). This is not a
+	// problem for memory accounting because each processor does that on its
+	// own, so the used memory will be accounted for.
+	r.Op, r.IsStreaming = c, true
+	r.MetadataSources = append(r.MetadataSources, c)
+	return nil
+}
+
 // NewColOperator creates a new columnar operator according to the given spec.
 func NewColOperator(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, args NewColOperatorArgs,
@@ -406,6 +499,10 @@ func NewColOperator(
 	// it is sufficient to look only at the "core" operator.
 	result.IsStreaming = false
 
+	// resultPreSpecPlanningStateShallowCopy is a shallow copy of the result
+	// before any specs are planned. Used if there is a need to backtrack.
+	resultPreSpecPlanningStateShallowCopy := result
+
 	supported, err := isSupported(spec)
 	if !supported {
 		// We refuse to wrap LocalPlanNode processor (which is a DistSQL wrapper
@@ -425,59 +522,19 @@ func NewColOperator(
 		}
 
 		log.VEventf(ctx, 1, "planning a wrapped processor because %s", err.Error())
-		var (
-			c          *Columnarizer
-			inputTypes [][]types.T
-		)
 
+		inputTypes := make([][]types.T, 0, len(spec.Input))
 		for _, input := range spec.Input {
 			inputTypes = append(inputTypes, input.ColumnTypes)
 		}
 
-		c, err = wrapRowSources(
-			ctx,
-			flowCtx,
-			inputs,
-			inputTypes,
-			streamingMemAccount,
-			func(inputs []execinfra.RowSource) (execinfra.RowSource, error) {
-				// We provide a slice with a single nil as 'outputs' parameter because
-				// all processors expect a single output. Passing nil is ok here
-				// because when wrapping the processor, the materializer will be its
-				// output, and it will be set up in wrapRowSources.
-				proc, err := processorConstructor(
-					ctx, flowCtx, spec.ProcessorID, core, post, inputs,
-					[]execinfra.RowReceiver{nil}, /* outputs */
-					nil,                          /* localProcessors */
-				)
-				if err != nil {
-					return nil, err
-				}
-				var (
-					rs execinfra.RowSource
-					ok bool
-				)
-				if rs, ok = proc.(execinfra.RowSource); !ok {
-					return nil, errors.Newf(
-						"processor %s is not an execinfra.RowSource", core.String(),
-					)
-				}
-				// The wrapped processors need to be passed the post-process specs,
-				// since they inspect them to figure out information about needed
-				// columns. This means that we'll let those processors do any renders
-				// or filters, which isn't ideal. We could improve this.
-				post = &execinfrapb.PostProcessSpec{}
-				result.ColumnTypes = rs.OutputTypes()
-				return rs, nil
-			},
-		)
+		err = result.createAndWrapRowSource(ctx, flowCtx, inputs, inputTypes, streamingMemAccount, spec, processorConstructor)
+		// The wrapped processors need to be passed the post-process specs,
+		// since they inspect them to figure out information about needed
+		// columns. This means that we'll let those processors do any renders
+		// or filters, which isn't ideal. We could improve this.
+		post = &execinfrapb.PostProcessSpec{}
 
-		// We say that the wrapped processor is "streaming" because it is not a
-		// buffering operator (even if it is a buffering processor). This is not a
-		// problem for memory accounting because each processor does that on its
-		// own, so the used memory will be accounted for.
-		result.Op, result.IsStreaming = c, true
-		result.MetadataSources = append(result.MetadataSources, c)
 	} else {
 		switch {
 		case core.Noop != nil:
@@ -727,14 +784,7 @@ func NewColOperator(
 			result.ColumnTypes = append(leftLogTypes, rightLogTypes...)
 
 			if !core.HashJoiner.OnExpr.Empty() && core.HashJoiner.Type == sqlbase.JoinType_INNER {
-				// We will plan other Operators on top of the hash joiner, so we need
-				// to account for the internal memory explicitly.
-				if internalMemOp, ok := result.Op.(InternalMemoryOperator); ok {
-					result.InternalMemUsage += internalMemOp.InternalMemoryUsage()
-				}
-				if err = result.planFilterExpr(
-					ctx, flowCtx.NewEvalCtx(), core.HashJoiner.OnExpr, streamingMemAccount,
-				); err != nil {
+				if err = result.planAndMaybeWrapOnExprAsFilter(ctx, flowCtx, core.HashJoiner.OnExpr, streamingMemAccount, processorConstructor); err != nil {
 					return result, err
 				}
 			}
@@ -762,6 +812,17 @@ func NewColOperator(
 			}
 
 			joinType := core.MergeJoiner.Type
+			var onExpr *execinfrapb.Expression
+			if !core.MergeJoiner.OnExpr.Empty() {
+				if joinType != sqlbase.JoinType_INNER {
+					return result, errors.AssertionFailedf(
+						"ON expression (%s) was unexpectedly planned for merge joiner with join type %s",
+						core.MergeJoiner.OnExpr.String(), core.MergeJoiner.Type.String(),
+					)
+				}
+				onExpr = &core.MergeJoiner.OnExpr
+			}
+
 			// We are using an unlimited memory monitor here because merge joiner
 			// itself is responsible for making sure that we stay within the memory
 			// limit, and it will fall back to disk if necessary.
@@ -780,15 +841,8 @@ func NewColOperator(
 
 			result.ColumnTypes = append(leftLogTypes, rightLogTypes...)
 
-			if !core.MergeJoiner.OnExpr.Empty() && joinType == sqlbase.JoinType_INNER {
-				// We will plan other Operators on top of the merge joiner, so we need
-				// to account for the internal memory explicitly.
-				if internalMemOp, ok := result.Op.(InternalMemoryOperator); ok {
-					result.InternalMemUsage += internalMemOp.InternalMemoryUsage()
-				}
-				if err = result.planFilterExpr(
-					ctx, flowCtx.NewEvalCtx(), core.MergeJoiner.OnExpr, streamingMemAccount,
-				); err != nil {
+			if onExpr != nil {
+				if err = result.planAndMaybeWrapOnExprAsFilter(ctx, flowCtx, *onExpr, streamingMemAccount, processorConstructor); err != nil {
 					return result, err
 				}
 			}
@@ -952,15 +1006,125 @@ func NewColOperator(
 	// Note: at this point, it is legal for ColumnTypes to be empty (it is
 	// legal for empty rows to be passed between processors).
 
+	ppr := postProcessResult{
+		Op:          result.Op,
+		ColumnTypes: result.ColumnTypes,
+	}
+	err = ppr.planPostProcessSpec(ctx, flowCtx, post, streamingMemAccount)
+	if err != nil {
+		log.VEventf(
+			ctx, 2,
+			"vectorized post process planning failed with error %v post spec is %s, attempting to wrap as a row source",
+			err, post,
+		)
+		if core.TableReader != nil {
+			// We cannot naively wrap a TableReader's post-processing spec since it
+			// might project out unneeded columns that are of unsupported types. These
+			// columns are still returned, either as coltypes.Unhandled if the type is
+			// unsupported, or as an empty column of a supported type. If we were to
+			// wrap an unsupported post-processing spec, a Materializer would naively
+			// decode these columns, which would return errors (e.g. UUIDs require 16
+			// bytes, coltypes.Unhandled may not be decoded).
+			inputTypes := make([][]types.T, 0, len(spec.Input))
+			for _, input := range spec.Input {
+				inputTypes = append(inputTypes, input.ColumnTypes)
+			}
+			result.resetToState(ctx, resultPreSpecPlanningStateShallowCopy)
+			err = result.createAndWrapRowSource(
+				ctx, flowCtx, inputs, inputTypes, streamingMemAccount, spec, processorConstructor,
+			)
+			if err != nil {
+				// There was an error wrapping the TableReader.
+				return result, err
+			}
+		} else {
+			err = result.wrapPostProcessSpec(ctx, flowCtx, post, streamingMemAccount, processorConstructor)
+		}
+	} else {
+		// The result can be updated with the post process result.
+		result.updateWithPostProcessResult(ppr)
+	}
+	return result, err
+}
+
+// planAndMaybeWrapOnExprAsFilter plans a joiner ON expression as a filter. If
+// the filter is unsupported, it is planned as a wrapped noop processor with
+// the filter as a post-processing stage.
+func (r *NewColOperatorResult) planAndMaybeWrapOnExprAsFilter(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	onExpr execinfrapb.Expression,
+	streamingMemAccount *mon.BoundAccount,
+	processorConstructor execinfra.ProcessorConstructor,
+) error {
+	// We will plan other Operators on top of r.Op, so we need to account for the
+	// internal memory explicitly.
+	if internalMemOp, ok := r.Op.(InternalMemoryOperator); ok {
+		r.InternalMemUsage += internalMemOp.InternalMemoryUsage()
+	}
+	ppr := postProcessResult{
+		Op:          r.Op,
+		ColumnTypes: r.ColumnTypes,
+	}
+	if err := ppr.planFilterExpr(
+		ctx, flowCtx.NewEvalCtx(), onExpr, streamingMemAccount,
+	); err != nil {
+		// ON expression planning failed. Fall back to planning the filter
+		// using row execution.
+		log.VEventf(
+			ctx, 2,
+			"vectorized join ON expr planning failed with error %v ON expr is %s, attempting to wrap as a row source",
+			err, onExpr.String(),
+		)
+
+		onExprAsFilter := &execinfrapb.PostProcessSpec{Filter: onExpr}
+		return r.wrapPostProcessSpec(ctx, flowCtx, onExprAsFilter, streamingMemAccount, processorConstructor)
+	}
+	r.updateWithPostProcessResult(ppr)
+	return nil
+}
+
+// wrapPostProcessSpec plans the given post process spec by wrapping a noop
+// processor with that output spec. This is used to fall back to row execution
+// when encountering unsupported post processing specs. An error is returned
+// if the wrapping failed. A reason for this could be an unsupported type, in
+// which case the row execution engine is used fully.
+func (r *NewColOperatorResult) wrapPostProcessSpec(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	post *execinfrapb.PostProcessSpec,
+	streamingMemAccount *mon.BoundAccount,
+	processorConstructor execinfra.ProcessorConstructor,
+) error {
+	noopSpec := &execinfrapb.ProcessorSpec{
+		Core: execinfrapb.ProcessorCoreUnion{
+			Noop: &execinfrapb.NoopCoreSpec{},
+		},
+		Post: *post,
+	}
+	return r.createAndWrapRowSource(
+		ctx, flowCtx, []Operator{r.Op}, [][]types.T{r.ColumnTypes}, streamingMemAccount, noopSpec, processorConstructor,
+	)
+}
+
+// planPostProcessSpec plans the post processing stage specified in post on top
+// of r.Op.
+func (r *postProcessResult) planPostProcessSpec(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	post *execinfrapb.PostProcessSpec,
+	streamingMemAccount *mon.BoundAccount,
+) error {
 	if !post.Filter.Empty() {
-		if err = result.planFilterExpr(
+		if err := r.planFilterExpr(
 			ctx, flowCtx.NewEvalCtx(), post.Filter, streamingMemAccount,
 		); err != nil {
-			return result, err
+			return err
 		}
 	}
+
 	if post.Projection {
-		result.addProjection(post.OutputColumns)
+		r.addProjection(post.OutputColumns)
 	} else if post.RenderExprs != nil {
 		log.VEventf(ctx, 2, "planning render expressions %+v", post.RenderExprs)
 		var renderedCols []uint32
@@ -969,37 +1133,37 @@ func NewColOperator(
 				helper            execinfra.ExprHelper
 				renderInternalMem int
 			)
-			err := helper.Init(expr, result.ColumnTypes, flowCtx.EvalCtx)
+			err := helper.Init(expr, r.ColumnTypes, flowCtx.EvalCtx)
 			if err != nil {
-				return result, err
+				return err
 			}
 			var outputIdx int
-			result.Op, outputIdx, result.ColumnTypes, renderInternalMem, err = planProjectionOperators(
-				ctx, flowCtx.NewEvalCtx(), helper.Expr, result.ColumnTypes, result.Op, streamingMemAccount,
+			r.Op, outputIdx, r.ColumnTypes, renderInternalMem, err = planProjectionOperators(
+				ctx, flowCtx.NewEvalCtx(), helper.Expr, r.ColumnTypes, r.Op, streamingMemAccount,
 			)
 			if err != nil {
-				return result, errors.Wrapf(err, "unable to columnarize render expression %q", expr)
+				return errors.Wrapf(err, "unable to columnarize render expression %q", expr)
 			}
 			if outputIdx < 0 {
-				return result, errors.AssertionFailedf("missing outputIdx")
+				return errors.AssertionFailedf("missing outputIdx")
 			}
-			result.InternalMemUsage += renderInternalMem
+			r.InternalMemUsage += renderInternalMem
 			renderedCols = append(renderedCols, uint32(outputIdx))
 		}
-		result.Op = NewSimpleProjectOp(result.Op, len(result.ColumnTypes), renderedCols)
+		r.Op = NewSimpleProjectOp(r.Op, len(r.ColumnTypes), renderedCols)
 		newTypes := make([]types.T, 0, len(renderedCols))
 		for _, j := range renderedCols {
-			newTypes = append(newTypes, result.ColumnTypes[j])
+			newTypes = append(newTypes, r.ColumnTypes[j])
 		}
-		result.ColumnTypes = newTypes
+		r.ColumnTypes = newTypes
 	}
 	if post.Offset != 0 {
-		result.Op = NewOffsetOp(result.Op, int(post.Offset))
+		r.Op = NewOffsetOp(r.Op, int(post.Offset))
 	}
 	if post.Limit != 0 {
-		result.Op = NewLimitOp(result.Op, int(post.Limit))
+		r.Op = NewLimitOp(r.Op, int(post.Limit))
 	}
-	return result, err
+	return nil
 }
 
 // createBufferingUnlimitedMemMonitor instantiates an unlimited memory monitor.
@@ -1071,7 +1235,19 @@ func (r *NewColOperatorResult) createStandaloneMemAccount(
 	return &standaloneMemAccount
 }
 
-func (r *NewColOperatorResult) planFilterExpr(
+type postProcessResult struct {
+	Op               Operator
+	ColumnTypes      []types.T
+	InternalMemUsage int
+}
+
+func (r *NewColOperatorResult) updateWithPostProcessResult(ppr postProcessResult) {
+	r.Op = ppr.Op
+	r.ColumnTypes = ppr.ColumnTypes
+	r.InternalMemUsage += ppr.InternalMemUsage
+}
+
+func (r *postProcessResult) planFilterExpr(
 	ctx context.Context,
 	evalCtx *tree.EvalContext,
 	filter execinfrapb.Expression,
@@ -1113,7 +1289,7 @@ func (r *NewColOperatorResult) planFilterExpr(
 
 // addProjection adds a simple projection to r (Op and ColumnTypes are updated
 // accordingly).
-func (r *NewColOperatorResult) addProjection(projection []uint32) {
+func (r *postProcessResult) addProjection(projection []uint32) {
 	r.Op = NewSimpleProjectOp(r.Op, len(r.ColumnTypes), projection)
 	// Update output ColumnTypes.
 	newTypes := make([]types.T, 0, len(projection))
@@ -1467,6 +1643,33 @@ func planProjectionOperators(
 	}
 }
 
+func checkSupportedProjectionExpr(binOp tree.Operator, left, right tree.TypedExpr) error {
+	leftTyp := left.ResolvedType()
+	rightTyp := right.ResolvedType()
+	if leftTyp.Equivalent(rightTyp) {
+		return nil
+	}
+
+	// The types are not equivalent. Check if either is a type we'd like to avoid.
+	for _, t := range []*types.T{leftTyp, rightTyp} {
+		switch t.Family() {
+		case types.DateFamily, types.TimestampFamily, types.TimestampTZFamily, types.IntervalFamily:
+			return errors.New("dates, timestamp(tz), and intervals not supported in mixed-type expressions in the vectorized engine")
+		}
+	}
+
+	// Because we want to be conservative, we allow specialized mixed-type
+	// operators with simple types and deny all else.
+	switch binOp {
+	case tree.Like, tree.NotLike:
+	case tree.In, tree.NotIn:
+	case tree.IsDistinctFrom, tree.IsNotDistinctFrom:
+	default:
+		return errors.New("binary operation not supported with mixed types")
+	}
+	return nil
+}
+
 func planProjectionExpr(
 	ctx context.Context,
 	evalCtx *tree.EvalContext,
@@ -1477,11 +1680,13 @@ func planProjectionExpr(
 	input Operator,
 	acc *mon.BoundAccount,
 ) (op Operator, resultIdx int, ct []types.T, internalMemUsed int, err error) {
+	if err := checkSupportedProjectionExpr(binOp, left, right); err != nil {
+		return nil, resultIdx, ct, internalMemUsed, err
+	}
 	resultIdx = -1
 	// There are 3 cases. Either the left is constant, the right is constant,
 	// or neither are constant.
-	lConstArg, lConst := left.(tree.Datum)
-	if lConst {
+	if lConstArg, lConst := left.(tree.Datum); lConst {
 		// Case one: The left is constant.
 		// Normally, the optimizer normalizes binary exprs so that the constant
 		// argument is on the right side. This doesn't happen for non-commutative

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1137,3 +1137,41 @@ SELECT b, d, e, f, g, sum(a) FROM t45481 GROUP BY b, d, e, f, g ORDER BY b, d, e
 7  5  5  5  55555555-5555-5555-5555-555555555555  196
 7  6  6  6  66666666-6666-6666-6666-666666666666  196
 7  7  7  7  77777777-7777-7777-7777-777777777777  196
+
+# Test that unsupported post process specs get wrapped in the vectorized engine.
+statement ok
+CREATE TABLE mixed_type_a (a INT, b TIMESTAMPTZ)
+
+statement ok
+CREATE TABLE mixed_type_b (a INT, b INTERVAL, c TIMESTAMP)
+
+statement ok
+INSERT INTO mixed_type_a VALUES (0, 0::TIMESTAMPTZ)
+
+statement ok
+INSERT INTO mixed_type_b VALUES (0, INTERVAL '0 days', 0::TIMESTAMP)
+
+# Set vectorize to experimental_always to ensure that no error occurs when
+# planning these mixed-type operations.
+statement ok
+SET vectorize=experimental_always
+
+query B
+SELECT b > now() - interval '1 day'  FROM mixed_type_a
+----
+false
+
+# Merge join ON expressions also get wrapped.
+query ITITT
+SELECT * FROM mixed_type_a AS a INNER MERGE JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
+----
+0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
+
+# So do hash inner hash join ON expressions.
+query ITITT
+SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
+----
+0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
+
+statement ok
+RESET vectorize

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -39,7 +39,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
 ----
 ·                    distributed  false                        ·                                                                                                                                                    ·
-·                    vectorized   false                        ·                                                                                                                                                    ·
+·                    vectorized   true                         ·                                                                                                                                                    ·
 render               ·            ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
  │                   render 0     (min)[int]                   ·                                                                                                                                                    ·
  │                   render 1     (max)[int]                   ·                                                                                                                                                    ·
@@ -1179,7 +1179,7 @@ EXPLAIN (VERBOSE)
         company_id
 ----
 ·                    distributed  false                         ·                               ·
-·                    vectorized   false                         ·                               ·
+·                    vectorized   true                          ·                               ·
 sort                 ·            ·                             (company_id, string_agg)        +company_id
  │                   order        +company_id                   ·                               ·
  └── group           ·            ·                             (company_id, string_agg)        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -81,7 +81,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
 ·                distributed         true                 ·            ·
-·                vectorized          false                ·            ·
+·                vectorized          true                 ·            ·
 render           ·                   ·                    (x, str)     ·
  │               render 0            x                    ·            ·
  │               render 1            str                  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -465,7 +465,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
 ·     distributed  false        ·       ·
-·     vectorized   false        ·       ·
+·     vectorized   true         ·       ·
 scan  ·            ·            (k, v)  ·
 ·     table        t@primary    ·       ·
 ·     spans        ALL          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -189,7 +189,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
 ----
 ·                    distributed  false              ·                   ·
-·                    vectorized   false              ·                   ·
+·                    vectorized   true               ·                   ·
 render               ·            ·                  (x, two, plus1)     ·
  │                   render 0     COALESCE(x, x)     ·                   ·
  │                   render 1     two                ·                   ·
@@ -530,7 +530,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
 ·                         distributed  false                ·                       ·
-·                         vectorized   false                ·                       ·
+·                         vectorized   true                 ·                       ·
 render                    ·            ·                    (a, b, n, sq)           ·
  │                        render 0     a                    ·                       ·
  │                        render 1     b                    ·                       ·
@@ -928,7 +928,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 ·                     distributed     false              ·                   ·
-·                     vectorized      false              ·                   ·
+·                     vectorized      true               ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
  └── render           ·               ·                  (x, y, u, v)        ·
@@ -1068,7 +1068,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 ·                     distributed     false              ·                   ·
-·                     vectorized      false              ·                   ·
+·                     vectorized      true               ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
  └── render           ·               ·                  (x, y, u, v)        ·
@@ -1262,7 +1262,7 @@ query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
 ·                distributed         false
-·                vectorized          false
+·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
       │          type                inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -166,7 +166,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) AS r FROM t
 ----
 ·          distributed  false                       ·       ·
-·          vectorized   false                       ·       ·
+·          vectorized   true                        ·       ·
 render     ·            ·                           (r)     ·
  │         render 0     (a, b) IN ((1, 2), (3, 4))  ·       ·
  └── scan  ·            ·                           (a, b)  ·
@@ -232,7 +232,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b AS r FROM t
 ----
 ·          distributed  false                     ·       ·
-·          vectorized   false                     ·       ·
+·          vectorized   true                      ·       ·
 render     ·            ·                         (r)     ·
  │         render 0     a IS NOT DISTINCT FROM b  ·       ·
  └── scan  ·            ·                         (a, b)  ·
@@ -265,7 +265,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b AS r FROM t
 ----
 ·          distributed  false                 ·       ·
-·          vectorized   false                 ·       ·
+·          vectorized   true                  ·       ·
 render     ·            ·                     (r)     ·
  │         render 0     a IS DISTINCT FROM b  ·       ·
  └── scan  ·            ·                     (a, b)  ·
@@ -276,7 +276,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT +a + (-b) AS r FROM t
 ----
 ·          distributed  false      ·       ·
-·          vectorized   false      ·       ·
+·          vectorized   true       ·       ·
 render     ·            ·          (r)     ·
  │         render 0     a + (-b)   ·       ·
  └── scan  ·            ·          (a, b)  ·
@@ -287,7 +287,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END AS r FROM t
 ----
 ·          distributed  false                                          ·    ·
-·          vectorized   false                                          ·    ·
+·          vectorized   true                                           ·    ·
 render     ·            ·                                              (r)  ·
  │         render 0     CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
  └── scan  ·            ·                                              (a)  ·
@@ -309,7 +309,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END AS r FROM t
 ----
 ·          distributed  false                                                       ·       ·
-·          vectorized   false                                                       ·       ·
+·          vectorized   true                                                        ·       ·
 render     ·            ·                                                           (r)     ·
  │         render 0     CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
  └── scan  ·            ·                                                           (a, b)  ·
@@ -332,7 +332,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END AS r FROM t
 ----
 ·          distributed  false                     ·    ·
-·          vectorized   false                     ·    ·
+·          vectorized   true                      ·    ·
 render     ·            ·                         (r)  ·
  │         render 0     CASE a WHEN 2 THEN 1 END  ·    ·
  └── scan  ·            ·                         (a)  ·
@@ -464,7 +464,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
 ·          distributed  false      ·       ·
-·          vectorized   false      ·       ·
+·          vectorized   true       ·       ·
 render     ·            ·          (a, b)  ·
  │         render 0     a::STRING  ·       ·
  │         render 1     b::FLOAT8  ·       ·
@@ -476,7 +476,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
 ·          distributed  false                  ·          ·
-·          vectorized   false                  ·          ·
+·          vectorized   true                   ·          ·
 render     ·            ·                      (text)     ·
  │         render 0     (c + (a + b))::STRING  ·          ·
  └── scan  ·            ·                      (a, b, c)  ·
@@ -487,7 +487,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT s::VARCHAR(2) FROM t
 ----
 ·          distributed  false          ·    ·
-·          vectorized   false          ·    ·
+·          vectorized   true           ·    ·
 render     ·            ·              (s)  ·
  │         render 0     s::VARCHAR(2)  ·    ·
  └── scan  ·            ·              (s)  ·
@@ -617,7 +617,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
 ----
 ·          distributed  false                       ·             ·
-·          vectorized   false                       ·             ·
+·          vectorized   true                        ·             ·
 render     ·            ·                           ("?column?")  ·
  │         render 0     1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
  └── scan  ·            ·                           (a)           ·
@@ -650,7 +650,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
 ----
 ·          distributed  false                 ·          ·
-·          vectorized   false                 ·          ·
+·          vectorized   true                  ·          ·
 render     ·            ·                     ("least")  ·
  │         render 0     least(NULL, 3, 6, a)  ·          ·
  └── scan  ·            ·                     (a)        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -830,7 +830,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
 ·     distributed  false                        ·            ·
-·     vectorized   false                        ·            ·
+·     vectorized   true                         ·            ·
 scan  ·            ·                            (d decimal)  ·
 ·     table        dec2@primary                 ·            ·
 ·     spans        ALL                          ·            ·
@@ -870,7 +870,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
 ·     distributed  false                      ·          ·
-·     vectorized   false                      ·          ·
+·     vectorized   true                       ·          ·
 scan  ·            ·                          (f float)  ·
 ·     table        flt@primary                ·          ·
 ·     spans        ALL                        ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -628,7 +628,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab WHERE (i, s) < (1, 'c')
 ----
 ·          distributed  false              ·       ·
-·          vectorized   false              ·       ·
+·          vectorized   true               ·       ·
 render     ·            ·                  (i, s)  ·
  │         render 0     i                  ·       ·
  │         render 1     s                  ·       ·
@@ -644,7 +644,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
 ·          distributed  false              ·       ·
-·          vectorized   false              ·       ·
+·          vectorized   true               ·       ·
 render     ·            ·                  (i, s)  ·
  │         render 0     i                  ·       ·
  │         render 1     s                  ·       ·
@@ -939,7 +939,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 ----
 ·     distributed  false                 ·       ·
-·     vectorized   false                 ·       ·
+·     vectorized   true                  ·       ·
 scan  ·            ·                     (k, v)  ·
 ·     table        str@str_v_idx         ·       ·
 ·     spans        /"ABC"-/"ABD"         ·       ·
@@ -1001,7 +1001,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ----
 ·     distributed  false                 ·       ·
-·     vectorized   false                 ·       ·
+·     vectorized   true                  ·       ·
 scan  ·            ·                     (x, y)  ·
 ·     table        xy@primary            ·       ·
 ·     spans        ALL                   ·       ·
@@ -1262,7 +1262,7 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
 ·           distributed  false
-·           vectorized   false
+·           vectorized   true
 index-join  ·            ·
  │          table        t2@primary
  │          key columns  a

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -46,7 +46,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
 ·                            distributed   false                                                                        ·               ·
-·                            vectorized    false                                                                        ·               ·
+·                            vectorized    true                                                                         ·               ·
 root                         ·             ·                                                                            (a, b, c)       ·
  ├── scan                    ·             ·                                                                            (a, b, c)       ·
  │                           table         abc@primary                                                                  ·               ·
@@ -140,7 +140,7 @@ WHERE
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 ·               distributed   false                                                                                                       ·                   ·
-·               vectorized    false                                                                                                       ·                   ·
+·               vectorized    true                                                                                                        ·                   ·
 root            ·             ·                                                                                                           (col0)              ·
  ├── render     ·             ·                                                                                                           (col0)              ·
  │    │         render 0      col0                                                                                                        ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -30,7 +30,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
 ·     distributed  false                   ·          ·
-·     vectorized   false                   ·          ·
+·     vectorized   true                    ·          ·
 scan  ·            ·                       (u, v, w)  +u,+v,+w
 ·     table        uvw@uvw_u_v_w_idx       ·          ·
 ·     spans        /!NULL-/2/3/2           ·          ·
@@ -40,7 +40,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
 ·     distributed  false                  ·          ·
-·     vectorized   false                  ·          ·
+·     vectorized   true                   ·          ·
 scan  ·            ·                      (u, v, w)  +u,+v,+w
 ·     table        uvw@uvw_u_v_w_idx      ·          ·
 ·     spans        /!NULL-/2/2/2          ·          ·
@@ -50,7 +50,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
 ·     distributed  false                   ·          ·
-·     vectorized   false                   ·          ·
+·     vectorized   true                    ·          ·
 scan  ·            ·                       (u, v, w)  +u,+v,+w
 ·     table        uvw@uvw_u_v_w_idx       ·          ·
 ·     spans        -/1/2/3 /1/2/4-         ·          ·
@@ -105,7 +105,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
 ·     distributed  false                  ·          ·
-·     vectorized   false                  ·          ·
+·     vectorized   true                   ·          ·
 scan  ·            ·                      (a, b, c)  ·
 ·     table        abc@abc_a_b_c_idx      ·          ·
 ·     spans        /1-                    ·          ·


### PR DESCRIPTION
Unsupported post process specs and ON expressions are now planned after a
columnar operator by wrapping a noop processor that evaluates the unsupported
expression before returning the row.

This commit also makes sure that two types are Equivalent before planning any
comparison or binary expression. Returning an error if not.

Release note (bug fix): mixed type comparison or binary expressions that could
have previously returned wrong results in the vectorized execution engine fall
back to using the row execution engine.

Fixes #45626 