### PR TITLE
kv: remove ChangeReplicasCanMixAddAndRemoveContext

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -78,7 +78,6 @@ func applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 		err := db.AdminMerge(ctx, o.Key)
 		o.Result = resultError(ctx, err)
 	case *ChangeReplicasOperation:
-		ctx = kv.ChangeReplicasCanMixAddAndRemoveContext(ctx)
 		desc := getRangeDesc(ctx, o.Key, db)
 		_, err := db.AdminChangeReplicas(ctx, o.Key, desc, o.Changes)
 		// TODO(dan): Save returned desc?

--- a/pkg/kv/kvserver/client_atomic_membership_change_test.go
+++ b/pkg/kv/kvserver/client_atomic_membership_change_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -60,10 +59,7 @@ func TestAtomicReplicationChange(t *testing.T) {
 
 	runChange := func(expDesc roachpb.RangeDescriptor, chgs []roachpb.ReplicationChange) roachpb.RangeDescriptor {
 		t.Helper()
-		desc, err := tc.Servers[0].DB().AdminChangeReplicas(
-			kv.ChangeReplicasCanMixAddAndRemoveContext(ctx),
-			k, expDesc, chgs,
-		)
+		desc, err := tc.Servers[0].DB().AdminChangeReplicas(ctx, k, expDesc, chgs)
 		require.NoError(t, err)
 
 		return *desc

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -372,8 +372,7 @@ func TestCannotTransferLeaseToVoterOutgoing(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err = tc.Server(0).DB().AdminChangeReplicas(
-				kv.ChangeReplicasCanMixAddAndRemoveContext(ctx),
+			_, err = tc.Server(0).DB().AdminChangeReplicas(ctx,
 				scratchStartKey, desc, []roachpb.ReplicationChange{
 					{ChangeType: roachpb.REMOVE_REPLICA, Target: tc.Target(2)},
 					{ChangeType: roachpb.ADD_REPLICA, Target: tc.Target(3)},

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2734,8 +2734,7 @@ func TestChangeReplicasLeaveAtomicRacesWithMerge(t *testing.T) {
 			},
 			ReplicationMode: base.ReplicationManual,
 		})
-		// Make a magical context which will allow us to use atomic replica changes.
-		ctx := kv.ChangeReplicasCanMixAddAndRemoveContext(context.Background())
+		ctx := context.Background()
 		defer tc.Stopper().Stop(ctx)
 
 		// We want to first get into a joint consensus scenario.


### PR DESCRIPTION
This context value was added to enable testing of atomic replica changes
in mixed version clusters and before they were generally live. It is not
needed any more.

Release justification: low risk, high benefit changes to existing functionality

Release note: None