### PR TITLE
kvserver/concurrency: allow lock acquisition out of seq num order

### DIFF
--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_idempotency
@@ -140,9 +140,9 @@ global: num=1
 local: num=0
 
 # -------------------------------------------------------------
-# Try to acquire lock with sequence number 3. Should throw an
-# error because this sequence does not already exist in the
-# lock's sequence history.
+# Try to acquire lock with sequence number 3. Should update the
+# lock's sequence history because the sequence does not already
+# exist in the sequence history.
 # -------------------------------------------------------------
 
 new-txn txn=txn1 ts=10,1 epoch=0 seq=3
@@ -157,13 +157,16 @@ start-waiting: false
 
 acquire r=req5 k=a durability=u
 ----
-missing lock at sequence: 3 not in [1 2 4]
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4]
+local: num=0
 
 dequeue r=req5
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4]
 local: num=0
 
 # -------------------------------------------------------------
@@ -184,12 +187,12 @@ acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4, 5]
 local: num=0
 
 dequeue r=req6
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 4, 5]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [1, 2, 3, 4, 5]
 local: num=0


### PR DESCRIPTION
This commit updates the lock-table to allow lock acquisition at
a sequence number below but not contained within an existing
lock's sequence number history. This is not possible to exercise
when locks are only added to the lock-table using AcquireLock,
but is possible when a later sequence number is added to the
lock=table through AddDiscoveredLock before the lock-table is
notified of the corresponding sequence of lock acquisitions.

This is possible because we do not immediately add replicated
locks to the lock-table. This means that a txn might acquire a
lock at sequence 2 and 3 with neither being added to the lock-table.
A second txn might then "discover" the lock and add it at seq 3
to the lock-table. If the first txn was to then replay its batch
with sequence 2 and 3, it would have previously hit the assertion.
I saw this while stressing kvnemesis.

Release justification: low risk bug fix that prevents a fatal server crash