### PR TITLE
sql: fix createrole privilege check

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/logictestccl/testdata/logic_test/role
@@ -779,6 +779,43 @@ REVOKE admin FROM public
 
 # Test "WITH CREATEROLE" option
 
+statement ok
+CREATE USER testuser
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role        member     isAdmin
+admin       root       true
+
+
+user testuser
+
+statement error pq: user testuser does not have CREATEROLE privilege
+CREATE ROLE rolef
+
+user root
+
+statement ok
+ALTER ROLE testuser CREATEROLE
+
+user testuser
+
+statement ok
+CREATE ROLE rolef
+
+statement ok
+ALTER ROLE rolef LOGIN
+
+statement ok
+DROP ROLE rolef
+
+# Testing invalid CREATEROLE combinations
+user root
+
+statement ok
+ALTER ROLE testuser NOCREATEROLE
+
 statement error pq: conflicting role options
 CREATE ROLE rolewithcreate WITH NOCREATEROLE CREATEROLE
 
@@ -820,9 +857,6 @@ CREATE ROLE IF NOT EXISTS anotherrolewithcreate2 CREATEROLE
 
 statement ok
 CREATE ROLE IF NOT EXISTS rolewithoutcreate2 WITH NOCREATEROLE
-
-statement ok
-CREATE USER testuser
 
 query TTB colnames
 SELECT * FROM system.role_members
@@ -1024,3 +1058,4 @@ CREATE ROLE thisshouldntwork LOGIN NOLOGIN
 
 statement error pq: redundant role options
 CREATE ROLE thisshouldntwork LOGIN LOGIN
+

--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Licensed as a CockroachDB Enterprise file under the Cockroach Community
 // License (the "License"); you may not use this file except in compliance with
@@ -72,7 +72,6 @@ func TestVerifyPassword(t *testing.T) {
 			[]interface{}{timeutil.Now().Add(-10 * time.Minute)}},
 		{"timelord", "12345", "", "VALID UNTIL $1",
 			[]interface{}{timeutil.Now().Add(59 * time.Minute).In(shanghaiLoc)}},
-		{"role1", "12345", "", "VALID UNTIL NULL", nil},
 	} {
 		cmd := fmt.Sprintf(
 			"CREATE ROLE %s WITH PASSWORD '%s' %s %s",
@@ -132,6 +131,15 @@ func TestVerifyPassword(t *testing.T) {
 			}
 
 			hashedPassword, err := pwRetrieveFn(ctx)
+			if err != nil {
+				t.Errorf(
+					"credentials %s/%s failed with error %s, wanted no error",
+					tc.username,
+					tc.password,
+					err,
+				)
+			}
+
 			err = security.CompareHashAndPassword(hashedPassword, tc.password)
 			if err != nil {
 				valid = false

--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Cockroach Authors.
+// Copyright 2018 The Cockroach Authors.
 //
 // Licensed as a CockroachDB Enterprise file under the Cockroach Community
 // License (the "License"); you may not use this file except in compliance with
@@ -72,6 +72,7 @@ func TestVerifyPassword(t *testing.T) {
 			[]interface{}{timeutil.Now().Add(-10 * time.Minute)}},
 		{"timelord", "12345", "", "VALID UNTIL $1",
 			[]interface{}{timeutil.Now().Add(59 * time.Minute).In(shanghaiLoc)}},
+		{"role1", "12345", "", "VALID UNTIL NULL", nil},
 	} {
 		cmd := fmt.Sprintf(
 			"CREATE ROLE %s WITH PASSWORD '%s' %s %s",
@@ -131,15 +132,6 @@ func TestVerifyPassword(t *testing.T) {
 			}
 
 			hashedPassword, err := pwRetrieveFn(ctx)
-			if err != nil {
-				t.Errorf(
-					"credentials %s/%s failed with error %s, wanted no error",
-					tc.username,
-					tc.password,
-					err,
-				)
-			}
-
 			err = security.CompareHashAndPassword(hashedPassword, tc.password)
 			if err != nil {
 				valid = false

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -308,6 +308,10 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 	}
 
 	var roles = tree.NewDArray(types.String)
+	err = roles.Append(tree.NewDString(normalizedName))
+	if err != nil {
+		return err
+	}
 	for role := range memberOf {
 		err := roles.Append(tree.NewDString(role))
 		if err != nil {
@@ -334,5 +338,5 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 
 	// User is not a member of a role that has CREATEROLE privilege.
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
-		"user %s does not have CREATEROLE privilege", user)
+		"user %s does not have %s privilege", user, roleOption.String())
 }

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -128,3 +128,31 @@ query T
 SHOW session_user
 ----
 root
+
+# Test CREATEROLE privilege.
+
+statement ok
+ALTER USER testuser CREATEROLE
+
+statement ok
+GRANT SELECT ON system.role_options to testuser
+
+user testuser
+
+statement ok
+CREATE USER user4 CREATEROLE
+
+statement ok
+ALTER USER user4 NOLOGIN
+
+query TTT
+SELECT * FROM system.role_options
+----
+admin     CREATEROLE  NULL
+root      CREATEROLE  NULL
+testuser  CREATEROLE  NULL
+user4     CREATEROLE  NULL
+user4     NOLOGIN     NULL
+
+statement ok
+DROP USER user4


### PR DESCRIPTION
Fixes #45857 

Fix issue where privileges would only be checked for roles that the user
is a member of but not the user itself.

Release note: none

Release justification: Bugfix: fixing bug where HasRoleOption doesn't check if the user itself has the role option. Added tests.