### PR TITLE
bors: Re-enable license/cla bors check

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,8 +2,7 @@ status = [
   "GitHub CI (Cockroach)"
 ]
 pr_status = [
-# The CLA check is being flaky 20200305
-#  "license/cla"
+  "license/cla"
 ]
 block_labels = [
   "do-not-merge"


### PR DESCRIPTION
This change re-enables bors checking for the CLA to have been signed before it
will accept an `r+` command.

X-Ref: https://github.com/cockroachdb/dev-inf/issues/51

Release note: None
Release justification: This returns us to our nominal workflow.