### PR TITLE
sql: add telemetry for certain column qualifications

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -170,8 +170,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 			}
 			d = newDef
+			incTelemetryForNewColumn(d)
 
-			telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
 			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx)
 			if err != nil {
 				return err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1640,7 +1640,7 @@ func makeTableDesc(
 		}
 		// Do not include virtual tables in these statistics.
 		if !sqlbase.IsVirtualTable(id) {
-			telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
+			incTelemetryForNewColumn(d)
 		}
 		newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, &n.Table)
 		if err != nil {
@@ -2054,4 +2054,19 @@ func MakeCheckConstraint(
 		ColumnIDs: colIDs,
 		Hidden:    d.Hidden,
 	}, nil
+}
+
+// incTelemetryForNewColumn increments relevant telemetry every time a new column
+// is added to a table.
+func incTelemetryForNewColumn(d *tree.ColumnTableDef) {
+	telemetry.Inc(sqltelemetry.SchemaNewTypeCounter(d.Type.TelemetryName()))
+	if d.IsComputed() {
+		telemetry.Inc(sqltelemetry.SchemaNewColumnTypeQualificationCounter("computed"))
+	}
+	if d.HasDefaultExpr() {
+		telemetry.Inc(sqltelemetry.SchemaNewColumnTypeQualificationCounter("default_expr"))
+	}
+	if d.Unique {
+		telemetry.Inc(sqltelemetry.SchemaNewColumnTypeQualificationCounter("unique"))
+	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1058,3 +1058,27 @@ ALTER TABLE t43092 ALTER COLUMN x DROP NOT NULL
 
 statement ok
 DROP TABLE t43092
+
+subtest regression_qualification_feature_counts
+
+statement ok
+CREATE TABLE telemetry_test (d int);
+ALTER TABLE telemetry_test
+  ADD COLUMN a int DEFAULT 1,
+  ADD COLUMN b int UNIQUE CHECK(b > 1),
+  ADD COLUMN c int AS (a + b) STORED
+
+query T rowsort
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.new_column.qualification.computed',
+  'sql.schema.new_column.qualification.default_expr',
+  'sql.schema.new_column.qualification.unique'
+)
+----
+sql.schema.new_column.qualification.unique
+sql.schema.new_column.qualification.computed
+sql.schema.new_column.qualification.default_expr
+
+statement ok
+DROP TABLE telemetry_test

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -29,7 +29,6 @@ SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name IN ('sql
 sql.schema.new_column_type.timetz_3_
 sql.schema.new_column_type.timetz_4_
 
-
 statement ok
 CREATE TABLE sec_col_fam(x INT, y INT, z INT, FAMILY (x), FAMILY (y), FAMILY (z), INDEX (x) STORING (y, z));
 CREATE INDEX ON sec_col_fam (x) STORING (y, z)
@@ -71,3 +70,23 @@ t  CREATE TABLE t (
    rowid_1 INT8 NULL,
    FAMILY fam_0_rowid_rowid_1_rowid_2 (rowid, rowid_1, rowid_2)
 )
+
+subtest regression_qualification_feature_counts
+
+statement ok
+CREATE TABLE telemetry_test (a int DEFAULT 1, b int UNIQUE CHECK(b > 1), c int AS (a + b) STORED)
+
+query T rowsort
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.new_column.qualification.computed',
+  'sql.schema.new_column.qualification.default_expr',
+  'sql.schema.new_column.qualification.unique'
+)
+----
+sql.schema.new_column.qualification.unique
+sql.schema.new_column.qualification.computed
+sql.schema.new_column.qualification.default_expr
+
+statement ok
+DROP TABLE telemetry_test

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -50,6 +50,12 @@ var (
 	TempObjectCleanerDeletionCounter = telemetry.GetCounterOnce("sql.schema.temp_object_cleaner.num_cleaned")
 )
 
+// SchemaNewColumnTypeQualificationCounter is to be incremented every time
+// a new qualification is used for a newly created column.
+func SchemaNewColumnTypeQualificationCounter(qual string) telemetry.Counter {
+	return telemetry.GetCounter("sql.schema.new_column.qualification." + qual)
+}
+
 // SchemaChangeCreate is to be incremented every time a CREATE
 // schema change was made.
 func SchemaChangeCreate(typ string) telemetry.Counter {


### PR DESCRIPTION
Added new telemetry for qualifications on new columns
(e.g. STORED, DefaultExpr, Unique expressions for columns).

Release note: None

Release justification: just telemetry