### PR TITLE
kvserver/concurrency: misc lock table tests to cover functionality

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -266,7 +266,7 @@ func TestLockTableBasic(t *testing.T) {
 				ts := scanTimestamp(t, d)
 				var epoch int
 				d.ScanArgs(t, "epoch", &epoch)
-				txnMeta = &enginepb.TxnMeta{ID: txnMeta.ID}
+				txnMeta = &enginepb.TxnMeta{ID: txnMeta.ID, Sequence: txnMeta.Sequence}
 				txnMeta.Epoch = enginepb.TxnEpoch(epoch)
 				txnMeta.WriteTimestamp = ts
 				txnsByName[txnName] = txnMeta

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -58,7 +58,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 finish req=req2
@@ -69,7 +69,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 reset

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -58,7 +58,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 finish req=req2
@@ -69,7 +69,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000012,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 reset

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -79,11 +79,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # --------------------------------
@@ -136,17 +136,17 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 6, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
@@ -274,11 +274,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # --------------------------------
@@ -344,18 +344,18 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 13, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 10
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 11
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
@@ -496,11 +496,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request name=req4w txn=txn4 ts=10,1
@@ -528,11 +528,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1
+  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
@@ -575,17 +575,17 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 19
  lock: "b"
-  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1
+  res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
    queued writers:
     active: true req: 18, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 18
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -79,11 +79,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # --------------------------------
@@ -136,17 +136,17 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 6, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
@@ -274,11 +274,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # --------------------------------
@@ -344,18 +344,18 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 13, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 10
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 11
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
@@ -496,11 +496,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 new-request name=req4w txn=txn4 ts=10,1
@@ -528,11 +528,11 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
   res: req: 17, txn: 00000004-0000-0000-0000-000000000000, ts: 0.000000010,1
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
@@ -575,7 +575,7 @@ debug-lock-table
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 19
@@ -585,7 +585,7 @@ global: num=3
     active: true req: 18, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 18
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -28,7 +28,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 sequence req=req1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -28,7 +28,7 @@ debug-lock-table
 ----
 global: num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 sequence req=req1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -25,14 +25,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1, info: epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1, info: epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1]
 local: num=0
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
@@ -49,14 +49,14 @@ acquire r=req2 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2, info: epoch: 0, seqs: [1, 2]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2]
 local: num=0
 
 dequeue r=req2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2, info: epoch: 0, seqs: [1, 2]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2]
 local: num=0
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
@@ -73,14 +73,14 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -101,14 +101,14 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -129,14 +129,14 @@ acquire r=req4 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req4
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -163,7 +163,7 @@ dequeue r=req5
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -184,12 +184,12 @@ acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5, info: epoch: 0, seqs: [1, 2, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4, 5]
 local: num=0
 
 dequeue r=req6
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5, info: epoch: 0, seqs: [1, 2, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4, 5]
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -25,14 +25,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1, info: epoch: 0, seqs: [1]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 1, info: epoch: 0, seqs: [1]
 local: num=0
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=2
@@ -49,14 +49,14 @@ acquire r=req2 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2, info: epoch: 0, seqs: [1, 2]
 local: num=0
 
 dequeue r=req2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 2, info: epoch: 0, seqs: [1, 2]
 local: num=0
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=4
@@ -73,14 +73,14 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -101,14 +101,14 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -129,14 +129,14 @@ acquire r=req4 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 dequeue r=req4
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -163,7 +163,7 @@ dequeue r=req5
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 4, info: epoch: 0, seqs: [1, 2, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -184,12 +184,12 @@ acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5, info: epoch: 0, seqs: [1, 2, 4, 5]
 local: num=0
 
 dequeue r=req6
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, seq: 5, info: epoch: 0, seqs: [1, 2, 4, 5]
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -28,25 +28,25 @@ acquire r=req1 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=e durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
@@ -62,22 +62,22 @@ acquire r=req2 k=b durability=u
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req2
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # txn1 holds locks on b, c, e.
@@ -97,11 +97,11 @@ dequeue r=req3
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
@@ -125,9 +125,9 @@ global: num=3
  lock: "b"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Still waiting, but on lock c which has a different ts in the TxnMeta.
@@ -145,7 +145,7 @@ global: num=3
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # No longer waiting since does not conflict with lock on e.
@@ -170,7 +170,7 @@ add-discovered r=req4 k=a txn=txn3
 ----
 global: num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -178,14 +178,14 @@ global: num=4
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 add-discovered r=req4 k=f txn=txn3
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -193,9 +193,9 @@ global: num=5
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Note that guard state has not changed yet. Discovering these locks means the caller has to
@@ -230,7 +230,7 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -239,9 +239,9 @@ global: num=5
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
@@ -258,7 +258,7 @@ dequeue r=req5
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -267,9 +267,9 @@ global: num=5
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
@@ -300,7 +300,7 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -312,9 +312,9 @@ global: num=5
  lock: "c"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -354,7 +354,7 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -369,9 +369,9 @@ global: num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Release a. req4 waits at f.
@@ -391,9 +391,9 @@ global: num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req4
@@ -420,9 +420,9 @@ global: num=5
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -446,7 +446,7 @@ global: num=4
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req4
@@ -479,7 +479,7 @@ global: num=4
  lock: "a"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -489,7 +489,7 @@ global: num=4
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req4 k=c durability=r
@@ -498,17 +498,17 @@ global: num=4
  lock: "a"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -525,34 +525,34 @@ global: num=4
  lock: "a"
   res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req4
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Locks:
@@ -574,14 +574,14 @@ release txn=txn2 span=c,f
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req7
@@ -596,14 +596,14 @@ print
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Now before req7 can scan again, release the lock at b. This will cause req6 to break the
@@ -617,7 +617,7 @@ global: num=3
  lock: "c"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -654,7 +654,7 @@ global: num=3
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 scan r=req7
@@ -676,7 +676,7 @@ global: num=2
  lock: "c"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req7
@@ -691,7 +691,7 @@ dequeue r=req7
 ----
 global: num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # e is still locked
@@ -711,7 +711,7 @@ dequeue r=req8
 ----
 global: num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn1 span=c,f
@@ -738,21 +738,21 @@ acquire r=req9 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req9
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
 local: num=0
 
 print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req10 txn=txn2 ts=8,12 spans=w@c
@@ -792,7 +792,7 @@ print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
@@ -842,7 +842,7 @@ acquire r=req10 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -861,7 +861,7 @@ print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -871,7 +871,7 @@ dequeue r=req10
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -881,7 +881,7 @@ acquire r=req12 k=c durability=r
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -891,7 +891,7 @@ dequeue r=req12
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -938,7 +938,7 @@ acquire r=req13 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req14 txn=txn1 ts=9,0 spans=w@c
@@ -1006,25 +1006,25 @@ acquire r=req17 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 acquire r=req17 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req17
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
@@ -1045,12 +1045,12 @@ print
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 18
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -1062,7 +1062,7 @@ global: num=2
  lock: "c"
   res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -1078,7 +1078,7 @@ global: num=2
  lock: "c"
   res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
@@ -1106,7 +1106,7 @@ global: num=2
  lock: "c"
   res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req19
@@ -1121,14 +1121,14 @@ dequeue r=req18
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req19
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn2 span=d
@@ -1150,14 +1150,14 @@ acquire r=req20 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req20
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req21 txn=txn1 ts=10 spans=w@d
@@ -1171,18 +1171,18 @@ acquire r=req21 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req21
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req22 txn=txn2 ts=10 spans=w@c+w@d
@@ -1196,12 +1196,12 @@ print
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req23 txn=txn3 ts=10 spans=w@d
@@ -1215,7 +1215,7 @@ release txn=txn1 span=d
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
@@ -1266,7 +1266,7 @@ global: num=2
  lock: "c"
   res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
@@ -1275,14 +1275,14 @@ dequeue r=req22
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req23
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn3 span=d

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -28,25 +28,25 @@ acquire r=req1 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=e durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # req2 is also for txn1 and will not wait for locks that are held by self.
@@ -62,22 +62,22 @@ acquire r=req2 k=b durability=u
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req2
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # txn1 holds locks on b, c, e.
@@ -97,11 +97,11 @@ dequeue r=req3
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,2, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
@@ -123,11 +123,11 @@ update txn=txn1 ts=11,1 epoch=1 span=b
 ----
 global: num=3
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # Still waiting, but on lock c which has a different ts in the TxnMeta.
@@ -141,11 +141,11 @@ update txn=txn1 ts=11,1 epoch=1 span=c,e
 ----
 global: num=3
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # No longer waiting since does not conflict with lock on e.
@@ -170,32 +170,32 @@ add-discovered r=req4 k=a txn=txn3
 ----
 global: num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 add-discovered r=req4 k=f txn=txn3
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # Note that guard state has not changed yet. Discovering these locks means the caller has to
@@ -230,18 +230,18 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
@@ -258,18 +258,18 @@ dequeue r=req5
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
@@ -300,21 +300,21 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -354,24 +354,24 @@ print
 ----
 global: num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # Release a. req4 waits at f.
@@ -379,21 +379,21 @@ release txn=txn3 span=a
 ----
 global: num=5
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req4
@@ -408,21 +408,21 @@ print
 ----
 global: num=5
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, info: repl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -434,19 +434,19 @@ release txn=txn3 span=f
 ----
 global: num=4
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req4
@@ -477,38 +477,38 @@ acquire r=req4 k=b durability=r
 ----
 global: num=4
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req4 k=c durability=r
 ----
 global: num=4
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -523,36 +523,36 @@ print
 ----
 global: num=4
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req4
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # Locks:
@@ -574,14 +574,14 @@ release txn=txn2 span=c,f
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req7
@@ -596,14 +596,14 @@ print
 ----
 global: num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # Now before req7 can scan again, release the lock at b. This will cause req6 to break the
@@ -613,11 +613,11 @@ release txn=txn2 span=b
 ----
 global: num=3
  lock: "b"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, seq: 0
  lock: "c"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req6
@@ -648,13 +648,13 @@ print
 ----
 global: num=3
  lock: "b"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, seq: 0
  lock: "c"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, seq: 0
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 scan r=req7
@@ -674,9 +674,9 @@ dequeue r=req6
 ----
 global: num=2
  lock: "c"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req7
@@ -691,7 +691,7 @@ dequeue r=req7
 ----
 global: num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # e is still locked
@@ -711,7 +711,7 @@ dequeue r=req8
 ----
 global: num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn1 span=c,f
@@ -738,21 +738,21 @@ acquire r=req9 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req9
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req10 txn=txn2 ts=8,12 spans=w@c
@@ -792,7 +792,7 @@ print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 10, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
@@ -804,7 +804,7 @@ release txn=txn1 span=c
 ----
 global: num=1
  lock: "c"
-  res: req: 10, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 10, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000002
@@ -831,7 +831,7 @@ print
 ----
 global: num=1
  lock: "c"
-  res: req: 10, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12
+  res: req: 10, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, seq: 0
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000002
@@ -842,7 +842,7 @@ acquire r=req10 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -861,7 +861,7 @@ print
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -871,7 +871,7 @@ dequeue r=req10
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -881,7 +881,7 @@ acquire r=req12 k=c durability=r
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -891,7 +891,7 @@ dequeue r=req12
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -905,7 +905,7 @@ release txn=txn2 span=b,d
 ----
 global: num=1
  lock: "c"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
 local: num=0
 
 guard-state r=req11
@@ -916,7 +916,7 @@ print
 ----
 global: num=1
  lock: "c"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000006,0, seq: 0
 local: num=0
 
 dequeue r=req11
@@ -938,7 +938,7 @@ acquire r=req13 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,12, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req14 txn=txn1 ts=9,0 spans=w@c
@@ -959,14 +959,14 @@ release txn=txn2 span=b,d
 ----
 global: num=1
  lock: "c"
-  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, seq: 0
 local: num=0
 
 dequeue r=req15
 ----
 global: num=1
  lock: "c"
-  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0
+  res: req: 14, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, seq: 0
 local: num=0
 
 new-request r=req16 txn=none ts=10,12 spans=r@c
@@ -1006,25 +1006,25 @@ acquire r=req17 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 acquire r=req17 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req17
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req18 txn=txn2 ts=10,0 spans=w@c+w@d
@@ -1045,12 +1045,12 @@ print
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 18
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -1060,9 +1060,9 @@ release txn=txn1 span=c
 ----
 global: num=2
  lock: "c"
-  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
@@ -1076,9 +1076,9 @@ print
 ----
 global: num=2
  lock: "c"
-  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000009,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
@@ -1089,9 +1089,9 @@ release txn=txn1 span=d
 ----
 global: num=2
  lock: "c"
-  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
@@ -1104,9 +1104,9 @@ acquire r=req18 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 18, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req19
@@ -1121,14 +1121,14 @@ dequeue r=req18
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req19
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn2 span=d
@@ -1150,14 +1150,14 @@ acquire r=req20 k=c durability=u
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req20
 ----
 global: num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req21 txn=txn1 ts=10 spans=w@d
@@ -1171,18 +1171,18 @@ acquire r=req21 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 dequeue r=req21
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req22 txn=txn2 ts=10 spans=w@c+w@d
@@ -1196,12 +1196,12 @@ print
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 new-request r=req23 txn=txn3 ts=10 spans=w@d
@@ -1215,12 +1215,12 @@ release txn=txn1 span=d
 ----
 global: num=2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
    queued writers:
     active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
-  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req23
@@ -1240,9 +1240,9 @@ release txn=txn1 span=c
 ----
 global: num=2
  lock: "c"
-  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 23, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req22
@@ -1253,9 +1253,9 @@ print
 ----
 global: num=2
  lock: "c"
-  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: false req: 23, txn: 00000000-0000-0000-0000-000000000003
 local: num=0
@@ -1264,9 +1264,9 @@ acquire r=req23 k=d durability=u
 ----
 global: num=2
  lock: "c"
-  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 22, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
@@ -1275,14 +1275,14 @@ dequeue r=req22
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req23
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn3 span=d

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -29,25 +29,25 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # In its next request, txn1 discovers a lock at c held by txn2.
@@ -67,11 +67,11 @@ add-discovered r=req2 k=c txn=txn2
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # A non-transactional read comes in at a and blocks on the lock.
@@ -117,19 +117,19 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 3, txn: none
    queued writers:
     active: true req: 4, txn: none
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 # Clearing removes all locks and allows all waiting requests to proceed.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -29,25 +29,25 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # In its next request, txn1 discovers a lock at c held by txn2.
@@ -67,11 +67,11 @@ add-discovered r=req2 k=c txn=txn2
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # A non-transactional read comes in at a and blocks on the lock.
@@ -117,19 +117,19 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 3, txn: none
    queued writers:
     active: true req: 4, txn: none
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000008,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Clearing removes all locks and allows all waiting requests to proceed.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -28,14 +28,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req2 txn=txn2 ts=10 spans=w@a+r@a
@@ -53,7 +53,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -63,7 +63,7 @@ release txn=txn1 span=a
 ----
 global: num=1
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req2
@@ -91,38 +91,38 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req3 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req3 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req4 txn=txn2 ts=10 spans=w@a+w@b
@@ -151,17 +151,17 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # req5 reserves "b" and waits at "c".
@@ -170,14 +170,14 @@ release txn=txn1 span=b
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req5
@@ -188,14 +188,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -207,11 +207,11 @@ release txn=txn1 span=a
 ----
 global: num=3
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -225,13 +225,13 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -243,13 +243,13 @@ release txn=txn1 span=c
 ----
 global: num=3
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req5
@@ -264,23 +264,23 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 4, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 dequeue r=req4
 ----
 global: num=2
  lock: "b"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 dequeue r=req5
@@ -311,38 +311,38 @@ acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req6 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req6 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req6
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req7 txn=txn2 ts=10 spans=w@a+w@b
@@ -385,18 +385,18 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
     active: true req: 9, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 8
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # req8 waits at "c".
@@ -405,14 +405,14 @@ release txn=txn1 span=b
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
-  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req8
@@ -423,14 +423,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
-  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -442,11 +442,11 @@ release txn=txn1 span=a
 ----
 global: num=3
  lock: "a"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -460,13 +460,13 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -480,11 +480,11 @@ acquire r=req7 k=b durability=u
 ----
 global: num=3
  lock: "a"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -495,9 +495,9 @@ release txn=txn1 span=c
 ----
 global: num=2
  lock: "a"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req8
@@ -508,9 +508,9 @@ print
 ----
 global: num=2
  lock: "a"
-  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -520,7 +520,7 @@ dequeue r=req7
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -530,7 +530,7 @@ dequeue r=req8
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn2 span=b
@@ -555,25 +555,25 @@ acquire r=req10 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req10 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req10
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req11 txn=txn2 ts=10 spans=w@a+w@b
@@ -602,12 +602,12 @@ print
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
@@ -619,12 +619,12 @@ release txn=txn1 span=b
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
  lock: "b"
-  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 # req11 reserves "a"
@@ -632,9 +632,9 @@ release txn=txn1 span=a
 ----
 global: num=2
  lock: "a"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 # req11 breaks the reservation at "b"
@@ -646,9 +646,9 @@ print
 ----
 global: num=2
  lock: "a"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
 local: num=0
@@ -661,14 +661,15 @@ acquire r=req11 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
 local: num=0
 
-# req12 ignores the lock at "b" when it encounters it again as a reader.
+# req12 ignores the lock at "b" when it encounters it again as a reader. So it will
+# enter the doneWaiting state. It will wait again when it rescans.
 
 guard-state r=req12
 ----
@@ -686,7 +687,7 @@ dequeue r=req11
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
@@ -696,7 +697,7 @@ dequeue r=req12
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn2 span=b

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -3,8 +3,10 @@
 new-lock-table maxlocks=10000
 ----
 
+# ---------------------------------------------------------------------------------
 # Test: req2 accesses "a" as both write and read. Once it has reservation for write
 # it does not wait at "a" for read.
+# ---------------------------------------------------------------------------------
 
 new-txn txn=txn1 ts=10 epoch=0
 ----
@@ -26,14 +28,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req2 txn=txn2 ts=10 spans=w@a+r@a
@@ -51,7 +53,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -73,8 +75,10 @@ dequeue r=req2
 global: num=0
 local: num=0
 
-# Test: req5 accesses "b" as both write and read. It has its reservation at "b" broken, but ignores
-# "b" when encounters it as reader.
+# ---------------------------------------------------------------------------------
+# Test: req5 accesses "b" as both write and read. It has its reservation at "b"
+# broken, but ignores "b" when encounters it as reader.
+# ---------------------------------------------------------------------------------
 
 new-request r=req3 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
@@ -87,38 +91,38 @@ acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req3 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req3 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req3
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req4 txn=txn2 ts=10 spans=w@a+w@b
@@ -147,17 +151,17 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req5 reserves "b" and waits at "c".
@@ -166,14 +170,14 @@ release txn=txn1 span=b
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req5
@@ -184,14 +188,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -207,7 +211,7 @@ global: num=3
  lock: "b"
   res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -227,7 +231,7 @@ global: num=3
    queued writers:
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -289,10 +293,12 @@ print
 global: num=0
 local: num=0
 
+# ---------------------------------------------------------------------------------
 # Test: Non-transactional req8 accesses "b" as both write and read. After it has stopped waiting
 # at "b", the reservation for "b" is acquired by a request with a lower seqnum. req8 does not ignore
 # "b" when encountering it as a reader. This is the non-transactional request version of the
 # previous test.
+# ---------------------------------------------------------------------------------
 
 new-request r=req6 txn=txn1 ts=10 spans=w@a+w@b+w@c
 ----
@@ -305,38 +311,38 @@ acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req6 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req6 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req6
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req7 txn=txn2 ts=10 spans=w@a+w@b
@@ -379,18 +385,18 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
     active: true req: 9, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 8
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # req8 waits at "c".
@@ -399,14 +405,14 @@ release txn=txn1 span=b
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
   res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req8
@@ -417,14 +423,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
   res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -440,7 +446,7 @@ global: num=3
  lock: "b"
   res: req: 9, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -460,7 +466,7 @@ global: num=3
    queued writers:
     active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -476,9 +482,9 @@ global: num=3
  lock: "a"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 8, txn: none
    distinguished req: 8
@@ -491,7 +497,7 @@ global: num=2
  lock: "a"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req8
@@ -504,7 +510,7 @@ global: num=2
  lock: "a"
   res: req: 7, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -514,7 +520,7 @@ dequeue r=req7
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 8, txn: none
    distinguished req: 8
@@ -524,10 +530,179 @@ dequeue r=req8
 ----
 global: num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn2 span=b
+----
+global: num=0
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Test: req12 accesses "b" as both write and read. It has its reservation at "b"
+# broken, and the lock is acquired at "b" before it encounters "b" as reader, but
+# it ignores the lock at "b".
+# ---------------------------------------------------------------------------------
+
+new-request r=req10 txn=txn1 ts=10 spans=w@a+w@b
+----
+
+scan r=req10
+----
+start-waiting: false
+
+acquire r=req10 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+acquire r=req10 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req10
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+new-request r=req11 txn=txn2 ts=10 spans=w@a+w@b
+----
+
+scan r=req11
+----
+start-waiting: true
+
+guard-state r=req11
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
+
+new-request r=req12 txn=txn3 ts=10 spans=w@b+r@b
+----
+
+scan r=req12
+----
+start-waiting: true
+
+guard-state r=req12
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="b" held=true guard-access=write
+
+print
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 11
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 12
+local: num=0
+
+# req12 reserves "b".
+
+release txn=txn1 span=b
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 11
+ lock: "b"
+  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+# req11 reserves "a"
+release txn=txn1 span=a
+----
+global: num=2
+ lock: "a"
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 12, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+local: num=0
+
+# req11 breaks the reservation at "b"
+guard-state r=req11
+----
+new: state=doneWaiting
+
+print
+----
+global: num=2
+ lock: "a"
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+local: num=0
+
+scan r=req11
+----
+start-waiting: false
+
+acquire r=req11 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  res: req: 11, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+local: num=0
+
+# req12 ignores the lock at "b" when it encounters it again as a reader.
+
+guard-state r=req12
+----
+new: state=doneWaiting
+
+scan r=req12
+----
+start-waiting: true
+
+guard-state r=req12
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="b" held=true guard-access=write
+
+dequeue r=req11
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 12
+local: num=0
+
+dequeue r=req12
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+release txn=txn2 span=b
+-----
+
+print
 ----
 global: num=0
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -20,28 +20,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
-local: num=0
-
-print
-----
-global: num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2]
 local: num=0
 
 release txn=txn2 span=a,c
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
-local: num=0
-
-print
-----
-global: num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2]
 local: num=0
 
 # ---------------------------------------------------------------------------------
@@ -58,18 +44,11 @@ acquire r=req2 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
-local: num=0
-
-print
-----
-global: num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
 local: num=0
 
 # ---------------------------------------------------------------------------------
-# Reader waits until it the timestamp of the lock is updated.
+# Reader waits until the timestamp of the lock is updated.
 # ---------------------------------------------------------------------------------
 
 new-request r=req3 txn=txn2 ts=12 spans=r@a
@@ -87,7 +66,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 1
@@ -103,15 +82,13 @@ acquire r=req4 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, info: unrepl epoch: 1, seqs: [0, 1]
 local: num=0
 
-print
+guard-state r=req3
 ----
-global: num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [0, 1]
-local: num=0
+new: state=doneWaiting
+
 
 # ---------------------------------------------------------------------------------
 # Discovery of replicated lock that was already held as unreplicated. The waiters
@@ -134,7 +111,7 @@ add-discovered r=req5 k=a txn=txn1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [1], epoch: 1, seqs: [0, 1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, info: repl epoch: 1, seqs: [1], unrepl epoch: 1, seqs: [0, 1]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -1,0 +1,145 @@
+# Misc tests where there is a change in state made or attempted for a lock.
+
+new-lock-table maxlocks=10000
+----
+
+# ---------------------------------------------------------------------------------
+# Lock being released is held by a different transaction.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=10 epoch=0 seq=2
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+local: num=0
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+local: num=0
+
+release txn=txn2 span=a,c
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+local: num=0
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 2, info: epoch: 0, seqs: [2]
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Lock is reacquired at a different epoch. The old sequence numbers are discarded.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=10 epoch=1 seq=0
+----
+
+new-request r=req2 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req2 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+local: num=0
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Reader waits until it the timestamp of the lock is updated.
+# ---------------------------------------------------------------------------------
+
+new-request r=req3 txn=txn2 ts=12 spans=r@a
+----
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=read
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 1, seqs: [0]
+   waiting readers:
+    req: 1, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 1
+local: num=0
+
+new-txn txn=txn1 ts=14 epoch=1 seq=1
+----
+
+new-request r=req4 txn=txn1 ts=14 spans=w@a
+----
+
+acquire r=req4 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [0, 1]
+local: num=0
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [0, 1]
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Discovery of replicated lock that was already held as unreplicated. The waiters
+# should be informed. It is unclear whether this can actually happen in the context
+# that the lock table is used.
+# ---------------------------------------------------------------------------------
+
+new-request r=req5 txn=txn2 ts=17 spans=r@a
+----
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn1 ts=14 key="a" held=true guard-access=read
+
+add-discovered r=req5 k=a txn=txn1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, seq: 1, info: epoch: 1, seqs: [1], epoch: 1, seqs: [0, 1]
+   waiting readers:
+    req: 2, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 2
+local: num=0
+
+guard-state r=req5
+----
+new: state=waitForDistinguished txn=txn1 ts=14 key="a" held=true guard-access=read

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -20,7 +20,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -29,24 +29,24 @@ add-discovered r=req1 k=b txn=txn2
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 add-discovered r=req1 k=c txn=txn2
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -57,13 +57,13 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -81,13 +81,13 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -106,14 +106,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -127,9 +127,9 @@ global: num=3
  lock: "a"
   res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -146,9 +146,9 @@ global: num=3
  lock: "a"
   res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -163,7 +163,7 @@ global: num=3
  lock: "a"
   res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
   res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
    queued writers:
@@ -184,7 +184,7 @@ global: num=3
  lock: "a"
   res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -20,7 +20,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -29,24 +29,24 @@ add-discovered r=req1 k=b txn=txn2
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
 add-discovered r=req1 k=c txn=txn2
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -57,13 +57,13 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -81,13 +81,13 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -106,14 +106,14 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -125,11 +125,11 @@ release txn=txn2 span=a
 ----
 global: num=3
  lock: "a"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -144,11 +144,11 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
@@ -161,11 +161,11 @@ release txn=txn2 span=c
 ----
 global: num=3
  lock: "a"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
  lock: "c"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -182,14 +182,14 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "c"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -200,9 +200,9 @@ release txn=txn2 span=b
 ----
 global: num=2
  lock: "a"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
 local: num=0
@@ -215,7 +215,7 @@ dequeue r=req1
 ----
 global: num=1
  lock: "c"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -22,38 +22,38 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # Next, two different transactional requests wait at a and b.
@@ -93,18 +93,18 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: none
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -245,7 +245,7 @@ global: num=2
  lock: "a"
   res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: none
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -22,38 +22,38 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # Next, two different transactional requests wait at a and b.
@@ -93,18 +93,18 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, txn: none
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
@@ -117,14 +117,14 @@ release txn=txn1 span=a,d
 ----
 global: num=3
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 4, txn: none
    distinguished req: 4
  lock: "b"
-  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req2
@@ -156,15 +156,15 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 4, txn: none
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "b"
-  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 # Release the reservation at a. The first waiter is non-transactional so it will not acquire the
@@ -175,11 +175,11 @@ dequeue r=req2
 ----
 global: num=3
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req4
@@ -194,14 +194,14 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "b"
-  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 4, txn: none
    distinguished req: 4
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 # Release the reservation at b. The non-transactional waiter will be done at b, and when it gets
@@ -211,9 +211,9 @@ dequeue r=req3
 ----
 global: num=2
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req4
@@ -228,9 +228,9 @@ print
 ----
 global: num=2
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 # Non-transactional request scans again and proceeds to evaluation and discovers a lock at c
@@ -243,9 +243,9 @@ add-discovered r=req4 k=c txn=txn2
 ----
 global: num=2
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 4, txn: none
     active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
@@ -273,9 +273,9 @@ release txn=txn2 span=c
 ----
 global: num=2
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 guard-state r=req4
@@ -292,16 +292,16 @@ dequeue r=req4
 ----
 global: num=2
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
  lock: "c"
-  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0
+  res: req: 5, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000010,0, seq: 0
 local: num=0
 
 dequeue r=req5
 ----
 global: num=1
  lock: "a"
-  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  res: req: 6, txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 0
 local: num=0
 
 dequeue r=req6

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -26,16 +26,16 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # c is locked both replicated and unreplicated, though we really only need it
@@ -47,33 +47,33 @@ acquire r=req1 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=c durability=r
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req2 txn=txn2 ts=10 spans=w@a,c
@@ -94,28 +94,28 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn1 span=a
 ----
 global: num=3
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req2
@@ -130,16 +130,16 @@ print
 ----
 global: num=3
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req4 txn=txn2 ts=10 spans=r@b
@@ -178,11 +178,11 @@ add-discovered r=req7 k=d txn=txn1
 ----
 global: num=4
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
@@ -190,12 +190,12 @@ global: num=4
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0], unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 6
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
@@ -213,7 +213,7 @@ acquire r=req8 k=e durability=u
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -26,16 +26,16 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=b durability=u
 ----
 global: num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 # c is locked both replicated and unreplicated, though we really only need it
@@ -47,33 +47,33 @@ acquire r=req1 k=c durability=u
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
 local: num=0
 
 acquire r=req1 k=c durability=r
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req2 txn=txn2 ts=10 spans=w@a,c
@@ -94,15 +94,15 @@ print
 ----
 global: num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
 local: num=0
 
 release txn=txn1 span=a
@@ -113,9 +113,9 @@ global: num=3
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
 local: num=0
 
 guard-state r=req2
@@ -134,12 +134,12 @@ global: num=3
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
 local: num=0
 
 new-request r=req4 txn=txn2 ts=10 spans=r@b
@@ -182,7 +182,7 @@ global: num=4
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
@@ -190,12 +190,12 @@ global: num=4
     active: true req: 5, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0], epoch: 0, seqs: [0]
    queued writers:
     active: true req: 6, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 6
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
 local: num=0
@@ -213,7 +213,7 @@ acquire r=req8 k=e durability=u
 ----
 global: num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
    queued writers:
     active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -29,14 +29,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
 local: num=0
 
 # -------------------------------------------------------------
@@ -95,7 +95,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -113,7 +113,7 @@ update txn=txn1 ts=11,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -133,7 +133,7 @@ update txn=txn1 ts=13,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -154,7 +154,25 @@ dequeue r=req2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
+   waiting readers:
+    req: 4, txn: none
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, txn: none
+   distinguished req: 4
+local: num=0
+
+# -------------------------------------------------------------
+# Update lock timestamp to 10,1 - noop since lock is already at
+# 13,1
+# -------------------------------------------------------------
+
+update txn=txn1 ts=10,1 epoch=0 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -171,7 +189,7 @@ update txn=txn1 ts=15,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,1, info: epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -190,7 +208,7 @@ update txn=txn1 ts=17,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -209,7 +227,7 @@ dequeue r=req4
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -224,7 +242,7 @@ update txn=txn1 ts=19,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000019,1
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000019,1, info: epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -274,6 +292,64 @@ scan r=req5
 start-waiting: false
 
 dequeue r=req5
+----
+global: num=0
+local: num=0
+
+# -------------------------------------------------------------
+# Lock is held at multiple seqnums and then updated to ignore
+# either a seqnum that is not in the held list or one that is
+# in the list. When all the seqnumes are ignored, the lock is
+# no longer held.
+# -------------------------------------------------------------
+
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0 seq=1
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req1 k=a durability=u
+---
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 1, info: epoch: 0, seqs: [1]
+local: num=0
+
+new-txn txn=txn1 ts=10 epoch=0 seq=5
+----
+
+new-request r=req2 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req2 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [1, 5]
+local: num=0
+
+update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [1, 5]
+local: num=0
+
+update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [5]
+local: num=0
+
+update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=5
 ----
 global: num=0
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -29,14 +29,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # -------------------------------------------------------------
@@ -95,7 +95,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -113,7 +113,7 @@ update txn=txn1 ts=11,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000011,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
@@ -133,7 +133,7 @@ update txn=txn1 ts=13,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -154,7 +154,7 @@ dequeue r=req2
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -172,7 +172,7 @@ update txn=txn1 ts=10,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000013,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -189,7 +189,7 @@ update txn=txn1 ts=15,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,1, info: unrepl epoch: 0, seqs: [0]
    waiting readers:
     req: 4, txn: none
    queued writers:
@@ -208,7 +208,7 @@ update txn=txn1 ts=17,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -227,7 +227,7 @@ dequeue r=req4
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000017,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -242,7 +242,7 @@ update txn=txn1 ts=19,1 epoch=0 span=a
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000019,1, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000019,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, txn: none
@@ -260,7 +260,7 @@ update txn=txn1 ts=19,1 epoch=1 span=a
 ----
 global: num=1
  lock: "a"
-  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000014,1
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000003, ts: 0.000000014,1, seq: 0
    queued writers:
     active: true req: 5, txn: none
    distinguished req: 5
@@ -299,30 +299,28 @@ local: num=0
 # -------------------------------------------------------------
 # Lock is held at multiple seqnums and then updated to ignore
 # either a seqnum that is not in the held list or one that is
-# in the list. When all the seqnumes are ignored, the lock is
-# no longer held.
+# in the list. When all the seqnums are ignored, the lock is
+# released. Additionally, tests the effect of updates with older
+# epochs -- they don't affect seqnums, but can advance ts.
 # -------------------------------------------------------------
 
 new-lock-table maxlocks=10000
 ----
 
-new-txn txn=txn1 ts=10 epoch=0 seq=1
+new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
 new-request r=req1 txn=txn1 ts=10 spans=w@a
 ----
 
 acquire r=req1 k=a durability=u
----
-
-print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 1, info: epoch: 0, seqs: [1]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1]
 local: num=0
 
-new-txn txn=txn1 ts=10 epoch=0 seq=5
+new-txn txn=txn1 ts=10 epoch=1 seq=5
 ----
 
 new-request r=req2 txn=txn1 ts=10 spans=w@a
@@ -332,24 +330,98 @@ acquire r=req2 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [1, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 5]
 local: num=0
 
-update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3
+new-txn txn=txn1 ts=10 epoch=1 seq=7
+----
+
+new-request r=req3 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [1, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 5, 7]
 local: num=0
 
-update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=1
+new-txn txn=txn1 ts=10 epoch=1 seq=10
+----
+
+new-request r=req4 txn=txn1 ts=10 spans=w@a
+----
+
+acquire r=req4 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, seq: 5, info: epoch: 0, seqs: [5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
 local: num=0
 
-update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=5
+# No seqnum change since lock is not held at seqnum 3, 8, 9.
+
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,8-9
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
+local: num=0
+
+# No change since update is using older epoch.
+
+update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3,5-7
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 5, 7, 10]
+local: num=0
+
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,5-7
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1, 10]
+local: num=0
+
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=9-11
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [1]
+local: num=0
+
+# No seqnum change since update is using older epoch. But since the update is using
+# a higher timestamp, the ts is advanced.
+
+update txn=txn1 ts=15 epoch=0 span=a ignored-seqs=1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,0, info: unrepl epoch: 1, seqs: [1]
+local: num=0
+
+# No change, since seqnum 3 is not held. Note that the ts is not updated.
+
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000015,0, info: unrepl epoch: 1, seqs: [1]
+local: num=0
+
+# Timestamp is updated again.
+update txn=txn1 ts=16 epoch=1 span=a
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000016,0, info: unrepl epoch: 1, seqs: [1]
+local: num=0
+
+# Seqnum 1 is also ignored, so the lock is released. Note that it does not
+# matter that the update is using an older timestamp.
+
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=1
 ----
 global: num=0
 local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -37,14 +37,14 @@ acquire r=req1 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 dequeue r=req1
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 scan r=req2
@@ -75,7 +75,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
@@ -87,7 +87,7 @@ release txn=txn1 span=a
 ----
 global: num=1
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
@@ -110,7 +110,7 @@ print
 ----
 global: num=1
  lock: "a"
-  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, seq: 0
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
@@ -132,17 +132,18 @@ new: state=waitSelf
 # ---------------------------------------------------------------------------------
 
 acquire r=req2 k=a durability=u
------
-
-guard-state r=req3
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
 local: num=0
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="a" held=true guard-access=write
 
 guard-state r=req4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -1,0 +1,153 @@
+# Waiting states when waiting for reservation or lock holder from same txn.
+
+new-lock-table maxlocks=10000
+----
+
+# ---------------------------------------------------------------------------------
+# req4 is waiting on locked "a", and req2 from the same txn acquires the
+# reservation. req4 transitions to waitForSelf state
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-txn txn=txn3 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a
+----
+
+new-request r=req2 txn=txn2 ts=10 spans=w@a
+----
+
+new-request r=req3 txn=txn3 ts=10 spans=w@a
+----
+
+new-request r=req4 txn=txn2 ts=10 spans=w@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req1
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+local: num=0
+
+scan r=req2
+----
+start-waiting: true
+
+scan r=req3
+----
+start-waiting: true
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req2
+----
+new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=write
+
+guard-state r=req3
+----
+new: state=waitFor txn=txn1 ts=10 key="a" held=true guard-access=write
+
+guard-state r=req4
+----
+new: state=waitFor txn=txn1 ts=10 key="a" held=true guard-access=write
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 2
+local: num=0
+
+release txn=txn1 span=a
+----
+global: num=1
+ lock: "a"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+local: num=0
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn2 ts=10 key="a" held=false guard-access=write
+
+guard-state r=req4
+----
+new: state=waitSelf
+
+print
+----
+global: num=1
+ lock: "a"
+  res: req: 2, txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+local: num=0
+
+# Stays in waitSelf state if scans again.
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitSelf
+
+# ---------------------------------------------------------------------------------
+# req4 is waiting on reserved "a", and req2 from the same txn acquires the
+# lock. req4 stops waiting
+# ---------------------------------------------------------------------------------
+
+acquire r=req2 k=a durability=u
+-----
+
+guard-state r=req3
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 3
+local: num=0
+
+guard-state r=req4
+----
+new: state=doneWaiting
+
+scan r=req4
+----
+start-waiting: false


### PR DESCRIPTION
that was not tested before and three bug fixes

Some of the following was based on looking at test coverage results:
- added wait_self: covers reservation by a different request from the
  the same txn and lock acquisition by the same txn
- we were not adding to the sequence nums in discoveredLock
  which was a bug found when printing the sequence numbers
- dup_access: added test when a request is both reading and writing
  to a key and the lock is held after it stops waiting for write
- added lock_changes: misc state changes for a lock that were not covered
  by existing tests
- added ignored seqnum tests to the update testdata file. It found
  a bug
- UpdateLocks now ignores updates with the same epoch but lower timestamp.
  It used to trigger an error after the ts had been updated which was
  severely muddled (tell the caller of the error after making the erroneous
  state change!).

Release note: None