### PR TITLE
sql: decrease job adopt interval for schema change tests

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1168,6 +1168,12 @@ CREATE TABLE t.test (
 // a retry.
 func TestSchemaChangeRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
 	params, _ := tests.CreateTestServerParams()
 
 	currChunk := 0
@@ -1242,6 +1248,12 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 // the number of chunks operated on during a retry.
 func TestSchemaChangeRetryOnVersionChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
 	params, _ := tests.CreateTestServerParams()
 	var upTableVersion func()
 	const maxValue = 2000


### PR DESCRIPTION
This PR decreases the job adopt interval to 100 ms for some schema
change tests for retries, so that the job registry adopts the jobs to
retry more quickly. These test were taking over a minute after the
schema change job refactor, and now take about 1 second.

Closes #45970.

Release justification: This change only fixes tests.
Release note: None