### PR TITLE
ui: (fix) Activate diagnostics action on Statements view

### DIFF
--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -238,7 +238,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
                     statements,
                     selectedApp,
                     search,
-                    this.activateDiagnosticsRef.current?.showModalFor,
+                    this.activateDiagnosticsRef,
                   )
                 }
                 sortSetting={this.state.sortSetting}


### PR DESCRIPTION
Resolves: #46053

Activate Diagnostics modal exposes forwardRef object with
single function `showModalFor(statementId)` and this
function can be called from parent component to open modal.

Activate Diagnostics modal was not opened after clicking
on Activate link because the way this function was
passed to `makeStatementsColumns` function.
Instead of passing entire ObjectRef, it was passed only
function and the problem that this curren.showModalFor
is undefined until compoennt is mounet in DOM. As result
accidentally it could fail after some page refreshes.

Introduced change passes entire `activateDiagnosticsRef` as
an argument to `makeStatementsColumns` function and eventually
this object mutates and has assigned `current.showModalFor`
function after mounting componennt in DOM.

Additionally this change has additional fix - it doesn't show
Diagnostics column on Databases > Table details > Statements tab.
Before current change `makeStatemensColumns` function was called
from two places and Diagnostics column was added without any
conditions. 
Now Diagnostics column is added only if `activateDiagnosticsRef`
param is passed.

<img width="1439" alt="Screenshot 2020-03-13 at 13 30 12" src="https://user-images.githubusercontent.com/3106437/76617749-a1c2fc00-652f-11ea-8b58-0674ccf71a33.png">

Release justification: It is bug fix for new functionality which
has low impact on existing functionality

Release note: None