### PR TITLE
colexec: add disk monitor to disk queue

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -668,6 +668,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		ExternalStorage:        externalStorage,
 		ExternalStorageFromURI: externalStorageFromURI,
 	}
+	s.cfg.TempStorageConfig.Mon.SetMetrics(distSQLMetrics.CurDiskBytesCount, distSQLMetrics.MaxDiskBytesHist)
 	if distSQLTestingKnobs := s.cfg.TestingKnobs.DistSQL; distSQLTestingKnobs != nil {
 		distSQLCfg.TestingKnobs = *distSQLTestingKnobs.(*execinfra.TestingKnobs)
 	}

--- a/pkg/sql/colcontainer/main_test.go
+++ b/pkg/sql/colcontainer/main_test.go
@@ -31,6 +31,11 @@ var (
 	// and a memory account bound to it for use in tests.
 	testMemMonitor *mon.BytesMonitor
 	testMemAcc     *mon.BoundAccount
+
+	// testDiskMonitor and testDiskmAcc are a test monitor with an unlimited budget
+	// and a disk account bound to it for use in tests.
+	testDiskMonitor *mon.BytesMonitor
+	testDiskAcc     *mon.BoundAccount
 )
 
 func TestMain(m *testing.M) {
@@ -43,6 +48,12 @@ func TestMain(m *testing.M) {
 		testMemAcc = &memAcc
 		testAllocator = colexec.NewAllocator(ctx, testMemAcc)
 		defer testMemAcc.Close(ctx)
+
+		testDiskMonitor = execinfra.NewTestDiskMonitor(ctx, cluster.MakeTestingClusterSettings())
+		defer testDiskMonitor.Stop(ctx)
+		diskAcc := testDiskMonitor.MakeBoundAccount()
+		testDiskAcc = &diskAcc
+		defer testDiskAcc.Close(ctx)
 		return m.Run()
 	}())
 }

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -36,7 +37,7 @@ type PartitionedQueue interface {
 	// CloseAllOpenWriteFileDescriptors notifies the PartitionedQueue that it can
 	// close all open write file descriptors. After this point, only new
 	// partitions may be Enqueued to.
-	CloseAllOpenWriteFileDescriptors() error
+	CloseAllOpenWriteFileDescriptors(ctx context.Context) error
 	// CloseAllOpenReadFileDescriptors closes the open read file descriptors
 	// belonging to partitions. These partitions may still be Dequeued from,
 	// although this will trigger files to be reopened.
@@ -45,9 +46,9 @@ type PartitionedQueue interface {
 	// from and have either been temporarily closed through
 	// CloseAllOpenReadFileDescriptors or have returned a coldata.ZeroBatch from
 	// Dequeue. This close removes the underlying files.
-	CloseInactiveReadPartitions() error
+	CloseInactiveReadPartitions(ctx context.Context) error
 	// Close closes all partitions created.
-	Close() error
+	Close(ctx context.Context) error
 }
 
 // partitionState is the state a partition is in.
@@ -117,7 +118,10 @@ type PartitionedDiskQueue struct {
 
 	numOpenFDs  int
 	fdSemaphore semaphore.Semaphore
+	diskAcc     *mon.BoundAccount
 }
+
+var _ PartitionedQueue = &PartitionedDiskQueue{}
 
 // NewPartitionedDiskQueue creates a PartitionedDiskQueue whose partitions are
 // all on-disk queues. Note that diskQueues will be lazily created when
@@ -134,6 +138,7 @@ func NewPartitionedDiskQueue(
 	cfg DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	partitionerStrategy PartitionerStrategy,
+	diskAcc *mon.BoundAccount,
 ) *PartitionedDiskQueue {
 	if len(typs) == 0 {
 		// DiskQueues cannot serialize zero length schemas, so catch this error
@@ -149,6 +154,7 @@ func NewPartitionedDiskQueue(
 		partitions:               make([]partition, 0),
 		lastEnqueuedPartitionIdx: -1,
 		fdSemaphore:              fdSemaphore,
+		diskAcc:                  diskAcc,
 	}
 }
 
@@ -166,12 +172,12 @@ const (
 // having to re-enter the semaphore. The argument should only be releaseFD if
 // reopening a different file in a different scope.
 func (p *PartitionedDiskQueue) closeWritePartition(
-	idx int, releaseFDOption closeWritePartitionArgument,
+	ctx context.Context, idx int, releaseFDOption closeWritePartitionArgument,
 ) error {
 	if p.partitions[idx].state != partitionStateWriting {
 		execerror.VectorizedInternalPanic(fmt.Sprintf("illegal state change from %d to partitionStateClosedForWriting, only partitionStateWriting allowed", p.partitions[idx].state))
 	}
-	if err := p.partitions[idx].Enqueue(coldata.ZeroBatch); err != nil {
+	if err := p.partitions[idx].Enqueue(ctx, coldata.ZeroBatch); err != nil {
 		return err
 	}
 	if releaseFDOption == releaseFD && p.fdSemaphore != nil {
@@ -225,7 +231,7 @@ func (p *PartitionedDiskQueue) Enqueue(
 				// Close the last enqueued partition. No need to release or acquire a new
 				// file descriptor, since the acquired FD will represent the new
 				// partition's FD opened in Enqueue below.
-				if err := p.closeWritePartition(idxToClose, retainFD); err != nil {
+				if err := p.closeWritePartition(ctx, idxToClose, retainFD); err != nil {
 					return err
 				}
 				needToAcquireFD = false
@@ -245,7 +251,7 @@ func (p *PartitionedDiskQueue) Enqueue(
 			}
 		}
 		// Partition has not been created yet.
-		q, err := NewDiskQueue(p.typs, p.cfg)
+		q, err := NewDiskQueue(ctx, p.typs, p.cfg, p.diskAcc)
 		if err != nil {
 			return err
 		}
@@ -260,7 +266,7 @@ func (p *PartitionedDiskQueue) Enqueue(
 		return errors.New("Enqueue illegally called after Dequeue or CloseAllOpenWriteFileDescriptors")
 	}
 	p.lastEnqueuedPartitionIdx = partitionIdx
-	return p.partitions[idx].Enqueue(batch)
+	return p.partitions[idx].Enqueue(ctx, batch)
 }
 
 // Dequeue dequeues a batch from partition partitionIdx, returns a
@@ -278,7 +284,7 @@ func (p *PartitionedDiskQueue) Dequeue(
 	case partitionStateWriting:
 		// Close this partition for writing. However, we keep a file descriptor
 		// acquired for the read file descriptor opened for Dequeue.
-		if err := p.closeWritePartition(idx, retainFD); err != nil {
+		if err := p.closeWritePartition(ctx, idx, retainFD); err != nil {
 			return err
 		}
 		p.partitions[idx].state = partitionStateReading
@@ -296,7 +302,7 @@ func (p *PartitionedDiskQueue) Dequeue(
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled state %d", state))
 	}
-	notEmpty, err := p.partitions[idx].Dequeue(batch)
+	notEmpty, err := p.partitions[idx].Dequeue(ctx, batch)
 	if err != nil {
 		return err
 	}
@@ -319,13 +325,13 @@ func (p *PartitionedDiskQueue) Dequeue(
 // CloseAllOpenWriteFileDescriptors closes all open write file descriptors
 // belonging to partitions that are being Enqueued to. Once this method is
 // called, existing partitions may not be enqueued to again.
-func (p *PartitionedDiskQueue) CloseAllOpenWriteFileDescriptors() error {
+func (p *PartitionedDiskQueue) CloseAllOpenWriteFileDescriptors(ctx context.Context) error {
 	for i, q := range p.partitions {
 		if q.state != partitionStateWriting {
 			continue
 		}
 		// closeWritePartition will Release the file descriptor.
-		if err := p.closeWritePartition(i, releaseFD); err != nil {
+		if err := p.closeWritePartition(ctx, i, releaseFD); err != nil {
 			return err
 		}
 	}
@@ -352,13 +358,13 @@ func (p *PartitionedDiskQueue) CloseAllOpenReadFileDescriptors() error {
 // and either Dequeued a coldata.ZeroBatch or were closed through
 // CloseAllOpenReadFileDescriptors. This method call Closes the underlying
 // DiskQueue to remove its files, so a partition may never be used again.
-func (p *PartitionedDiskQueue) CloseInactiveReadPartitions() error {
+func (p *PartitionedDiskQueue) CloseInactiveReadPartitions(ctx context.Context) error {
 	var lastErr error
 	for i, q := range p.partitions {
 		if q.state != partitionStateClosedForReading {
 			continue
 		}
-		lastErr = q.Close()
+		lastErr = q.Close(ctx)
 		p.partitions[i].state = partitionStatePermanentlyClosed
 	}
 	return lastErr
@@ -367,14 +373,14 @@ func (p *PartitionedDiskQueue) CloseInactiveReadPartitions() error {
 // Close closes all the PartitionedDiskQueue's partitions. If an error is
 // encountered, the PartitionedDiskQueue will attempt to close all partitions
 // anyway and return the last error encountered.
-func (p *PartitionedDiskQueue) Close() error {
+func (p *PartitionedDiskQueue) Close(ctx context.Context) error {
 	var lastErr error
 	for i, q := range p.partitions {
 		if q.state == partitionStatePermanentlyClosed {
 			// Already closed.
 			continue
 		}
-		lastErr = q.Close()
+		lastErr = q.Close(ctx)
 		p.partitions[i].state = partitionStatePermanentlyClosed
 	}
 	if p.numOpenFDs != 0 {

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -418,9 +418,9 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 
 // reset resets the orderedAggregator for another run. Primarily used for
 // benchmarks.
-func (a *orderedAggregator) reset() {
+func (a *orderedAggregator) reset(ctx context.Context) {
 	if resetter, ok := a.input.(resetter); ok {
-		resetter.reset()
+		resetter.reset(ctx)
 	}
 	a.done = false
 	a.seenNonEmptyBatch = false

--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -765,7 +765,7 @@ func BenchmarkAggregator(b *testing.B) {
 										// Only count the int64 column.
 										b.SetBytes(int64(8 * nTuples))
 										for i := 0; i < b.N; i++ {
-											a.(resetter).reset()
+											a.(resetter).reset(ctx)
 											source.reset()
 											// Exhaust aggregator until all batches have been read.
 											for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -13,7 +13,6 @@ package colexec
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -233,28 +232,28 @@ func (d *diskSpillerBase) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (d *diskSpillerBase) reset() {
+func (d *diskSpillerBase) reset(ctx context.Context) {
 	for _, input := range d.inputs {
 		if r, ok := input.(resetter); ok {
-			r.reset()
+			r.reset(ctx)
 		}
 	}
 	if d.inMemoryOpInitStatus == OperatorInitialized {
 		if r, ok := d.inMemoryOp.(resetter); ok {
-			r.reset()
+			r.reset(ctx)
 		}
 	}
 	if d.distBackedOpInitStatus == OperatorInitialized {
 		if r, ok := d.diskBackedOp.(resetter); ok {
-			r.reset()
+			r.reset(ctx)
 		}
 	}
 	d.spilled = false
 }
 
-func (d *diskSpillerBase) Close() error {
-	if c, ok := d.diskBackedOp.(io.Closer); ok {
-		return c.Close()
+func (d *diskSpillerBase) Close(ctx context.Context) error {
+	if c, ok := d.diskBackedOp.(closer); ok {
+		return c.Close(ctx)
 	}
 	return nil
 }
@@ -335,12 +334,12 @@ func (b *bufferExportingOperator) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (b *bufferExportingOperator) reset() {
+func (b *bufferExportingOperator) reset(ctx context.Context) {
 	if r, ok := b.firstSource.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 	if r, ok := b.secondSource.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 	b.firstSourceDone = false
 }

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -213,11 +213,11 @@ func (p *sortedDistinct_TYPEOp) Init() {
 	p.input.Init()
 }
 
-func (p *sortedDistinct_TYPEOp) reset() {
+func (p *sortedDistinct_TYPEOp) reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
 	if resetter, ok := p.input.(resetter); ok {
-		resetter.reset()
+		resetter.reset(ctx)
 	}
 }
 

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -148,9 +148,9 @@ type NewColOperatorResult struct {
 	// make the corresponding adjustment to 'isSupported' check so that we can
 	// plan wrapped processor core in the vectorized flow rather than rejecting
 	// the vectorization entirely in 'auto' mode.
-	CanRunInAutoMode       bool
-	BufferingOpMemMonitors []*mon.BytesMonitor
-	BufferingOpMemAccounts []*mon.BoundAccount
+	CanRunInAutoMode bool
+	OpMonitors       []*mon.BytesMonitor
+	OpAccounts       []*mon.BoundAccount
 }
 
 // resetToState resets r to the state specified in arg. arg may be a shallow
@@ -159,23 +159,23 @@ func (r *NewColOperatorResult) resetToState(ctx context.Context, arg NewColOpera
 	// MetadataSources are left untouched since there is no need to do any
 	// cleaning there.
 
-	// Close BoundAccounts that are not present in arg.BufferingOpMemAccounts.
+	// Close BoundAccounts that are not present in arg.OpAccounts.
 	accs := make(map[*mon.BoundAccount]struct{})
-	for _, a := range arg.BufferingOpMemAccounts {
+	for _, a := range arg.OpAccounts {
 		accs[a] = struct{}{}
 	}
-	for _, a := range r.BufferingOpMemAccounts {
+	for _, a := range r.OpAccounts {
 		if _, ok := accs[a]; !ok {
 			a.Close(ctx)
 		}
 	}
-	// Stop BytesMonitors that are not present in arg.BufferingOpMemMonitors.
+	// Stop BytesMonitors that are not present in arg.OpMonitors.
 	mons := make(map[*mon.BytesMonitor]struct{})
-	for _, m := range arg.BufferingOpMemMonitors {
+	for _, m := range arg.OpMonitors {
 		mons[m] = struct{}{}
 	}
 
-	for _, m := range r.BufferingOpMemMonitors {
+	for _, m := range r.OpMonitors {
 		if _, ok := mons[m]; !ok {
 			m.Stop(ctx)
 		}
@@ -407,6 +407,7 @@ func (r *NewColOperatorResult) createDiskBackedSort(
 			standaloneMemAccount := r.createStandaloneMemAccount(
 				ctx, flowCtx, monitorNamePrefix,
 			)
+			diskAccount := r.createDiskAccount(ctx, flowCtx, monitorNamePrefix)
 			// Make a copy of the DiskQueueCfg and set defaults for the sorter.
 			// The cache mode is chosen to reuse the cache to have a smaller
 			// cache per partition without affecting performance.
@@ -426,6 +427,7 @@ func (r *NewColOperatorResult) createDiskBackedSort(
 				args.TestingKnobs.DelegateFDAcquisitions,
 				diskQueueCfg,
 				args.FDSemaphore,
+				diskAccount,
 			)
 		},
 		args.TestingKnobs.SpillingCallbackFn,
@@ -504,14 +506,14 @@ func NewColOperator(
 		returnedErr := err
 		panicErr := recover()
 		if returnedErr != nil || panicErr != nil {
-			for _, memAccount := range result.BufferingOpMemAccounts {
-				memAccount.Close(ctx)
+			for _, acc := range result.OpAccounts {
+				acc.Close(ctx)
 			}
-			result.BufferingOpMemAccounts = result.BufferingOpMemAccounts[:0]
-			for _, memMonitor := range result.BufferingOpMemMonitors {
-				memMonitor.Stop(ctx)
+			result.OpAccounts = result.OpAccounts[:0]
+			for _, mon := range result.OpMonitors {
+				mon.Stop(ctx)
 			}
-			result.BufferingOpMemMonitors = result.BufferingOpMemMonitors[:0]
+			result.OpMonitors = result.OpMonitors[:0]
 		}
 		if panicErr != nil {
 			execerror.VectorizedInternalPanic(panicErr)
@@ -793,6 +795,7 @@ func NewColOperator(
 				// joiner.
 				result.Op = inMemoryHashJoiner
 			} else {
+				diskAccount := result.createDiskAccount(ctx, flowCtx, hashJoinerMemMonitorName)
 				result.Op = newTwoInputDiskSpiller(
 					inputs[0], inputs[1], inMemoryHashJoiner.(bufferingInMemoryOperator),
 					hashJoinerMemMonitorName,
@@ -830,6 +833,7 @@ func NewColOperator(
 							},
 							args.TestingKnobs.NumForcedRepartitions,
 							args.TestingKnobs.DelegateFDAcquisitions,
+							diskAccount,
 						)
 					},
 					args.TestingKnobs.SpillingCallbackFn,
@@ -880,18 +884,21 @@ func NewColOperator(
 				onExpr = &core.MergeJoiner.OnExpr
 			}
 
+			monitorName := "merge-joiner"
 			// We are using an unlimited memory monitor here because merge joiner
 			// itself is responsible for making sure that we stay within the memory
 			// limit, and it will fall back to disk if necessary.
 			unlimitedAllocator := NewAllocator(
 				ctx, result.createBufferingUnlimitedMemAccount(
-					ctx, flowCtx, "merge-joiner",
+					ctx, flowCtx, monitorName,
 				))
+			diskAccount := result.createDiskAccount(ctx, flowCtx, monitorName)
 			result.Op, err = newMergeJoinOp(
 				unlimitedAllocator, execinfra.GetWorkMemLimit(flowCtx.Cfg),
 				args.DiskQueueCfg, args.FDSemaphore,
 				joinType, inputs[0], inputs[1], leftPhysTypes, rightPhysTypes,
 				core.MergeJoiner.LeftOrdering.Columns, core.MergeJoiner.RightOrdering.Columns,
+				diskAccount,
 			)
 			if err != nil {
 				return result, err
@@ -1008,13 +1015,15 @@ func NewColOperator(
 					// relative rank operators themselves are responsible for
 					// making sure that we stay within the memory limit, and
 					// they will fall back to disk if necessary.
+					memAccName := memMonitorsPrefix + "relative-rank"
 					unlimitedAllocator := NewAllocator(
-						ctx, result.createBufferingUnlimitedMemAccount(ctx, flowCtx, memMonitorsPrefix+"relative-rank"),
+						ctx, result.createBufferingUnlimitedMemAccount(ctx, flowCtx, memAccName),
 					)
+					diskAcc := result.createDiskAccount(ctx, flowCtx, memAccName)
 					result.Op, err = NewRelativeRankOperator(
 						unlimitedAllocator, execinfra.GetWorkMemLimit(flowCtx.Cfg), args.DiskQueueCfg,
 						args.FDSemaphore, input, typs, windowFn, wf.Ordering.Columns,
-						int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx,
+						int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx, diskAcc,
 					)
 					// Relative rank operators are buffering operators, and we
 					// are not comfortable running them with `auto` mode.
@@ -1231,7 +1240,7 @@ func (r *NewColOperatorResult) createBufferingUnlimitedMemMonitor(
 	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
 		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
 	)
-	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpUnlimitedMemMonitor)
+	r.OpMonitors = append(r.OpMonitors, bufferingOpUnlimitedMemMonitor)
 	return bufferingOpUnlimitedMemMonitor
 }
 
@@ -1245,9 +1254,9 @@ func (r *NewColOperatorResult) createMemAccountForSpillStrategy(
 	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
 		ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, name+"-limited",
 	)
-	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, bufferingOpMemMonitor)
+	r.OpMonitors = append(r.OpMonitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
-	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &bufferingMemAccount)
+	r.OpAccounts = append(r.OpAccounts, &bufferingMemAccount)
 	return &bufferingMemAccount
 }
 
@@ -1261,7 +1270,7 @@ func (r *NewColOperatorResult) createBufferingUnlimitedMemAccount(
 ) *mon.BoundAccount {
 	bufferingOpUnlimitedMemMonitor := r.createBufferingUnlimitedMemMonitor(ctx, flowCtx, name)
 	bufferingMemAccount := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
-	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &bufferingMemAccount)
+	r.OpAccounts = append(r.OpAccounts, &bufferingMemAccount)
 	return &bufferingMemAccount
 }
 
@@ -1283,11 +1292,25 @@ func (r *NewColOperatorResult) createStandaloneMemAccount(
 		math.MaxInt64, /* noteworthy */
 		flowCtx.Cfg.Settings,
 	)
-	r.BufferingOpMemMonitors = append(r.BufferingOpMemMonitors, &standaloneMemMonitor)
+	r.OpMonitors = append(r.OpMonitors, &standaloneMemMonitor)
 	standaloneMemMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
 	standaloneMemAccount := standaloneMemMonitor.MakeBoundAccount()
-	r.BufferingOpMemAccounts = append(r.BufferingOpMemAccounts, &standaloneMemAccount)
+	r.OpAccounts = append(r.OpAccounts, &standaloneMemAccount)
 	return &standaloneMemAccount
+}
+
+// createDiskAccount instantiates an unlimited disk monitor and a disk account
+// to be used for disk spilling infrastructure in vectorized engine.
+// TODO(azhng): consolidates all allocation monitors/account manage into one
+// place after branch cut for 20.1.
+func (r *NewColOperatorResult) createDiskAccount(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
+) *mon.BoundAccount {
+	opDiskMonitor := execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, name)
+	r.OpMonitors = append(r.OpMonitors, opDiskMonitor)
+	opDiskAccount := opDiskMonitor.MakeBoundAccount()
+	r.OpAccounts = append(r.OpAccounts, &opDiskAccount)
+	return &opDiskAccount
 }
 
 type postProcessResult struct {

--- a/pkg/sql/colexec/fn_op.go
+++ b/pkg/sql/colexec/fn_op.go
@@ -37,4 +37,8 @@ func (f fnOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (f fnOp) reset() {}
+func (f fnOp) reset(ctx context.Context) {
+	if resettableOp, ok := f.input.(resetter); ok {
+		resettableOp.reset(ctx)
+	}
+}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -500,9 +500,9 @@ func (op *hashAggregator) onlineAgg() {
 
 // reset resets the hashAggregator for another run. Primarily used for
 // benchmarks.
-func (op *hashAggregator) reset() {
+func (op *hashAggregator) reset(ctx context.Context) {
 	if r, ok := op.input.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 
 	op.aggFuncMap = hashAggFuncMap{}

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -570,14 +570,14 @@ func (hj *hashJoiner) resetOutput() {
 	}
 }
 
-func (hj *hashJoiner) reset() {
+func (hj *hashJoiner) reset(ctx context.Context) {
 	for _, input := range []Operator{hj.inputOne, hj.inputTwo} {
 		if r, ok := input.(resetter); ok {
-			r.reset()
+			r.reset(ctx)
 		}
 	}
 	hj.state = hjBuilding
-	hj.ht.reset()
+	hj.ht.reset(ctx)
 	copy(hj.probeState.buildIdx[:coldata.BatchSize()], zeroIntColumn)
 	copy(hj.probeState.probeIdx[:coldata.BatchSize()], zeroIntColumn)
 	if hj.spec.left.outer {

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -462,7 +462,7 @@ func (ht *hashTable) findNext(next []uint64, nToCheck uint64) {
 // vectors, and the capacities would stay the same until an actual new
 // allocation is needed, and at that time the allocator will update the memory
 // account accordingly.
-func (ht *hashTable) reset() {
+func (ht *hashTable) reset(_ context.Context) {
 	for n := 0; n < len(ht.buildScratch.first); n += copy(ht.buildScratch.first[n:], zeroUint64Column) {
 	}
 	ht.vals.ResetInternalBatch()

--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -34,6 +34,11 @@ var (
 	// and a memory account bound to it for use in tests.
 	testMemMonitor *mon.BytesMonitor
 	testMemAcc     *mon.BoundAccount
+
+	// testDiskMonitor and testDiskmAcc are a test monitor with an unlimited budget
+	// and a disk account bound to it for use in tests.
+	testDiskMonitor *mon.BytesMonitor
+	testDiskAcc     *mon.BoundAccount
 )
 
 func TestMain(m *testing.M) {
@@ -46,6 +51,13 @@ func TestMain(m *testing.M) {
 		testMemAcc = &memAcc
 		testAllocator = NewAllocator(ctx, testMemAcc)
 		defer testMemAcc.Close(ctx)
+
+		testDiskMonitor = execinfra.NewTestDiskMonitor(ctx, cluster.MakeTestingClusterSettings())
+		defer testDiskMonitor.Stop(ctx)
+		diskAcc := testDiskMonitor.MakeBoundAccount()
+		testDiskAcc = &diskAcc
+		defer testDiskAcc.Close(ctx)
+
 		// Pick a random batch size in [coldata.MinBatchSize, coldata.MaxBatchSize]
 		// range. The randomization can be disabled using COCKROACH_RANDOMIZE_BATCH_SIZE=false.
 		randomBatchSize := generateBatchSize()

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1488,13 +1488,16 @@ func TestMergeJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
-		Cfg:     &execinfra.ServerConfig{Settings: st},
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: testDiskMonitor,
+		},
 	}
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	var (
-		memAccounts []*mon.BoundAccount
-		memMonitors []*mon.BytesMonitor
+		accounts []*mon.BoundAccount
+		monitors []*mon.BytesMonitor
 	)
 	for _, tc := range mjTestCases {
 		tc.init()
@@ -1548,18 +1551,18 @@ func TestMergeJoiner(t *testing.T) {
 						if err != nil {
 							return nil, err
 						}
-						memAccounts = append(memAccounts, result.BufferingOpMemAccounts...)
-						memMonitors = append(memMonitors, result.BufferingOpMemMonitors...)
+						accounts = append(accounts, result.OpAccounts...)
+						monitors = append(monitors, result.OpMonitors...)
 						return result.Op, nil
 					})
 			})
 		}
 	}
-	for _, memAccount := range memAccounts {
-		memAccount.Close(ctx)
+	for _, acc := range accounts {
+		acc.Close(ctx)
 	}
-	for _, memMonitor := range memMonitors {
-		memMonitor.Stop(ctx)
+	for _, mon := range monitors {
+		mon.Stop(ctx)
 	}
 }
 
@@ -1598,6 +1601,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					testDiskAcc,
 				)
 				if err != nil {
 					t.Fatal("error in merge join op constructor", err)
@@ -1672,6 +1676,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+						testDiskAcc,
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1751,6 +1756,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
+						testDiskAcc,
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1880,6 +1886,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 								leftSource, rightSource, typs, typs,
 								[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 								[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+								testDiskAcc,
 							)
 
 							if err != nil {
@@ -1982,6 +1989,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					testDiskAcc,
 				)
 				require.NoError(b, err)
 				s := mergeJoinInnerOp{mergeJoinBase: base}
@@ -2012,6 +2020,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					testDiskAcc,
 				)
 				require.NoError(b, err)
 				s := mergeJoinInnerOp{mergeJoinBase: base}
@@ -2044,6 +2053,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
+					testDiskAcc,
 				)
 				require.NoError(b, err)
 				s := mergeJoinInnerOp{mergeJoinBase: base}

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -153,13 +153,22 @@ type InternalMemoryOperator interface {
 // resetter is an interface that operators can implement if they can be reset
 // either for reusing (to keep the already allocated memory) or during tests.
 type resetter interface {
-	reset()
+	reset(ctx context.Context)
 }
 
 // resettableOperator is an Operator that can be reset.
 type resettableOperator interface {
 	Operator
 	resetter
+}
+
+type closer interface {
+	Close(ctx context.Context) error
+}
+
+type closableOperator interface {
+	Operator
+	closer
 }
 
 type noopOperator struct {
@@ -182,9 +191,9 @@ func (n *noopOperator) Next(ctx context.Context) coldata.Batch {
 	return n.input.Next(ctx)
 }
 
-func (n *noopOperator) reset() {
+func (n *noopOperator) reset(ctx context.Context) {
 	if r, ok := n.input.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 }
 

--- a/pkg/sql/colexec/partially_ordered_distinct.go
+++ b/pkg/sql/colexec/partially_ordered_distinct.go
@@ -108,7 +108,7 @@ func (p *partiallyOrderedDistinct) Next(ctx context.Context) coldata.Batch {
 				return coldata.ZeroBatch
 			}
 			// p.distinct will reset p.input.
-			p.distinct.reset()
+			p.distinct.reset(ctx)
 		} else {
 			return batch
 		}
@@ -224,7 +224,7 @@ func (c *chunkerOperator) done() bool {
 	return c.input.done()
 }
 
-func (c *chunkerOperator) reset() {
+func (c *chunkerOperator) reset(_ context.Context) {
 	c.currentChunkFinished = false
 	if c.newChunksCol != nil {
 		if c.outputTupleStartIdx == c.numTuplesInChunks {

--- a/pkg/sql/colexec/simple_project.go
+++ b/pkg/sql/colexec/simple_project.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -32,7 +31,7 @@ type simpleProjectOp struct {
 	numBatchesLoggingThreshold int
 }
 
-var _ Operator = &simpleProjectOp{}
+var _ closableOperator = &simpleProjectOp{}
 
 // projectingBatch is a Batch that applies a simple projection to another,
 // underlying batch, discarding all columns but the ones in its projection
@@ -125,9 +124,9 @@ func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
 	return projBatch
 }
 
-func (d *simpleProjectOp) Close() error {
-	if c, ok := d.input.(io.Closer); ok {
-		return c.Close()
+func (d *simpleProjectOp) Close(ctx context.Context) error {
+	if c, ok := d.input.(closer); ok {
+		return c.Close(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -182,9 +182,9 @@ func (p *allSpooler) getWindowedBatch(startIdx, endIdx int) coldata.Batch {
 	return p.windowedBatch
 }
 
-func (p *allSpooler) reset() {
+func (p *allSpooler) reset(ctx context.Context) {
 	if r, ok := p.input.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 	p.spooled = false
 	p.bufferedTuples.SetLength(0)
@@ -411,9 +411,9 @@ func (p *sortOp) resetOutput() {
 	}
 }
 
-func (p *sortOp) reset() {
+func (p *sortOp) reset(ctx context.Context) {
 	if r, ok := p.input.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 	p.emitted = 0
 	p.exported = 0

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -101,7 +101,7 @@ func (c *sortChunksOp) Next(ctx context.Context) coldata.Batch {
 			// the full reset of the chunker because we're in the middle of
 			// processing of the input to sortChunksOp.
 			c.input.emptyBuffer()
-			c.sorter.reset()
+			c.sorter.reset(ctx)
 		} else {
 			return batch
 		}

--- a/pkg/sql/colexec/stats_test.go
+++ b/pkg/sql/colexec/stats_test.go
@@ -91,6 +91,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			[]coltypes.T{coltypes.Int64}, []coltypes.T{coltypes.Int64},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
+			testDiskAcc,
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -116,14 +116,14 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 }
 
 // reset resets the unorderedDistinct.
-func (op *unorderedDistinct) reset() {
+func (op *unorderedDistinct) reset(ctx context.Context) {
 	if r, ok := op.input.(resetter); ok {
-		r.reset()
+		r.reset(ctx)
 	}
 	op.ht.vals.ResetInternalBatch()
 	op.ht.vals.SetLength(0)
 	op.buildFinished = false
-	op.ht.reset()
+	op.ht.reset(ctx)
 	op.distinctCount = 0
 	op.outputBatchStart = 0
 }

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -13,7 +13,6 @@ package colexec
 import (
 	"context"
 	"fmt"
-	"io"
 	"math"
 	"math/rand"
 	"reflect"
@@ -276,11 +275,11 @@ func runTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
-		if c, ok := originalOp.(io.Closer); ok {
-			require.NoError(t, c.Close())
+		if c, ok := originalOp.(closer); ok {
+			require.NoError(t, c.Close(ctx))
 		}
-		if c, ok := opWithNulls.(io.Closer); ok {
-			require.NoError(t, c.Close())
+		if c, ok := opWithNulls.(closer); ok {
+			require.NoError(t, c.Close(ctx))
 		}
 	})
 }
@@ -403,10 +402,10 @@ func runTestsWithoutAllNullsInjection(
 						assert.False(t, maybeHasNulls(b))
 					}
 				}
-				if c, ok := op.(io.Closer); ok {
+				if c, ok := op.(closer); ok {
 					// Some operators need an explicit Close if not drained completely of
 					// input.
-					assert.NoError(t, c.Close())
+					assert.NoError(t, c.Close(ctx))
 				}
 			}
 		})

--- a/pkg/sql/colflow/main_test.go
+++ b/pkg/sql/colflow/main_test.go
@@ -37,6 +37,11 @@ var (
 	// and a memory account bound to it for use in tests.
 	testMemMonitor *mon.BytesMonitor
 	testMemAcc     *mon.BoundAccount
+
+	// testDiskMonitor and testDiskmAcc are a test monitor with an unlimited budget
+	// and a disk account bound to it for use in tests.
+	testDiskMonitor *mon.BytesMonitor
+	testDiskAcc     *mon.BoundAccount
 )
 
 func TestMain(m *testing.M) {
@@ -52,6 +57,13 @@ func TestMain(m *testing.M) {
 		testMemAcc = &memAcc
 		testAllocator = colexec.NewAllocator(ctx, testMemAcc)
 		defer testMemAcc.Close(ctx)
+
+		testDiskMonitor = execinfra.NewTestDiskMonitor(ctx, cluster.MakeTestingClusterSettings())
+		defer testDiskMonitor.Stop(ctx)
+		diskAcc := testDiskMonitor.MakeBoundAccount()
+		testDiskAcc = &diskAcc
+		defer testDiskAcc.Close(ctx)
+
 		return m.Run()
 	}())
 }

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -164,7 +164,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					defer acc.Close(ctxRemote)
 					allocators[i] = colexec.NewAllocator(ctxRemote, &acc)
 				}
-				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg, &colexec.TestingSemaphore{})
+				hashRouter, hashRouterOutputs := colexec.NewHashRouter(allocators, hashRouterInput, typs, []uint32{0}, 64<<20 /* 64 MiB */, queueCfg, &colexec.TestingSemaphore{}, testDiskAcc)
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -37,7 +37,10 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &execinfra.FlowCtx{
-		Cfg:     &execinfra.ServerConfig{Settings: st},
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: testDiskMonitor,
+		},
 		EvalCtx: &evalCtx,
 	}
 
@@ -121,7 +124,10 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &execinfra.FlowCtx{
-		Cfg:     &execinfra.ServerConfig{Settings: st},
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: testDiskMonitor,
+		},
 		EvalCtx: &evalCtx,
 	}
 
@@ -234,10 +240,10 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					result.Op.Next(ctx)
 					result.Op.Next(ctx)
 				})
-				for _, memAccount := range result.BufferingOpMemAccounts {
+				for _, memAccount := range result.OpAccounts {
 					memAccount.Close(ctx)
 				}
-				for _, memMonitor := range result.BufferingOpMemMonitors {
+				for _, memMonitor := range result.OpMonitors {
 					memMonitor.Stop(ctx)
 				}
 				if expectNoMemoryError {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -134,10 +134,10 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		return err
 	}
 	defer func() {
-		for _, memAccount := range result.BufferingOpMemAccounts {
+		for _, memAccount := range result.OpAccounts {
 			memAccount.Close(ctx)
 		}
-		for _, memMonitor := range result.BufferingOpMemMonitors {
+		for _, memMonitor := range result.OpMonitors {
 			memMonitor.Stop(ctx)
 		}
 	}()

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -19,15 +19,17 @@ import (
 // DistSQLMetrics contains pointers to the metrics for monitoring DistSQL
 // processing.
 type DistSQLMetrics struct {
-	QueriesActive *metric.Gauge
-	QueriesTotal  *metric.Counter
-	FlowsActive   *metric.Gauge
-	FlowsTotal    *metric.Counter
-	FlowsQueued   *metric.Gauge
-	QueueWaitHist *metric.Histogram
-	MaxBytesHist  *metric.Histogram
-	CurBytesCount *metric.Gauge
-	VecOpenFDs    *metric.Gauge
+	QueriesActive     *metric.Gauge
+	QueriesTotal      *metric.Counter
+	FlowsActive       *metric.Gauge
+	FlowsTotal        *metric.Counter
+	FlowsQueued       *metric.Gauge
+	QueueWaitHist     *metric.Histogram
+	MaxBytesHist      *metric.Histogram
+	CurBytesCount     *metric.Gauge
+	VecOpenFDs        *metric.Gauge
+	CurDiskBytesCount *metric.Gauge
+	MaxDiskBytesHist  *metric.Histogram
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -90,6 +92,18 @@ var (
 		Measurement: "Files",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaDiskCurBytes = metric.Metadata{
+		Name:        "sql.disk.distsql.current",
+		Help:        "Current sql statement disk usage for distsql",
+		Measurement: "Disk",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaDiskMaxBytes = metric.Metadata{
+		Name:        "sql.disk.distsql.max",
+		Help:        "Disk usage per sql statement for distsql",
+		Measurement: "Disk",
+		Unit:        metric.Unit_BYTES,
+	}
 )
 
 // See pkg/sql/mem_metrics.go
@@ -99,15 +113,17 @@ const log10int64times1000 = 19 * 1000
 // MakeDistSQLMetrics instantiates the metrics holder for DistSQL monitoring.
 func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 	return DistSQLMetrics{
-		QueriesActive: metric.NewGauge(metaQueriesActive),
-		QueriesTotal:  metric.NewCounter(metaQueriesTotal),
-		FlowsActive:   metric.NewGauge(metaFlowsActive),
-		FlowsTotal:    metric.NewCounter(metaFlowsTotal),
-		FlowsQueued:   metric.NewGauge(metaFlowsQueued),
-		QueueWaitHist: metric.NewLatency(metaQueueWaitHist, histogramWindow),
-		MaxBytesHist:  metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
-		CurBytesCount: metric.NewGauge(metaMemCurBytes),
-		VecOpenFDs:    metric.NewGauge(metaVecOpenFDs),
+		QueriesActive:     metric.NewGauge(metaQueriesActive),
+		QueriesTotal:      metric.NewCounter(metaQueriesTotal),
+		FlowsActive:       metric.NewGauge(metaFlowsActive),
+		FlowsTotal:        metric.NewCounter(metaFlowsTotal),
+		FlowsQueued:       metric.NewGauge(metaFlowsQueued),
+		QueueWaitHist:     metric.NewLatency(metaQueueWaitHist, histogramWindow),
+		MaxBytesHist:      metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
+		CurBytesCount:     metric.NewGauge(metaMemCurBytes),
+		VecOpenFDs:        metric.NewGauge(metaVecOpenFDs),
+		CurDiskBytesCount: metric.NewGauge(metaDiskCurBytes),
+		MaxDiskBytesHist:  metric.NewHistogram(metaDiskMaxBytes, histogramWindow, log10int64times1000, 3),
 	}
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1374,6 +1374,14 @@ var charts = []sectionDescription{
 				Title:   "Vectorized Temporary Storage Open File Descriptors",
 				Metrics: []string{"sql.distsql.vec.openfds"},
 			},
+			{
+				Title:   "Current Disk Usage",
+				Metrics: []string{"sql.disk.distsql.current"},
+			},
+			{
+				Title:   "Disk Usage per Statement",
+				Metrics: []string{"sql.disk.distsql.max"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This commit plumbs down disk monitor from FlowCtx to disk queue. It will
be monitoring disk usage of vectorize engine similar to row engine.

Release justification: bug fixes and low-risk updates to new functionality
since it is necessary for the new disk spilling infrastructure to have
disk monitoring

Release note: None

Closes #45169