### PR TITLE
jobs,adminui: fix handling of `Job` struct unclonable fields

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -566,17 +566,6 @@ func (j *Job) Progress() jobspb.Progress {
 	return j.mu.progress
 }
 
-// ToProto returns the protobuf representation of the job.
-func (j *Job) ToProto() *jobspb.Job {
-	jpb := &jobspb.Job{}
-	j.mu.Lock()
-	defer j.mu.Unlock()
-	jpb.Id = *j.ID()
-	jpb.Payload = protoutil.Clone(&j.mu.payload).(*jobspb.Payload)
-	jpb.Progress = protoutil.Clone(&j.mu.progress).(*jobspb.Progress)
-	return jpb
-}
-
 // Details returns the details from the most recently sent Payload for this Job.
 func (j *Job) Details() jobspb.Details {
 	j.mu.Lock()


### PR DESCRIPTION
We report status of jobs running in a cluster by making a copy of the
fields `Payload` and `Progress` of the `Job` struct. These protos can
however contain unclonable fields (arrays). We deal with this by only
performing a shallow copy which is ok since the job struct that we copy
from is not being modified. A failing test was added to confirm that
this addresses the issue. In the long run we should split out some of
the `Job` API into read-only to make such reasoning about shallow
copies and such easier.

Fixes #46049.

Release justification: fixes a critical bug introduced in 20.1.
Release note: none.