### PR TITLE
importccl: remove unused parameter from readFileFunc

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2647,7 +2647,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 
 	delimited := &fileReader{Reader: producer}
 	b.ResetTimer()
-	require.NoError(b, r.readFile(ctx, delimited, 0, "benchmark", 0, nil))
+	require.NoError(b, r.readFile(ctx, delimited, 0, 0, nil))
 	close(kvCh)
 	b.ReportAllocs()
 }

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -478,12 +478,7 @@ func (a *avroInputReader) readFiles(
 }
 
 func (a *avroInputReader) readFile(
-	ctx context.Context,
-	input *fileReader,
-	inputIdx int32,
-	inputName string,
-	resumePos int64,
-	rejected chan string,
+	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
 ) error {
 	producer, consumer, err := newImportAvroPipeline(a, input)
 	if err != nil {

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -110,7 +110,7 @@ func runImport(
 	return summary, nil
 }
 
-type readFileFunc func(context.Context, *fileReader, int32, string, int64, chan string) error
+type readFileFunc func(context.Context, *fileReader, int32, int64, chan string) error
 
 // readInputFile reads each of the passed dataFiles using the passed func. The
 // key part of dataFiles is the unique index of the data file among all files in
@@ -231,7 +231,7 @@ func readInputFiles(
 
 				grp.GoCtx(func(ctx context.Context) error {
 					defer close(rejected)
-					if err := fileFunc(ctx, src, dataFileIndex, dataFile, resumePos[dataFileIndex], rejected); err != nil {
+					if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], rejected); err != nil {
 						return err
 					}
 					return nil
@@ -241,7 +241,7 @@ func readInputFiles(
 					return errors.Wrap(err, dataFile)
 				}
 			} else {
-				if err := fileFunc(ctx, src, dataFileIndex, dataFile, resumePos[dataFileIndex], nil /* rejected */); err != nil {
+				if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], nil /* rejected */); err != nil {
 					return errors.Wrap(err, dataFile)
 				}
 			}

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -66,12 +66,7 @@ func (c *csvInputReader) readFiles(
 }
 
 func (c *csvInputReader) readFile(
-	ctx context.Context,
-	input *fileReader,
-	inputIdx int32,
-	inputName string, // TODO(bartem): seems like this is unused field might need refactoring/cleanup to remove it
-	resumePos int64,
-	rejected chan string,
+	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
 ) error {
 	producer, consumer := newCSVPipeline(c, input)
 

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -91,12 +91,7 @@ func (m *mysqldumpReader) readFiles(
 }
 
 func (m *mysqldumpReader) readFile(
-	ctx context.Context,
-	input *fileReader,
-	inputIdx int32,
-	inputName string,
-	resumePos int64,
-	rejected chan string,
+	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
 ) error {
 	var inserts, count int64
 	r := bufio.NewReaderSize(input, 1024*64)

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -60,7 +60,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	defer in.Close()
 	wrapped := &fileReader{Reader: in, counter: byteCounter{r: in}}
 
-	if err := converter.readFile(ctx, wrapped, 1, "", 0, nil); err != nil {
+	if err := converter.readFile(ctx, wrapped, 1, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	close(kvCh)

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -336,12 +336,7 @@ func (d *delimitedConsumer) FillDatums(
 }
 
 func (d *mysqloutfileReader) readFile(
-	ctx context.Context,
-	input *fileReader,
-	inputIdx int32,
-	inputName string,
-	resumePos int64,
-	rejected chan string,
+	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
 ) error {
 	producer := &delimitedProducer{
 		importCtx: d.importCtx,


### PR DESCRIPTION
Currently readFileFunc type introduces a need to pass inputName
parameter, however in practice it's not being used and simply ignored.
The only place there is attempt to use it is to include in into error
messages with with `makeRowErr` and `wrapRowErr`, where in fact none of
these are using it neither. Therefore seems that readFileFunc could be
simplified by removing unused parameter.

This commit takes care to remove the parameter corresponding to
inputName from readFileFunc.

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note: none