### PR TITLE
colexec: make hash table store all columns

### DIFF
--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1978,9 +1978,8 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
-					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
+					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)
@@ -2009,9 +2008,8 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
-					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
+					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)
@@ -2042,9 +2040,8 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg,
-					NewTestingSemaphore(mjFDLimit), leftSource, rightSource,
-					[]uint32{0, 1}, []uint32{2, 3}, sourceTypes, sourceTypes,
+					NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, NewTestingSemaphore(mjFDLimit),
+					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 				)


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

Previously, hashTable would only store the union of equality and output
columns. When used by the hash joiner, this would mean that only
equality columns are stored in case of LEFT SEMI and LEFT ANTI joins.
However, in order to be able to fallback to external hash joiner we need
to have access to the whole tuples that came from both inputs. This
commit plumbs the assumption that all input columns are "out columns" as
well.

Also, the same assumption is plumbed into the in-memory hash joiner and
merge joiner (we already were populating outCols to include everything,
this is just plumbing it down further).

Fixes: #45634.

Release note: None