### PR TITLE
Makefile: misc improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1494,46 +1494,14 @@ settings-doc-gen := $(if $(filter buildshort,$(MAKECMDGOALS)),$(COCKROACHSHORT),
 $(SETTINGS_DOC_PAGE): $(settings-doc-gen)
 	@$(settings-doc-gen) gen settings-list --format=html > $@
 
-pkg/col/coldata/vec.eg.go: pkg/col/coldata/vec_tmpl.go
-pkg/sql/colexec/and_or_projection.eg.go: pkg/sql/colexec/and_or_projection_tmpl.go
-pkg/sql/colexec/any_not_null_agg.eg.go: pkg/sql/colexec/any_not_null_agg_tmpl.go
-pkg/sql/colexec/avg_agg.eg.go: pkg/sql/colexec/avg_agg_tmpl.go
-pkg/sql/colexec/bool_and_or_agg.eg.go: pkg/sql/colexec/bool_and_or_agg_tmpl.go
-pkg/sql/colexec/cast.eg.go: pkg/sql/colexec/cast_tmpl.go
-pkg/sql/colexec/const.eg.go: pkg/sql/colexec/const_tmpl.go
-pkg/sql/colexec/count_agg.eg.go: pkg/sql/colexec/count_agg_tmpl.go
-pkg/sql/colexec/distinct.eg.go: pkg/sql/colexec/distinct_tmpl.go
-pkg/sql/colexec/hash_aggregator.eg.go: pkg/sql/colexec/hash_aggregator_tmpl.go
-pkg/sql/colexec/hashjoiner.eg.go: pkg/sql/colexec/hashjoiner_tmpl.go
-pkg/sql/colexec/hashtable.eg.go: pkg/sql/colexec/hashtable_tmpl.go
-pkg/sql/colexec/hash_utils.eg.go: pkg/sql/colexec/hash_utils_tmpl.go
-pkg/sql/colexec/like_ops.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
-pkg/sql/colexec/mergejoinbase.eg.go: pkg/sql/colexec/mergejoinbase_tmpl.go
-pkg/sql/colexec/mergejoiner_fullouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/mergejoiner_inner.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/mergejoiner_leftanti.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/mergejoiner_leftouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/mergejoiner_leftsemi.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/mergejoiner_rightouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
-pkg/sql/colexec/min_max_agg.eg.go: pkg/sql/colexec/min_max_agg_tmpl.go
-pkg/sql/colexec/orderedsynchronizer.eg.go: pkg/sql/colexec/orderedsynchronizer_tmpl.go
-pkg/sql/colexec/overloads_test_utils.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
-pkg/sql/colexec/proj_const_left_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
-pkg/sql/colexec/proj_const_right_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
-pkg/sql/colexec/proj_non_const_ops.eg.go: pkg/sql/colexec/proj_non_const_ops_tmpl.go
-pkg/sql/colexec/quicksort.eg.go: pkg/sql/colexec/quicksort_tmpl.go
-pkg/sql/colexec/rank.eg.go: pkg/sql/colexec/rank_tmpl.go
-pkg/sql/colexec/relative_rank.eg.go: pkg/sql/colexec/relative_rank_tmpl.go
-pkg/sql/colexec/row_number.eg.go: pkg/sql/colexec/row_number_tmpl.go
-pkg/sql/colexec/rowstovec.eg.go: pkg/sql/colexec/rowstovec_tmpl.go
-pkg/sql/colexec/select_in.eg.go: pkg/sql/colexec/select_in_tmpl.go
-pkg/sql/colexec/selection_ops.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
-pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
-pkg/sql/colexec/substring.eg.go: pkg/sql/colexec/substring_tmpl.go
-pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
-pkg/sql/colexec/values_differ.eg.go: pkg/sql/colexec/values_differ_tmpl.go
-pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go
-pkg/sql/colexec/window_peer_grouper.eg.go: pkg/sql/colexec/window_peer_grouper_tmpl.go
+# Produce the dependency list for all the .eg.go files, to make them
+# depend on the right template. We use the -M flag to execgen which
+# produces the dependencies, then include them below.
+bin/execgen_out.d: bin/execgen
+	@echo EXECGEN $@; execgen -M $(EXECGEN_TARGETS) >$@.tmp || { rm -f $@.tmp; exit 1; }
+	@mv -f $@.tmp $@
+
+include bin/execgen_out.d
 
 %.eg.go: bin/execgen
 	@echo EXECGEN $@; execgen $@ > $@.tmp || { rm -f $@.tmp; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -839,9 +839,11 @@ EXECGEN_TARGETS = \
 
 execgen-exclusions = $(addprefix -not -path ,$(EXECGEN_TARGETS))
 
-$(info Cleaning old generated files.)
-$(shell find pkg/sql/colexec -type f -name '*.eg.go' $(execgen-exclusions) -print -delete 2>/dev/null)
-$(shell find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) -print -delete 2>/dev/null)
+$(shell for obsolete in $$(find pkg/sql/colexec -type f -name '*.eg.go' $(execgen-exclusions) 2>/dev/null) \
+			$$(find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) 2>/dev/null); do \
+	  echo "Removing obsolete file $$obsolete..."; \
+	  rm -f $$obsolete; \
+	done)
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \

--- a/Makefile
+++ b/Makefile
@@ -840,8 +840,8 @@ EXECGEN_TARGETS = \
 execgen-exclusions = $(addprefix -not -path ,$(EXECGEN_TARGETS))
 
 $(info Cleaning old generated files.)
-$(shell find pkg/sql/colexec -type f -name '*.eg.go' $(execgen-exclusions) -delete)
-$(shell find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) -delete 2>/dev/null)
+$(shell find pkg/sql/colexec -type f -name '*.eg.go' $(execgen-exclusions) -print -delete 2>/dev/null)
+$(shell find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) -print -delete 2>/dev/null)
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
@@ -1535,9 +1535,9 @@ pkg/sql/colexec/values_differ.eg.go: pkg/sql/colexec/values_differ_tmpl.go
 pkg/sql/colexec/vec_comparators.eg.go: pkg/sql/colexec/vec_comparators_tmpl.go
 pkg/sql/colexec/window_peer_grouper.eg.go: pkg/sql/colexec/window_peer_grouper_tmpl.go
 
-$(EXECGEN_TARGETS): bin/execgen
-	execgen $@ > $@.tmp; cmp $@.tmp $@ && rm -f $@.tmp || mv $@.tmp $@
-
+%.eg.go: bin/execgen
+	@echo EXECGEN $@; execgen $@ > $@.tmp || { rm -f $@.tmp; exit 1; }
+	@cmp $@.tmp $@ && rm -f $@.tmp || mv -f $@.tmp $@
 
 optgen-defs := pkg/sql/opt/ops/*.opt
 optgen-norm-rules := pkg/sql/opt/norm/rules/*.opt

--- a/Makefile
+++ b/Makefile
@@ -1503,9 +1503,38 @@ bin/execgen_out.d: bin/execgen
 
 include bin/execgen_out.d
 
+# Generate the colexec files.
+#
+# Note how the dependency work is complete after the cmp/rm/mv
+# dance to write to the output.
+# However, because it does not always change the timestamp of the
+# target file, it is possible to get a situation where the target is
+# older than both bin/execgen and the _tmpl.go file, but does not get
+# changed by this rule. This happens e.g. after a 'git checkout' to a
+# different branch, when the execgen binary and templates do not
+# change across branches.
+#
+# In order to prevent the rule from kicking again in every
+# make invocation, we tweak the timestamp of the output file
+# to be the latest of either bin/execgen or the input template.
+# This makes it just new enough that 'make' will be satisfied
+# that it does not need an update any more.
+#
+# Note that we don't want to ratchet the timestamp all the way
+# to the present, because then it will becomes newer
+# than all the other produced artifacts downstream and force
+# them to rebuild too.
 %.eg.go: bin/execgen
-	@echo EXECGEN $@; execgen $@ > $@.tmp || { rm -f $@.tmp; exit 1; }
-	@cmp $@.tmp $@ && rm -f $@.tmp || mv -f $@.tmp $@
+	@echo EXECGEN $@
+	@execgen $@ > $@.tmp || { rm -f $@.tmp; exit 1; }
+	@cmp $@.tmp $@ 2>/dev/null && rm -f $@.tmp || mv -f $@.tmp $@
+	@set -e; \
+	  depfile=$$(execgen -M $@ | cut -d: -f2); \
+	  target_timestamp_file=$${depfile:-bin/execgen}; \
+	  if test bin/execgen -nt $$target_timestamp_file; then \
+	    target_timestamp_file=bin/execgen; \
+	  fi; \
+	  touch -r $$target_timestamp_file $@
 
 optgen-defs := pkg/sql/opt/ops/*.opt
 optgen-norm-rules := pkg/sql/opt/norm/rules/*.opt

--- a/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
@@ -24,8 +24,10 @@ type logicalOperation struct {
 	IsOr bool
 }
 
+const andOrProjTmpl = "pkg/sql/colexec/and_or_projection_tmpl.go"
+
 func genAndOrProjectionOps(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/and_or_projection_tmpl.go")
+	t, err := ioutil.ReadFile(andOrProjTmpl)
 	if err != nil {
 		return err
 	}
@@ -66,5 +68,5 @@ func genAndOrProjectionOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genAndOrProjectionOps, "and_or_projection.eg.go")
+	registerGenerator(genAndOrProjectionOps, "and_or_projection.eg.go", andOrProjTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const anyNotNullAggTmpl = "pkg/sql/colexec/any_not_null_agg_tmpl.go"
+
 func genAnyNotNullAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/any_not_null_agg_tmpl.go")
+	t, err := ioutil.ReadFile(anyNotNullAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -47,5 +49,5 @@ func genAnyNotNullAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genAnyNotNullAgg, "any_not_null_agg.eg.go")
+	registerGenerator(genAnyNotNullAgg, "any_not_null_agg.eg.go", anyNotNullAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -56,8 +56,10 @@ var (
 	_ = avgAggTmplInfo{}.AssignDivInt64
 )
 
+const avgAggTmpl = "pkg/sql/colexec/avg_agg_tmpl.go"
+
 func genAvgAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/avg_agg_tmpl.go")
+	t, err := ioutil.ReadFile(avgAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -102,5 +104,5 @@ func genAvgAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genAvgAgg, "avg_agg.eg.go")
+	registerGenerator(genAvgAgg, "avg_agg.eg.go", avgAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
@@ -58,8 +58,10 @@ var (
 	_ = booleanAggTmplInfo{}.DefaultVal
 )
 
+const boolAggTmpl = "pkg/sql/colexec/bool_and_or_agg_tmpl.go"
+
 func genBooleanAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/bool_and_or_agg_tmpl.go")
+	t, err := ioutil.ReadFile(boolAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -84,5 +86,5 @@ func genBooleanAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genBooleanAgg, "bool_and_or_agg.eg.go")
+	registerGenerator(genBooleanAgg, "bool_and_or_agg.eg.go", boolAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -17,8 +17,10 @@ import (
 	"text/template"
 )
 
+const castTmpl = "pkg/sql/colexec/cast_tmpl.go"
+
 func genCastOperators(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/cast_tmpl.go")
+	t, err := ioutil.ReadFile(castTmpl)
 	if err != nil {
 		return err
 	}
@@ -55,5 +57,5 @@ func genCastOperators(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genCastOperators, "cast.eg.go")
+	registerGenerator(genCastOperators, "cast.eg.go", castTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/const_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/const_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
+const constTmpl = "pkg/sql/colexec/const_tmpl.go"
+
 func genConstOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/const_tmpl.go")
+	d, err := ioutil.ReadFile(constTmpl)
 	if err != nil {
 		return err
 	}
@@ -43,5 +45,5 @@ func genConstOps(wr io.Writer) error {
 	return tmpl.Execute(wr, coltypes.AllTypes)
 }
 func init() {
-	registerGenerator(genConstOps, "const.eg.go")
+	registerGenerator(genConstOps, "const.eg.go", constTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
@@ -18,8 +18,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const countAggTmpl = "pkg/sql/colexec/count_agg_tmpl.go"
+
 func genCountAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/count_agg_tmpl.go")
+	t, err := ioutil.ReadFile(countAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -38,5 +40,5 @@ func genCountAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genCountAgg, "count_agg.eg.go")
+	registerGenerator(genCountAgg, "count_agg.eg.go", countAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const distinctOpsTmpl = "pkg/sql/colexec/distinct_tmpl.go"
+
 func genDistinctOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/distinct_tmpl.go")
+	d, err := ioutil.ReadFile(distinctOpsTmpl)
 	if err != nil {
 		return err
 	}
@@ -53,5 +55,5 @@ func genDistinctOps(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genDistinctOps, "distinct.eg.go")
+	registerGenerator(genDistinctOps, "distinct.eg.go", distinctOpsTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const hashAggTmpl = "pkg/sql/colexec/hash_aggregator_tmpl.go"
+
 func genHashAggregator(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/hash_aggregator_tmpl.go")
+	t, err := ioutil.ReadFile(hashAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -47,5 +49,5 @@ func genHashAggregator(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genHashAggregator, "hash_aggregator.eg.go")
+	registerGenerator(genHashAggregator, "hash_aggregator.eg.go", hashAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -17,8 +17,10 @@ import (
 	"text/template"
 )
 
+const hashUtilsTmpl = "pkg/sql/colexec/hash_utils_tmpl.go"
+
 func genHashUtils(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/hash_utils_tmpl.go")
+	t, err := ioutil.ReadFile(hashUtilsTmpl)
 	if err != nil {
 		return err
 	}
@@ -46,5 +48,5 @@ func genHashUtils(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genHashUtils, "hash_utils.eg.go")
+	registerGenerator(genHashUtils, "hash_utils.eg.go", hashUtilsTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -16,8 +16,10 @@ import (
 	"text/template"
 )
 
+const hashJoinerTmpl = "pkg/sql/colexec/hashjoiner_tmpl.go"
+
 func genHashJoiner(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/hashjoiner_tmpl.go")
+	t, err := ioutil.ReadFile(hashJoinerTmpl)
 	if err != nil {
 		return err
 	}
@@ -48,5 +50,5 @@ func genHashJoiner(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genHashJoiner, "hashjoiner.eg.go")
+	registerGenerator(genHashJoiner, "hashjoiner.eg.go", hashJoinerTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -20,8 +20,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const hashTableTmpl = "pkg/sql/colexec/hashtable_tmpl.go"
+
 func genHashTable(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/hashtable_tmpl.go")
+	t, err := ioutil.ReadFile(hashTableTmpl)
 	if err != nil {
 		return err
 	}
@@ -79,5 +81,5 @@ func genHashTable(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genHashTable, "hashtable.eg.go")
+	registerGenerator(genHashTable, "hashtable.eg.go", hashTableTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -117,5 +117,5 @@ func genLikeOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genLikeOps, "like_ops.eg.go")
+	registerGenerator(genLikeOps, "like_ops.eg.go", selectionOpsTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const mergeJoinBaseTmpl = "pkg/sql/colexec/mergejoinbase_tmpl.go"
+
 func genMergeJoinBase(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/mergejoinbase_tmpl.go")
+	d, err := ioutil.ReadFile(mergeJoinBaseTmpl)
 	if err != nil {
 		return err
 	}
@@ -46,5 +48,5 @@ func genMergeJoinBase(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genMergeJoinBase, "mergejoinbase.eg.go")
+	registerGenerator(genMergeJoinBase, "mergejoinbase.eg.go", mergeJoinBaseTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -50,8 +50,10 @@ type joinTypeInfo struct {
 	String string
 }
 
+const mergeJoinerTmpl = "pkg/sql/colexec/mergejoiner_tmpl.go"
+
 func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/mergejoiner_tmpl.go")
+	d, err := ioutil.ReadFile(mergeJoinerTmpl)
 	if err != nil {
 		return err
 	}
@@ -212,6 +214,6 @@ func init() {
 	}
 
 	for _, join := range joinTypeInfos {
-		registerGenerator(mergeJoinGenerator(join), fmt.Sprintf("mergejoiner_%s.eg.go", strings.ToLower(join.String)))
+		registerGenerator(mergeJoinGenerator(join), fmt.Sprintf("mergejoiner_%s.eg.go", strings.ToLower(join.String)), mergeJoinerTmpl)
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -38,8 +38,10 @@ func (a aggOverloads) AggNameTitle() string {
 var _ = aggOverloads{}.AggNameLower()
 var _ = aggOverloads{}.AggNameTitle()
 
+const minMaxAggTmpl = "pkg/sql/colexec/min_max_agg_tmpl.go"
+
 func genMinMaxAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/min_max_agg_tmpl.go")
+	t, err := ioutil.ReadFile(minMaxAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -79,5 +81,5 @@ func genMinMaxAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genMinMaxAgg, "min_max_agg.eg.go")
+	registerGenerator(genMinMaxAgg, "min_max_agg.eg.go", minMaxAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const ordSyncTmpl = "pkg/sql/colexec/orderedsynchronizer_tmpl.go"
+
 func genOrderedSynchronizer(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/orderedsynchronizer_tmpl.go")
+	d, err := ioutil.ReadFile(ordSyncTmpl)
 	if err != nil {
 		return err
 	}
@@ -43,5 +45,5 @@ func genOrderedSynchronizer(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genOrderedSynchronizer, "orderedsynchronizer.eg.go")
+	registerGenerator(genOrderedSynchronizer, "orderedsynchronizer.eg.go", ordSyncTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -65,5 +65,5 @@ func genOverloadsTestUtils(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genOverloadsTestUtils, "overloads_test_utils.eg.go")
+	registerGenerator(genOverloadsTestUtils, "overloads_test_utils.eg.go", "")
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -19,10 +19,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
+const projConstOpsTmpl = "pkg/sql/colexec/proj_const_ops_tmpl.go"
+
 // getProjConstOpTmplString returns a "projConstOp" template with isConstLeft
 // determining whether the constant is on the left or on the right.
 func getProjConstOpTmplString(isConstLeft bool) (string, error) {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/proj_const_ops_tmpl.go")
+	t, err := ioutil.ReadFile(projConstOpsTmpl)
 	if err != nil {
 		return "", err
 	}
@@ -87,9 +89,11 @@ func replaceProjConstTmplVariables(tmpl string, isConstLeft bool) string {
 	return replaceProjTmplVariables(tmpl)
 }
 
+const projNonConstOpsTmpl = "pkg/sql/colexec/proj_non_const_ops_tmpl.go"
+
 // genProjNonConstOps is the generator for projection operators on two vectors.
 func genProjNonConstOps(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/proj_non_const_ops_tmpl.go")
+	t, err := ioutil.ReadFile(projNonConstOpsTmpl)
 	if err != nil {
 		return err
 	}
@@ -139,7 +143,7 @@ func init() {
 		}
 	}
 
-	registerGenerator(projConstOpsGenerator(true /* isConstLeft */), "proj_const_left_ops.eg.go")
-	registerGenerator(projConstOpsGenerator(false /* isConstLeft */), "proj_const_right_ops.eg.go")
-	registerGenerator(genProjNonConstOps, "proj_non_const_ops.eg.go")
+	registerGenerator(projConstOpsGenerator(true /* isConstLeft */), "proj_const_left_ops.eg.go", projConstOpsTmpl)
+	registerGenerator(projConstOpsGenerator(false /* isConstLeft */), "proj_const_right_ops.eg.go", projConstOpsTmpl)
+	registerGenerator(genProjNonConstOps, "proj_non_const_ops.eg.go", projNonConstOpsTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
@@ -57,8 +57,10 @@ var (
 	_ = rankTmplInfo{}.UpdateRankIncrement()
 )
 
+const rankTmpl = "pkg/sql/colexec/rank_tmpl.go"
+
 func genRankOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/rank_tmpl.go")
+	d, err := ioutil.ReadFile(rankTmpl)
 	if err != nil {
 		return err
 	}
@@ -88,5 +90,5 @@ func genRankOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genRankOps, "rank.eg.go")
+	registerGenerator(genRankOps, "rank.eg.go", rankTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
@@ -24,8 +24,10 @@ type relativeRankTmplInfo struct {
 	String        string
 }
 
+const relativeRankTmpl = "pkg/sql/colexec/relative_rank_tmpl.go"
+
 func genRelativeRankOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/relative_rank_tmpl.go")
+	d, err := ioutil.ReadFile(relativeRankTmpl)
 	if err != nil {
 		return err
 	}
@@ -55,5 +57,5 @@ func genRelativeRankOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genRelativeRankOps, "relative_rank.eg.go")
+	registerGenerator(genRelativeRankOps, "relative_rank.eg.go", relativeRankTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
@@ -22,8 +22,10 @@ type rowNumberTmplInfo struct {
 	String       string
 }
 
+const rowNumberTmpl = "pkg/sql/colexec/row_number_tmpl.go"
+
 func genRowNumberOp(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/row_number_tmpl.go")
+	d, err := ioutil.ReadFile(rowNumberTmpl)
 	if err != nil {
 		return err
 	}
@@ -46,5 +48,5 @@ func genRowNumberOp(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genRowNumberOp, "row_number.eg.go")
+	registerGenerator(genRowNumberOp, "row_number.eg.go", rowNumberTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -46,8 +46,10 @@ type columnConversion struct {
 	ExecType coltypes.T
 }
 
+const rowsToVecTmpl = "pkg/sql/colexec/rowstovec_tmpl.go"
+
 func genRowsToVec(wr io.Writer) error {
-	f, err := ioutil.ReadFile("pkg/sql/colexec/rowstovec_tmpl.go")
+	f, err := ioutil.ReadFile(rowsToVecTmpl)
 	if err != nil {
 		return err
 	}
@@ -111,5 +113,5 @@ func genRowsToVec(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genRowsToVec, "rowstovec.eg.go")
+	registerGenerator(genRowsToVec, "rowstovec.eg.go", rowsToVecTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const selectInTmpl = "pkg/sql/colexec/select_in_tmpl.go"
+
 func genSelectIn(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/select_in_tmpl.go")
+	t, err := ioutil.ReadFile(selectInTmpl)
 	if err != nil {
 		return err
 	}
@@ -44,5 +46,5 @@ func genSelectIn(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genSelectIn, "select_in.eg.go")
+	registerGenerator(genSelectIn, "select_in.eg.go", selectInTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
+const selectionOpsTmpl = "pkg/sql/colexec/selection_ops_tmpl.go"
+
 func getSelectionOpsTmpl() (*template.Template, error) {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/selection_ops_tmpl.go")
+	t, err := ioutil.ReadFile(selectionOpsTmpl)
 	if err != nil {
 		return nil, err
 	}
@@ -72,5 +74,5 @@ func genSelectionOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genSelectionOps, "selection_ops.eg.go")
+	registerGenerator(genSelectionOps, "selection_ops.eg.go", selectionOpsTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
@@ -36,8 +36,10 @@ type sortOverloads struct {
 // the overload representing the sort direction.
 var typesToSortOverloads map[coltypes.T]map[bool]sortOverloads
 
+const sortOpsTmpl = "pkg/sql/colexec/sort_tmpl.go"
+
 func genSortOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/sort_tmpl.go")
+	d, err := ioutil.ReadFile(sortOpsTmpl)
 	if err != nil {
 		return err
 	}
@@ -68,8 +70,10 @@ func genSortOps(wr io.Writer) error {
 	return tmpl.Execute(wr, typesToSortOverloads)
 }
 
+const quickSortTmpl = "pkg/sql/colexec/quicksort_tmpl.go"
+
 func genQuickSortOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/quicksort_tmpl.go")
+	d, err := ioutil.ReadFile(quickSortTmpl)
 	if err != nil {
 		return err
 	}
@@ -91,8 +95,8 @@ func genQuickSortOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genSortOps, "sort.eg.go")
-	registerGenerator(genQuickSortOps, "quicksort.eg.go")
+	registerGenerator(genSortOps, "sort.eg.go", sortOpsTmpl)
+	registerGenerator(genQuickSortOps, "quicksort.eg.go", quickSortTmpl)
 	typesToSortOverloads = make(map[coltypes.T]map[bool]sortOverloads)
 	for _, o := range sameTypeComparisonOpToOverloads[tree.LT] {
 		typesToSortOverloads[o.LTyp] = make(map[bool]sortOverloads)

--- a/pkg/sql/colexec/execgen/cmd/execgen/substring_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/substring_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
+const substringTmpl = "pkg/sql/colexec/substring_tmpl.go"
+
 func genSubstring(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/substring_tmpl.go")
+	t, err := ioutil.ReadFile(substringTmpl)
 	if err != nil {
 		return err
 	}
@@ -45,5 +47,5 @@ func genSubstring(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genSubstring, "substring.eg.go")
+	registerGenerator(genSubstring, "substring.eg.go", substringTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const sumAggTmpl = "pkg/sql/colexec/sum_agg_tmpl.go"
+
 func genSumAgg(wr io.Writer) error {
-	t, err := ioutil.ReadFile("pkg/sql/colexec/sum_agg_tmpl.go")
+	t, err := ioutil.ReadFile(sumAggTmpl)
 	if err != nil {
 		return err
 	}
@@ -47,5 +49,5 @@ func genSumAgg(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genSumAgg, "sum_agg.eg.go")
+	registerGenerator(genSumAgg, "sum_agg.eg.go", sumAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const valuesDifferTmpl = "pkg/sql/colexec/values_differ_tmpl.go"
+
 func genValuesDiffer(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/values_differ_tmpl.go")
+	d, err := ioutil.ReadFile(valuesDifferTmpl)
 	if err != nil {
 		return err
 	}
@@ -47,5 +49,5 @@ func genValuesDiffer(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genValuesDiffer, "values_differ.eg.go")
+	registerGenerator(genValuesDiffer, "values_differ.eg.go", valuesDifferTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const vecCmpTmpl = "pkg/sql/colexec/vec_comparators_tmpl.go"
+
 func genVecComparators(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/vec_comparators_tmpl.go")
+	d, err := ioutil.ReadFile(vecCmpTmpl)
 	if err != nil {
 		return err
 	}
@@ -41,5 +43,5 @@ func genVecComparators(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genVecComparators, "vec_comparators.eg.go")
+	registerGenerator(genVecComparators, "vec_comparators.eg.go", vecCmpTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+const vecTmpl = "pkg/col/coldata/vec_tmpl.go"
+
 func genVec(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/col/coldata/vec_tmpl.go")
+	d, err := ioutil.ReadFile(vecTmpl)
 	if err != nil {
 		return err
 	}
@@ -45,5 +47,5 @@ func genVec(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genVec, "vec.eg.go")
+	registerGenerator(genVec, "vec.eg.go", vecTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/window_peer_grouper_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/window_peer_grouper_gen.go
@@ -23,8 +23,10 @@ type windowPeerGrouperTmplInfo struct {
 	String       string
 }
 
+const windowPeerGrouperOpsTmpl = "pkg/sql/colexec/window_peer_grouper_tmpl.go"
+
 func genWindowPeerGrouperOps(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/colexec/window_peer_grouper_tmpl.go")
+	d, err := ioutil.ReadFile(windowPeerGrouperOpsTmpl)
 	if err != nil {
 		return err
 	}
@@ -48,5 +50,5 @@ func genWindowPeerGrouperOps(wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genWindowPeerGrouperOps, "window_peer_grouper.eg.go")
+	registerGenerator(genWindowPeerGrouperOps, "window_peer_grouper.eg.go", windowPeerGrouperOpsTmpl)
 }


### PR DESCRIPTION
1. both `find` invocations to clean up stale generated files can
   redirect errors to stderr.

2. the `.tmp` file produced by `execgen >.tmp` must be removed if
   `execgen` encounters an error.

3. the `execgen` + `cmp` + `mv/rm` invocation was very wide and
   verbose. Let's make it shorter.

4. there was no need to duplicate the dep graph between `execgen` and `Makefile`. Let's simplify.

5. it's a little bit sad (although functionally 100% correct) that the `execgen` targets must run again on every `make` invocation. To make the build a tad more compact, this can be simplified too.


Release note: None