### PR TITLE
ui: Fix OOM exception while building Karma tests

### DIFF
--- a/pkg/ui/karma.conf.js
+++ b/pkg/ui/karma.conf.js
@@ -70,8 +70,8 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "ccl/src/**": ["webpack", "sourcemap"],
-      "src/**": ["webpack", "sourcemap"],
+      "ccl/src/**": ["webpack"],
+      "src/**": ["webpack"],
     },
 
     // test results reporter to use
@@ -85,8 +85,8 @@ module.exports = function(config) {
 
     // https://github.com/airbnb/enzyme/blob/master/docs/guides/webpack.md
     webpack: {
-      devtool: "source-map",
-      mode: "development",
+      devtool: "eval",
+      mode: "none",
       module: webpackConfig.module,
       resolve: webpackConfig.resolve,
     },


### PR DESCRIPTION
This exception was fixed in past and that
time main root cause was tied to Helmet library.

Now this OOM exception more likely is caused by
increasing code base.
Previously, webpack configuration provided to Karma
contained `devtool = sourcemap` and might caused
growing memory usage along with increased codebase.

To mitigate this problem as a quick fix during
stabilization period, following non-production
changes were made:
- Changed source maps generation for karma tests
to use lightweight 'eval' option
- `Sourcemap` preprocessors are removed

While testing locally, I couldn't get OOM exception
with following configs.

Related issue in Karma repo: https://github.com/karma-runner/karma/issues/1868#issuecomment-342263996

Release justification: Non-production code change

Release note: None