### PR TITLE
kv: add a metric to track when queries retry due to refresh scan bytes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -292,8 +292,9 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 		// because those are the only places where we have all of the
 		// refresh spans. If this is a leaf, as in a distributed sql flow,
 		// we need to propagate the error to the root for an epoch restart.
-		canAutoRetry:     typ == kv.RootTxn,
-		autoRetryCounter: tc.metrics.AutoRetries,
+		canAutoRetry:                    typ == kv.RootTxn,
+		autoRetryCounter:                tc.metrics.AutoRetries,
+		refreshSpanBytesExceededCounter: tc.metrics.RefreshSpanBytesExceeded,
 	}
 	tc.interceptorAlloc.txnLockGatekeeper = txnLockGatekeeper{
 		wrapped:                 tc.wrapped,

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -130,6 +130,9 @@ type txnSpanRefresher struct {
 	// autoRetryCounter counts the number of auto retries which avoid
 	// client-side restarts.
 	autoRetryCounter *metric.Counter
+	// refreshSpanBytesExceeded counter counts the number of transactions which
+	// do not refresh because they exceed the MaxRefreshSpanBytes.
+	refreshSpanBytesExceededCounter *metric.Counter
 }
 
 // SendLocked implements the lockedSender interface.
@@ -331,6 +334,7 @@ func (sr *txnSpanRefresher) tryUpdatingTxnSpans(
 
 	if sr.refreshInvalid {
 		log.VEvent(ctx, 2, "can't refresh txn spans; not valid")
+		sr.refreshSpanBytesExceededCounter.Inc(1)
 		return false
 	} else if len(sr.refreshSpans) == 0 {
 		log.VEvent(ctx, 2, "there are no txn spans to refresh")

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -19,12 +19,13 @@ import (
 
 // TxnMetrics holds all metrics relating to KV transactions.
 type TxnMetrics struct {
-	Aborts          *metric.Counter
-	Commits         *metric.Counter
-	Commits1PC      *metric.Counter // Commits which finished in a single phase
-	ParallelCommits *metric.Counter // Commits which entered the STAGING state
-	AutoRetries     *metric.Counter // Auto retries which avoid client-side restarts
-	Durations       *metric.Histogram
+	Aborts                   *metric.Counter
+	Commits                  *metric.Counter
+	Commits1PC               *metric.Counter // Commits which finished in a single phase
+	ParallelCommits          *metric.Counter // Commits which entered the STAGING state
+	AutoRetries              *metric.Counter // Auto retries which avoid client-side restarts
+	RefreshSpanBytesExceeded *metric.Counter // Transactions which don't refresh due to span bytes
+	Durations                *metric.Histogram
 
 	// Restarts is the number of times we had to restart the transaction.
 	Restarts *metric.Histogram
@@ -68,6 +69,12 @@ var (
 	metaAutoRetriesRates = metric.Metadata{
 		Name:        "txn.autoretries",
 		Help:        "Number of automatic retries to avoid serializable restarts",
+		Measurement: "Retries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRefreshSpanBytesExceeded = metric.Metadata{
+		Name:        "txn.refreshspanbytesexceeded",
+		Help:        "Number of transaction retries which fail to refresh due to the refresh span bytes",
 		Measurement: "Retries",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -169,6 +176,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		Commits1PC:                    metric.NewCounter(metaCommits1PCRates),
 		ParallelCommits:               metric.NewCounter(metaParallelCommitsRates),
 		AutoRetries:                   metric.NewCounter(metaAutoRetriesRates),
+		RefreshSpanBytesExceeded:      metric.NewCounter(metaRefreshSpanBytesExceeded),
 		Durations:                     metric.NewLatency(metaDurationsHistograms, histogramWindow),
 		Restarts:                      metric.NewHistogram(metaRestartsHistogram, histogramWindow, 100, 3),
 		RestartsWriteTooOld:           telemetry.NewCounterWithMetric(metaRestartsWriteTooOld),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -769,6 +769,10 @@ var charts = []sectionDescription{
 				Metrics: []string{"txn.autoretries"},
 			},
 			{
+				Title:   "Refresh Span Bytes Exceeded",
+				Metrics: []string{"txn.refreshspanbytesexceeded"},
+			},
+			{
 				Title: "Commits",
 				Metrics: []string{
 					"txn.commits",


### PR DESCRIPTION
This is useful for debugging issues with retries.

Release justification: low risk, high benefit changes to existing functionality

Release note: None