### PR TITLE
UI Telemetry for Statements

### DIFF
--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -189,8 +189,8 @@ export class AnalyticsSync {
     /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
     track(msg: TrackMessage) {
       const cluster = this.getCluster();
-      const { cluster_id } = cluster;
-      const message = Object.assign({ userId: cluster_id }, msg);
+      const clusterId = cluster ? cluster.cluster_id : "null";
+      const message = { userId: clusterId, ...msg };
       this.analyticsService.track(message);
     }
 

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -189,8 +189,27 @@ export class AnalyticsSync {
     /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
     track(msg: TrackMessage) {
       const cluster = this.getCluster();
-      const clusterId = cluster ? cluster.cluster_id : "null";
-      const message = { userId: clusterId, ...msg };
+      if (cluster === null) {
+        return;
+      }
+
+      // get cluster_id to id the event
+      const { cluster_id } = cluster;
+      const pagePath = this.redact(history.location.pathname);
+
+      // break down properties from message
+      const { properties, ...rest } = msg;
+      const props = {
+        pagePath,
+        ...properties,
+      }
+
+      const message = { 
+        userId: cluster_id,
+        properties: { ...props },
+        ...rest,
+      };
+
       this.analyticsService.track(message);
     }
 

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -20,6 +20,12 @@ import { COCKROACHLABS_ADDR } from "src/util/cockroachlabsAPI";
 
 type ClusterResponse = protos.cockroach.server.serverpb.IClusterResponse;
 
+interface TrackMessage {
+    event: string;
+    properties?: Object;
+    timestamp?: Date;
+    context?: Object;
+}
 /**
  * List of current redactions needed for pages tracked by the Admin UI.
  * TODO(mrtracy): It this list becomes more extensive, it might benefit from a
@@ -178,6 +184,14 @@ export class AnalyticsSync {
             },
         });
         this.identifyEventSent = true;
+    }
+
+    /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
+    track(msg: TrackMessage) {
+      const cluster = this.getCluster();
+      const { cluster_id } = cluster;
+      const message = Object.assign({ userId: cluster_id }, msg);
+      this.analyticsService.track(message);
     }
 
     /**

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -202,9 +202,9 @@ export class AnalyticsSync {
       const props = {
         pagePath,
         ...properties,
-      }
+      };
 
-      const message = { 
+      const message = {
         userId: cluster_id,
         properties: { ...props },
         ...rest,

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -10,13 +10,13 @@
 
 import React from "react";
 import classNames from "classnames";
-import map from 'lodash/map';
-import isUndefined from 'lodash/isUndefined';
-import times from 'lodash/times';
+import map from "lodash/map";
+import isUndefined from "lodash/isUndefined";
+import times from "lodash/times";
 
 import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
-import { analytics } from '../../../../redux/analytics';
+import { analytics } from "src/redux/analytics";
 
 import "./sortabletable.styl";
 
@@ -242,7 +242,7 @@ export class SortableTable extends React.Component<TableProps> {
     const path = window.location.pathname + window.location.hash;
     const tableName = name || "";
     const columnName = col.title || "";
-    const sortDirection = (sortSetting.ascending) ? 'asc' : 'desc';
+    const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
 
     const payload = {
       event: "Table Sort",

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -239,7 +239,6 @@ export class SortableTable extends React.Component<TableProps> {
   }
 
   trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
-    const path = window.location.pathname + window.location.hash;
     const tableName = name || "";
     const columnName = col.title || "";
     const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
@@ -247,7 +246,6 @@ export class SortableTable extends React.Component<TableProps> {
     const payload = {
       event: "Table Sort",
       properties: {
-        pagePath: path,
         tableName,
         columnName,
         sortDirection,

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -8,11 +8,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import classNames from "classnames";
-import _ from "lodash";
-import getHighlightedText from "oss/src/util/highlightedText";
 import React from "react";
+import classNames from "classnames";
+import map from 'lodash/map';
+import isUndefined from 'lodash/isUndefined';
+import times from 'lodash/times';
+
+import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
+import { analytics } from '../../../../redux/analytics';
+
 import "./sortabletable.styl";
 
 /**
@@ -172,7 +177,7 @@ export class SortableTable extends React.Component<TableProps> {
         }}
       >
         {expandableConfig ? this.expansionControl(expanded) : null}
-        {_.map(columns, (c: SortableColumn, colIndex: number) => {
+        {map(columns, (c: SortableColumn, colIndex: number) => {
           return (
             <td className={classNames("sort-table__cell", { "sort-table__cell--header": firstCellBordered && colIndex === 0 }, c.className)} key={colIndex}>
               {c.cell(rowIndex)}
@@ -233,25 +238,45 @@ export class SortableTable extends React.Component<TableProps> {
     });
   }
 
+  trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
+    const path = window.location.pathname + window.location.hash;
+    const tableName = name || "";
+    const columnName = col.title || "";
+    const sortDirection = (sortSetting.ascending) ? 'asc' : 'desc';
+
+    const payload = {
+      event: "Table Sort",
+      properties: {
+        pagePath: path,
+        tableName,
+        columnName,
+        sortDirection,
+      },
+    };
+
+    analytics.track(payload);
+  }
+
   render() {
-    const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult } = this.props;
+    const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult, className } = this.props;
     const { visible, drawerData } = this.state;
     return (
       <React.Fragment>
-        <table className={classNames("sort-table", this.props.className)}>
+        <table className={classNames("sort-table", className)}>
           <thead>
             <tr className="sort-table__row sort-table__row--header">
               {expandableConfig ? <th className="sort-table__cell" /> : null}
-              {_.map(columns, (c: SortableColumn, colIndex: number) => {
+              {map(columns, (c: SortableColumn, colIndex: number) => {
                 const classes = ["sort-table__cell"];
                 const style = {
                   textAlign: c.titleAlign,
                 };
                 let onClick: (e: any) => void = undefined;
 
-                if (!_.isUndefined(c.sortKey)) {
+                if (!isUndefined(c.sortKey)) {
                   classes.push("sort-table__cell--sortable");
                   onClick = () => {
+                    this.trackTableSort(className, c, sortSetting);
                     this.clickSort(c.sortKey);
                   };
                   if (c.sortKey === sortSetting.sortKey) {
@@ -268,14 +293,14 @@ export class SortableTable extends React.Component<TableProps> {
                 return (
                   <th className={classNames(classes)} key={colIndex} onClick={onClick} style={style}>
                     {c.title}
-                    {!_.isUndefined(c.sortKey) && <span className="sortable__actions" />}
+                    {!isUndefined(c.sortKey) && <span className="sortable__actions" />}
                   </th>
                 );
               })}
             </tr>
           </thead>
           <tbody>
-            {_.times(this.props.count, this.renderRow)}
+            {times(this.props.count, this.renderRow)}
           </tbody>
         </table>
         {drawer && (

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,18 +17,29 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
+import { AggregateStatistics } from "../statementsTable";
+import { analytics } from "src/redux/analytics";
 
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
+function trackActivateDiagnostics (statement: AggregateStatistics) {
+  analytics.track({
+    event: "Diagnostics Activation",
+    properties: {
+      fingerprint: statement.label,
+    },
+  });
+}
+
 export interface ActivateDiagnosticsModalRef {
-  showModalFor: (statement: string) => void;
+  showModalFor: (statement: AggregateStatistics) => void;
 }
 
 // tslint:disable-next-line:variable-name
 const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: React.RefObject<ActivateDiagnosticsModalRef>) => {
   const {activate} = props;
   const [visible, setVisible] = useState(false);
-  const [statement, setStatement] = useState();
+  const [statement, setStatement] = useState<string>();
 
   const onOkHandler = useCallback(
     () => {
@@ -42,8 +53,9 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
 
   useImperativeHandle(ref, () => {
     return {
-      showModalFor: (forwardStatement: string) => {
-        setStatement(forwardStatement);
+      showModalFor: (forwardStatement: AggregateStatistics) => {
+        setStatement(forwardStatement.label);
+        trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,22 +17,21 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { AggregateStatistics } from "../statementsTable";
 import { analytics } from "src/redux/analytics";
 
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
-function trackActivateDiagnostics (statement: AggregateStatistics) {
+function trackActivateDiagnostics (statement: string) {
   analytics.track({
     event: "Diagnostics Activation",
     properties: {
-      fingerprint: statement.label,
+      fingerprint: statement,
     },
   });
 }
 
 export interface ActivateDiagnosticsModalRef {
-  showModalFor: (statement: AggregateStatistics) => void;
+  showModalFor: (statement: string) => void;
 }
 
 // tslint:disable-next-line:variable-name
@@ -53,8 +52,8 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
 
   useImperativeHandle(ref, () => {
     return {
-      showModalFor: (forwardStatement: AggregateStatistics) => {
-        setStatement(forwardStatement.label);
+      showModalFor: (forwardStatement: string) => {
+        setStatement(forwardStatement);
         trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -43,6 +43,7 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
   const onOkHandler = useCallback(
     () => {
       activate(statement);
+      trackActivateDiagnostics(statement);
       setVisible(false);
     },
     [statement],
@@ -54,7 +55,6 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
     return {
       showModalFor: (forwardStatement: string) => {
         setStatement(forwardStatement);
-        trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -164,6 +164,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
   onChangePage = (current: number) => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
+    this.trackPaginate(current);
   }
 
   getStatementsData = () => {
@@ -196,18 +197,22 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
   }
 
   trackSearch = (searchTerm: string, numberOfResults: number) => {
-    const pagePath = window.location.pathname + window.location.hash;
-
-    const payload = {
+    analytics.track({
       event: "Search",
       properties: {
         searchTerm,
         numberOfResults,
-        pagePath,
       },
-    };
+    });
+  }
 
-    analytics.track(payload);
+  trackPaginate = (page: number) => {
+    analytics.track({
+      event: "Paginate",
+      properties: {
+        selectedPage: page,
+      },
+    });
   }
 
   renderPage = (_page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next", originalElement: React.ReactNode) => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { Icon, Pagination } from "antd";
-import isNil from "lodash/isNil";
+import { isNil, merge, forIn } from "lodash";
 import moment from "moment";
 import { DATE_FORMAT } from "src/util/format";
 import React from "react";
@@ -87,7 +87,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     };
 
     const stateFromHistory = this.getStateFromHistory();
-    this.state = _.merge(defaultState, stateFromHistory);
+    this.state = merge(defaultState, stateFromHistory);
     this.activateDiagnosticsRef = React.createRef();
   }
 
@@ -112,7 +112,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     const currentSearchParams = new URLSearchParams(history.location.search);
     // const nextSearchParams = new URLSearchParams(params);
 
-    _.forIn(params, (value, key) => {
+    forIn(params, (value, key) => {
       if (!value) {
         currentSearchParams.delete(key);
       } else {
@@ -146,19 +146,16 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     this.props.refreshStatementDiagnosticsRequests();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
+    if (this.state.search && this.state.search !== prevState.search) {
+      this.trackSearch(this.state.search, this.filteredStatementsData().length);
+    }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
   }
 
   componentWillUnmount() {
     this.props.dismissAlertMessage();
-  }
-
-  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
-    if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.state.search, this.filteredStatementsData().length);
-    }
   }
 
   onChangePage = (current: number) => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -148,7 +148,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
 
   componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
     if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.state.search, this.filteredStatementsData().length);
+      this.trackSearch(this.filteredStatementsData().length);
     }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
@@ -193,11 +193,10 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     return statements.filter(statement => search.split(" ").every(val => statement.label.toLowerCase().includes(val.toLowerCase())));
   }
 
-  trackSearch = (searchTerm: string, numberOfResults: number) => {
+  trackSearch = (numberOfResults: number) => {
     analytics.track({
       event: "Search",
       properties: {
-        searchTerm,
         numberOfResults,
       },
     });

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -155,8 +155,8 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     this.props.dismissAlertMessage();
   }
 
-  componentDidUpdate = () => {
-    if (this.state.search) {
+  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
+    if (this.state.search && this.state.search !== prevState.search) {
       this.trackSearch(this.state.search, this.filteredStatementsData().length);
     }
   }

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -37,19 +37,19 @@ export interface AggregateStatistics {
   diagnosticsReport?: IStatementDiagnosticsReport;
 }
 
-export class StatementsSortedTable extends SortedTable<AggregateStatistics> { }
+export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
 
 function StatementLink(props: { statement: string, app: string, implicitTxn: boolean, search: string }) {
   const summary = summarize(props.statement);
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
-    <Link to={`${base}/${encodeURIComponent(props.statement)}`}>
+    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
       <div className="cl-table-link__tooltip">
         <Tooltip overlayClassName="preset-black" placement="bottom" title={
-          <pre style={{ whiteSpace: "pre-wrap" }}>{getHighlightedText(props.statement, props.search)}</pre>
+          <pre style={{ whiteSpace: "pre-wrap" }}>{ getHighlightedText(props.statement, props.search) }</pre>
         }>
           <div className="cl-table-link__tooltip-hover-area">
-            {getHighlightedText(shortStatement(summary, props.statement), props.search, true)}
+            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
           </div>
         </Tooltip>
       </div>
@@ -81,10 +81,10 @@ export function makeStatementsColumns(
       className: "cl-table__col-query-text",
       cell: (stmt) => (
         <StatementLink
-          statement={stmt.label}
-          implicitTxn={stmt.implicitTxn}
+          statement={ stmt.label }
+          implicitTxn={ stmt.implicitTxn }
           search={search}
-          app={selectedApp}
+          app={ selectedApp }
         />
       ),
       sort: (stmt) => stmt.label,
@@ -127,18 +127,18 @@ export function makeStatementsColumns(
 
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
   return (
-    <Link to={`/node/${props.nodeId}`}>
+    <Link to={ `/node/${props.nodeId}` }>
       <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
     </Link>
   );
 }
 
 export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: { [nodeId: string]: string })
-  : ColumnDescriptor<AggregateStatistics>[] {
+    : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: null,
-      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={nodeNames} />,
+      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
       // sort: (stmt) => stmt.label,
     },
   ];
@@ -147,7 +147,7 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
 }
 
 function makeCommonColumns(statements: AggregateStatistics[])
-  : ColumnDescriptor<AggregateStatistics>[] {
+    : ColumnDescriptor<AggregateStatistics>[] {
   const countBar = countBarChart(statements);
   const retryBar = retryBarChart(statements);
   const rowsBar = rowsBarChart(statements);

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -37,19 +37,19 @@ export interface AggregateStatistics {
   diagnosticsReport?: IStatementDiagnosticsReport;
 }
 
-export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
+export class StatementsSortedTable extends SortedTable<AggregateStatistics> { }
 
 function StatementLink(props: { statement: string, app: string, implicitTxn: boolean, search: string }) {
   const summary = summarize(props.statement);
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
-    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
+    <Link to={`${base}/${encodeURIComponent(props.statement)}`}>
       <div className="cl-table-link__tooltip">
         <Tooltip overlayClassName="preset-black" placement="bottom" title={
-          <pre style={{ whiteSpace: "pre-wrap" }}>{ getHighlightedText(props.statement, props.search) }</pre>
+          <pre style={{ whiteSpace: "pre-wrap" }}>{getHighlightedText(props.statement, props.search)}</pre>
         }>
           <div className="cl-table-link__tooltip-hover-area">
-            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
+            {getHighlightedText(shortStatement(summary, props.statement), props.search, true)}
           </div>
         </Tooltip>
       </div>
@@ -81,10 +81,10 @@ export function makeStatementsColumns(
       className: "cl-table__col-query-text",
       cell: (stmt) => (
         <StatementLink
-          statement={ stmt.label }
-          implicitTxn={ stmt.implicitTxn }
+          statement={stmt.label}
+          implicitTxn={stmt.implicitTxn}
           search={search}
-          app={ selectedApp }
+          app={selectedApp}
         />
       ),
       sort: (stmt) => stmt.label,
@@ -127,18 +127,18 @@ export function makeStatementsColumns(
 
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
   return (
-    <Link to={ `/node/${props.nodeId}` }>
+    <Link to={`/node/${props.nodeId}`}>
       <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
     </Link>
   );
 }
 
 export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: { [nodeId: string]: string })
-    : ColumnDescriptor<AggregateStatistics>[] {
+  : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: null,
-      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
+      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={nodeNames} />,
       // sort: (stmt) => stmt.label,
     },
   ];
@@ -147,7 +147,7 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
 }
 
 function makeCommonColumns(statements: AggregateStatistics[])
-    : ColumnDescriptor<AggregateStatistics>[] {
+  : ColumnDescriptor<AggregateStatistics>[] {
   const countBar = countBarChart(statements);
   const retryBar = retryBarChart(statements);
   const rowsBar = rowsBarChart(statements);


### PR DESCRIPTION
fixes cockroachdb/cockroach#45506

- [x] Changing sort order (want to see which column and asc vs desc)
- [x] Search
- [x] Clicking to paginate
- [x] Diagnostic bundle activations (capturing high level statement performance information as part of the event is nice, e.g. latency or execution count; we should scrub the actual fingerprint)

Adding a tracking function to [`analytics.ts`]() to send analytics payloads Segment.io. I begin by adding tracking calls to interesting events on the [Statements]() page of the Admin UI. The events being tracked are as follows,

### Table Sort
This event is fired when the sorting order is changed by clicking a column header on the Statements page. 

![statements-sort-order](https://user-images.githubusercontent.com/397448/77473575-0a419100-6dec-11ea-850d-8663af4ccc37.gif)
```
{
  userId: 'ac7aafbc-1a79-4a5b-bc60-c1221cf80e1e'
  event: 'Table Sort',
  properties: {
    columnName: 'Txn Type',
    pagePath: '/statements',
    sortDirection: 'desc',
    tableName: 'statements-table'
  }
}
```

### Search
This event is fired when a the statements are filtered using a search term.

![statements-search](https://user-images.githubusercontent.com/397448/77474910-5097ef80-6dee-11ea-828c-43b387354327.gif)

```
{
  userId: 'ac7aafbc-1a79-4a5b-bc60-c1221cf80e1e',
  event: 'Search',
  properties: {
    numberOfResults: 17,
    pagePath: '/statements',
    searchTerm: 'system'
  }
}
```

### Paginate
This event is fired when the user interacts with pagination on the statements page.
![statements-pagination](https://user-images.githubusercontent.com/397448/77474995-7ae9ad00-6dee-11ea-948f-00fcc500438a.gif)

```
{
  userId: 'ac7aafbc-1a79-4a5b-bc60-c1221cf80e1e',
  event: 'Paginate',
  properties: {
    pagePath: '/statements/',
    selectedPage: 4
  }
}
```

### Diagnostics Activation
This event it tracked when a user clicks "Activate" on the diagnostics activation modal.
![statements-diagnostics-activation](https://user-images.githubusercontent.com/397448/77475062-95bc2180-6dee-11ea-96c6-d72c91915000.gif)

```
{
  userId: 'ac7aafbc-1a79-4a5b-bc60-c1221cf80e1e',
  event: 'Diagnostics Activation',
  properties: {
    fingerprint: 'SELECT blah, blah FROM blah.blah WHERE blah blah blah'
    pagePath: '/statements/'
  }
}
```
