### PR TITLE
release-19.2: cli: debug.zip jobs table in hex representation

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -92,6 +92,12 @@ var debugZipTablesPerNode = []string{
 	"crdb_internal.node_txn_stats",
 }
 
+// Override for the default SELECT * when dumping the table.
+var customSelectClause = map[string]string{
+	"system.jobs":       "*, to_hex(payload) AS hex_payload, to_hex(progress) AS hex_progress",
+	"system.descriptor": "*, to_hex(descriptor) AS hex_descriptor",
+}
+
 type zipper struct {
 	f *os.File
 	z *zip.Writer
@@ -307,7 +313,11 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, table := range debugZipTablesPerCluster {
-		if err := dumpTableDataForZip(z, sqlConn, timeout, base, table); err != nil {
+		selectClause, ok := customSelectClause[table]
+		if !ok {
+			selectClause = "*"
+		}
+		if err := dumpTableDataForZip(z, sqlConn, timeout, base, table, selectClause); err != nil {
 			return errors.Wrap(err, table)
 		}
 	}
@@ -360,7 +370,11 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 			fmt.Printf("using SQL connection URL for node %s: %s\n", id, curSQLConn.url)
 
 			for _, table := range debugZipTablesPerNode {
-				if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table); err != nil {
+				selectClause, ok := customSelectClause[table]
+				if !ok {
+					selectClause = "*"
+				}
+				if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table, selectClause); err != nil {
 					return errors.Wrap(err, table)
 				}
 			}
@@ -609,9 +623,9 @@ func (fne *fileNameEscaper) escape(f string) string {
 }
 
 func dumpTableDataForZip(
-	z *zipper, conn *sqlConn, timeout time.Duration, base, table string,
+	z *zipper, conn *sqlConn, timeout time.Duration, base, table, selectClause string,
 ) error {
-	query := fmt.Sprintf(`SET statement_timeout = '%s'; SELECT * FROM %s`, timeout, table)
+	query := fmt.Sprintf(`SET statement_timeout = '%s'; SELECT %s FROM %s`, timeout, selectClause, table)
 	name := base + "/" + table + ".txt"
 
 	fmt.Printf("retrieving SQL data for %s... ", table)

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -11,7 +11,10 @@
 package cli
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	enc_hex "encoding/hex"
 	"os"
 	"regexp"
 	"sort"
@@ -20,8 +23,10 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -29,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -688,4 +694,93 @@ requesting table details for system.web_sessions... writing: debug/schema/system
 requesting table details for system.zones... writing: debug/schema/system/zones.json
 `
 	assert.Equal(t, expected, out)
+}
+
+// This test the operation of zip over secure clusters.
+func TestToHex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+	c := newCLITest(cliTestParams{
+		storeSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+	})
+	defer c.cleanup()
+
+	// Create a job to have non-empty system.jobs table.
+	c.RunWithArgs([]string{"sql", "-e", "CREATE STATISTICS foo FROM system.namespace"})
+
+	_, err := c.RunWithCapture("debug zip " + dir + "/debug.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := zip.OpenReader(dir + "/debug.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type hexField struct {
+		idx int
+		msg protoutil.Message
+	}
+	// Stores index and type of marshaled messages in the table row.
+	// Negative indices work from the end - this is needed because parsing the
+	// fields is not alway s precise as there can be spaces in the fields but the
+	// hex fields are always in the end of the row and they don't contain spaces.
+	hexFiles := map[string][]hexField{
+		"debug/system.jobs.txt": {
+			{idx: -2, msg: &jobspb.Payload{}},
+			{idx: -1, msg: &jobspb.Progress{}},
+		},
+		"debug/system.descriptor.txt": {
+			{idx: 2, msg: &sqlbase.Descriptor{}},
+		},
+	}
+
+	for _, f := range r.File {
+		fieldsToCheck, ok := hexFiles[f.Name]
+		if !ok {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rc.Close()
+
+		buf := new(bytes.Buffer)
+		if _, err = buf.ReadFrom(rc); err != nil {
+			t.Fatal(err)
+		}
+		// Skip header.
+		if _, err = buf.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		}
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fields := strings.Fields(line)
+		for _, hf := range fieldsToCheck {
+			i := hf.idx
+			if i < 0 {
+				i = len(fields) + i
+			}
+			bts, err := enc_hex.DecodeString(fields[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := protoutil.Unmarshal(bts, hf.msg); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err = r.Close(); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #45721.

/cc @cockroachdb/release

---

Touches #45019.

Release note (cli change): debug.zip now contains hex representation
of marshalled jobs payload and progress. This allows to copy this
string and unmarshal it when debugging.
