### PR TITLE
release-19.1: opt: fix error when referencing name of CTE

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -448,3 +448,14 @@ delete xy
                 │         │                        └── variable: u [type=int]
                 │         └── const: 5 [type=int]
                 └── variable: x [type=int]
+
+# Regression test for #43963.
+build
+WITH a AS (SELECT 1 AS testval) SELECT a.testval FROM a
+----
+project
+ ├── columns: testval:1(int!null)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: 1 [type=int]


### PR DESCRIPTION
Prior to this commit, a reference to a CTE in the SELECT list using the
syntax `<cte-name>.<col-name>` could cause the name resolution error
"no data source matches prefix". This commit fixes the issue by ensuring
that all columns of the CTE include the name of the CTE as their "table
name".

Fixes #43963

Release note (bug fix): Fixed a name resolution error that could occur
when a CTE was referenced in the SELECT list of a query using the syntax
`<cte-name>.<col-name>`.