### PR TITLE
colexec: add disk spilling to merge joiner

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -706,6 +706,9 @@ func (d *diskQueue) Rewind() error {
 	if err := d.closeFileDeserializer(); err != nil {
 		return err
 	}
+	if err := d.CloseRead(); err != nil {
+		return err
+	}
 	d.deserializerState.curBatch = 0
 	d.readFile = nil
 	d.readFileIdx = 0

--- a/pkg/sql/colexec/constants.go
+++ b/pkg/sql/colexec/constants.go
@@ -23,3 +23,5 @@ const DefaultVectorizeRowCountThreshold = 1000
 // that the vectorized engine can have (globally) for use of the temporary
 // storage.
 const VecMaxOpenFDsLimit = 256
+
+const defaultMemoryLimit = 64 << 20 /* 64 MiB */

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -787,25 +787,17 @@ func NewColOperator(
 			}
 
 			joinType := core.MergeJoiner.Type
-			mergeJoinerMemAccount := streamingMemAccount
-			if !result.IsStreaming && !useStreamingMemAccountForBuffering {
-				// If the merge joiner is buffering, create an unlimited buffering
-				// account for now.
-				// TODO(asubiotto): Once we support spilling to disk in the merge
-				//  joiner, make this a limited account. Done this way so that we can
-				//  still run plans that include a merge join with a low memory limit
-				//  to test disk spilling of other components for the time being.
-				mergeJoinerMemAccount = result.createBufferingUnlimitedMemAccount(ctx, flowCtx, "merge-joiner")
-			}
+			// We are using an unlimited memory monitor here because merge joiner
+			// itself is responsible for making sure that we stay within the memory
+			// limit, and it will fall back to disk if necessary.
+			unlimitedAllocator := NewAllocator(
+				ctx, result.createBufferingUnlimitedMemAccount(
+					ctx, flowCtx, "merge-joiner",
+				))
 			result.Op, err = NewMergeJoinOp(
-				NewAllocator(ctx, mergeJoinerMemAccount),
-				joinType,
-				inputs[0],
-				inputs[1],
-				leftPhysTypes,
-				rightPhysTypes,
-				core.MergeJoiner.LeftOrdering.Columns,
-				core.MergeJoiner.RightOrdering.Columns,
+				unlimitedAllocator, execinfra.GetWorkMemLimit(flowCtx.Cfg), args.DiskQueueCfg, args.FDSemaphore,
+				joinType, inputs[0], inputs[1], leftPhysTypes, rightPhysTypes,
+				core.MergeJoiner.LeftOrdering.Columns, core.MergeJoiner.RightOrdering.Columns,
 			)
 			if err != nil {
 				return result, err
@@ -825,6 +817,10 @@ func NewColOperator(
 					return result, err
 				}
 			}
+
+			// Merge joiner can run in auto mode because it falls back to disk if
+			// there is not enough memory available.
+			result.CanRunInAutoMode = true
 
 		case core.Sorter != nil:
 			if err := checkNumIn(inputs, 1); err != nil {

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -114,6 +114,11 @@ func newRewindableSpillingQueue(
 
 func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error {
 	if batch.Length() == 0 {
+		if q.diskQueue != nil {
+			if err := q.diskQueue.Enqueue(batch); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -33,7 +33,7 @@ query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
 ·                distributed     true               ·             ·
-·                vectorized      false              ·             ·
+·                vectorized      true               ·             ·
 render           ·               ·                  (a, b)        ·
  │               render 0        a                  ·             ·
  │               render 1        b                  ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -35,7 +35,7 @@ WHERE
 ----
 tree                  field               description
 ·                     distributed         false
-·                     vectorized          false
+·                     vectorized          true
 render                ·                   ·
  └── filter           ·                   ·
       │               filter              z IS NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -409,7 +409,7 @@ query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
 ·           distributed         false
-·           vectorized          false
+·           vectorized          true
 merge-join  ·                   ·
  │          type                inner
  │          equality            (cust) = (id)
@@ -865,7 +865,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -886,7 +886,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -907,7 +907,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -952,7 +952,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
 ·           distributed     false              ·                   ·
-·           vectorized      false              ·                   ·
+·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -968,7 +968,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 ·           distributed     false              ·                   ·
-·           vectorized      false              ·                   ·
+·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -984,7 +984,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 ·           distributed     false              ·                   ·
-·           vectorized      false              ·                   ·
+·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -1000,7 +1000,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1026,7 +1026,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1047,7 +1047,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1091,7 +1091,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 ·           distributed     false              ·                   ·
-·           vectorized      false              ·                   ·
+·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -1107,7 +1107,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1131,7 +1131,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
 ·                distributed     false              ·                   ·
-·                vectorized      false              ·                   ·
+·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1614,7 +1614,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
 ·                    distributed     false
-·                    vectorized      false
+·                    vectorized      true
 render               ·               ·
  └── merge-join      ·               ·
       │              type            inner
@@ -1636,7 +1636,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
 ·                    distributed     false
-·                    vectorized      false
+·                    vectorized      true
 render               ·               ·
  └── merge-join      ·               ·
       │              type            inner
@@ -1658,7 +1658,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
 ·               distributed     false
-·               vectorized      false
+·               vectorized      true
 merge-join      ·               ·
  │              type            inner
  │              equality        (x) = (x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -678,7 +678,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
 ·           distributed     true         ·                   ·
-·           vectorized      false        ·                   ·
+·           vectorized      true         ·                   ·
 merge-join  ·               ·            (d, e, f, a, b, c)  +f
  │          type            inner        ·                   ·
  │          equality        (f) = (a)    ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -196,7 +196,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t x JOIN t y USING(b) WHERE x.b = '3'
 ----
 ·                     distributed     false                ·                         ·
-·                     vectorized      false                ·                         ·
+·                     vectorized      true                 ·                         ·
 render                ·               ·                    (b, a, c, d, a, c, d)     ·
  │                    render 0        b                    ·                         ·
  │                    render 1        a                    ·                         ·


### PR DESCRIPTION
This commit adds disk spilling to the buffered group in the merge joiner
which allows planning the latter with `auto` setting. Since all tuples
in the buffered groups on both sides are match of each other (except for
LEFT SEMI join case), we basically need to have a cross product among
them. As a reminder, on the left side we need to repeat each tuple as
many times as there are tuples on the right side, and only then we would
proceed to the next tuple on the left side. On the other hand, on the
right side we need to fully emit the whole right buffered group at once,
and then repeat this procedure the same number of times as there are
tuples on the left side.

Currently, there is an inefficiency in that we allocate new batches
every time we append to the buffered group because `spillingQueue`
simply holds the enqueued batches in-memory, without copying them. This
will be addressed in a follow up work.

Fixes: #44555.

Release note (sql change): Queries with MERGE join can now run via the
vectorized engine when `vectorize` is set to `auto`.