### PR TITLE
roachtest: fix copy/bank roachtest on 19.1

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -164,5 +164,9 @@ func getDefaultRangeSize(
         AS range_max_bytes
 FROM
     [SHOW ZONE CONFIGURATION FOR RANGE default];`).Scan(&rangeMinBytes, &rangeMaxBytes)
+	// Older cluster versions do not contain this column. Use the old default.
+	if err != nil && strings.Contains(err.Error(), `column "raw_config_sql" does not exist`) {
+		rangeMinBytes, rangeMaxBytes, err = 32<<20 /* 32MB */, 64<<20 /* 64MB */, nil
+	}
 	return rangeMinBytes, rangeMaxBytes, err
 }


### PR DESCRIPTION
In 19.2 we changed the name of the column from
SHOW ZONE CONFIGURATION from `config_sql` to `raw_config_sql`.
I relied on this column name in #45451.

This change updates the test to fall back to the old defaults if the column
does not exist.

Fixes #45489.

Release note: None