### PR TITLE
sql: add telemetry for changing of EXPERIMENTAL_AUDIT values

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -820,6 +820,8 @@ func (p *planner) setAuditMode(
 		return false, err
 	}
 
+	telemetry.Inc(sqltelemetry.SchemaSetAuditModeCounter(auditMode.TelemetryName()))
+
 	return desc.SetAuditMode(auditMode)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -820,6 +820,11 @@ ROLLBACK
 statement ok
 CREATE TABLE audit(x INT); ALTER TABLE audit EXPERIMENTAL_AUDIT SET READ WRITE;
 
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.set_audit_mode.read_write'
+----
+sql.schema.set_audit_mode.read_write
+
 # The user must be able to issue ALTER for this test to be meaningful.
 statement ok
 GRANT CREATE ON audit TO testuser
@@ -832,9 +837,17 @@ ALTER TABLE audit ADD COLUMN y INT
 
 # But not the audit settings.
 statement error change auditing settings on a table
-ALTER TABLE audit EXPERIMENTAL_AUDIT SET OFF;
+ALTER TABLE audit EXPERIMENTAL_AUDIT SET OFF
 
 user root
+
+statement ok
+ALTER TABLE audit EXPERIMENTAL_AUDIT SET OFF
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.set_audit_mode.off'
+----
+sql.schema.set_audit_mode.off
 
 # Check column backfill in the presence of fks
 subtest 27402

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -11,6 +11,8 @@
 package tree
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -502,6 +504,12 @@ var auditModeName = [...]string{
 
 func (m AuditMode) String() string {
 	return auditModeName[m]
+}
+
+// TelemetryName returns a friendly string for use in telemetry that represents
+// the AuditMode.
+func (m AuditMode) TelemetryName() string {
+	return strings.ReplaceAll(strings.ToLower(m.String()), " ", "_")
 }
 
 // AlterTableSetAudit represents an ALTER TABLE AUDIT SET statement.

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -86,6 +86,11 @@ func SchemaChangeAlterWithExtra(typ string, extra string) telemetry.Counter {
 	return telemetry.GetCounter(fmt.Sprintf("sql.schema.alter_%s%s", typ, extra))
 }
 
+// SchemaSetAuditModeCounter is to be incremented every time an audit mode is set.
+func SchemaSetAuditModeCounter(mode string) telemetry.Counter {
+	return telemetry.GetCounter("sql.schema.set_audit_mode." + mode)
+}
+
 // SecondaryIndexColumnFamiliesCounter is a counter that is incremented every time
 // a secondary index that is separated into different column families is created.
 var SecondaryIndexColumnFamiliesCounter = telemetry.GetCounterOnce("sql.schema.secondary_index_column_families")


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/45027

This PR add telemetry for when EXPERIMENTAL_AUDIT values are changed (as
we currently do not have gauges to measure this).

Release justification: This is safe as it is simply telemetry.

Release note: None