### PR TITLE
sql: allow single-char usernames

### DIFF
--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -234,7 +234,7 @@ func (n *CreateRoleNode) FastPathResults() (int, bool) { return n.run.rowsAffect
 const usernameHelp = "Usernames are case insensitive, must start with a letter, " +
 	"digit or underscore, may contain letters, digits, dashes, periods, or underscores, and must not exceed 63 characters."
 
-var usernameRE = regexp.MustCompile(`^[\p{Ll}0-9_][---\p{Ll}0-9_.]+$`)
+var usernameRE = regexp.MustCompile(`^[\p{Ll}0-9_][---\p{Ll}0-9_.]*$`)
 
 var blacklistedUsernames = map[string]struct{}{
 	security.NodeUser: {},

--- a/pkg/sql/create_role_test.go
+++ b/pkg/sql/create_role_test.go
@@ -42,6 +42,8 @@ func TestUserName(t *testing.T) {
 		{".ABC", "", `username ".abc" invalid`, pgcode.InvalidName},
 		{"*.wildcard", "", `username "\*.wildcard" invalid`, pgcode.InvalidName},
 		{"foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof", "", `username "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof" is too long`, pgcode.NameTooLong},
+		{"M", "m", "", ""},
+		{".", "", `username "." invalid`, pgcode.InvalidName},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Previously, the regex which validated usernames changed from
`^[\p{Ll}0-9_][\p{Ll}0-9_-]{0,62}$` to `^[\p{Ll}0-9_][---\p{Ll}0-9_.]+$`
however in the process also prevented usernames of length 1 to be
created (we previously supported this, and so does Postgres). This
commit changes the + to a *.

Closes #45867.

Release note: None