### PR TITLE
sql/parser: fix the ctx help for savepoints, simplify gram

### DIFF
--- a/docs/generated/sql/bnf/rollback_transaction.bnf
+++ b/docs/generated/sql/bnf/rollback_transaction.bnf
@@ -1,5 +1,5 @@
 rollback_stmt ::=
 	'ROLLBACK' 
-	| 'ROLLBACK'  'TO' 'SAVEPOINT' cockroach_restart
-	| 'ROLLBACK' 'TO' 'SAVEPOINT' cockroach_restart
 	| 'ROLLBACK' 
+	| 'ROLLBACK'  'TO' 'SAVEPOINT' cockroach_restart
+	| 'ROLLBACK'  'TO' 'SAVEPOINT' cockroach_restart

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -283,7 +283,8 @@ commit_stmt ::=
 	| 'END' opt_transaction
 
 rollback_stmt ::=
-	'ROLLBACK' opt_to_savepoint
+	'ROLLBACK' opt_transaction
+	| 'ROLLBACK' opt_transaction 'TO' savepoint_name
 
 abort_stmt ::=
 	'ABORT' opt_abort_mod
@@ -960,12 +961,6 @@ opt_transaction ::=
 
 begin_transaction ::=
 	transaction_mode_list
-	| 
-
-opt_to_savepoint ::=
-	'TRANSACTION'
-	| 'TRANSACTION' 'TO' savepoint_name
-	| 'TO' savepoint_name
 	| 
 
 opt_abort_mod ::=

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1010,7 +1010,7 @@ var specs = []stmtSpec{
 	{
 		name:    "rollback_transaction",
 		stmt:    "rollback_stmt",
-		inline:  []string{"opt_to_savepoint"},
+		inline:  []string{"opt_transaction"},
 		match:   []*regexp.Regexp{regexp.MustCompile("'ROLLBACK'")},
 		replace: map[string]string{"'TRANSACTION'": "", "'TO'": "'TO' 'SAVEPOINT'", "savepoint_name": "cockroach_restart"},
 		unlink:  []string{"cockroach_restart"},


### PR DESCRIPTION
The contextual help for the savepoint syntax was wrong. This patch
fixes it. It also performs a minor simplification of the grammar.

Release note: None