### PR TITLE
storage/metamorphic: Run pebble with different options

### DIFF
--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -174,6 +174,8 @@ func TestRocksPebbleEquivalence(t *testing.T) {
 				engineSequences: [][]engineImpl{
 					{engineImplRocksDB},
 					{engineImplPebble},
+					{engineImplPebbleManySSTs},
+					{engineImplPebbleVarOpts},
 				},
 			}
 			runMetaTest(run)
@@ -206,6 +208,7 @@ func TestRocksPebbleRestarts(t *testing.T) {
 					{engineImplRocksDB},
 					{engineImplPebble},
 					{engineImplRocksDB, engineImplPebble},
+					{engineImplRocksDB, engineImplPebbleManySSTs, engineImplPebbleVarOpts},
 				},
 			}
 			runMetaTest(run)

--- a/pkg/storage/metamorphic/operands.go
+++ b/pkg/storage/metamorphic/operands.go
@@ -167,12 +167,7 @@ func (v *valueGenerator) toString(value []byte) string {
 }
 
 func (v *valueGenerator) parse(input string) []byte {
-	var value = make([]byte, 0, maxValueSize)
-	_, err := fmt.Sscanf(input, "%s", &value)
-	if err != nil {
-		panic(err)
-	}
-	return value
+	return []byte(input)
 }
 
 type txnID string

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -437,7 +437,10 @@ func (b batchCommitOp) run(ctx context.Context) string {
 	if b.id == "engine" {
 		return "noop"
 	}
-	batch := b.m.getReadWriter(b.id)
+	batch := b.m.getReadWriter(b.id).(storage.Batch)
+	if err := batch.Commit(true); err != nil {
+		return err.Error()
+	}
 	batch.Close()
 	delete(b.m.openBatches, b.id)
 	return "ok"


### PR DESCRIPTION
This change updates the MVCC metamorphic tests to run Pebble
with different, random options, as well as one configuration
that seems to uncover many issues (the one with low
TargetFileSizes on all levels).

Also fixes batchCommitOp to actually commit the batch
passed in.

Release note: None

Release justification: Safe for this release because it only
updates testing code.