### PR TITLE
cli: deprecate --socket in favor of --socket-dir

### DIFF
--- a/pkg/acceptance/testdata/psql/test-psql-unix.sh
+++ b/pkg/acceptance/testdata/psql/test-psql-unix.sh
@@ -19,14 +19,14 @@ set -x
 # We use a different port number from standard for an extra guarantee that
 # "psql" is not going to find it.
 "$crdb" start-single-node --background --insecure \
-              --socket=/tmp/.s.PGSQL.1111 \
+              --socket-dir=/tmp \
               --listen-addr=:12345
 
 # Wait for server ready.
 "$crdb" sql --insecure -e "select 1" -p 12345
 
 # Verify that psql can connect to the server.
-psql -h /tmp -p 1111 -c "select 1" | grep "1 row"
+psql -h /tmp -p 12345 -c "select 1" | grep "1 row"
 
 # It worked.
 "$crdb" quit --insecure -p 12345
@@ -38,14 +38,14 @@ set -x
 
 # Restart the server in secure mode.
 "$crdb" start-single-node --background \
-              --certs-dir="$CERTS_DIR" --socket=/tmp/.s.PGSQL.1111 \
+              --certs-dir="$CERTS_DIR" --socket-dir=/tmp \
               --listen-addr=:12345
 
 # Wait for server ready; also create a user that can log in.
 "$crdb" sql --certs-dir="$CERTS_DIR" -e "create user foo with password 'pass'" -p 12345
 
 # Also verify that psql can connect to the server.
-env PGPASSWORD=pass psql -U foo -h /tmp -p 1111 -c "select 1" | grep "1 row"
+env PGPASSWORD=pass psql -U foo -h /tmp -p 12345 -c "select 1" | grep "1 row"
 
 set +x
 # Done.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -561,6 +561,12 @@ To use, for example: psql -h /path/to -p NNNN ...
 `,
 	}
 
+	SocketDir = FlagInfo{
+		Name:        "socket-dir",
+		EnvVar:      "COCKROACH_SOCKET_DIR",
+		Description: `Deprecated in favor of --socket-dir.`,
+	}
+
 	ClientInsecure = FlagInfo{
 		Name:   "insecure",
 		EnvVar: "COCKROACH_INSECURE",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -13,6 +13,7 @@ package cli
 import (
 	"flag"
 	"net"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -43,7 +44,7 @@ import (
 // - the underlying context parameters must receive defaults in
 //   initCLIDefaults() even when they are otherwise overridden by the
 //   flags logic, because some tests to not use the flag logic at all.
-var serverListenPort string
+var serverListenPort, serverSocketDir string
 var serverAdvertiseAddr, serverAdvertisePort string
 var serverSQLAddr, serverSQLPort string
 var serverSQLAdvertiseAddr, serverSQLAdvertisePort string
@@ -54,6 +55,7 @@ var localityAdvertiseHosts localityList
 // defined above.
 func initPreFlagsDefaults() {
 	serverListenPort = base.DefaultPort
+	serverSocketDir = ""
 	serverAdvertiseAddr = ""
 	serverAdvertisePort = ""
 
@@ -316,6 +318,11 @@ func init() {
 		VarFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		VarFlag(f, addrSetter{&serverSQLAdvertiseAddr, &serverSQLAdvertisePort}, cliflags.SQLAdvertiseAddr)
 		VarFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
+		StringFlag(f, &serverSocketDir, cliflags.SocketDir, serverSocketDir)
+		// --socket is deprecated as of 20.1.
+		// TODO(knz): remove in 20.2.
+		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
+		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
 
 		// Backward-compatibility flags.
 
@@ -349,8 +356,6 @@ func init() {
 		VarFlag(f, &serverCfg.Stores, cliflags.Store)
 		VarFlag(f, &serverCfg.StorageEngine, cliflags.StorageEngine)
 		VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
-
-		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
 
 		StringFlag(f, &startCtx.listeningURLFile, cliflags.ListeningURLFile, startCtx.listeningURLFile)
 
@@ -695,6 +700,23 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	// Construct the main RPC listen address.
 	serverCfg.Addr = net.JoinHostPort(startCtx.serverListenAddr, serverListenPort)
 
+	fs := flagSetForCmd(cmd)
+
+	// Construct the socket name, if requested.
+	if !fs.Lookup(cliflags.Socket.Name).Changed && fs.Lookup(cliflags.SocketDir.Name).Changed {
+		// If --socket (DEPRECATED) was set, then serverCfg.SocketFile is
+		// already set and we don't want to change it.
+		// However, if --socket-dir is set, then we'll use that.
+		// There are two cases:
+		// --socket-dir is set and is empty; in this case the user is telling us "disable the socket".
+		// is set and non-empty. Then it should be used as specified.
+		if serverSocketDir == "" {
+			serverCfg.SocketFile = ""
+		} else {
+			serverCfg.SocketFile = filepath.Join(serverSocketDir, ".s.PGSQL."+serverListenPort)
+		}
+	}
+
 	// Fill in the defaults for --advertise-addr.
 	if serverAdvertiseAddr == "" {
 		serverAdvertiseAddr = startCtx.serverListenAddr
@@ -712,11 +734,11 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		serverSQLPort = serverListenPort
 	}
 	serverCfg.SQLAddr = net.JoinHostPort(serverSQLAddr, serverSQLPort)
-	serverCfg.SplitListenSQL = flagSetForCmd(cmd).Lookup(cliflags.ListenSQLAddr.Name).Changed
+	serverCfg.SplitListenSQL = fs.Lookup(cliflags.ListenSQLAddr.Name).Changed
 
 	// Fill in the defaults for --advertise-sql-addr.
-	advSpecified := flagSetForCmd(cmd).Lookup(cliflags.AdvertiseAddr.Name).Changed ||
-		flagSetForCmd(cmd).Lookup(cliflags.AdvertiseHost.Name).Changed
+	advSpecified := fs.Lookup(cliflags.AdvertiseAddr.Name).Changed ||
+		fs.Lookup(cliflags.AdvertiseHost.Name).Changed
 	if serverSQLAdvertiseAddr == "" {
 		if advSpecified {
 			serverSQLAdvertiseAddr = serverAdvertiseAddr


### PR DESCRIPTION
Previously, the name of the unix domain socket was specified
exactly using `--socket`. This created very brittle UX: client
drivers expect a particular structure for the name of the socket,
and it was easy to use `--socket` in a way that simply did not work
with drivers.

Instead, this patch makes CockroachDB responsible for choosing a name
for the socket file that's guaranteed to be compatible with PostgreSQL
client drivers.

How this works now:

- `--socket-dir` defines the directory where to create the socket.
- the name of the socket is constructed based on the port number
  in the `--listen-addr` (or the deprecated `--port`).

The two bits of information can then reliably be passed to client
drivers, e.g. with the DSN `host=/socket/dir port=NNNN` or the URL
`postgresq://localhost?host=/socket/dir&port=NNNN`

Release justification: Category 3: Fixes for high-priority or high-severity bugs in existing functionality

Release note (cli change): The command-line flag `--socket` for
`cockroach start` is now deprecated in favor of `--socket-dir`.
CockroachDB now automatically chooses a name for the socket in the
specified directory based on the configured port number. `--socket`
will be removed in a later version.