### PR TITLE
leaktest: recover from panics

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -88,14 +88,18 @@ var leakDetectorDisabled uint32
 // function to be run at the end of tests to see whether any
 // goroutines leaked.
 func AfterTest(t testing.TB) func() {
-	if atomic.LoadUint32(&leakDetectorDisabled) != 0 {
-		return func() {}
-	}
 	orig := interestingGoroutines()
 	return func() {
+		t.Helper()
 		// If there was a panic, "leaked" goroutines are expected.
 		if r := recover(); r != nil {
-			panic(r)
+			atomic.StoreUint32(&leakDetectorDisabled, 1)
+			t.Fatalf("panic: %+v", r)
+			return
+		}
+
+		if atomic.LoadUint32(&leakDetectorDisabled) != 0 {
+			return
 		}
 
 		// If the test already failed, we don't pile on any more errors but we check


### PR DESCRIPTION
This turns tests that panic into failed tests, which means that the test
suite has a chance of running to completion.

Release justification: testing-only change
Release note: None