### PR TITLE
ui: Adjust Statements table width to fit more columns

### DIFF
--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -11,10 +11,19 @@
 @require '~styl/base/palette.styl'
 @require '~src/views/shared/util/table.styl'
 
+$medium-screen-width = 1440px
+
+.cl-statements-table-wrapper
+  overflow-y auto
+
 .statements-table
   &__col-query-text
     font-family monospace
     white-space pre-wrap
+
+  @media (max-width: $medium-screen-width)
+    .sort-table__cell
+      padding 10px 16px
 
 .statements
   &__last-hour-note
@@ -164,6 +173,13 @@
 
   .latency-overall-dev
     background-color $blue
+
+@media (max-width: $medium-screen-width)
+  .statements-table__col-rows, .statements-table__col-latency
+    .bar-chart
+      min-width 0
+  .bar-chart > div[class^='bar-chart__'], div[class*=' bar-chart__']
+      display none
 
 .numeric-stats-table
   @extend $table-base

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -308,7 +308,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
             />
           )}
           {(data.length > 0 || search.length > 0) && (
-            <div className="cl-table-wrapper">
+            <div className="cl-table-wrapper cl-statements-table-wrapper">
               <StatementsSortedTable
                 className="statements-table"
                 data={data}


### PR DESCRIPTION
The problem occurred after two more columns were added to
Statements table and table became wide and didn't fit on
screen.

To fix this issue, two changes were introduced:
- Added overflow-y for table wrapper container, in case screen
size become very small - user can horizontally scroll and have
access to all table columns

- Second change adds @media queries to hide bar charts in table
cells when screen width becomes smaller than 1440px. Also to
save some space, padding for header cells are decreased to make
table more dense.

Release justification: bug fixes and low-risk updates to new functionality

Before:
<img width="1439" alt="Screenshot 2020-03-09 at 20 50 19" src="https://user-images.githubusercontent.com/3106437/76306767-29aacb00-62d0-11ea-814c-3f7742108441.png">


After:
<img width="1440" alt="Screenshot 2020-03-10 at 13 06 42" src="https://user-images.githubusercontent.com/3106437/76306784-2f081580-62d0-11ea-9777-c094a00d4ae1.png">
