### PR TITLE
cli: allow for `cockroach demo` to start in secure mode

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -408,8 +408,16 @@ func Example_demo() {
 		{`demo`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
 		{`demo`, `startrek`, `-e`, `show databases`},
 		{`demo`, `startrek`, `-e`, `show databases`, `--format=table`},
+		// Test that if we start with --insecure=false we can perform
+		// commands that require a secure cluster.
+		{`demo`, `--insecure=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
+		{`demo`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 	}
 	setCLIDefaultsForTests()
+	// We must reset the security asset loader here, otherwise the dummy
+	// asset loader that is set by default in tests will not be able to
+	// find the certs that demo sets up.
+	security.ResetAssetLoader()
 	for _, cmd := range testData {
 		c.RunWithArgs(cmd)
 	}
@@ -457,6 +465,11 @@ func Example_demo() {
 	//   startrek
 	//   system
 	// (4 rows)
+	// demo --insecure=false -e CREATE USER test WITH PASSWORD 'testpass'
+	// CREATE USER 1
+	// demo -e CREATE USER test WITH PASSWORD 'testpass'
+	// ERROR: setting or updating a password is not supported in insecure mode
+	// SQLSTATE: 28P01
 }
 
 func Example_sql() {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -162,6 +162,7 @@ func initCLIDefaults() {
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
+	demoCtx.insecure = true
 
 	authCtx.validityPeriod = 1 * time.Hour
 
@@ -378,4 +379,5 @@ var demoCtx struct {
 	geoPartitionedReplicas    bool
 	simulateLatency           bool
 	transientCluster          *transientCluster
+	insecure                  bool
 }

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -12,6 +12,8 @@
 
 package cli
 
+import "github.com/cockroachdb/cockroach/pkg/security"
+
 func Example_demo_locality() {
 	c := newCLITest(cliTestParams{noServer: true})
 	defer c.cleanup()
@@ -23,6 +25,10 @@ func Example_demo_locality() {
 			`-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
 	}
 	setCLIDefaultsForTests()
+	// We must reset the security asset loader here, otherwise the dummy
+	// asset loader that is set by default in tests will not be able to
+	// find the certs that demo sets up.
+	security.ResetAssetLoader()
 	for _, cmd := range testData {
 		c.RunWithArgs(cmd)
 	}

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -38,7 +38,6 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			cacheSize:         1 << 10,
 			expected: base.TestServerArgs{
 				PartOfCluster:     true,
-				Insecure:          true,
 				JoinAddr:          "127.0.0.1",
 				SQLMemoryPoolSize: 2 << 10,
 				CacheSize:         1 << 10,
@@ -51,7 +50,6 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			cacheSize:         4 << 10,
 			expected: base.TestServerArgs{
 				PartOfCluster:     true,
-				Insecure:          true,
 				JoinAddr:          "127.0.0.1",
 				SQLMemoryPoolSize: 4 << 10,
 				CacheSize:         4 << 10,

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -605,6 +605,7 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
 	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
+	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, true)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
 	_ = demoFlags.MarkHidden(cliflags.Global.Name)

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -19,3 +19,23 @@ eexpect root@
 # Ensure db is movr.
 eexpect "movr>"
 end_test
+
+start_test "Check that demo secure mode says hello properly"
+spawn $argv demo --insecure=false
+# Be polite.
+eexpect "Welcome"
+# Warn the user that they won't get persistence.
+eexpect "your changes to data stored in the demo session will not be saved!"
+# Inform the necessary URL.
+eexpect "Web UI: https:"
+# Ensure that user login information is present.
+eexpect "The user \"root\" with password \"admin\" has been created."
+# Ensure same messages as cockroach sql.
+eexpect "Server version"
+eexpect "Cluster ID"
+eexpect "brief introduction"
+# Ensure user is root.
+eexpect root@
+# Ensure db is movr.
+eexpect "movr>"
+end_test


### PR DESCRIPTION
Fixes #45607.

Release note (cli change): This PR adds support for `cockroach demo`
to start in secure mode using the flag `--insecure=false`.