### PR TITLE
sql: add a notice to primary key changes about async jobs

### DIFF
--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -17,5 +17,10 @@ send "CREATE TABLE drop_index_test(a int); CREATE INDEX drop_index_test_index ON
 eexpect "NOTICE: index \"drop_index_test_index\" will be dropped asynchronously and will be complete after the GC TTL"
 end_test
 
+start_test "Check that altering the primary key of a table prints a message about async jobs."
+send "CREATE TABLE alterpk (x INT NOT NULL); ALTER TABLE alterpk ALTER PRIMARY KEY USING COLUMNS (x);\r"
+eexpect "NOTICE: primary key changes spawn async cleanup jobs. Future schema changes on \"alterpk\" may be delayed as these jobs finish"
+end_test
+
 send "\\q\r"
 eexpect eof

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -663,6 +663,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// Mark descriptorChanged so that a mutation job is scheduled at the end of startExec.
 			descriptorChanged = true
 
+			// Send a notice to users about the async cleanup jobs.
+			params.p.noticeSender.AppendNotice(
+				pgerror.Noticef(
+					"primary key changes spawn async cleanup jobs. Future schema changes on %q may be delayed as these jobs finish",
+					n.tableDesc.Name,
+				),
+			)
+
 		case *tree.AlterTableDropColumn:
 			if params.SessionData().SafeUpdates {
 				return pgerror.DangerousStatementf("ALTER TABLE DROP COLUMN will remove all data in that column")


### PR DESCRIPTION
Fixes #45730.

Release note: None