### PR TITLE
docgen: update savepoint-related definitions, bnfs

### DIFF
--- a/docs/generated/sql/bnf/rollback_transaction.bnf
+++ b/docs/generated/sql/bnf/rollback_transaction.bnf
@@ -1,5 +1,5 @@
 rollback_stmt ::=
 	'ROLLBACK' 
 	| 'ROLLBACK' 
-	| 'ROLLBACK'  'TO' 'SAVEPOINT' cockroach_restart
-	| 'ROLLBACK'  'TO' 'SAVEPOINT' cockroach_restart
+	| 'ROLLBACK'  'TO' 'SAVEPOINT' savepoint_name
+	| 'ROLLBACK'  'TO' 'SAVEPOINT' savepoint_name

--- a/docs/generated/sql/bnf/show_savepoint_status.bnf
+++ b/docs/generated/sql/bnf/show_savepoint_status.bnf
@@ -1,0 +1,2 @@
+show_savepoint_stmt ::=
+	'SHOW' 'SAVEPOINT' 'STATUS'

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1012,8 +1012,7 @@ var specs = []stmtSpec{
 		stmt:    "rollback_stmt",
 		inline:  []string{"opt_transaction"},
 		match:   []*regexp.Regexp{regexp.MustCompile("'ROLLBACK'")},
-		replace: map[string]string{"'TRANSACTION'": "", "'TO'": "'TO' 'SAVEPOINT'", "savepoint_name": "cockroach_restart"},
-		unlink:  []string{"cockroach_restart"},
+		replace: map[string]string{"'TRANSACTION'": "", "'TO'": "'TO' 'SAVEPOINT'"},
 	},
 	{
 		name:   "limit_clause",
@@ -1263,6 +1262,11 @@ var specs = []stmtSpec{
 		name:  "show_transaction",
 		stmt:  "show_stmt",
 		match: []*regexp.Regexp{regexp.MustCompile("'SHOW' 'TRANSACTION'")},
+	},
+	{
+		name:  "show_savepoint_status",
+		stmt:  "show_savepoint_stmt",
+		match: []*regexp.Regexp{regexp.MustCompile("'SHOW' 'SAVEPOINT' 'STATUS'")},
 	},
 	{
 		name:  "show_users",


### PR DESCRIPTION
This change updates the syntax diagram definitions and generated BNF for
several SAVEPOINT-related statements, specifically:

- Add the SHOW SAVEPOINT STATUS statement to the list of syntax diagrams
  generated by pkg/cmd/docgen

- Add the SHOW SAVEPOINT STATUS BNF file to the other generated BNF
  files

- Update ROLLBACK TO SAVEPOINT to note that the savepoint name does not
  have to be 'cockroach_restart'

It uses the changes in #45794, which enabled docgen for SHOW SAVEPOINT
STATUS.

It is part of the work surrounding #45566, which added preliminary SQL
savepoints support.

Release justification: low-risk update to documentation diagrams

Release note: None