### PR TITLE
jobs, *: remove job Resumer OnSuccess and OnTerminal

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -531,9 +531,6 @@ func (b *backupResumer) OnFailOrCancel(context.Context, interface{}) error {
 	return nil
 }
 
-// OnSuccess is part of the jobs.Resumer interface.
-func (b *backupResumer) OnSuccess(context.Context, *client.Txn) error { return nil }
-
 // OnTerminal is part of the jobs.Resumer interface.
 func (b *backupResumer) OnTerminal(
 	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -505,6 +505,16 @@ func (b *backupResumer) Resume(
 	if err != nil {
 		log.Warningf(ctx, "unable to clear stats from job payload: %+v", err)
 	}
+	b.deleteCheckpoint(ctx)
+
+	resultsCh <- tree.Datums{
+		tree.NewDInt(tree.DInt(*b.job.ID())),
+		tree.NewDString(string(jobs.StatusSucceeded)),
+		tree.NewDFloat(tree.DFloat(1.0)),
+		tree.NewDInt(tree.DInt(b.res.Rows)),
+		tree.NewDInt(tree.DInt(b.res.IndexEntries)),
+		tree.NewDInt(tree.DInt(b.res.DataSize)),
+	}
 	return nil
 }
 
@@ -527,14 +537,12 @@ func (b *backupResumer) clearStats(ctx context.Context, DB *client.DB) error {
 }
 
 // OnFailOrCancel is part of the jobs.Resumer interface.
-func (b *backupResumer) OnFailOrCancel(context.Context, interface{}) error {
+func (b *backupResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
+	b.deleteCheckpoint(ctx)
 	return nil
 }
 
-// OnTerminal is part of the jobs.Resumer interface.
-func (b *backupResumer) OnTerminal(
-	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
-) {
+func (b *backupResumer) deleteCheckpoint(ctx context.Context) {
 	// Attempt to delete BACKUP-CHECKPOINT.
 	if err := func() error {
 		details := b.job.Details().(jobspb.BackupDetails)
@@ -551,22 +559,6 @@ func (b *backupResumer) OnTerminal(
 		return exportStore.Delete(ctx, BackupManifestCheckpointName)
 	}(); err != nil {
 		log.Warningf(ctx, "unable to delete checkpointed backup descriptor: %+v", err)
-	}
-
-	if status == jobs.StatusSucceeded {
-		// TODO(benesch): emit periodic progress updates.
-
-		// TODO(mjibson): if a restore was resumed, then these counts will only have
-		// the current coordinator's counts.
-
-		resultsCh <- tree.Datums{
-			tree.NewDInt(tree.DInt(*b.job.ID())),
-			tree.NewDString(string(jobs.StatusSucceeded)),
-			tree.NewDFloat(tree.DFloat(1.0)),
-			tree.NewDInt(tree.DInt(b.res.Rows)),
-			tree.NewDInt(tree.DInt(b.res.IndexEntries)),
-			tree.NewDInt(tree.DInt(b.res.DataSize)),
-		}
 	}
 }
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1010,6 +1010,15 @@ func (r *restoreResumer) Resume(
 		}
 	}
 
+	resultsCh <- tree.Datums{
+		tree.NewDInt(tree.DInt(*r.job.ID())),
+		tree.NewDString(string(jobs.StatusSucceeded)),
+		tree.NewDFloat(tree.DFloat(1.0)),
+		tree.NewDInt(tree.DInt(r.res.Rows)),
+		tree.NewDInt(tree.DInt(r.res.IndexEntries)),
+		tree.NewDInt(tree.DInt(r.res.DataSize)),
+	}
+
 	return nil
 }
 
@@ -1199,27 +1208,6 @@ func (r *restoreResumer) restoreSystemTables(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// OnTerminal is part of the jobs.Resumer interface.
-func (r *restoreResumer) OnTerminal(
-	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
-) {
-	if status == jobs.StatusSucceeded {
-		// TODO(benesch): emit periodic progress updates.
-
-		// TODO(mjibson): if a restore was resumed, then these counts will only have
-		// the current coordinator's counts.
-
-		resultsCh <- tree.Datums{
-			tree.NewDInt(tree.DInt(*r.job.ID())),
-			tree.NewDString(string(jobs.StatusSucceeded)),
-			tree.NewDFloat(tree.DFloat(1.0)),
-			tree.NewDInt(tree.DInt(r.res.Rows)),
-			tree.NewDInt(tree.DInt(r.res.IndexEntries)),
-			tree.NewDInt(tree.DInt(r.res.DataSize)),
-		}
-	}
 }
 
 var _ jobs.Resumer = &restoreResumer{}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1162,11 +1162,6 @@ func (r *restoreResumer) dropTables(ctx context.Context, txn *client.Txn) error 
 	return nil
 }
 
-// OnSuccess is part of the jobs.Resumer interface.
-func (r *restoreResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
-	return nil
-}
-
 // restoreSystemTables atomically replaces the contents of the system tables
 // with the data from the restored system tables.
 func (r *restoreResumer) restoreSystemTables(ctx context.Context) error {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -546,6 +546,3 @@ func (b *changefeedResumer) Resume(
 
 // OnFailOrCancel is part of the jobs.Resumer interface.
 func (b *changefeedResumer) OnFailOrCancel(context.Context, interface{}) error { return nil }
-
-// OnTerminal is part of the jobs.Resumer interface.
-func (b *changefeedResumer) OnTerminal(context.Context, jobs.Status, chan<- tree.Datums) {}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -547,9 +546,6 @@ func (b *changefeedResumer) Resume(
 
 // OnFailOrCancel is part of the jobs.Resumer interface.
 func (b *changefeedResumer) OnFailOrCancel(context.Context, interface{}) error { return nil }
-
-// OnSuccess is part of the jobs.Resumer interface.
-func (b *changefeedResumer) OnSuccess(context.Context, *client.Txn) error { return nil }
 
 // OnTerminal is part of the jobs.Resumer interface.
 func (b *changefeedResumer) OnTerminal(context.Context, jobs.Status, chan<- tree.Datums) {}

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -480,10 +480,9 @@ func (r *cancellableImportResumer) Resume(
 ) error {
 	r.jobID = *r.wrapped.job.ID()
 	r.jobIDCh <- r.jobID
-	return r.wrapped.Resume(r.ctx, phs, resultsCh)
-}
-
-func (r *cancellableImportResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
+	if err := r.wrapped.Resume(r.ctx, phs, resultsCh); err != nil {
+		return err
+	}
 	if r.onSuccessBarrier != nil {
 		defer r.onSuccessBarrier.Enter()()
 	}
@@ -498,7 +497,7 @@ func (r *cancellableImportResumer) OnTerminal(
 
 func (r *cancellableImportResumer) OnFailOrCancel(ctx context.Context, phs interface{}) error {
 	// This callback is invoked when an error or cancellation occurs
-	// during the import. Since our OnSuccess handler returned an
+	// during the import. Since our Resume handler returned an
 	// error (after pausing the job), we need to short-circuits
 	// jobs machinery so that this job is not marked as failed.
 	return errors.New("bail out")

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -489,12 +489,6 @@ func (r *cancellableImportResumer) Resume(
 	return errors.New("job succeed, but we're forcing it to be paused")
 }
 
-func (r *cancellableImportResumer) OnTerminal(
-	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
-) {
-	r.wrapped.OnTerminal(ctx, status, resultsCh)
-}
-
 func (r *cancellableImportResumer) OnFailOrCancel(ctx context.Context, phs interface{}) error {
 	// This callback is invoked when an error or cancellation occurs
 	// during the import. Since our Resume handler returned an

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1053,9 +1053,7 @@ func (r *importResumer) Resume(
 	}
 	// TODO(ajwerner): Should this actually return the error? At this point we've
 	// successfully finished the import but failed to drop the protected
-	// timestamp. The reconciliation loop ought to pick it up. Ideally we'd do
-	// this in OnSuccess but we don't have access to the protectedts.Storage
-	// there.
+	// timestamp. The reconciliation loop ought to pick it up.
 	if ptsID != nil && !r.testingKnobs.ignoreProtectedTimestamps {
 		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			return r.releaseProtectedTimestamp(ctx, txn, p.ExecCfg().ProtectedTimestampProvider)
@@ -1263,11 +1261,6 @@ func (r *importResumer) dropTables(ctx context.Context, txn *client.Txn) error {
 			existingDesc)
 	}
 	return errors.Wrap(txn.Run(ctx, b), "rolling back tables")
-}
-
-// OnSuccess is part of the jobs.Resumer interface.
-func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
-	return nil
 }
 
 // OnTerminal is part of the jobs.Resumer interface.

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -30,7 +30,6 @@ type FakeResumer struct {
 	OnResume     func(context.Context) error
 	FailOrCancel func(context.Context) error
 	Success      func() error
-	Terminal     func()
 }
 
 func (d FakeResumer) Resume(ctx context.Context, _ interface{}, _ chan<- tree.Datums) error {
@@ -50,12 +49,6 @@ func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
 		return d.FailOrCancel(ctx)
 	}
 	return nil
-}
-
-func (d FakeResumer) OnTerminal(_ context.Context, _ Status, _ chan<- tree.Datums) {
-	if d.Terminal != nil {
-		d.Terminal()
-	}
 }
 
 var _ Resumer = FakeResumer{}

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -136,7 +136,7 @@ func TestJobsTableProgressFamily(t *testing.T) {
 }
 
 type counters struct {
-	ResumeExit, OnFailOrCancelExit, Terminal int
+	ResumeExit, OnFailOrCancelExit int
 	// These sometimes retry so just use bool.
 	ResumeStart, OnFailOrCancelStart, Success bool
 }
@@ -247,14 +247,6 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				rts.mu.a.Success = true
 				return rts.successErr
 			},
-
-			Terminal: func() {
-				t.Log("Starting terminal")
-				rts.mu.Lock()
-				rts.mu.a.Terminal++
-				rts.mu.Unlock()
-				t.Log("Exiting terminal")
-			},
 		}
 	})
 }
@@ -320,7 +312,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -342,7 +333,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -377,7 +367,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.mu.e.ResumeExit++
 
 		rts.mu.e.Success = true
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -415,7 +404,6 @@ func TestRegistryLifecycle(t *testing.T) {
 
 		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -440,7 +428,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.failOrCancelCheckCh <- struct{}{}
 		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 
 		rts.check(t, jobs.StatusCanceled)
 	})
@@ -492,7 +479,6 @@ func TestRegistryLifecycle(t *testing.T) {
 
 		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusCanceled)
 	})
 
@@ -530,7 +516,6 @@ func TestRegistryLifecycle(t *testing.T) {
 
 		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -637,7 +622,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusSucceeded)
 	})
 
@@ -664,12 +648,10 @@ func TestRegistryLifecycle(t *testing.T) {
 
 		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
-	// Attempt to mark success, but fail, but fail that also. Thus it should not
-	// trigger OnTerminal.
+	// Attempt to mark success, but fail, but fail that also.
 	t.Run("fail marking success and fail OnFailOrCancel", func(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
@@ -698,11 +680,10 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.failOrCancelCheckCh <- struct{}{}
 		rts.mu.e.OnFailOrCancelExit++
 		rts.failOrCancelCh <- errors.New("reverting failed")
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
-	// Fail the job, but also fail to mark it failed. No OnTerminal.
+	// Fail the job, but also fail to mark it failed.
 	t.Run("fail marking failed", func(t *testing.T) {
 		rts := registryTestSuite{}
 		rts.setUp(t)
@@ -730,7 +711,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		// But let it fail.
 		rts.mu.e.OnFailOrCancelExit++
 		rts.failOrCancelCh <- errors.New("resume failed")
-		rts.mu.e.Terminal++
 		rts.check(t, jobs.StatusFailed)
 	})
 
@@ -1856,12 +1836,12 @@ func TestJobInTxn(t *testing.T) {
 		return jobs.FakeResumer{
 			OnResume: func(ctx context.Context) error {
 				t.Logf("Resuming job: %+v", job.Payload())
+				atomic.AddInt32(&hasRun, 1)
 				return nil
 			},
-			Terminal: func() {
-				t.Logf("Finished job: %+v", job.Payload())
-				// Inc instead of just storing 1 to count how many jobs ran.
+			FailOrCancel: func(ctx context.Context) error {
 				atomic.AddInt32(&hasRun, 1)
+				return nil
 			},
 		}
 	})

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -668,36 +668,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.check(t, jobs.StatusFailed)
 	})
 
-	// Attempt to mark success, but fail.
-	t.Run("fail marking success", func(t *testing.T) {
-		rts := registryTestSuite{}
-		rts.setUp(t)
-		defer rts.tearDown()
-
-		// Make marking success fail.
-		rts.successErr = errors.New("marking success failed")
-		j, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
-		if err != nil {
-			t.Fatal(err)
-		}
-		rts.job = j
-
-		rts.mu.e.ResumeStart = true
-		rts.resumeCheckCh <- struct{}{}
-		rts.check(t, jobs.StatusRunning)
-
-		rts.resumeCh <- nil
-		rts.mu.e.ResumeExit++
-
-		rts.mu.e.Success = true
-		rts.mu.e.OnFailOrCancelStart = true
-		rts.failOrCancelCheckCh <- struct{}{}
-		rts.failOrCancelCh <- nil
-		rts.mu.e.OnFailOrCancelExit++
-		rts.mu.e.Terminal++
-		rts.check(t, jobs.StatusFailed)
-	})
-
 	// Attempt to mark success, but fail, but fail that also. Thus it should not
 	// trigger OnTerminal.
 	t.Run("fail marking success and fail OnFailOrCancel", func(t *testing.T) {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -488,12 +488,6 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 // OnFailOrCancel is part of the jobs.Resumer interface.
 func (r *createStatsResumer) OnFailOrCancel(context.Context, interface{}) error { return nil }
 
-// OnTerminal is part of the jobs.Resumer interface.
-func (r *createStatsResumer) OnTerminal(
-	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
-) {
-}
-
 func init() {
 	createResumerFn := func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
 		return &createStatsResumer{job: job}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -333,13 +333,10 @@ func (n *createStatsNode) makePlanForExplainDistSQL(
 }
 
 // createStatsResumer implements the jobs.Resumer interface for CreateStats
-// jobs. A new instance is created for each job. evalCtx is populated inside
-// createStatsResumer.Resume so it can be used in createStatsResumer.OnSuccess
-// (if the job is successful).
+// jobs. A new instance is created for each job.
 type createStatsResumer struct {
 	job     *jobs.Job
 	tableID sqlbase.ID
-	evalCtx *extendedEvalContext
 }
 
 var _ jobs.Resumer = &createStatsResumer{}
@@ -359,10 +356,10 @@ func (r *createStatsResumer) Resume(
 	}
 
 	r.tableID = details.Table.ID
-	r.evalCtx = p.ExtendedEvalContext()
+	evalCtx := p.ExtendedEvalContext()
 
 	ci := sqlbase.ColTypeInfoFromColTypes([]types.T{})
-	rows := rowcontainer.NewRowContainer(r.evalCtx.Mon.MakeBoundAccount(), ci, 0)
+	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci, 0)
 	defer func() {
 		if rows != nil {
 			rows.Close(ctx)
@@ -370,17 +367,17 @@ func (r *createStatsResumer) Resume(
 	}()
 
 	dsp := p.DistSQLPlanner()
-	return p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		if details.AsOf != nil {
 			p.semaCtx.AsOfTimestamp = details.AsOf
 			p.extendedEvalCtx.SetTxnTimestamp(details.AsOf.GoTime())
 			txn.SetFixedTimestamp(ctx, *details.AsOf)
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, r.evalCtx, txn)
+		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn)
 		planCtx.planner = p
 		if err := dsp.planAndRunCreateStats(
-			ctx, r.evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
+			ctx, evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
 		); err != nil {
 			// Check if this was a context canceled error and restart if it was.
 			if s, ok := status.FromError(errors.UnwrapAll(err)); ok {
@@ -409,6 +406,38 @@ func (r *createStatsResumer) Resume(
 		}
 
 		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Invalidate the local cache synchronously; this guarantees that the next
+	// statement in the same session won't use a stale cache (whereas the gossip
+	// update is handled asynchronously).
+	evalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(ctx, r.tableID)
+
+	// Record this statistics creation in the event log.
+	if !createStatsPostEvents.Get(&evalCtx.Settings.SV) {
+		return nil
+	}
+
+	// TODO(rytaft): This creates a new transaction for the CREATE STATISTICS
+	// event. It must be different from the CREATE STATISTICS transaction,
+	// because that transaction must be read-only. In the future we may want
+	// to use the transaction that inserted the new stats into the
+	// system.table_statistics table, but that would require calling
+	// MakeEventLogger from the distsqlrun package.
+	return evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		return MakeEventLogger(evalCtx.ExecCfg).InsertEventRecord(
+			ctx,
+			txn,
+			EventLogCreateStatistics,
+			int32(details.Table.ID),
+			int32(evalCtx.NodeID),
+			struct {
+				TableName string
+				Statement string
+			}{details.FQTableName, details.Statement},
+		)
 	})
 }
 
@@ -458,41 +487,6 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 
 // OnFailOrCancel is part of the jobs.Resumer interface.
 func (r *createStatsResumer) OnFailOrCancel(context.Context, interface{}) error { return nil }
-
-// OnSuccess is part of the jobs.Resumer interface.
-func (r *createStatsResumer) OnSuccess(ctx context.Context, _ *client.Txn) error {
-	details := r.job.Details().(jobspb.CreateStatsDetails)
-
-	// Invalidate the local cache synchronously; this guarantees that the next
-	// statement in the same session won't use a stale cache (whereas the gossip
-	// update is handled asynchronously).
-	r.evalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(ctx, r.tableID)
-
-	// Record this statistics creation in the event log.
-	if !createStatsPostEvents.Get(&r.evalCtx.Settings.SV) {
-		return nil
-	}
-
-	// TODO(rytaft): This creates a new transaction for the CREATE STATISTICS
-	// event. It must be different from the CREATE STATISTICS transaction,
-	// because that transaction must be read-only. In the future we may want
-	// to use the transaction that inserted the new stats into the
-	// system.table_statistics table, but that would require calling
-	// MakeEventLogger from the distsqlrun package.
-	return r.evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		return MakeEventLogger(r.evalCtx.ExecCfg).InsertEventRecord(
-			ctx,
-			txn,
-			EventLogCreateStatistics,
-			int32(details.Table.ID),
-			int32(r.evalCtx.NodeID),
-			struct {
-				TableName string
-				Statement string
-			}{details.FQTableName, details.Statement},
-		)
-	})
-}
 
 // OnTerminal is part of the jobs.Resumer interface.
 func (r *createStatsResumer) OnTerminal(


### PR DESCRIPTION
This eliminates the OnSuccess and OnTerminal methods from the job Resumer API.

The OnSuccess method is clearly duplicative with Resume: it is called when, and only when, Resume() has returned successfully, so whatever work it was going to do could just be done at the end of Resume instead -- and almost all implementations had already been refactored to do so. There was no need to share a txn with moving the job to the terminal state -- the job itself can use a txn to do whatever work it wants, optionally updating a field in the job progress or details with that same txn if it wants those semantics.

The OnTerminal method is similarly surplus to requirements -- whatever it was doing can simply be done at the end of both Resume and OnFailOrCancel. In practice, most OnTerminals were entirely logic conditional on success, to push rows into the result channel, making it trivial to simply move that code to the end of Resume.

Release note: none.