### PR TITLE
opt: improve distinct count estimation for multi-span constraints

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -59,7 +59,7 @@ inner-join (lookup abcd)
  │    ├── fd: (7)-->(4,5), (1)==(4), (4)==(1)
  │    ├── select
  │    │    ├── columns: m:1(int) n:2(int!null)
- │    │    ├── stats: [rows=9.9, distinct(1)=9.9, null(1)=0, distinct(2)=0.333333333, null(2)=0]
+ │    │    ├── stats: [rows=9.9, distinct(1)=9.9, null(1)=0, distinct(2)=1, null(2)=0]
  │    │    ├── scan small
  │    │    │    ├── columns: m:1(int) n:2(int)
  │    │    │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0.1]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -150,7 +150,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -158,7 +158,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [/'foo' - /'bar']
  │    │    └── [/'aaa' - /NULL)
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -169,7 +169,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS 
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -177,7 +177,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [/'foo' - /'bar']
  │    │    └── [/'aaa' - /NULL]
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
@@ -198,7 +198,7 @@ SELECT s, d, x FROM a WHERE (s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -206,7 +206,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [ - /'foobar']
  │    │    └── [/'foo' - /'bar']
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -215,39 +215,31 @@ select
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5.0
 ----
-index-join a
+select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=500, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
- └── select
-      ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=111.111111, distinct(3)=0.222222222, null(3)=0, distinct(4)=100, null(4)=0]
-      ├── key: (1)
-      ├── fd: (1)-->(3,4), (3,4)-->(1)
-      ├── scan a@secondary
-      │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      │    ├── constraint: /-3/4
-      │    │    ├── [ - /'foobar']
-      │    │    └── (/'foo'/5.0 - /'bar']
-      │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=300, null(4)=0]
-      │    ├── key: (1)
-      │    └── fd: (1)-->(3,4), (3,4)-->(1)
-      └── filters
-           ├── (s:3 <= 'foo') OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
-           └── d:4 > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) b:5(bool)
+ │    ├── stats: [rows=3000, distinct(1)=2000, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=300, null(4)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+ └── filters
+      ├── ((s:3 >= 'bar') AND (s:3 <= 'foo')) OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo'] [/'foobar' - ]; tight)]
+      └── d:4 > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 5.0 AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=500, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=33.3333333, null(4)=0]
+      ├── stats: [rows=166.666667, distinct(3)=1, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -255,7 +247,7 @@ index-join a
       │    ├── constraint: /-3/4
       │    │    ├── [ - /'foobar'/5.0]
       │    │    └── [/'foo' - /'bar'/5.0]
-      │    ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+      │    ├── stats: [rows=500, distinct(1)=478.548451, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
@@ -416,7 +408,7 @@ index-join a
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.333333333, null(3)=0, distinct(4)=33.3333333, null(4)=0]
+      ├── stats: [rows=111.111111, distinct(3)=1, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1732,3 +1732,32 @@ select
  │         └── CASE WHEN c0:1 > 0 THEN 1 ELSE t0.rowid:2 END [as=rowid:3, type=int, outer=(1,2)]
  └── filters
       └── rowid:3 > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2020-01-28 03:02:57.841772+00:00",
+    "row_count": 3,
+    "distinct_count": 3
+  }
+]'
+----
+
+# Regression test for #44563. Set a lower bound on the distinct count from
+# the multi-span constraint.
+norm
+SELECT * FROM a WHERE x <= 5 OR x = 10 OR x = 15
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=2, distinct(1)=2, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── stats: [rows=3, distinct(1)=3, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── ((x:1 <= 5) OR (x:1 = 10)) OR (x:1 = 15) [type=bool, outer=(1), constraints=(/1: (/NULL - /5] [/10 - /10] [/15 - /15]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -949,7 +949,7 @@ project
  │    │    │    │    ├── outer: (4)
  │    │    │    │    ├── limit hint: 10.00
  │    │    │    │    ├── scan b
- │    │    │    │    │    └── limit hint: 30.00
+ │    │    │    │    │    └── limit hint: 10.00
  │    │    │    │    └── filters
  │    │    │    │         └── s:4 >= 'foo' [outer=(4), constraints=(/4: [/'foo' - ]; tight)]
  │    │    │    └── 10


### PR DESCRIPTION
Prior to this commit, we would always estimate the selectivity of
constraints with at least one open-ended span (e.g., `/a: [ - 5][10 - 10]`)
to be 1/3 if no histogram was available. However, this leads to under-
estimation in the case of a small number of rows. For example, if there
are only input 2 rows, the estimated number of output rows after the above
constraint is applied is 0.66.

This commit fixes the problem by using information from the constraint
to infer the number of distinct values. For example, in the example above,
we can infer that there is likely at least one distinct value (10), so
we can use 1 as our lower bound (instead of 0.66).

Fixes #44563

Release note (performance improvement): Improved cardinality estimation
in the optimizer for relations with a small number of rows. This may lead
to the optimizer choosing a better query plan in some cases.