### PR TITLE
storage/cloud: Make it possible to disable  implicit credentials.

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -706,7 +706,11 @@ type ExternalIOConfig struct {
 	// This turns off http:// external storage as well as any custom
 	// endpoints cloud storage implementations.
 	DisableHTTP bool
-	// TODO(yevgeniy): Support disabling of implicit credentials in cloud storage.
+	// Disables the use of implicit credentials when accessing external services.
+	// Implicit credentials are obtained from the system environment.
+	// This turns off implicit credentials, and requires the user to provide
+	// necessary access keys.
+	DisableImplicitCredentials bool
 }
 
 // TempStorageConfigFromEnv creates a TempStorageConfig.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -584,6 +584,13 @@ a public network without combining it with --listen-addr.`,
 		Description: `Disable use of HTTP when accessing external data.`,
 	}
 
+	ExtenralIODisableImplicitCredentials = FlagInfo{
+		Name: "external-io-disable-implicit-credentials",
+		Description: `
+Disable use of implicit credentials when accessing external data.  
+Instead, require the user to always specify access keys.`,
+	}
+
 	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for
 	// certificate generation functions.
 	KeySize = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -362,7 +362,10 @@ func init() {
 
 		// Enable/disable various external storage endpoints.
 		serverCfg.ExternalIOConfig = base.ExternalIOConfig{}
-		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableHTTP, cliflags.ExternalIODisableHTTP, false)
+		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableHTTP,
+			cliflags.ExternalIODisableHTTP, false)
+		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableImplicitCredentials,
+			cliflags.ExtenralIODisableImplicitCredentials, false)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment
 		// variables, but share the same default.

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -294,7 +294,7 @@ func MakeExternalStorage(
 		return makeS3Storage(ctx, conf, dest.S3Config, settings)
 	case roachpb.ExternalStorageProvider_GoogleCloud:
 		telemetry.Count("external-io.google_cloud")
-		return makeGCSStorage(ctx, dest.GoogleCloudConfig, settings)
+		return makeGCSStorage(ctx, conf, dest.GoogleCloudConfig, settings)
 	case roachpb.ExternalStorageProvider_Azure:
 		telemetry.Count("external-io.azure")
 		return makeAzureStorage(dest.AzureConfig, settings)

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -63,7 +63,10 @@ func (g *gcsStorage) Conf() roachpb.ExternalStorage {
 }
 
 func makeGCSStorage(
-	ctx context.Context, conf *roachpb.ExternalStorage_GCS, settings *cluster.Settings,
+	ctx context.Context,
+	ioConf base.ExternalIOConfig,
+	conf *roachpb.ExternalStorage_GCS,
+	settings *cluster.Settings,
 ) (ExternalStorage, error) {
 	if conf == nil {
 		return nil, errors.Errorf("google cloud storage upload requested but info missing")
@@ -111,6 +114,10 @@ func makeGCSStorage(
 		}
 		opts = append(opts, option.WithTokenSource(source.TokenSource(ctx)))
 	case authParamImplicit:
+		if ioConf.DisableImplicitCredentials {
+			return nil, errors.New(
+				"implicit credentials disallowed for gs due to --external-io-implicit-credentials flag")
+		}
 		// Do nothing; use implicit params:
 		// https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials
 	default:

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -107,6 +107,10 @@ func makeS3Storage(
 		}
 		opts.Config.MergeIn(config)
 	case authParamImplicit:
+		if ioConf.DisableImplicitCredentials {
+			return nil, errors.New(
+				"implicit credentials disallowed for s3 due to --external-io-implicit-credentials flag")
+		}
 		opts.SharedConfigState = session.SharedConfigEnable
 	default:
 		return nil, errors.Errorf("unsupported value %s for %s", conf.Auth, AuthParam)


### PR DESCRIPTION
Fixes #44320

Make it possible to disable the use of implicit credentials
when accessing external http storage.

This change enables the operators to disable access to external
cloud services using implicit (i.e. environment/default) credentials.

Release note (security update): Make it possible for operators
to disable the use of implicit credentials when accessing
external cloud storage services for various bulk operations
(BACKUP, IMPORT, etc).

The use of implicit credentials can be disabled by an
--external-io-disable-implicit-credentials flag.

Release justification: Bug fix/security improvement.  This change
is a low/no-impact change addressing an outstanding security related
issue.