### PR TITLE
sql: add telemetry for ORDER BY and INTERLEAVE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -169,6 +169,9 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
+	if n.n.Interleave != nil {
+		telemetry.Inc(sqltelemetry.CreateInterleavedTableCounter)
+	}
 	if isTemporary {
 		telemetry.Inc(sqltelemetry.CreateTempTableCounter)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -544,6 +544,12 @@ CREATE TABLE c3 (
   id STRING PRIMARY KEY REFERENCES b2 ON DELETE CASCADE
 ) INTERLEAVE IN PARENT b2 (id);
 
+# Check that telemetry is being collected on creation of interleaved tables.
+query B
+SELECT usage_count >= 5 FROM crdb_internal.feature_usage WHERE feature_name = 'sql.schema.create_interleaved_table'
+----
+true
+
 statement ok
 INSERT INTO a VALUES ('pk1'), ('pk2');
 INSERT INTO b1 VALUES ('pk1'), ('pk2');

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -444,3 +444,9 @@ SELECT a, b, c FROM abc2 AS x ORDER BY INDEX x@bc
 
 statement error no data source matches prefix: test.public.abc2
 SELECT a, b, c FROM abc2 AS x ORDER BY INDEX abc2@bc
+
+# Check that telemetry is being collected on the usage of ORDER BY.
+query B
+SELECT usage_count > 0 FROM crdb_internal.feature_usage WHERE feature_name = 'sql.plan.opt.node.sort'
+----
+true

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3683,3 +3683,9 @@ ORDER BY
 9   2     9  0.1  NULL  NULL  NULL   NULL          {2,2,2,2}    NULL         {0.1}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
 10  4     9  0.2  NULL  NULL  NULL   NULL          {4,4,4}      NULL         {0.2}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
 11  NULL  9  0.3  NULL  NULL  NULL   NULL          {NULL,NULL}  {NULL,NULL}  {0.3}  NULL  {NULL,NULL,NULL}  {NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}  {NULL,NULL,NULL,NULL}
+
+# Check that telemetry is being collected on the window functions' usage.
+query B
+SELECT count(*) = 26 FROM crdb_internal.feature_usage WHERE feature_name LIKE 'sql.plan.window_function%' AND usage_count > 0
+----
+true

--- a/pkg/sql/opt/ops/enforcer.opt
+++ b/pkg/sql/opt/ops/enforcer.opt
@@ -15,7 +15,7 @@
 # be sorted by one or more of the input columns, each of which can be sorted in
 # either ascending or descending order. See the Ordering field in the
 # PhysicalProps struct.
-[Enforcer]
+[Enforcer, Telemetry]
 define Sort {
     # InputOrdering specifies the ordering that the sort requires
     # from its input. It allows the optimizer and DistSQL to plan

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -31,6 +31,10 @@ func SchemaNewTypeCounter(t string) telemetry.Counter {
 }
 
 var (
+	// CreateInterleavedTableCounter is to be incremented every time an
+	// interleaved table is being created.
+	CreateInterleavedTableCounter = telemetry.GetCounterOnce("sql.schema.create_interleaved_table")
+
 	// CreateTempTableCounter is to be incremented every time a TEMP TABLE
 	// has been created.
 	CreateTempTableCounter = telemetry.GetCounterOnce("sql.schema.create_temp_table")


### PR DESCRIPTION
Release justification: reporting changes only.

This commit adds the reporting of telemetry on the usage of INTERLEAVE
(in `createTableNode.startExec`) and of ORDER BY (by marking
`opt.SortOp` with "Telemetry" flag in the optbuilder and reusing the
same "infrastructure" as relational operators do, right before
constructing the sort). Also it adds a logic test for the telemetry
collection on the window functions' usage.

Addresses: #45210.

Release note: None