### PR TITLE
importccl: handle protected timestamp removal upon resume

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -978,7 +978,13 @@ func (r *importResumer) Resume(
 	ptsID := details.ProtectedTimestampRecord
 	if ptsID != nil && !r.testingKnobs.ignoreProtectedTimestamps {
 		if err := p.ExecCfg().ProtectedTimestampProvider.Verify(ctx, *ptsID); err != nil {
-			return err
+			if errors.Is(err, protectedts.ErrNotExists) {
+				// No reason to return an error which might cause problems if it doesn't
+				// seem to exist.
+				log.Warningf(ctx, "failed to release protected which seems not to exist: %v", err)
+			} else {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
If a protected timestamp is removed and the import job is resumed, we
should still be able to mark the job as successfully complete.

Release note: None