### PR TITLE
githooks: fix suggested syntax for release justification

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -93,7 +93,7 @@ $cchar     <pkg>: <short description>\\
 
 if [ "$require_justification" = 1 ]; then
   sed_script+="$cchar\\
-$cchar     Release justification (category): <release justification>\\
+$cchar     Release justification: <release justification>\\
 "
 fi
 sed_script+="$cchar\\


### PR DESCRIPTION
The currently suggested syntax doesn't pass the linter.

Release justification: non-production code change.

Release note: None