### PR TITLE
sql: add telemetry for various show commands

### DIFF
--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 func (d *delegator) delegateShowJobs(n *tree.ShowJobs) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Jobs)
 	const (
 		selectClause = `SELECT job_id, job_type, description, statement, user_name, status,
 				       running_status, created, started, finished, modified,

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -13,9 +13,11 @@ package delegate
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 func (d *delegator) delegateShowQueries(n *tree.ShowQueries) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Queries)
 	const query = `SELECT query_id, node_id, session_id, user_name, start, query, client_address, application_name, distributed, phase FROM crdb_internal.`
 	table := `node_queries`
 	if n.Cluster {

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -44,6 +44,7 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
 }
 
 func (d *delegator) delegateShowIndexes(n *tree.ShowIndexes) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Indexes)
 	getIndexesQuery := `
 SELECT
 	table_name,
@@ -127,6 +128,7 @@ ORDER BY ordinal_position`
 }
 
 func (d *delegator) delegateShowConstraints(n *tree.ShowConstraints) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Constraints)
 	const getConstraintsQuery = `
     SELECT
         t.relname AS table_name,

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -416,3 +416,40 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.locality' AND usage_count > 0
 ----
 sql.show.locality
+
+# Test SHOW INDEXES telemetry.
+statement ok
+CREATE TABLE show_test (x INT PRIMARY KEY);
+SHOW INDEXES FROM show_test
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.indexes' AND usage_count > 0
+----
+sql.show.indexes
+
+# Test SHOW CONSTRAINTS telemetry.
+statement ok
+SHOW CONSTRAINTS FROM show_test
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.constraints' AND usage_count > 0
+----
+sql.show.constraints
+
+# Test SHOW QUERIES telemetry.
+statement ok
+SHOW QUERIES
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.queries' AND usage_count > 0
+----
+sql.show.queries
+
+# Test SHOW JOBS telemetry.
+statement ok
+SHOW JOBS
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.jobs' AND usage_count > 0
+----
+sql.show.jobs

--- a/pkg/sql/sqltelemetry/show.go
+++ b/pkg/sql/sqltelemetry/show.go
@@ -32,6 +32,14 @@ const (
 	Create
 	// RangeForRow represents the SHOW RANGE FOR ROW command.
 	RangeForRow
+	// Queries represents the SHOW QUERIES command.
+	Queries
+	// Indexes represents the SHOW INDEXES command.
+	Indexes
+	// Constraints represents the SHOW CONSTRAINTS command.
+	Constraints
+	// Jobs represents the SHOW JOBS command.
+	Jobs
 )
 
 var showTelemetryNameMap = map[ShowTelemetryType]string{
@@ -40,6 +48,10 @@ var showTelemetryNameMap = map[ShowTelemetryType]string{
 	Locality:    "locality",
 	Create:      "create",
 	RangeForRow: "rangeforrow",
+	Queries:     "queries",
+	Indexes:     "indexes",
+	Constraints: "constraints",
+	Jobs:        "jobs",
 }
 
 func (s ShowTelemetryType) String() string {


### PR DESCRIPTION
Release note (sql change): This PR adds telemetry reporting
for the commands `SHOW INDEXES`, `SHOW QUERIES`, `SHOW JOBS`,
and `SHOW CONSTRAINTS`.