### PR TITLE
sql: add the 'every' aggregate function

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -65,6 +65,8 @@
 </span></td></tr>
 <tr><td><a name="count_rows"></a><code>count_rows() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of rows.</p>
 </span></td></tr>
+<tr><td><a name="every"></a><code>every(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Calculates the boolean value of <code>AND</code>ing all selected values.</p>
+</span></td></tr>
 <tr><td><a name="json_agg"></a><code>json_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.</p>
 </span></td></tr>
 <tr><td><a name="jsonb_agg"></a><code>jsonb_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.</p>

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -61,7 +61,7 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 27
+const Version execinfrapb.DistSQLVersion = 28
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2170,3 +2170,56 @@ SELECT x, SUM (y) FROM t GROUP BY (x) ORDER BY SUM (y)
 [1, 2]                        25
 {"bar": "baz", "foo": "bar"}  35
 {"foo": {"bar": "baz"}}       45
+
+# Tests for the 'every' aggregate function.
+subtest every
+
+statement ok
+CREATE TABLE t_every (x BOOL)
+
+query B
+SELECT every (x) FROM t_every
+----
+NULL
+
+statement ok
+INSERT INTO t_every VALUES (true), (true)
+
+query B
+SELECT every (x) FROM t_every
+----
+true
+
+statement ok
+INSERT INTO t_every VALUES (NULL), (true)
+
+query B
+SELECT every (x) FROM t_every
+----
+true
+
+statement ok
+INSERT INTO t_every VALUES (false), (NULL)
+
+query B
+SELECT every (x) FROM t_every
+----
+false
+
+statement ok
+TRUNCATE t_every;
+INSERT INTO t_every VALUES (false)
+
+query B
+SELECT every (x) FROM t_every
+----
+false
+
+statement ok
+TRUNCATE t_every;
+INSERT INTO t_every VALUES (NULL), (NULL), (NULL)
+
+query B
+SELECT every (x) FROM t_every
+----
+NULL

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -750,7 +750,7 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 		return b.factory.ConstructBitAndAgg(args[0])
 	case "bit_or":
 		return b.factory.ConstructBitOrAgg(args[0])
-	case "bool_and":
+	case "bool_and", "every":
 		return b.factory.ConstructBoolAnd(args[0])
 	case "bool_or":
 		return b.factory.ConstructBoolOr(args[0])

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -105,3 +105,7 @@
     - Add the numeric tuple field accessor and the ByIndex field to ColumnAccessExpr.
 - Version: 27 (MinAcceptedVersion: 27)
     - Change how DArray datums are hashed for distinct and aggregation operations.
+- Version: 28 (MinAcceptedVersion: 28)
+    - The CORR aggregate function has been added which will not be recognized
+      by older nodes. However, new nodes can process plans from older nodes,
+      so MinAcceptedVersion is unchanged.

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -192,6 +192,11 @@ var aggregates = map[string]builtinDefinition{
 		},
 	),
 
+	"every": makeBuiltin(aggProps(),
+		makeAggOverload([]*types.T{types.Bool}, types.Bool, newBoolAndAggregate,
+			"Calculates the boolean value of `AND`ing all selected values."),
+	),
+
 	"max": collectOverloads(aggProps(), types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeAggOverload([]*types.T{t}, t, newMaxAggregate,


### PR DESCRIPTION
Fixes #45842.

Release justification: low risk update to functionality
Release note (sql change): This PR adds the `every` aggregate function.