### PR TITLE
release-19.2: colexec: fix simpleProjectOp in some cases

### DIFF
--- a/pkg/sql/colexec/simple_project.go
+++ b/pkg/sql/colexec/simple_project.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // simpleProjectOp is an operator that implements "simple projection" - removal of
@@ -24,7 +25,12 @@ type simpleProjectOp struct {
 	OneInputNode
 	NonExplainable
 
-	batch *projectingBatch
+	projection []uint32
+	batches    map[coldata.Batch]*projectingBatch
+	// numBatchesLoggingThreshold is the threshold on the number of items in
+	// 'batches' map at which we will log a message when a new projectingBatch
+	// is created. It is growing exponentially.
+	numBatchesLoggingThreshold int
 }
 
 var _ Operator = &simpleProjectOp{}
@@ -81,8 +87,10 @@ func NewSimpleProjectOp(input Operator, numInputCols int, projection []uint32) O
 		}
 	}
 	return &simpleProjectOp{
-		OneInputNode: NewOneInputNode(input),
-		batch:        newProjectionBatch(projection),
+		OneInputNode:               NewOneInputNode(input),
+		projection:                 projection,
+		batches:                    make(map[coldata.Batch]*projectingBatch),
+		numBatchesLoggingThreshold: 128,
 	}
 }
 
@@ -92,7 +100,18 @@ func (d *simpleProjectOp) Init() {
 
 func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
 	batch := d.input.Next(ctx)
-	d.batch.Batch = batch
-
-	return d.batch
+	projBatch, found := d.batches[batch]
+	if !found {
+		// We pass in a copy of d.projection just to be safe.
+		projBatch = newProjectionBatch(append([]uint32{}, d.projection...))
+		d.batches[batch] = projBatch
+		if len(d.batches) == d.numBatchesLoggingThreshold {
+			if log.V(1) {
+				log.Infof(ctx, "simpleProjectOp: size of 'batches' map = %d", len(d.batches))
+			}
+			d.numBatchesLoggingThreshold = d.numBatchesLoggingThreshold * 2
+		}
+	}
+	projBatch.Batch = batch
+	return projBatch
 }


### PR DESCRIPTION
Backport 1/1 commits from #45690.

/cc @cockroachdb/release

---

`simpleProjectOp` doesn't work well together with unordered
synchronizers (and possibly other components that can return
`coldata.Batch`es that point to different regions of memory). The
problem is that `simpleProjectOp` adds a `projectingBatch` wrapper on
top its input batch, but if "different internally" batches come in, the
wrapper is not updated/reset. Now this is fixed by tracking different
input batches and having a separate `projectingBatch` for them.

Fixes: #45686.

Release note (bug fix): Previously, an internal error could occur in
CockroachDB when executing queries via the vectorized engine in queries
that contained unordered synchronizers, and now this has been fixed.
