### PR TITLE
ui: Fix width (max-content, fit-content) styles in Firefox

### DIFF
--- a/pkg/ui/src/components/badge/badge.styl
+++ b/pkg/ui/src/components/badge/badge.styl
@@ -16,6 +16,7 @@
   border-radius 3px
   text-transform uppercase
   width max-content
+  width -moz-max-content
   padding $spacing-xx-small $spacing-x-small
   cursor default
 

--- a/pkg/ui/src/components/button/button.styl
+++ b/pkg/ui/src/components/button/button.styl
@@ -14,6 +14,7 @@
   border-radius 3px
   cursor pointer
   width max-content
+  width -moz-max-content
 
 .crl-button--type-flat
   border solid 1px transparent

--- a/pkg/ui/src/views/jobs/index.styl
+++ b/pkg/ui/src/views/jobs/index.styl
@@ -122,6 +122,7 @@
       height 20px
   .jobs-table__status
     width fit-content
+    width -moz-fit-content
     font-size 12px
     margin-bottom 0
   .job-status__line

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticStatusBadge.styl
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticStatusBadge.styl
@@ -11,3 +11,4 @@
 .diagnostic-status-badge
   &__content
     width fit-content
+    width -moz-fit-content


### PR DESCRIPTION
In general we use nib() extension for Stylus to apply
browser prefixes for styles if necessary and in most
cases we don't need to do this manually.

But it happened, `width` values `max-content`, `fit-content`
require browser prefix -moz- to be recognized by Firefox and
nib() extension doesn't do this.

It is required for Firefox browser only.

Release justification: bug fixes and low-risk updates to new functionality