### PR TITLE
colexec: enable hash aggregator and unordered distinct in vectorize auto

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -132,7 +132,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
 ·                    distributed  false                       ·                              ·
-·                    vectorized   false                       ·                              ·
+·                    vectorized   true                        ·                              ·
 render               ·            ·                           (count int, r int)             ·
  │                   render 0     (count_rows)[int]           ·                              ·
  │                   render 1     (column6)[int]              ·                              ·
@@ -233,7 +233,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -255,7 +255,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -278,7 +278,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -582,7 +582,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 ----
 ·               distributed  false       ·                   ·
-·               vectorized   false       ·                   ·
+·               vectorized   true        ·                   ·
 sort            ·            ·           (v int, count int)  +count
  │              order        +count      ·                   ·
  └── group      ·            ·           (v int, count int)  ·
@@ -597,7 +597,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 ----
 ·               distributed  false         ·                   ·
-·               vectorized   false         ·                   ·
+·               vectorized   true          ·                   ·
 sort            ·            ·             (v int, count int)  +count
  │              order        +count        ·                   ·
  └── group      ·            ·             (v int, count int)  ·
@@ -612,7 +612,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(1) FROM kv GROUP BY v ORDER BY count(1)
 ----
 ·                    distributed  false           ·                     ·
-·                    vectorized   false           ·                     ·
+·                    vectorized   true            ·                     ·
 sort                 ·            ·               (v int, count int)    +count
  │                   order        +count          ·                     ·
  └── group           ·            ·               (v int, count int)    ·
@@ -631,7 +631,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(1) FROM kv GROUP BY v) WHERE v > 10
 ----
 ·               distributed  false           ·             ·
-·               vectorized   false           ·             ·
+·               vectorized   true            ·             ·
 group           ·            ·               (v, count)    ·
  │              aggregate 0  v               ·             ·
  │              aggregate 1  count(column5)  ·             ·
@@ -710,7 +710,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
 ·                     distributed  false                             ·                     ·
-·                     vectorized   false                             ·                     ·
+·                     vectorized   true                              ·                     ·
 render                ·            ·                                 (sum decimal)         ·
  │                    render 0     (sum)[decimal]                    ·                     ·
  └── group            ·            ·                                 (k int, sum decimal)  ·
@@ -954,7 +954,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
 ----
 ·                         distributed  false                                      ·                         ·
-·                         vectorized   false                                      ·                         ·
+·                         vectorized   true                                       ·                         ·
 render                    ·            ·                                          (a int)                   ·
  │                        render 0     (1)[int]                                   ·                         ·
  └── distinct             ·            ·                                          (column5 decimal, v int)  ·
@@ -976,7 +976,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
 ·                    distributed  false        ·               ·
-·                    vectorized   false        ·               ·
+·                    vectorized   true         ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·
@@ -994,7 +994,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
 ·                    distributed  false        ·               ·
-·                    vectorized   false        ·               ·
+·                    vectorized   true         ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -10,7 +10,7 @@ query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 ·          distributed  true
-·          vectorized   false
+·          vectorized   true
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -91,7 +91,7 @@ query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
 ·               distributed  false
-·               vectorized   false
+·               vectorized   true
 sort            ·            ·
  │              order        +w
  └── distinct   ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -28,7 +28,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
 ·          distributed  false        ·          ·
-·          vectorized   false        ·          ·
+·          vectorized   true         ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -39,7 +39,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
 ·               distributed  false        ·          ·
-·               vectorized   false        ·          ·
+·               vectorized   true         ·          ·
 render          ·            ·            (x)        ·
  │              render 0     x            ·          ·
  └── distinct   ·            ·            (x, y, z)  ·
@@ -90,7 +90,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
 ·               distributed  false        ·       ·
-·               vectorized   false        ·       ·
+·               vectorized   true         ·       ·
 render          ·            ·            (y, x)  ·
  │              render 0     y            ·       ·
  │              render 1     x            ·       ·
@@ -104,7 +104,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
 ·               distributed  false        ·       ·
-·               vectorized   false        ·       ·
+·               vectorized   true         ·       ·
 render          ·            ·            (x)     ·
  │              render 0     x            ·       ·
  └── distinct   ·            ·            (x, y)  ·
@@ -117,7 +117,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   false        ·       ·
+·          vectorized   true         ·       ·
 distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
@@ -128,7 +128,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
 ·               distributed  false        ·         ·
-·               vectorized   false        ·         ·
+·               vectorized   true         ·         ·
 render          ·            ·            (pk1, x)  ·
  │              render 0     pk1          ·         ·
  │              render 1     x            ·         ·
@@ -143,7 +143,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
 ·               distributed  false        ·          ·
-·               vectorized   false        ·          ·
+·               vectorized   true         ·          ·
 render          ·            ·            (a, b)     ·
  │              render 0     a            ·          ·
  │              render 1     b            ·          ·
@@ -158,7 +158,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
 ·               distributed  false        ·          ·
-·               vectorized   false        ·          ·
+·               vectorized   true         ·          ·
 render          ·            ·            (b, c, a)  ·
  │              render 0     b            ·          ·
  │              render 1     c            ·          ·
@@ -215,7 +215,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
 ·               distributed  false        ·    ·
-·               vectorized   false        ·    ·
+·               vectorized   true         ·    ·
 sort            ·            ·            (x)  -x
  │              order        -x           ·    ·
  └── distinct   ·            ·            (x)  ·
@@ -228,7 +228,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
 ·                    distributed  false        ·          ·
-·                    vectorized   false        ·          ·
+·                    vectorized   true         ·          ·
 render               ·            ·            (y, z, x)  ·
  │                   render 0     y            ·          ·
  │                   render 1     z            ·          ·
@@ -302,7 +302,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
 ·               distributed  false        ·         ·
-·               vectorized   false        ·         ·
+·               vectorized   true         ·         ·
 render          ·            ·            (min)     ·
  │              render 0     min          ·         ·
  └── group      ·            ·            (y, min)  ·
@@ -317,7 +317,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
 ----
 ·                         distributed  false        ·         ·
-·                         vectorized   false        ·         ·
+·                         vectorized   true         ·         ·
 render                    ·            ·            (min)     ·
  │                        render 0     min          ·         ·
  └── limit                ·            ·            (y, min)  ·
@@ -340,7 +340,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
 ·                    distributed  false                                                                  ·                ·
-·                    vectorized   false                                                                  ·                ·
+·                    vectorized   true                                                                   ·                ·
 render               ·            ·                                                                      (y)              ·
  │                   render 0     y                                                                      ·                ·
  └── distinct        ·            ·                                                                      (y, row_number)  ·
@@ -360,7 +360,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
 ·          distributed  false        ·          ·
-·          vectorized   false        ·          ·
+·          vectorized   true         ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x            ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -386,7 +386,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   false        ·       ·
+·          vectorized   true         ·       ·
 distinct   ·            ·            (y, x)  ·
  │         distinct on  y            ·       ·
  └── scan  ·            ·            (y, x)  ·
@@ -398,7 +398,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
 ·          distributed  false        ·    ·
-·          vectorized   false        ·    ·
+·          vectorized   true         ·    ·
 distinct   ·            ·            (y)  ·
  │         distinct on  y            ·    ·
  └── scan  ·            ·            (y)  ·
@@ -413,7 +413,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
 ·          distributed  false        ·       ·
-·          vectorized   false        ·       ·
+·          vectorized   true         ·       ·
 distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
@@ -440,7 +440,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
 ·                    distributed  false        ·               ·
-·                    vectorized   false        ·               ·
+·                    vectorized   true         ·               ·
 render               ·            ·            (pk1)           ·
  │                   render 0     pk1          ·               ·
  └── distinct        ·            ·            (x, y, z, pk1)  +x

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -68,7 +68,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
 ·          distributed  true         ·          ·
-·          vectorized   false        ·          ·
+·          vectorized   true         ·          ·
 distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -85,7 +85,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
 ·               distributed  true         ·          ·
-·               vectorized   false        ·          ·
+·               vectorized   true         ·          ·
 distinct        ·            ·            (x, y, z)  +x
  │              distinct on  x, y, z      ·          ·
  │              order key    x            ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -504,7 +504,7 @@ query TTT
 EXPLAIN SELECT DISTINCT v FROM t
 ----
 ·          distributed  false
-·          vectorized   false
+·          vectorized   true
 distinct   ·            ·
  │         distinct on  v
  └── scan  ·            ·
@@ -515,7 +515,7 @@ query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
 ·                    distributed  false
-·                    vectorized   false
+·                    vectorized   true
 limit                ·            ·
  │                   offset       1
  └── limit           ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -247,7 +247,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, a
 ----
 tree                      field        description        columns                                   ordering
 ·                         distributed  true               ·                                         ·
-·                         vectorized   false              ·                                         ·
+·                         vectorized   true               ·                                         ·
 distinct                  ·            ·                  (name)                                    ·
  │                        distinct on  name               ·                                         ·
  └── render               ·            ·                  (name)                                    ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -48,7 +48,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
 ·                         distributed  false      ·       ·
-·                         vectorized   false      ·       ·
+·                         vectorized   true       ·       ·
 render                    ·            ·          (c, b)  ·
  │                        render 0     c          ·       ·
  │                        render 1     b          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -782,7 +782,7 @@ GROUP BY resource_key
 ORDER BY total DESC
 ----
 ·                    distributed  false
-·                    vectorized   false
+·                    vectorized   true
 sort                 ·            ·
  │                   order        -total
  └── group           ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -10,7 +10,7 @@ query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 ·          distributed  false
-·          vectorized   false
+·          vectorized   true
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -197,7 +197,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
 ·                                   distributed  false                                                                                                               ·                                                              ·
-·                                   vectorized   false                                                                                                               ·                                                              ·
+·                                   vectorized   true                                                                                                                ·                                                              ·
 render                              ·            ·                                                                                                                   (max int, "?column?" decimal)                                  ·
  │                                  render 0     (max)[int]                                                                                                          ·                                                              ·
  │                                  render 1     ("?column?")[decimal]                                                                                               ·                                                              ·
@@ -226,7 +226,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
 ·                         distributed  false                                                                                                             ·                                            ·
-·                         vectorized   false                                                                                                             ·                                            ·
+·                         vectorized   true                                                                                                              ·                                            ·
 sort                      ·            ·                                                                                                                 (max int, stddev decimal)                    +max
  │                        order        +max                                                                                                              ·                                            ·
  └── render               ·            ·                                                                                                                 (max int, stddev decimal)                    ·


### PR DESCRIPTION
colexec: enable hash aggregator and unordered distinct to run in vecotrize auto

Release note (sql change): hash aggregator and unordered distinct is now
supported in vectorize=auto mode.