### PR TITLE
importccl: Make sure avro correctly handles hidden columns.

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -3619,6 +3619,12 @@ func TestImportAvro(t *testing.T) {
 			args:   []interface{}{simpleOcf},
 		},
 		{
+			name:   "import-ocf-into-table-with-strict-validation",
+			sql:    "IMPORT INTO simple AVRO DATA ($1)  WITH strict_validation",
+			create: "CREATE TABLE simple (i INT8, s text, b bytea)",
+			args:   []interface{}{simpleOcf},
+		},
+		{
 			name: "import-ocf-create-using",
 			sql:  "IMPORT TABLE simple CREATE USING $1 AVRO DATA ($2)",
 			args: []interface{}{tableSchema, simpleOcf},

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -207,7 +207,7 @@ func (a *avroConsumer) FillDatums(
 	// Set any nil datums to DNull (in case native
 	// record didn't have the value set at all)
 	for i := range conv.Datums {
-		if conv.Datums[i] == nil {
+		if _, isTargetCol := conv.IsTargetCol[i]; isTargetCol && conv.Datums[i] == nil {
 			if a.strict {
 				return fmt.Errorf("field %s was not set in the avro import", conv.VisibleCols[i].Name)
 			}


### PR DESCRIPTION
Fixes #45775

Verify column is visible before accessing its datums.
Add a unit test to verify this behavior.

Release notes (bug fix):
Verify column is visible before accessing its datums.