### PR TITLE
libroach: avoid ToDBKey'ing split keys

### DIFF
--- a/c-deps/libroach/incremental_iterator.cc
+++ b/c-deps/libroach/incremental_iterator.cc
@@ -113,7 +113,10 @@ void DBIncrementalIterator::maybeSkipKeys() {
       // phantom MVCCKey.Keys. These keys may not be seen by the main iterator
       // due to aborted transactions and keys which have been subsumed due to
       // range tombstones. In this case we can SeekGE() the TBI to the main iterator.
-      state = DBIterSeek(time_bound_iter.get(), ToDBKey(iter_key));
+      DBKey seek_to;
+      // NB: We don't ToDBKey as iter_key is already split.
+      seek_to.key = ToDBSlice(iter_key);
+      state = DBIterSeek(time_bound_iter.get(), seek_to);
       if (!state.valid) {
         status = state.status;
         valid = false;
@@ -131,7 +134,10 @@ void DBIncrementalIterator::maybeSkipKeys() {
       // keys. The main iterator is seeked to the TBI in hopes that many keys
       // were skipped. Note that a Seek() is an order of magnitude more
       // expensive than a Next().
-      state = DBIterSeek(iter.get(), ToDBKey(tbi_key));
+      DBKey seek_to;
+      // NB: We don't ToDBKey as iter_key is already split.
+      seek_to.key = ToDBSlice(tbi_key);
+      state = DBIterSeek(iter.get(), seek_to);
       if (!state.valid) {
         status = state.status;
         valid = false;

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -309,7 +309,7 @@ func backup(
 				}
 				rawRes, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
 				if pErr != nil {
-					return pErr.GoError()
+					return errors.Wrapf(pErr.GoError(), "exporting %s", span.span)
 				}
 				res := rawRes.(*roachpb.ExportResponse)
 


### PR DESCRIPTION
ToDBKey assumes its argument is an mvcc key and splits it accordingly.

If it is passed an already split user key it will fail when it tries to
split it again, either misinterpreting the suffix as a ts or detecting a
bad ts length and returning an empty DBKey. In the latter case, the
incremental iterator then interprets that as /Min and dutifully seeks
its underlying iterator there.

Fixes #46069.

Release note: none. (this code is disabled)

Release justification: low-risk, high impact bug fix.

While i'm here: have BACKUP print the span to which a failing ExportRequest was sent.