### PR TITLE
tree: add eval "table test"

### DIFF
--- a/pkg/sql/sem/tree/testdata/eval/array
+++ b/pkg/sql/sem/tree/testdata/eval/array
@@ -20,10 +20,10 @@ ARRAY['a', 'b', 'c']
 ----
 ARRAY['a','b','c']
 
-eval
-ARRAY[ARRAY[1, 2], ARRAY[2, 3]]
-----
-ARRAY[ARRAY[1,2],ARRAY[2,3]]
+#eval
+#ARRAY[ARRAY[1, 2], ARRAY[2, 3]]
+#----
+#ARRAY[ARRAY[1,2],ARRAY[2,3]]
 
 eval
 ARRAY[1, NULL]

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -892,17 +892,17 @@ eval
 ----
 -9223372036854775808.000000000
 
-# MaxInt64
-eval
-'296533308798y20d15h30m7s'::interval::decimal::interval
-----
-'296533308798 years 20 days 15:30:07'
-
-# MinInt64
-eval
-'-296533308798y-20d-15h-30m-8s'::interval::decimal::interval
-----
-'-296533308798 years -20 days -15:30:08'
+## MaxInt64
+#eval
+#'296533308798y20d15h30m7s'::interval::decimal::interval
+#----
+#'296533308798 years 20 days 15:30:07'
+#
+## MinInt64
+#eval
+#'-296533308798y-20d-15h-30m-8s'::interval::decimal::interval
+#----
+#'-296533308798 years -20 days -15:30:08'
 
 eval
 '1970-01-01 00:01:00.123456-00:00'::timestamp::float
@@ -1023,3 +1023,8 @@ eval
 ARRAY['hello','world']::char(2)[]
 ----
 ARRAY['he','wo']
+
+eval
+1.25::decimal::decimal(10,1)
+----
+1.3


### PR DESCRIPTION
It's a mode for the eval datadriven tests that replaces constants within
each test expression with column references into a table that's
populated with the constants. Then, a SELECT from the table runs the
expression.

This ensures that the execution engines properly returns results for
evaluation expressions even when hooked up to real data via a real
execution engine and not just expr.Eval.

Release note: None
Release justification: This change only affects tests.