### PR TITLE
ui: Revert "Revert "ui: fix and refactor job status""

### DIFF
--- a/pkg/ui/src/components/badge/badge.styl
+++ b/pkg/ui/src/components/badge/badge.styl
@@ -15,7 +15,7 @@
   flex-direction row
   border-radius 3px
   text-transform uppercase
-  width fit-content
+  width max-content
   padding $spacing-xx-small $spacing-x-small
   cursor default
 

--- a/pkg/ui/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/src/views/jobs/jobDetails.tsx
@@ -28,6 +28,7 @@ import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import JobsRequest = cockroach.server.serverpb.JobsRequest;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
 import { Button, BackIcon } from "src/components/button";
+import { DATE_FORMAT } from "src/util/format";
 import { JobStatusCell } from "./jobStatusCell";
 
 interface JobsTableProps extends RouteComponentProps {
@@ -70,7 +71,7 @@ class JobDetails extends React.Component<JobsTableProps, {}> {
             <Row>
               <Col span={24}>
                 <div className="summary--card__counting">
-                  <h3 className="summary--card__counting--value">{TimestampToMoment(job.created).format("MMM DD, YYYY [at] hh:mma")}</h3>
+                  <h3 className="summary--card__counting--value">{TimestampToMoment(job.created).format(DATE_FORMAT)}</h3>
                   <p className="summary--card__counting--label">Creation time</p>
                 </div>
               </Col>

--- a/pkg/ui/src/views/jobs/jobStatusOptions.ts
+++ b/pkg/ui/src/views/jobs/jobStatusOptions.ts
@@ -52,6 +52,7 @@ export const statusOptions = [
   {value: "", label: "All"},
   {value: "succeeded", label: "Succeeded"},
   {value: "failed", label: "Failed"},
+  {value: "running", label: "Running"},
   {value: "pending", label: "Pending"},
   {value: "canceled", label: "Canceled"},
   {value: "paused", label: "Paused"},

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -131,7 +131,7 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
     return data;
   }
 
-  noJobsResult = () => (
+  noJobResult = () => (
     <>
       <p>There are no jobs that match your search in filter.</p>
       <a href="https://www.cockroachlabs.com/docs/stable/admin-ui-jobs-page.html" target="_blank">Learn more about jobs</a>
@@ -165,7 +165,7 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
             className="jobs-table"
             rowClass={job => "jobs-table__row--" + job.status}
             columns={jobsTableColumns}
-            renderNoResult={this.noJobsResult()}
+            renderNoResult={this.noJobResult()}
           />
         </section>
         <Pagination

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -179,7 +179,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
   }
 
-  noStatementsResult = () => (
+  noStatementResult = () => (
     <>
       <p>There are no SQL statements that match your search or filter since this page was last cleared.</p>
       <a href="https://www.cockroachlabs.com/docs/stable/admin-ui-statements-page.html" target="_blank">Learn more about the statement page</a>
@@ -243,7 +243,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
                 }
                 sortSetting={this.state.sortSetting}
                 onChangeSortSetting={this.changeSortSetting}
-                renderNoResult={this.noStatementsResult()}
+                renderNoResult={this.noStatementResult()}
               />
             </div>
           )}

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -20,6 +20,12 @@
   &.is-selected
     color $link-color !important
 
+.Select.is-focused
+  &:not(.is-open)
+    .Select-control
+      box-shadow none
+      border none
+
 .Select-value, .Select-placeholder
   line-height inherit !important
   height auto !important
@@ -32,10 +38,10 @@
   line-height inherit !important
   height auto !important
   border-width 0 !important
-  box-shadow 0 0 0 black !important
-  border-radius 0 3px 3px 0 !important
   background-color transparent !important
   width auto !important 
+  &:hover
+    box-shadow none
 
 .Select-input
   line-height inherit !important


### PR DESCRIPTION
This reverts commit d679f4b280a66f9aa75853ca5043c1b0ee2559d1.

This revert omits the changes to the JobTable component
that were using a reverted Pagination component that no
longer exists on master.

This change also re-adds the "running" status in the jobs
page dropdown for filtering lists of jobs. A prior commit that
re-designed the page had omitted this status options.

Release justification: Low risk update to existing functionality
Release note (admin ui change): Jobs status filter now includes
"running" which was previously omitted by mistake.