### PR TITLE
sql: add telemetry for schema job control changes

### DIFF
--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -14,7 +14,9 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -70,6 +72,14 @@ func (n *controlJobsNode) startExec(params runParams) error {
 			return err
 		}
 		n.numRows++
+	}
+	switch n.desiredStatus {
+	case jobs.StatusPaused:
+		telemetry.Inc(sqltelemetry.SchemaJobControlCounter("pause"))
+	case jobs.StatusRunning:
+		telemetry.Inc(sqltelemetry.SchemaJobControlCounter("resume"))
+	case jobs.StatusCanceled:
+		telemetry.Inc(sqltelemetry.SchemaJobControlCounter("cancel"))
 	}
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -108,3 +108,17 @@ PAUSE JOB 1
 
 query error only users with the admin role are allowed to RESUME JOBS
 RESUME JOB 1
+
+user root
+
+query T rowsort
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.job.control.pause',
+  'sql.schema.job.control.resume',
+  'sql.schema.job.control.cancel'
+)
+----
+sql.schema.job.control.pause
+sql.schema.job.control.cancel
+sql.schema.job.control.resume

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -97,6 +97,12 @@ func SchemaSetAuditModeCounter(mode string) telemetry.Counter {
 	return telemetry.GetCounter("sql.schema.set_audit_mode." + mode)
 }
 
+// SchemaJobControlCounter is to be incremented every time a job control action
+// is taken.
+func SchemaJobControlCounter(desiredStatus string) telemetry.Counter {
+	return telemetry.GetCounter("sql.schema.job.control." + desiredStatus)
+}
+
 // SecondaryIndexColumnFamiliesCounter is a counter that is incremented every time
 // a secondary index that is separated into different column families is created.
 var SecondaryIndexColumnFamiliesCounter = telemetry.GetCounterOnce("sql.schema.secondary_index_column_families")


### PR DESCRIPTION
Release justification: telemetry only; no user features.

Release note: None