### PR TITLE
cli: report partial result rows in case of error

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -499,6 +499,8 @@ func Example_sql() {
 	c.RunWithArgs([]string{`sql`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`})
 	c.RunWithArgs([]string{`sql`, `--set`, `echo=true`, `-e`, `select 123 as "123"`})
 	c.RunWithArgs([]string{`sql`, `--set`, `unknownoption`, `-e`, `select 123 as "123"`})
+	// Check that partial results + error get reported together.
+	c.RunWithArgs([]string{`sql`, `-e`, `select 1/(@1-3) from generate_series(1,4)`})
 
 	// Output:
 	// sql -e show application_name
@@ -556,6 +558,13 @@ func Example_sql() {
 	// sql --set unknownoption -e select 123 as "123"
 	// invalid syntax: \set unknownoption. Try \? for help.
 	// ERROR: invalid syntax
+	// sql -e select 1/(@1-3) from generate_series(1,4)
+	// ?column?
+	// -0.5
+	// -1
+	// (error encountered after some results were delivered)
+	// ERROR: division by zero
+	// SQLSTATE: 22012
 }
 
 func Example_sql_watch() {

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 )
 
 // rowStrIter is an iterator interface for the printQueryOutput function. It is
@@ -160,10 +160,13 @@ type rowReporter interface {
 
 // render iterates using the rowReporter object.
 // The caller can pass a noRowsHook helper that will be called in the
-// case there were no result rows. The helper is guaranteed to be called
+// case there were no result rows and no error.
+// This helper is guaranteed to be called
 // after the iteration through iter.Next(). Used in runQueryAndFormatResults.
+//
 // The completedHook is called after the last row is received/passed to the
-// rendered, but before the final rendering takes place.
+// rendered, but before the final rendering takes place. It is called
+// regardless of whether an error occurred.
 func render(
 	r rowReporter,
 	w io.Writer,
@@ -171,11 +174,39 @@ func render(
 	iter rowStrIter,
 	completedHook func(),
 	noRowsHook func() (bool, error),
-) error {
-	if err := r.describe(w, cols); err != nil {
-		return err
-	}
+) (err error) {
+	described := false
 	nRows := 0
+	defer func() {
+		// If the column headers are not printed yet, do it now.
+		if !described {
+			err = errors.WithSecondaryError(err, r.describe(w, cols))
+		}
+
+		// completedHook, if provided, is called unconditonally of error.
+		if completedHook != nil {
+			completedHook()
+		}
+
+		// We need to call doneNoRows/doneRows also unconditionally.
+		var handled bool
+		if nRows == 0 && noRowsHook != nil {
+			handled, err = noRowsHook()
+			if err != nil {
+				return
+			}
+		}
+		if handled {
+			err = errors.WithSecondaryError(err, r.doneNoRows(w))
+		} else {
+			err = errors.WithSecondaryError(err, r.doneRows(w, nRows))
+		}
+
+		if err != nil && nRows > 0 {
+			fmt.Fprintf(stderr, "(error encountered after some results were delivered)\n")
+		}
+	}()
+
 	for {
 		// Get a next row.
 		row, err := iter.Next()
@@ -189,33 +220,24 @@ func render(
 		}
 		if nRows == 0 {
 			// First row? Report.
-			if err := r.beforeFirstRow(w, iter); err != nil {
+			described = true
+			if err = r.describe(w, cols); err != nil {
+				return err
+			}
+			if err = r.beforeFirstRow(w, iter); err != nil {
 				return err
 			}
 		}
 
 		// Report every row including the first.
-		if err := r.iter(w, nRows, row); err != nil {
+		if err = r.iter(w, nRows, row); err != nil {
 			return err
 		}
 
 		nRows++
 	}
 
-	if completedHook != nil {
-		completedHook()
-	}
-
-	if nRows == 0 && noRowsHook != nil {
-		handled, err := noRowsHook()
-		if err != nil {
-			return err
-		}
-		if handled {
-			return r.doneNoRows(w)
-		}
-	}
-	return r.doneRows(w, nRows)
+	return nil
 }
 
 type asciiTableReporter struct {
@@ -264,6 +286,10 @@ func (p *asciiTableReporter) describe(w io.Writer, cols []string) error {
 }
 
 func (p *asciiTableReporter) beforeFirstRow(w io.Writer, iter rowStrIter) error {
+	if p.table == nil {
+		return nil
+	}
+
 	p.table.SetColumnAlignment(iter.Align())
 	return nil
 }
@@ -298,6 +324,7 @@ func (p *asciiTableReporter) iter(_ io.Writer, _ int, row []string) error {
 func (p *asciiTableReporter) doneRows(w io.Writer, seenRows int) error {
 	if p.table != nil {
 		p.table.Render()
+		p.table = nil
 	} else {
 		// A simple delimiter, like in psql.
 		fmt.Fprintln(w, "--")
@@ -307,7 +334,10 @@ func (p *asciiTableReporter) doneRows(w io.Writer, seenRows int) error {
 	return nil
 }
 
-func (p *asciiTableReporter) doneNoRows(_ io.Writer) error { return nil }
+func (p *asciiTableReporter) doneNoRows(_ io.Writer) error {
+	p.table = nil
+	return nil
+}
 
 type csvReporter struct {
 	mu struct {


### PR DESCRIPTION
First half of the work for #45833.  (The other half is delaying notices to the end - will send a different PR.)

Before this patch:

```
root@127.0.0.1:61756/defaultdb> select 1/(@1-10) from generate_series(1,11);
ERROR: division by zero
SQLSTATE: 22012
```

After:

```
root@127.0.0.1:61756/defaultdb> select 1/(@1-10) from generate_series(1,11);
         ?column?
---------------------------
  -0.11111111111111111111
                   -0.125
  -0.14285714285714285714
  -0.16666666666666666667
                     -0.2
                    -0.25
  -0.33333333333333333333
                     -0.5
                       -1
(9 rows)
(error encountered after some results rows were delivered)
ERROR: division by zero
SQLSTATE: 22012
```

Release note (cli change): In case some result rows have already been
received from the server when an error is encountered, CockroachDB's
SQL shell (`cockroach sql/demo`) now present both the result rows and
the error in the output regardless of the selected table
formatter. Previously, only the error was reported with some
formatters, or both with other formatters.