### PR TITLE
colexec: enable hash aggregator to run in vecotrize auto

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -594,6 +594,12 @@ func NewColOperator(
 					NewAllocator(ctx, hashAggregatorMemAccount), inputs[0], typs, aggFns,
 					aggSpec.GroupCols, aggCols,
 				)
+				// Auto mode is enabled for hashAggregator since it performs online
+				// aggregation. This limits memory growth in the aggregator to be
+				// proportional to the number of distinct groups. hashAggregator does
+				// not spill to disk, but neither does the hashAggregator in the row
+				// execution engine.
+				result.CanRunInAutoMode = true
 			} else {
 				result.Op, err = NewOrderedAggregator(
 					NewAllocator(ctx, streamingMemAccount), inputs[0], typs, aggFns,

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -132,7 +132,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
 ·                    distributed  false                       ·                              ·
-·                    vectorized   false                       ·                              ·
+·                    vectorized   true                        ·                              ·
 render               ·            ·                           (count int, r int)             ·
  │                   render 0     (count_rows)[int]           ·                              ·
  │                   render 1     (column6)[int]              ·                              ·
@@ -233,7 +233,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -255,7 +255,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -278,7 +278,7 @@ EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     min
  └── group            ·            ·
@@ -582,7 +582,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 ----
 ·               distributed  false       ·                   ·
-·               vectorized   false       ·                   ·
+·               vectorized   true        ·                   ·
 sort            ·            ·           (v int, count int)  +count
  │              order        +count      ·                   ·
  └── group      ·            ·           (v int, count int)  ·
@@ -597,7 +597,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 ----
 ·               distributed  false         ·                   ·
-·               vectorized   false         ·                   ·
+·               vectorized   true          ·                   ·
 sort            ·            ·             (v int, count int)  +count
  │              order        +count        ·                   ·
  └── group      ·            ·             (v int, count int)  ·
@@ -612,7 +612,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT v, count(1) FROM kv GROUP BY v ORDER BY count(1)
 ----
 ·                    distributed  false           ·                     ·
-·                    vectorized   false           ·                     ·
+·                    vectorized   true            ·                     ·
 sort                 ·            ·               (v int, count int)    +count
  │                   order        +count          ·                     ·
  └── group           ·            ·               (v int, count int)    ·
@@ -631,7 +631,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(1) FROM kv GROUP BY v) WHERE v > 10
 ----
 ·               distributed  false           ·             ·
-·               vectorized   false           ·             ·
+·               vectorized   true            ·             ·
 group           ·            ·               (v, count)    ·
  │              aggregate 0  v               ·             ·
  │              aggregate 1  count(column5)  ·             ·
@@ -710,7 +710,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
 ·                     distributed  false                             ·                     ·
-·                     vectorized   false                             ·                     ·
+·                     vectorized   true                              ·                     ·
 render                ·            ·                                 (sum decimal)         ·
  │                    render 0     (sum)[decimal]                    ·                     ·
  └── group            ·            ·                                 (k int, sum decimal)  ·
@@ -976,7 +976,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
 ·                    distributed  false        ·               ·
-·                    vectorized   false        ·               ·
+·                    vectorized   true         ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·
@@ -994,7 +994,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
 ·                    distributed  false        ·               ·
-·                    vectorized   false        ·               ·
+·                    vectorized   true         ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -302,7 +302,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
 ·               distributed  false        ·         ·
-·               vectorized   false        ·         ·
+·               vectorized   true         ·         ·
 render          ·            ·            (min)     ·
  │              render 0     min          ·         ·
  └── group      ·            ·            (y, min)  ·
@@ -317,7 +317,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
 ----
 ·                         distributed  false        ·         ·
-·                         vectorized   false        ·         ·
+·                         vectorized   true         ·         ·
 render                    ·            ·            (min)     ·
  │                        render 0     min          ·         ·
  └── limit                ·            ·            (y, min)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -782,7 +782,7 @@ GROUP BY resource_key
 ORDER BY total DESC
 ----
 ·                    distributed  false
-·                    vectorized   false
+·                    vectorized   true
 sort                 ·            ·
  │                   order        -total
  └── group           ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -197,7 +197,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
 ·                                   distributed  false                                                                                                               ·                                                              ·
-·                                   vectorized   false                                                                                                               ·                                                              ·
+·                                   vectorized   true                                                                                                                ·                                                              ·
 render                              ·            ·                                                                                                                   (max int, "?column?" decimal)                                  ·
  │                                  render 0     (max)[int]                                                                                                          ·                                                              ·
  │                                  render 1     ("?column?")[decimal]                                                                                               ·                                                              ·
@@ -226,7 +226,7 @@ query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
 ·                         distributed  false                                                                                                             ·                                            ·
-·                         vectorized   false                                                                                                             ·                                            ·
+·                         vectorized   true                                                                                                              ·                                            ·
 sort                      ·            ·                                                                                                                 (max int, stddev decimal)                    +max
  │                        order        +max                                                                                                              ·                                            ·
  └── render               ·            ·                                                                                                                 (max int, stddev decimal)                    ·


### PR DESCRIPTION
colexec: enable hash aggregator to run in vecotrize auto

Release note (sql change): hash aggregator  is now supported
in vectorize=auto mode.