### PR TITLE
cloud: require nodeID in nodelocal URIs

### DIFF
--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkClusterRestore(b *testing.B) {
 	b.SetBytes(backup.Desc.EntryCounts.DataSize / int64(b.N))
 
 	b.ResetTimer()
-	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal:///foo'`)
+	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal://0/foo'`)
 	b.StopTimer()
 }
 

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -51,7 +51,7 @@ func TestFullClusterBackup(t *testing.T) {
 	sqlDB.Exec(t, `ALTER DATABASE data2 CONFIGURE ZONE USING gc.ttlseconds = 900`)
 	// Populate system.jobs.
 	// Note: this is not the backup under test, this just serves as a job which should appear in the restore.
-	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal:///throwawayjob'`)
+	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal://0/throwawayjob'`)
 	preBackupJobs := sqlDB.QueryStr(t, "SELECT * FROM system.jobs")
 	// Populate system.settings.
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_io_write.concurrent_addsstable_requests = 5`)
@@ -190,7 +190,7 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
-	const incrementalBackupLocation = "nodelocal:///inc-full-backup"
+	const incrementalBackupLocation = "nodelocal://0/inc-full-backup"
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
 	defer cleanupFn()

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -492,7 +492,7 @@ func (f *cloudFeedFactory) Feed(create string, args ...interface{}) (TestFeed, e
 	}
 	feedDir := strconv.Itoa(f.feedIdx)
 	f.feedIdx++
-	sinkURI := `experimental-nodelocal:///` + feedDir
+	sinkURI := `experimental-nodelocal://0/` + feedDir
 	// TODO(dan): This is a pretty unsatisfying way to test that the sink passes
 	// through params it doesn't understand to ExternalStorage.
 	sinkURI += `?should_be=ignored`

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1665,12 +1665,12 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with format=experimental_avro`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='experimental_avro', confluent_schema_registry=$2`,
-		`experimental-nodelocal:///bar`, `schemareg-nope`,
+		`experimental-nodelocal://0/bar`, `schemareg-nope`,
 	)
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with envelope=key_only`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH envelope='key_only'`,
-		`experimental-nodelocal:///bar`,
+		`experimental-nodelocal://0/bar`,
 	)
 
 	// WITH key_in_value requires envelope=wrapped

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -108,7 +108,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		sinkDir := `golden`
 		s, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+sinkDir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+sinkDir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestCloudStorageSink(t *testing.T) {
 				timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 				dir := `single-node` + compression
 				s, err := makeCloudStorageSink(
-					ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+					ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 					settings, opts, timestampOracle, externalStorageFromURI,
 				)
 				require.NoError(t, err)
@@ -220,12 +220,12 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `multi-node`
 		s1, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s2, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 2, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 2, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -254,12 +254,12 @@ func TestCloudStorageSink(t *testing.T) {
 		// this happens before checkpointing, some data is written again but
 		// this is unavoidable.
 		s1R, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s2R, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 2, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 2, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -300,14 +300,14 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `zombie`
 		s1, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
 		s1.(*cloudStorageSink).sinkID = 7         // Force a deterministic sinkID.
 		s1.(*cloudStorageSink).jobSessionID = "a" // Force deterministic job session ID.
 		s2, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -342,7 +342,7 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `bucketing`
 		const targetMaxFileSize = 6
 		s, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, targetMaxFileSize,
+			ctx, `nodelocal://0/`+dir, 1, targetMaxFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 		require.NoError(t, err)
@@ -429,7 +429,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `file-ordering`
 		s, err := makeCloudStorageSink(
-			ctx, `nodelocal:///`+dir, 1, unlimitedFileSize,
+			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
 			settings, opts, timestampOracle, externalStorageFromURI,
 		)
 
@@ -488,7 +488,7 @@ func TestCloudStorageSink(t *testing.T) {
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
 		dir := `ordering-among-schema-versions`
 		var targetMaxFileSize int64 = 10
-		s, err := makeCloudStorageSink(ctx, `nodelocal:///`+dir, 1, targetMaxFileSize, settings,
+		s, err := makeCloudStorageSink(ctx, `nodelocal://0/`+dir, 1, targetMaxFileSize, settings,
 			opts, timestampOracle, externalStorageFromURI)
 		require.NoError(t, err)
 

--- a/pkg/ccl/importccl/csv_testdata_helpers_test.go
+++ b/pkg/ccl/importccl/csv_testdata_helpers_test.go
@@ -100,20 +100,20 @@ func getTestFiles(numFiles int) csvTestFiles {
 		suffix = "-race"
 	}
 	for i := 0; i < numFiles; i++ {
-		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s", i, suffix)+"?nonsecret=nosecrets"))
-		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?AWS_SESSION_TOKEN=secrets"))
-		testFiles.bzipFiles = append(testFiles.bzipFiles, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d%s.bz2", i, suffix)))
-		testFiles.filesWithOpts = append(testFiles.filesWithOpts, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d-opts%s", i, suffix)))
-		testFiles.filesWithDups = append(testFiles.filesWithDups, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("data-%d-dup%s", i, suffix)))
+		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s", i, suffix)+"?nonsecret=nosecrets"))
+		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?AWS_SESSION_TOKEN=secrets"))
+		testFiles.bzipFiles = append(testFiles.bzipFiles, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s.bz2", i, suffix)))
+		testFiles.filesWithOpts = append(testFiles.filesWithOpts, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d-opts%s", i, suffix)))
+		testFiles.filesWithDups = append(testFiles.filesWithDups, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d-dup%s", i, suffix)))
 	}
 
-	testFiles.fileWithDupKeySameValue = append(testFiles.fileWithDupKeySameValue, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("dup-key-same-value%s", suffix)))
-	testFiles.fileWithShadowKeys = append(testFiles.fileWithShadowKeys, fmt.Sprintf(`'nodelocal:///%s'`, fmt.Sprintf("shadow-data%s", suffix)))
+	testFiles.fileWithDupKeySameValue = append(testFiles.fileWithDupKeySameValue, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("dup-key-same-value%s", suffix)))
+	testFiles.fileWithShadowKeys = append(testFiles.fileWithShadowKeys, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("shadow-data%s", suffix)))
 
 	wildcardFileName := "data-[0-9]"
-	testFiles.filesUsingWildcard = append(testFiles.filesUsingWildcard, fmt.Sprintf(`'nodelocal:///%s%s'`, wildcardFileName, suffix))
-	testFiles.gzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal:///%s%s.gz'`, wildcardFileName, suffix))
-	testFiles.bzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal:///%s%s.bz2'`, wildcardFileName, suffix))
+	testFiles.filesUsingWildcard = append(testFiles.filesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s'`, wildcardFileName, suffix))
+	testFiles.gzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s.gz'`, wildcardFileName, suffix))
+	testFiles.bzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s.bz2'`, wildcardFileName, suffix))
 
 	return testFiles
 }

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1133,12 +1133,12 @@ func TestImportCSVStmt(t *testing.T) {
 	`), 0666); err != nil {
 		t.Fatal(err)
 	}
-	schema := []interface{}{"nodelocal:///table"}
+	schema := []interface{}{"nodelocal://0/table"}
 
 	if err := ioutil.WriteFile(filepath.Join(baseDir, "empty.csv"), nil, 0666); err != nil {
 		t.Fatal(err)
 	}
-	empty := []string{"'nodelocal:///empty.csv'"}
+	empty := []string{"'nodelocal://0/empty.csv'"}
 
 	// Support subtests by keeping track of the number of jobs that are executed.
 	testNum := -1
@@ -1576,20 +1576,20 @@ func TestExportImportRoundTrip(t *testing.T) {
 		// need to differ across runs, so we let the test runner format the stmts field
 		// with a unique directory name per run.
 		{
-			stmts: `EXPORT INTO CSV 'nodelocal:///%[1]s' FROM SELECT ARRAY['a', 'b', 'c'];
-							IMPORT TABLE t (x TEXT[]) CSV DATA ('nodelocal:///%[1]s/n1.0.csv')`,
+			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT ARRAY['a', 'b', 'c'];
+							IMPORT TABLE t (x TEXT[]) CSV DATA ('nodelocal://0/%[1]s/n1.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT ARRAY['a', 'b', 'c']`,
 		},
 		{
-			stmts: `EXPORT INTO CSV 'nodelocal:///%[1]s' FROM SELECT ARRAY[b'abc', b'\141\142\143', b'\x61\x62\x63'];
-							IMPORT TABLE t (x BYTES[]) CSV DATA ('nodelocal:///%[1]s/n1.0.csv')`,
+			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT ARRAY[b'abc', b'\141\142\143', b'\x61\x62\x63'];
+							IMPORT TABLE t (x BYTES[]) CSV DATA ('nodelocal://0/%[1]s/n1.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT ARRAY[b'abc', b'\141\142\143', b'\x61\x62\x63']`,
 		},
 		{
-			stmts: `EXPORT INTO CSV 'nodelocal:///%[1]s' FROM SELECT 'dog' COLLATE en;
-							IMPORT TABLE t (x STRING COLLATE en) CSV DATA ('nodelocal:///%[1]s/n1.0.csv')`,
+			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT 'dog' COLLATE en;
+							IMPORT TABLE t (x STRING COLLATE en) CSV DATA ('nodelocal://0/%[1]s/n1.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT 'dog' COLLATE en`,
 		},
@@ -1667,7 +1667,7 @@ func TestImportIntoCSV(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(baseDir, "empty.csv"), nil, 0666); err != nil {
 		t.Fatal(err)
 	}
-	empty := []string{"'nodelocal:///empty.csv'"}
+	empty := []string{"'nodelocal://0/empty.csv'"}
 
 	// Support subtests by keeping track of the number of jobs that are executed.
 	testNum := -1
@@ -1834,7 +1834,7 @@ func TestImportIntoCSV(t *testing.T) {
 		{
 			"import-no-files-match-wildcard",
 			`IMPORT INTO t (a, b) CSV DATA (%s) WITH decompress = 'auto'`,
-			[]string{`'nodelocal:///data-[0-9][0-9]*'`},
+			[]string{`'nodelocal://0/data-[0-9][0-9]*'`},
 			` WITH decompress = 'auto'`,
 			`pq: no files matched uri provided`,
 		},
@@ -3095,11 +3095,11 @@ func TestImportMysql(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	files := getMysqldumpTestdata(t)
-	simple := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(files.simple, baseDir))}
-	second := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(files.second, baseDir))}
-	multitable := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(files.wholeDB, baseDir))}
-	multitableGz := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(files.wholeDB+".gz", baseDir))}
-	multitableBz := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(files.wholeDB+".bz2", baseDir))}
+	simple := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(files.simple, baseDir))}
+	second := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(files.second, baseDir))}
+	multitable := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(files.wholeDB, baseDir))}
+	multitableGz := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(files.wholeDB+".gz", baseDir))}
+	multitableBz := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(files.wholeDB+".bz2", baseDir))}
 
 	const expectSimple, expectSecond, expectEverything = 1 << 0, 1 << 2, 1 << 3
 	const expectAll = -1
@@ -3228,7 +3228,7 @@ func TestImportMysqlOutfile(t *testing.T) {
 			var opts []interface{}
 
 			cmd := fmt.Sprintf(`IMPORT TABLE test%d (i INT8 PRIMARY KEY, s text, b bytea) DELIMITED DATA ($1)`, i)
-			opts = append(opts, fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(cfg.filename, baseDir)))
+			opts = append(opts, fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(cfg.filename, baseDir)))
 
 			var flags []string
 			if cfg.opts.RowSeparator != '\n' {
@@ -3289,7 +3289,7 @@ func TestImportPgCopy(t *testing.T) {
 			var opts []interface{}
 
 			cmd := fmt.Sprintf(`IMPORT TABLE test%d (i INT8 PRIMARY KEY, s text, b bytea) PGCOPY DATA ($1)`, i)
-			opts = append(opts, fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(cfg.filename, baseDir)))
+			opts = append(opts, fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(cfg.filename, baseDir)))
 
 			var flags []string
 			if cfg.opts.Delimiter != '\t' {
@@ -3349,11 +3349,11 @@ func TestImportPgDump(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	simplePgTestRows, simpleFile := getSimplePostgresDumpTestdata(t)
-	simple := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(simpleFile, baseDir))}
+	simple := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(simpleFile, baseDir))}
 	secondTableRowCount, secondFile := getSecondPostgresDumpTestdata(t)
-	second := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(secondFile, baseDir))}
+	second := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(secondFile, baseDir))}
 	multitableFile := getMultiTablePostgresDumpTestdata(t)
-	multitable := []interface{}{fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(multitableFile, baseDir))}
+	multitable := []interface{}{fmt.Sprintf("nodelocal://0%s", strings.TrimPrefix(multitableFile, baseDir))}
 
 	const expectAll, expectSimple, expectSecond = 1, 2, 3
 
@@ -3498,7 +3498,7 @@ func TestImportCockroachDump(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal:///cockroachdump/dump.sql")
+	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal://0/cockroachdump/dump.sql")
 	sqlDB.CheckQueryResults(t, "SELECT * FROM t ORDER BY i", [][]string{
 		{"1", "test"},
 		{"2", "other"},
@@ -3553,7 +3553,7 @@ func TestCreateStatsAfterImport(t *testing.T) {
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
 
-	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal:///cockroachdump/dump.sql")
+	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal://0/cockroachdump/dump.sql")
 
 	// Verify that statistics have been created.
 	sqlDB.CheckQueryResultsRetry(t,
@@ -3587,12 +3587,12 @@ func TestImportAvro(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
-	simpleOcf := fmt.Sprintf("nodelocal:///%s", "simple.ocf")
-	simpleSchemaURI := fmt.Sprintf("nodelocal:///%s", "simple-schema.json")
-	simpleJSON := fmt.Sprintf("nodelocal:///%s", "simple-sorted.json")
-	simplePrettyJSON := fmt.Sprintf("nodelocal:///%s", "simple-sorted.pjson")
-	simpleBinRecords := fmt.Sprintf("nodelocal:///%s", "simple-sorted-records.avro")
-	tableSchema := fmt.Sprintf("nodelocal:///%s", "simple-schema.sql")
+	simpleOcf := fmt.Sprintf("nodelocal://0/%s", "simple.ocf")
+	simpleSchemaURI := fmt.Sprintf("nodelocal://0/%s", "simple-schema.json")
+	simpleJSON := fmt.Sprintf("nodelocal://0/%s", "simple-sorted.json")
+	simplePrettyJSON := fmt.Sprintf("nodelocal://0/%s", "simple-sorted.pjson")
+	simpleBinRecords := fmt.Sprintf("nodelocal://0/%s", "simple-sorted-records.avro")
+	tableSchema := fmt.Sprintf("nodelocal://0/%s", "simple-schema.sql")
 
 	data, err := ioutil.ReadFile("testdata/avro/simple-schema.json")
 	if err != nil {

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -109,7 +109,7 @@ func TestImportChunking(t *testing.T) {
 	}
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts), "data", "nodelocal://"+dir, ts, chunkSize, dir, dir)
+	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts), "data", "nodelocal://0"+dir, ts, chunkSize, dir, dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -142,7 +142,7 @@ func TestImportOutOfOrder(t *testing.T) {
 	fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, strings.Join(row1, `,`))
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", "nodelocal:///foo", ts, 0, dir, dir)
+	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", "nodelocal://0/foo", ts, 0, dir, dir)
 	if !testutils.IsError(err, "out of order row") {
 		t.Fatalf("expected out of order row, got: %+v", err)
 	}

--- a/pkg/ccl/importccl/read_import_base_test.go
+++ b/pkg/ccl/importccl/read_import_base_test.go
@@ -28,8 +28,8 @@ func TestRejectedFilename(t *testing.T) {
 		},
 		{
 			name:     "nodelocal",
-			fname:    "nodelocal:///file.csv",
-			rejected: "nodelocal:///file.csv.rejected",
+			fname:    "nodelocal://0/file.csv",
+			rejected: "nodelocal://0/file.csv.rejected",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -152,7 +152,7 @@ func BenchmarkImport(b *testing.B) {
 			if err != nil {
 				b.Fatalf("%+v", err)
 			}
-			storage, err := cloud.ExternalStorageConfFromURI(`nodelocal:///` + subdir)
+			storage, err := cloud.ExternalStorageConfFromURI(`nodelocal://0/` + subdir)
 			if err != nil {
 				b.Fatalf("%+v", err)
 			}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -225,7 +225,7 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 	defer s.Stopper().Stop(ctx)
 	init(s.ClusterSettings())
 
-	storage, err := cloud.ExternalStorageConfFromURI("nodelocal:///foo")
+	storage, err := cloud.ExternalStorageConfFromURI("nodelocal://0/foo")
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -62,7 +62,7 @@ func toBackup(t testing.TB, data workload.Table, dir string, chunkBytes int64) (
 
 	// TODO(dan): The csv load will be less overhead, use it when we have it.
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := importccl.Load(ctx, db, &stmts, `data`, `nodelocal:///`, ts, chunkBytes, tempDir, dir)
+	desc, err := importccl.Load(ctx, db, &stmts, `data`, `nodelocal://0/`, ts, chunkBytes, tempDir, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
@@ -61,7 +61,7 @@ func TestToBackup(t *testing.T) {
 					sqlDB := sqlutils.MakeSQLRunner(db)
 					sqlDB.Exec(t, `DROP DATABASE IF EXISTS data CASCADE`)
 					sqlDB.Exec(t, `CREATE DATABASE data`)
-					sqlDB.Exec(t, `RESTORE data.* FROM $1`, `nodelocal:///`+dir)
+					sqlDB.Exec(t, `RESTORE data.* FROM $1`, `nodelocal://0/`+dir)
 
 					var rowCount int
 					sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s`, data.Name)).Scan(&rowCount)

--- a/pkg/kv/kvserver/cloud/external_storage.go
+++ b/pkg/kv/kvserver/cloud/external_storage.go
@@ -195,8 +195,17 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 		conf.Provider = roachpb.ExternalStorageProvider_Http
 		conf.HttpPath.BaseUri = path
 	case "nodelocal":
+		if uri.Host == "" {
+			return conf, errors.Errorf(
+				"host component of nodelocal URI must be a node ID (" +
+					"use 'self' to specify each node should access its own local filesystem)",
+			)
+		} else if uri.Host == "self" {
+			uri.Host = "0"
+		}
+
 		nodeID, err := strconv.Atoi(uri.Host)
-		if err != nil && uri.Host != "" {
+		if err != nil {
 			return conf, errors.Errorf("host component of nodelocal URI must be a node ID: %s", path)
 		}
 		conf.Provider = roachpb.ExternalStorageProvider_LocalFile

--- a/pkg/kv/kvserver/cloud/nodelocal_storage.go
+++ b/pkg/kv/kvserver/cloud/nodelocal_storage.go
@@ -34,7 +34,7 @@ var _ ExternalStorage = &localFileStorage{}
 // MakeLocalStorageURI converts a local path (should always be relative) to a
 // valid nodelocal URI.
 func MakeLocalStorageURI(path string) string {
-	return fmt.Sprintf("nodelocal:///%s", path)
+	return fmt.Sprintf("nodelocal://0/%s", path)
 }
 
 func makeNodeLocalURIWithNodeID(nodeID roachpb.NodeID, path string) string {

--- a/pkg/kv/kvserver/cloud/nodelocal_storage.go
+++ b/pkg/kv/kvserver/cloud/nodelocal_storage.go
@@ -39,9 +39,6 @@ func MakeLocalStorageURI(path string) string {
 
 func makeNodeLocalURIWithNodeID(nodeID roachpb.NodeID, path string) string {
 	path = strings.TrimPrefix(path, "/")
-	if nodeID == 0 {
-		return fmt.Sprintf("nodelocal:///%s", path)
-	}
 	return fmt.Sprintf("nodelocal://%d/%s", nodeID, path)
 }
 

--- a/pkg/kv/kvserver/cloud/nodelocal_storage_test.go
+++ b/pkg/kv/kvserver/cloud/nodelocal_storage_test.go
@@ -31,7 +31,7 @@ func TestPutLocal(t *testing.T) {
 	dest := MakeLocalStorageURI(p)
 
 	testExportStore(t, dest, false)
-	testListFiles(t, "nodelocal:///listing-test/basepath")
+	testListFiles(t, "nodelocal://0/listing-test/basepath")
 }
 
 func TestLocalIOLimits(t *testing.T) {
@@ -44,13 +44,13 @@ func TestLocalIOLimits(t *testing.T) {
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 
 	baseDir, err := ExternalStorageFromURI(
-		ctx, "nodelocal:///", base.ExternalIOConfig{}, testSettings, clientFactory)
+		ctx, "nodelocal://0/", base.ExternalIOConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
-		u := fmt.Sprintf("nodelocal://%s", dest)
+		u := fmt.Sprintf("nodelocal://0%s", dest)
 		e, err := ExternalStorageFromURI(
 			ctx, u, base.ExternalIOConfig{}, testSettings, clientFactory)
 		if err != nil {
@@ -66,7 +66,7 @@ func TestLocalIOLimits(t *testing.T) {
 	}
 
 	for host, expectErr := range map[string]bool{"": false, "1": false, "0": false, "blah": true} {
-		u := fmt.Sprintf("nodelocal://%s/path/to/file", host)
+		u := fmt.Sprintf("nodelocal://0%s/path/to/file", host)
 
 		var expected string
 		if expectErr {

--- a/pkg/sql/opt/optbuilder/testdata/misc_statements
+++ b/pkg/sql/opt/optbuilder/testdata/misc_statements
@@ -132,7 +132,7 @@ CANCEL QUERIES VALUES (1, 2)
 error (42601): too many columns in CANCEL QUERIES data
 
 build
-EXPORT INTO CSV 'nodelocal://foo' FROM SELECT * FROM ab
+EXPORT INTO CSV 'nodelocal://0/foo' FROM SELECT * FROM ab
 ----
 export
  ├── columns: filename:4 rows:5 bytes:6
@@ -141,10 +141,10 @@ export
  │    ├── columns: a:1 b:2
  │    └── scan ab
  │         └── columns: a:1 b:2 rowid:3!null
- └── 'nodelocal://foo'
+ └── 'nodelocal://0/foo'
 
 build
-EXPORT INTO CSV 'nodelocal://foo' WITH 'foo', 'bar'='baz' FROM SELECT * FROM ab
+EXPORT INTO CSV 'nodelocal://0/foo' WITH 'foo', 'bar'='baz' FROM SELECT * FROM ab
 ----
 export
  ├── columns: filename:4 rows:5 bytes:6
@@ -153,7 +153,7 @@ export
  │    ├── columns: a:1 b:2
  │    └── scan ab
  │         └── columns: a:1 b:2 rowid:3!null
- ├── 'nodelocal://foo'
+ ├── 'nodelocal://0/foo'
  └── k-v-options
       ├── k-v-options-item foo
       │    └── CAST(NULL AS STRING)
@@ -161,7 +161,7 @@ export
            └── 'baz'
 
 build
-EXPORT INTO CSV 'nodelocal://foo' WITH 'foo' = $1 FROM SELECT * FROM ab
+EXPORT INTO CSV 'nodelocal://0/foo' WITH 'foo' = $1 FROM SELECT * FROM ab
 ----
 export
  ├── columns: filename:4 rows:5 bytes:6
@@ -170,7 +170,7 @@ export
  │    ├── columns: a:1 b:2
  │    └── scan ab
  │         └── columns: a:1 b:2 rowid:3!null
- ├── 'nodelocal://foo'
+ ├── 'nodelocal://0/foo'
  └── k-v-options
       └── k-v-options-item foo
            └── $1

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1375,17 +1375,17 @@ func TestParse(t *testing.T) {
 		{`BACKUP TABLE foo TO 'bar' WITH key1, key2 = 'value'`},
 		{`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
 
-		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
-		{`EXPLAIN IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
-		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' DELIMITED DATA ('path/to/some/file', $1)`},
+		{`IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
+		{`EXPLAIN IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
+		{`IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' DELIMITED DATA ('path/to/some/file', $1)`},
 		{`IMPORT TABLE foo (id INT8 PRIMARY KEY, email STRING, age INT8) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT8, email STRING, age INT8) CSV DATA ('path/to/some/file', $1) WITH comma = ',', "nullif" = 'n/a', temp = $2`},
-		{`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`},
+		{`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},
 		{`IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 
-		{`IMPORT PGDUMP 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`},
-		{`EXPLAIN IMPORT PGDUMP 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`},
+		{`IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},
+		{`EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},
 
 		{`EXPORT INTO CSV 'a' FROM TABLE a`}, // TODO(knz): Make this explainable.
 		{`EXPORT INTO CSV 'a' FROM SELECT * FROM a`},
@@ -2068,11 +2068,11 @@ $function$`,
 			`DROP ROLE IF EXISTS 'foo', 'bar'`},
 
 		// Backward-compat, deprecated IMPORT syntax
-		{`IMPORT PGDUMP ('nodelocal:///foo/bar') WITH temp = 'path/to/temp'`,
-			`IMPORT PGDUMP 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`,
+		{`IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'`,
+			`IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`,
 		},
-		{`IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal:///foo/bar') WITH temp = 'path/to/temp'`,
-			`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`,
+		{`IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'`,
+			`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`,
 		},
 
 		// Clarify the ambiguity between "ON ROLE" (RBAC) and "ON ROLE"


### PR DESCRIPTION
Previously nodelocal URIs without a host specified, or with a nodeID of
0, would be interpreted as 'which ever node happens to be evaluating
this URI'. This behavior often leads to confusion and typically a user
is better served by specifying which node, e.g. with
nodelocal://1/foo/bar.

This change now *requires* users specify a nodeID in nodelocal URIs. If
a user truely wants the old behavior of picking the local node, they can
speicfy a nodeID of zero or use the reserved hostname 'self'.

Release note (general change): nodelocal:// format URIs now require a nodeID be specified in the hostname field. The special nodeID of 'self' is equivalent to the old behavior when unspecified.
