### PR TITLE
sql: add telemetry reporting for inverted and hash sharded indexes

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -15,10 +15,12 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -167,6 +169,7 @@ func (p *planner) AlterPrimaryKey(
 				return err
 			}
 		}
+		telemetry.Inc(sqltelemetry.HashShardedIndexCounter)
 	}
 
 	if err := newPrimaryIndexDesc.FillColumns(alterPKNode.Columns); err != nil {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -142,6 +142,7 @@ func MakeIndexDescriptor(
 			return nil, pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique")
 		}
 		indexDesc.Type = sqlbase.IndexDescriptor_INVERTED
+		telemetry.Inc(sqltelemetry.InvertedIndexCounter)
 	}
 
 	if n.Sharded != nil {
@@ -169,6 +170,7 @@ func MakeIndexDescriptor(
 				return nil, err
 			}
 		}
+		telemetry.Inc(sqltelemetry.HashShardedIndexCounter)
 	}
 
 	if err := indexDesc.FillColumns(n.Columns); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1594,6 +1594,20 @@ func MakeTableDesc(
 	//
 	// See https://github.com/golang/go/issues/23188.
 	err := desc.AllocateIDs()
+
+	// Record the types of indexes that the table has.
+	if err := desc.ForeachNonDropIndex(func(idx *sqlbase.IndexDescriptor) error {
+		if idx.IsSharded() {
+			telemetry.Inc(sqltelemetry.HashShardedIndexCounter)
+		}
+		if idx.Type == sqlbase.IndexDescriptor_INVERTED {
+			telemetry.Inc(sqltelemetry.InvertedIndexCounter)
+		}
+		return nil
+	}); err != nil {
+		return desc, err
+	}
+
 	return desc, err
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -117,3 +117,28 @@ table_name  index_name  non_unique  seq_in_index  column_name  direction  storin
 privs       primary     false       1             a            ASC        false    false
 privs       foo         true        1             b            ASC        false    false
 privs       foo         true        2             a            ASC        false    true
+
+
+user root
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true;
+CREATE TABLE telemetry (
+  x INT PRIMARY KEY,
+  y INT,
+  z JSONB
+)
+
+statement ok
+CREATE INVERTED INDEX ON telemetry (z);
+CREATE INDEX ON telemetry (y) USING HASH WITH BUCKET_COUNT = 4
+
+query T rowsort
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.inverted_index',
+  'sql.schema.hash_sharded_index'
+)
+----
+sql.schema.inverted_index
+sql.schema.hash_sharded_index

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -90,3 +90,23 @@ sql.schema.new_column.qualification.default_expr
 
 statement ok
 DROP TABLE telemetry_test
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true;
+CREATE TABLE telemetry (
+  x INT PRIMARY KEY,
+  y INT,
+  z JSONB,
+  INVERTED INDEX (z),
+  INDEX (y) USING HASH WITH BUCKET_COUNT = 4
+)
+
+query T rowsort
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.inverted_index',
+  'sql.schema.hash_sharded_index'
+)
+----
+sql.schema.inverted_index
+sql.schema.hash_sharded_index

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -45,6 +45,16 @@ var (
 )
 
 var (
+	// HashShardedIndexCounter is to be incremented every time a hash
+	// sharded index is created.
+	HashShardedIndexCounter = telemetry.GetCounterOnce("sql.schema.hash_sharded_index")
+
+	// InvertedIndexCounter is to be incremented every time an inverted
+	// index is created.
+	InvertedIndexCounter = telemetry.GetCounterOnce("sql.schema.inverted_index")
+)
+
+var (
 	// TempObjectCleanerDeletionCounter is to be incremented every time a temporary schema
 	// has been deleted by the temporary object cleaner.
 	TempObjectCleanerDeletionCounter = telemetry.GetCounterOnce("sql.schema.temp_object_cleaner.num_cleaned")


### PR DESCRIPTION
Release justification: low risk changes
Release note (sql change): This PR adds telemetry reporting
for usages of inverted and hash sharded indexes.