### PR TITLE
kvserver: fix up multiTestContext clocks

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -95,6 +95,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	sc := kvserver.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableMergeQueue = true
 	sc.EnableEpochRangeLeases = true
+	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 1)

--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -154,6 +154,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	mtc := &multiTestContext{}
 	cfg := kvserver.TestStoreConfig(nil)
 	cfg.TestingKnobs.DisableEagerReplicaRemoval = true
+	cfg.Clock = nil // manual clock
 	mtc.storeConfig = &cfg
 
 	defer mtc.Stop()

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1409,6 +1409,7 @@ func runSetupSplitSnapshotRace(
 	// Disable the split delay mechanism, or it'll spend 10s going in circles.
 	// (We can't set it to zero as otherwise the default overrides us).
 	sc.RaftDelaySplitToSuppressSnapshotTicks = -1
+	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 6)

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -44,6 +44,7 @@ import (
 func TestConsistencyQueueRequiresLive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	sc := kvserver.TestStoreConfig(nil)
+	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
@@ -55,7 +56,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 
 	// Verify that queueing is immediately possible.
 	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); !shouldQ {
+		context.TODO(), mtc.clock().Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); !shouldQ {
 		t.Fatalf("expected shouldQ true; got %t, %f", shouldQ, priority)
 	}
 
@@ -64,7 +65,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 	mtc.advanceClock(context.TODO())
 
 	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); shouldQ {
+		context.TODO(), mtc.clock().Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); shouldQ {
 		t.Fatalf("expected shouldQ false; got %t, %f", shouldQ, priority)
 	}
 }
@@ -176,6 +177,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := kvserver.TestStoreConfig(nil)
+	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{
 		storeConfig: &sc,
 		// This test was written before the multiTestContext started creating many

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -224,7 +224,7 @@ func TestNodeHeartbeatCallback(t *testing.T) {
 
 	// Verify that last update time has been set for all nodes.
 	verifyUptimes := func() error {
-		expected := mtc.clock.Now()
+		expected := mtc.clock().Now()
 		for i, s := range mtc.stores {
 			uptm, err := s.ReadLastUpTimestamp(context.Background())
 			if err != nil {
@@ -506,7 +506,7 @@ func TestNodeLivenessGetLivenesses(t *testing.T) {
 
 	livenesses := mtc.nodeLivenesses[0].GetLivenesses()
 	actualLMapNodes := make(map[roachpb.NodeID]struct{})
-	originalExpiration := mtc.clock.PhysicalNow() + mtc.nodeLivenesses[0].GetLivenessThreshold().Nanoseconds()
+	originalExpiration := mtc.clock().PhysicalNow() + mtc.nodeLivenesses[0].GetLivenessThreshold().Nanoseconds()
 	for _, l := range livenesses {
 		if a, e := l.Epoch, int64(1); a != e {
 			t.Errorf("liveness record had epoch %d, wanted %d", a, e)
@@ -985,7 +985,7 @@ func TestNodeLivenessDecommissionAbsent(t *testing.T) {
 	if err := mtc.dbs[0].CPut(ctx, keys.NodeLivenessKey(goneNodeID), &storagepb.Liveness{
 		NodeID:     goneNodeID,
 		Epoch:      1,
-		Expiration: hlc.LegacyTimestamp(mtc.clock.Now()),
+		Expiration: hlc.LegacyTimestamp(mtc.clock().Now()),
 	}, nil); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
multiTestContext is a piece of garbage. The particular shortcoming I'm
fixing here is that it was easy to accidentally mix manual and automatic
clocks. This would happen whenever passing a `storeConfig` in, which
by default comes with a real-time clock (whereas the mtc also has
m.clock, which is by default manual). Components using the store
config would use real time, but other components fake time.
You can imagine how this is not going to work well. In the particular
example motivating this PR, GC ran and set a real-time GC threshold,
so that heartbeats (which were using fake time) could never go through
as their manual timestamp didn't change in the wall time compoment
thanks to their underlying manual clock.

Now mtc will blow up more eagerly if you try to mix clocks like that -
you have to go all manual or all automatic (and nobody should choose
to go manual btw, this doesn't work very well).

Fixes #45814.

Release justification: test fix in non-production code.

Release note: None