### PR TITLE
colexec: add disk spilling to percent_rank and cume_dist

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
@@ -36,10 +36,10 @@ func genRelativeRankOps(wr io.Writer) error {
 
 	s = strings.Replace(s, "_RELATIVE_RANK_STRING", "{{.String}}", -1)
 
-	computeNumPeersRe := makeFunctionRegex("_COMPUTE_NUM_PEERS", 0)
-	s = computeNumPeersRe.ReplaceAllString(s, `{{template "computeNumPeers"}}`)
-	computeCumeDistRe := makeFunctionRegex("_COMPUTE_CUME_DIST", 0)
-	s = computeCumeDistRe.ReplaceAllString(s, `{{template "computeCumeDist"}}`)
+	computePartitionsSizesRe := makeFunctionRegex("_COMPUTE_PARTITIONS_SIZES", 0)
+	s = computePartitionsSizesRe.ReplaceAllString(s, `{{template "computePartitionsSizes"}}`)
+	computePeerGroupsSizesRe := makeFunctionRegex("_COMPUTE_PEER_GROUPS_SIZES", 0)
+	s = computePeerGroupsSizesRe.ReplaceAllString(s, `{{template "computePeerGroupsSizes"}}`)
 
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("relative_rank_op").Parse(s)

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -24,9 +24,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/errors"
+	"github.com/marusama/semaphore"
 )
 
 // TODO(yuzefovich): add benchmarks.
@@ -36,7 +38,10 @@ import (
 // outputColIdx specifies in which coldata.Vec the operator should put its
 // output (if there is no such column, a new column is appended).
 func NewRelativeRankOperator(
-	allocator *Allocator,
+	unlimitedAllocator *Allocator,
+	memoryLimit int64,
+	diskQueueCfg colcontainer.DiskQueueCfg,
+	fdSemaphore semaphore.Semaphore,
 	input Operator,
 	inputTypes []coltypes.T,
 	windowFn execinfrapb.WindowerSpec_WindowFunc,
@@ -50,90 +55,186 @@ func NewRelativeRankOperator(
 		if windowFn == execinfrapb.WindowerSpec_CUME_DIST {
 			constValue = 1
 		}
-		return NewConstOp(allocator, input, coltypes.Float64, constValue, outputColIdx)
+		return NewConstOp(unlimitedAllocator, input, coltypes.Float64, constValue, outputColIdx)
 	}
-	initFields := rankInitFields{
-		OneInputNode:    NewOneInputNode(input),
-		allocator:       allocator,
-		outputColIdx:    outputColIdx,
-		partitionColIdx: partitionColIdx,
-		peersColIdx:     peersColIdx,
+	rrInitFields := relativeRankInitFields{
+		rankInitFields: rankInitFields{
+			OneInputNode:    NewOneInputNode(input),
+			allocator:       unlimitedAllocator,
+			outputColIdx:    outputColIdx,
+			partitionColIdx: partitionColIdx,
+			peersColIdx:     peersColIdx,
+		},
+		memoryLimit:  memoryLimit,
+		diskQueueCfg: diskQueueCfg,
+		fdSemaphore:  fdSemaphore,
+		inputTypes:   inputTypes,
 	}
 	switch windowFn {
 	case execinfrapb.WindowerSpec_PERCENT_RANK:
 		if partitionColIdx != columnOmitted {
 			return &percentRankWithPartitionOp{
-				rankInitFields: initFields,
-				inputTypes:     inputTypes,
+				relativeRankInitFields: rrInitFields,
 			}, nil
 		}
 		return &percentRankNoPartitionOp{
-			rankInitFields: initFields,
-			inputTypes:     inputTypes,
+			relativeRankInitFields: rrInitFields,
 		}, nil
 	case execinfrapb.WindowerSpec_CUME_DIST:
 		if partitionColIdx != columnOmitted {
 			return &cumeDistWithPartitionOp{
-				rankInitFields: initFields,
-				inputTypes:     inputTypes,
+				relativeRankInitFields: rrInitFields,
 			}, nil
 		}
 		return &cumeDistNoPartitionOp{
-			rankInitFields: initFields,
-			inputTypes:     inputTypes,
+			relativeRankInitFields: rrInitFields,
 		}, nil
 	default:
 		return nil, errors.Errorf("unsupported relative rank type %s", windowFn)
 	}
 }
 
+// NOTE: in the context of window functions "partitions" mean a different thing
+// from "partition" in the context of external algorithms and some disk
+// infrastructure: here, "partitions" are sets of tuples that are not distinct
+// on the columns specified in PARTITION BY clause of the window function. If
+// such clause is omitted, then all tuples from the input belong to the same
+// partition.
+
 type relativeRankState int
 
 const (
 	// relativeRankBuffering is the state in which relativeRank operators fully
-	// buffer their input. Once a zero-length batch is received, the operator
-	// transitions to relativeRankEmitting state.
+	// buffer their input using spillingQueue. Additionally, the operators will
+	// be computing the sizes of the partitions and peer groups (if needed)
+	// using separate spillingQueues for each. Once a zero-length batch is
+	// received, the operator transitions to relativeRankEmitting state.
 	relativeRankBuffering relativeRankState = iota
-	// relativeRankEmitting is the state in which relativeRank operators emit the
-	// output. The output batch is populated by copying a "chunk" of all buffered
-	// tuples and then populating the rank column.
+	// relativeRankEmitting is the state in which relativeRank operators emit
+	// the output. The output batch is populated by copying the next batch from
+	// the "buffered tuples" spilling queue and manually computing the output
+	// column for the window function using the already computed sizes of
+	// partitions and peer groups. Once a zero-length batch is dequeued from
+	// the "buffered tuples" queue, the operator transitions to
+	// relativeRankFinished state.
 	relativeRankEmitting
+	// relativeRankFinished is the state in which relativeRank operators close
+	// any non-closed disk resources and emit the zero-length batch.
+	relativeRankFinished
 )
 
 // {{/*
-// _COMPUTE_NUM_PEERS is a code snippet that computes the number of tuples in
-// the peer group. It should be called when a new peer group is encountered.
-func _COMPUTE_NUM_PEERS() { // */}}
-	// {{define "computeNumPeers" -}}
-	r.numPeers = 1
-	for j := r.resumeTupleIdx + i + 1; j < r.bufferedTuples.Length(); j++ {
-		if peersCol[j] {
-			break
+// _COMPUTE_PARTITIONS_SIZES is a code snippet that computes the sizes of
+// partitions. It looks at i'th partitionCol value to check whether a new
+// partition begins at index i, and if so, it records the already computed
+// size of the previous partition into partitionsState.runningSizes vector.
+func _COMPUTE_PARTITIONS_SIZES() { // */}}
+	// {{define "computePartitionsSizes" -}}
+	if partitionCol[i] {
+		// We have encountered a start of a new partition, so we
+		// need to save the computed size of the previous one
+		// (if there was one).
+		if r.partitionsState.runningSizes == nil {
+			// TODO(yuzefovich): do not instantiate a new batch here once
+			// spillingQueues actually copy the batches when those are kept
+			// in-memory.
+			r.partitionsState.runningSizes = r.allocator.NewMemBatch([]coltypes.T{coltypes.Int64})
+			runningPartitionsSizesCol = r.partitionsState.runningSizes.ColVec(0).Int64()
 		}
-		r.numPeers++
+		if r.numTuplesInPartition > 0 {
+			runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
+			r.numTuplesInPartition = 0
+			r.partitionsState.idx++
+			if r.partitionsState.idx == coldata.BatchSize() {
+				// We need to flush the vector of partitions sizes.
+				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
+				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				r.partitionsState.runningSizes = nil
+				r.partitionsState.idx = 0
+			}
+		}
 	}
+	r.numTuplesInPartition++
 	// {{end}}
 	// {{/*
 } // */}}
 
 // {{/*
-// _COMPUTE_CUME_DIST is a code snippet that computes the value of cume_dist
-// window function. The numbers of preceding tuples and of peers as well as
-// the partition size *must* have already been computed.
-func _COMPUTE_CUME_DIST() { // */}}
-	// {{define "computeCumeDist" -}}
-	relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
+// _COMPUTE_PEER_GROUPS_SIZES is a code snippet that computes the sizes of
+// peer groups. It looks at i'th peersCol value to check whether a new
+// peer group begins at index i, and if so, it records the already computed
+// size of the previous peer group into peerGroupsState.runningSizes vector.
+func _COMPUTE_PEER_GROUPS_SIZES() { // */}}
+	// {{define "computePeerGroupsSizes" -}}
+	if peersCol[i] {
+		// We have encountered a start of a new peer group, so we
+		// need to save the computed size of the previous one
+		// (if there was one).
+		if r.peerGroupsState.runningSizes == nil {
+			// TODO(yuzefovich): do not instantiate a new batch here once
+			// spillingQueues actually copy the batches when those are kept
+			// in-memory.
+			r.peerGroupsState.runningSizes = r.allocator.NewMemBatch([]coltypes.T{coltypes.Int64})
+			runningPeerGroupsSizesCol = r.peerGroupsState.runningSizes.ColVec(0).Int64()
+		}
+		if r.numPeers > 0 {
+			runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
+			r.numPeers = 0
+			r.peerGroupsState.idx++
+			if r.peerGroupsState.idx == coldata.BatchSize() {
+				// We need to flush the vector of peer group sizes.
+				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
+				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				r.peerGroupsState.runningSizes = nil
+				r.peerGroupsState.idx = 0
+			}
+		}
+	}
+	r.numPeers++
 	// {{end}}
 	// {{/*
 } // */}}
+
+type relativeRankInitFields struct {
+	rankInitFields
+
+	closed       bool
+	state        relativeRankState
+	memoryLimit  int64
+	diskQueueCfg colcontainer.DiskQueueCfg
+	fdSemaphore  semaphore.Semaphore
+	inputTypes   []coltypes.T
+}
+
+type relativeRankSizesState struct {
+	*spillingQueue
+
+	// runningSizes is a batch consisting of a single int64 vector that stores
+	// sizes while we're computing them. Once all coldata.BatchSize() slots are
+	// filled, it will be flushed to the spillingQueue.
+	runningSizes coldata.Batch
+	// dequeuedSizes is a batch of already computed sizes that is dequeued
+	// from the spillingQueue.
+	dequeuedSizes coldata.Batch
+	// idx stores the index of the current slot in one of the batches above
+	// that we're currently working with.
+	idx int
+}
+
+// relativeRankUtilityQueueMemLimitFraction defines the fraction of the memory
+// limit that will be given to the "utility" spillingQueues of relativeRank
+// operators (i.e. non "buffered tuples" queues).
+const relativeRankUtilityQueueMemLimitFraction = 0.1
 
 // {{range .}}
 
 type _RELATIVE_RANK_STRINGOp struct {
-	rankInitFields
+	relativeRankInitFields
 
-	state      relativeRankState
-	inputTypes []coltypes.T
 	// {{if .IsPercentRank}}
 	// rank indicates which rank should be assigned to the next tuple.
 	rank int64
@@ -141,27 +242,27 @@ type _RELATIVE_RANK_STRINGOp struct {
 	// tuple distinct from the previous one on the ordering columns is seen.
 	rankIncrement int64
 	// {{end}}
+
 	// {{if .IsCumeDist}}
+	peerGroupsState relativeRankSizesState
 	// numPrecedingTuples stores the number of tuples preceding to the first
-	// peer of the current tuple in the current partition. This number will be
-	// computed once a new peer group is encountered.
-	numPrecedingTuples int
+	// peer of the current tuple in the current partition.
+	numPrecedingTuples int64
 	// numPeers stores the number of tuples that are peers with the current
-	// tuple. This number will be computed once a new peer group is encountered.
-	numPeers int
+	// tuple.
+	numPeers int64
 	// {{end}}
-	// bufferedTuples store all the buffered up tuples because relativeRank needs
-	// to know the number of tuples in the partition, so it needs to buffer up
-	// the tuples before it can return the output.
-	bufferedTuples coldata.Batch
-	// resumeTupleIdx stores the index of the first tuple to be emitted on the
-	// next call to Next().
-	resumeTupleIdx int
+
+	// {{if .HasPartition}}
+	partitionsState relativeRankSizesState
+	// {{end}}
 	// numTuplesInPartition contains the number of tuples in the current
 	// partition.
-	numTuplesInPartition int
+	numTuplesInPartition int64
 
-	output coldata.Batch
+	bufferedTuples *spillingQueue
+	scratch        coldata.Batch
+	output         coldata.Batch
 }
 
 var _ Operator = &_RELATIVE_RANK_STRINGOp{}
@@ -169,7 +270,28 @@ var _ Operator = &_RELATIVE_RANK_STRINGOp{}
 func (r *_RELATIVE_RANK_STRINGOp) Init() {
 	r.Input().Init()
 	r.state = relativeRankBuffering
-	r.bufferedTuples = r.allocator.NewMemBatchWithSize(r.inputTypes, 0 /* size */)
+	usedMemoryLimitFraction := 0.0
+	// {{if .HasPartition}}
+	r.partitionsState.spillingQueue = newSpillingQueue(
+		r.allocator, []coltypes.T{coltypes.Int64},
+		int64(float64(r.memoryLimit)*relativeRankUtilityQueueMemLimitFraction),
+		r.diskQueueCfg, r.fdSemaphore, coldata.BatchSize(),
+	)
+	usedMemoryLimitFraction += relativeRankUtilityQueueMemLimitFraction
+	// {{end}}
+	// {{if .IsCumeDist}}
+	r.peerGroupsState.spillingQueue = newSpillingQueue(
+		r.allocator, []coltypes.T{coltypes.Int64},
+		int64(float64(r.memoryLimit)*relativeRankUtilityQueueMemLimitFraction),
+		r.diskQueueCfg, r.fdSemaphore, coldata.BatchSize(),
+	)
+	usedMemoryLimitFraction += relativeRankUtilityQueueMemLimitFraction
+	// {{end}}
+	r.bufferedTuples = newSpillingQueue(
+		r.allocator, r.inputTypes,
+		int64(float64(r.memoryLimit)*(1.0-usedMemoryLimitFraction)),
+		r.diskQueueCfg, r.fdSemaphore, coldata.BatchSize(),
+	)
 	r.output = r.allocator.NewMemBatch(append(r.inputTypes, coltypes.Float64))
 	// {{if .IsPercentRank}}
 	// All rank functions start counting from 1. Before we assign the rank to a
@@ -181,16 +303,91 @@ func (r *_RELATIVE_RANK_STRINGOp) Init() {
 }
 
 func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
+	var err error
 	for {
 		switch r.state {
 		case relativeRankBuffering:
+			// The outline of what we need to do in "buffering" state:
+			//
+			// 1. we need to buffer the tuples that we read from the input.
+			// These are simply copied into r.bufferedTuples spillingQueue.
+			//
+			// 2. (if we have PARTITION BY clause) we need to compute the sizes of
+			// partitions. These sizes are stored in r.partitionsState.runningSizes
+			// batch (that consists of a single vector) and r.partitionsState.idx
+			// points at the next slot in that vector to write to. Once it
+			// reaches coldata.BatchSize(), the batch is "flushed" to the
+			// corresponding spillingQueue. The "running" value of the current
+			// partition size is stored in r.numTuplesInPartition.
+			//
+			// 3. (if we have CUME_DIST function) we need to compute the sizes
+			// of peer groups. These sizes are stored in r.peerGroupsState.runningSizes
+			// batch (that consists of a single vector) and r.peerGroupsState.idx
+			// points at the next slot in that vector to write to. Once it
+			// reaches coldata.BatchSize(), the batch is "flushed" to the
+			// corresponding spillingQueue. The "running" value of the current
+			// peer group size is stored in r.numPeers.
+			//
+			// For example, if we have the following setup:
+			//   partitionCol = {true, false, false, true, false, false, false, false}
+			//   peersCol     = {true, false, true, true, false, false, true, false}
+			// we want this as the result:
+			//   partitionsSizes = {3, 5}
+			//   peerGroupsSizes = {2, 1, 3, 2}.
+			// This example also shows why we need to use two different queues
+			// (since every partition can have multiple peer groups, the
+			// schedule of "flushing" is different).
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
+				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				// {{if .HasPartition}}
+				// We need to flush the last vector of the running partitions
+				// sizes, including the very last partition.
+				if r.partitionsState.runningSizes == nil {
+					// TODO(yuzefovich): do not instantiate a new batch here once
+					// spillingQueues actually copy the batches when those are kept
+					// in-memory.
+					r.partitionsState.runningSizes = r.allocator.NewMemBatch([]coltypes.T{coltypes.Int64})
+				}
+				runningPartitionsSizesCol := r.partitionsState.runningSizes.ColVec(0).Int64()
+				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
+				r.partitionsState.idx++
+				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
+				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				if err := r.partitionsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				// {{end}}
+				// {{if .IsCumeDist}}
+				// We need to flush the last vector of the running peer groups
+				// sizes, including the very last peer group.
+				if r.peerGroupsState.runningSizes == nil {
+					// TODO(yuzefovich): do not instantiate a new batch here once
+					// spillingQueues actually copy the batches when those are kept
+					// in-memory.
+					r.peerGroupsState.runningSizes = r.allocator.NewMemBatch([]coltypes.T{coltypes.Int64})
+				}
+				runningPeerGroupsSizesCol := r.peerGroupsState.runningSizes.ColVec(0).Int64()
+				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
+				r.peerGroupsState.idx++
+				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
+				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				if err := r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				// {{end}}
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
 			}
+
 			// {{if .HasPartition}}
 			// For simplicity, we will fully consume the input before we start
 			// producing the output.
@@ -200,138 +397,222 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// All tuples belong to the same partition, so we need to fully consume
 			// the input before we can proceed.
 			// {{end}}
-			r.allocator.PerformOperation(r.bufferedTuples.ColVecs(), func() {
-				numBufferedTuples := r.bufferedTuples.Length()
-				for colIdx, vec := range r.bufferedTuples.ColVecs() {
+
+			sel := batch.Selection()
+			// First, we buffer up all of the tuples.
+			// TODO(yuzefovich): do not instantiate a new batch here once
+			// spillingQueues actually copy the batches when those are kept
+			// in-memory.
+			r.scratch = r.allocator.NewMemBatchWithSize(r.inputTypes, n)
+			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
+				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Append(
 						coldata.SliceArgs{
 							ColType:   r.inputTypes[colIdx],
 							Src:       batch.ColVec(colIdx),
-							Sel:       batch.Selection(),
-							DestIdx:   numBufferedTuples,
+							Sel:       sel,
 							SrcEndIdx: n,
 						},
 					)
 				}
-				r.bufferedTuples.SetLength(numBufferedTuples + n)
+				r.scratch.SetLength(n)
 			})
+			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+
+			// Then, we need to update the sizes of the partitions.
+			// {{if .HasPartition}}
+			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
+			var runningPartitionsSizesCol []int64
+			if sel != nil {
+				for _, i := range sel[:n] {
+					_COMPUTE_PARTITIONS_SIZES()
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					_COMPUTE_PARTITIONS_SIZES()
+				}
+			}
+			// {{else}}
+			// There is a single partition in the whole input.
+			r.numTuplesInPartition += int64(n)
+			// {{end}}
+
+			// {{if .IsCumeDist}}
+			// Next, we need to update the sizes of the peer groups.
+			peersCol := batch.ColVec(r.peersColIdx).Bool()
+			var runningPeerGroupsSizesCol []int64
+			if sel != nil {
+				for _, i := range sel[:n] {
+					_COMPUTE_PEER_GROUPS_SIZES()
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					_COMPUTE_PEER_GROUPS_SIZES()
+				}
+			}
+			// {{end}}
 			continue
 
 		case relativeRankEmitting:
-			if r.resumeTupleIdx == r.bufferedTuples.Length() {
-				return coldata.ZeroBatch
+			if r.scratch, err = r.bufferedTuples.dequeue(); err != nil {
+				execerror.VectorizedInternalPanic(err)
 			}
+			n := r.scratch.Length()
+			if n == 0 {
+				r.state = relativeRankFinished
+				continue
+			}
+			// {{if .HasPartition}}
+			// Get the next batch of partition sizes if we haven't already.
+			if r.partitionsState.dequeuedSizes == nil {
+				if r.partitionsState.dequeuedSizes, err = r.partitionsState.dequeue(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				r.partitionsState.idx = 0
+				r.numTuplesInPartition = 0
+			}
+			// {{end}}
+			// {{if .IsCumeDist}}
+			// Get the next batch of peer group sizes if we haven't already.
+			if r.peerGroupsState.dequeuedSizes == nil {
+				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.dequeue(); err != nil {
+					execerror.VectorizedInternalPanic(err)
+				}
+				r.peerGroupsState.idx = 0
+				r.numPeers = 0
+			}
+			// {{end}}
+
 			r.output.ResetInternalBatch()
-			toCopy := r.bufferedTuples.Length() - r.resumeTupleIdx
-			if toCopy > coldata.BatchSize() {
-				toCopy = coldata.BatchSize()
-			}
-			// First, we copy over the appropriate slices of all buffered up columns.
+			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:r.outputColIdx], func() {
 				for colIdx, vec := range r.output.ColVecs()[:r.outputColIdx] {
 					vec.Append(
 						coldata.SliceArgs{
-							ColType:     r.inputTypes[colIdx],
-							Src:         r.bufferedTuples.ColVec(colIdx),
-							DestIdx:     0,
-							SrcStartIdx: r.resumeTupleIdx,
-							SrcEndIdx:   r.resumeTupleIdx + toCopy,
+							ColType:   r.inputTypes[colIdx],
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}
 			})
+
 			// Now we will populate the output column.
-			peersCol := r.bufferedTuples.ColVec(r.peersColIdx).Bool()
 			relativeRankOutputCol := r.output.ColVec(r.outputColIdx).Float64()
-			if r.bufferedTuples.Length() == 1 {
-				// {{if .IsPercentRank}}
-				// There is only a single tuple in the whole input, so we return
-				// zero, per spec.
-				relativeRankOutputCol[0] = 0
-				// {{end}}
-				// {{if .IsCumeDist}}
-				// There is only a single tuple in the whole input, so we return 1.
-				// {{/*
-				// Note: we could have avoided special casing in this scenario, but
-				// that would make the template less pleasing to the eye.
-				// */}}
-				relativeRankOutputCol[0] = 1
-				// {{end}}
-			} else {
+			// {{if .HasPartition}}
+			partitionCol := r.scratch.ColVec(r.partitionColIdx).Bool()
+			// {{end}}
+			peersCol := r.scratch.ColVec(r.peersColIdx).Bool()
+			// We don't need to think about the selection vector since all the
+			// buffered up tuples have been "deselected" during the buffering
+			// stage.
+			for i := range relativeRankOutputCol[:n] {
+				// We need to set r.numTuplesInPartition to the size of the
+				// partition that i'th tuple belongs to (which we have already
+				// computed).
 				// {{if .HasPartition}}
-				partitionCol := r.bufferedTuples.ColVec(r.partitionColIdx).Bool()
-				// {{end}}
-				// We don't need to think about the selection vector since all the
-				// buffered up tuples have been "deselected" during the buffering
-				// stage.
-				for i := range relativeRankOutputCol[:toCopy] {
-					// {{if .HasPartition}}
-					if partitionCol[r.resumeTupleIdx+i] {
-						// We have encountered a start of a new partition. Before we can
-						// populate the output for the consequent tuples, we'll need to
-						// know the size of the partition.
-						r.numTuplesInPartition = 1
-						for j := r.resumeTupleIdx + i + 1; j < r.bufferedTuples.Length(); j++ {
-							if partitionCol[j] {
-								break
-							}
-							r.numTuplesInPartition++
+				if partitionCol[i] {
+					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
+						if r.partitionsState.dequeuedSizes, err = r.partitionsState.dequeue(); err != nil {
+							execerror.VectorizedInternalPanic(err)
 						}
-						// {{if .IsPercentRank}}
-						// We need to reset the internal state because of the new
-						// partition.
-						r.rank = 1
-						r.rankIncrement = 1
-						relativeRankOutputCol[i] = 0
-						// {{end}}
-						// {{if .IsCumeDist}}
-						// We need to reset the number of preceding tuples because of the
-						// new partition.
-						r.numPrecedingTuples = 0
-						// Because we have encountered a start of a new partition, we have
-						// encountered a new peer group as well, and we need to compute the
-						// number of tuples in this peer group.
-						_COMPUTE_NUM_PEERS()
-						_COMPUTE_CUME_DIST()
-						// {{end}}
-						continue
+						r.partitionsState.idx = 0
 					}
-					// {{else}}
-					// There is a single partition in the whole input, so we already
-					// know all the necessary information to populate the output.
-					r.numTuplesInPartition = r.bufferedTuples.Length()
-					// {{end}}
-					if peersCol[r.resumeTupleIdx+i] {
-						// {{if .IsPercentRank}}
-						r.rank += r.rankIncrement
-						r.rankIncrement = 0
-						// {{end}}
-						// {{if .IsCumeDist}}
-						// We have encountered a new peer group, and we need to update the
-						// number of preceding tuples and compute the number of tuples in
-						// this peer group.
-						r.numPrecedingTuples += r.numPeers
-						_COMPUTE_NUM_PEERS()
-						// {{end}}
-					}
+					r.numTuplesInPartition = r.partitionsState.dequeuedSizes.ColVec(0).Int64()[r.partitionsState.idx]
+					r.partitionsState.idx++
 					// {{if .IsPercentRank}}
-					relativeRankOutputCol[i] = float64(r.rank-1) / float64(r.numTuplesInPartition-1)
-					r.rankIncrement++
+					// We need to reset the internal state because of the new
+					// partition.
+					r.rank = 0
+					r.rankIncrement = 1
 					// {{end}}
 					// {{if .IsCumeDist}}
-					_COMPUTE_CUME_DIST()
+					// We need to reset the number of preceding tuples because of the
+					// new partition.
+					r.numPrecedingTuples = 0
+					r.numPeers = 0
 					// {{end}}
 				}
+				// {{else}}
+				// There is a single partition in the whole input, and
+				// r.numTuplesInPartition already contains the correct number.
+				// {{end}}
+
+				if peersCol[i] {
+					// {{if .IsPercentRank}}
+					r.rank += r.rankIncrement
+					r.rankIncrement = 0
+					// {{end}}
+					// {{if .IsCumeDist}}
+					// We have encountered a new peer group, and we need to update the
+					// number of preceding tuples and get the number of tuples in
+					// this peer group.
+					r.numPrecedingTuples += r.numPeers
+					if r.peerGroupsState.idx == r.peerGroupsState.dequeuedSizes.Length() {
+						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.dequeue(); err != nil {
+							execerror.VectorizedInternalPanic(err)
+						}
+						r.peerGroupsState.idx = 0
+					}
+					r.numPeers = r.peerGroupsState.dequeuedSizes.ColVec(0).Int64()[r.peerGroupsState.idx]
+					r.peerGroupsState.idx++
+					// {{end}}
+				}
+
+				// Now we can compute the value of the window function for i'th
+				// tuple.
+				// {{if .IsPercentRank}}
+				if r.numTuplesInPartition == 1 {
+					// There is a single tuple in the partition, so we return 0, per spec.
+					relativeRankOutputCol[i] = 0
+				} else {
+					relativeRankOutputCol[i] = float64(r.rank-1) / float64(r.numTuplesInPartition-1)
+				}
+				r.rankIncrement++
+				// {{end}}
+				// {{if .IsCumeDist}}
+				relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
+				// {{end}}
 			}
-			r.resumeTupleIdx += toCopy
-			r.output.SetLength(toCopy)
+			r.output.SetLength(n)
 			return r.output
+
+		case relativeRankFinished:
+			if err := r.Close(); err != nil {
+				execerror.VectorizedInternalPanic(err)
+			}
+			return coldata.ZeroBatch
+
 		default:
 			execerror.VectorizedInternalPanic("percent rank operator in unhandled state")
 			// This code is unreachable, but the compiler cannot infer that.
 			return nil
 		}
 	}
+}
+
+func (r *_RELATIVE_RANK_STRINGOp) Close() error {
+	if r.closed {
+		return nil
+	}
+	var lastErr error
+	if err := r.bufferedTuples.close(); err != nil {
+		lastErr = err
+	}
+	// {{if .HasPartition}}
+	if err := r.partitionsState.close(); err != nil {
+		lastErr = err
+	}
+	// {{end}}
+	// {{if .IsCumeDist}}
+	if err := r.peerGroupsState.close(); err != nil {
+		lastErr = err
+	}
+	// {{end}}
+	r.closed = true
+	return lastErr
 }
 
 // {{end}}

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -19,7 +20,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/marusama/semaphore"
+	"github.com/stretchr/testify/require"
 )
 
 type windowFnTestCase struct {
@@ -46,233 +51,264 @@ func TestWindowFunctions(t *testing.T) {
 			Settings: st,
 		},
 	}
+	// All supported window function operators will use from 0 to 3 disk queues
+	// with each using a single FD at any point in time. Additionally, the
+	// disk-backed sorter (that will be planned depending on PARTITION BY and
+	// ORDER BY combinations) will be limited to this number using a testing
+	// knob, so 3 is necessary and sufficient.
+	const maxNumberFDs = 3
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	var (
+		memAccounts []*mon.BoundAccount
+		memMonitors []*mon.BytesMonitor
+	)
 
 	rowNumberFn := execinfrapb.WindowerSpec_ROW_NUMBER
 	rankFn := execinfrapb.WindowerSpec_RANK
 	denseRankFn := execinfrapb.WindowerSpec_DENSE_RANK
 	percentRankFn := execinfrapb.WindowerSpec_PERCENT_RANK
 	cumeDistFn := execinfrapb.WindowerSpec_CUME_DIST
-	for _, tc := range []windowFnTestCase{
-		// With PARTITION BY, no ORDER BY.
-		//
-		// Without ORDER BY, the output of row_number is non-deterministic, so we
-		// skip such a case for rowNumberFn.
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1}, {nil, 1}, {1, 1}, {1, 1}, {2, 1}, {3, 1}, {3, 1}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
-						OutputColIdx: 1,
+	for _, spillForced := range []bool{false, true} {
+		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
+		for _, tc := range []windowFnTestCase{
+			// With PARTITION BY, no ORDER BY.
+			//
+			// Without ORDER BY, the output of row_number is non-deterministic, so we
+			// skip such a case for rowNumberFn.
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1}, {nil, 1}, {1, 1}, {1, 1}, {2, 1}, {3, 1}, {3, 1}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1}, {nil, 1}, {1, 1}, {1, 1}, {2, 1}, {3, 1}, {3, 1}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1}, {nil, 1}, {1, 1}, {1, 1}, {2, 1}, {3, 1}, {3, 1}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 0}, {nil, 0}, {1, 0}, {1, 0}, {2, 0}, {3, 0}, {3, 0}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 0}, {nil, 0}, {1, 0}, {1, 0}, {2, 0}, {3, 0}, {3, 0}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1.0}, {nil, 1.0}, {1, 1.0}, {1, 1.0}, {2, 1.0}, {3, 1.0}, {3, 1.0}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1.0}, {nil, 1.0}, {1, 1.0}, {1, 1.0}, {2, 1.0}, {3, 1.0}, {3, 1.0}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
 
-		// No PARTITION BY, with ORDER BY.
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1}, {nil, 2}, {1, 3}, {1, 4}, {2, 5}, {3, 6}, {3, 7}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rowNumberFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
-						OutputColIdx: 1,
+			// No PARTITION BY, with ORDER BY.
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1}, {nil, 2}, {1, 3}, {1, 4}, {2, 5}, {3, 6}, {3, 7}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rowNumberFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1}, {nil, 1}, {1, 3}, {1, 3}, {2, 5}, {3, 6}, {3, 6}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1}, {nil, 1}, {1, 3}, {1, 3}, {2, 5}, {3, 6}, {3, 6}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 1}, {nil, 1}, {1, 2}, {1, 2}, {2, 3}, {3, 4}, {3, 4}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 1}, {nil, 1}, {1, 2}, {1, 2}, {2, 3}, {3, 4}, {3, 4}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {1}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 0}, {nil, 0}, {1, 2.0 / 7}, {1, 2.0 / 7}, {1, 2.0 / 7}, {2, 5.0 / 7}, {3, 6.0 / 7}, {3, 6.0 / 7}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {1}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 0}, {nil, 0}, {1, 2.0 / 7}, {1, 2.0 / 7}, {1, 2.0 / 7}, {2, 5.0 / 7}, {3, 6.0 / 7}, {3, 6.0 / 7}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3}, {1}, {2}, {1}, {nil}, {1}, {nil}, {3}},
-			expected: tuples{{nil, 2.0 / 8}, {nil, 2.0 / 8}, {1, 5.0 / 8}, {1, 5.0 / 8}, {1, 5.0 / 8}, {2, 6.0 / 8}, {3, 1.0}, {3, 1.0}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
-						OutputColIdx: 1,
+			{
+				tuples:   tuples{{3}, {1}, {2}, {1}, {nil}, {1}, {nil}, {3}},
+				expected: tuples{{nil, 2.0 / 8}, {nil, 2.0 / 8}, {1, 5.0 / 8}, {1, 5.0 / 8}, {1, 5.0 / 8}, {2, 6.0 / 8}, {3, 1.0}, {3, 1.0}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}}},
+							OutputColIdx: 1,
+						},
 					},
 				},
 			},
-		},
 
-		// With both PARTITION BY and ORDER BY.
-		{
-			tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
-			expected: tuples{{nil, nil, 1}, {nil, nil, 2}, {nil, 1, 3}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rowNumberFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
-						OutputColIdx: 2,
+			// With both PARTITION BY and ORDER BY.
+			{
+				tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
+				expected: tuples{{nil, nil, 1}, {nil, nil, 2}, {nil, 1, 3}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rowNumberFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
+							OutputColIdx: 2,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
-			expected: tuples{{nil, nil, 1}, {nil, nil, 1}, {nil, 1, 3}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
-						OutputColIdx: 2,
+			{
+				tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
+				expected: tuples{{nil, nil, 1}, {nil, nil, 1}, {nil, 1, 3}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
+							OutputColIdx: 2,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
-			expected: tuples{{nil, nil, 1}, {nil, nil, 1}, {nil, 1, 2}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
-						OutputColIdx: 2,
+			{
+				tuples:   tuples{{3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {nil, nil}, {3, 1}},
+				expected: tuples{{nil, nil, 1}, {nil, nil, 1}, {nil, 1, 2}, {1, nil, 1}, {1, 2, 2}, {2, 1, 1}, {3, 1, 1}, {3, 2, 2}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &denseRankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
+							OutputColIdx: 2,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{nil, 2}, {3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {1, 3}, {nil, nil}, {3, 1}},
-			expected: tuples{{nil, nil, 0}, {nil, nil, 0}, {nil, 1, 2.0 / 3}, {nil, 2, 1}, {1, nil, 0}, {1, 2, 1.0 / 2}, {1, 3, 1}, {2, 1, 0}, {3, 1, 0}, {3, 2, 1}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
-						OutputColIdx: 2,
+			{
+				tuples:   tuples{{nil, 2}, {3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {1, 3}, {nil, nil}, {3, 1}},
+				expected: tuples{{nil, nil, 0}, {nil, nil, 0}, {nil, 1, 2.0 / 3}, {nil, 2, 1}, {1, nil, 0}, {1, 2, 1.0 / 2}, {1, 3, 1}, {2, 1, 0}, {3, 1, 0}, {3, 2, 1}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &percentRankFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
+							OutputColIdx: 2,
+						},
 					},
 				},
 			},
-		},
-		{
-			tuples:   tuples{{nil, 2}, {3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {1, 3}, {nil, nil}, {3, 1}},
-			expected: tuples{{nil, nil, 2.0 / 4}, {nil, nil, 2.0 / 4}, {nil, 1, 3.0 / 4}, {nil, 2, 1}, {1, nil, 1.0 / 3}, {1, 2, 2.0 / 3}, {1, 3, 1}, {2, 1, 1}, {3, 1, 1.0 / 2}, {3, 2, 1}},
-			windowerSpec: execinfrapb.WindowerSpec{
-				PartitionBy: []uint32{0},
-				WindowFns: []execinfrapb.WindowerSpec_WindowFn{
-					{
-						Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
-						Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
-						OutputColIdx: 2,
+			{
+				tuples:   tuples{{nil, 2}, {3, 2}, {1, nil}, {2, 1}, {nil, nil}, {1, 2}, {nil, 1}, {1, 3}, {nil, nil}, {3, 1}},
+				expected: tuples{{nil, nil, 2.0 / 4}, {nil, nil, 2.0 / 4}, {nil, 1, 3.0 / 4}, {nil, 2, 1}, {1, nil, 1.0 / 3}, {1, 2, 2.0 / 3}, {1, 3, 1}, {2, 1, 1}, {3, 1, 1.0 / 2}, {3, 2, 1}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &cumeDistFn},
+							Ordering:     execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 1}}},
+							OutputColIdx: 2,
+						},
 					},
 				},
 			},
-		},
-	} {
-		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, func(inputs []Operator) (Operator, error) {
-			tc.init()
-			ct := make([]types.T, len(tc.tuples[0]))
-			for i := range ct {
-				ct[i] = *types.Int
-			}
-			spec := &execinfrapb.ProcessorSpec{
-				Input: []execinfrapb.InputSyncSpec{{ColumnTypes: ct}},
-				Core: execinfrapb.ProcessorCoreUnion{
-					Windower: &tc.windowerSpec,
-				},
-			}
-			args := NewColOperatorArgs{
-				Spec:                spec,
-				Inputs:              inputs,
-				StreamingMemAccount: testMemAcc,
-				FDSemaphore:         NewTestingSemaphore(VecMaxOpenFDsLimit),
-			}
-			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-			result, err := NewColOperator(ctx, flowCtx, args)
-			if err != nil {
-				return nil, err
-			}
-			return result.Op, nil
-		})
+		} {
+			t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.windowerSpec.WindowFns[0].Func.String()), func(t *testing.T) {
+				var semsToCheck []semaphore.Semaphore
+				runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, func(inputs []Operator) (Operator, error) {
+					tc.init()
+					ct := make([]types.T, len(tc.tuples[0]))
+					for i := range ct {
+						ct[i] = *types.Int
+					}
+					spec := &execinfrapb.ProcessorSpec{
+						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: ct}},
+						Core: execinfrapb.ProcessorCoreUnion{
+							Windower: &tc.windowerSpec,
+						},
+					}
+					sem := NewTestingSemaphore(maxNumberFDs)
+					args := NewColOperatorArgs{
+						Spec:                spec,
+						Inputs:              inputs,
+						StreamingMemAccount: testMemAcc,
+						DiskQueueCfg:        queueCfg,
+						FDSemaphore:         sem,
+					}
+					semsToCheck = append(semsToCheck, sem)
+					args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+					args.TestingKnobs.NumForcedRepartitions = maxNumberFDs
+					result, err := NewColOperator(ctx, flowCtx, args)
+					memAccounts = append(memAccounts, result.BufferingOpMemAccounts...)
+					memMonitors = append(memMonitors, result.BufferingOpMemMonitors...)
+					return result.Op, err
+				})
+				for i, sem := range semsToCheck {
+					require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+				}
+			})
+		}
+	}
+	for _, account := range memAccounts {
+		account.Close(ctx)
+	}
+	for _, monitor := range memMonitors {
+		monitor.Stop(ctx)
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -1,5 +1,3 @@
-# LogicTest: local-vec fakedist-vec
-
 statement ok
 CREATE TABLE t (a INT, b INT, c INT PRIMARY KEY)
 
@@ -9,9 +7,6 @@ INSERT INTO t VALUES
   (1, 1, 1),
   (0, 2, 2),
   (1, 2, 3)
-
-statement ok
-SET vectorize=experimental_always
 
 # We sort the output on all queries with row_number window function to get
 # deterministic results.

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec fakedist fakedist-metadata fakedist-vec 5node-local 5node-dist 5node-dist-metadata 5node-dist-disk
+# LogicTest: local local-vec fakedist fakedist-metadata fakedist-vec fakedist-vec-disk 5node-local 5node-dist 5node-dist-metadata 5node-dist-disk
 
 statement ok
 CREATE TABLE kv (


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality (the code in question will only run with `experimental_on`
vectorize setting, i.e. it is not used by default).

This commit adds the disk spilling to `percent_rank` and `cume_dist`
window functionsg. This involved the following refactor: since we can no
longer have the access to long vectors of `partitionCol` and `peersCol`
(so that we are able to compute the sizes of the partitions and peer
groups on the fly when emitting the output), we will be computing those
values while buffering the input and writing the values into two
separate `spillingQueue`s.

Fixes: #45596.

Release note: None