### PR TITLE
storage: enforce gc ttl strictly

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -321,7 +321,7 @@ func MakeTableFeedFactory(
 }
 
 // Feed implements the TestFeedFactory interface
-func (f *tableFeedFactory) Feed(create string, args ...interface{}) (TestFeed, error) {
+func (f *tableFeedFactory) Feed(create string, args ...interface{}) (_ TestFeed, err error) {
 	sink := f.sink
 	sink.Path = fmt.Sprintf(`table_%d`, timeutil.Now().UnixNano())
 
@@ -329,6 +329,11 @@ func (f *tableFeedFactory) Feed(create string, args ...interface{}) (TestFeed, e
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			_ = db.Close()
+		}
+	}()
 
 	sink.Scheme = `experimental-sql`
 	c := &TableFeed{

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -811,3 +811,10 @@ func (sj *StartableJob) CleanupOnRollback(ctx context.Context) error {
 	sj.registry.unregister(*sj.ID())
 	return nil
 }
+
+// Cancel will mark the job as canceled and release its resources in the
+// Registry.
+func (sj *StartableJob) Cancel(ctx context.Context) error {
+	defer sj.registry.unregister(*sj.ID())
+	return sj.registry.CancelRequested(ctx, nil, *sj.ID())
+}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -470,6 +470,14 @@ func (r *Replica) UnquiesceAndWakeLeader() {
 	r.unquiesceAndWakeLeaderLocked()
 }
 
+func (r *Replica) ReadProtectedTimestamps(ctx context.Context) {
+	var ts cachedProtectedTimestampState
+	defer r.maybeUpdateCachedProtectedTS(&ts)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ts = r.readProtectedTimestampsRLocked(ctx, nil /* f */)
+}
+
 func (nl *NodeLiveness) SetDrainingInternal(
 	ctx context.Context, liveness storagepb.Liveness, drain bool,
 ) error {

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -242,7 +242,7 @@ type replicaInQueue interface {
 	IsDestroyed() (DestroyReason, error)
 	Desc() *roachpb.RangeDescriptor
 	maybeInitializeRaftGroup(context.Context)
-	redirectOnOrAcquireLease(context.Context) (storagepb.LeaseStatus, *roachpb.Error)
+	redirectOnOrAcquireLease(context.Context) (storagepb.LeaseStatus, hlc.Timestamp, *roachpb.Error)
 	IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool
 	GetLease() (roachpb.Lease, roachpb.Lease)
 }
@@ -932,7 +932,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			// order to be processed, check whether this replica has range lease
 			// and renew or acquire if necessary.
 			if bq.needsLease {
-				if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+				if _, _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 					switch v := pErr.GetDetail().(type) {
 					case *roachpb.NotLeaseHolderError, *roachpb.RangeNotFoundError:
 						log.VEventf(ctx, 3, "%s; skipping", v)

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -169,9 +169,9 @@ func (fr *fakeReplica) Desc() *roachpb.RangeDescriptor {
 func (fr *fakeReplica) maybeInitializeRaftGroup(context.Context) {}
 func (fr *fakeReplica) redirectOnOrAcquireLease(
 	context.Context,
-) (storagepb.LeaseStatus, *roachpb.Error) {
+) (storagepb.LeaseStatus, hlc.Timestamp, *roachpb.Error) {
 	// baseQueue only checks that the returned error is nil.
-	return storagepb.LeaseStatus{}, nil
+	return storagepb.LeaseStatus{}, hlc.Timestamp{}, nil
 }
 func (fr *fakeReplica) IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool { return true }
 func (fr *fakeReplica) GetLease() (roachpb.Lease, roachpb.Lease) {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -525,7 +525,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 		// Without the lease, a replica's local descriptor can be arbitrarily
 		// stale, which will result in a ConditionFailedError. To avoid this, we
 		// make sure that we still have the lease before each attempt.
-		if _, pErr := r.redirectOnOrAcquireLease(ctx); pErr != nil {
+		if _, _, pErr := r.redirectOnOrAcquireLease(ctx); pErr != nil {
 			return pErr
 		}
 

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -216,7 +216,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 		ctx, "storage.Replica: acquiring lease to gossip",
 		func(ctx context.Context) {
 			// Check for or obtain the lease, if none active.
-			_, pErr = r.redirectOnOrAcquireLease(ctx)
+			_, _, pErr = r.redirectOnOrAcquireLease(ctx)
 			hasLease = pErr == nil
 			if pErr != nil {
 				switch e := pErr.GetDetail().(type) {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -657,7 +657,7 @@ func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Err
 	// Make sure there's a leaseholder. If there's no leaseholder, there's no
 	// closed timestamp updates.
 	var leaseholderNodeID roachpb.NodeID
-	_, err := r.redirectOnOrAcquireLease(ctx)
+	_, _, err := r.redirectOnOrAcquireLease(ctx)
 	if err == nil {
 		// We have the lease. Request is essentially a wrapper for calling EmitMLAI
 		// on a remote node, so cut out the middleman.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -366,7 +366,7 @@ func (r *Replica) executeAdminBatch(
 	}
 
 	// Admin commands always require the range lease.
-	status, pErr := r.redirectOnOrAcquireLease(ctx)
+	status, now, pErr := r.redirectOnOrAcquireLease(ctx)
 	if pErr != nil {
 		return nil, pErr
 	}
@@ -376,7 +376,7 @@ func (r *Replica) executeAdminBatch(
 	// NB: we pass nil for the spanlatch guard because we haven't acquired
 	// latches yet. This is ok because each individual request that the admin
 	// request sends will acquire latches.
-	if err := r.checkExecutionCanProceed(ba, nil /* lg */, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, nil /* g */, now, &status); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -922,7 +922,7 @@ func TestReplicaRangeBoundsChecking(t *testing.T) {
 	key := roachpb.RKey("a")
 	firstRepl := tc.store.LookupReplica(key)
 	newRepl := splitTestRange(tc.store, key, key, t)
-	if _, pErr := newRepl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
+	if _, _, pErr := newRepl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -1011,7 +1011,7 @@ func TestReplicaLease(t *testing.T) {
 	}
 
 	{
-		_, pErr := tc.repl.redirectOnOrAcquireLease(context.Background())
+		_, _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background())
 		if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok || lErr == nil {
 			t.Fatalf("wanted NotLeaseHolderError, got %s", pErr)
 		}
@@ -1027,7 +1027,7 @@ func TestReplicaLease(t *testing.T) {
 	filterErr.Store(roachpb.NewError(&roachpb.LeaseRejectedError{Message: "replica not found"}))
 
 	{
-		_, err := tc.repl.redirectOnOrAcquireLease(context.Background())
+		_, _, err := tc.repl.redirectOnOrAcquireLease(context.Background())
 		if _, ok := err.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 			t.Fatalf("expected %T, got %s", &roachpb.NotLeaseHolderError{}, err)
 		}
@@ -1409,7 +1409,7 @@ func TestReplicaDrainLease(t *testing.T) {
 
 	// Acquire initial lease.
 	ctx := context.Background()
-	status, pErr := tc.repl.redirectOnOrAcquireLease(ctx)
+	status, _, pErr := tc.repl.redirectOnOrAcquireLease(ctx)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1424,7 +1424,7 @@ func TestReplicaDrainLease(t *testing.T) {
 	}
 	tc.store.SetDraining(false)
 	// Newly undrained, leases work again.
-	if _, pErr := tc.repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+	if _, _, pErr := tc.repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 		t.Fatal(pErr)
 	}
 }
@@ -1557,7 +1557,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 
 	// Make sure the information for db1 is not gossiped. Since obtaining
 	// a lease updates the gossiped information, we do that.
-	if _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
+	if _, _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)
 	}
 	// Fetch the raw gossip info. GetSystemConfig is based on callbacks at

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -311,7 +311,7 @@ func (rq *replicateQueue) processOneChange(
 	if _, err := repl.IsDestroyed(); err != nil {
 		return false, err
 	}
-	if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+	if _, _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 		return false, pErr.GoError()
 	}
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1587,7 +1587,7 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 			s.renewableLeases.Range(func(k int64, v unsafe.Pointer) bool {
 				repl := (*Replica)(v)
 				annotatedCtx := repl.AnnotateCtx(ctx)
-				if _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
+				if _, _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
 					if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 						log.Warningf(annotatedCtx, "failed to proactively renew lease: %s", pErr)
 					}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -704,9 +704,8 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal("replica was not marked as destroyed")
 	}
 
-	if err = repl1.checkExecutionCanProceed(
-		&roachpb.BatchRequest{}, nil /* lg */, nil, /* st */
-	); err != expErr {
+	now := repl1.Clock().Now()
+	if err = repl1.checkExecutionCanProceed(&roachpb.BatchRequest{}, nil /* g */, now, nil /* st */); err != expErr {
 		t.Fatalf("expected error %s, but got %v", expErr, err)
 	}
 }

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -916,6 +916,10 @@ func TestTxnObeysTableModificationTime(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -886,6 +886,10 @@ func TestAbortSchemaChangeBackfill(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.TODO())
 
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
@@ -1396,6 +1400,10 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.TODO())
 
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
@@ -1611,6 +1619,10 @@ func TestSchemaChangeReverseMutations(t *testing.T) {
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
 
 	// Create a k-v table.
 	if _, err := sqlDB.Exec(`
@@ -2819,6 +2831,11 @@ func TestPrimaryKeyIndexRewritesGetRemoved(t *testing.T) {
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT NOT NULL, w INT, INDEX i (w));
@@ -2879,6 +2896,10 @@ func TestPrimaryKeyChangeWithCancel(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	db = sqlDB
 	defer s.Stopper().Stop(ctx)
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -3800,6 +3821,10 @@ func TestTruncateCompletion(t *testing.T) {
 	ctx := context.TODO()
 	defer s.Stopper().Stop(ctx)
 
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.pi (d DECIMAL PRIMARY KEY);
@@ -4347,6 +4372,10 @@ func TestCancelSchemaChange(t *testing.T) {
 	db = tc.ServerConn(0)
 	kvDB := tc.Server(0).DB()
 	sqlDB = sqlutils.MakeSQLRunner(db)
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, db)()
 
 	sqlDB.Exec(t, `
 		CREATE DATABASE t;
@@ -5548,6 +5577,10 @@ func TestOrphanedGCMutationsRemoved(t *testing.T) {
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
 
 	retryOpts := retry.Options{
 		InitialBackoff: 20 * time.Millisecond,


### PR DESCRIPTION
This PR creates a cluster setting to control whether the GC TTL is enforced
"strictly". Strict GC enforcement is not a strong guarantee that we will
serve no user reads whatsoever for timestamps that are older than the current
reading of the node's clock less the GC TTL. Rather it is a setting to enable
the behavior that most of the time, most requests will see an error if they
use a timestamp which is older than the GC TTL.

The main case in which the user will see an error is if the only reason a
read would be able to request a timestamp was because of a protected timestamp.
The process of verifying a protected timestamp will prevent this case.
If the users of protected timestamps verify the protected timestamp before
they operate, or they use admin commands, they'll be fine.

In the presence of a protected timestamp, all requests can read back to
that protected timestamp.

Lease transfers are another source possibility for data to be visible at the
GC Threshold rather than the TTL.

Strict mode is controlled via a cluster setting.

Strict mode does not apply to admin commands or to system ranges.

The interesting thing with this all is that the problem which prompted this
setting in the first place was due to backups being run at a period longer
than the GC TTL and pretty much never failing.

Backups in 20.1 (in theory) are going to use protected timestamps. If they
successfully verify the protected timestamp then they'll be able to still
succeed an even higher percentage of the time! If we want to discourage this
behavior we could

* Have the protected timestamp subsystem enforce that clients can't save
  data they currently view as expired. This is probably a bad idea because
  interestingly enough the protected timestamp subsystem ignores zone configs
  completely.

* Have the higher levels try to do it. This seems probably better. The backup
  pulls the table descriptors and knows exactly the timestamp ranges it's
  backing up. In a lot of cases I can imagine wanting to back up data that
  is expired. Making that hard would probably be worse than making messing
  up like this worse. It probably also has zone configs. I might instead
  just warn loudly in this case.

What this will do is bring greater awareness of the GC ttl. If you don't
update or delete data frequently the GC hueristic won't kick in for quite
some time.


Release justification: bug fixes and low-risk updates to new functionality

Release note (general change): GC TTLs will now be enforced by default.
This enforcement can be controlled by disabling `kv.gc_ttl.strict_enforcement`