### PR TITLE
sql: update kvtrace logictest option to accept parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
+++ b/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
@@ -105,3 +105,16 @@ SELECT y, z, w, v, u FROM t@i
 2 3 4 5 20
 7 8 9 10 20
 12 13 14 15 20
+
+# Regression for #42992.
+statement ok
+CREATE TABLE t42992 (x TIMESTAMP PRIMARY KEY, y INT, z INT, UNIQUE INDEX i (y) STORING (z), FAMILY (x), FAMILY (y), FAMILY (z))
+
+statement ok
+INSERT INTO t42992 VALUES (now(), NULL, 2)
+
+query II
+SELECT y, z FROM t42992@i
+----
+NULL 2
+

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -10,69 +10,35 @@ CREATE TABLE t1 (
 )
 
 # Ensure that inserts into each index look like we expect them to.
-statement ok
-SET TRACING=on,kv,results; INSERT INTO t1 VALUES (1, 1, 1, 1, 1); SET TRACING=off;
 
-# Inserts into nonuniqueidx or uniqueidx (which don't store anything) should be a single kv pair of the old format.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'InitPut /Table/53/2/%' OR
-message LIKE 'InitPut /Table/53/3/%'
-ORDER BY message
+# Inserts into nonuniqueidx or uniqueidx (which don't store anything) should
+# be a single kv pair of the old format (BYTES value with PK cols in
+# the value, if needed). Inserts into nonuniqueidxstoring and
+# uniqueidxstoring both should generate 3 K/V pairs.
+query T kvtrace(InitPut)
+INSERT INTO t1 VALUES (1, 1, 1, 1, 1)
 ----
 InitPut /Table/53/2/1/1/0 -> /BYTES/
 InitPut /Table/53/3/1/0 -> /BYTES/0x89
-
-# Inserts into nonuniqueidxstoring should generate 3 K/V pairs.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'InitPut /Table/53/4/%'
-ORDER BY message
-----
 InitPut /Table/53/4/1/1/0 -> /BYTES/
 InitPut /Table/53/4/1/1/2/1 -> /TUPLE/3:3:Int/1
 InitPut /Table/53/4/1/1/3/1 -> /TUPLE/4:4:Int/1/1:5:Int/1
-
-# Inserts into uniqueidxstoring should generate 3 K/V pairs.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'InitPut /Table/53/5/%'
-ORDER BY message
-----
 InitPut /Table/53/5/1/0 -> /BYTES/0x89
 InitPut /Table/53/5/1/2/1 -> /TUPLE/3:3:Int/1
 InitPut /Table/53/5/1/3/1 -> /TUPLE/4:4:Int/1/1:5:Int/1
 
-# Deletions should delete all k/v pairs for each index.
-statement ok
-SET TRACING=on,kv,results; DELETE FROM t1 WHERE x = 1; SET TRACING=off;
 
-# Deletes on nonuniqueidx or uniqueidx (which don't store anything) should be a single kv pair of the old format.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/53/2/%' OR
-message LIKE 'Del /Table/53/3/%'
-ORDER BY message
+# Deletes on nonuniqueidx or uniqueidx should result in a deletion
+# of a single key. Deletes on nonuniqueidxstoring and uniqueidxstoring
+# should result in 3 K/V pair deletions.
+query T kvtrace(Del,prefix=/Table/53/2/,prefix=/Table/53/3/,prefix=/Table/53/4/,prefix=/Table/53/5/)
+DELETE FROM t1 WHERE x = 1
 ----
 Del /Table/53/2/1/1/0
 Del /Table/53/3/1/0
-
-# Deletes on nonuniqueidxstoring should generate 3 K/V pairs.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/53/4/%'
-ORDER BY message
-----
 Del /Table/53/4/1/1/0
 Del /Table/53/4/1/1/2/1
 Del /Table/53/4/1/1/3/1
-
-# Deletes on uniqueidxstoring should generate 3 K/V pairs.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/53/5/%'
-ORDER BY message
-----
 Del /Table/53/5/1/0
 Del /Table/53/5/1/2/1
 Del /Table/53/5/1/3/1
@@ -168,6 +134,8 @@ fetched: /t1/uniqueidxstoring/NULL/z -> /3
 fetched: /t1/uniqueidxstoring/NULL/z -> /4
 
 # Ensure that updates delete and insert all K/V pairs for each index.
+# Note: we don't use kvtrace query type here because it is clearer to
+# replay the trace multiple times to separate the operations by index.
 statement ok
 SET TRACING=on,kv,results;
 UPDATE t1 SET
@@ -217,20 +185,7 @@ InitPut /Table/53/5/2/0 -> /BYTES/0x8a
 InitPut /Table/53/5/2/2/1 -> /TUPLE/3:3:Int/2
 InitPut /Table/53/5/2/3/1 -> /TUPLE/4:4:Int/2/1:5:Int/2
 
-# Regression for #42992.
-statement ok
-CREATE TABLE t42992 (x TIMESTAMP PRIMARY KEY, y INT, z INT, UNIQUE INDEX i (y) STORING (z), FAMILY (x), FAMILY (y), FAMILY (z))
-
-statement ok
-INSERT INTO t42992 VALUES (now(), NULL, 2)
-
-query II
-SELECT y, z FROM t42992@i
-----
-NULL 2
-
 # Ensure that reads only scan the necessary k/v's.
-
 statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (
@@ -242,21 +197,15 @@ CREATE TABLE t (
 INSERT INTO t VALUES (1, 2, 3)
 
 query I
-SET TRACING=on,kv,results;
-SELECT y FROM t@i WHERE x = 1;
-SET TRACING=off
+SELECT y FROM t@i WHERE x = 1
 ----
 2
 
 # In this case, we scan only families 0 and 1.
-# We don't really need family 0, but removing that
-# from the needed families code is a further optimization.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Scan%'
-ORDER BY message
+query T kvtrace(Scan,prefix=/Table/54/2/)
+SELECT y FROM t@i WHERE x = 1
 ----
-Scan /Table/55/2/1/{0-1/2}
+Scan /Table/54/2/1/{0-1/2}
 
 # Make sure that family splitting doesn't affect
 # lookups when there are null values along the
@@ -265,29 +214,20 @@ statement ok
 INSERT INTO t VALUES (NULL, 3, 4)
 
 query I
-SET TRACING=on,kv,results;
-SELECT y FROM t@i WHERE x IS NULL;
-SET TRACING=off
+SELECT y FROM t@i WHERE x IS NULL
 ----
 3
 
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Scan%'
-ORDER BY message
+query T kvtrace(Scan,prefix=/Table/54/2/)
+SELECT y FROM t@i WHERE x IS NULL
 ----
-Scan /Table/55/2/{NULL-!NULL}
+Scan /Table/54/2/{NULL-!NULL}
 
 # Ensure that updates only touch the changed column families.
-query T
-SET TRACING=on,kv,results;
-UPDATE t SET y = 5 WHERE x = 1;
-SET TRACING=off;
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'CPut /Table/55/2%'
-ORDER BY message
+query T kvtrace(CPut,prefix=/Table/54/2/)
+UPDATE t SET y = 5 WHERE x = 1
 ----
-CPut /Table/55/2/1/1/1 -> /TUPLE/2:2:Int/5 (replacing raw_bytes:"\000\000\000\000\n#\004" timestamp:<> , if exists)
+CPut /Table/54/2/1/1/1 -> /TUPLE/2:2:Int/5 (replacing raw_bytes:"\000\000\000\000\n#\004" timestamp:<> , if exists)
 
 # Test composite datatypes.
 statement ok
@@ -304,20 +244,16 @@ CREATE TABLE t (
 INSERT INTO t VALUES (1, 2.01, 3.001, 4, 5)
 
 query TTI
-SET TRACING=on,kv,results;
-SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001;
-SET TRACING=off;
+SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
 2.01 3.001 5
 
 # We only need a point scan on family 0, because the composite values
 # are stored in family 0, and a scan on family 2 for v.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Scan%'
-ORDER BY message
+query T kvtrace(Scan,prefix=/Table/55/2/)
+SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
-Scan /Table/56/2/2.01/3.001/{0-1}, /Table/56/2/2.01/3.001/2/{1-2}
+Scan /Table/55/2/2.01/3.001/{0-1}, /Table/55/2/2.01/3.001/2/{1-2}
 
 query TTT
 EXPLAIN SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
@@ -341,19 +277,15 @@ CREATE TABLE t (
 INSERT INTO t VALUES (1, 2, 3)
 
 query I
-SET TRACING=on,kv,results;
-SELECT y FROM t@i WHERE y = 2;
-SET TRACING=off;
+SELECT y FROM t@i WHERE y = 2
 ----
 2
 
 # Prove that we can scan only column family 0 and find the row.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Scan%'
-ORDER BY message
+query T kvtrace(Scan,prefix=/Table/56/2/)
+SELECT y FROM t@i WHERE y = 2
 ----
-Scan /Table/57/2/2/{0-1}
+Scan /Table/56/2/2/{0-1}
 
 # Ensure that when backfilling an index we only insert the needed k/vs.
 statement ok
@@ -406,21 +338,14 @@ BEGIN
 statement ok
 CREATE INDEX i ON t (y) STORING (z, w)
 
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET z = 3 WHERE y = 2;
-SET TRACING=off
-
 # Because i is in a delete only state, we should see a delete
 # for each k/v for i for the row (1, 2, NULL, NULL).
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del%'
-ORDER BY message
+query T kvtrace(Del,prefix=/Table/58/2/)
+UPDATE t SET z = 3 WHERE y = 2
 ----
-Del /Table/59/2/2/1/0
-Del /Table/59/2/2/1/2/1
-Del /Table/59/2/2/1/3/1
+Del /Table/58/2/2/1/0
+Del /Table/58/2/2/1/2/1
+Del /Table/58/2/2/1/3/1
 
 statement ok
 COMMIT
@@ -440,113 +365,76 @@ CREATE TABLE t (
 );
 
 # Ensure we only insert the correct keys.
-statement ok
-SET TRACING=on,kv,results;
-INSERT INTO t VALUES (1, 2, 3, NULL, 5, 6, NULL, 8);
-SET TRACING=off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'InitPut%'
-ORDER BY message
+query T kvtrace(InitPut,prefix=/Table/59/2/,prefix=/Table/59/3/)
+INSERT INTO t VALUES (1, 2, 3, NULL, 5, 6, NULL, 8)
 ----
-InitPut /Table/60/2/2/1/0 -> /BYTES/
-InitPut /Table/60/2/2/1/2/1 -> /TUPLE/3:3:Int/3
-InitPut /Table/60/2/2/1/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
-InitPut /Table/60/2/2/1/5/1 -> /TUPLE/8:8:Int/8
-InitPut /Table/60/3/2/0 -> /BYTES/0x89
-InitPut /Table/60/3/2/2/1 -> /TUPLE/3:3:Int/3
-InitPut /Table/60/3/2/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
-InitPut /Table/60/3/2/5/1 -> /TUPLE/8:8:Int/8
+InitPut /Table/59/2/2/1/0 -> /BYTES/
+InitPut /Table/59/2/2/1/2/1 -> /TUPLE/3:3:Int/3
+InitPut /Table/59/2/2/1/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
+InitPut /Table/59/2/2/1/5/1 -> /TUPLE/8:8:Int/8
+InitPut /Table/59/3/2/0 -> /BYTES/0x89
+InitPut /Table/59/3/2/2/1 -> /TUPLE/3:3:Int/3
+InitPut /Table/59/3/2/3/1 -> /TUPLE/5:5:Int/5/1:6:Int/6
+InitPut /Table/59/3/2/5/1 -> /TUPLE/8:8:Int/8
 
 # Test some cases of the updater.
 
 # Ensure success when some family k/v's are deleted,
 # some family k/v's have different values, and some
 # family k/v's are added.
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2;
-SET TRACING=off
+query T kvtrace(Put,Del,CPut,prefix=/Table/59/2/)
+UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
+----
+CPut /Table/59/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4 (replacing raw_bytes:"\000\000\000\000\n3\006" timestamp:<> , if exists)
+Del /Table/59/2/2/1/3/1
+CPut /Table/59/2/2/1/4/1 -> /TUPLE/7:7:Int/7 (expecting does not exist)
+Del /Table/59/2/2/1/5/1
 
 query IIIIIIII
 SELECT * FROM t@i2
 ----
 1 2 3 4 NULL NULL 7 NULL
 
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/60/2/%' OR
-message LIKE 'Del /Table/60/2/%' OR
-message LIKE 'CPut /Table/60/2/%'
-----
-CPut /Table/60/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4 (replacing raw_bytes:"\000\000\000\000\n3\006" timestamp:<> , if exists)
-Del /Table/60/2/2/1/3/1
-CPut /Table/60/2/2/1/4/1 -> /TUPLE/7:7:Int/7 (expecting does not exist)
-Del /Table/60/2/2/1/5/1
-
 # Test a case where no k/v's other than the sentinel exist
 # and all new k/v's have to be added.
 statement ok
 INSERT INTO t VALUES (3, 3, NULL, NULL, NULL, NULL, NULL, NULL)
 
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET a = 10, b = 11, c = 12, d = 13, e = 14, f = 15 WHERE y = 3;
-SET TRACING=off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/60/2/%' OR
-message LIKE 'Del /Table/60/2/%' OR
-message LIKE 'CPut /Table/60/2/%'
+query T kvtrace(Put,Del,CPut,prefix=/Table/59/2/)
+UPDATE t SET a = 10, b = 11, c = 12, d = 13, e = 14, f = 15 WHERE y = 3
 ----
-CPut /Table/60/2/3/3/2/1 -> /TUPLE/3:3:Int/10/1:4:Int/11 (expecting does not exist)
-CPut /Table/60/2/3/3/3/1 -> /TUPLE/5:5:Int/12/1:6:Int/13 (expecting does not exist)
-CPut /Table/60/2/3/3/4/1 -> /TUPLE/7:7:Int/14 (expecting does not exist)
-CPut /Table/60/2/3/3/5/1 -> /TUPLE/8:8:Int/15 (expecting does not exist)
+CPut /Table/59/2/3/3/2/1 -> /TUPLE/3:3:Int/10/1:4:Int/11 (expecting does not exist)
+CPut /Table/59/2/3/3/3/1 -> /TUPLE/5:5:Int/12/1:6:Int/13 (expecting does not exist)
+CPut /Table/59/2/3/3/4/1 -> /TUPLE/7:7:Int/14 (expecting does not exist)
+CPut /Table/59/2/3/3/5/1 -> /TUPLE/8:8:Int/15 (expecting does not exist)
 
 # Test a case where the update causes all k/v's other than
 # the sentinel k/v to get deleted.
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3;
-SET TRACING=off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/60/2/%' OR
-message LIKE 'Del /Table/60/2/%' OR
-message LIKE 'CPut /Table/60/2/%'
+query T kvtrace(Del,Put,CPut,prefix=/Table/59/2/)
+UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3
 ----
-Del /Table/60/2/3/3/2/1
-Del /Table/60/2/3/3/3/1
-Del /Table/60/2/3/3/4/1
-Del /Table/60/2/3/3/5/1
+Del /Table/59/2/3/3/2/1
+Del /Table/59/2/3/3/3/1
+Del /Table/59/2/3/3/4/1
+Del /Table/59/2/3/3/5/1
 
 
 # Test a case that each k/v in the index entry gets
 # rewritten when the key changes.
 statement ok
 INSERT INTO t VALUES (20, 21, 22, NULL, NULL, 25, NULL, 27);
-SET TRACING=on,kv,results;
-UPDATE t SET y = 22 WHERE y = 21;
-SET TRACING=off
 
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/60/2/%' OR
-message LIKE 'Del /Table/60/2/%' OR
-message LIKE 'CPut /Table/60/2/%'
+query T kvtrace(Put,Del,CPut,prefix=/Table/59/2/)
+UPDATE t SET y = 22 WHERE y = 21
 ----
-Del /Table/60/2/21/20/0
-CPut /Table/60/2/22/20/0 -> /BYTES/ (expecting does not exist)
-Del /Table/60/2/21/20/2/1
-CPut /Table/60/2/22/20/2/1 -> /TUPLE/3:3:Int/22 (expecting does not exist)
-Del /Table/60/2/21/20/3/1
-CPut /Table/60/2/22/20/3/1 -> /TUPLE/6:6:Int/25 (expecting does not exist)
-Del /Table/60/2/21/20/5/1
-CPut /Table/60/2/22/20/5/1 -> /TUPLE/8:8:Int/27 (expecting does not exist)
+Del /Table/59/2/21/20/0
+CPut /Table/59/2/22/20/0 -> /BYTES/ (expecting does not exist)
+Del /Table/59/2/21/20/2/1
+CPut /Table/59/2/22/20/2/1 -> /TUPLE/3:3:Int/22 (expecting does not exist)
+Del /Table/59/2/21/20/3/1
+CPut /Table/59/2/22/20/3/1 -> /TUPLE/6:6:Int/25 (expecting does not exist)
+Del /Table/59/2/21/20/5/1
+CPut /Table/59/2/22/20/5/1 -> /TUPLE/8:8:Int/27 (expecting does not exist)
 
 # Ensure that the final results on both indexes make sense.
 query IIIIIIII rowsort
@@ -574,30 +462,14 @@ CREATE TABLE t (
 INSERT INTO t VALUES (1, 2, 3, 4)
 
 # When the key is changed, we always delete and cput.
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET y = 5 where y = 2;
-SET TRACING=off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/61/2/%' OR
-message LIKE 'Del /Table/61/2/%' OR
-message LIKE 'CPut /Table/61/2/%'
+query T kvtrace(Put,CPut,Del,prefix=/Table/60/2/)
+UPDATE t SET y = 5 where y = 2
 ----
-Del /Table/61/2/2/1/0
-CPut /Table/61/2/5/1/0 -> /BYTES/0x33061308 (expecting does not exist)
-
-statement ok
-SET TRACING=on,kv,results;
-UPDATE t SET z = 5 where y = 5;
-SET TRACING=off
+Del /Table/60/2/2/1/0
+CPut /Table/60/2/5/1/0 -> /BYTES/0x33061308 (expecting does not exist)
 
 # Changing the value just results in a cput.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Put /Table/61/2/%' OR
-message LIKE 'Del /Table/61/2/%' OR
-message LIKE 'CPut /Table/61/2/%'
+query T kvtrace(Put,Del,CPut,prefix=/Table/60/2/)
+UPDATE t SET z = 5 where y = 5
 ----
-CPut /Table/61/2/5/1/0 -> /BYTES/0x330a1308 (replacing raw_bytes:"\000\000\000\000\0033\006\023\010" timestamp:<> , if exists)
+CPut /Table/60/2/5/1/0 -> /BYTES/0x330a1308 (replacing raw_bytes:"\000\000\000\000\0033\006\023\010" timestamp:<> , if exists)


### PR DESCRIPTION
The kvtrace logictest option now accepts parameters
to filter the results by. These parameters include
operation type and prefix the k/v's in the operation.

This PR also a bulk of the secondary_index_column_families
logictest to demonstrate the use of the new feature.

Release justification: non-production code change

Release note: None