### PR TITLE
importccl: allow clients to disconnect and jobs to still finish

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -657,6 +657,7 @@ func importPlanHook(
 			Details:     importDetails,
 			Progress:    jobspb.ImportProgress{},
 		}
+
 		var sj *jobs.StartableJob
 		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 			sj, err = p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, jr, txn, resultsCh)
@@ -681,11 +682,7 @@ func importPlanHook(
 			}
 			return err
 		}
-		errCh, err := sj.Start(ctx)
-		if err != nil {
-			return err
-		}
-		return <-errCh
+		return sj.Run(ctx)
 	}
 	return fn, backupccl.RestoreHeader, nil, false, nil
 }

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -27,14 +27,16 @@ func ResetConstructors() func() {
 
 // FakeResumer calls optional callbacks during the job lifecycle.
 type FakeResumer struct {
-	OnResume     func(context.Context) error
+	OnResume     func(context.Context, chan<- tree.Datums) error
 	FailOrCancel func(context.Context) error
 	Success      func() error
 }
 
-func (d FakeResumer) Resume(ctx context.Context, _ interface{}, _ chan<- tree.Datums) error {
+func (d FakeResumer) Resume(
+	ctx context.Context, _ interface{}, resultsCh chan<- tree.Datums,
+) error {
 	if d.OnResume != nil {
-		if err := d.OnResume(ctx); err != nil {
+		if err := d.OnResume(ctx, resultsCh); err != nil {
 			return err
 		}
 	}

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -128,7 +129,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		hookCallCount++
 		lock.Unlock()
 		return jobs.FakeResumer{
-			OnResume: func(ctx context.Context) error {
+			OnResume: func(ctx context.Context, _ chan<- tree.Datums) error {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -246,7 +247,7 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 	defer jobs.ResetConstructors()()
 	jobs.RegisterConstructor(jobspb.TypeBackup, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
-			OnResume: func(ctx context.Context) error {
+			OnResume: func(ctx context.Context, _ chan<- tree.Datums) error {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()


### PR DESCRIPTION
This commit deals with the case where the client disconnects. Prior to this
commit, the job would attempt to send its results on the client resultsCh
and block forever.

Release justification: fixes for high-priority or high-severity bugs in existing functionality

Release note: None