### PR TITLE
opt/exec: update one logic test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1416,7 +1416,7 @@ ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
 ·                                                   distributed            true
-·                                                   vectorized             false
+·                                                   vectorized             true
 limit                                               ·                      ·
  │                                                  count                  100
  └── sort                                           ·                      ·


### PR DESCRIPTION
Now that vectorized merge joiner is planned in `auto` mode, one query in
`lookup_join` test is vectorized. I'm not sure how I didn't hit this
before merging the merge joiner PR.

Fixes: #43043.

Release note: None