### PR TITLE
sql: remove experimental flags around primary key changes

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -486,7 +486,6 @@ func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 
 	backupAndRestore(ctx, t, tc, []string{localFoo}, []string{localFoo}, numAccounts)
 
-	sqlDB.Exec(t, `SET experimental_enable_primary_key_changes = true`)
 	sqlDB.Exec(t, `CREATE UNIQUE INDEX id2 ON data.bank (id)`)
 	sqlDB.Exec(t, `ALTER TABLE data.bank ALTER PRIMARY KEY USING COLUMNS(id)`)
 

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -77,7 +77,6 @@ func registerAlterPK(r *testRegistry) {
 			db := c.Conn(ctx, roachNodes[0])
 			defer db.Close()
 			cmd := `
-			SET experimental_enable_primary_key_changes=true;
 			USE bank;
 			ALTER TABLE bank ALTER COLUMN balance SET NOT NULL;
 			ALTER TABLE bank ALTER PRIMARY KEY USING COLUMNS (id, balance)
@@ -144,9 +143,7 @@ func registerAlterPK(r *testRegistry) {
 
 			db := c.Conn(ctx, roachNodes[0])
 			defer db.Close()
-			alterCmd := `SET experimental_enable_primary_key_changes = true;
-							USE tpcc;
-							%s;`
+			alterCmd := `USE tpcc; %s;`
 			t.Status("beginning primary key change")
 			if _, err := db.ExecContext(ctx, fmt.Sprintf(alterCmd, randStmt)); err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -104,13 +104,6 @@ func registerSQLSmith(r *testRegistry) {
 			logStmt(setup)
 		}
 
-		stmt := "SET experimental_enable_primary_key_changes = true;"
-		if _, err := conn.Exec(stmt); err != nil {
-			t.Fatal(err)
-		} else {
-			logStmt(stmt)
-		}
-
 		const timeout = time.Minute
 		setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", timeout.String())
 		t.Status("setting statement_timeout")

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -381,11 +381,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 					"all nodes are not the correct version for primary key changes")
 			}
 
-			if !params.p.EvalContext().SessionData.PrimaryKeyChangesEnabled {
-				return pgerror.Newf(pgcode.FeatureNotSupported,
-					"session variable experimental_enable_primary_key_changes is set to false, cannot perform primary key change")
-			}
-
 			if t.Sharded != nil {
 				if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionHashShardedIndexes) {
 					return invalidClusterForShardedIndexError

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -153,12 +153,6 @@ var requireExplicitPrimaryKeysClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
-var primaryKeyChangesEnabledClusterMode = settings.RegisterBoolSetting(
-	"sql.defaults.experimental_primary_key_changes.enabled",
-	"default value for experimental_enable_primary_key_changes session setting; allows use of primary key changes by default",
-	false,
-)
-
 var temporaryTablesEnabledClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_temporary_tables.enabled",
 	"default value for experimental_enable_temp_tables; allows for use of temporary tables by default",
@@ -1900,10 +1894,6 @@ func (m *sessionDataMutator) SetDistSQLMode(val sessiondata.DistSQLExecMode) {
 
 func (m *sessionDataMutator) SetForceSavepointRestart(val bool) {
 	m.data.ForceSavepointRestart = val
-}
-
-func (m *sessionDataMutator) SetPrimaryKeyChangesEnabled(val bool) {
-	m.data.PrimaryKeyChangesEnabled = val
 }
 
 func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,5 +1,4 @@
 statement ok
-SET experimental_enable_primary_key_changes = true;
 SET experimental_enable_hash_sharded_indexes = true
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1582,7 +1582,6 @@ enable_implicit_select_for_update         on                  NULL      NULL    
 enable_insert_fast_path                   on                  NULL      NULL        NULL        string
 enable_zigzag_join                        on                  NULL      NULL        NULL        string
 experimental_enable_hash_sharded_indexes  off                 NULL      NULL        NULL        string
-experimental_enable_primary_key_changes   off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables           off                 NULL      NULL        NULL        string
 experimental_optimizer_foreign_keys       on                  NULL      NULL        NULL        string
 experimental_serial_normalization         rowid               NULL      NULL        NULL        string
@@ -1642,7 +1641,6 @@ enable_implicit_select_for_update         on                  NULL  user     NUL
 enable_insert_fast_path                   on                  NULL  user     NULL      on                  on
 enable_zigzag_join                        on                  NULL  user     NULL      on                  on
 experimental_enable_hash_sharded_indexes  off                 NULL  user     NULL      off                 off
-experimental_enable_primary_key_changes   off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables           off                 NULL  user     NULL      off                 off
 experimental_optimizer_foreign_keys       on                  NULL  user     NULL      on                  on
 experimental_serial_normalization         rowid               NULL  user     NULL      rowid               rowid
@@ -1698,7 +1696,6 @@ enable_implicit_select_for_update         NULL    NULL     NULL     NULL        
 enable_insert_fast_path                   NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                        NULL    NULL     NULL     NULL        NULL
 experimental_enable_hash_sharded_indexes  NULL    NULL     NULL     NULL        NULL
-experimental_enable_primary_key_changes   NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables           NULL    NULL     NULL     NULL        NULL
 experimental_optimizer_foreign_keys       NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -41,7 +41,6 @@ enable_implicit_select_for_update         on
 enable_insert_fast_path                   on
 enable_zigzag_join                        on
 experimental_enable_hash_sharded_indexes  off
-experimental_enable_primary_key_changes   off
 experimental_enable_temp_tables           off
 experimental_optimizer_foreign_keys       on
 experimental_serial_normalization         rowid

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -53,8 +53,6 @@ type SessionData struct {
 	// ZigzagJoinEnabled indicates whether the optimizer should try and plan a
 	// zigzag join.
 	ZigzagJoinEnabled bool
-	// PrimaryKeyChangesEnabled indicates whether are allowed to be used.
-	PrimaryKeyChangesEnabled bool
 	// ReorderJoinsLimit indicates the number of joins at which the optimizer should
 	// stop attempting to reorder.
 	ReorderJoinsLimit int

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -326,25 +326,6 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_enable_primary_key_changes`: {
-		GetStringVal: makeBoolGetStringValFn(`experimental_enable_primary_key_changes`),
-		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
-			b, err := parsePostgresBool(s)
-			if err != nil {
-				return err
-			}
-			m.SetPrimaryKeyChangesEnabled(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.PrimaryKeyChangesEnabled)
-		},
-		GlobalDefault: func(sv *settings.Values) string {
-			return formatBoolAsPostgresSetting(primaryKeyChangesEnabledClusterMode.Get(sv))
-		},
-	},
-
-	// CockroachDB extension.
 	`enable_zigzag_join`: {
 		GetStringVal: makeBoolGetStringValFn(`enable_zigzag_join`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Release note (sql change): This PR removes the experimental
variable gating around usages of online primary key changes.