### PR TITLE
backupccl: allow addition of db and table between full cluster backups

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -282,3 +282,17 @@ func TestRestoreSystemTableFromFullClusterBackup(t *testing.T) {
 
 	sqlDB.CheckQueryResults(t, "SELECT * FROM temp_sys.users", sqlDB.QueryStr(t, "SELECT * FROM system.users"))
 }
+
+func TestCreateDBAndTableIncrementalFullClusterBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, initNone)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
+	sqlDB.Exec(t, `CREATE DATABASE foo`)
+	sqlDB.Exec(t, `CREATE TABLE foo.bar (a int)`)
+
+	// Ensure that the new backup succeeds.
+	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
+}


### PR DESCRIPTION
Previously, when a user would create a database and table between 2
incremental full cluster backups, the second one would fail. The check
for allowing new descriptors is not needed on full cluster backups since
we ensure that an incremental full cluster backup is taken on top of
another full cluster backup. Thus, this should be allowed for the same
reason we allow new tables to be introduced if its database was
previously backed up.

Fixes #46065.

Release justification: bug fix
Release note (bug fix): Allow the creation of a database and table
between incremental full cluster backups.