### PR TITLE
colexec: add fallback from external hash join to sort + merge join

### DIFF
--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -52,7 +52,7 @@ func TestExternalSort(t *testing.T) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
-	const maxNumberPartitions = 2
+	const maxNumberPartitions = 3
 	// Test the case in which the default memory is used as well as the case in
 	// which the joiner spills to disk.
 	for _, spillForced := range []bool{false, true} {
@@ -149,7 +149,7 @@ func TestExternalSortRandomized(t *testing.T) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
-	const maxNumberPartitions = 2
+	const maxNumberPartitions = 3
 	// Interesting disk spilling scenarios:
 	// 1) The sorter is forced to spill to disk as soon as possible.
 	// 2) The memory limit is dynamically set to repartition twice, this will also

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1592,13 +1592,10 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 				}
 				leftSource := newChunkingBatchSource(typs, colsLeft, nTuples)
 				rightSource := newChunkingBatchSource(typs, colsRight, nTuples)
-				a, err := NewMergeJoinOp(
-					testAllocator, defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-					sqlbase.FullOuterJoin,
-					leftSource,
-					rightSource,
-					typs,
-					typs,
+				a, err := newMergeJoinOp(
+					testAllocator, defaultMemoryLimit, queueCfg,
+					NewTestingSemaphore(mjFDLimit), sqlbase.FullOuterJoin,
+					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)
@@ -1669,14 +1666,10 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 					leftSource := newChunkingBatchSource(typs, cols, nTuples)
 					rightSource := newChunkingBatchSource(typs, cols, nTuples)
 
-					a, err := NewMergeJoinOp(
-						testAllocator,
-						defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-						sqlbase.InnerJoin,
-						leftSource,
-						rightSource,
-						typs,
-						typs,
+					a, err := newMergeJoinOp(
+						testAllocator, defaultMemoryLimit,
+						queueCfg, NewTestingSemaphore(mjFDLimit), sqlbase.InnerJoin,
+						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					)
@@ -1752,14 +1745,10 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					leftSource := newChunkingBatchSource(typs, cols, nTuples)
 					rightSource := newChunkingBatchSource(typs, cols, nTuples)
 
-					a, err := NewMergeJoinOp(
-						testAllocator,
-						defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-						sqlbase.InnerJoin,
-						leftSource,
-						rightSource,
-						typs,
-						typs,
+					a, err := newMergeJoinOp(
+						testAllocator, defaultMemoryLimit,
+						queueCfg, NewTestingSemaphore(mjFDLimit), sqlbase.InnerJoin,
+						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 					)
@@ -1885,14 +1874,10 @@ func TestMergeJoinerRandomized(t *testing.T) {
 							leftSource := newChunkingBatchSource(typs, lCols, nTuples)
 							rightSource := newChunkingBatchSource(typs, rCols, nTuples)
 
-							a, err := NewMergeJoinOp(
-								testAllocator,
-								defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-								sqlbase.InnerJoin,
-								leftSource,
-								rightSource,
-								typs,
-								typs,
+							a, err := newMergeJoinOp(
+								testAllocator, defaultMemoryLimit,
+								queueCfg, NewTestingSemaphore(mjFDLimit), sqlbase.InnerJoin,
+								leftSource, rightSource, typs, typs,
 								[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 								[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 							)
@@ -1993,10 +1978,9 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-					leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3},
-					sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
+					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
+					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)
@@ -2025,10 +2009,9 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-					leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3},
-					sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
+					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
+					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)
@@ -2059,10 +2042,9 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
-					leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3},
-					sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
+					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
+					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1241,8 +1241,8 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup(ctx conte
 	// We cannot yet reset the buffered groups because the builder will be taking
 	// input from them. The actual reset will take place on the next call to
 	// initProberState().
-	o.proberState.lBufferedGroup.needToReset = true
-	o.proberState.rBufferedGroup.needToReset = true
+	o.proberState.lBufferedGroupNeedToReset = true
+	o.proberState.rBufferedGroupNeedToReset = true
 }
 
 // exhaustLeftSource sets up the builder to process any remaining tuples from
@@ -1482,17 +1482,11 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				return o.output
 			}
 		case mjDone:
-			if o.proberState.lBufferedGroup.spillingQueue != nil {
-				if err := o.proberState.lBufferedGroup.close(); err != nil {
-					execerror.VectorizedInternalPanic(err)
-				}
-				o.proberState.lBufferedGroup.spillingQueue = nil
+			if err := o.proberState.lBufferedGroup.close(); err != nil {
+				execerror.VectorizedInternalPanic(err)
 			}
-			if o.proberState.rBufferedGroup.spillingQueue != nil {
-				if err := o.proberState.rBufferedGroup.close(); err != nil {
-					execerror.VectorizedInternalPanic(err)
-				}
-				o.proberState.rBufferedGroup.spillingQueue = nil
+			if err := o.proberState.rBufferedGroup.close(); err != nil {
+				execerror.VectorizedInternalPanic(err)
 			}
 			return coldata.ZeroBatch
 		default:

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -159,9 +159,6 @@ func (p *allSpooler) getValues(i int) coldata.Vec {
 }
 
 func (p *allSpooler) getNumTuples() int {
-	if !p.spooled {
-		execerror.VectorizedInternalPanic("getNumTuples() is called before spool()")
-	}
 	return p.bufferedTuples.Length()
 }
 
@@ -186,12 +183,12 @@ func (p *allSpooler) getWindowedBatch(startIdx, endIdx int) coldata.Batch {
 }
 
 func (p *allSpooler) reset() {
-	p.spooled = false
-	p.bufferedTuples.SetLength(0)
-	p.bufferedTuples.ResetInternalBatch()
 	if r, ok := p.input.(resetter); ok {
 		r.reset()
 	}
+	p.spooled = false
+	p.bufferedTuples.SetLength(0)
+	p.bufferedTuples.ResetInternalBatch()
 }
 
 type sortOp struct {

--- a/pkg/sql/colexec/stats_test.go
+++ b/pkg/sql/colexec/stats_test.go
@@ -85,9 +85,9 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		rightInput := NewVectorizedStatsCollector(rightSource, 1 /* id */, true /* isStall */, timeutil.NewTestStopWatch(timeSource.Now))
 		rightInput.SetOutputWatch(mjInputWatch)
 
-		mergeJoiner, err := NewMergeJoinOp(
-			testAllocator, defaultMemoryLimit, queueCfg, NewTestingSemaphore(4),
-			sqlbase.InnerJoin, leftInput, rightInput,
+		mergeJoiner, err := newMergeJoinOp(
+			testAllocator, defaultMemoryLimit, queueCfg,
+			NewTestingSemaphore(4), sqlbase.InnerJoin, leftInput, rightInput,
 			[]coltypes.T{coltypes.Int64}, []coltypes.T{coltypes.Int64},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality - this commit completed the feature that we committed to.

This commit finishes the implementation of the external hash joiner by
adding the fallback to (disk-backed) sort + merge join strategy for the
case when recursive partitioning doesn't reduce the size of the
partition enough to fit in the memory. The idea is very simple: we
accumulate the indices of the partitions that are too big to join using
in-memory hash joiner, and once there are no more indices that the
in-memory hash joiner can join, we transition to different state in
which we will join the partitions with the accumulated indices one at
a time with a chain of disk-backed sort followed by disk-backed merge
join.

Fixes: #45594.
Fixes: #44199.

Release note: None