### PR TITLE
roachtest: add a tag for the owner

### DIFF
--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -61,6 +61,8 @@ var roachtestOwners = map[Owner]OwnerMetadata{
 	`unittest`: {},
 }
 
+const defaultTag = "default"
+
 type testRegistry struct {
 	m map[string]*testSpec
 	// buildVersion is the version of the Cockroach binary that tests will run against.
@@ -133,6 +135,10 @@ func (r *testRegistry) prepareSpec(spec *testSpec) error {
 	if _, ok := roachtestOwners[spec.Owner]; !ok {
 		return fmt.Errorf(`%s: unknown owner [%s]`, spec.Name, spec.Owner)
 	}
+	if len(spec.Tags) == 0 {
+		spec.Tags = []string{defaultTag}
+	}
+	spec.Tags = append(spec.Tags, "owner-"+string(spec.Owner))
 
 	return nil
 }
@@ -211,8 +217,8 @@ func newFilter(filter []string) *testFilter {
 	}
 
 	if len(tag) == 0 {
-		tag = []string{"default"}
-		rawTag = []string{"tag:default"}
+		tag = []string{defaultTag}
+		rawTag = []string{"tag:" + defaultTag}
 	}
 
 	makeRE := func(strs []string) *regexp.Regexp {


### PR DESCRIPTION
Automatically add an `owner-<X>` tag to each roachtest. This allows
listing all of the tests owned by a certain owner, for example

    ./bin/roachtest list tag:owner-kv

Furthermore a bit of piping can generate a regexp suitable for usage
in roachdash:

    ./bin/roachtest list tag:owner-kv | \
      grep -v 'skipped:' | \
      grep -Eo '^[^ ]+' | tr '\n' '|'

(You need to cut the trailing `|` and prefix with `.*` to make it work
in roachdash).

Ideally we would also add a Project field to each OwnerMetadata and
assign to that project upon creating an issue. Alas, the GitHub API does
not let you do that:

https://developer.github.com/v3/issues/#create-an-issue

Release note: None