### PR TITLE
sql: add get_bit() and set_bit() builtin functions for bits

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -865,6 +865,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="from_uuid"></a><code>from_uuid(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of a UUID to its character string representation.</p>
 </span></td></tr>
+<tr><td><a name="get_bit"></a><code>get_bit(bit_string: varbit, index: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts a bit at given index in the bit array</p>
+</span></td></tr>
 <tr><td><a name="initcap"></a><code>initcap(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Capitalizes the first letter of <code>val</code>.</p>
 </span></td></tr>
 <tr><td><a name="left"></a><code>left(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the first <code>return_set</code> bytes from <code>input</code>.</p>
@@ -1006,6 +1008,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>For example, <code>rtrim('doggie', 'ei')</code> returns <code>dogg</code>.</p>
 </span></td></tr>
 <tr><td><a name="rtrim"></a><code>rtrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes all spaces from the end (right-hand side) of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><a name="set_bit"></a><code>set_bit(bit_string: varbit, index: <a href="int.html">int</a>, to_set: <a href="int.html">int</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Updates a bit at given index in the bit array</p>
 </span></td></tr>
 <tr><td><a name="sha1"></a><code>sha1(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA1 hash value of a set of values.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2563,3 +2563,46 @@ query T
 SELECT getdatabaseencoding()
 ----
 UTF8
+
+subtest get_bit
+
+query I rowsort
+SELECT get_bit(B'100101110101', 3) UNION SELECT get_bit(B'100101110101', 2)
+----
+1
+0
+
+query I rowsort
+SELECT get_bit('000000'::varbit, 5) UNION SELECT get_bit('1111111'::varbit, 5)
+----
+1
+0
+
+query error get_bit\(\): GetBitAtIndex: bit index 10 out of valid range \(0..4\)
+SELECT get_bit(B'10110', 10)
+
+query error get_bit\(\): GetBitAtIndex: bit index 0 out of valid range \(0..-1\)
+SELECT get_bit(B'', 0);
+
+subtest set_bit
+
+query T rowsort
+SELECT set_bit(B'1101010', 0, 0) UNION SELECT set_bit(B'1101010', 2, 1)
+----
+0101010
+1111010
+
+query T rowsort
+SELECT set_bit('000000'::varbit, 5, 1) UNION SELECT set_bit('111111'::varbit, 5, 0)
+----
+000001
+111110
+
+query error set_bit\(\): SetBitAtIndex: bit index 10 out of valid range \(0..6\)
+SELECT set_bit(B'1101010', 10, 1)
+
+query error set_bit\(\): new bit must be 0 or 1.
+SELECT set_bit(B'1001010', 0, 2)
+
+query error set_bit\(\): SetBitAtIndex: bit index 0 out of valid range \(0..-1\)
+SELECT set_bit(B'', 0, 1)

--- a/pkg/util/bitarray/bitarray_test.go
+++ b/pkg/util/bitarray/bitarray_test.go
@@ -679,3 +679,67 @@ func TestConcatRand(t *testing.T) {
 
 	}
 }
+
+func TestGetBitAtIndex(t *testing.T) {
+	testData := []struct {
+		bitString, err string
+		index, res     int
+	}{
+		{"1001010", "", 0, 1},
+		{"1010101", "", 1, 0},
+		{"111111111111110001010101000000", "", 20, 0},
+		{"111111111111110001011101000000", "", 20, 1},
+		{"11111111", "", 7, 1},
+		{"010110", "GetBitAtIndex: bit index -1 out of valid range (0..5)", -1, 0},
+		{"", "GetBitAtIndex: bit index 0 out of valid range (0..-1)", 0, 0},
+		{"10100110", "GetBitAtIndex: bit index 8 out of valid range (0..7)", 8, 0},
+	}
+	for _, test := range testData {
+		t.Run(fmt.Sprintf("{%v,%d}", test.bitString, test.index), func(t *testing.T) {
+			ba, err := Parse(test.bitString)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := ba.GetBitAtIndex(test.index)
+			if test.err != "" && (err == nil || test.err != err.Error()) {
+				t.Errorf("expected %q error, but got: %+v", test.err, err)
+			} else if test.err == "" && err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+			} else if !reflect.DeepEqual(test.res, res) {
+				t.Errorf("expected %d, got %d", test.res, res)
+			}
+		})
+	}
+}
+
+func TestSetBitAtIndex(t *testing.T) {
+	testData := []struct {
+		bitString, err, res string
+		index, toSet        int
+	}{
+		{"1001010", "", "1101010", 1, 1},
+		{"1010101", "", "0010101", 0, 0},
+		{"1010101011", "", "1010101011", 0, 1},
+		{"1010101011", "", "1010101011", 1, 0},
+		{"111111111111110001010101000000", "", "111111111111110001011101000000", 20, 1},
+		{"010110", "SetBitAtIndex: bit index -1 out of valid range (0..5)", "", -1, 0},
+		{"10100110", "SetBitAtIndex: bit index 8 out of valid range (0..7)", "", 8, 0},
+		{"", "SetBitAtIndex: bit index 0 out of valid range (0..-1)", "", 0, 0},
+	}
+	for _, test := range testData {
+		t.Run(fmt.Sprintf("{%v,%d,%d}", test.bitString, test.index, test.toSet), func(t *testing.T) {
+			ba, err := Parse(test.bitString)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := ba.SetBitAtIndex(test.index, test.toSet)
+			if test.err != "" && (err == nil || test.err != err.Error()) {
+				t.Errorf("expected %q error, but got: %+v", test.err, err)
+			} else if test.err == "" && err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+			} else if !reflect.DeepEqual(test.res, res.String()) {
+				t.Errorf("expected %s, got %s", test.res, res.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
refs #45851

This commit adds builtin function get_bit() and set_bit() for varbits,
along with thier respective testcases.

Characteristics of the above builtin functions are:
    * get_bit() allows us to extracts a bit at given index in
      the bit array.
    * set_bit() enable us updates a bit at given index in the
      bit array.

Release justification: Release justification: low-risk addition of builtin functions.

Release note (sql change): This PR is introduced to add get_bits()
and set_bit() builtin functions for bits.