### PR TITLE
sql: fix race with ResolvableFunctionReference

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2280,7 +2280,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		if query.hidden {
 			continue
 		}
-		sql := truncateSQL(query.stmt.String())
+		sql := truncateSQL(query.getStatement())
 		progress := math.Float64frombits(atomic.LoadUint64(&query.progressAtomic))
 		activeQueries = append(activeQueries, serverpb.ActiveQuery{
 			ID:            id.String(),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -165,7 +165,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// Canceling a query cancels its transaction's context so we take a reference
 	// to the cancelation function here.
-	unregisterFn := ex.addActiveQuery(stmt.queryID, stmt.AST, ex.state.cancel)
+	unregisterFn := ex.addActiveQuery(stmt.queryID, stmt, ex.state.cancel)
 
 	// queryDone is a cleanup function dealing with unregistering a query.
 	// It also deals with overwriting res.Error to a more user-friendly message in
@@ -1180,13 +1180,13 @@ func (ex *connExecutor) enableTracing(modes []string) error {
 // longer executing. NOTE(andrei): As of Feb 2018, "executing" does not imply
 // that the results have been delivered to the client.
 func (ex *connExecutor) addActiveQuery(
-	queryID ClusterWideID, stmt tree.Statement, cancelFun context.CancelFunc,
+	queryID ClusterWideID, stmt Statement, cancelFun context.CancelFunc,
 ) func() {
 
-	_, hidden := stmt.(tree.HiddenFromShowQueries)
+	_, hidden := stmt.AST.(tree.HiddenFromShowQueries)
 	qm := &queryMeta{
 		start:         ex.phaseTimes[sessionQueryReceived],
-		stmt:          stmt,
+		rawStmt:       stmt.SQL,
 		phase:         preparing,
 		isDistributed: false,
 		ctxCancel:     cancelFun,
@@ -1203,7 +1203,7 @@ func (ex *connExecutor) addActiveQuery(
 			panic(fmt.Sprintf("query %d missing from ActiveQueries", queryID))
 		}
 		delete(ex.mu.ActiveQueries, queryID)
-		ex.mu.LastActiveQuery = qm.stmt
+		ex.mu.LastActiveQuery = stmt.AST
 
 		ex.mu.Unlock()
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -996,8 +996,10 @@ type queryMeta struct {
 	// The timestamp when this query began execution.
 	start time.Time
 
-	// AST of the SQL statement - converted to query string only when necessary.
-	stmt tree.Statement
+	// The string of the SQL statement being executed. This string may
+	// contain sensitive information, so it must be converted back into
+	// an AST and dumped before use in logging.
+	rawStmt string
 
 	// States whether this query is distributed. Note that all queries,
 	// including those that are distributed, have this field set to false until
@@ -1023,6 +1025,16 @@ type queryMeta struct {
 // txn context.
 func (q *queryMeta) cancel() {
 	q.ctxCancel()
+}
+
+// getStatement returns a cleaned version of the query associated
+// with this queryMeta.
+func (q *queryMeta) getStatement() string {
+	parsed, err := parser.ParseOne(q.rawStmt)
+	if err != nil {
+		return fmt.Sprintf("error retrieving statement: %+v", err)
+	}
+	return parsed.AST.String()
 }
 
 // SessionDefaults mirrors fields in Session, for restoring default


### PR DESCRIPTION
This PR fixes the race that has appeared recently
with the ResolvableFunctionReference and the optimizer,
but that race seemed to be hiding other problems.

Some phases/parts of resolution and type checking
mutate expressions and AST nodes. This is problematic
because before we begin to execute a statement, we take
a reference of it to keep track of currently executing
queries. This leads to a race when a consumer wants to
inspect the list of running queries. The race occurs
when the system is trying to format the stored AST
while the optimizer is building a plan for the query.

This PR addresses this problem by storing a query's
raw SQL in the queryMeta rather than the query's AST
to avoid having to worry about sharing the AST with
the optimizer. When the active queries are attempted
to be read, we re-parse and then format strip the
query to report it back. In this way, active query
recording is still cheap if no active query requests
are made.

However, it is unclear why these races suddenly started
occuring. Somewhere the system is making more calls to
`SHOW QUERIES` than before so this race got revealed.

Release justification: bug fix

Release note: None