### PR TITLE
ui: Show Activate button (Statements table) on hover only

### DIFF
--- a/pkg/ui/src/components/anchor/anchor.tsx
+++ b/pkg/ui/src/components/anchor/anchor.tsx
@@ -15,12 +15,13 @@ interface AnchorProps {
   onClick?: () => void;
   href?: string;
   target?: "_blank" | "_parent" | "_self";
+  className?: string;
 }
 export function Anchor(props: React.PropsWithChildren<AnchorProps>) {
-  const { href, target, children, onClick } = props;
+  const { href, target, children, onClick, className } = props;
   return (
     <a
-      className="crl-anchor"
+      className={`crl-anchor ${className}`}
       href={href}
       target={target}
       onClick={onClick}
@@ -32,4 +33,5 @@ export function Anchor(props: React.PropsWithChildren<AnchorProps>) {
 
 Anchor.defaultProps = {
   target: "_blank",
+  className: "",
 };

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -16,6 +16,12 @@
     font-family monospace
     white-space pre-wrap
 
+  &__col--show-on-hover
+    display none
+
+  .sort-table__row--body:hover .statements-table__col--show-on-hover
+    display initial
+
 .statements
   &__last-hour-note
     margin-left 3px

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -75,7 +75,7 @@ export function makeStatementsColumns(
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
 ): ColumnDescriptor<AggregateStatistics>[]  {
-  const columns: ColumnDescriptor<AggregateStatistics>[] = [
+  const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: "Statement",
       className: "cl-table__col-query-text",
@@ -96,33 +96,33 @@ export function makeStatementsColumns(
       sort: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
     },
   ];
-  columns.push(...makeCommonColumns(statements));
 
-  if (activateDiagnosticsRef) {
-    const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
-      title: "Diagnostics",
-      cell: (stmt) => {
-        if (stmt.diagnosticsReport) {
-          return <DiagnosticStatusBadge status={stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"}/>;
-        }
-        return (
-          <Anchor
-            onClick={() => activateDiagnosticsRef?.current?.showModalFor(stmt.label)}
-          >
-            Activate
-          </Anchor>
-        );
-      },
-      sort: (stmt) => {
-        if (stmt.diagnosticsReport) {
-          return stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY";
-        }
-        return null;
-      },
-    };
-    columns.push(diagnosticsColumn);
-  }
-  return columns;
+  const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
+    title: "Diagnostics",
+    cell: (stmt) => {
+      if (stmt.diagnosticsReport) {
+        return <DiagnosticStatusBadge status={stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"} />;
+      }
+      return (
+        <Anchor
+          className="statements-table__col--show-on-hover"
+          onClick={() => activateDiagnosticsRef?.current?.showModalFor(stmt.label)}
+        >
+          Activate
+        </Anchor>
+      );
+    },
+    sort: (stmt) => {
+      if (stmt.diagnosticsReport) {
+        return stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY";
+      }
+      return null;
+    },
+  };
+
+  return original
+    .concat(makeCommonColumns(statements))
+    .concat([diagnosticsColumn]);
 }
 
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {


### PR DESCRIPTION
Resolves: #45250

According to #45250 issue we should show Activate link when
user hovers a row in Statements table. This part of requirement
was missed during main implementation and Activate link was
visible always.

With current fix, Activate link is hidden by default and is
shown when user hovers on the row.

To apply this logic conditionally (hide for Activate link and
show diagnostics statuses permanently in Diagnostics column)
the styles are applied on content of cell instead of cell itself.
That is why Badge component was extended to accept `className` prop
from parent component.

Release justification: bug fixes and low-risk updates to new functionality

Before:
<img width="1440" alt="Screenshot 2020-03-10 at 13 42 33" src="https://user-images.githubusercontent.com/3106437/76309537-a2f8ec80-62d5-11ea-9db2-d9538d980189.png">


After:
![out](https://user-images.githubusercontent.com/3106437/76309811-38947c00-62d6-11ea-9c7c-81911344b049.gif)
