### PR TITLE
release-19.2: colexec: fix behavior of some operators on zero-length batches

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -136,33 +136,39 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	// {{ else }}
 	knownResult := false
 	// {{ end }}
-	leftCol := batch.ColVec(o.leftIdx)
-	leftColVals := leftCol.Bool()
-	var curIdx uint16
-	if usesSel {
-		sel := batch.Selection()
-		origSel := o.origSel[:origLen]
-		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
-			for _, i := range origSel {
-				_ADD_TUPLE_FOR_RIGHT(true)
+	var (
+		leftCol     coldata.Vec
+		leftColVals []bool
+		curIdx      uint16
+	)
+	if origLen > 0 {
+		leftCol = batch.ColVec(o.leftIdx)
+		leftColVals = leftCol.Bool()
+		if usesSel {
+			sel := batch.Selection()
+			origSel := o.origSel[:origLen]
+			if leftCol.MaybeHasNulls() {
+				leftNulls := leftCol.Nulls()
+				for _, i := range origSel {
+					_ADD_TUPLE_FOR_RIGHT(true)
+				}
+			} else {
+				for _, i := range origSel {
+					_ADD_TUPLE_FOR_RIGHT(false)
+				}
 			}
 		} else {
-			for _, i := range origSel {
-				_ADD_TUPLE_FOR_RIGHT(false)
-			}
-		}
-	} else {
-		batch.SetSelection(true)
-		sel := batch.Selection()
-		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
-			for i := uint16(0); i < origLen; i++ {
-				_ADD_TUPLE_FOR_RIGHT(true)
-			}
-		} else {
-			for i := uint16(0); i < origLen; i++ {
-				_ADD_TUPLE_FOR_RIGHT(false)
+			batch.SetSelection(true)
+			sel := batch.Selection()
+			if leftCol.MaybeHasNulls() {
+				leftNulls := leftCol.Nulls()
+				for i := uint16(0); i < origLen; i++ {
+					_ADD_TUPLE_FOR_RIGHT(true)
+				}
+			} else {
+				for i := uint16(0); i < origLen; i++ {
+					_ADD_TUPLE_FOR_RIGHT(false)
+				}
 			}
 		}
 	}

--- a/pkg/sql/colexec/bool_vec_to_sel.go
+++ b/pkg/sql/colexec/bool_vec_to_sel.go
@@ -123,6 +123,9 @@ func (d selBoolOp) Init() {
 
 func (d selBoolOp) Next(ctx context.Context) coldata.Batch {
 	batch := d.input.Next(ctx)
+	if batch.Length() == 0 {
+		return batch
+	}
 	inputCol := batch.ColVec(d.colIdx)
 	d.boolVecToSelOp.outputCol = inputCol.Bool()
 	if inputCol.MaybeHasNulls() {

--- a/pkg/sql/colexec/buffer.go
+++ b/pkg/sql/colexec/buffer.go
@@ -24,9 +24,8 @@ type bufferOp struct {
 	initStatus OperatorInitStatus
 
 	// read is true if someone has read the current batch already.
-	read     bool
-	batch    *selectionBatch
-	batchLen uint16
+	read  bool
+	batch *selectionBatch
 }
 
 var _ StaticMemoryOperator = &bufferOp{}
@@ -71,8 +70,6 @@ func (b *bufferOp) rewind() {
 // for reads.
 func (b *bufferOp) advance(ctx context.Context) {
 	b.batch.Batch = b.input.Next(ctx)
-	b.batchLen = b.batch.Length()
-	b.read = false
 }
 
 func (b *bufferOp) Next(ctx context.Context) coldata.Batch {

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -109,102 +109,106 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 		copy(c.origSel, sel)
 	}
 
-	outputCol := c.buffer.batch.Batch.ColVec(c.outputIdx)
+	var outputCol coldata.Vec
+	if origLen > 0 {
+		outputCol = c.buffer.batch.Batch.ColVec(c.outputIdx)
+	}
 	for i := range c.caseOps {
 		c.buffer.rewind()
 		// Run the next case operator chain. It will project its THEN expression
 		// for all tuples that matched its WHEN expression and that were not
 		// already matched.
 		batch := c.caseOps[i].Next(ctx)
-		// The batch's projection column now additionally contains results for all
-		// of the tuples that passed the ith WHEN clause. The batch's selection
-		// vector is set to the same selection of tuples.
-		// Now, we must subtract this selection vector from the last buffered
-		// selection vector, so that the next operator gets to operate on the
-		// remaining set of tuples in the input that haven't matched an arm of the
-		// case statement.
-		// As an example, imagine the first WHEN op matched tuple 3. The following
-		// diagram shows the selection vector before running WHEN, after running
-		// WHEN, and then the desired selection vector after subtraction:
-		// - origSel
-		// | - selection vector after running WHEN
-		// | | - desired selection vector after subtraction
-		// | | |
-		// 1   1
-		// 2   2
-		// 3 3
-		// 4   4
-		toSubtract := batch.Selection()
-		toSubtract = toSubtract[:batch.Length()]
-		// toSubtract is now a selection vector containing all matched tuples of the
-		// current case arm.
-		var subtractIdx int
-		var curIdx uint16
-		inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[i])
-		// Copy the results into the output vector, using the toSubtract selection
-		// vector to copy only the elements that we actually wrote according to the
-		// current case arm.
-		outputCol.Copy(coldata.CopySliceArgs{
-			SliceArgs: coldata.SliceArgs{
-				ColType:     c.typ,
-				Src:         inputCol,
-				Sel:         toSubtract,
-				SrcStartIdx: 0,
-				SrcEndIdx:   uint64(len(toSubtract)),
-			},
-			SelOnDest: true,
-		})
-		if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
-			// We have an old selection vector, which represents the tuples that
-			// haven't yet been matched. Remove the ones that just matched from the
-			// old selection vector.
-			for i := range oldSel[:c.buffer.batch.Batch.Length()] {
-				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == oldSel[i] {
-					// The ith element of the old selection vector matched the current one
-					// in toSubtract. Skip writing this element, removing it from the old
-					// selection vector.
-					subtractIdx++
-					continue
+		if batch.Length() > 0 {
+			// The batch's projection column now additionally contains results for all
+			// of the tuples that passed the ith WHEN clause. The batch's selection
+			// vector is set to the same selection of tuples.
+			// Now, we must subtract this selection vector from the last buffered
+			// selection vector, so that the next operator gets to operate on the
+			// remaining set of tuples in the input that haven't matched an arm of the
+			// case statement.
+			// As an example, imagine the first WHEN op matched tuple 3. The following
+			// diagram shows the selection vector before running WHEN, after running
+			// WHEN, and then the desired selection vector after subtraction:
+			// - origSel
+			// | - selection vector after running WHEN
+			// | | - desired selection vector after subtraction
+			// | | |
+			// 1   1
+			// 2   2
+			// 3 3
+			// 4   4
+			toSubtract := batch.Selection()
+			toSubtract = toSubtract[:batch.Length()]
+			// toSubtract is now a selection vector containing all matched tuples of the
+			// current case arm.
+			var subtractIdx int
+			var curIdx uint16
+			inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[i])
+			// Copy the results into the output vector, using the toSubtract selection
+			// vector to copy only the elements that we actually wrote according to the
+			// current case arm.
+			outputCol.Copy(coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:     c.typ,
+					Src:         inputCol,
+					Sel:         toSubtract,
+					SrcStartIdx: 0,
+					SrcEndIdx:   uint64(len(toSubtract)),
+				},
+				SelOnDest: true,
+			})
+			if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
+				// We have an old selection vector, which represents the tuples that
+				// haven't yet been matched. Remove the ones that just matched from the
+				// old selection vector.
+				for i := range oldSel[:c.buffer.batch.Batch.Length()] {
+					if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == oldSel[i] {
+						// The ith element of the old selection vector matched the current one
+						// in toSubtract. Skip writing this element, removing it from the old
+						// selection vector.
+						subtractIdx++
+						continue
+					}
+					oldSel[curIdx] = oldSel[i]
+					curIdx++
 				}
-				oldSel[curIdx] = oldSel[i]
-				curIdx++
-			}
-		} else {
-			// No selection vector means there have been no matches yet, and we were
-			// considering the entire batch of tuples for this case arm. Make a new
-			// selection vector with all of the tuples but the ones that just matched.
-			c.buffer.batch.Batch.SetSelection(true)
-			oldSel = c.buffer.batch.Batch.Selection()
-			for i := uint16(0); i < c.buffer.batch.Batch.Length(); i++ {
-				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == i {
-					subtractIdx++
-					continue
+			} else {
+				// No selection vector means there have been no matches yet, and we were
+				// considering the entire batch of tuples for this case arm. Make a new
+				// selection vector with all of the tuples but the ones that just matched.
+				c.buffer.batch.Batch.SetSelection(true)
+				oldSel = c.buffer.batch.Batch.Selection()
+				for i := uint16(0); i < c.buffer.batch.Batch.Length(); i++ {
+					if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == i {
+						subtractIdx++
+						continue
+					}
+					oldSel[curIdx] = i
+					curIdx++
 				}
-				oldSel[curIdx] = i
-				curIdx++
 			}
+			c.buffer.batch.Batch.SetLength(curIdx)
 		}
-		c.buffer.batch.Batch.SetLength(curIdx)
-
-		// Now our selection vector is set to exclude all the things that have
-		// matched so far. Reset the buffer and run the next case arm.
-		c.buffer.rewind()
 	}
+	c.buffer.rewind()
 	// Finally, run the else operator, which will project into all tuples that
 	// are remaining in the selection vector (didn't match any case arms). Once
 	// that's done, restore the original selection vector and return the batch.
 	batch := c.elseOp.Next(ctx)
-	inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
-	outputCol.Copy(coldata.CopySliceArgs{
-		SliceArgs: coldata.SliceArgs{
-			ColType:     c.typ,
-			Src:         inputCol,
-			Sel:         batch.Selection(),
-			SrcStartIdx: 0,
-			SrcEndIdx:   uint64(batch.Length()),
-		},
-		SelOnDest: true,
-	})
+	if batch.Length() > 0 {
+		inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
+		outputCol.Copy(coldata.CopySliceArgs{
+			SliceArgs: coldata.SliceArgs{
+				ColType:     c.typ,
+				Src:         inputCol,
+				Sel:         batch.Selection(),
+				SrcStartIdx: 0,
+				SrcEndIdx:   uint64(batch.Length()),
+			},
+			SelOnDest: true,
+		})
+	}
 	batch.SetLength(origLen)
 	batch.SetSelection(origHasSel)
 	if origHasSel {


### PR DESCRIPTION
This commit fixes the behavior of CaseOp, AndProjOp, and OrProjOp when
they encounter a zero-length batch. Previously, these operators would
attempt to get the output vector in all cases, however, on zero-length
batch we are not guaranteed anything about the schema of the columns
this resulted in an internal error. This problem has been fixed in 20.1
by refactoring the way we do short-circuiting logic in case of
a zero-length batch, so this commit is directly against the 19.2
release.

Also it adds a missing check for zero-length batch in selBoolOp.

Release note (bug fix): Previously, CockroachDB could return an internal
error in some cases when running queries with CASE, AND, OR operators
via the vectorized execution engine, and this has now been fixed.