### PR TITLE
colexec: disallow casts from decimal to unequal decimal

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_cast
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_cast
@@ -1,0 +1,16 @@
+# LogicTest: local local-vec
+
+statement ok
+CREATE TABLE t45837 AS SELECT 1.25::decimal AS d
+
+# Test that decimals get rounded when casting.
+query T
+SELECT d::decimal(10,1) FROM t45837
+----
+1.3
+
+statement ok
+CREATE TABLE t2 AS SELECT 18446744073709551616::FLOAT AS f
+
+statement error pgcode 22003 integer out of range
+SELECT f::int FROM t2


### PR DESCRIPTION
Release justification: fixes decimal rounding errors in the
vectorized execution engine.

These could occur when, for example, rounding a decimal. The vectorized
execution engine does not support this cast because the conversion from types.T
to coltypes.T is lossy and therefore loses the rounding information. When
casting to a decimal, we now check that the decimal we're casting from is of
the same decimal type as the decimal type we're casting to and run this
expression through the row execution engine if not.

Release note (bug fix): bug fix to decimal rounding errors in the vectorized
execution engine

Fixes #45837 