### PR TITLE
ui: Update colors and typography

### DIFF
--- a/pkg/ui/src/components/button/button.styl
+++ b/pkg/ui/src/components/button/button.styl
@@ -107,7 +107,7 @@
   margin-bottom 17px
   .crl-button__content
     font-family $font-family--base
-    font-size 14px
+    font-size $font-size--medium
     line-height 22px
     letter-spacing 0.1px
     color $colors--neutral-7

--- a/pkg/ui/src/views/app/components/Search/search.styl
+++ b/pkg/ui/src/views/app/components/Search/search.styl
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 @require '~styl/base/palette.styl'
+@require "~src/components/core/index.styl"
 
 ._search-form
   width 280px
@@ -37,7 +38,7 @@
     &:hover
       color $text-color
   ._submit-search
-    font-family Lato-Regular
+    font-family $font-family--base
     font-size 14px
     color $adminui-grey-2
     line-height 0px !important
@@ -45,7 +46,7 @@
       color $adminui-grey-2
   .ant-input
     font-size 14px
-    font-family Lato-Regular
+    font-family $font-family--base
     color $adminui-grey-1
     border-radius 3px
     border 2px solid $grey5

--- a/pkg/ui/src/views/app/components/chip/styles.styl
+++ b/pkg/ui/src/views/app/components/chip/styles.styl
@@ -9,10 +9,11 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
-  
+@require '~src/components/core/index'
+
 .Chip
   padding 4px 17px
-  color #5f6c87
+  color $colors--neutral-6
   font-family SourceSansPro-Regular
   font-size 12px
   border-radius 20px

--- a/pkg/ui/src/views/app/components/layoutSidebar/navigation-bar.styl
+++ b/pkg/ui/src/views/app/components/layoutSidebar/navigation-bar.styl
@@ -10,6 +10,7 @@
 
 @require '~styl/base/palette.styl'
 @require '~styl/base/layout-vars.styl'
+@require "~src/components/core/index.styl"
 
 // ---- Navigation ----
 $navbar-bg            = white
@@ -45,7 +46,7 @@ $subnav-underline-height = 3px
     width 100%
     padding 0
     border 0
-    font-family Lato-Bold
+    font-family $font-family--bold
     font-size 8px
     text-transform uppercase
     float left
@@ -69,7 +70,7 @@ $subnav-underline-height = 3px
       text-align center
 
       &--insecure
-        font-family Lato-Bold
+        font-family $font-family--bold
         font-size 8px
         text-transform uppercase
         text-align center
@@ -146,7 +147,7 @@ $subnav-underline-height = 3px
     list-style-type none
     line-height $subnav-height - $subnav-underline-height
 
-    font-family Lato-Bold
+    font-family $font-family--bold
     font-size 9px
     max-width calc(100vw - 80px)
     @media (min-width: 1300px)
@@ -204,7 +205,7 @@ $subnav-underline-height = 3px
 ul.pagination
   letter-spacing 2.17px
   text-transform uppercase
-  font-family Lato-Bold
+  font-family $font-family--bold
   font-size 1.1rem
   color $tooltip-color
   list-style-type none

--- a/pkg/ui/src/views/app/components/modal/styles.styl
+++ b/pkg/ui/src/views/app/components/modal/styles.styl
@@ -8,15 +8,17 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require '~src/components/core/index'
+
 .custom--modal
   border-radius 5px
   box-shadow 0 0 1px 0 rgba(71, 88, 114, 0.47)
-  background-color #ffffff
+  background-color $colors--white
   padding 0
   min-width 905px
   .ant-modal-close-x
     font-size 14px
-    color #242a35
+    color $colors--neutral-8
   .ant-modal-footer
     display flex
     justify-content flex-end
@@ -32,7 +34,7 @@
     font-size 20px
     line-height 1.6
     letter-spacing -0.2px
-    color #242a35
+    color $colors--neutral-8
   &__close--button
     width 70px
     height 40px
@@ -40,8 +42,8 @@
     justify-content center
     align-items center
     border-radius 3px
-    background-color #3a7ce1
-    color #ffffff
+    background-color $colors--primary-blue-3
+    color $colors--white
     font-family SourceSansPro-SemiBold
     font-size 14px
     line-height 1.71
@@ -49,5 +51,5 @@
     text-transform none
     margin 0
     &:hover, &:focus
-      background-color #3a7ce1
-      color #ffffff
+      background-color $colors--primary-blue-3
+      color $colors--white

--- a/pkg/ui/src/views/app/components/userMenu/userMenu.styl
+++ b/pkg/ui/src/views/app/components/userMenu/userMenu.styl
@@ -25,7 +25,7 @@
   padding 0 16px
 
 .user-menu__username
-  color #394455
+  color $colors--neutral-7
   padding 10px 16px
   font-weight bold
 

--- a/pkg/ui/src/views/app/components/userMenu/userMenu.styl
+++ b/pkg/ui/src/views/app/components/userMenu/userMenu.styl
@@ -19,7 +19,7 @@
   text-transform none
   text-align left
   font-weight normal
-  font-family Lato-Regular
+  font-family $font-family--base
 
 .user-menu__item
   padding 0 16px

--- a/pkg/ui/src/views/app/components/userMenu/userMenu.styl
+++ b/pkg/ui/src/views/app/components/userMenu/userMenu.styl
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
+@require '~src/components/core/index'
 
 .user-menu
   display flex
@@ -29,7 +30,7 @@
   font-weight bold
 
 .user-menu__logout-menu-item
-  color #3a7ce1
+  color $colors--primary-blue-3
   border-top-width 1px
   border-top-color $popover-border-color
   border-top-style solid

--- a/pkg/ui/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/src/views/app/containers/layout/layout.styl
@@ -94,7 +94,7 @@ $subnav-background  = $background-color
 .parent-link a
   color $link-color
   font-size 14px
-  font-family Lato-Regular
+  font-family $font-family--base
   font-weight bold
   text-transform uppercase
   text-decoration none
@@ -142,7 +142,7 @@ $subnav-background  = $background-color
   &__tooltip
     color $tooltip-color
     display inline-block
-    font-family Lato-Regular
+    font-family $font-family--base
     font-size 14px
     font-weight normal
     letter-spacing 0

--- a/pkg/ui/src/views/cluster/components/controls/controls.styl
+++ b/pkg/ui/src/views/cluster/components/controls/controls.styl
@@ -29,7 +29,7 @@
     letter-spacing 0.1px
     border-radius 4px
     &:hover
-      background-color #ededed
+      background-color $colors--white
   .btn__now.disabled button
     color rgba($colors--neutral-7, 0.5)
   .disabled
@@ -50,7 +50,7 @@
       &:first-child
         margin-left 0px
       &:hover
-        background-color #ededed
+        background-color $colors--white
       .anticon
           color $colors--neutral-5
       &.active

--- a/pkg/ui/src/views/cluster/components/controls/controls.styl
+++ b/pkg/ui/src/views/cluster/components/controls/controls.styl
@@ -18,7 +18,7 @@
   .btn__now.active, .btn__now button
     width 60px
     height 40px
-    border 1px solid #c8cbd4
+    border 1px solid $colors--neutral-4
     background-color transparent
     margin-left 8px
     color $colors--neutral-7
@@ -39,7 +39,7 @@
     display flex
     ._action, ._action > button
       margin-right 0px
-      border-color #c8cbd4
+      border-color $colors--neutral-4
       background-color transparent
       width 40px
       height 40px
@@ -52,7 +52,7 @@
       &:hover
         background-color #ededed
       .anticon
-          color #b8bbbc
+          color $colors--neutral-5
       &.active
         .anticon
-          color #3a7ce1
+          color $colors--primary-blue-3

--- a/pkg/ui/src/views/cluster/components/range/range.styl
+++ b/pkg/ui/src/views/cluster/components/range/range.styl
@@ -60,7 +60,7 @@
     flex-direction column
   ._title
     color $body-color
-    font-family Lato-Bold
+    font-family $font-family--bold
     font-size 12px
     margin-bottom 7.5px
     letter-spacing 0.1px
@@ -82,7 +82,7 @@
       vertical-align middle
     &.active
       .__option-label
-        font-family Lato-Regular
+        font-family $font-family--base
         color $colors--primary-blue-3
 
 .trigger
@@ -99,7 +99,7 @@
     text-transform initial
   ._label-time
     font-size: 13.5px
-    font-family Lato-Bold
+    font-family $font-family--bold
 
 .ant-calendar-today-btn
   color $link-color
@@ -138,7 +138,7 @@
     align-items center
     height 40px
     span
-      font-family Lato-Bold
+      font-family $font-family--bold
       color $colors--neutral-7
       font-size 14px
       letter-spacing 0.1px
@@ -166,7 +166,7 @@
   .ant-fullcalendar-calendar-body
     padding 8px 16px
     .ant-fullcalendar-column-header
-      font-family Lato-Bold
+      font-family $font-family--bold
       font-size 12px
       line-height 2
       letter-spacing 0.1px
@@ -179,7 +179,7 @@
           justify-content center
           align-items center
           padding 1.5px 4.95px
-          font-family Lato-Regular
+          font-family $font-family--base
           font-size 12px
           line-height 1.83
           letter-spacing 0.1px
@@ -213,7 +213,7 @@
             border 1px solid $colors--primary-blue-3
             color $colors--primary-blue-3
             &:hover
-              font-family Lato-Bold
+              font-family $font-family--bold
               background $colors--primary-blue-1
           &.ant-fullcalendar-selected-day
             .ant-fullcalendar-value
@@ -224,7 +224,7 @@
             &:hover
               background $background-color
             .ant-fullcalendar-value
-                font-family Lato-Bold
+                font-family $font-family--bold
                 color $colors--neutral-5
                 background $background-color
                 border 1px solid $colors--neutral-5

--- a/pkg/ui/src/views/cluster/components/range/range.styl
+++ b/pkg/ui/src/views/cluster/components/range/range.styl
@@ -41,7 +41,7 @@
   top: 45px
   background-color white
   box-shadow 0 0 4px 0 rgba(154, 161, 171, 0.33)
-  border solid 0.5px #e7ecf3
+  border solid 0.5px $colors--neutral-2
   border-radius 4px
   display flex
   flex-direction row

--- a/pkg/ui/src/views/cluster/components/range/range.styl
+++ b/pkg/ui/src/views/cluster/components/range/range.styl
@@ -123,12 +123,12 @@
 .range-calendar
   width 248px
   border-radius 4px
-  border solid 1px #e5e5e5
+  border solid 1px $colors--neutral-3
   margin-bottom 20px
   .calendar-today-btn
     width 100%
     height 40px
-    border-top solid 1px #e5e5e5
+    border-top solid 1px $colors--neutral-3
     display flex
     justify-content center
     align-items center

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -10,6 +10,7 @@
 
 @require nib
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 $viz-bottom = 65px
 $viz-sides = 62px
@@ -39,14 +40,14 @@ $viz-sides = 62px
 
   &__title
     font-size 14px
-    font-family Lato-Bold
+    font-family $font-family--bold
     color $body-color
 
   &__subtitle
     color $tooltip-color
     margin-left 5px
     font-size 12px
-    font-family Lato-Regular
+    font-family $font-family--base
 
   &__spinner
     width 40px

--- a/pkg/ui/src/views/cluster/containers/events/events.styl
+++ b/pkg/ui/src/views/cluster/containers/events/events.styl
@@ -14,7 +14,7 @@
 $event-message-line-height = 22px
 
 .events
-  font-family Lato-Regular
+  font-family $font-family--base
   table
     width 100%
     border-collapse collapse
@@ -47,7 +47,7 @@ $event-message-line-height = 22px
 .events__more-link
   text-align center
   color $link-color
-  font-family Lato-Bold
+  font-family $font-family--bold
   text-transform uppercase
   font-size 12px
   letter-spacing 2px

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/logs.styl
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/logs.styl
@@ -8,9 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require '~src/components/core/index'
+
 .logs-table
   tbody
-    font-family monospace
+    font-family $font-family--monospace
 
   &__message
     white-space pre

--- a/pkg/ui/src/views/cluster/containers/timescale/timescale.styl
+++ b/pkg/ui/src/views/cluster/containers/timescale/timescale.styl
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 .timescale
   display flex
@@ -25,6 +26,6 @@
   margin-left 15px
   color $button-border-color
   font-size 12px
-  font-family Lato-Regular
+  font-family $font-family--base
   &__time, &__date
     color $body-color

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -26,7 +26,7 @@ type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
 // Global set of colors for graph series.
 const seriesPalette = [
-  "#5F6C87", "#F2BE2C", "#F16969", "#4E9FD1", "#49D990", "#D77FBF", "#87326D", "#A3415B",
+  "#475872", "#FFCD02", "#F16969", "#4E9FD1", "#49D990", "#D77FBF", "#87326D", "#A3415B",
   "#B59153", "#C9DB6D", "#203D9B", "#748BF2", "#91C8F2", "#FF9696", "#EF843C", "#DCCD4B",
 ];
 

--- a/pkg/ui/src/views/reports/containers/customChart/customChart.styl
+++ b/pkg/ui/src/views/reports/containers/customChart/customChart.styl
@@ -10,6 +10,7 @@
 
 @require nib
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 .metric-table-dropdown
   line-height 17px
@@ -55,7 +56,7 @@ button.edit-button
   &__header
     background white
     padding 10px 20px
-    font-family Lato-Regular
+    font-family $font-family--base
     font-size 12px
     font-weight bold
     letter-spacing 2px

--- a/pkg/ui/src/views/reports/containers/localities/localities.styl
+++ b/pkg/ui/src/views/reports/containers/localities/localities.styl
@@ -9,12 +9,13 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 .locality-table
   width 100%
   border 1px solid $table-border-color
   border-collapse collapse
-  font-family Lato-Regular
+  font-family $font-family--base
   font-weight 300
   font-size 14px
   vertical-align top

--- a/pkg/ui/src/views/reports/containers/network/filter/filter.styl
+++ b/pkg/ui/src/views/reports/containers/network/filter/filter.styl
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require '~src/components/core/index'
+
 .multiple-filter__selection
   position absolute
   top 50px
@@ -38,21 +40,21 @@
     font-size 14px
     line-height 1.57
     letter-spacing 0.1px
-    color #5f6c87
+    color $colors--neutral-6
   .ant-select-arrow
     color #475872
   .ant-select-selection
     &:hover
-      border-color #3a7ce1
+      border-color $colors--primary-blue-3
     &:focus, &:active
-      border-color #3a7ce1
+      border-color $colors--primary-blue-3
 
 .filter--label
   font-family SourceSansPro-SemiBold
   font-size 12px
   line-height 1.67
   letter-spacing 0.3px
-  color #5f6c87
+  color $colors--neutral-6
   margin-bottom 7.5px
 
 .select-selection__deselect
@@ -62,7 +64,7 @@
     font-size 14px
     line-height 1.57
     letter-spacing 0.1px
-    color #3a7ce1
+    color $colors--primary-blue-3
 
 .filter__checkbox
   padding 7.5px 15px
@@ -75,4 +77,4 @@
     color #7e89a9
     margin-left 14px
     &__active
-      color #3a7ce1
+      color $colors--primary-blue-3

--- a/pkg/ui/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/src/views/reports/containers/network/latency/latency.styl
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 @require "~styl/base/palette.styl"
+@require '~src/components/core/index'
 
 .latency-table
   width 100%
@@ -15,7 +16,7 @@
   margin-top 17px
   border-radius 3px
   box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41)
-  background-color #ffffff
+  background-color $colors--white
   thead
     border-bottom 2px solid #e7ecf3
   tbody

--- a/pkg/ui/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/src/views/reports/containers/network/latency/latency.styl
@@ -18,15 +18,15 @@
   box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41)
   background-color $colors--white
   thead
-    border-bottom 2px solid #e7ecf3
+    border-bottom 2px solid $colors--neutral-2
   tbody
     .latency-table__cell
       &:not(:nth-child(1))
-        border-right 1px solid #e7ecf3
-        border-bottom 1px solid #e7ecf3
+        border-right 1px solid $colors--neutral-2
+        border-bottom 1px solid $colors--neutral-2
     .latency-table__cell--end
       &:not(:nth-child(1))
-        border-right 2px solid #e7ecf3
+        border-right 2px solid $colors--neutral-2
    .latency-table__row
       &:last-child
         .latency-table__cell
@@ -44,41 +44,41 @@
       letter-spacing 0.3px
       color $adminui-grey-2
       &:hover
-        color #0788ff
+        color $colors--primary-blue-3
         text-decoration underline
     &:first-child
-      border-right 2px solid #e7ecf3
+      border-right 2px solid $colors--neutral-2
     .Chip
       text-transform lowercase
 
 .latency-table__multiple
   .latency-table__cell--start
-    border-left 2px solid #e7ecf3
+    border-left 2px solid $colors--neutral-2
   th
     font-family SourceSansPro-SemiBold
-    font-size 12px
-    font-weight 600
+    font-size $font-size--small
+    font-weight $font-weight--bold
     line-height 1.67
     letter-spacing 0.3px
-    color $adminui-grey-2
+    color $colors--neutral-6
   thead
     .region-name
-      border-left 2px solid #e7ecf3
+      border-left 2px solid $colors--neutral-2
       text-align center
       padding-top 30px
   tbody
     th
       width 115px
-      border-bottom 2px solid #e7ecf3
+      border-bottom 2px solid $colors--neutral-2
       padding-left 22px
     .latency-table__cell
       &--header
         &:nth-child(1), &:nth-child(2)
           width 45px
           border-bottom none
-          border-right 2px solid #e7ecf3
+          border-right 2px solid $colors--neutral-2
     .latency-table__row--end
-        border-bottom 2px solid #e7ecf3
+        border-bottom 2px solid $colors--neutral-2
 
 .latency-table__empty
   padding: 30px;

--- a/pkg/ui/src/views/reports/containers/network/legend/legend.styl
+++ b/pkg/ui/src/views/reports/containers/network/legend/legend.styl
@@ -8,10 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require '~src/components/core/index'
+
 .Legend
   display flex
   max-width 713px
-  background-color #ffffff
+  background-color $colors--white
   border-radius 3px
   box-shadow 0 0 1px 0 rgba(67, 90, 111, 0.41)
   padding 20px 24px 12px
@@ -28,7 +30,7 @@
         text-transform uppercase
         font-family SourceSansPro-SemiBold
         font-size 12px
-        color #5f6c87
+        color $colors--neutral-6
         line-height 1.17
         letter-spacing 1.5px
         margin 0
@@ -48,7 +50,7 @@
           text-transform uppercase
           font-family SourceSansPro-SemiBold
           font-size 12px
-          color #5f6c87
+          color $colors--neutral-6
           line-height 1.17
           letter-spacing 1.5px
 
@@ -60,7 +62,7 @@
     font-size 12px
     line-height 2
     letter-spacing 0.1px
-    color #5f6c87
+    color $colors--neutral-6
     &:nth-child(3)
       border-left 1px solid #e7ecf3
   &--item
@@ -76,5 +78,4 @@
     &__normal
       font-family SourceSansPro-Regular
   &--item:nth-child(2n)
-    background #f6f6f6
- 
+    background $colors--background

--- a/pkg/ui/src/views/reports/containers/network/legend/legend.styl
+++ b/pkg/ui/src/views/reports/containers/network/legend/legend.styl
@@ -58,7 +58,7 @@
   width 100%
   td, th
     padding 11px 20px
-    font-family Lato-Bold
+    font-family $font-family--bold
     font-size 12px
     line-height 2
     letter-spacing 0.1px

--- a/pkg/ui/src/views/reports/containers/network/legend/legend.styl
+++ b/pkg/ui/src/views/reports/containers/network/legend/legend.styl
@@ -35,7 +35,7 @@
         letter-spacing 1.5px
         margin 0
       .info-icon
-        color #7e89a9
+        color $colors--neutral-5
         font-size 16px
         margin-left 7px
     &__body
@@ -64,7 +64,7 @@
     letter-spacing 0.1px
     color $colors--neutral-6
     &:nth-child(3)
-      border-left 1px solid #e7ecf3
+      border-left 1px solid $colors--neutral-2
   &--item
     td
       padding 16px 20px

--- a/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
+++ b/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 .alert-box
   clearfix()
@@ -19,7 +20,7 @@
   padding 20px
   border 1px solid $headings-color
   border-radius 5px
-  font-family Lato-Regular
+  font-family $font-family--base
 
   &__icon
     flex 0

--- a/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
+++ b/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
@@ -13,7 +13,7 @@
 .alert-massage
   max-width 470px
   min-height 50px
-  font-size 12px
+  font-size $font-size--small
   // it is !important because Ant sets margin to 0
   // when closing animation happens and Alert panel
   // jumps to the left side.
@@ -37,9 +37,8 @@
     top 0
     padding-right 16px
   .ant-alert-message
-    font-size 14px
+    @extends $text--body-strong
     color $colors--neutral-8
-    font-weight 600
 
   &__close-text
     color $colors--neutral-7
@@ -49,4 +48,4 @@
     font-weight $font-weight--extra-bold
 
 .ant-alert-success .alert-massage__icon
-  color #37a806
+  color $colors--primary-green-3

--- a/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
+++ b/pkg/ui/src/views/shared/components/alertMessage/alertMessage.styl
@@ -21,8 +21,8 @@
   padding-left 48px
   border-radius 3px
   box-shadow 0 0 10px 0 rgba(71, 88, 114, 0.47)
-  background-color #ffffff
-  border-color #ffffff
+  background-color $colors--white
+  border-color $colors--white
   display: flex;
   flex-direction column
   justify-content center
@@ -38,7 +38,7 @@
     padding-right 16px
   .ant-alert-message
     font-size 14px
-    color #242a35
+    color $colors--neutral-8
     font-weight 600
 
   &__close-text

--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
@@ -71,7 +71,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
     font-size 12px
     line-height 24px
     letter-spacing 0.1px
-    font-family Lato-Bold
+    font-family $font-family--bold
 
   &__select
     display inline-block
@@ -88,7 +88,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
       background-color $dropdown-hover-color
 
   &__side-arrow
-    font-family Lato-Bold
+    font-family $font-family--bold
     display none
     color $adminui-grey-1
     cursor pointer

--- a/pkg/ui/src/views/shared/components/icons/index.tsx
+++ b/pkg/ui/src/views/shared/components/icons/index.tsx
@@ -88,7 +88,7 @@ export let warningIcon: string = `<svg width="21px" height="21px" viewBox="0 0 2
         <g id="Alert" transform="translate(-18.000000, -20.000000)">
             <g id="Group-4">
                 <g id="Group-2" transform="translate(18.000000, 20.000000)">
-                    <circle id="Oval-5" fill="#F2BE2C" cx="10.5" cy="10.5" r="10.5"></circle>
+                    <circle id="Oval-5" fill="#FFCD02" cx="10.5" cy="10.5" r="10.5"></circle>
                     <text id="!" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="#FFFFFF">
                         <tspan x="8" y="16">!</tspan>
                     </text>

--- a/pkg/ui/src/views/shared/components/icons/index.tsx
+++ b/pkg/ui/src/views/shared/components/icons/index.tsx
@@ -68,7 +68,7 @@ export let criticalIcon: string = `<svg width="20px" height="20px" viewBox="0 0 
             <g id="Group-3">
                 <g transform="translate(25.000000, 19.000000)">
                     <path d="M8.75139389,1.26729609 C9.24631171,0.277343549 10.0519669,0.283622947 10.5438615,1.26729609 L19.1995435,18.5766161 C19.4476073,19.0726851 19.1933971,19.4748284 18.6568996,19.4748284 L0.640505826,19.4748284 C0.092748094,19.4748284 -0.15156708,19.0753209 0.0977558747,18.5766161 L8.75139389,1.26729609 Z" id="Rectangle-4" fill="#F26969"></path>
-                    <g id="Group-2" transform="translate(8.000000, 3.000000)" font-size="14" font-family="Lato-Bold, Lato" fill="#FFFFFF" font-weight="bold">
+                    <g id="Group-2" transform="translate(8.000000, 3.000000)" font-size="14" font-family="SourceSansPro-Bold, SourceSansPro-Regular" fill="#FFFFFF" font-weight="bold">
                         <text id="!">
                             <tspan x="0" y="14">!</tspan>
                         </text>
@@ -89,7 +89,7 @@ export let warningIcon: string = `<svg width="21px" height="21px" viewBox="0 0 2
             <g id="Group-4">
                 <g id="Group-2" transform="translate(18.000000, 20.000000)">
                     <circle id="Oval-5" fill="#FFCD02" cx="10.5" cy="10.5" r="10.5"></circle>
-                    <text id="!" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="#FFFFFF">
+                    <text id="!" font-family="SourceSansPro-Bold, SourceSansPro-Regular" font-size="14" font-weight="bold" fill="#FFFFFF">
                         <tspan x="8" y="16">!</tspan>
                     </text>
                 </g>

--- a/pkg/ui/src/views/shared/components/sql/sqlhighlight.styl
+++ b/pkg/ui/src/views/shared/components/sql/sqlhighlight.styl
@@ -9,9 +9,10 @@
 // licenses/APL.txt.
 
 @require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
 
 .box-highlight
-  font-family Inconsolata-Regular
+  font-family $font-family--monospace
   padding 20px
   width 100%
   margin-bottom 10px

--- a/pkg/ui/src/views/shared/components/sql/sqlhighlight.styl
+++ b/pkg/ui/src/views/shared/components/sql/sqlhighlight.styl
@@ -55,5 +55,5 @@
 .higlight-divider
   width 100%
   height 1px
-  border-bottom 1px dashed #475872
+  border-bottom 1px dashed $colors--neutral-6
   margin 15px 0

--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -91,7 +91,7 @@
     font-size 12px
     line-height 18px
     letter-spacing 0.1px
-    font-family Lato-Regular
+    font-family $font-family--base
     color $colors--neutral-6
 
   & + &
@@ -119,7 +119,7 @@
   &--link &__value
     a
       text-decoration none
-      font-family Lato-Regular
+      font-family $font-family--base
       color $link-color
 
 .summary-stat-breakdown

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -36,7 +36,7 @@
     background rgba($colors--neutral-0, .98)
     font-family Lato-Regular
     text-align left
-    color #5F6C87
+    color $colors--neutral-6
 
 .tooltip__preset--placement-bottom
   .ant-tooltip-content

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -34,7 +34,7 @@
     border solid 1px $colors--neutral-2
     box-shadow 0 4px 4px 0 rgba(0, 0, 0, 0.15)
     background rgba($colors--neutral-0, .98)
-    font-family Lato-Regular
+    font-family $font-family--base
     text-align left
     color $colors--neutral-6
 

--- a/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
+++ b/pkg/ui/src/views/shared/components/userAvatar/userAvatar.styl
@@ -14,8 +14,8 @@
   height $line-height--large
   width $line-height--large
   border-radius 50%
-  background-color #e0eefb
-  color: #0788ff
+  background-color $colors--primary-blue-1
+  color: $colors--primary-blue-3
   font-size 14px
   font-weight bold
   line-height $line-height--large
@@ -24,12 +24,12 @@
   text-align center
 
 .user-avatar:hover
-  border solid 2px #0788ff
+  border solid 2px $colors--primary-blue-3
   line-height "calc( %s - 4px )" % $line-height--large
 
 .user-avatar--disabled
-  background-color #e7ecf3
-  color #7e89a9
+  background-color $colors--neutral-2
+  color $colors--neutral-5
 
 .user-avatar--disabled:hover
   border none

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -207,13 +207,7 @@
       height 3px
       background-color $blue
 
-$plan-node-line-color = #DADADA                                 // connecting line: light gray
-$plan-node-warning-color = #b26000                              // dark orange
 $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
-$plan-node-warning-border-color = rgba(209, 135, 55, 0.3)       // dark orange 2
-$plan-node-details-background-color = $colors--background       // grayish-white
-$plan-node-details-border-color = #ACB8CB                       // dark gray
-$plan-node-attribute-key-color = #37a806                        // light green
 
 .plan-view-table
   @extend $table-base
@@ -263,12 +257,12 @@ $plan-node-attribute-key-color = #37a806                        // light green
     position relative
     top 3px
     path
-      fill $plan-node-warning-color
+      fill $colors--functional-orange-4
 
   .warn
     position relative
     left -5px
-    color $plan-node-warning-color
+    color $colors--functional-orange-4
     background-color $plan-node-warning-background-color
     border-radius 2px
     padding 2px
@@ -296,7 +290,7 @@ $plan-node-attribute-key-color = #37a806                        // light green
     line-height 1.83
 
     .nodeAttributeKey
-      color $plan-node-attribute-key-color
+      color $colors--primary-green-3
 
   ul
     padding 0

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -14,7 +14,7 @@
 
 .statements-table
   &__col-query-text
-    font-family monospace
+    font-family $font-family--monospace
     white-space pre-wrap
 
 .statements
@@ -37,7 +37,7 @@
   letter-spacing 0.1px
   .label
     font-family $font-family--bold
-    color #394455
+    color $colors--neutral-7
 
 .last-cleared-tooltip, .numeric-stats-table, .plan-view-table
   &__tooltip

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -36,7 +36,7 @@
   line-height 1.57
   letter-spacing 0.1px
   .label
-    font-family Lato-Bold
+    font-family $font-family--bold
     color #394455
 
 .last-cleared-tooltip, .numeric-stats-table, .plan-view-table

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -10,6 +10,7 @@
 
 @require '~styl/base/palette.styl'
 @require '~src/views/shared/util/table.styl'
+@require '~src/components/core/index'
 
 .statements-table
   &__col-query-text
@@ -210,7 +211,7 @@ $plan-node-line-color = #DADADA                                 // connecting li
 $plan-node-warning-color = #b26000                              // dark orange
 $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
 $plan-node-warning-border-color = rgba(209, 135, 55, 0.3)       // dark orange 2
-$plan-node-details-background-color = #F6F6F6                   // grayish-white
+$plan-node-details-background-color = $colors--background       // grayish-white
 $plan-node-details-border-color = #ACB8CB                       // dark gray
 $plan-node-attribute-key-color = #37a806                        // light green
 
@@ -385,7 +386,7 @@ $plan-node-attribute-key-color = #37a806                        // light green
     top 50%
     left 50%
     transform: translate(-50%, -50%)
-    color #b8bbbc
+    color $colors--neutral-5
     font-size 14px
     letter-spacing 1.5px
   .anticon

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -11,16 +11,16 @@
 @require '~src/components/core/index'
 
 // Primary Palette
-$headings-color = #00294d
+$headings-color = $colors--primary-blue-5
 $healthy-color = #66AA26
 $warning-color   = $colors--warning
 $alert-color    = $colors--alert
-$adminui-grey-1    = #242a35
+$adminui-grey-1    = $colors--neutral-8
 $adminui-grey-2    = #5f6c87
 $adminui-blue-1-base    = #3a7ce1
 $body-color = #5F6C87
-$text-color = #394455
-$secondary-text-color = #7e89a9
+$text-color = $colors--neutral-7
+$secondary-text-color = $colors--neutral-5
 $link-color = #3A7DE1
 $tooltip-color = #B8BBBC
 $tooltip-shadow = rgba(0, 0, 0, .20)
@@ -29,8 +29,8 @@ $button-border-color = #C8CBD4
 $background-color  = $colors--background
 $main-blue-color = #3A7DE1  // This should match MAIN_BLUE from colors.tsx
 $grey = #b8bbbc
-$grey-light = #c0c6d9
-$adminui-white = #fff
+$grey-light = $colors--neutral-4
+$adminui-white = $colors--white
 $table-border = #dbe1ea
 
 // Alert colors
@@ -51,27 +51,27 @@ $syntax-string-color = #E4843C
 $syntax-keyword-color = #91C8F2
 
 // Popover colors
-$popover-color = #394455
+$popover-color = $colors--neutral-7
 $popover-shadow-color = #9aa1ab
-$popover-border-color = #e7ecf3
+$popover-border-color = $colors--neutral-2
 
 // classes colors
 $link = #3a7ce1
-$checkbox-border = #7e89a9
-$checkbox-border-hover = #c0c6d9
+$checkbox-border = $colors--neutral-5
+$checkbox-border-hover = $colors--neutral-4
 
 // default
 $lightgreen = #e1f2d1
 $lightblue = #e0f1ff
-$yellow = #fef1da
-$placeholder = #475872
-$blue = #0788ff
-$light-blue = #74bdfd
-$green = #37a806
-$grey2 = #d6dbe7
+$yellow = $colors--functional-orange-1
+$placeholder = $colors--neutral-6
+$blue = $colors--primary-blue-3
+$light-blue = $colors--primary-blue-2
+$green = $colors--primary-green-3
+$grey2 = $colors--neutral-3
 $chip-green = #b5e28b
 $chip-lightgreen = #e1f2d1
-$chip-grey = #f5f7fa
+$chip-grey = $colors--neutral-1
 $chip-blue = #bee1ff
 $chip-lightblue = #e0f1ff
-$chip-yellow = #fef1da
+$chip-yellow = $colors--functional-orange-1

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -12,66 +12,65 @@
 
 // Primary Palette
 $headings-color = $colors--primary-blue-5
-$healthy-color = #66AA26
+$healthy-color = $colors--primary-green-3
 $warning-color   = $colors--warning
 $alert-color    = $colors--alert
 $adminui-grey-1    = $colors--neutral-8
-$adminui-grey-2    = #5f6c87
-$adminui-blue-1-base    = #3a7ce1
-$body-color = #5F6C87
+$adminui-grey-2    = $colors--neutral-6
+$adminui-blue-1-base    = $colors--primary-blue-3
+$body-color = $colors--neutral-6
 $text-color = $colors--neutral-7
 $secondary-text-color = $colors--neutral-5
-$link-color = #3A7DE1
-$tooltip-color = #B8BBBC
-$tooltip-shadow = rgba(0, 0, 0, .20)
-$table-border-color = #EDEDED
-$button-border-color = #C8CBD4
+$link-color = $colors--primary-blue-3
+$tooltip-color = $colors--neutral-5
+$table-border-color = $colors--neutral-2
+$button-border-color = $colors--neutral-4
 $background-color  = $colors--background
-$main-blue-color = #3A7DE1  // This should match MAIN_BLUE from colors.tsx
-$grey = #b8bbbc
+$main-blue-color = $colors--primary-blue-3
+$grey = $colors--neutral-5
 $grey-light = $colors--neutral-4
 $adminui-white = $colors--white
-$table-border = #dbe1ea
+$table-border = $colors--neutral-2
 
 // Alert colors
-$notification-alert-fill-color = #F4D9D9
-$notification-alert-border-color = #F2B7B7
-$notification-info-fill-color = #F2F8EC
-$notification-info-border-color = #C8E0AF
-$notification-warning-fill-color = #FDF8E9
-$notification-warning-border-color = #F9E6AF
+$notification-alert-fill-color = $colors--functional-red-1
+$notification-alert-border-color = $colors--functional-red-2
+$notification-info-fill-color = $colors--primary-blue-1
+$notification-info-border-color = $colors--primary-blue-2
+$notification-warning-fill-color = $colors--functional-orange-1
+$notification-warning-border-color = $colors--functional-orange-2
 
 // Info box colors
-$info-box-fill-color = #EEF7FE
-$info-box-border-color = #3A7DE1
-$info-box-heading-color = #3A7DE1
+$info-box-fill-color = $colors--primary-blue-1
+$info-box-border-color = $colors--primary-blue-3
+$info-box-heading-color = $colors--primary-blue-3
 
 // Syntax highlight colors
-$syntax-string-color = #E4843C
-$syntax-keyword-color = #91C8F2
+$syntax-string-color = $colors--functional-orange-4
+$syntax-keyword-color = $colors--primary-blue-2
 
 // Popover colors
 $popover-color = $colors--neutral-7
-$popover-shadow-color = #9aa1ab
+$popover-shadow-color = $colors--neutral-5
 $popover-border-color = $colors--neutral-2
 
 // classes colors
-$link = #3a7ce1
+$link = $colors--primary-blue-3
 $checkbox-border = $colors--neutral-5
 $checkbox-border-hover = $colors--neutral-4
 
 // default
-$lightgreen = #e1f2d1
-$lightblue = #e0f1ff
+$lightgreen = $colors--primary-green-1
+$lightblue = $colors--primary-blue-1
 $yellow = $colors--functional-orange-1
 $placeholder = $colors--neutral-6
 $blue = $colors--primary-blue-3
 $light-blue = $colors--primary-blue-2
 $green = $colors--primary-green-3
 $grey2 = $colors--neutral-3
-$chip-green = #b5e28b
-$chip-lightgreen = #e1f2d1
+$chip-green = $colors--primary-green-1
+$chip-lightgreen = $colors--primary-green-1
 $chip-grey = $colors--neutral-1
-$chip-blue = #bee1ff
-$chip-lightblue = #e0f1ff
+$chip-blue = #74bdfd80 // $colors--primary-blue-2 + 0.5 opacity
+$chip-lightblue = $colors--primary-blue-1
 $chip-yellow = $colors--functional-orange-1

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -9,18 +9,19 @@
 // licenses/APL.txt.
 
 @require 'utils/fonts.styl'
+@require "~src/components/core/index.styl"
 
 // Using the same strategy as sassline: establish the root size (rems) as 1/2
 // of our chosen baseline height. This allows easy, integer math for baseline units
 // using rems.
 html
-  font-size 14px
+  font-size $font-size--medium
 
 body
-  line-height 20px
+  line-height $line-height--small
   font-size $font-base-size
   font-family Lato-Regular
-  font-weight 400
+  font-weight $font-weight--light
 
 h1.base-heading
   font-size 24px
@@ -32,7 +33,7 @@ h2.base-heading
   font-family SourceSansPro-Regular
 
 code
-  font-family Inconsolata-Regular
+  font-family $font-family--monospace
 
 font-face('Lato-Light')
 font-face('Lato-Bold')


### PR DESCRIPTION
Resolves: #45471

Current change is intended to:
- unify styles across entire app (fonts, sizes, colors)
- remove dependency on redundant styles in `palette.styl`

Before, the main source of design tokens was located in `palette.styl` and `pkg/ui/styl/base` dir. 
These styles in general don't match to new changed designs and have to be replaced with a new ones, which now are stored in `src/components/core` (colors and typography).
Also a lot of styles were hardcoded across entire app in different style files.

To make styles more unified and make one step forward to get rid of old styles, following
changes were made:
- Hardcoded values in component styles were replaced to appropriate design tokens;
- Defined tokens in `palette.styl` which exactly match to new designs are re-referenced to new designs (so the act like aliases so it doesn't break existing code)
- Remapped colors and font styles according to rules defined in #45471 

~~What is not included:~~
- ~~Current which required total redesign of particular components~~
- ~~or changes which might affect/break page layouts.~~

Release note (admin ui change): 
- Update colors according to new designs
-  Use new SourceSansPro
font across all Admin UI
- Update font styles for monospace text
(sql statements, etc)

Release justification: bug fixes and low-risk updates to new functionality