### PR TITLE
opt: fix distinct-on negative limit hint

### DIFF
--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -178,13 +178,17 @@ func BuildChildPhysicalProps(
 // twice as high as needed) tend to occur when distinctCount is very close to
 // neededRows.
 func distinctOnLimitHint(distinctCount, neededRows float64) float64 {
-	if neededRows >= distinctCount {
+	// The harmonic function below is not intended for values under 1 (for one,
+	// it's not monotonic until 0.5); make sure we never return negative results.
+	if neededRows >= distinctCount-1.0 {
 		return 0
 	}
 
 	// Return an approximation of the nth harmonic number.
 	H := func(n float64) float64 {
-		const gamma = 0.5772156649 // Euler–Mascheroni constant
+		// Euler–Mascheroni constant; this is included for clarity but is canceled
+		// out in our formula below.
+		const gamma = 0.5772156649
 		return math.Log(n) + gamma + 1/(2*n)
 	}
 

--- a/pkg/sql/opt/xform/physical_props_test.go
+++ b/pkg/sql/opt/xform/physical_props_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package xform
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestDistinctOnLimitHint verifies that distinctOnLimitHint never returns a
+// negative result.
+func TestDistinctOnLimitHint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Generate a list of test values. We want to try the 0 value, very small
+	// values, very large values, and cases where the two values are ~1 off from
+	// each other, or very close to each other.
+	var values []float64
+	for _, v := range []float64{0, 1e-10, 1e-5, 0.1, 1, 2, 3, 10, 1e5, 1e10} {
+		values = append(values, v)
+		for _, noise := range []float64{1e-10, 1e-7, 0.1, 1} {
+			values = append(values, v+noise)
+			if v-noise >= 0 {
+				values = append(values, v-noise)
+			}
+		}
+	}
+
+	for _, distinctCount := range values {
+		for _, neededRows := range values {
+			hint := distinctOnLimitHint(distinctCount, neededRows)
+			if hint < 0 || math.IsNaN(hint) || math.IsInf(hint, +1) {
+				t.Fatalf("distinctOnLimitHint(%g,%g)=%g", distinctCount, neededRows, hint)
+			}
+		}
+	}
+}

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -242,21 +242,22 @@ limit
 
 # DistinctOn operator.
 opt
-SELECT DISTINCT z FROM t LIMIT 2
+SELECT DISTINCT z FROM t LIMIT 1
 ----
 limit
  ├── columns: z:3
- ├── cardinality: [0 - 2]
- ├── key: (3)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
  ├── distinct-on
  │    ├── columns: z:3
  │    ├── grouping columns: z:3
  │    ├── key: (3)
- │    ├── limit hint: 2.00
+ │    ├── limit hint: 1.00
  │    └── scan t
  │         ├── columns: z:3
- │         └── limit hint: 3.44
- └── 2
+ │         └── limit hint: 1.23
+ └── 1
 
 # No limit hint propagation if number of distinct rows < required number of rows.
 opt


### PR DESCRIPTION
The distinct on formula can return negative numbers in certain cases (leading to
a "negative limit hint" internal error); restrict its usage to the domain where
that doesn't happen and add a test.

Fixes #45571.
Fixes #45570.

Release note (bug fix): Fixed "negative limit hint" internal query error.

Release justification: Category 2 (bug fixes and low-risk updates to new functionality).