### PR TITLE
sqltelemetry: append Counter to end of Counter names

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -61,7 +61,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 	for _, cmd := range n.n.Cmds {
 		switch t := cmd.(type) {
 		case *tree.AlterIndexPartitionBy:
-			telemetry.Inc(sqltelemetry.SchemaChangeAlterWithExtra("index", "partition_by"))
+			telemetry.Inc(sqltelemetry.SchemaChangeAlterCounterWithExtra("index", "partition_by"))
 			partitioning, err := CreatePartitioning(
 				params.ctx, params.extendedEvalCtx.Settings,
 				params.EvalContext(),

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -50,7 +50,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 func (n *alterSequenceNode) ReadingOwnWrites() {}
 
 func (n *alterSequenceNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeAlter("sequence"))
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("sequence"))
 	desc := n.seqDesc
 
 	err := assignSequenceOptions(desc.SequenceOpts, n.n.Options, false /* setDefaults */, &params, desc.GetID())

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -120,7 +120,7 @@ func isAlterCmdValidWithoutPrimaryKey(cmd tree.AlterTableCmd) bool {
 func (n *alterTableNode) ReadingOwnWrites() {}
 
 func (n *alterTableNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeAlter("table"))
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounter("table"))
 
 	// Commands can either change the descriptor directly (for
 	// alterations that don't require a backfill) or add a mutation to

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -75,7 +75,7 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 }
 
 func (n *createDatabaseNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("database"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("database"))
 	desc := makeDatabaseDesc(n.n)
 
 	created, err := params.p.createDatabase(

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -265,7 +265,7 @@ func maybeCreateAndAddShardCol(
 }
 
 func (n *createIndexNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("index"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("index"))
 	_, dropped, err := n.tableDesc.FindIndexByName(string(n.n.Name))
 	if err == nil {
 		if dropped {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -51,7 +51,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 func (n *createSequenceNode) ReadingOwnWrites() {}
 
 func (n *createSequenceNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("sequence"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("sequence"))
 	isTemporary := n.n.Temporary
 
 	_, schemaID, err := getTableCreateParams(params, n.dbDesc.ID, isTemporary, n.n.Name.Table())

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -72,7 +72,7 @@ type createStatsRun struct {
 }
 
 func (n *createStatsNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("stats"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("stats"))
 	n.run.resultsCh = make(chan tree.Datums)
 	n.run.errCh = make(chan error)
 	go func() {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -158,7 +158,7 @@ func getTableCreateParams(
 }
 
 func (n *createTableNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("table"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("table"))
 	isTemporary := n.n.Temporary
 
 	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.ID, isTemporary, n.n.Table.Table())

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -46,7 +46,7 @@ type createViewNode struct {
 func (n *createViewNode) ReadingOwnWrites() {}
 
 func (n *createViewNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreate("view"))
+	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("view"))
 
 	viewName := string(n.viewName)
 	isTemporary := n.temporary

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -124,7 +124,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 }
 
 func (n *dropDatabaseNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeDrop("database"))
+	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("database"))
 
 	ctx := params.ctx
 	p := params.p

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -68,7 +68,7 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 func (n *dropIndexNode) ReadingOwnWrites() {}
 
 func (n *dropIndexNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeDrop("index"))
+	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("index"))
 
 	ctx := params.ctx
 	for _, index := range n.idxNames {

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -63,7 +63,7 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 func (n *dropSequenceNode) ReadingOwnWrites() {}
 
 func (n *dropSequenceNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeDrop("sequence"))
+	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("sequence"))
 
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -104,7 +104,7 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 func (n *dropTableNode) ReadingOwnWrites() {}
 
 func (n *dropTableNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeDrop("table"))
+	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("table"))
 
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -77,7 +77,7 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 func (n *dropViewNode) ReadingOwnWrites() {}
 
 func (n *dropViewNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeDrop("view"))
+	telemetry.Inc(sqltelemetry.SchemaChangeDropCounter("view"))
 
 	ctx := params.ctx
 	for _, toDel := range n.td {

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -107,7 +107,7 @@ type AlterTableAddColumn struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableAddColumn) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "add_column")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "add_column")
 }
 
 // Format implements the NodeFormatter interface.
@@ -182,7 +182,7 @@ type AlterTableAddConstraint struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableAddConstraint) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "add_constraint")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "add_constraint")
 }
 
 // Format implements the NodeFormatter interface.
@@ -204,7 +204,7 @@ type AlterTableAlterColumnType struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableAlterColumnType) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "alter_column_type")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "alter_column_type")
 }
 
 // Format implements the NodeFormatter interface.
@@ -237,7 +237,7 @@ type AlterTableAlterPrimaryKey struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableAlterPrimaryKey) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "alter_primary_key")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "alter_primary_key")
 }
 
 // Format implements the NodeFormatter interface.
@@ -262,7 +262,7 @@ type AlterTableDropColumn struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableDropColumn) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "drop_column")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_column")
 }
 
 // Format implements the NodeFormatter interface.
@@ -286,7 +286,7 @@ type AlterTableDropConstraint struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableDropConstraint) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "drop_constraint")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_constraint")
 }
 
 // Format implements the NodeFormatter interface.
@@ -308,7 +308,7 @@ type AlterTableValidateConstraint struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableValidateConstraint) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "validate_constraint")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "validate_constraint")
 }
 
 // Format implements the NodeFormatter interface.
@@ -324,7 +324,7 @@ type AlterTableRenameTable struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableRenameTable) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "rename_table")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "rename_table")
 }
 
 // Format implements the NodeFormatter interface.
@@ -341,7 +341,7 @@ type AlterTableRenameColumn struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableRenameColumn) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "rename_column")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "rename_column")
 }
 
 // Format implements the NodeFormatter interface.
@@ -360,7 +360,7 @@ type AlterTableRenameConstraint struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableRenameConstraint) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "rename_constraint")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "rename_constraint")
 }
 
 // Format implements the NodeFormatter interface.
@@ -385,7 +385,7 @@ func (node *AlterTableSetDefault) GetColumn() Name {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableSetDefault) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "set_default")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_default")
 }
 
 // Format implements the NodeFormatter interface.
@@ -413,7 +413,7 @@ func (node *AlterTableSetNotNull) GetColumn() Name {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableSetNotNull) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "set_not_null")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_not_null")
 }
 
 // Format implements the NodeFormatter interface.
@@ -436,7 +436,7 @@ func (node *AlterTableDropNotNull) GetColumn() Name {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableDropNotNull) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "drop_not_null")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_not_null")
 }
 
 // Format implements the NodeFormatter interface.
@@ -459,7 +459,7 @@ func (node *AlterTableDropStored) GetColumn() Name {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableDropStored) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "drop_stored")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_stored")
 }
 
 // Format implements the NodeFormatter interface.
@@ -477,7 +477,7 @@ type AlterTablePartitionBy struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTablePartitionBy) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "partition_by")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "partition_by")
 }
 
 // Format implements the NodeFormatter interface.
@@ -511,7 +511,7 @@ type AlterTableSetAudit struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableSetAudit) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "set_audit")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_audit")
 }
 
 // Format implements the NodeFormatter interface.
@@ -527,7 +527,7 @@ type AlterTableInjectStats struct {
 
 // TelemetryCounter implements the AlterTableCmd interface.
 func (node *AlterTableInjectStats) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterWithExtra("table", "inject_stats")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "inject_stats")
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -146,7 +146,7 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 					"unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
 			telemetry.Inc(
-				sqltelemetry.SchemaSetZoneConfig(
+				sqltelemetry.SchemaSetZoneConfigCounter(
 					n.ZoneSpecifier.TelemetryName(),
 					string(opt.Key),
 				),
@@ -305,7 +305,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	}
 
 	telemetry.Inc(
-		sqltelemetry.SchemaChangeAlterWithExtra(n.zoneSpecifier.TelemetryName(), "configure_zone"),
+		sqltelemetry.SchemaChangeAlterCounterWithExtra(n.zoneSpecifier.TelemetryName(), "configure_zone"),
 	)
 
 	// If the specifier is for a table, partition or index, this will

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -56,36 +56,36 @@ func SchemaNewColumnTypeQualificationCounter(qual string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.new_column.qualification." + qual)
 }
 
-// SchemaChangeCreate is to be incremented every time a CREATE
+// SchemaChangeCreateCounter is to be incremented every time a CREATE
 // schema change was made.
-func SchemaChangeCreate(typ string) telemetry.Counter {
+func SchemaChangeCreateCounter(typ string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.create_" + typ)
 }
 
-// SchemaChangeDrop is to be incremented every time a DROP
+// SchemaChangeDropCounter is to be incremented every time a DROP
 // schema change was made.
-func SchemaChangeDrop(typ string) telemetry.Counter {
+func SchemaChangeDropCounter(typ string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.drop_" + typ)
 }
 
-// SchemaSetZoneConfig is to be incremented every time a ZoneConfig
+// SchemaSetZoneConfigCounter is to be incremented every time a ZoneConfig
 // argument is parsed.
-func SchemaSetZoneConfig(configName, keyChange string) telemetry.Counter {
+func SchemaSetZoneConfigCounter(configName, keyChange string) telemetry.Counter {
 	return telemetry.GetCounter(
 		fmt.Sprintf("sql.schema.zone_config.%s.%s", configName, keyChange),
 	)
 }
 
-// SchemaChangeAlter behaves the same as SchemaChangeAlterWithExtra
+// SchemaChangeAlterCounter behaves the same as SchemaChangeAlterCounterWithExtra
 // but with no extra metadata.
-func SchemaChangeAlter(typ string) telemetry.Counter {
-	return SchemaChangeAlterWithExtra(typ, "")
+func SchemaChangeAlterCounter(typ string) telemetry.Counter {
+	return SchemaChangeAlterCounterWithExtra(typ, "")
 }
 
-// SchemaChangeAlterWithExtra is to be incremented for ALTER schema changes.
+// SchemaChangeAlterCounterWithExtra is to be incremented for ALTER schema changes.
 // `typ` is for declaring which type was altered, e.g. TABLE, DATABASE.
 // `extra` can be used for extra trailing useful metadata.
-func SchemaChangeAlterWithExtra(typ string, extra string) telemetry.Counter {
+func SchemaChangeAlterCounterWithExtra(typ string, extra string) telemetry.Counter {
 	if extra != "" {
 		extra = "." + extra
 	}


### PR DESCRIPTION
Doing some spring cleaning of consistency in the sqltelemetry package by
making sure all counters end with the word `Counter`.

Release justification: telemetry / small refactor with no user facing changes.

Release note: None