### PR TITLE
sqltelemetry: adjust IAM telemetry methods to have Inc/Counter

### DIFF
--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -96,7 +96,7 @@ func grantRolePlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	sqltelemetry.IncIAMGrant(grant.AdminOption)
+	sqltelemetry.IncIAMGrantCounter(grant.AdminOption)
 
 	fn = func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
@@ -250,7 +250,7 @@ func revokeRolePlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	sqltelemetry.IncIAMRevoke(revoke.AdminOption)
+	sqltelemetry.IncIAMRevokeCounter(revoke.AdminOption)
 
 	fn = func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -86,10 +86,10 @@ type alterRoleRun struct {
 func (n *alterRoleNode) startExec(params runParams) error {
 	var opName string
 	if n.isRole {
-		sqltelemetry.IAMAlter(sqltelemetry.Role)
+		sqltelemetry.IncIAMAlterCounter(sqltelemetry.Role)
 		opName = "alter-role"
 	} else {
-		sqltelemetry.IAMAlter(sqltelemetry.User)
+		sqltelemetry.IncIAMAlterCounter(sqltelemetry.User)
 		opName = "alter-user"
 	}
 	name, err := n.name()

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -97,10 +97,10 @@ func (p *planner) CreateRoleNode(
 func (n *CreateRoleNode) startExec(params runParams) error {
 	var opName string
 	if n.isRole {
-		sqltelemetry.IncIAMCreate(sqltelemetry.Role)
+		sqltelemetry.IncIAMCreateCounter(sqltelemetry.Role)
 		opName = "create-role"
 	} else {
-		sqltelemetry.IncIAMCreate(sqltelemetry.User)
+		sqltelemetry.IncIAMCreateCounter(sqltelemetry.User)
 		opName = "create-user"
 	}
 

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -70,10 +70,10 @@ type dropRoleRun struct {
 func (n *DropRoleNode) startExec(params runParams) error {
 	var opName string
 	if n.isRole {
-		sqltelemetry.IncIAMDrop(sqltelemetry.Role)
+		sqltelemetry.IncIAMDropCounter(sqltelemetry.Role)
 		opName = "drop-role"
 	} else {
-		sqltelemetry.IncIAMDrop(sqltelemetry.User)
+		sqltelemetry.IncIAMDropCounter(sqltelemetry.User)
 		opName = "drop-user"
 	}
 

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -31,9 +31,9 @@ import (
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
 func (p *planner) Grant(ctx context.Context, n *tree.Grant) (planNode, error) {
 	if n.Targets.Databases != nil {
-		sqltelemetry.IncIAMGrantPrivileges(sqltelemetry.OnDatabase)
+		sqltelemetry.IncIAMGrantPrivilegesCounter(sqltelemetry.OnDatabase)
 	} else {
-		sqltelemetry.IncIAMGrantPrivileges(sqltelemetry.OnTable)
+		sqltelemetry.IncIAMGrantPrivilegesCounter(sqltelemetry.OnTable)
 	}
 
 	return &changePrivilegesNode{
@@ -57,9 +57,9 @@ func (p *planner) Grant(ctx context.Context, n *tree.Grant) (planNode, error) {
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
 func (p *planner) Revoke(ctx context.Context, n *tree.Revoke) (planNode, error) {
 	if n.Targets.Databases != nil {
-		sqltelemetry.IncIAMRevokePrivileges(sqltelemetry.OnDatabase)
+		sqltelemetry.IncIAMRevokePrivilegesCounter(sqltelemetry.OnDatabase)
 	} else {
-		sqltelemetry.IncIAMRevokePrivileges(sqltelemetry.OnTable)
+		sqltelemetry.IncIAMRevokePrivilegesCounter(sqltelemetry.OnTable)
 	}
 
 	return &changePrivilegesNode{

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -97,7 +97,7 @@ func (rol List) GetSQLStmts(op string) (map[string]func() (bool, string, error),
 	}
 
 	for _, ro := range rol {
-		sqltelemetry.IncIAMOption(
+		sqltelemetry.IncIAMOptionCounter(
 			op,
 			strings.ToLower(ro.Option.String()),
 		)

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -16,53 +16,51 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 )
 
-// Role is used when the syntax used is the ROLE version (ie. CREATE ROLE).
-const Role = "role"
+const (
+	// Role is used when the syntax used is the ROLE version (ie. CREATE ROLE).
+	Role = "role"
+	// User is used when the syntax used is the USER version (ie. CREATE USER).
+	User = "user"
 
-// User is used when the syntax used is the USER version (ie. CREATE USER).
-const User = "user"
+	// AlterRole is used when an ALTER ROLE / USER is the operation.
+	AlterRole = "alter"
+	// CreateRole is used when an CREATE ROLE / USER is the operation.
+	CreateRole = "create"
+	// OnDatabase is used when a GRANT/REVOKE is happening on a database.
+	OnDatabase = "on_database"
+	// OnTable is used when a GRANT/REVOKE is happening on a table.
+	OnTable = "on_table"
 
-// AlterRole is used when an ALTER ROLE / USER is the operation.
-const AlterRole = "alter"
+	iamRoles = "iam.roles"
+)
 
-// CreateRole is used when an CREATE ROLE / USER is the operation.
-const CreateRole = "create"
-
-// OnDatabase is used when a GRANT/REVOKE is happening on a database.
-const OnDatabase = "on_database"
-
-// OnTable is used when a GRANT/REVOKE is happening on a table.
-const OnTable = "on_table"
-
-const iamRoles = "iam.roles"
-
-// IncIAMOption is to be incremented every time a CREATE/ALTER role
+// IncIAMOptionCounter is to be incremented every time a CREATE/ALTER role
 // with an OPTION (ie. NOLOGIN) happens.
-func IncIAMOption(opName string, option string) {
+func IncIAMOptionCounter(opName string, option string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s", iamRoles, opName, option)))
 }
 
-// IncIAMCreate is to be incremented every time a CREATE ROLE happens.
-func IncIAMCreate(typ string) {
+// IncIAMCreateCounter is to be incremented every time a CREATE ROLE happens.
+func IncIAMCreateCounter(typ string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s", iamRoles, "create", typ)))
 }
 
-// IAMAlter is to be incremented every time an ALTER ROLE happens.
-func IAMAlter(typ string) {
+// IncIAMAlterCounter is to be incremented every time an ALTER ROLE happens.
+func IncIAMAlterCounter(typ string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s", iamRoles, "alter", typ)))
 }
 
-// IncIAMDrop is to be incremented every time a DROP ROLE happens.
-func IncIAMDrop(typ string) {
+// IncIAMDropCounter is to be incremented every time a DROP ROLE happens.
+func IncIAMDropCounter(typ string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s", iamRoles, "drop", typ)))
 }
 
-// IncIAMGrant is to be incremented every time a GRANT ROLE happens.
-func IncIAMGrant(withAdmin bool) {
+// IncIAMGrantCounter is to be incremented every time a GRANT ROLE happens.
+func IncIAMGrantCounter(withAdmin bool) {
 	var s string
 	if withAdmin {
 		s = fmt.Sprintf("%s.%s.with_admin", iamRoles, "grant")
@@ -72,8 +70,8 @@ func IncIAMGrant(withAdmin bool) {
 	telemetry.Inc(telemetry.GetCounter(s))
 }
 
-// IncIAMRevoke is to be incremented every time a REVOKE ROLE happens.
-func IncIAMRevoke(withAdmin bool) {
+// IncIAMRevokeCounter is to be incremented every time a REVOKE ROLE happens.
+func IncIAMRevokeCounter(withAdmin bool) {
 	var s string
 	if withAdmin {
 		s = fmt.Sprintf("%s.%s.with_admin", iamRoles, "revoke")
@@ -83,14 +81,14 @@ func IncIAMRevoke(withAdmin bool) {
 	telemetry.Inc(telemetry.GetCounter(s))
 }
 
-// IncIAMGrantPrivileges is to be incremented every time a GRANT <privileges> happens.
-func IncIAMGrantPrivileges(on string) {
+// IncIAMGrantPrivilegesCounter is to be incremented every time a GRANT <privileges> happens.
+func IncIAMGrantPrivilegesCounter(on string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s.%s", iamRoles, "grant", "privileges", on)))
 }
 
-// IncIAMRevokePrivileges is to be incremented every time a REVOKE <privileges> happens.
-func IncIAMRevokePrivileges(on string) {
+// IncIAMRevokePrivilegesCounter is to be incremented every time a REVOKE <privileges> happens.
+func IncIAMRevokePrivilegesCounter(on string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s.%s", iamRoles, "revoke", "privileges", on)))
 }


### PR DESCRIPTION
Trying to standardise the sqltelemetry package such that every name ends
with `Counter`, so this is a `sed` replace to do just that. Also noticed
that `IAMAlter` has a different name, so fixing that form too.

Release justification: Refactoring of names only.

Release note: None