### PR TITLE
k8s: remove liveness probes

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -159,13 +159,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -216,13 +216,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -119,12 +119,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -173,13 +173,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -107,13 +107,6 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -223,13 +223,6 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -162,12 +162,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -253,13 +253,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"


### PR DESCRIPTION
This removes the liveness probes from our K8s configs. In #44832, we mostly
reached an agreement that the liveness probe is doing more harm than good.
There is still some disagreement about whether other failure conditions, such
as disk stalls, are better served by having CockroachDB detect them itself or
by detecting them in a separate process responsible for running the liveness
probe. Either way, that is not what the current liveness probe is doing.

The readiness probe has been left as-is for now.

Release note: None