### PR TITLE
cli,security: add --cert-principal-map

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -641,6 +641,23 @@ Instead, require the user to always specify access keys.`,
 		Description: CertsDir.Description,
 	}
 
+	CertPrincipalMap = FlagInfo{
+		Name: "cert-principal-map",
+		Description: `
+A comma separated list of <cert-principal>:<db-principal> mappings. This allows
+mapping the principal in a cert to a DB principal such as "node" or "root" or
+any SQL user. This is intended for use in situations where the certificate
+management system places restrictions on the Subject.CommonName or
+SubjectAlternateName fields in the certificate (e.g. disallowing a CommonName
+such as "node" or "root"). If multiple mappings are provided for the same
+<cert-principal>, the last one specified in the list takes precedence. A
+principal not specified in the map is passed through as-is via the identity
+function. A cert is allowed to authenticate a DB principal if the DB principal
+name is contained in the mapped CommonName or DNS-type SubjectAlternateName
+fields.
+`,
+	}
+
 	CAKey = FlagInfo{
 		Name:        "ca-key",
 		EnvVar:      "COCKROACH_CA_KEY",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -117,6 +117,7 @@ func initCLIDefaults() {
 
 	startCtx.serverInsecure = baseCfg.Insecure
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
+	startCtx.serverCertPrincipalMap = nil
 	startCtx.serverListenAddr = ""
 	startCtx.tempDir = ""
 	startCtx.externalIODir = ""
@@ -291,9 +292,10 @@ var debugCtx struct {
 // Defaults set by InitCLIDefaults() above.
 var startCtx struct {
 	// server-specific values of some flags.
-	serverInsecure    bool
-	serverSSLCertsDir string
-	serverListenAddr  string
+	serverInsecure         bool
+	serverSSLCertsDir      string
+	serverCertPrincipalMap []string
+	serverListenAddr       string
 
 	// temporary directory to use to spill computation results to disk.
 	tempDir string

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -376,6 +376,10 @@ func init() {
 		// variables, but share the same default.
 		StringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir, startCtx.serverSSLCertsDir)
 
+		// Certificate principal map.
+		StringSlice(f, &startCtx.serverCertPrincipalMap,
+			cliflags.CertPrincipalMap, startCtx.serverCertPrincipalMap)
+
 		// Cluster joining flags. We need to enable this both for 'start'
 		// and 'start-single-node' although the latter does not support
 		// --join, because it delegates its logic to that of 'start', and

--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -31,7 +31,7 @@ eexpect "interrupted"
 eexpect $prompt
 end_test
 
-start_test "Check that the server reports no warning if the avertise addr is in th cert."
+start_test "Check that the server reports no warning if the avertise addr is in the cert."
 send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=localhost\r"
 expect {
   "not in node certificate" {
@@ -40,6 +40,33 @@ expect {
   }
   "node starting" {}
 }
+interrupt
+eexpect "interrupted"
+expect $prompt
+end_test
+
+send "rm -f $certs_dir/node.*\r"
+eexpect $prompt
+send "COCKROACH_CERT_NODE_USER=foo.bar $argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+
+start_test "Check that the server reports an error if the node cert does not contain a node principal."
+send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=localhost\r"
+eexpect "cannot load certificates"
+expect $prompt
+end_test
+
+start_test "Check that the cert principal map can allow the use of non-standard cert principal."
+send "$argv start-single-node --certs-dir=$certs_dir --cert-principal-map=foo.bar:node --advertise-addr=localhost\r"
+eexpect "node starting"
+interrupt
+eexpect "interrupted"
+expect $prompt
+end_test
+
+start_test "Check that the cert principal map can allow the use of a SAN principal."
+send "$argv start-single-node --certs-dir=$certs_dir --cert-principal-map=localhost:node --advertise-addr=localhost\r"
+eexpect "node starting"
 interrupt
 eexpect "interrupted"
 expect $prompt

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -544,6 +544,9 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	//
 	// This includes propagating server flags dependent on the
 	// flags specified for the command.
+	if err := security.SetCertPrincipalMap(startCtx.serverCertPrincipalMap); err != nil {
+		return err
+	}
 	serverCfg.Insecure = startCtx.serverInsecure
 	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
 	serverCfg.User = security.NodeUser

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -121,7 +121,7 @@ func requireSuperUser(ctx context.Context) error {
 		// This is an in-process request. Bypass authentication check.
 	} else if peer, ok := peer.FromContext(ctx); ok {
 		if tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo); ok {
-			certUser, err := security.GetCertificateUser(&tlsInfo.State)
+			certUsers, err := security.GetCertificateUsers(&tlsInfo.State)
 			if err != nil {
 				return err
 			}
@@ -129,8 +129,9 @@ func requireSuperUser(ctx context.Context) error {
 			// NodeUser. This is not a security concern, as RootUser has access to
 			// read and write all data, merely good hygiene. For example, there is
 			// no reason to permit the root user to send raw Raft RPCs.
-			if certUser != security.NodeUser && certUser != security.RootUser {
-				return errors.Errorf("user %s is not allowed to perform this RPC", certUser)
+			if !security.ContainsUser(security.NodeUser, certUsers) &&
+				!security.ContainsUser(security.RootUser, certUsers) {
+				return errors.Errorf("user %s is not allowed to perform this RPC", certUsers)
 			}
 		}
 	} else {

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -14,108 +14,200 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
-// Construct a fake tls.ConnectionState object with one peer certificate
-// for each 'commonNames', and one chain of length 'chainLengths[i]' for each 'chainLengths'.
-func makeFakeTLSState(commonNames []string, chainLengths []int) *tls.ConnectionState {
-	tls := &tls.ConnectionState{
-		PeerCertificates: []*x509.Certificate{},
-		VerifiedChains:   [][]*x509.Certificate{},
-	}
-	for _, name := range commonNames {
-		tls.PeerCertificates = append(tls.PeerCertificates, &x509.Certificate{Subject: pkix.Name{CommonName: name}})
-	}
-	for i, length := range chainLengths {
-		chain := []*x509.Certificate{}
-		for j := 0; j < length; j++ {
-			name := fmt.Sprintf("chain%d:%d", i, j)
-			chain = append(chain, &x509.Certificate{Subject: pkix.Name{CommonName: name}})
+// Construct a fake tls.ConnectionState object. The spec is a semicolon
+// separated list if peer certificate specifications. Each peer certificate
+// specification is a comma separated list of names where the first name is the
+// CommonName and the remaining names are SubjectAlternateNames. For example,
+// "foo" creates a single peer certificate with the CommonName "foo". The spec
+// "foo,bar" creates a single peer certificate with the CommonName "foo" and a
+// single SubjectAlternateName "bar". Contrast that with "foo;bar" which
+// creates two peer certificates with the CommonNames "foo" and "bar"
+// respectively.
+func makeFakeTLSState(spec string) *tls.ConnectionState {
+	tls := &tls.ConnectionState{}
+	if spec != "" {
+		for _, peerSpec := range strings.Split(spec, ";") {
+			names := strings.Split(peerSpec, ",")
+			if len(names) == 0 {
+				continue
+			}
+			peerCert := &x509.Certificate{}
+			peerCert.Subject = pkix.Name{CommonName: names[0]}
+			peerCert.DNSNames = names[1:]
+			tls.PeerCertificates = append(tls.PeerCertificates, peerCert)
 		}
-		tls.VerifiedChains = append(tls.VerifiedChains, chain)
 	}
 	return tls
 }
 
-func TestGetCertificateUser(t *testing.T) {
+func TestGetCertificateUsers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Nil TLS state.
-	if _, err := security.GetCertificateUser(nil); err == nil {
+	if _, err := security.GetCertificateUsers(nil); err == nil {
 		t.Error("unexpected success")
 	}
 
 	// No certificates.
-	if _, err := security.GetCertificateUser(makeFakeTLSState(nil, nil)); err == nil {
+	if _, err := security.GetCertificateUsers(makeFakeTLSState("")); err == nil {
 		t.Error("unexpected success")
 	}
 
 	// Good request: single certificate.
-	if name, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo"}, []int{2})); err != nil {
+	if names, err := security.GetCertificateUsers(makeFakeTLSState("foo")); err != nil {
 		t.Error(err)
-	} else if name != "foo" {
-		t.Errorf("expected name: foo, got: %s", name)
+	} else {
+		require.EqualValues(t, names, []string{"foo"})
 	}
 
 	// Request with multiple certs, but only one chain (eg: origin certs are client and CA).
-	if name, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo", "CA"}, []int{2})); err != nil {
+	if names, err := security.GetCertificateUsers(makeFakeTLSState("foo;CA")); err != nil {
 		t.Error(err)
-	} else if name != "foo" {
-		t.Errorf("expected name: foo, got: %s", name)
+	} else {
+		require.EqualValues(t, names, []string{"foo"})
 	}
 
 	// Always use the first certificate.
-	if name, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo", "bar"}, []int{2, 1})); err != nil {
+	if names, err := security.GetCertificateUsers(makeFakeTLSState("foo;bar")); err != nil {
 		t.Error(err)
-	} else if name != "foo" {
-		t.Errorf("expected name: foo, got: %s", name)
+	} else {
+		require.EqualValues(t, names, []string{"foo"})
+	}
+
+	// Extract all of the principals from the first certificate.
+	if names, err := security.GetCertificateUsers(makeFakeTLSState("foo,bar,blah;CA")); err != nil {
+		t.Error(err)
+	} else {
+		require.EqualValues(t, names, []string{"foo", "bar", "blah"})
+	}
+}
+
+func TestSetCertPrincipalMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer func() { _ = security.SetCertPrincipalMap(nil) }()
+
+	testCases := []struct {
+		vals     []string
+		expected string
+	}{
+		{[]string{}, ""},
+		{[]string{"foo"}, "invalid <cert-principal>:<db-principal> mapping:"},
+		{[]string{"foo:bar"}, ""},
+		{[]string{"foo:bar", "blah:blah"}, ""},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := security.SetCertPrincipalMap(c.vals)
+			if !testutils.IsError(err, c.expected) {
+				t.Fatalf("expected %q, but found %v", c.expected, err)
+			}
+		})
+	}
+}
+
+func TestGetCertificateUsersMapped(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer func() { _ = security.SetCertPrincipalMap(nil) }()
+
+	testCases := []struct {
+		spec     string
+		val      string
+		expected string
+	}{
+		// No mapping present.
+		{"foo", "", "foo"},
+		// The basic mapping case.
+		{"foo", "foo:bar", "bar"},
+		// Identity mapping.
+		{"foo", "foo:foo", "foo"},
+		// Mapping does not apply to cert principals.
+		{"foo", "bar:bar", "foo"},
+		// The last mapping for a principal takes precedence.
+		{"foo", "foo:bar,foo:blah", "blah"},
+		// First principal mapped, second principal unmapped.
+		{"foo,bar", "foo:blah", "blah,bar"},
+		// First principal unmapped, second principal mapped.
+		{"bar,foo", "foo:blah", "bar,blah"},
+		// Both principals mapped.
+		{"foo,bar", "foo:bar,bar:foo", "bar,foo"},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			vals := strings.Split(c.val, ",")
+			if err := security.SetCertPrincipalMap(vals); err != nil {
+				t.Fatal(err)
+			}
+			names, err := security.GetCertificateUsers(makeFakeTLSState(c.spec))
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.EqualValues(t, strings.Join(names, ","), c.expected)
+		})
 	}
 }
 
 func TestAuthenticationHook(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer func() { _ = security.SetCertPrincipalMap(nil) }()
 
 	testCases := []struct {
 		insecure           bool
-		tls                *tls.ConnectionState
+		tlsSpec            string
 		username           string
+		principalMap       string
 		buildHookSuccess   bool
 		publicHookSuccess  bool
 		privateHookSuccess bool
 	}{
 		// Insecure mode, empty username.
-		{true, nil, "", true, false, false},
+		{true, "", "", "", true, false, false},
 		// Insecure mode, non-empty username.
-		{true, nil, "foo", true, true, false},
+		{true, "", "foo", "", true, true, false},
 		// Secure mode, no TLS state.
-		{false, nil, "", false, false, false},
+		{false, "", "", "", false, false, false},
 		// Secure mode, bad user.
-		{false, makeFakeTLSState([]string{"foo"}, []int{1}), "node", true, false, false},
+		{false, "foo", "node", "", true, false, false},
 		// Secure mode, node user.
-		{false, makeFakeTLSState([]string{security.NodeUser}, []int{1}), "node", true, true, true},
+		{false, security.NodeUser, "node", "", true, true, true},
 		// Secure mode, root user.
-		{false, makeFakeTLSState([]string{security.RootUser}, []int{1}), "node", true, false, false},
+		{false, security.RootUser, "node", "", true, false, false},
+		// Secure mode, multiple cert principals.
+		{false, "foo,bar", "foo", "", true, true, false},
+		{false, "foo,bar", "bar", "", true, true, false},
+		// Secure mode, principal map.
+		{false, "foo,bar", "blah", "foo:blah", true, true, false},
+		{false, "foo,bar", "blah", "bar:blah", true, true, false},
 	}
 
-	for tcNum, tc := range testCases {
-		hook, err := security.UserAuthCertHook(tc.insecure, tc.tls)
-		if (err == nil) != tc.buildHookSuccess {
-			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.buildHookSuccess, err)
-		}
-		if err != nil {
-			continue
-		}
-		err = hook(tc.username, true /*public*/)
-		if (err == nil) != tc.publicHookSuccess {
-			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.publicHookSuccess, err)
-		}
-		err = hook(tc.username, false /*not public*/)
-		if (err == nil) != tc.privateHookSuccess {
-			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.privateHookSuccess, err)
-		}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
+			if err != nil {
+				t.Fatal(err)
+			}
+			hook, err := security.UserAuthCertHook(tc.insecure, makeFakeTLSState(tc.tlsSpec))
+			if (err == nil) != tc.buildHookSuccess {
+				t.Fatalf("expected success=%t, got err=%v", tc.buildHookSuccess, err)
+			}
+			if err != nil {
+				return
+			}
+			err = hook(tc.username, true /* clientConnection */)
+			if (err == nil) != tc.publicHookSuccess {
+				t.Fatalf("expected success=%t, got err=%v", tc.publicHookSuccess, err)
+			}
+			err = hook(tc.username, false /* clientConnection */)
+			if (err == nil) != tc.privateHookSuccess {
+				t.Fatalf("expected success=%t, got err=%v", tc.privateHookSuccess, err)
+			}
+		})
 	}
 }

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -284,7 +284,7 @@ func TestNamingScheme(t *testing.T) {
 			},
 			certs: []security.CertInfo{
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
-					Error: errors.New("client certificate has Subject \"CN=notroot\", expected \"CN=root")},
+					Error: errors.New(`client certificate has principals \["notroot"\], expected "root"`)},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
 					FileContents: badUserNodeCert, KeyFileContents: []byte("node.key")},
 			},

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -11,10 +11,18 @@
 package security_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManagerWithEmbedded(t *testing.T) {
@@ -56,4 +64,80 @@ func TestManagerWithEmbedded(t *testing.T) {
 	if _, err := cm.GetClientTLSConfig("my-random-user"); err == nil {
 		t.Error("unexpected success")
 	}
+}
+
+func TestManagerWithPrincipalMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Do not mock cert access for this test.
+	security.ResetAssetLoader()
+	defer ResetTest()
+
+	defer func() { _ = security.SetCertPrincipalMap(nil) }()
+	defer func() {
+		_ = os.Setenv("COCKROACH_CERT_NODE_USER", security.NodeUser)
+		envutil.ClearEnvCache()
+	}()
+	require.NoError(t, os.Setenv("COCKROACH_CERT_NODE_USER", "node.crdb.io"))
+
+	certsDir, err := ioutil.TempDir("", "certs_test")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(certsDir))
+	}()
+
+	caKey := filepath.Join(certsDir, "ca.key")
+	require.NoError(t, security.CreateCAPair(
+		certsDir, caKey, testKeySize, time.Hour*96, true, true,
+	))
+	require.NoError(t, security.CreateClientPair(
+		certsDir, caKey, testKeySize, time.Hour*48, true, "testuser", false,
+	))
+	require.NoError(t, security.CreateNodePair(
+		certsDir, caKey, testKeySize, time.Hour*48, true, []string{"127.0.0.1", "foo"},
+	))
+
+	setCertPrincipalMap := func(s string) {
+		require.NoError(t, security.SetCertPrincipalMap(strings.Split(s, ",")))
+	}
+	newCertificateManager := func() error {
+		_, err := security.NewCertificateManager(certsDir)
+		return err
+	}
+	loadUserCert := func(user string) error {
+		cm, err := security.NewCertificateManager(certsDir)
+		if err != nil {
+			return err
+		}
+		ci := cm.ClientCerts()[user]
+		if ci == nil {
+			return fmt.Errorf("user %q not found", user)
+		}
+		return ci.Error
+	}
+
+	setCertPrincipalMap("")
+	require.Regexp(t, `node certificate has principals \["node.crdb.io" "foo"\]`, newCertificateManager())
+
+	// We can map the "node.crdb.io" principal to "node".
+	setCertPrincipalMap("node.crdb.io:node")
+	require.NoError(t, newCertificateManager())
+
+	// We can map the "foo" principal to "node".
+	setCertPrincipalMap("foo:node")
+	require.NoError(t, newCertificateManager())
+
+	// Mapping the "testuser" principal to a different name should result in an
+	// error as it no longer matches the file name.
+	setCertPrincipalMap("testuser:foo,node.crdb.io:node")
+	require.Regexp(t, `client certificate has principals \["foo"\], expected "testuser"`, loadUserCert("testuser"))
+
+	// Renaming "client.testuser.crt" to "client.foo.crt" allows us to load it
+	// under that name.
+	require.NoError(t, os.Rename(filepath.Join(certsDir, "client.testuser.crt"),
+		filepath.Join(certsDir, "client.foo.crt")))
+	require.NoError(t, os.Rename(filepath.Join(certsDir, "client.testuser.key"),
+		filepath.Join(certsDir, "client.foo.key")))
+	setCertPrincipalMap("testuser:foo,node.crdb.io:node")
+	require.NoError(t, loadUserCert("foo"))
 }

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
@@ -265,7 +266,11 @@ func CreateNodePair(
 		return errors.Errorf("could not generate new node key: %v", err)
 	}
 
-	nodeCert, err := GenerateServerCert(caCert, caPrivateKey, nodeKey.Public(), lifetime, hosts)
+	// Allow control of the principal to place in the cert via an env var. This
+	// is intended for testing purposes only.
+	nodeUser := envutil.EnvOrDefaultString("COCKROACH_CERT_NODE_USER", NodeUser)
+	nodeCert, err := GenerateServerCert(caCert, caPrivateKey,
+		nodeKey.Public(), lifetime, nodeUser, hosts)
 	if err != nil {
 		return errors.Errorf("error creating node server certificate and key: %s", err)
 	}

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -114,10 +114,11 @@ func GenerateServerCert(
 	caPrivateKey crypto.PrivateKey,
 	nodePublicKey crypto.PublicKey,
 	lifetime time.Duration,
+	user string,
 	hosts []string,
 ) ([]byte, error) {
-	// Create template for user "NodeUser".
-	template, err := newTemplate(NodeUser, lifetime)
+	// Create template for user.
+	template, err := newTemplate(user, lifetime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/x509_test.go
+++ b/pkg/security/x509_test.go
@@ -61,14 +61,16 @@ func TestGenerateCertLifetime(t *testing.T) {
 
 	// Create a Node certificate expiring in 4 days. Fails on shorter CA lifetime.
 	nodeDuration := time.Hour * 96
-	_, err = security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	_, err = security.GenerateServerCert(caCert, testKey,
+		testKey.Public(), nodeDuration, security.NodeUser, []string{"localhost"})
 	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
 		t.Fatal(err)
 	}
 
 	// Try again, but expiring before the CA cert.
 	nodeDuration = time.Hour * 24
-	nodeBytes, err := security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	nodeBytes, err := security.GenerateServerCert(caCert, testKey,
+		testKey.Public(), nodeDuration, security.NodeUser, []string{"localhost"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -794,7 +794,7 @@ func TestGRPCAuthentication(t *testing.T) {
 	for _, subsystem := range subsystems {
 		t.Run(fmt.Sprintf("bad-user/%s", subsystem.name), func(t *testing.T) {
 			err := subsystem.sendRPC(ctx, conn)
-			if exp := "user testuser is not allowed to perform this RPC"; !testutils.IsError(err, exp) {
+			if exp := `user \[testuser\] is not allowed to perform this RPC`; !testutils.IsError(err, exp) {
 				t.Errorf("expected %q error, but got %v", exp, err)
 			}
 		})


### PR DESCRIPTION
Add a `--cert-principal-map` flag to `start` which specifies a comma
separated list of "cert-principal:db-principal" mappings which are used
to map the principals found in certificates to DB principals.

Renamed `security.GetCertificateUser` to `security.GetCertificateUsers`
and changed it to return a list of principals in the servers. This list
contains the Subject CommonName and all of the DNS
SubjectAlternateNames. Changed the two users of this function to search
the list for the user they are authenticating.

Added `COCKROACH_CERT_NODE_USER` env var which controls the principal to
place in node certs created by `cert create-node`. This is intended for
testing purposes only.

Fixes #28408

Release note (cli change): Add `--cert-principal-map` flag to `start`
which specifies a comma separated list of "cert-principal:db-principal"
mappings which are used to map the principals found in certificates to
DB principals. This allows the usage of "node" and "root" certificates
where the common name contains dots or a host name, which in turn allows
such certificates to be generated by certificate authorities which place
restrictions on the contents of the common name field.

Release note (security update): Allow client and node certificates to
specify the principal in either the Subject CommonName field or the
SubjectAlternateNames field. Previously, the principal could only be
specified in the Subject CommonName field.

Release justification: Category 4. Low risk, high reward change to
existing functionality. Should only affect users who specify
`--cert-principal-map`, and the change itself is limited in scope.
