### PR TITLE
blobs: enforce disabled external-io-dir

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -62,11 +62,12 @@ type cliTest struct {
 }
 
 type cliTestParams struct {
-	t          *testing.T
-	insecure   bool
-	noServer   bool
-	storeSpecs []base.StoreSpec
-	locality   roachpb.Locality
+	t           *testing.T
+	insecure    bool
+	noServer    bool
+	storeSpecs  []base.StoreSpec
+	locality    roachpb.Locality
+	noNodelocal bool
 }
 
 func (c *cliTest) fail(err interface{}) {
@@ -125,13 +126,17 @@ func newCLITest(params cliTestParams) cliTest {
 			baseCfg.SSLCertsDir = certsDir
 		}
 
-		s, err := serverutils.StartServerRaw(base.TestServerArgs{
+		args := base.TestServerArgs{
 			Insecure:      params.insecure,
 			SSLCertsDir:   c.certsDir,
 			StoreSpecs:    params.storeSpecs,
 			Locality:      params.locality,
 			ExternalIODir: filepath.Join(certsDir, "extern"),
-		})
+		}
+		if params.noNodelocal {
+			args.ExternalIODir = ""
+		}
+		s, err := serverutils.StartServerRaw(args)
 		if err != nil {
 			c.fail(err)
 		}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -271,7 +271,7 @@ func (c *copyMachine) processCopyData(
 		}
 	}
 	// Only do work if we have a full batch of rows or this is the end.
-	if ln := len(c.rows); ln == 0 || (ln < copyBatchRowSize && !final) {
+	if ln := len(c.rows); !final && (ln == 0 || ln < copyBatchRowSize) {
 		return nil
 	}
 	return c.processRows(ctx)
@@ -317,6 +317,9 @@ func (c *copyMachine) preparePlanner(ctx context.Context) func(context.Context, 
 
 // insertRows transforms the buffered rows into an insertNode and executes it.
 func (c *copyMachine) insertRows(ctx context.Context) (retErr error) {
+	if len(c.rows) == 0 {
+		return nil
+	}
 	cleanup := c.preparePlanner(ctx)
 	defer func() {
 		retErr = cleanup(ctx, retErr)

--- a/pkg/storage/cloud/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal_storage.go
@@ -55,13 +55,6 @@ func makeLocalStorage(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create blob client")
 	}
-
-	// In non-server execution we have no settings and no restriction on local IO.
-	if settings != nil {
-		if settings.ExternalIODir == "" {
-			return nil, errors.Errorf("local file access is disabled")
-		}
-	}
 	return &localFileStorage{base: cfg.Path, cfg: cfg, blobClient: client}, nil
 }
 


### PR DESCRIPTION
The `nodelocal` cloud storage implementation previously did its own
file IO, and checked for and enforced the ExternalIODirectory, including
checking when it was disabled completely ("").

However after the switch to backing `nodelocal` with the local-or-remote
blob service, this enforcement now needs to be done in that service,
when it actually goes to do local IO,  as it is a per-node decision if
and where to allow IO.

Release note (security update): ensure --external-io-dir=disabled applies to `nodelocal upload` requests as well.

Release justification: Bug fix.

Separately: add a zero-byte write at the end of upload to ensure any errors in the pipe are flushed (otherwise zero-byte files never saw errors).