### PR TITLE
sql/opt/exec: perform implicit SELECT FOR UPDATE on UPDATE with index join

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -601,5 +601,3 @@ message LIKE 'Del /Table/61/2/%' OR
 message LIKE 'CPut /Table/61/2/%'
 ----
 CPut /Table/61/2/5/1/0 -> /BYTES/0x330a1308 (replacing raw_bytes:"\000\000\000\000\0033\006\023\010" timestamp:<> , if exists)
-
-

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -447,7 +447,7 @@ count                ·                 ·
 ·                    locking strength  for update
 
 query TTT
-EXPLAIN UPDATE kv SET v=k WHERE k > 1 AND k < 10;
+EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 ·                    distributed       false
 ·                    vectorized        false
@@ -482,6 +482,55 @@ count                ·                 ·
 ·                    locking strength  for update
 
 statement ok
+CREATE TABLE kv3 (
+  k    INT PRIMARY KEY,
+  v    INT,
+  meta INT,
+  INDEX (v),
+  FAMILY (k, v, meta)
+)
+
+query TTT
+EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
+----
+·                          distributed       false
+·                          vectorized        false
+count                      ·                 ·
+ └── update                ·                 ·
+      │                    table             kv3
+      │                    set               k
+      │                    strategy          updater
+      │                    auto commit       ·
+      └── render           ·                 ·
+           └── index-join  ·                 ·
+                │          table             kv3@primary
+                │          key columns       k
+                └── scan   ·                 ·
+·                          table             kv3@kv3_v_idx
+·                          spans             /10-/11
+·                          locking strength  for update
+
+query TTT
+EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
+----
+·                          distributed       false
+·                          vectorized        false
+count                      ·                 ·
+ └── update                ·                 ·
+      │                    table             kv3
+      │                    set               k
+      │                    strategy          updater
+      │                    auto commit       ·
+      └── render           ·                 ·
+           └── index-join  ·                 ·
+                │          table             kv3@primary
+                │          key columns       k
+                └── scan   ·                 ·
+·                          table             kv3@kv3_v_idx
+·                          spans             /2-/10
+·                          locking strength  for update
+
+statement ok
 SET enable_implicit_select_for_update = false
 
 query TTT
@@ -501,7 +550,7 @@ count                ·            ·
 ·                    spans        /3-/3/#
 
 query TTT
-EXPLAIN UPDATE kv SET v=k WHERE k > 1 AND k < 10;
+EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 ·                    distributed  false
 ·                    vectorized   false
@@ -570,6 +619,44 @@ count                ·            ·
 ·                    table        kv@primary
 ·                    spans        -/2/#
 ·                    limit        1
+
+query TTT
+EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
+----
+·                          distributed  false
+·                          vectorized   false
+count                      ·            ·
+ └── update                ·            ·
+      │                    table        kv3
+      │                    set          k
+      │                    strategy     updater
+      │                    auto commit  ·
+      └── render           ·            ·
+           └── index-join  ·            ·
+                │          table        kv3@primary
+                │          key columns  k
+                └── scan   ·            ·
+·                          table        kv3@kv3_v_idx
+·                          spans        /10-/11
+
+query TTT
+EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
+----
+·                          distributed  false
+·                          vectorized   false
+count                      ·            ·
+ └── update                ·            ·
+      │                    table        kv3
+      │                    set          k
+      │                    strategy     updater
+      │                    auto commit  ·
+      └── render           ·            ·
+           └── index-join  ·            ·
+                │          table        kv3@primary
+                │          key columns  k
+                └── scan   ·            ·
+·                          table        kv3@kv3_v_idx
+·                          spans        /2-/10
 
 # Update single column family.
 query TTT


### PR DESCRIPTION
Fixes #45511.

This commit enables implicit row-level locking on UPDATEs with an index-join
in its initial row scan. To support this, two new patterns were needed in
`Builder.shouldApplyImplicitLockingToUpdateInput`:

```
(Update
    $input:(IndexJoin
        $input:(Scan $scanPrivate:*)
        $indexJoinPrivate:*
    )
    $checks:*
    $mutationPrivate:*
)

AND

(Update
    $input:(Project
        $input:(IndexJoin
            $input:(Scan $scanPrivate:*)
            $indexJoinPrivate:*
        )
        $projections:*
        $passthrough:*
    )
    $checks:*
    $mutationPrivate:*
)
```

These extra patterns are pushing the limits of this form of pattern matching,
but this is ok for the next release. If/when we want to make any more general,
we should strongly consider Andy's proposal to fold the patten matching and
analysis into the explorer rather than execbuilder.