### PR TITLE
jobs: job id and its address can be confused

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -388,7 +388,7 @@ func (j *Job) resumed(ctx context.Context) error {
 func (j *Job) cancelRequested(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		if md.Payload.Noncancelable {
-			return errors.Newf("job %d: not cancelable", j.ID())
+			return errors.Newf("job %d: not cancelable", *j.ID())
 		}
 		if md.Status == StatusCancelRequested || md.Status == StatusCanceled {
 			return nil
@@ -398,7 +398,7 @@ func (j *Job) cancelRequested(ctx context.Context, fn func(context.Context, *kv.
 		}
 		if md.Status == StatusPaused && md.Payload.FinalResumeError != nil {
 			decodedErr := errors.DecodeError(ctx, *md.Payload.FinalResumeError)
-			return fmt.Errorf("job %d is paused and has non-nil FinalResumeError %s hence cannot be canceled and should be reverted", j.ID(), decodedErr.Error())
+			return fmt.Errorf("job %d is paused and has non-nil FinalResumeError %s hence cannot be canceled and should be reverted", *j.ID(), decodedErr.Error())
 		}
 		if fn != nil {
 			if err := fn(ctx, txn); err != nil {

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1741,7 +1741,7 @@ func TestShowJobWhenComplete(t *testing.T) {
 			}
 			if *job.ID() != out.id {
 				return errors.Errorf(
-					"Expected job id %d but got %d", job.ID(), out.id)
+					"Expected job id %d but got %d", *job.ID(), out.id)
 			}
 			return nil
 		})

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -847,7 +847,7 @@ func (r *Registry) stepThroughStateMachine(
 		}
 		if err, ok := errors.Cause(err).(*InvalidStatusError); ok {
 			if err.status != StatusPauseRequested {
-				errorMsg := fmt.Sprintf("job %d: unexpected status %s provided for a reverting job", job.ID(), err.status)
+				errorMsg := fmt.Sprintf("job %d: unexpected status %s provided for a reverting job", *job.ID(), err.status)
 				return errors.NewAssertionErrorWithWrappedErrf(jobErr, errorMsg)
 			}
 			return err
@@ -1027,7 +1027,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 		// has been upgraded to 2.1 then we know nothing is running the job and it
 		// can be safely failed.
 		if nullProgress, ok := row[2].(*tree.DBool); ok && bool(*nullProgress) {
-			log.Warningf(ctx, "job %d predates cluster upgrade and must be re-run", id)
+			log.Warningf(ctx, "job %d predates cluster upgrade and must be re-run", *id)
 			versionErr := errors.New("job predates cluster upgrade and must be re-run")
 			payload.Error = versionErr.Error()
 			payloadBytes, err := protoutil.Marshal(payload)
@@ -1045,7 +1045,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 				return err
 			})
 			if err != nil {
-				log.Warningf(ctx, "job %d: has no progress but unable to mark failed: %s", id, err)
+				log.Warningf(ctx, "job %d: has no progress but unable to mark failed: %s", *id, err)
 			}
 			continue
 		}


### PR DESCRIPTION
In a few places we are logging the address of the job id
instead of its value.
In a follow up PR the job id will be refactored to be
`int64` instead of `*int64` to prevent such mistakes and
also to simplify the code as using `*int64` is unnatural.

Release note: none.

Release justification: this commit is safe for this release
because it only affects log messages.