### PR TITLE
release-19.2: opt: improve distinct count and tightness estimation for multi-span constraints

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2657,7 +2657,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 	}
 
 	// Calculate distinct counts.
-	applied := sb.updateDistinctCountsFromConstraint(c, e, relProps)
+	applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, relProps)
 	for i, n := 0, c.ConstrainedColumns(sb.evalCtx); i < n; i++ {
 		col := c.Columns.Get(i).ID()
 		constrainedCols.Add(col)
@@ -2672,7 +2672,11 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 
 		// Set the distinct count for the current column of the constraint
 		// according to unknownDistinctCountRatio.
-		sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts)
+		var lowerBound float64
+		if i == applied {
+			lowerBound = lastColMinDistinct
+		}
+		sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts, lowerBound)
 	}
 
 	if !sb.shouldUseHistogram(relProps) {
@@ -2714,7 +2718,7 @@ func (sb *statisticsBuilder) applyConstraintSet(
 		col := c.Columns.Get(0).ID()
 
 		// Calculate distinct counts.
-		applied := sb.updateDistinctCountsFromConstraint(c, e, relProps)
+		applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, relProps)
 		if applied == 0 {
 			// If a constraint cannot be applied, it may represent an
 			// inequality like x < 1. As a result, distinctCounts does not fully
@@ -2725,7 +2729,7 @@ func (sb *statisticsBuilder) applyConstraintSet(
 
 			// Set the distinct count for the first column of the constraint
 			// according to unknownDistinctCountRatio.
-			sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts)
+			sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts, lastColMinDistinct)
 		}
 
 		if !tight {
@@ -2806,9 +2810,20 @@ func (sb *statisticsBuilder) updateNullCountsFromProps(e RelExpr, relProps *prop
 // constraint. For example, /a: [/1 - /1000000] would find a distinct count of
 // 1000000 for column "a" even if there are only 10 rows in the table. This
 // discrepancy must be resolved by the calling function.
+//
+// Even if the distinct count can not be inferred for a particular column,
+// It's possible that we can determine a lower bound. In particular, if the
+// query specifically mentions some exact values we should use that as a hint.
+// For example, consider the following constraint:
+//
+//   /a: [ - 5][10 - 10][15 - 15]
+//
+// In this case, updateDistinctCountsFromConstraint will infer that there
+// are at least two distinct values (10 and 15). This lower bound will be
+// returned in the second return value, lastColMinDistinct.
 func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 	c *constraint.Constraint, e RelExpr, relProps *props.Relational,
-) (applied int) {
+) (applied int, lastColMinDistinct float64) {
 	// All of the columns that are part of the prefix have a finite number of
 	// distinct values.
 	prefix := c.Prefix(sb.evalCtx)
@@ -2824,13 +2839,15 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 		distinctCount := 1.0
 
 		var val tree.Datum
+		countable := true
 		for i := 0; i < c.Spans.Count(); i++ {
 			sp := c.Spans.Get(i)
 			if sp.StartKey().Length() <= col || sp.EndKey().Length() <= col {
 				// We can't determine the distinct count for this column. For example,
 				// the number of distinct values for column b in the constraint
 				// /a/b: [/1/1 - /1] cannot be determined.
-				return applied
+				countable = false
+				continue
 			}
 			startVal := sp.StartKey().Value(col)
 			endVal := sp.EndKey().Value(col)
@@ -2847,7 +2864,8 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 					if !startDate.IsFinite() || !endDate.IsFinite() {
 						// One of the boundaries is not finite, so we can't determine the
 						// distinct count for this column.
-						return applied
+						countable = false
+						continue
 					}
 					start = float64(startDate.PGEpochDays())
 					end = float64(endDate.PGEpochDays())
@@ -2855,7 +2873,8 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 					// We can't determine the distinct count for this column. For example,
 					// the number of distinct values in the constraint
 					// /a: [/'cherry' - /'mango'] cannot be determined.
-					return applied
+					countable = false
+					continue
 				}
 				// We assume that both start and end boundaries are inclusive. This
 				// should be the case for integer and date columns (due to
@@ -2866,7 +2885,7 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 					distinctCount += start - end
 				}
 			}
-			if i != 0 {
+			if i != 0 && val != nil {
 				compare := startVal.Compare(sb.evalCtx, val)
 				ascending := c.Columns.Get(col).Ascending()
 				if (compare > 0 && ascending) || (compare < 0 && !ascending) {
@@ -2883,10 +2902,18 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 					// In this case, /a is a prefix, but not an exact prefix. Trying to
 					// figure out the distinct count for column b may be more trouble
 					// than it's worth. For now, don't bother trying.
-					return applied
+					countable = false
+					continue
 				}
 			}
 			val = endVal
+		}
+
+		if !countable {
+			// The last column was not fully applied since there was at least one
+			// uncountable span. The calculated distinct count will be used as a
+			// lower bound for updateDistinctCountFromUnappliedConjuncts.
+			return applied, distinctCount
 		}
 
 		colID := c.Columns.Get(col).ID()
@@ -2894,17 +2921,20 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 		applied = col + 1
 	}
 
-	return applied
+	return applied, 0
 }
 
 // updateDistinctCountFromUnappliedConjuncts is used to update the distinct
 // count for a constrained column when the exact count cannot be determined.
+// The provided lowerBound serves as a lower bound on the calculated distinct
+// count.
 func (sb *statisticsBuilder) updateDistinctCountFromUnappliedConjuncts(
-	colID opt.ColumnID, e RelExpr, relProps *props.Relational, numConjuncts float64,
+	colID opt.ColumnID, e RelExpr, relProps *props.Relational, numConjuncts, lowerBound float64,
 ) {
 	colSet := opt.MakeColSet(colID)
 	inputStat, _ := sb.colStatFromInput(colSet, e)
 	distinctCount := inputStat.DistinctCount * math.Pow(unknownFilterSelectivity, numConjuncts)
+	distinctCount = max(distinctCount, lowerBound)
 	sb.ensureColStat(colSet, distinctCount, e, relProps)
 }
 

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1239,3 +1239,82 @@ select
       └── similar-to [type=bool, outer=(3), constraints=(/3: [/'' - ])]
            ├── variable: v [type=string]
            └── const: '.*' [type=string]
+
+# We can determine that the constraint set is tight when there is a single
+# variable and tight constraints are combined with OR.
+opt
+SELECT * FROM a WHERE x <= 5 OR x = 10 OR x = 15
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── prune: (2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /5] [/10 - /10] [/15 - /15]; tight)]
+           ├── or [type=bool]
+           │    ├── le [type=bool]
+           │    │    ├── variable: x [type=int]
+           │    │    └── const: 5 [type=int]
+           │    └── eq [type=bool]
+           │         ├── variable: x [type=int]
+           │         └── const: 10 [type=int]
+           └── eq [type=bool]
+                ├── variable: x [type=int]
+                └── const: 15 [type=int]
+
+# The constraint set is also tight when each side has a single constraint with
+# matching columns.
+opt
+SELECT * FROM a WHERE (x, y) < (1, 2) OR (x, y) > (3, 4)
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1] [/3/5 - ]; tight)]
+           ├── lt [type=bool]
+           │    ├── tuple [type=tuple{int, int}]
+           │    │    ├── variable: x [type=int]
+           │    │    └── variable: y [type=int]
+           │    └── tuple [type=tuple{int, int}]
+           │         ├── const: 1 [type=int]
+           │         └── const: 2 [type=int]
+           └── gt [type=bool]
+                ├── tuple [type=tuple{int, int}]
+                │    ├── variable: x [type=int]
+                │    └── variable: y [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 3 [type=int]
+                     └── const: 4 [type=int]
+
+
+# The constraint set is not tight if there are multiple constraints with
+# different variables.
+opt
+SELECT * FROM a WHERE (x > 1 AND y > 10) OR (x < 5 AND y < 50)
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
+           ├── and [type=bool]
+           │    ├── gt [type=bool]
+           │    │    ├── variable: x [type=int]
+           │    │    └── const: 1 [type=int]
+           │    └── gt [type=bool]
+           │         ├── variable: y [type=int]
+           │         └── const: 10 [type=int]
+           └── and [type=bool]
+                ├── lt [type=bool]
+                │    ├── variable: x [type=int]
+                │    └── const: 5 [type=int]
+                └── lt [type=bool]
+                     ├── variable: y [type=int]
+                     └── const: 50 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -176,7 +176,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /'2017-01-04'] [/'2019-08-07' - /'2019-08-07'] [/'2019-08-08' - /'2019-08-08'])]
+      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /'2017-01-04'] [/'2019-08-07' - /'2019-08-07'] [/'2019-08-08' - /'2019-08-08']; tight)]
            ├── in [type=bool]
            │    ├── variable: d [type=date]
            │    └── tuple [type=tuple{date, date}]

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -114,7 +114,7 @@ SELECT * FROM a WHERE s = 'foo' OR s = 'bar'
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=133.333333, distinct(1)=133.333333, null(1)=0, distinct(2)=74.8385577, null(2)=0, distinct(3)=2, null(3)=0, distinct(2,3)=128.888889, null(2,3)=0, distinct(1-3)=133.333333, null(1-3)=0]
+ ├── stats: [rows=400, distinct(1)=400, null(1)=0, distinct(2)=98.8470785, null(2)=0, distinct(3)=2, null(3)=0, distinct(2,3)=360, null(2,3)=0, distinct(1-3)=400, null(1-3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  └── scan a@secondary
@@ -131,7 +131,7 @@ SELECT * FROM a WHERE s = 'foo' OR s = 'bar'
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=133.333333, distinct(3)=2, null(3)=0]
+ ├── stats: [rows=400, distinct(3)=2, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── scan a
@@ -140,7 +140,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
-      └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+      └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
 
 # Bump up null counts.
 exec-ddl
@@ -226,12 +226,12 @@ SELECT * FROM a WHERE (s = 'foo' OR s = 'bar') AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=66.6666667, distinct(1)=66.6666667, null(1)=0, distinct(2)=49.3854989, null(2)=33.3333333, distinct(3)=2, null(3)=0, distinct(2,3)=65.7755838, null(2,3)=50, distinct(1-3)=63.4151782, null(1-3)=50]
+ ├── stats: [rows=200, distinct(1)=200, null(1)=0, distinct(2)=88.4618791, null(2)=100, distinct(3)=2, null(3)=0, distinct(2,3)=191.943229, null(2,3)=150, distinct(1-3)=172.017276, null(1-3)=150]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=66.6666667, distinct(3)=2, null(3)=0]
+      ├── stats: [rows=200, distinct(3)=2, null(3)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -243,14 +243,14 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+           └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
 
 norm
 SELECT * FROM a WHERE (s = 'foo' OR s = 'bar') AND s IS NOT NULL
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=66.6666667, distinct(3)=2, null(3)=0]
+ ├── stats: [rows=200, distinct(3)=2, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── scan a
@@ -259,5 +259,4 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
-      ├── (s = 'foo') OR (s = 'bar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
-      └── s IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
+      └── ((s = 'foo') OR (s = 'bar')) AND (s IS NOT NULL) [type=bool, outer=(3), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -59,7 +59,7 @@ inner-join (lookup abcd)
  │    ├── fd: (7)-->(4,5), (1)==(4), (4)==(1)
  │    ├── select
  │    │    ├── columns: m:1(int) n:2(int!null)
- │    │    ├── stats: [rows=9.9, distinct(1)=9.9, null(1)=0, distinct(2)=0.333333333, null(2)=0]
+ │    │    ├── stats: [rows=9.9, distinct(1)=9.9, null(1)=0, distinct(2)=1, null(2)=0]
  │    │    ├── scan small
  │    │    │    ├── columns: m:1(int) n:2(int)
  │    │    │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0.1]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -150,7 +150,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -162,14 +162,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s <= 'aaa') OR (s >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ])]
+      └── (s <= 'aaa') OR (s >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ]; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS NULL
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -181,7 +181,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
-      └── ((s <= 'aaa') OR ((s >= 'bar') AND (s <= 'foo'))) OR (s IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo'])]
+      └── ((s <= 'aaa') OR ((s >= 'bar') AND (s <= 'foo'))) OR (s IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo']; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE s IS NOT NULL
@@ -198,7 +198,7 @@ SELECT s, d, x FROM a WHERE (s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -210,19 +210,19 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+      └── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5.0
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=37.037037, null(4)=0]
+      ├── stats: [rows=111.111111, distinct(3)=0.222222222, null(3)=0, distinct(4)=100, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -234,7 +234,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
 
 opt
@@ -242,12 +242,12 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=12.345679, distinct(3)=0.222222222, null(3)=0, distinct(4)=12.345679, null(4)=0]
+      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -259,7 +259,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
 
 # Bump up null counts.
@@ -344,7 +344,7 @@ SELECT s, d, x FROM a WHERE ((s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')) AND s 
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -356,14 +356,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s <= 'aaa') OR (s >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ])]
+      └── (s <= 'aaa') OR (s >= 'bar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'aaa'] [/'bar' - ]; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS NULL
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=333.333333]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=1000]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -375,7 +375,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
-      └── ((s <= 'aaa') OR ((s >= 'bar') AND (s <= 'foo'))) OR (s IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo'])]
+      └── ((s <= 'aaa') OR ((s >= 'bar') AND (s <= 'foo'))) OR (s IS NULL) [type=bool, outer=(3), constraints=(/3: [/NULL - /'aaa'] [/'bar' - /'foo']; tight)]
 
 opt
 SELECT s, d, x FROM a WHERE s IS NOT NULL
@@ -392,7 +392,7 @@ SELECT s, d, x FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=1000, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -404,19 +404,19 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
-      └── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+      └── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 5.0 AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=111.111111, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=12.345679, distinct(3)=0.333333333, null(3)=0, distinct(4)=12.345679, null(4)=0]
+      ├── stats: [rows=37.037037, distinct(3)=0.333333333, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -428,7 +428,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ])]
+           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
            └── d <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
 
 exec-ddl
@@ -770,7 +770,9 @@ SELECT * FROM hist WHERE c = 20 OR (c < 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(3)=15, null(3)=0]
+ ├── stats: [rows=110, distinct(3)=10, null(3)=0]
+ │   histogram(3)=  0  0  90  0   0  20
+ │                <--- 0 ---- 10 --- 20
  └── scan hist@idx_c
       ├── columns: c:3(decimal!null) rowid:8(int!null)
       ├── constraint: /3/8
@@ -787,7 +789,9 @@ SELECT * FROM hist WHERE c = 20 OR (c <= 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(3)=15, null(3)=0]
+ ├── stats: [rows=120, distinct(3)=11, null(3)=0]
+ │   histogram(3)=  0  0  90  10  0  20
+ │                <--- 0 ---- 10 --- 20
  └── scan hist@idx_c
       ├── columns: c:3(decimal!null) rowid:8(int!null)
       ├── constraint: /3/8
@@ -804,10 +808,14 @@ SELECT * FROM hist WHERE (d >= 5 AND d < 15) OR d >= 40
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float!null) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=111.111111, distinct(4)=15, null(4)=0]
+ ├── stats: [rows=185, distinct(4)=11.5, null(4)=0]
+ │   histogram(4)=  0          0          45   10   90          0           0   40
+ │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
  └── select
       ├── columns: d:4(float!null) rowid:8(int!null)
-      ├── stats: [rows=20.5555556, distinct(4)=3.83333333, null(4)=0]
+      ├── stats: [rows=185, distinct(4)=11.5, null(4)=0]
+      │   histogram(4)=  0          0          45   10   90          0           0   40
+      │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
       ├── key: (8)
       ├── fd: (8)-->(4)
       ├── scan hist@idx_d
@@ -821,7 +829,7 @@ index-join hist
       │    ├── key: (8)
       │    └── fd: (8)-->(4)
       └── filters
-           └── (d < 15.0) OR (d >= 40.0) [type=bool, outer=(4), constraints=(/4: (/NULL - /14.999999999999998] [/40.0 - ])]
+           └── (d < 15.0) OR (d >= 40.0) [type=bool, outer=(4), constraints=(/4: (/NULL - /14.999999999999998] [/40.0 - ]; tight)]
 
 opt
 SELECT * FROM hist WHERE e < '2018-07-31 23:00:00'::TIMESTAMP
@@ -861,7 +869,9 @@ SELECT * FROM hist WHERE g = 'mango' OR g = 'foo'
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string!null)
- ├── stats: [rows=16.6666667, distinct(7)=2, null(7)=0]
+ ├── stats: [rows=165, distinct(7)=2, null(7)=0]
+ │   histogram(7)=  0   135   0    30
+ │                <--- 'foo' --- 'mango'
  └── scan hist@idx_g
       ├── columns: g:7(string!null) rowid:8(int!null)
       ├── constraint: /7/8
@@ -879,13 +889,19 @@ SELECT * FROM hist WHERE (a = 10 OR a = 20) AND (b = '2018-08-31'::DATE OR b = '
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=0.0925925926, distinct(1)=0.0925925926, null(1)=0, distinct(2)=0.0925925926, null(2)=0]
+ ├── stats: [rows=1.5, distinct(1)=1.5, null(1)=0, distinct(2)=1.5, null(2)=0]
+ │   histogram(1)=  0 0.5  0  1
+ │                <--- 10 --- 20
+ │   histogram(2)=  0      0.6       0      0.9
+ │                <--- '2018-08-31' --- '2018-09-30'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- │    ├── stats: [rows=10]
+ │    ├── stats: [rows=30]
  │    └── select
  │         ├── columns: a:1(int!null) rowid:8(int!null)
- │         ├── stats: [rows=10, distinct(1)=2, null(1)=0]
+ │         ├── stats: [rows=30, distinct(1)=2, null(1)=0]
+ │         │   histogram(1)=  0  10  0  20
+ │         │                <--- 10 --- 20
  │         ├── key: (8)
  │         ├── fd: (8)-->(1)
  │         ├── scan hist@idx_a
@@ -899,22 +915,28 @@ select
  │         │    ├── key: (8)
  │         │    └── fd: (8)-->(1)
  │         └── filters
- │              └── (a = 10) OR (a = 20) [type=bool, outer=(1), constraints=(/1: [/10 - /10] [/20 - /20])]
+ │              └── (a = 10) OR (a = 20) [type=bool, outer=(1), constraints=(/1: [/10 - /10] [/20 - /20]; tight)]
  └── filters
-      └── (b = '2018-08-31') OR (b = '2018-09-30') [type=bool, outer=(2), constraints=(/2: [/'2018-08-31' - /'2018-08-31'] [/'2018-09-30' - /'2018-09-30'])]
+      └── (b = '2018-08-31') OR (b = '2018-09-30') [type=bool, outer=(2), constraints=(/2: [/'2018-08-31' - /'2018-08-31'] [/'2018-09-30' - /'2018-09-30']; tight)]
 
 opt
 SELECT * FROM hist WHERE (a = 30 OR a = 40) AND (b = '2018-06-30'::DATE OR b = '2018-07-31'::DATE)
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=0.0925925926, distinct(1)=0.0925925926, null(1)=0, distinct(2)=0.0925925926, null(2)=0]
+ ├── stats: [rows=0.7, distinct(1)=0.7, null(1)=0, distinct(2)=0.7, null(2)=0]
+ │   histogram(1)=  0 0.3  0 0.4
+ │                <--- 30 --- 40
+ │   histogram(2)=  0      0.7
+ │                <--- '2018-07-31'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- │    ├── stats: [rows=3.33333333]
+ │    ├── stats: [rows=10]
  │    └── select
  │         ├── columns: b:2(date!null) rowid:8(int!null)
- │         ├── stats: [rows=3.33333333, distinct(2)=1, null(2)=0]
+ │         ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+ │         │   histogram(2)=  0       10
+ │         │                <--- '2018-07-31'
  │         ├── key: (8)
  │         ├── fd: (8)-->(2)
  │         ├── scan hist@idx_b
@@ -928,6 +950,6 @@ select
  │         │    ├── key: (8)
  │         │    └── fd: (8)-->(2)
  │         └── filters
- │              └── (b = '2018-06-30') OR (b = '2018-07-31') [type=bool, outer=(2), constraints=(/2: [/'2018-06-30' - /'2018-06-30'] [/'2018-07-31' - /'2018-07-31'])]
+ │              └── (b = '2018-06-30') OR (b = '2018-07-31') [type=bool, outer=(2), constraints=(/2: [/'2018-06-30' - /'2018-06-30'] [/'2018-07-31' - /'2018-07-31']; tight)]
  └── filters
-      └── (a = 30) OR (a = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40])]
+      └── (a = 30) OR (a = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -150,7 +150,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -158,7 +158,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [/'foo' - /'bar']
  │    │    └── [/'aaa' - /NULL)
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -169,7 +169,7 @@ SELECT s, d, x FROM a WHERE (s <= 'aaa') OR (s >= 'bar' AND s <= 'foo') OR s IS 
 ----
 select
  ├── columns: s:3(string) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)~~>(1)
  ├── scan a@secondary
@@ -177,7 +177,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [/'foo' - /'bar']
  │    │    └── [/'aaa' - /NULL]
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
@@ -198,7 +198,7 @@ SELECT s, d, x FROM a WHERE (s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')
 ----
 select
  ├── columns: s:3(string!null) d:4(decimal!null) x:1(int!null)
- ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,4), (3,4)-->(1)
  ├── scan a@secondary
@@ -206,7 +206,7 @@ select
  │    ├── constraint: /-3/4
  │    │    ├── [ - /'foobar']
  │    │    └── [/'foo' - /'bar']
- │    ├── stats: [rows=1000, distinct(3)=0.666666667, null(3)=0]
+ │    ├── stats: [rows=1500, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -215,39 +215,31 @@ select
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5.0
 ----
-index-join a
+select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=500, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
- └── select
-      ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=111.111111, distinct(3)=0.222222222, null(3)=0, distinct(4)=100, null(4)=0]
-      ├── key: (1)
-      ├── fd: (1)-->(3,4), (3,4)-->(1)
-      ├── scan a@secondary
-      │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      │    ├── constraint: /-3/4
-      │    │    ├── [ - /'foobar']
-      │    │    └── (/'foo'/5.0 - /'bar']
-      │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=300, null(4)=0]
-      │    ├── key: (1)
-      │    └── fd: (1)-->(3,4), (3,4)-->(1)
-      └── filters
-           ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo'] [/'foobar' - ]; tight)]
-           └── d > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) b:5(bool)
+ │    ├── stats: [rows=3000, distinct(1)=2000, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=300, null(4)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+ └── filters
+      ├── ((s >= 'bar') AND (s <= 'foo')) OR (s >= 'foobar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo'] [/'foobar' - ]; tight)]
+      └── d > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 5.0 AND s IS NOT NULL
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+ ├── stats: [rows=500, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.222222222, null(3)=0, distinct(4)=33.3333333, null(4)=0]
+      ├── stats: [rows=166.666667, distinct(3)=1, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
@@ -255,7 +247,7 @@ index-join a
       │    ├── constraint: /-3/4
       │    │    ├── [ - /'foobar'/5.0]
       │    │    └── [/'foo' - /'bar'/5.0]
-      │    ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
+      │    ├── stats: [rows=500, distinct(1)=478.548451, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
@@ -416,7 +408,7 @@ index-join a
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(3)=0.333333333, null(3)=0, distinct(4)=33.3333333, null(4)=0]
+      ├── stats: [rows=111.111111, distinct(3)=1, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1514,7 +1514,7 @@ SELECT * FROM nation WHERE n_name = 'FRANCE' OR n_name = 'GERMANY'
 ----
 select
  ├── columns: n_nationkey:1(int!null) n_name:2(char!null) n_regionkey:3(int!null) neighbor:4(char!null)
- ├── stats: [rows=333333.333, distinct(2)=2, null(2)=0]
+ ├── stats: [rows=1000000, distinct(2)=2, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan nation
@@ -1523,7 +1523,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  └── filters
-      └── (n_name = 'FRANCE') OR (n_name = 'GERMANY') [type=bool, outer=(2), constraints=(/2: [/'FRANCE' - /'FRANCE'] [/'GERMANY' - /'GERMANY'])]
+      └── (n_name = 'FRANCE') OR (n_name = 'GERMANY') [type=bool, outer=(2), constraints=(/2: [/'FRANCE' - /'FRANCE'] [/'GERMANY' - /'GERMANY']; tight)]
 
 opt
 SELECT * FROM nation WHERE (n_name = 'FRANCE' AND neighbor = 'GERMANY') OR (n_name = 'GERMANY' AND neighbor = 'FRANCE')

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1732,3 +1732,32 @@ select
  │         └── CASE WHEN c0 > 0 THEN 1 ELSE t0.rowid END [type=int, outer=(1,2)]
  └── filters
       └── rowid > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2020-01-28 03:02:57.841772+00:00",
+    "row_count": 3,
+    "distinct_count": 3
+  }
+]'
+----
+
+# Regression test for #44563. Set a lower bound on the distinct count from
+# the multi-span constraint.
+norm
+SELECT * FROM a WHERE x <= 5 OR x = 10 OR x = 15
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=2, distinct(1)=2, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── stats: [rows=3, distinct(1)=3, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── ((x <= 5) OR (x = 10)) OR (x = 15) [type=bool, outer=(1), constraints=(/1: (/NULL - /5] [/10 - /10] [/15 - /15]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -339,7 +339,7 @@ project
  │    ├── scan a
  │    │    └── columns: f:3(float)
  │    └── filters
- │         └── (f IS NULL) OR (f != 10.5) [type=bool, outer=(3), constraints=(/3: [/NULL - /10.499999999999998] [/10.500000000000002 - ])]
+ │         └── (f IS NULL) OR (f != 10.5) [type=bool, outer=(3), constraints=(/3: [/NULL - /10.499999999999998] [/10.500000000000002 - ]; tight)]
  └── projections
       └── (f IS NULL) OR (f != 10.5) [type=bool, outer=(3)]
 

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -133,7 +133,7 @@ right-join (merge)
  │    │    ├── fd: (1)-->(2-5)
  │    │    └── ordering: +1 opt(4) [actual: +1]
  │    └── filters
- │         ├── (i < 0) OR (i > 10) [type=bool, outer=(2), constraints=(/2: (/NULL - /-1] [/11 - ])]
+ │         ├── (i < 0) OR (i > 10) [type=bool, outer=(2), constraints=(/2: (/NULL - /-1] [/11 - ]; tight)]
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
@@ -259,7 +259,7 @@ left-join (merge)
  │    │    ├── fd: (3)-->(4-7)
  │    │    └── ordering: +3 opt(6) [actual: +3]
  │    └── filters
- │         ├── (i < 0) OR (i > 10) [type=bool, outer=(4), constraints=(/4: (/NULL - /-1] [/11 - ])]
+ │         ├── (i < 0) OR (i > 10) [type=bool, outer=(4), constraints=(/4: (/NULL - /-1] [/11 - ]; tight)]
  │         └── s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
  └── filters
       └── y = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -551,7 +551,7 @@ select
  │    │    └── ordering: +6
  │    └── filters (true)
  └── filters
-      └── (x = 6) OR (x IS NULL) [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL] [/6 - /6])]
+      └── (x = 6) OR (x IS NULL) [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL] [/6 - /6]; tight)]
 
 opt expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
@@ -680,7 +680,7 @@ select
  │    │    │    └── fd: (1)-->(2-5)
  │    │    └── filters
  │    │         ├── f = 1.1 [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight), fd=()-->(3)]
- │    │         └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+ │    │         └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
  │    └── filters (true)
  └── filters
       └── (i < y) OR (y IS NULL) [type=bool, outer=(2,7)]
@@ -745,7 +745,7 @@ select
  │    │    └── ordering: +6
  │    └── filters (true)
  └── filters
-      └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
+      └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Don't push down conditions in case of FULL JOIN.
 opt
@@ -773,7 +773,7 @@ select
  │    │    └── ordering: +6
  │    └── filters (true)
  └── filters
-      └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100])]
+      └── (i = 100) OR (i IS NULL) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Push into semi-join.
 opt expect=PushSelectIntoJoinLeft
@@ -867,7 +867,7 @@ select
  │    │    │    └── fd: (3)-->(4-7)
  │    │    └── filters
  │    │         ├── f = 1.1 [type=bool, outer=(5), constraints=(/5: [/1.1 - /1.1]; tight), fd=()-->(5)]
- │    │         └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(6), constraints=(/6: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+ │    │         └── (s = 'foo') OR (s = 'bar') [type=bool, outer=(6), constraints=(/6: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
  │    └── filters (true)
  └── filters
       └── (i < y) OR (y IS NULL) [type=bool, outer=(2,4)]
@@ -898,7 +898,7 @@ select
  │    │    └── ordering: +3
  │    └── filters (true)
  └── filters
-      └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
+      └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # Don't push down conditions in case of FULL JOIN.
 opt
@@ -926,7 +926,7 @@ select
  │    │    └── ordering: +3
  │    └── filters (true)
  └── filters
-      └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100])]
+      └── (i = 100) OR (i IS NULL) [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL] [/100 - /100]; tight)]
 
 # --------------------------------------------------
 # MergeSelectInnerJoin

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -247,7 +247,7 @@ project
  │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
  │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
  │    │    │         │    │    │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r'])]
+ │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
  │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28(oid!null) n.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -250,7 +250,7 @@ sort
       │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
       │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
       │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r'])]
+      │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
       │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
       │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28(oid!null) n.nspname:29(string!null)
       │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']


### PR DESCRIPTION
Backport:
  * 1/1 commits from "opt: improve tightness estimation for constraints with OR" (#45732)
  * 1/1 commits from "opt: improve distinct count estimation for multi-span constraints" (#45771)

Please see individual PRs for details.

/cc @cockroachdb/release
