### PR TITLE
sql: integrate support bundle with diagnostics

### DIFF
--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -74,7 +74,7 @@ func (s *statusServer) CreateStatementDiagnosticsReport(
 		Report: &serverpb.StatementDiagnosticsReport{},
 	}
 
-	_, err := s.stmtDiagnosticsRequester.InsertRequest(ctx, req.StatementFingerprint)
+	err := s.stmtDiagnosticsRequester.InsertRequest(ctx, req.StatementFingerprint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -15,37 +15,81 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 )
 
-// handleExplainBundle creates the bundle and returns the result for an
-// EXPLAIN BUNDLE statement. The result is text containing a URL for the bundle.
-func handleExplainBundle(
-	ctx context.Context, res RestrictedCommandResult, plan *planTop, execCfg *ExecutorConfig,
+// setExplainBundleResult creates the diagnostics and returns the bundle
+// information for an EXPLAIN BUNDLE statement.
+//
+// Returns an error if information rows couldn't be added to the result.
+func setExplainBundleResult(
+	ctx context.Context,
+	res RestrictedCommandResult,
+	ast tree.Statement,
+	trace tracing.Recording,
+	plan *planTop,
+	execCfg *ExecutorConfig,
 ) error {
 	res.ResetStmtType(&tree.ExplainBundle{})
 	res.SetColumns(ctx, sqlbase.ExplainBundleColumns)
 
-	id, err := buildStatementBundle(ctx, plan, execCfg)
+	traceJSON, bundle, err := getTraceAndBundle(trace, plan)
 	if err != nil {
-		return err
+		res.SetError(err)
+		return nil
 	}
 
-	url := fmt.Sprintf("%s/_admin/v1/stmtbundle/%d", execCfg.AdminURL(), id)
-	text := fmt.Sprintf(""+
-		"Download the bundle from:\n"+
-		"  %s\n"+
-		"or from the Admin UI (Advanced Debug -> Statement Diagnostics).",
-		url,
+	fingerprint := tree.AsStringWithFlags(ast, tree.FmtHideConstants)
+	stmtStr := tree.AsString(ast)
+
+	diagID, err := insertStatementDiagnostics(
+		ctx,
+		execCfg.DB,
+		execCfg.InternalExecutor,
+		0, /* requestID */
+		fingerprint,
+		stmtStr,
+		traceJSON,
+		bundle,
+		nil, /* collectionErr */
 	)
-	return res.AddRow(ctx, tree.Datums{tree.NewDString(text)})
+	if err != nil {
+		res.SetError(err)
+		return nil
+	}
+
+	url := fmt.Sprintf("  %s/_admin/v1/stmtbundle/%d", execCfg.AdminURL(), diagID)
+	text := []string{
+		"Download the bundle from:",
+		url,
+		"or from the Admin UI (Advanced Debug -> Statement Diagnostics).",
+	}
+
+	if err := res.Err(); err != nil {
+		// Add the bundle information as a detail to the query error.
+		//
+		// TODO(radu): if the statement gets auto-retried, we will generate a
+		// bundle for each iteration. If the statement eventually succeeds we
+		// will have a link to the last iteration's bundle. It's not clear what
+		// the ideal behavior is here; if we keep all bundles we should try to
+		// list them all in the final message.
+		res.SetError(errors.WithDetail(err, strings.Join(text, "\n")))
+		return nil
+	}
+
+	for _, line := range text {
+		if err := res.AddRow(ctx, tree.Datums{tree.NewDString(line)}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // buildStatementBundle collects metadata related the planning and execution of
@@ -55,72 +99,32 @@ func handleExplainBundle(
 //
 // Returns the bundle ID, which is the key for the row added in
 // statement_diagnostics.
-func buildStatementBundle(
-	ctx context.Context, plan *planTop, execCfg *ExecutorConfig,
-) (bundleID int64, _ error) {
-	b := makeStmtBundleBuilder(plan)
+func buildStatementBundle(plan *planTop, trace string) (*bytes.Buffer, error) {
+	if plan == nil {
+		return nil, errors.AssertionFailedf("execution terminated early")
+	}
+	b := makeStmtBundleBuilder(plan, trace)
 
 	b.addStatement()
 	b.addOptPlans()
 	b.addExecPlan()
+	b.addTrace()
 
-	buf, err := b.finalize()
-	if err != nil {
-		return 0, err
-	}
-
-	db, ie := execCfg.DB, execCfg.InternalExecutor
-	fingerprint := tree.AsStringWithFlags(plan.stmt.AST, tree.FmtHideConstants)
-	statement := tree.AsString(plan.stmt.AST)
-	description := "query support bundle"
-
-	err = db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		// Insert the bundle into system.statement_bundle_chunks.
-		// TODO(radu): split in chunks.
-		row, err := ie.QueryRowEx(
-			ctx, "statement-bundle-chunks-insert", txn,
-			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-			"INSERT INTO system.statement_bundle_chunks(description, data) VALUES ($1, $2) RETURNING id",
-			description,
-			tree.NewDBytes(tree.DBytes(buf.String())),
-		)
-		if err != nil {
-			return err
-		}
-		chunkID := row[0].(*tree.DInt)
-		chunks := tree.NewDArray(types.Int)
-		if err := chunks.Append(chunkID); err != nil {
-			return err
-		}
-
-		row, err = ie.QueryRowEx(
-			ctx, "statement-bundle-info-insert", txn,
-			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-			`INSERT INTO
-			  system.statement_diagnostics(statement_fingerprint, statement, collected_at, bundle_chunks)
-			  VALUES ($1, $2, $3, $4)
-				RETURNING id
-				`,
-			fingerprint, statement, timeutil.Now(), chunks,
-		)
-		if err != nil {
-			return err
-		}
-		bundleID = int64(*row[0].(*tree.DInt))
-		return err
-	})
-	return bundleID, err
+	return b.finalize()
 }
 
 // stmtBundleBuilder is a helper for building a statement bundle.
 type stmtBundleBuilder struct {
 	plan *planTop
 
+	// trace is the recorded trace (formatted as JSON).
+	trace string
+
 	z memZipper
 }
 
-func makeStmtBundleBuilder(plan *planTop) stmtBundleBuilder {
-	b := stmtBundleBuilder{plan: plan}
+func makeStmtBundleBuilder(plan *planTop, trace string) stmtBundleBuilder {
+	b := stmtBundleBuilder{plan: plan, trace: trace}
 	b.z.Init()
 	return b
 }
@@ -141,6 +145,11 @@ func (b *stmtBundleBuilder) addStatement() {
 // addOptPlans adds the EXPLAIN (OPT) variants as files opt.txt, opt-v.txt,
 // opt-vv.txt.
 func (b *stmtBundleBuilder) addOptPlans() {
+	if b.plan.mem == nil {
+		// No optimizer plans; an error must have occurred during planning.
+		return
+	}
+
 	b.z.AddFile("opt.txt", b.plan.formatOptPlan(memo.ExprFmtHideAll))
 	b.z.AddFile("opt-v.txt", b.plan.formatOptPlan(
 		memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
@@ -150,7 +159,15 @@ func (b *stmtBundleBuilder) addOptPlans() {
 
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.
 func (b *stmtBundleBuilder) addExecPlan() {
-	b.z.AddFile("plan.txt", b.plan.instrumentation.planString)
+	if plan := b.plan.instrumentation.planString; plan != "" {
+		b.z.AddFile("plan.txt", plan)
+	}
+}
+
+func (b *stmtBundleBuilder) addTrace() {
+	if b.trace != "" {
+		b.z.AddFile("trace.json", b.trace)
+	}
 }
 
 // finalize generates the zipped bundle and returns it as a buffer.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -356,9 +356,6 @@ func (p *planTop) close(ctx context.Context) {
 // formatOptPlan returns a visual representation of the optimizer plan that was
 // used.
 func (p *planTop) formatOptPlan(flags memo.ExprFmtFlags) string {
-	if p.mem == nil {
-		return "No optimizer plan; this happens if an error occurred during planning."
-	}
 	f := memo.MakeExprFmtCtx(flags, p.mem, p.catalog)
 	f.FormatExpr(p.mem.RootExpr())
 	return f.Buffer.String()

--- a/pkg/sql/statement_diagnostics.go
+++ b/pkg/sql/statement_diagnostics.go
@@ -11,9 +11,9 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
-	"errors"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -21,11 +21,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
 )
 
@@ -84,6 +86,10 @@ func newStmtDiagnosticsRequestRegistry(
 // column in statement_diagnostics_requests.
 // A zero ID is invalid.
 type stmtDiagRequestID int
+
+// stmtDiagID is the ID of an instance of collected diagnostics, corresponding
+// to the id column in statement_diagnostics.
+type stmtDiagID int
 
 // addRequestInternalLocked adds a request to r.mu.requests. If the request is
 // already present, the call is a noop.
@@ -171,15 +177,23 @@ func (r *stmtDiagnosticsRequestRegistry) insertRequestInternal(
 	return requestID, nil
 }
 
+func (r *stmtDiagnosticsRequestRegistry) removeOngoing(requestID stmtDiagRequestID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Remove the request from r.mu.ongoing.
+	delete(r.mu.ongoing, requestID)
+}
+
 // shouldCollectDiagnostics checks whether any data should be collected for the
-// given query. If data is to be collected, the returned function needs to be
-// called once the data was collected.
+// given query, which is the case if the registry has a request for this
+// statement's fingerprint; in this case shouldCollectDiagnostics will not
+// return true again on this note for the same diagnostics request.
 //
-// Once shouldCollectDiagnostics returns true, it will not return true again on
-// this node for the same diagnostics request.
+// If data is to be collected, Finish() must always be called on the returned
+// stmtDiagnosticsHelper once the data was collected.
 func (r *stmtDiagnosticsRequestRegistry) shouldCollectDiagnostics(
 	ctx context.Context, ast tree.Statement,
-) (bool, func(ctx context.Context, trace tracing.Recording)) {
+) (bool, *stmtDiagnosticsHelper) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -188,11 +202,10 @@ func (r *stmtDiagnosticsRequestRegistry) shouldCollectDiagnostics(
 		return false, nil
 	}
 
-	fprint := tree.AsStringWithFlags(ast, tree.FmtHideConstants)
-
+	fingerprint := tree.AsStringWithFlags(ast, tree.FmtHideConstants)
 	var reqID stmtDiagRequestID
-	for id, fingerprint := range r.mu.requestFingerprints {
-		if fingerprint == fprint {
+	for id, f := range r.mu.requestFingerprints {
+		if f == fingerprint {
 			reqID = id
 			break
 		}
@@ -208,37 +221,84 @@ func (r *stmtDiagnosticsRequestRegistry) shouldCollectDiagnostics(
 	}
 
 	r.mu.ongoing[reqID] = struct{}{}
+	return true, makeStmtDiagnosticsHelper(r, fingerprint, tree.AsString(ast), reqID)
+}
 
-	return true, func(ctx context.Context, trace tracing.Recording) {
-		defer func() {
-			r.mu.Lock()
-			defer r.mu.Unlock()
-			// Remove the request from r.mu.ongoing.
-			delete(r.mu.ongoing, reqID)
-		}()
+type stmtDiagnosticsHelper struct {
+	r            *stmtDiagnosticsRequestRegistry
+	fingerprint  string
+	statementStr string
+	requestID    stmtDiagRequestID
+}
 
-		if err := r.insertDiagnostics(ctx, reqID, fprint, tree.AsString(ast), trace); err != nil {
-			log.Warningf(ctx, "failed to insert trace: %s", err)
-		}
+func makeStmtDiagnosticsHelper(
+	r *stmtDiagnosticsRequestRegistry,
+	fingerprint string,
+	statementStr string,
+	requestID stmtDiagRequestID,
+) *stmtDiagnosticsHelper {
+	return &stmtDiagnosticsHelper{
+		r:            r,
+		fingerprint:  fingerprint,
+		statementStr: statementStr,
+		requestID:    requestID,
 	}
 }
 
-// insertDiagnostics inserts a trace into system.statement_diagnostics and marks
-// the corresponding request as completed in
+// Finish reports the trace and creates the support bundle, and inserts them in
+// the system tables.
+//
+// Returns any collection error or error inserting the diagnostics in the system
+// tables.
+//
+// On success, returns the ID of the inserted statement_diagnostics row.
+func (h *stmtDiagnosticsHelper) Finish(
+	ctx context.Context, trace tracing.Recording, plan *planTop,
+) {
+	defer h.r.removeOngoing(h.requestID)
+
+	traceJSON, bundle, collectionErr := getTraceAndBundle(trace, plan)
+
+	_, err := insertStatementDiagnostics(
+		ctx,
+		h.r.db,
+		h.r.ie,
+		h.requestID,
+		h.fingerprint,
+		h.statementStr,
+		traceJSON,
+		bundle,
+		collectionErr,
+	)
+	if err != nil {
+		log.Warningf(ctx, "failed to report statement diagnostics: %s", err)
+	}
+}
+
+// insertStatementDiagnostics inserts a trace into system.statement_diagnostics.
+// If requestID is not zero, it also marks the request as completed in
 // system.statement_diagnostics_requests.
-func (r *stmtDiagnosticsRequestRegistry) insertDiagnostics(
+//
+// traceJSON is either DNull (when collectionErr should not be nil) or a *DJSON.
+//
+func insertStatementDiagnostics(
 	ctx context.Context,
-	reqID stmtDiagRequestID,
+	db *kv.DB,
+	ie *InternalExecutor,
+	requestID stmtDiagRequestID,
 	stmtFingerprint string,
 	stmt string,
-	trace tracing.Recording,
-) error {
-	return r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		{
-			row, err := r.ie.QueryRowEx(ctx, "stmt-diag-check-completed", txn,
+	traceJSON tree.Datum,
+	bundle *bytes.Buffer,
+	collectionErr error,
+) (stmtDiagID, error) {
+	var diagID stmtDiagID
+	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if requestID != 0 {
+			row, err := ie.QueryRowEx(ctx, "stmt-diag-check-completed", txn,
 				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 				"SELECT count(1) FROM system.statement_diagnostics_requests WHERE id = $1 AND completed = false",
-				reqID)
+				requestID)
 			if err != nil {
 				return err
 			}
@@ -251,40 +311,66 @@ func (r *stmtDiagnosticsRequestRegistry) insertDiagnostics(
 			}
 		}
 
-		var traceID int
-		if json, err := traceToJSON(trace); err != nil {
-			row, err := r.ie.QueryRowEx(ctx, "stmt-diag-insert-trace", txn,
-				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-				"INSERT INTO system.statement_diagnostics "+
-					"(statement_fingerprint, statement, collected_at, error) "+
-					"VALUES ($1, $2, $3, $4) RETURNING id",
-				stmtFingerprint, stmt, timeutil.Now(), err.Error())
-			if err != nil {
-				return err
-			}
-			traceID = int(*row[0].(*tree.DInt))
-		} else {
-			// Insert the trace into system.statement_diagnostics.
-			row, err := r.ie.QueryRowEx(ctx, "stmt-diag-insert-trace", txn,
-				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-				"INSERT INTO system.statement_diagnostics "+
-					"(statement_fingerprint, statement, collected_at, trace) "+
-					"VALUES ($1, $2, $3, $4) RETURNING id",
-				stmtFingerprint, stmt, timeutil.Now(), json)
-			if err != nil {
-				return err
-			}
-			traceID = int(*row[0].(*tree.DInt))
+		// Generate the values that will be inserted.
+		errorVal := tree.DNull
+		if collectionErr != nil {
+			errorVal = tree.NewDString(collectionErr.Error())
 		}
 
-		// Mark the request from system.statement_diagnostics_request as completed.
-		_, err := r.ie.ExecEx(ctx, "stmt-diag-mark-completed", txn,
+		bundleChunksVal := tree.DNull
+		if bundle != nil && bundle.Len() != 0 {
+			// Insert the bundle into system.statement_bundle_chunks.
+			// TODO(radu): split in chunks.
+			row, err := ie.QueryRowEx(
+				ctx, "stmt-bundle-chunks-insert", txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+				"INSERT INTO system.statement_bundle_chunks(description, data) VALUES ($1, $2) RETURNING id",
+				"statement diagnostics bundle",
+				tree.NewDBytes(tree.DBytes(bundle.String())),
+			)
+			if err != nil {
+				return err
+			}
+			chunkID := row[0].(*tree.DInt)
+
+			array := tree.NewDArray(types.Int)
+			if err := array.Append(chunkID); err != nil {
+				return err
+			}
+			bundleChunksVal = array
+		}
+
+		// Insert the trace into system.statement_diagnostics.
+		row, err := ie.QueryRowEx(
+			ctx, "stmt-diag-insert", txn,
 			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
-			"UPDATE system.statement_diagnostics_requests "+
-				"SET completed = true, statement_diagnostics_id = $1 WHERE id = $2",
-			traceID, reqID)
-		return err
+			"INSERT INTO system.statement_diagnostics "+
+				"(statement_fingerprint, statement, collected_at, trace, bundle_chunks, error) "+
+				"VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+			stmtFingerprint, stmt, timeutil.Now(), traceJSON, bundleChunksVal, errorVal,
+		)
+		if err != nil {
+			return err
+		}
+		diagID = stmtDiagID(*row[0].(*tree.DInt))
+
+		if requestID != 0 {
+			// Mark the request from system.statement_diagnostics_request as completed.
+			_, err := ie.ExecEx(ctx, "stmt-diag-mark-completed", txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+				"UPDATE system.statement_diagnostics_requests "+
+					"SET completed = true, statement_diagnostics_id = $1 WHERE id = $2",
+				diagID, requestID)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	})
+	if err != nil {
+		return 0, err
+	}
+	return diagID, nil
 }
 
 // pollRequests reads the pending rows from system.statement_diagnostics_requests and
@@ -375,15 +461,42 @@ func normalizeSpan(s tracing.RecordedSpan, trace tracing.Recording) tracing.Norm
 	return n
 }
 
-// traceToJSON converts a trace to a JSON format suitable for the
-// system.statement_diagnostics.trace column.
+// traceToJSON converts a trace to a JSON datum suitable for the
+// system.statement_diagnostics.trace column. In case of error, the returned
+// datum is DNull. Also returns the string representation of the trace.
 //
 // traceToJSON assumes that the first span in the recording contains all the
 // other spans.
-func traceToJSON(trace tracing.Recording) (string, error) {
+func traceToJSON(trace tracing.Recording) (tree.Datum, string, error) {
 	root := normalizeSpan(trace[0], trace)
 	marshaller := jsonpb.Marshaler{
 		Indent: "  ",
 	}
-	return marshaller.MarshalToString(&root)
+	str, err := marshaller.MarshalToString(&root)
+	if err != nil {
+		return tree.DNull, "", err
+	}
+	d, err := tree.ParseDJSON(str)
+	if err != nil {
+		return tree.DNull, "", err
+	}
+	return d, str, nil
+}
+
+// getTraceAndBundle converts the trace to a JSON datum and creates a statement
+// bundle. It tries to return as much information as possible even in error
+// case.
+func getTraceAndBundle(
+	trace tracing.Recording, plan *planTop,
+) (traceJSON tree.Datum, bundle *bytes.Buffer, _ error) {
+	traceJSON, traceStr, err := traceToJSON(trace)
+	bundle, bundleErr := buildStatementBundle(plan, traceStr)
+	if bundleErr != nil {
+		if err == nil {
+			err = bundleErr
+		} else {
+			err = errors.WithMessage(bundleErr, err.Error())
+		}
+	}
+	return traceJSON, bundle, err
 }


### PR DESCRIPTION
#### sql: statement diagnostics cleanup

Minor cleanup of the statement diagnostics infrastructure:
 - use a custom type `stmtDiagRequestID` instead of int
 - use maps instead of slices
 - `InsertRequest` no longer returns an ID (it wasn't useful for an external
   caller).

Release note: None

#### sql: integrate support bundle with diagnostics

This change integrates the logic of getting a support bundle with statement
diagnostics. When diagnostics are requested for a fingerprint, the bundle is now
created along with the trace.

EXPLAIN BUNDLE now shares the same logic and it now generates a bundle even if
the query hits an error (in which case the bundle information is added to the
error as a DETAIL.

To make the code easier to follow, we replace the func returned by
`shouldCollectDiagnostics` with a helper type that stores the necessary
information.

Release note: None

Release justification: Category 2 (fixes/updates to new functionality).