### PR TITLE
importccl: Improve error messages when importing mysql dump.

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -295,6 +295,9 @@ func readMysqlCreateTable(
 	var names []string
 	for {
 		stmt, err := mysql.ParseNextStrictDDL(tokens)
+		if err == nil {
+			err = tokens.LastError
+		}
 		if err == io.EOF {
 			break
 		}


### PR DESCRIPTION
Improve error reporting when importing mysql tables
using unsupported features (such as fulltext index).

Prior to this change, if we attempt to import:
CREATE TABLE posts (
  id INT NOT NULL AUTO_INCREMENT,
  title VARCHAR(255) NOT NULL,
  body TEXT,
  PRIMARY KEY (id),
  FULLTEXT KEY (body )
)

We would receive an error message:
  error executing 'IMPORT TABLE posts FROM MYSQLDUMP ($1)':
     pq: could not read definition for table "posts" (possible unsupported type?)

After this change, the error reporting improves to:
  error executing 'IMPORT TABLE posts FROM MYSQLDUMP ($1)': pq: mysql parse error:
    syntax error at position 914 near 'fulltext'

Release justification: Bug fix; minor, low/no impact formatting
change in the error messages.