### PR TITLE
roachtest: use team owner information fallback on issue assignee

### DIFF
--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -42,20 +42,21 @@ const (
 // OwnerMetadata contains information about a roachtest owning team, such as
 // team slack room, and github project.
 type OwnerMetadata struct {
-	SlackRoom string
+	SlackRoom    string
+	ContactEmail string
 }
 
 // roachtestOwners maps an owner in code (as specified on a roachtest spec) to
 // metadata used for github issue posting/slack rooms, etc.
 var roachtestOwners = map[Owner]OwnerMetadata{
-	OwnerAppDev:       {SlackRoom: `app-dev`},
-	OwnerBulkIO:       {SlackRoom: `bulk-io`},
-	OwnerCDC:          {SlackRoom: `cdc`},
-	OwnerKV:           {SlackRoom: `kv`},
-	OwnerPartitioning: {SlackRoom: `partitioning`},
-	OwnerSQLExec:      {SlackRoom: `sql-execution-team`},
-	OwnerSQLSchema:    {SlackRoom: `sql-schema`},
-	OwnerStorage:      {SlackRoom: `storage`},
+	OwnerAppDev:       {SlackRoom: `app-dev`, ContactEmail: `rafi@cockroachlabs.com`},
+	OwnerBulkIO:       {SlackRoom: `bulk-io`, ContactEmail: `david@cockroachlabs.com`},
+	OwnerCDC:          {SlackRoom: `cdc`, ContactEmail: `ajwerner@cockroachlabs.com`},
+	OwnerKV:           {SlackRoom: `kv`, ContactEmail: `andrei@cockroachlabs.com`},
+	OwnerPartitioning: {SlackRoom: `partitioning`, ContactEmail: `andrei@cockroachlabs.com`},
+	OwnerSQLExec:      {SlackRoom: `sql-execution-team`, ContactEmail: `jordan@cockroachlabs.com`},
+	OwnerSQLSchema:    {SlackRoom: `sql-schema`, ContactEmail: `lucy@cockroachlabs.com`},
+	OwnerStorage:      {SlackRoom: `storage`, ContactEmail: `peter@cockroachlabs.com`},
 	// Only for use in roachtest package unittests.
 	`unittest`: {},
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -628,6 +628,12 @@ func (r *testRunner) runTest(
 			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
 			if issues.CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
 				authorEmail := getAuthorEmail(t.spec.Tags, failLoc.file, failLoc.line)
+				if authorEmail == "" {
+					ownerInfo, ok := roachtestOwners[t.spec.Owner]
+					if ok {
+						authorEmail = ownerInfo.ContactEmail
+					}
+				}
 				branch := "<unknown branch>"
 				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
 					branch = b


### PR DESCRIPTION
This PR allows roachtest to use information about the team
owner of the roachtest to always give a roachtest failure
an assignee.

Release justification: non production code change

Release note: None