### PR TITLE
build: use make builtins for determining obsolete execgen targets

### DIFF
--- a/build/cleanup.sh
+++ b/build/cleanup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-for obsolete in $(find pkg/sql/colexec -type f -name '*.eg.go' "$@" 2>/dev/null) \
-		$(find pkg/sql/exec -type f -name '*.eg.go' "$@" 2>/dev/null); do \
-  echo "Removing obsolete file $obsolete..."; \
-  rm -f $obsolete; \
-done


### PR DESCRIPTION
Release justification (category 1): non-production code changes