### PR TITLE
workload/ycsb: take advantage of SELECT FOR UPDATE

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -27,12 +27,13 @@ func registerYCSB(r *testRegistry) {
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
+			sfu := fmt.Sprintf(" --select-for-update=%t", t.IsBuildVersion("v19.2.0"))
 			ramp := " --ramp=" + ifLocal("0s", "1m")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
 				"./workload run ycsb --init --insert-count=1000000 --splits=100"+
 					" --workload=%s --concurrency=64 --histograms="+perfArtifactsDir+"/stats.json"+
-					ramp+duration+" {pgurl:1-%d}",
+					sfu+ramp+duration+" {pgurl:1-%d}",
 				wl, nodes)
 			c.Run(ctx, c.Node(nodes+1), cmd)
 			return nil

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -90,6 +90,7 @@ type ycsb struct {
 	recordCount int
 	json        bool
 	families    bool
+	sfu         bool
 	splits      int
 
 	workload                                                        string
@@ -120,6 +121,7 @@ var ycsbMeta = workload.Meta{
 		g.flags.IntVar(&g.recordCount, `record-count`, 0, `Key to start workload insertions from. Must be >= insert-start + insert-count. (Default: insert-start + insert-count)`)
 		g.flags.BoolVar(&g.json, `json`, false, `Use JSONB rather than relational data`)
 		g.flags.BoolVar(&g.families, `families`, true, `Place each column in its own column family`)
+		g.flags.BoolVar(&g.sfu, `select-for-update`, true, `Use SELECT FOR UPDATE syntax in read-modify-write transactions`)
 		g.flags.IntVar(&g.splits, `splits`, 0, `Number of splits to perform before starting normal operations`)
 		g.flags.StringVar(&g.workload, `workload`, `B`, `Workload type. Choose from A-F.`)
 		g.flags.StringVar(&g.requestDistribution, `request-distribution`, ``, `Distribution for request key generation [zipfian, uniform, latest]. The default for workloads A, B, C, E, and F is zipfian, and the default for workload D is latest.`)
@@ -252,7 +254,7 @@ func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 		return workload.QueryLoad{}, err
 	}
 
-	readFieldStmts := make([]*gosql.Stmt, numTableFields)
+	readFieldForUpdateStmts := make([]*gosql.Stmt, numTableFields)
 	for i := 0; i < numTableFields; i++ {
 		var q string
 		if g.json {
@@ -260,12 +262,15 @@ func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 		} else {
 			q = fmt.Sprintf(`SELECT field%d FROM usertable WHERE ycsb_key = $1`, i)
 		}
+		if g.sfu {
+			q = fmt.Sprintf(`%s FOR UPDATE`, q)
+		}
 
 		stmt, err := db.Prepare(q)
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}
-		readFieldStmts[i] = stmt
+		readFieldForUpdateStmts[i] = stmt
 	}
 
 	scanStmt, err := db.Prepare(`SELECT * FROM usertable WHERE ycsb_key >= $1 LIMIT $2`)
@@ -354,21 +359,21 @@ func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 	for i := 0; i < g.connFlags.Concurrency; i++ {
 		rng := rand.New(rand.NewSource(g.seed + int64(i)))
 		w := &ycsbWorker{
-			config:          g,
-			hists:           reg.GetHandle(),
-			db:              db,
-			readStmt:        readStmt,
-			readFieldStmts:  readFieldStmts,
-			scanStmt:        scanStmt,
-			insertStmt:      insertStmt,
-			updateStmts:     updateStmts,
-			rowIndex:        rowIndex,
-			rowCounter:      rowCounter,
-			nextInsertIndex: nil,
-			requestGen:      requestGen,
-			scanLengthGen:   scanLengthGen,
-			rng:             rng,
-			hashFunc:        fnv.New64(),
+			config:                  g,
+			hists:                   reg.GetHandle(),
+			db:                      db,
+			readStmt:                readStmt,
+			readFieldForUpdateStmts: readFieldForUpdateStmts,
+			scanStmt:                scanStmt,
+			insertStmt:              insertStmt,
+			updateStmts:             updateStmts,
+			rowIndex:                rowIndex,
+			rowCounter:              rowCounter,
+			nextInsertIndex:         nil,
+			requestGen:              requestGen,
+			scanLengthGen:           scanLengthGen,
+			rng:                     rng,
+			hashFunc:                fnv.New64(),
 		}
 		ql.WorkerFns = append(ql.WorkerFns, w.run)
 	}
@@ -386,10 +391,10 @@ type ycsbWorker struct {
 	db     *gosql.DB
 	// Statement to read all the fields of a row. Used for read requests.
 	readStmt *gosql.Stmt
-	// Statements to read a specific field of a row. Used for read-modify-write
-	// requests.
-	readFieldStmts       []*gosql.Stmt
-	scanStmt, insertStmt *gosql.Stmt
+	// Statements to read a specific field of a row in preparation for
+	// updating it. Used for read-modify-write requests.
+	readFieldForUpdateStmts []*gosql.Stmt
+	scanStmt, insertStmt    *gosql.Stmt
 	// In normal mode this is one statement per field, since the field name
 	// cannot be parametrized. In JSON mode it's a single statement.
 	updateStmts []*gosql.Stmt
@@ -585,7 +590,8 @@ func (yw *ycsbWorker) readModifyWriteRow(ctx context.Context) error {
 	args[0] = key
 	err := crdb.ExecuteTx(ctx, yw.db, nil, func(tx *gosql.Tx) error {
 		var oldValue []byte
-		if err := tx.StmtContext(ctx, yw.readFieldStmts[fieldIdx]).QueryRowContext(ctx, key).Scan(&oldValue); err != nil {
+		readStmt := yw.readFieldForUpdateStmts[fieldIdx]
+		if err := tx.StmtContext(ctx, readStmt).QueryRowContext(ctx, key).Scan(&oldValue); err != nil {
 			return err
 		}
 		var updateStmt *gosql.Stmt

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -39,29 +39,29 @@ const (
 
 	usertableSchemaRelational = `(
 		ycsb_key VARCHAR(255) PRIMARY KEY NOT NULL,
-		FIELD0 TEXT,
-		FIELD1 TEXT,
-		FIELD2 TEXT,
-		FIELD3 TEXT,
-		FIELD4 TEXT,
-		FIELD5 TEXT,
-		FIELD6 TEXT,
-		FIELD7 TEXT,
-		FIELD8 TEXT,
-		FIELD9 TEXT
+		FIELD0 TEXT NOT NULL,
+		FIELD1 TEXT NOT NULL,
+		FIELD2 TEXT NOT NULL,
+		FIELD3 TEXT NOT NULL,
+		FIELD4 TEXT NOT NULL,
+		FIELD5 TEXT NOT NULL,
+		FIELD6 TEXT NOT NULL,
+		FIELD7 TEXT NOT NULL,
+		FIELD8 TEXT NOT NULL,
+		FIELD9 TEXT NOT NULL
 	)`
 	usertableSchemaRelationalWithFamilies = `(
 		ycsb_key VARCHAR(255) PRIMARY KEY NOT NULL,
-		FIELD0 TEXT,
-		FIELD1 TEXT,
-		FIELD2 TEXT,
-		FIELD3 TEXT,
-		FIELD4 TEXT,
-		FIELD5 TEXT,
-		FIELD6 TEXT,
-		FIELD7 TEXT,
-		FIELD8 TEXT,
-		FIELD9 TEXT,
+		FIELD0 TEXT NOT NULL,
+		FIELD1 TEXT NOT NULL,
+		FIELD2 TEXT NOT NULL,
+		FIELD3 TEXT NOT NULL,
+		FIELD4 TEXT NOT NULL,
+		FIELD5 TEXT NOT NULL,
+		FIELD6 TEXT NOT NULL,
+		FIELD7 TEXT NOT NULL,
+		FIELD8 TEXT NOT NULL,
+		FIELD9 TEXT NOT NULL,
 		FAMILY (ycsb_key),
 		FAMILY (FIELD0),
 		FAMILY (FIELD1),
@@ -210,7 +210,7 @@ func (g *ycsb) Tables() []workload.Table {
 		if g.json {
 			return []interface{}{key, "{}"}
 		}
-		return []interface{}{key, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+		return []interface{}{key, "", "", "", "", "", "", "", "", "", ""}
 	}
 	if g.json {
 		usertable.Schema = usertableSchemaJSON


### PR DESCRIPTION
Performance numbers for this change and #45701 aren't quite ready to share,
but I'll post here and there when they are.


#### workload/ycsb: define all fields as NOT NULL

This change marks all columns in the ycsb "usertable" as NOT NULL. Doing
so allows the load generator to take advantage of #44239, which avoids
the KV lookup on the primary column family entirely when querying one of
the other column families. The query plans before and after demonstrate
this:

```
--- Before
root@:26257/ycsb> EXPLAIN SELECT field5 FROM usertable WHERE ycsb_key = 'key';
    tree    |    field    |               description
------------+-------------+------------------------------------------
            | distributed | false
            | vectorized  | false
  render    |             |
   └── scan |             |
            | table       | usertable@primary
            | spans       | /"key"/0-/"key"/1 /"key"/6/1-/"key"/6/2
            | parallel    |


--- After
root@:26257/ycsb> EXPLAIN SELECT field5 FROM usertable WHERE ycsb_key = 'key';
    tree    |    field    |      description
------------+-------------+------------------------
            | distributed | false
            | vectorized  | false
  render    |             |
   └── scan |             |
            | table       | usertable@primary
            | spans       | /"key"/6/1-/"key"/6/2
```

This becomes very important when running YCSB with a column family per
field and with implicit SELECT FOR UPDATE (see #45159). Now that (as of
#45701) UPDATE statements acquire upgrade locks during their initial row
fetch, we don't want them acquiring upgrade locks on the primary column
family of the row they are intending to update a single column in. This
re-introduces the contention between writes to different columns in the
same row that column families helped avoid (see #32704). By marking each
column as NOT NULL, we can continue to avoid this contention.


#### workload/ycsb: use SELECT FOR UPDATE in read-modify-write transactions

50% of workload F is read-modify-write transactions. These transactions
scan a single column from a row using a SELECT statement and then modify
that single column using an UPDATE statement. Like most workloads, the
default request distribution is zipfian, meaning that there are some rows
that are heavily contended.

This is the perfect use case for explicit SELECT FOR UPDATE. Using it for
the "read" portion of the read-modify-write transaction dramatically improves
throughput and eliminates transaction retries. This commit makes that change.

Confusingly, these are not implemented as real transactions in the official
YCSB load generator, but that seems strictly incorrect and was likely
dictated by the lack of support for transactions in NoSQL engines of the
time:
  https://github.com/brianfrankcooper/YCSB/blob/cd1589ce6f5abf96e17aa8ab80c78a4348fdf29a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java#L729

Also, strangely Workload F wasn't in the initial YCSB paper:
  https://www2.cs.duke.edu/courses/fall13/compsci590.4/838-CloudPapers/ycsb.pdf
But it was in the initial commit of the YCSB load generator:
  https://github.com/brianfrankcooper/YCSB/commit/24efaff35cb20b4ae730b3f23716ed73fea783d9#diff-d240bdb33fb042b95010733db8ccec63

This might break compatibility with old versions of CRDB, as I think we
only started accepting SELECT FOR UPDATE in 19.2. The commit includes a
flag to avoid the functionality if necessary.