### PR TITLE
tree: fix data race for ResolvableFunctionReference

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -651,7 +651,7 @@ var countStar = func() tree.TypedExpr {
 	fn := tree.FunDefs["count"]
 	typ := types.Int
 	return tree.NewTypedFuncExpr(
-		tree.ResolvableFunctionReference{FunctionReference: fn},
+		fn,
 		0, /* aggQualifier */
 		tree.TypedExprs{tree.UnqualifiedStar{}},
 		nil, /* filter */

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -441,7 +441,7 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 	// Cast the return and arguments to prevent ambiguity during function
 	// implementation choosing.
 	return castType(tree.NewTypedFuncExpr(
-		tree.ResolvableFunctionReference{FunctionReference: fn.def},
+		fn.def,
 		0, /* aggQualifier */
 		args,
 		nil, /* filter */

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1755,8 +1755,8 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 			Parts:    tree.NameParts{name},
 		}
 	}
-	unresolvedFunc := func(funcName string) tree.ResolvableFunctionReference {
-		return tree.ResolvableFunctionReference{
+	unresolvedFunc := func(funcName string) *tree.ResolvableFunctionReference {
+		return &tree.ResolvableFunctionReference{
 			FunctionReference: unresolvedName(funcName),
 		}
 	}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1830,7 +1830,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		}
 
 		exprs[i] = tree.NewTypedFuncExpr(
-			tree.WrapFunction(name),
+			tree.FunctionReferenceFromString(name),
 			0,
 			args,
 			builtFilter,

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -262,9 +262,8 @@ func (b *Builder) buildFunction(
 			return nil, err
 		}
 	}
-	funcRef := tree.WrapFunction(fn.Name)
 	return tree.NewTypedFuncExpr(
-		funcRef,
+		tree.FunctionReferenceFromString(fn.Name),
 		0, /* aggQualifier */
 		exprs,
 		nil, /* filter */

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -337,9 +337,8 @@ func (c *CustomFuncs) FoldFunction(
 	for i := range exprs {
 		exprs[i] = memo.ExtractConstDatum(args[i])
 	}
-	funcRef := tree.WrapFunction(private.Name)
 	fn := tree.NewTypedFuncExpr(
-		funcRef,
+		tree.FunctionReferenceFromString(private.Name),
 		0, /* aggQualifier */
 		exprs,
 		nil, /* filter */

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1223,7 +1223,7 @@ func (s *scope) replaceCount(
 			// TypeCheck()).  Replace the function with COUNT_ROWS (which doesn't
 			// take any arguments).
 			e := &tree.FuncExpr{
-				Func: tree.ResolvableFunctionReference{
+				Func: &tree.ResolvableFunctionReference{
 					FunctionReference: &tree.UnresolvedName{
 						NumParts: 1, Parts: tree.NameParts{"count_rows"},
 					},

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -88,7 +88,7 @@ func helpWith(sqllex sqlLexer, helpText string) int {
 // helpWithFunction is to be used in parser actions to mark the parser
 // "in error", with the error set to a contextual help message about
 // the current built-in function.
-func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
+func helpWithFunction(sqllex sqlLexer, f *tree.ResolvableFunctionReference) int {
 	d, err := f.Resolve(sessiondata.SearchPath{})
 	if err != nil {
 		return 1
@@ -133,7 +133,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 
 func helpWithFunctionByName(sqllex sqlLexer, s string) int {
 	un := &tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{s}}
-	return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: un})
+	return helpWithFunction(sqllex, &tree.ResolvableFunctionReference{FunctionReference: un})
 }
 
 const (

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -481,8 +481,8 @@ func (u *sqlSymUnion) scrubOptions() tree.ScrubOptions {
 func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
     return u.val.(tree.ScrubOption)
 }
-func (u *sqlSymUnion) resolvableFuncRefFromName() tree.ResolvableFunctionReference {
-    return tree.ResolvableFunctionReference{FunctionReference: u.unresolvedName()}
+func (u *sqlSymUnion) resolvableFuncRefFromName() *tree.ResolvableFunctionReference {
+    return &tree.ResolvableFunctionReference{FunctionReference: u.unresolvedName()}
 }
 func (u *sqlSymUnion) rowsFromExpr() *tree.RowsFromExpr {
     return u.val.(*tree.RowsFromExpr)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1218,7 +1218,7 @@ func NewTypedUnaryExpr(op UnaryOperator, expr TypedExpr, typ *types.T) *UnaryExp
 
 // FuncExpr represents a function call.
 type FuncExpr struct {
-	Func  ResolvableFunctionReference
+	Func  *ResolvableFunctionReference
 	Type  funcType
 	Exprs Exprs
 	// Filter is used for filters on aggregates: SUM(k) FILTER (WHERE k > 0)
@@ -1235,7 +1235,7 @@ type FuncExpr struct {
 
 // NewTypedFuncExpr returns a FuncExpr that is already well-typed and resolved.
 func NewTypedFuncExpr(
-	ref ResolvableFunctionReference,
+	ref FunctionReference,
 	aggQualifier funcType,
 	exprs TypedExprs,
 	filter TypedExpr,
@@ -1245,7 +1245,7 @@ func NewTypedFuncExpr(
 	overload *Overload,
 ) *FuncExpr {
 	f := &FuncExpr{
-		Func:           ref,
+		Func:           &ResolvableFunctionReference{FunctionReference: ref},
 		Type:           aggQualifier,
 		Exprs:          make(Exprs, len(exprs)),
 		Filter:         filter,
@@ -1338,7 +1338,7 @@ func (node *FuncExpr) Format(ctx *FmtCtx) {
 	// We need to remove name anonymization for the function name in
 	// particular. Do this by overriding the flags.
 	ctx.WithFlags(ctx.flags&^FmtAnonymize, func() {
-		ctx.FormatNode(&node.Func)
+		ctx.FormatNode(node.Func)
 	})
 
 	ctx.WriteByte('(')

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -680,7 +680,7 @@ func (node *AliasedTableExpr) doc(p *PrettyCfg) pretty.Doc {
 }
 
 func (node *FuncExpr) doc(p *PrettyCfg) pretty.Doc {
-	d := p.Doc(&node.Func)
+	d := p.Doc(node.Func)
 
 	if len(node.Exprs) > 0 {
 		args := node.Exprs.doc(p)


### PR DESCRIPTION
`ResolvableFunctionReference` currently has a data race where the
process of resolvable a function name can race with the output of a
function name. Not sure how much we want to optimize for fixing this,
but this lead to the occasional data race error.

Race link: https://teamcity.cockroachdb.com/downloadBuildLog.html?buildId=1797598&plain=true
OG PR: https://github.com/cockroachdb/cockroach/pull/45669

Release note: None