### PR TITLE
changefeedccl: check context errors before logging

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -514,6 +514,9 @@ func (b *changefeedResumer) Resume(
 			return nil
 		}
 		if !IsRetryableError(err) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			log.Warningf(ctx, `CHANGEFEED job %d returning with error: %+v`, jobID, err)
 			return err
 		}
@@ -526,6 +529,9 @@ func (b *changefeedResumer) Resume(
 		// been updated by the changeFrontier processor since the flow started.
 		reloadedJob, reloadErr := execCfg.JobRegistry.LoadJob(ctx, jobID)
 		if reloadErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			log.Warningf(ctx, `CHANGEFEED job %d could not reload job progress; `+
 				`continuing from last known high-water of %s: %v`,
 				jobID, progress.GetHighWater(), reloadErr)


### PR DESCRIPTION
Fell out of testing changefeeds. Found some of my database row keys in some logs and found scary-looking errors that were really just due to context cancellation. 

Release justification: low-risk change

Release note: None