### PR TITLE
sqlbase: change default jobs ttl back to default (25h)

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -559,7 +559,6 @@ FROM crdb_internal.zones
 ----
 RANGE default                                                                 default   NULL         NULL                          NULL       NULL
 DATABASE system                                                               NULL      system       NULL                          NULL       NULL
-TABLE system.public.jobs                                                      NULL      system       jobs                          NULL       NULL
 RANGE meta                                                                    meta      NULL         NULL                          NULL       NULL
 RANGE system                                                                  system    NULL         NULL                          NULL       NULL
 RANGE liveness                                                                liveness  NULL         NULL                          NULL       NULL

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -774,7 +774,6 @@ func TestReportUsage(t *testing.T) {
 		keys.RootNamespaceID,
 		keys.LivenessRangesID,
 		keys.MetaRangesID,
-		keys.JobsTableID,
 		keys.RangeEventTableID,
 		keys.SystemDatabaseID,
 	} {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -229,7 +229,6 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 ----
 0   RANGE default
 1   DATABASE system
-15  TABLE system.public.jobs
 16  RANGE meta
 17  RANGE system
 18  RANGE timeseries

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -1512,16 +1512,11 @@ func addSystemDatabaseToSchema(
 
 	systemZoneConf := defaultSystemZoneConfig
 	metaRangeZoneConf := protoutil.Clone(defaultSystemZoneConfig).(*zonepb.ZoneConfig)
-	jobsZoneConf := protoutil.Clone(defaultSystemZoneConfig).(*zonepb.ZoneConfig)
 	livenessZoneConf := protoutil.Clone(defaultSystemZoneConfig).(*zonepb.ZoneConfig)
 
 	// .meta zone config entry with a shorter GC time.
 	metaRangeZoneConf.GC.TTLSeconds = 60 * 60 // 1h
 	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.MetaRangesID, metaRangeZoneConf))
-
-	// Jobs zone config entry with a shorter GC time.
-	jobsZoneConf.GC.TTLSeconds = 10 * 60 // 10m
-	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.JobsTableID, jobsZoneConf))
 
 	// Some reporting tables have shorter GC times.
 	replicationConstraintStatsZoneConf := &zonepb.ZoneConfig{

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -31,7 +31,7 @@ import (
 func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const keysPerDesc = 2
-	const nonDescKeys = 10
+	const nonDescKeys = 9
 
 	ms := sqlbase.MakeMetadataSchema(zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef())
 	kv, _ /* splits */ := ms.GetInitialValues(clusterversion.TestingClusterVersion)


### PR DESCRIPTION
We changed the default TTL on the jobs table to be 10min in reaction to some
issues where bisbehaved jobs destabilized a cluster by causing the jobs range
to become oversized due to mvcc garbage.

However this low TTL breaks incremental backups. Previously this was not a
significant issue for most users as BACKUP was typically only run on user
tables, but increasingly users are finding they want to backup metadata in
their system tables too, plus 20.1 will showcase full-cluster backups that
include system tables automatically.

This reverts the default TTL override for the jobs table, effectively
meaning 20.1-created clusters will inherit the 25h TTL. This also means
that if a user changes the default TTL to account for a different BACKUP
cadence, they don't need to also update a second TTL for the jobs table.

Release note (general change): on new clusters the internal system.jobs table now uses the default zoneconfig and TTL (25h)