### PR TITLE
colexec: request file descriptors up front in external sorts/joins

### DIFF
--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -52,7 +52,6 @@ func TestExternalSort(t *testing.T) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
-	const maxNumberPartitions = 3
 	// Test the case in which the default memory is used as well as the case in
 	// which the joiner spills to disk.
 	for _, spillForced := range []bool{false, true} {
@@ -87,10 +86,10 @@ func TestExternalSort(t *testing.T) {
 						tc.expected,
 						orderedVerifier,
 						func(input []Operator) (Operator, error) {
-							// A sorter should never exceed maxNumberPartitions+1, even during
-							// repartitioning. A panic will happen if a sorter requests more
-							// than this number of file descriptors.
-							sem := NewTestingSemaphore(maxNumberPartitions + 1)
+							// A sorter should never exceed externalSorterMinPartitions, even
+							// during repartitioning. A panic will happen if a sorter requests
+							// more than this number of file descriptors.
+							sem := NewTestingSemaphore(externalSorterMinPartitions)
 							// If a limit is satisfied before the sorter is drained of all its
 							// tuples, the sorter will not close its partitioner. During a
 							// flow this will happen in Cleanup, since there is no way to tell
@@ -100,7 +99,7 @@ func TestExternalSort(t *testing.T) {
 							}
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, tc.logTypes, tc.ordCols, tc.matchLen, tc.k, func() {},
-								maxNumberPartitions, queueCfg, sem,
+								externalSorterMinPartitions, false /* delegateFDAcquisition */, queueCfg, sem,
 							)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
@@ -149,7 +148,6 @@ func TestExternalSortRandomized(t *testing.T) {
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor
 	)
-	const maxNumberPartitions = 3
 	// Interesting disk spilling scenarios:
 	// 1) The sorter is forced to spill to disk as soon as possible.
 	// 2) The memory limit is dynamically set to repartition twice, this will also
@@ -162,8 +160,9 @@ func TestExternalSortRandomized(t *testing.T) {
 	memoryToSort := (nTups / coldata.BatchSize()) * estimateBatchSizeBytes(colTyps, coldata.BatchSize())
 	// partitionSize will be the memory limit passed in to tests with a memory
 	// limit. With a maximum number of partitions of 2 this will result in
-	// repartitioning twice.
-	partitionSize := int64(memoryToSort / 4)
+	// repartitioning twice. To make this a total amount of memory, we also need
+	// to add the cache sizes of the queues.
+	partitionSize := int64(memoryToSort/4) + int64(externalSorterMinPartitions*queueCfg.BufferSizeBytes)
 	for _, tk := range []execinfra.TestingKnobs{{ForceDiskSpill: true}, {MemoryLimitBytes: partitionSize}} {
 		flowCtx.Cfg.TestingKnobs = tk
 		for nCols := 1; nCols <= maxCols; nCols++ {
@@ -172,7 +171,8 @@ func TestExternalSortRandomized(t *testing.T) {
 				if tk.ForceDiskSpill {
 					namePrefix = "ForceDiskSpill=true"
 				}
-				name := fmt.Sprintf("%s/nCols=%d/nOrderingCols=%d", namePrefix, nCols, nOrderingCols)
+				delegateFDAcquisition := rng.Float64() < 0.5
+				name := fmt.Sprintf("%s/nCols=%d/nOrderingCols=%d/delegateFDAcquisition=%t", namePrefix, nCols, nOrderingCols, delegateFDAcquisition)
 				t.Run(name, func(t *testing.T) {
 					// Unfortunately, there is currently no better way to check that a
 					// sorter does not have leftover file descriptors other than appending
@@ -194,12 +194,12 @@ func TestExternalSortRandomized(t *testing.T) {
 						expected,
 						orderedVerifier,
 						func(input []Operator) (Operator, error) {
-							sem := NewTestingSemaphore(maxNumberPartitions + 1)
+							sem := NewTestingSemaphore(externalSorterMinPartitions)
 							semsToCheck = append(semsToCheck, sem)
 							sorter, accounts, monitors, err := createDiskBackedSorter(
 								ctx, flowCtx, input, logTypes[:nCols], ordCols,
 								0 /* matchLen */, 0 /* k */, func() {},
-								maxNumberPartitions, queueCfg, sem)
+								externalSorterMinPartitions, delegateFDAcquisition, queueCfg, sem)
 							memAccounts = append(memAccounts, accounts...)
 							memMonitors = append(memMonitors, monitors...)
 							return sorter, err
@@ -276,7 +276,7 @@ func BenchmarkExternalSort(b *testing.B) {
 						sorter, accounts, monitors, err := createDiskBackedSorter(
 							ctx, flowCtx, []Operator{source}, logTypes, ordCols,
 							0 /* matchLen */, 0 /* k */, func() { spilled = true },
-							64 /* maxNumberPartitions */, queueCfg, &TestingSemaphore{},
+							64 /* maxNumberPartitions */, false /* delegateFDAcquisitions */, queueCfg, &TestingSemaphore{},
 						)
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
@@ -317,6 +317,7 @@ func createDiskBackedSorter(
 	k uint16,
 	spillingCallbackFn func(),
 	maxNumberPartitions int,
+	delegateFDAcquisitions bool,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	testingSemaphore semaphore.Semaphore,
 ) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
@@ -345,6 +346,7 @@ func createDiskBackedSorter(
 	// the streaming memory account.
 	args.TestingKnobs.SpillingCallbackFn = spillingCallbackFn
 	args.TestingKnobs.NumForcedRepartitions = maxNumberPartitions
+	args.TestingKnobs.DelegateFDAcquisitions = delegateFDAcquisitions
 	result, err := NewColOperator(ctx, flowCtx, args)
 	return result.Op, result.BufferingOpMemAccounts, result.BufferingOpMemMonitors, err
 }

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -62,6 +62,8 @@ type spillingQueue struct {
 // newSpillingQueue creates a new spillingQueue. An unlimited allocator must be
 // passed in. The spillingQueue will use this allocator to check whether memory
 // usage exceeds the given memory limit and use disk if so.
+// If fdSemaphore is nil, no Acquire or Release calls will happen. The caller
+// may want to do this if requesting FDs up front.
 func newSpillingQueue(
 	unlimitedAllocator *Allocator,
 	typs []coltypes.T,
@@ -204,6 +206,16 @@ func (q *spillingQueue) dequeue() (coldata.Batch, error) {
 	return res, nil
 }
 
+func (q *spillingQueue) numFDsOpenAtAnyGivenTime() int {
+	if q.diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeDefault {
+		// The access pattern must be write-everything then read-everything so
+		// either a read FD or a write FD are open at any one point.
+		return 1
+	}
+	// Otherwise, both will be open.
+	return 2
+}
+
 func (q *spillingQueue) maybeSpillToDisk(ctx context.Context) error {
 	if q.diskQueue != nil {
 		return nil
@@ -211,8 +223,10 @@ func (q *spillingQueue) maybeSpillToDisk(ctx context.Context) error {
 	var err error
 	// Acquire two file descriptors for the DiskQueue: one for the write file and
 	// one for the read file.
-	if err = q.fdSemaphore.Acquire(ctx, 2); err != nil {
-		return err
+	if q.fdSemaphore != nil {
+		if err = q.fdSemaphore.Acquire(ctx, q.numFDsOpenAtAnyGivenTime()); err != nil {
+			return err
+		}
 	}
 	log.VEvent(ctx, 1, "spilled to disk")
 	if q.rewindable {
@@ -237,7 +251,9 @@ func (q *spillingQueue) spilled() bool {
 
 func (q *spillingQueue) close() error {
 	if q.diskQueue != nil {
-		q.fdSemaphore.Release(2)
+		if q.fdSemaphore != nil {
+			q.fdSemaphore.Release(q.numFDsOpenAtAnyGivenTime())
+		}
 		return q.diskQueue.Close()
 	}
 	return nil

--- a/pkg/sql/colexec/testutils.go
+++ b/pkg/sql/colexec/testutils.go
@@ -176,7 +176,7 @@ func (s *TestingSemaphore) Acquire(_ context.Context, n int) error {
 		return errors.New("acquiring a negative amount")
 	}
 	if s.limit != 0 && s.count+n > s.limit {
-		return errors.New("testing semaphore limit exceeded")
+		return errors.Errorf("testing semaphore limit exceeded: tried acquiring %d but already have a count of %d from a total limit of %d", n, s.count, s.limit)
 	}
 	s.count += n
 	return nil

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -265,6 +265,7 @@ func TestWindowFunctions(t *testing.T) {
 				Spec:                spec,
 				Inputs:              inputs,
 				StreamingMemAccount: testMemAcc,
+				FDSemaphore:         NewTestingSemaphore(VecMaxOpenFDsLimit),
 			}
 			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := NewColOperator(ctx, flowCtx, args)


### PR DESCRIPTION
Release justification: fix for high-severity bug in existing functionality. The
current methodology of requesting file descriptors one at a time could lead to
a potential deadlock when spilling many queries to disk at the same time.

These operators would previously call semaphore.Acquire as needed. This could
lead to a situation where concurrent sorts/joins could block since they could
potentially deadlock Acquiring a file descriptor and never release ones
already held.

Now, sorts and joins that spill to disk will acquire all necessary resources
before spilling to disk.

Release note: None (no release with this potential issue)

Fixes #45602