### PR TITLE
cli: deprecated `quit --decommission`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -846,10 +846,8 @@ long and not particularly human-readable.`,
 	}
 
 	Decommission = FlagInfo{
-		Name: "decommission",
-		Description: `
-If specified, decommissions the node and waits for it to rebalance before
-shutting down the node.`,
+		Name:        "decommission",
+		Description: `Deprecated: use 'node decommission' instead.`,
 	}
 
 	Wait = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -535,7 +535,15 @@ func init() {
 	VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 
 	// Quit command.
-	BoolFlag(quitCmd.Flags(), &quitCtx.serverDecommission, cliflags.Decommission, quitCtx.serverDecommission)
+	{
+		f := quitCmd.Flags()
+		// The --decommission flag for quit is now deprecated.
+		// Users should use `node decommission` and then `quit` after
+		// decommission completes.
+		// TODO(knz): Remove in 20.2.
+		BoolFlag(f, &quitCtx.serverDecommission, cliflags.Decommission, quitCtx.serverDecommission)
+		_ = f.MarkDeprecated(cliflags.Decommission.Name, `use 'cockroach node decommission' then 'cockroach quit' instead`)
+	}
 
 	for _, cmd := range append([]*cobra.Command{sqlShellCmd, demoCmd}, demoCmd.Commands()...) {
 		f := cmd.Flags()

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -462,6 +462,8 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		t.Fatalf("recommission failed: %v", err)
 	}
 
+	// TODO(knz): quit --decommission is deprecated in 20.1. Remove
+	// this part of the roachtest in 20.2.
 	t.l.Printf("decommissioning third node via `quit --decommission`\n")
 	func() {
 		// This should not take longer than five minutes, and if it does, it's

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1728,6 +1728,7 @@ func (s *adminServer) Decommission(
 	if nodeIDs == nil {
 		// If no NodeIDs are specified, decommission the current node. This is
 		// used by `quit --decommission`.
+		// TODO(knz): This behavior is deprecated in 20.1. Remove in 20.2.
 		nodeIDs = []roachpb.NodeID{s.server.NodeID()}
 	}
 


### PR DESCRIPTION
Discussed with @jseldess @BramGruneir 
Recommended by @tbg 

Fixes #45901

Since about v2.1 / v19.1, the sureway and risk-proof way to
decommission a node has been to use `cockroach node decommission`.

The behavior of `quit --decommission` was historically the first, but
has been superseded by `node decommission` ever since that was first
implemented.

Moreover, `quit --decommission` is less flexible (can't decommission
off nodes), at higher risk of causing an unclear outcome (what if
there is an error? is the node decommissioned or not), and conflicts
with service managers.

Release justification: Category 4: Low risk, high reward changes to existing functionality

Release note (cli change): The flag `--decommission` to `cockroach
quit` is now deprecated. It will be removed altogether in a next
stable release. Deployments should use `cockroach node decommission`
followed by either `cockroach quit` or an equivalent form of server
shut down.