### PR TITLE
bors: Disable requiring CLA check

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,7 +2,8 @@ status = [
   "GitHub CI (Cockroach)"
 ]
 pr_status = [
-  "license/cla"
+# The CLA check is being flaky 20200305
+#  "license/cla"
 ]
 block_labels = [
   "do-not-merge"


### PR DESCRIPTION
Per discussion on Slack, the third-party CLA check has been somewhat flaky as
of late and unnecessarily blocking bors commits. This change makes bors ignore
the CLA check as a required status.

X-Ref: https://github.com/cockroachdb/dev-inf/issues/51

Release note: None