### PR TITLE
kvnemesis: structure the config for the operation generator

### DIFF
--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -11,18 +11,56 @@
 package kvnemesis
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
-// TODO(dan): Test that all operations actually are in newAllOperationsConfig.
+func trueForEachIntField(c *OperationConfig, fn func(int) bool) bool {
+	var forEachIntField func(v reflect.Value) bool
+	forEachIntField = func(v reflect.Value) bool {
+		switch v.Type().Kind() {
+		case reflect.Ptr:
+			return forEachIntField(v.Elem())
+		case reflect.Int:
+			ok := fn(int(v.Int()))
+			if !ok {
+				if log.V(1) {
+					log.Infof(context.Background(), "returned false for %d: %v", v.Int(), v)
+				}
+			}
+			return ok
+		case reflect.Struct:
+			for fieldIdx := 0; fieldIdx < v.NumField(); fieldIdx++ {
+				if !forEachIntField(v.Field(fieldIdx)) {
+					if log.V(1) {
+						log.Infof(context.Background(), "returned false for %s in %s",
+							v.Type().Field(fieldIdx).Name, v.Type().Name())
+					}
+					return false
+				}
+			}
+			return true
+		default:
+			panic(errors.AssertionFailedf(`unexpected type: %s`, v.Type()))
+		}
+
+	}
+	return forEachIntField(reflect.ValueOf(c))
+}
 
 // TestRandStep generates random steps until we've seen each type at least N
-// times, validating each step along the way.
+// times, validating each step along the way. This both verifies that the config
+// returned by `newAllOperationsConfig()` in fact contains all operations as
+// well as verifies that Generator actually generates all of these operation
+// types.
 func TestRandStep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -31,7 +69,7 @@ func TestRandStep(t *testing.T) {
 	config.NumNodes, config.NumReplicas = 2, 1
 	rng, _ := randutil.NewPseudoRand()
 	getReplicasFn := func(_ roachpb.Key) []roachpb.ReplicationTarget {
-		return make([]roachpb.ReplicationTarget, rng.Intn(1)+1)
+		return make([]roachpb.ReplicationTarget, rng.Intn(2)+1)
 	}
 	g, err := MakeGenerator(config, getReplicasFn)
 	require.NoError(t, err)
@@ -55,62 +93,81 @@ func TestRandStep(t *testing.T) {
 
 	splits := make(map[string]struct{})
 
-	counts := make(map[OpP]int, len(config.OpPs))
+	var countClientOps func(*ClientOperationConfig, *BatchOperationConfig, ...Operation)
+	countClientOps = func(client *ClientOperationConfig, batch *BatchOperationConfig, ops ...Operation) {
+		for _, op := range ops {
+			switch o := op.GetValue().(type) {
+			case *GetOperation:
+				if _, ok := keys[string(o.Key)]; ok {
+					client.GetExisting++
+				} else {
+					client.GetMissing++
+				}
+			case *PutOperation:
+				if _, ok := keys[string(o.Key)]; ok {
+					client.PutExisting++
+				} else {
+					client.PutMissing++
+				}
+			case *BatchOperation:
+				batch.Batch++
+				countClientOps(&batch.Ops, nil, o.Ops...)
+			}
+		}
+	}
+
+	counts := OperationConfig{}
 	for {
 		step := g.RandStep(rng)
-
 		switch o := step.Op.GetValue().(type) {
-		case *GetOperation:
-			if _, ok := keys[string(o.Key)]; ok {
-				counts[OpPGetExisting]++
-			} else {
-				counts[OpPGetMissing]++
-			}
-		case *PutOperation:
-			if _, ok := keys[string(o.Key)]; ok {
-				counts[OpPPutExisting]++
-			} else {
-				counts[OpPPutMissing]++
-			}
+		case *GetOperation, *PutOperation, *BatchOperation:
+			countClientOps(&counts.DB, &counts.Batch, step.Op)
 		case *ClosureTxnOperation:
+			countClientOps(&counts.ClosureTxn.TxnClientOps, &counts.ClosureTxn.TxnBatchOps, o.Ops...)
 			if o.CommitInBatch != nil {
-				if o.Type != ClosureTxnType_Commit {
-					t.Fatalf(`commit type %s is invalid with CommitInBatch`, o.Type)
-				}
-				counts[OpPClosureTxnCommitInBatch]++
-			} else {
-				counts[OpPClosureTxn]++
+				counts.ClosureTxn.CommitInBatch++
+				countClientOps(&counts.ClosureTxn.CommitBatchOps, nil, o.CommitInBatch.Ops...)
+			} else if o.Type == ClosureTxnType_Commit {
+				counts.ClosureTxn.Commit++
+			} else if o.Type == ClosureTxnType_Rollback {
+				counts.ClosureTxn.Rollback++
 			}
-		case *BatchOperation:
-			counts[OpPBatch]++
 		case *SplitOperation:
 			if _, ok := splits[string(o.Key)]; ok {
-				counts[OpPSplitAgain]++
+				counts.Split.SplitAgain++
 			} else {
-				counts[OpPSplitNew]++
+				counts.Split.SplitNew++
 			}
 			splits[string(o.Key)] = struct{}{}
 		case *MergeOperation:
 			if _, ok := splits[string(o.Key)]; ok {
-				counts[OpPMergeIsSplit]++
+				counts.Merge.MergeIsSplit++
 			} else {
-				counts[OpPMergeNotSplit]++
+				counts.Merge.MergeNotSplit++
 			}
 		case *ChangeReplicasOperation:
-			counts[OpPChangeReplicas]++
+			var adds, removes int
+			for _, change := range o.Changes {
+				switch change.ChangeType {
+				case roachpb.ADD_REPLICA:
+					adds++
+				case roachpb.REMOVE_REPLICA:
+					removes++
+				}
+			}
+			if adds == 1 && removes == 0 {
+				counts.ChangeReplicas.AddReplica++
+			} else if adds == 0 && removes == 1 {
+				counts.ChangeReplicas.RemoveReplica++
+			} else if adds == 1 && removes == 1 {
+				counts.ChangeReplicas.AtomicSwapReplica++
+			}
 		}
 		updateKeys(step.Op)
 
 		// TODO(dan): Make sure the proportions match the requested ones to within
 		// some bounds.
-		done := true
-		for op := range config.OpPs {
-			if counts[op] < minEachType {
-				done = false
-				break
-			}
-		}
-		if done {
+		if trueForEachIntField(&counts, func(count int) bool { return count >= minEachType }) {
 			break
 		}
 	}

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -73,10 +73,8 @@ func TestKVNemesisMultiNode(t *testing.T) {
 	// kvnemesis found a rare bug with closed timestamps when splits (and maybe
 	// merges) happen on a multinode cluster. Disable the combo for now to keep
 	// the test from flaking. #44878
-	config.OpPs[OpPMergeIsSplit] = 0
-	config.OpPs[OpPMergeNotSplit] = 0
-	config.OpPs[OpPSplitNew] = 0
-	config.OpPs[OpPSplitAgain] = 0
+	config.Ops.Merge = MergeConfig{}
+	config.Ops.Split = SplitConfig{}
 	rng, _ := randutil.NewPseudoRand()
 	ct := sqlClosedTimestampTargetInterval{sqlDBs: sqlDBs}
 	failures, err := RunNemesis(ctx, rng, ct, config, dbs...)


### PR DESCRIPTION
Previously, it was an all flatted into a string->int map. This caused
the addition of another "client" operation, such as CPut, to require
quite a bit of unnecessary duplication.

It also was limiting in that the proportion of client operations
couldn't be varied between DB, Txn, Batch, and CommitInBatch. They can
now, though this isn't yet used.

Release justification: non-production code changes

Release note: None