### PR TITLE
execgen: don't depend on sqlbase

### DIFF
--- a/pkg/sql/colexec/dep_test.go
+++ b/pkg/sql/colexec/dep_test.go
@@ -28,4 +28,11 @@ func TestNoLinkForbidden(t *testing.T) {
 			"github.com/cockroachdb/cockroach/pkg/sql/rowflow",
 		}, nil,
 	)
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen/cmd/execgen", true,
+		[]string{
+			"github.com/cockroachdb/cockroach/pkg/sql/sqlbase",
+			"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb",
+		}, nil,
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -16,18 +16,17 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 type aggOverloads struct {
-	Agg       execinfrapb.AggregatorSpec_Func
+	Agg       string
 	Overloads []*overload
 }
 
 // AggNameLower returns the aggregation name in lower case, e.g. "min".
 func (a aggOverloads) AggNameLower() string {
-	return strings.ToLower(a.Agg.String())
+	return strings.ToLower(a.Agg)
 }
 
 // AggNameTitle returns the aggregation name in title case, e.g. "Min".
@@ -68,11 +67,11 @@ func genMinMaxAgg(wr io.Writer) error {
 	}
 	data := []aggOverloads{
 		{
-			Agg:       execinfrapb.AggregatorSpec_MIN,
+			Agg:       "MIN",
 			Overloads: sameTypeComparisonOpToOverloads[tree.LT],
 		},
 		{
-			Agg:       execinfrapb.AggregatorSpec_MAX,
+			Agg:       "MAX",
 			Overloads: sameTypeComparisonOpToOverloads[tree.GT],
 		},
 	}


### PR DESCRIPTION
Previously, execgen accidentally had a dep chain that took it to
sqlbase. Sqlbase is a giant dep that changes all the time, which caused
way too many execgen recompiles. This should improve things a bit.

cc @irfansharif 

Release note: None