### PR TITLE
colserde: add Interval serialization

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -29,17 +29,9 @@ func randomBatch(allocator *colexec.Allocator) ([]coltypes.T, coldata.Batch) {
 	const maxTyps = 16
 	rng, _ := randutil.NewPseudoRand()
 
-	availableTyps := make([]coltypes.T, 0, len(coltypes.AllTypes))
-	for _, typ := range coltypes.AllTypes {
-		// TODO(yuzefovich): We do not support interval conversion yet.
-		if typ == coltypes.Interval {
-			continue
-		}
-		availableTyps = append(availableTyps, typ)
-	}
 	typs := make([]coltypes.T, rng.Intn(maxTyps)+1)
 	for i := range typs {
-		typs[i] = availableTyps[rng.Intn(len(availableTyps))]
+		typs[i] = coltypes.AllTypes[rng.Intn(len(coltypes.AllTypes))]
 	}
 
 	capacity := rng.Intn(coldata.BatchSize()) + 1
@@ -51,7 +43,7 @@ func randomBatch(allocator *colexec.Allocator) ([]coltypes.T, coldata.Batch) {
 func TestArrowBatchConverterRejectsUnsupportedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	unsupportedTypes := []coltypes.T{coltypes.Interval}
+	unsupportedTypes := []coltypes.T{coltypes.Unhandled}
 	for _, typ := range unsupportedTypes {
 		_, err := colserde.NewArrowBatchConverter([]coltypes.T{typ})
 		require.Error(t, err)

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -378,6 +378,11 @@ func schema(fb *flatbuffers.Builder, typs []coltypes.T) flatbuffers.UOffsetT {
 			arrowserde.BinaryStart(fb)
 			fbTypOffset = arrowserde.BinaryEnd(fb)
 			fbTyp = arrowserde.TypeTimestamp
+		case coltypes.Interval:
+			// Intervals are marshaled into bytes, so we use binary headers.
+			arrowserde.BinaryStart(fb)
+			fbTypOffset = arrowserde.BinaryEnd(fb)
+			fbTyp = arrowserde.TypeInterval
 		default:
 			panic(errors.Errorf(`don't know how to map %s`, typ))
 		}
@@ -465,6 +470,8 @@ func typeFromField(field *arrowserde.Field) (coltypes.T, error) {
 		return coltypes.Decimal, nil
 	case arrowserde.TypeTimestamp:
 		return coltypes.Timestamp, nil
+	case arrowserde.TypeInterval:
+		return coltypes.Interval, nil
 	}
 	// It'd be nice if this error could include more details, but flatbuffers
 	// doesn't make a String method or anything like that.

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -36,7 +36,7 @@ func numBuffersForType(t coltypes.T) int {
 	// null bitmap and one for the values.
 	numBuffers := 2
 	switch t {
-	case coltypes.Bytes, coltypes.Decimal, coltypes.Timestamp:
+	case coltypes.Bytes, coltypes.Decimal, coltypes.Timestamp, coltypes.Interval:
 		// This type has an extra offsets buffer.
 		numBuffers = 3
 	}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -32,15 +32,6 @@ func TestDiskQueue(t *testing.T) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
-	availableTyps := make([]coltypes.T, 0, len(coltypes.AllTypes))
-	for _, typ := range coltypes.AllTypes {
-		// TODO(yuzefovich): We do not support interval serialization yet.
-		if typ == coltypes.Interval {
-			continue
-		}
-		availableTyps = append(availableTyps, typ)
-	}
-
 	rng, _ := randutil.NewPseudoRand()
 	for _, rewindable := range []bool{false, true} {
 		for _, bufferSizeBytes := range []int{0, 16<<10 + rng.Intn(1<<20) /* 16 KiB up to 1 MiB */} {
@@ -71,10 +62,9 @@ func TestDiskQueue(t *testing.T) {
 					// Create random input.
 					batches := make([]coldata.Batch, 0, numBatches)
 					op := colexec.NewRandomDataOp(testAllocator, rng, colexec.RandomDataOpArgs{
-						AvailableTyps: availableTyps,
-						NumBatches:    cap(batches),
-						BatchSize:     1 + rng.Intn(coldata.BatchSize()),
-						Nulls:         true,
+						NumBatches: cap(batches),
+						BatchSize:  1 + rng.Intn(coldata.BatchSize()),
+						Nulls:      true,
 						BatchAccumulator: func(b coldata.Batch) {
 							batches = append(batches, colexec.CopyBatch(testAllocator, b))
 						},

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -30,15 +29,6 @@ func TestSpillingQueue(t *testing.T) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-
-	availableTyps := make([]coltypes.T, 0, len(coltypes.AllTypes))
-	for _, typ := range coltypes.AllTypes {
-		// TODO(yuzefovich): We do not support interval serialization yet.
-		if typ == coltypes.Interval {
-			continue
-		}
-		availableTyps = append(availableTyps, typ)
-	}
 
 	rng, _ := randutil.NewPseudoRand()
 	for _, rewindable := range []bool{false, true} {
@@ -67,10 +57,9 @@ func TestSpillingQueue(t *testing.T) {
 				// Create random input.
 				batches := make([]coldata.Batch, 0, numBatches)
 				op := NewRandomDataOp(testAllocator, rng, RandomDataOpArgs{
-					AvailableTyps: availableTyps,
-					NumBatches:    cap(batches),
-					BatchSize:     1 + rng.Intn(coldata.BatchSize()),
-					Nulls:         true,
+					NumBatches: cap(batches),
+					BatchSize:  1 + rng.Intn(coldata.BatchSize()),
+					Nulls:      true,
 					BatchAccumulator: func(b coldata.Batch) {
 						batches = append(batches, CopyBatch(testAllocator, b))
 					},

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -59,11 +59,6 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	for _, typ := range allSupportedSQLTypes {
-		if typ.Equal(*types.Interval) {
-			// Serialization of Intervals is currently not supported.
-			// TODO(yuzefovich): remove this once it is supported.
-			continue
-		}
 		for _, numRows := range []int{
 			// A few interesting sizes.
 			1,

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -259,16 +259,6 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 	}
 }
 
-// ensureSerializableTypes swaps out any types whose serialization that we don't
-// currently support in the vectorized engine with Ints.
-func ensureSerializableTypes(inputTypes []types.T) {
-	for i, t := range inputTypes {
-		if t.Family() == types.IntervalFamily {
-			inputTypes[i] = *types.Int
-		}
-	}
-}
-
 func TestSorterAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	st := cluster.MakeTestingClusterSettings()
@@ -297,7 +287,6 @@ func TestSorterAgainstProcessor(t *testing.T) {
 					)
 					if rng.Float64() < randTypesProbability {
 						inputTypes = generateRandomSupportedTypes(rng, nCols)
-						ensureSerializableTypes(inputTypes)
 						rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -372,7 +361,6 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 					)
 					if rng.Float64() < randTypesProbability {
 						inputTypes = generateRandomSupportedTypes(rng, nCols)
-						ensureSerializableTypes(inputTypes)
 						rows = sqlbase.RandEncDatumRowsOfTypes(rng, nRows, inputTypes)
 					} else {
 						inputTypes = intTyps[:nCols]
@@ -482,7 +470,6 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 								)
 								if rng.Float64() < randTypesProbability {
 									lInputTypes = generateRandomSupportedTypes(rng, nCols)
-									ensureSerializableTypes(lInputTypes)
 									lEqCols = generateEqualityColumns(rng, nCols, nEqCols)
 									rInputTypes = append(rInputTypes[:0], lInputTypes...)
 									rEqCols = append(rEqCols[:0], lEqCols...)


### PR DESCRIPTION
This allows us to fall back to disk when using this type and send the type
over the wire.

Release note (sql change): vectorized distributed flows and disk spilling now
support the INTERVAL type.

Closes #45392 