### PR TITLE
release-19.2: storage/engine: add missing cast from DBString to DBSlice

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2775,7 +2775,7 @@ func dbGetProto(
 		// Make a byte slice that is backed by result.data. This slice
 		// cannot live past the lifetime of this method, but we're only
 		// using it to unmarshal the roachpb.
-		data := cSliceToUnsafeGoBytes(result)
+		data := cSliceToUnsafeGoBytes(C.DBSlice{data: result.data, len: result.len})
 		err = protoutil.Unmarshal(data, msg)
 	}
 	C.free(unsafe.Pointer(result.data))


### PR DESCRIPTION
This isn't technically needed, but it is a very small/safe change and will remove irritation when we switch to go1.14 on master and then try to go back and test a fix on 19.2. 

Backport 1/1 commits from #45560.

/cc @cockroachdb/release

---

go1.14 complains about passing a `DBString` to
`cSliceToUnsafeGoBytes`. I'm not sure why go1.13 doesn't complain.
Casting the `DBString` parameter to a `DBSlice` avoids the issue.

Release note: None
