### PR TITLE
 importccl: Correctly resolve column names when importing.

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -507,13 +507,13 @@ func importPlanHook(
 			var intoCols []string
 			var isTargetCol = make(map[string]bool)
 			for _, name := range importStmt.IntoCols {
-				var err error
-				if _, err = found.FindActiveColumnByName(name.String()); err != nil {
+				active, err := found.FindActiveColumnsByNames(tree.NameList{name})
+				if err != nil {
 					return errors.Wrap(err, "verifying target columns")
 				}
 
-				isTargetCol[name.String()] = true
-				intoCols = append(intoCols, name.String())
+				isTargetCol[active[0].Name] = true
+				intoCols = append(intoCols, active[0].Name)
 			}
 
 			// IMPORT INTO does not support columns with DEFAULT expressions. Ensure


### PR DESCRIPTION
Fixes #45421

Previously, import processors used column names when
identifying which columns to import the data into.

This is problematic because column names might contain
special characters and need to be quoted. We thus would
fail to find a matching column in the table descriptor,
resulting in an error.

Instead of storing column names directly in the jobs
descriptor, resolve column name first, and then use
the resolved name.

Release justification: Bug fix.  This change is a low
risk bug fix.
Release notes (bug fix): Correctly handle columns named with
reserved keywords.