### PR TITLE
opt: improve tightness estimation for constraints with OR

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -601,5 +601,3 @@ message LIKE 'Del /Table/61/2/%' OR
 message LIKE 'CPut /Table/61/2/%'
 ----
 CPut /Table/61/2/5/1/0 -> /BYTES/0x330a1308 (replacing raw_bytes:"\000\000\000\000\0033\006\023\010" timestamp:<> , if exists)
-
-

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1219,3 +1219,82 @@ select
       └── similar-to [type=bool, outer=(3), constraints=(/3: [/'' - ])]
            ├── variable: v:3 [type=string]
            └── const: '.*' [type=string]
+
+# We can determine that the constraint set is tight when there is a single
+# variable and tight constraints are combined with OR.
+opt
+SELECT * FROM a WHERE x <= 5 OR x = 10 OR x = 15
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── prune: (2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /5] [/10 - /10] [/15 - /15]; tight)]
+           ├── or [type=bool]
+           │    ├── le [type=bool]
+           │    │    ├── variable: x:1 [type=int]
+           │    │    └── const: 5 [type=int]
+           │    └── eq [type=bool]
+           │         ├── variable: x:1 [type=int]
+           │         └── const: 10 [type=int]
+           └── eq [type=bool]
+                ├── variable: x:1 [type=int]
+                └── const: 15 [type=int]
+
+# The constraint set is also tight when each side has a single constraint with
+# matching columns.
+opt
+SELECT * FROM a WHERE (x, y) < (1, 2) OR (x, y) > (3, 4)
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1] [/3/5 - ]; tight)]
+           ├── lt [type=bool]
+           │    ├── tuple [type=tuple{int, int}]
+           │    │    ├── variable: x:1 [type=int]
+           │    │    └── variable: y:2 [type=int]
+           │    └── tuple [type=tuple{int, int}]
+           │         ├── const: 1 [type=int]
+           │         └── const: 2 [type=int]
+           └── gt [type=bool]
+                ├── tuple [type=tuple{int, int}]
+                │    ├── variable: x:1 [type=int]
+                │    └── variable: y:2 [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 3 [type=int]
+                     └── const: 4 [type=int]
+
+
+# The constraint set is not tight if there are multiple constraints with
+# different variables.
+opt
+SELECT * FROM a WHERE (x > 1 AND y > 10) OR (x < 5 AND y < 50)
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
+           ├── and [type=bool]
+           │    ├── gt [type=bool]
+           │    │    ├── variable: x:1 [type=int]
+           │    │    └── const: 1 [type=int]
+           │    └── gt [type=bool]
+           │         ├── variable: y:2 [type=int]
+           │         └── const: 10 [type=int]
+           └── and [type=bool]
+                ├── lt [type=bool]
+                │    ├── variable: x:1 [type=int]
+                │    └── const: 5 [type=int]
+                └── lt [type=bool]
+                     ├── variable: y:2 [type=int]
+                     └── const: 50 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -176,7 +176,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /'2017-01-04'] [/'2019-08-07' - /'2019-08-07'] [/'2019-08-08' - /'2019-08-08'])]
+      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /'2017-01-04'] [/'2019-08-07' - /'2019-08-07'] [/'2019-08-08' - /'2019-08-08']; tight)]
            ├── in [type=bool]
            │    ├── variable: d:1 [type=date]
            │    └── tuple [type=tuple{date, date}]

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -114,7 +114,7 @@ SELECT * FROM a WHERE s = 'foo' OR s = 'bar'
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=133.333333, distinct(1)=133.333333, null(1)=0, distinct(2)=74.8385577, null(2)=0, distinct(3)=2, null(3)=0, distinct(2,3)=128.888889, null(2,3)=0, distinct(1-3)=133.333333, null(1-3)=0]
+ ├── stats: [rows=400, distinct(1)=400, null(1)=0, distinct(2)=98.8470785, null(2)=0, distinct(3)=2, null(3)=0, distinct(2,3)=360, null(2,3)=0, distinct(1-3)=400, null(1-3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  └── scan a@secondary
@@ -131,7 +131,7 @@ SELECT * FROM a WHERE s = 'foo' OR s = 'bar'
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=133.333333, distinct(3)=2, null(3)=0]
+ ├── stats: [rows=400, distinct(3)=2, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── scan a
@@ -140,7 +140,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
-      └── (s:3 = 'foo') OR (s:3 = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+      └── (s:3 = 'foo') OR (s:3 = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
 
 # Bump up null counts.
 exec-ddl
@@ -226,12 +226,12 @@ SELECT * FROM a WHERE (s = 'foo' OR s = 'bar') AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=66.6666667, distinct(1)=66.6666667, null(1)=0, distinct(2)=49.3854989, null(2)=33.3333333, distinct(3)=2, null(3)=0, distinct(2,3)=65.7755838, null(2,3)=50, distinct(1-3)=63.4151782, null(1-3)=50]
+ ├── stats: [rows=200, distinct(1)=200, null(1)=0, distinct(2)=88.4618791, null(2)=100, distinct(3)=2, null(3)=0, distinct(2,3)=191.943229, null(2,3)=150, distinct(1-3)=172.017276, null(1-3)=150]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=66.6666667, distinct(3)=2, null(3)=0]
+      ├── stats: [rows=200, distinct(3)=2, null(3)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -243,14 +243,14 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           └── (s:3 = 'foo') OR (s:3 = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+           └── (s:3 = 'foo') OR (s:3 = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
 
 norm
 SELECT * FROM a WHERE (s = 'foo' OR s = 'bar') AND s IS NOT NULL
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=66.6666667, distinct(3)=2, null(3)=0]
+ ├── stats: [rows=200, distinct(3)=2, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── scan a
@@ -259,5 +259,4 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
-      ├── (s:3 = 'foo') OR (s:3 = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
-      └── s:3 IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
+      └── ((s:3 = 'foo') OR (s:3 = 'bar')) AND (s:3 IS NOT NULL) [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -150,7 +150,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -162,14 +162,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s:3 <= 'aaa') OR (s:3 >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ])]
+      └── (s:3 <= 'aaa') OR (s:3 >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ]; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS NULL
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -181,7 +181,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
-      └── ((s:3 <= 'aaa') OR ((s:3 >= 'bar') AND (s:3 <= 'foo'))) OR (s:3 IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo'])]
+      └── ((s:3 <= 'aaa') OR ((s:3 >= 'bar') AND (s:3 <= 'foo'))) OR (s:3 IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo']; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE s IS NOT NULL
@@ -198,7 +198,7 @@ SELECT s, d, x FROM a WHERE (s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -210,19 +210,19 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+      └── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5.0
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=37.037037, null(4)=0]
+      ├── stats: [rows=111.111111, distinct(3)=0.222222222, null(3)=0, distinct(4)=100, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -234,7 +234,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d:4 > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
 
 opt
@@ -242,12 +242,12 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=12.345679, distinct(3)=0.222222222, null(3)=0, distinct(4)=12.345679, null(4)=0]
+      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -259,7 +259,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d:4 <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
 
 # Bump up null counts.
@@ -344,7 +344,7 @@ SELECT s, d, x FROM a WHERE ((s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')) AND s 
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -356,14 +356,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s:3 <= 'aaa') OR (s:3 >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ])]
+      └── (s:3 <= 'aaa') OR (s:3 >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ]; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS NULL
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=333.333333]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=1000]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -375,7 +375,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
-      └── ((s:3 <= 'aaa') OR ((s:3 >= 'bar') AND (s:3 <= 'foo'))) OR (s:3 IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo'])]
+      └── ((s:3 <= 'aaa') OR ((s:3 >= 'bar') AND (s:3 <= 'foo'))) OR (s:3 IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo']; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE s IS NOT NULL
@@ -392,7 +392,7 @@ SELECT s, d, x FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -404,19 +404,19 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+      └── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 5.0 AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=12.345679, distinct(3)=0.333333333, null(3)=0, distinct(4)=12.345679, null(4)=0]
+      ├── stats: [rows=37.037037, distinct(3)=0.333333333, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -428,7 +428,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d:4 <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
 
 exec-ddl
@@ -770,7 +770,9 @@ SELECT * FROM hist WHERE c = 20 OR (c < 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(3)=15, null(3)=0]
+ ├── stats: [rows=110, distinct(3)=10, null(3)=0]
+ │   histogram(3)=  0  0  90  0   0  20
+ │                <--- 0 ---- 10 --- 20
  └── scan hist@idx_c
       ├── columns: c:3(decimal!null) rowid:8(int!null)
       ├── constraint: /3/8
@@ -787,7 +789,9 @@ SELECT * FROM hist WHERE c = 20 OR (c <= 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(3)=15, null(3)=0]
+ ├── stats: [rows=120, distinct(3)=11, null(3)=0]
+ │   histogram(3)=  0  0  90  10  0  20
+ │                <--- 0 ---- 10 --- 20
  └── scan hist@idx_c
       ├── columns: c:3(decimal!null) rowid:8(int!null)
       ├── constraint: /3/8
@@ -804,10 +808,14 @@ SELECT * FROM hist WHERE (d >= 5 AND d < 15) OR d >= 40
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float!null) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(4)=15, null(4)=0]
+ ├── stats: [rows=185, distinct(4)=11.5, null(4)=0]
+ │   histogram(4)=  0          0          45   10   90          0           0   40
+ │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
  └── select
       ├── columns: d:4(float!null) rowid:8(int!null)
-      ├── stats: [rows=20.5555556, distinct(4)=3.83333333, null(4)=0]
+      ├── stats: [rows=185, distinct(4)=11.5, null(4)=0]
+      │   histogram(4)=  0          0          45   10   90          0           0   40
+      │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
       ├── key: (8)
       ├── fd: (8)-->(4)
       ├── scan hist@idx_d
@@ -821,7 +829,7 @@ index-join hist
       │    ├── key: (8)
       │    └── fd: (8)-->(4)
       └── filters
-           └── (d:4 < 15.0) OR (d:4 >= 40.0) [type=bool, outer=(4), constraints=(/4: (/NULL - /14.999999999999998] [/40.0 - ])]
+           └── (d:4 < 15.0) OR (d:4 >= 40.0) [type=bool, outer=(4), constraints=(/4: (/NULL - /14.999999999999998] [/40.0 - ]; tight)]
 
 opt
 SELECT * FROM hist WHERE e < '2018-07-31 23:00:00'::TIMESTAMP
@@ -861,7 +869,9 @@ SELECT * FROM hist WHERE g = 'mango' OR g = 'foo'
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string!null)
- ├── stats: [rows=16.6666667, distinct(7)=2, null(7)=0]
+ ├── stats: [rows=165, distinct(7)=2, null(7)=0]
+ │   histogram(7)=  0   135   0    30
+ │                <--- 'foo' --- 'mango'
  └── scan hist@idx_g
       ├── columns: g:7(string!null) rowid:8(int!null)
       ├── constraint: /7/8
@@ -879,13 +889,19 @@ SELECT * FROM hist WHERE (a = 10 OR a = 20) AND (b = '2018-08-31'::DATE OR b = '
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=0.0925925926, distinct(1)=0.0925925926, null(1)=0, distinct(2)=0.0925925926, null(2)=0]
+ ├── stats: [rows=1.5, distinct(1)=1.5, null(1)=0, distinct(2)=1.5, null(2)=0]
+ │   histogram(1)=  0 0.5  0  1
+ │                <--- 10 --- 20
+ │   histogram(2)=  0      0.6       0      0.9
+ │                <--- '2018-08-31' --- '2018-09-30'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- │    ├── stats: [rows=10]
+ │    ├── stats: [rows=30]
  │    └── select
  │         ├── columns: a:1(int!null) rowid:8(int!null)
- │         ├── stats: [rows=10, distinct(1)=2, null(1)=0]
+ │         ├── stats: [rows=30, distinct(1)=2, null(1)=0]
+ │         │   histogram(1)=  0  10  0  20
+ │         │                <--- 10 --- 20
  │         ├── key: (8)
  │         ├── fd: (8)-->(1)
  │         ├── scan hist@idx_a
@@ -899,22 +915,28 @@ select
  │         │    ├── key: (8)
  │         │    └── fd: (8)-->(1)
  │         └── filters
- │              └── (a:1 = 10) OR (a:1 = 20) [type=bool, outer=(1), constraints=(/1: [/10 - /10] [/20 - /20])]
+ │              └── (a:1 = 10) OR (a:1 = 20) [type=bool, outer=(1), constraints=(/1: [/10 - /10] [/20 - /20]; tight)]
  └── filters
-      └── (b:2 = '2018-08-31') OR (b:2 = '2018-09-30') [type=bool, outer=(2), constraints=(/2: [/'2018-08-31' - /'2018-08-31'] [/'2018-09-30' - /'2018-09-30'])]
+      └── (b:2 = '2018-08-31') OR (b:2 = '2018-09-30') [type=bool, outer=(2), constraints=(/2: [/'2018-08-31' - /'2018-08-31'] [/'2018-09-30' - /'2018-09-30']; tight)]
 
 opt
 SELECT * FROM hist WHERE (a = 30 OR a = 40) AND (b = '2018-06-30'::DATE OR b = '2018-07-31'::DATE)
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=0.0925925926, distinct(1)=0.0925925926, null(1)=0, distinct(2)=0.0925925926, null(2)=0]
+ ├── stats: [rows=0.7, distinct(1)=0.7, null(1)=0, distinct(2)=0.7, null(2)=0]
+ │   histogram(1)=  0 0.3  0 0.4
+ │                <--- 30 --- 40
+ │   histogram(2)=  0      0.7
+ │                <--- '2018-07-31'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- │    ├── stats: [rows=3.33333333]
+ │    ├── stats: [rows=10]
  │    └── select
  │         ├── columns: b:2(date!null) rowid:8(int!null)
- │         ├── stats: [rows=3.33333333, distinct(2)=1, null(2)=0]
+ │         ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+ │         │   histogram(2)=  0       10
+ │         │                <--- '2018-07-31'
  │         ├── key: (8)
  │         ├── fd: (8)-->(2)
  │         ├── scan hist@idx_b
@@ -928,6 +950,6 @@ select
  │         │    ├── key: (8)
  │         │    └── fd: (8)-->(2)
  │         └── filters
- │              └── (b:2 = '2018-06-30') OR (b:2 = '2018-07-31') [type=bool, outer=(2), constraints=(/2: [/'2018-06-30' - /'2018-06-30'] [/'2018-07-31' - /'2018-07-31'])]
+ │              └── (b:2 = '2018-06-30') OR (b:2 = '2018-07-31') [type=bool, outer=(2), constraints=(/2: [/'2018-06-30' - /'2018-06-30'] [/'2018-07-31' - /'2018-07-31']; tight)]
  └── filters
-      └── (a:1 = 30) OR (a:1 = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40])]
+      └── (a:1 = 30) OR (a:1 = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1514,7 +1514,7 @@ SELECT * FROM nation WHERE n_name = 'FRANCE' OR n_name = 'GERMANY'
 ----
 select
  ├── columns: n_nationkey:1(int!null) n_name:2(char!null) n_regionkey:3(int!null) neighbor:4(char!null)
- ├── stats: [rows=333333.333, distinct(2)=2, null(2)=0]
+ ├── stats: [rows=1000000, distinct(2)=2, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan nation
@@ -1523,7 +1523,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  └── filters
-      └── (n_name:2 = 'FRANCE') OR (n_name:2 = 'GERMANY') [type=bool, outer=(2), constraints=(/2: [/'FRANCE' - /'FRANCE'] [/'GERMANY' - /'GERMANY'])]
+      └── (n_name:2 = 'FRANCE') OR (n_name:2 = 'GERMANY') [type=bool, outer=(2), constraints=(/2: [/'FRANCE' - /'FRANCE'] [/'GERMANY' - /'GERMANY']; tight)]
 
 opt
 SELECT * FROM nation WHERE (n_name = 'FRANCE' AND neighbor = 'GERMANY') OR (n_name = 'GERMANY' AND neighbor = 'FRANCE')

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -331,7 +331,7 @@ project
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
  │    └── filters
- │         └── (k:1 <= 1) OR (k:1 > 5) [outer=(1), constraints=(/1: (/NULL - /1] [/6 - ])]
+ │         └── (k:1 <= 1) OR (k:1 > 5) [outer=(1), constraints=(/1: (/NULL - /1] [/6 - ]; tight)]
  └── projections
       └── (k:1 <= 1) OR (k:1 > 5) [as=expr:6, outer=(1)]
 
@@ -346,7 +346,7 @@ project
  │    ├── scan a
  │    │    └── columns: f:3
  │    └── filters
- │         └── (f:3 IS NULL) OR (f:3 != 10.5) [outer=(3), constraints=(/3: [/NULL - /10.499999999999998] [/10.500000000000002 - ])]
+ │         └── (f:3 IS NULL) OR (f:3 != 10.5) [outer=(3), constraints=(/3: [/NULL - /10.499999999999998] [/10.500000000000002 - ]; tight)]
  └── projections
       └── (f:3 IS NULL) OR (f:3 != 10.5) [as=expr:6, outer=(3)]
 
@@ -593,9 +593,10 @@ project
       │         │    ├── scan xy
       │         │    │    ├── columns: x:7!null y:8
       │         │    │    ├── key: (7)
-      │         │    │    └── fd: (7)-->(8)
+      │         │    │    ├── fd: (7)-->(8)
+      │         │    │    └── limit hint: 500.00
       │         │    └── filters
-      │         │         └── (x:7 = 1) OR (x:7 = 2) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2])]
+      │         │         └── (x:7 = 1) OR (x:7 = 2) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2]; tight)]
       │         └── 1
       └── (k:1 + 1) * 2 [as=r:10, outer=(1)]
 

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -248,7 +248,7 @@ left-join (hash)
  │    │    ├── key: (3)
  │    │    └── fd: (3)-->(4-7)
  │    └── filters
- │         ├── (i:4 < 0) OR (i:4 > 10) [outer=(4), constraints=(/4: (/NULL - /-1] [/11 - ])]
+ │         ├── (i:4 < 0) OR (i:4 > 10) [outer=(4), constraints=(/4: (/NULL - /-1] [/11 - ]; tight)]
  │         └── s:6 = 'foo' [outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
  └── filters
       ├── y:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -576,7 +576,7 @@ select
  │    └── filters
  │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
-      └── (x:6 = 6) OR (x:6 IS NULL) [outer=(6), constraints=(/6: [/NULL - /NULL] [/6 - /6])]
+      └── (x:6 = 6) OR (x:6 IS NULL) [outer=(6), constraints=(/6: [/NULL - /NULL] [/6 - /6]; tight)]
 
 norm expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
@@ -683,7 +683,7 @@ select
  │    │    │    └── fd: (1)-->(2-5)
  │    │    └── filters
  │    │         ├── f:3 = 1.1 [outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
- │    │         └── (s:4 = 'foo') OR (s:4 = 'bar') [outer=(4), constraints=(/4: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+ │    │         └── (s:4 = 'foo') OR (s:4 = 'bar') [outer=(4), constraints=(/4: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
  │    ├── scan xy
  │    │    ├── columns: x:6!null y:7
  │    │    ├── key: (6)
@@ -750,7 +750,7 @@ select
  │    └── filters
  │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
-      └── (i:2 = 100) OR (i:2 IS NULL) [outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
+      └── (i:2 = 100) OR (i:2 IS NULL) [outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Don't push down conditions in case of FULL JOIN.
 norm
@@ -775,7 +775,7 @@ select
  │    └── filters
  │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
-      └── (i:2 = 100) OR (i:2 IS NULL) [outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
+      └── (i:2 = 100) OR (i:2 IS NULL) [outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Push into semi-join.
 norm expect=PushSelectIntoJoinLeft
@@ -848,7 +848,7 @@ select
  │    └── filters
  │         └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── filters
-      └── (i:4 = 100) OR (i:4 IS NULL) [outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
+      └── (i:4 = 100) OR (i:4 IS NULL) [outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Don't push down conditions in case of FULL JOIN.
 norm
@@ -873,7 +873,7 @@ select
  │    └── filters
  │         └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── filters
-      └── (i:4 = 100) OR (i:4 IS NULL) [outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
+      └── (i:4 = 100) OR (i:4 IS NULL) [outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # --------------------------------------------------
 # MergeSelectInnerJoin

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -247,7 +247,7 @@ project
  │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
  │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
  │    │    │         │    │    │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r'])]
+ │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
  │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28!null n.nspname:29!null
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -250,7 +250,7 @@ sort
       │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
       │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
       │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r'])]
+      │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
       │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
       │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28!null n.nspname:29!null
       │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -111,7 +111,7 @@ select
  │         └── c_mult_2:5
  │              └── k_int:1 + 1
  └── filters
-      └── (k_int:1 = 2) OR (k_int:1 = 3) [outer=(1), constraints=(/1: [/2 - /2] [/3 - /3])]
+      └── (k_int:1 = 2) OR (k_int:1 = 3) [outer=(1), constraints=(/1: [/2 - /2] [/3 - /3]; tight)]
 
 # Don't constrain the index for a NULL value.
 opt


### PR DESCRIPTION
Prior to this commit, the constraint builder determined that any
constraint based on a predicate with OR was not tight. This was
because when there are multiple columns in a constraint, the
union of two constraints may not be tight, even if the input
constraints are tight. For example, the constraint produced for
`(x > 1 AND y > 10) OR (x < 5 AND y < 50)` is unconstrained (and
thus allows combinations like x,y = 10,0, which neither of the
input sets allowed).

However, if the constraint only contains a single column, it should
be possible to determine that it is tight. This commit adds a special
case for constraints with a single column.

Informs #44563

Release note (performance improvement): Improved the selectivity
estimation of some predicates containing OR, leading to better plan
selection by the optimizer in some cases.