### PR TITLE
roachtest: add extra logging to alterpk-tpcc roachtest

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -283,6 +283,10 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 			return err
 		}
 	}
+
+	log.Infof(ctx, "Completed backfill for %q, v=%d, m=%d",
+		tableDesc.Name, tableDesc.Version, sc.mutationID)
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds some extra logging to the backfiller
and alterpk roachtest to have more insight on where #45812
is failing.

Release justification: non production code change
Release note: None