### PR TITLE
sql,docgen: enable doc gen for SHOW SAVEPOINT STATUS

### DIFF
--- a/docs/generated/sql/bnf/show_var.bnf
+++ b/docs/generated/sql/bnf/show_var.bnf
@@ -13,6 +13,7 @@ show_stmt ::=
 	| show_ranges_stmt
 	| show_range_for_row_stmt
 	| show_roles_stmt
+	| show_savepoint_stmt
 	| show_schemas_stmt
 	| show_sequences_stmt
 	| show_session_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -185,6 +185,7 @@ show_stmt ::=
 	| show_ranges_stmt
 	| show_range_for_row_stmt
 	| show_roles_stmt
+	| show_savepoint_stmt
 	| show_schemas_stmt
 	| show_sequences_stmt
 	| show_session_stmt
@@ -534,6 +535,9 @@ show_range_for_row_stmt ::=
 
 show_roles_stmt ::=
 	'SHOW' 'ROLES'
+
+show_savepoint_stmt ::=
+	'SHOW' 'SAVEPOINT' 'STATUS'
 
 show_schemas_stmt ::=
 	'SHOW' 'SCHEMAS' 'FROM' name

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3828,7 +3828,6 @@ show_syntax_stmt:
 show_savepoint_stmt:
   SHOW SAVEPOINT STATUS
   {
-    /* SKIP DOC */
     $$.val = &tree.ShowSavepointStatus{}
   }
 | SHOW SAVEPOINT error // SHOW HELP: SHOW SAVEPOINT


### PR DESCRIPTION
The SHOW SAVEPOINT STATUS statement is getting documented, so there's
no point in excluding it from the syntax diagrams.

Release note: None