### PR TITLE
release-19.2: execerror: user errors package

### DIFF
--- a/pkg/sql/colexec/cancel_checker_test.go
+++ b/pkg/sql/colexec/cancel_checker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,5 +34,5 @@ func TestCancelChecker(t *testing.T) {
 	err := execerror.CatchVectorizedRuntimeError(func() {
 		op.Next(ctx)
 	})
-	require.Equal(t, sqlbase.QueryCanceledError, err)
+	require.True(t, errors.Is(err, sqlbase.QueryCanceledError))
 }

--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -12,12 +12,15 @@ package execerror
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"runtime/debug"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/causer"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -28,65 +31,66 @@ const panicLineSubstring = "runtime/panic.go"
 // related to the vectorized engine occurs, it is not recovered from.
 func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 	defer func() {
-		if err := recover(); err != nil {
-			stackTrace := string(debug.Stack())
-			scanner := bufio.NewScanner(strings.NewReader(stackTrace))
-			panicLineFound := false
-			for scanner.Scan() {
-				if strings.Contains(scanner.Text(), panicLineSubstring) {
-					panicLineFound = true
-					break
-				}
-			}
-			if !panicLineFound {
-				panic(fmt.Sprintf("panic line %q not found in the stack trace\n%s", panicLineSubstring, stackTrace))
-			}
-			if scanner.Scan() {
-				panicEmittedFrom := strings.TrimSpace(scanner.Text())
-				if isPanicFromVectorizedEngine(panicEmittedFrom) {
-					// We only want to catch runtime errors coming from the vectorized
-					// engine.
-					if e, ok := err.(error); ok {
-						if _, ok := err.(*StorageError); ok {
-							// A StorageError was caused by something below SQL, and represents
-							// an error that we'd simply like to propagate along.
-							// Do nothing.
-						} else {
-							doNotAnnotate := false
-							if nvie, ok := e.(*notVectorizedInternalError); ok {
-								// A notVectorizedInternalError was not caused by the
-								// vectorized engine and represents an error that we don't
-								// want to annotate in case it doesn't have a valid PG code.
-								doNotAnnotate = true
-								// We want to unwrap notVectorizedInternalError so that in case
-								// the original error does have a valid PG code, the code is
-								// correctly propagated.
-								e = nvie.error
-							}
-							if code := pgerror.GetPGCode(e); !doNotAnnotate && code == pgcode.Uncategorized {
-								// Any error without a code already is "surprising" and
-								// needs to be annotated to indicate that it was
-								// unexpected.
-								e = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", e)
-							}
-						}
-						retErr = e
-					} else {
-						// Not an error object. Definitely unexpected.
-						surprisingObject := err
-						retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", surprisingObject)
-					}
-				} else {
-					// Do not recover from the panic not related to the vectorized
-					// engine.
-					panic(err)
-				}
-			} else {
-				panic(fmt.Sprintf("unexpectedly there is no line below the panic line in the stack trace\n%s", stackTrace))
+		panicObj := recover()
+		if panicObj == nil {
+			// No panic happened, so the operation must have been executed
+			// successfully.
+			return
+		}
+
+		// Find where the panic came from and only proceed if it is related to the
+		// vectorized engine.
+		stackTrace := string(debug.Stack())
+		scanner := bufio.NewScanner(strings.NewReader(stackTrace))
+		panicLineFound := false
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), panicLineSubstring) {
+				panicLineFound = true
+				break
 			}
 		}
-		// No panic happened, so the operation must have been executed
-		// successfully.
+		if !panicLineFound {
+			panic(fmt.Sprintf("panic line %q not found in the stack trace\n%s", panicLineSubstring, stackTrace))
+		}
+		if !scanner.Scan() {
+			panic(fmt.Sprintf("unexpectedly there is no line below the panic line in the stack trace\n%s", stackTrace))
+		}
+		panicEmittedFrom := strings.TrimSpace(scanner.Text())
+		if !isPanicFromVectorizedEngine(panicEmittedFrom) {
+			// Do not recover from the panic not related to the vectorized
+			// engine.
+			panic(panicObj)
+		}
+
+		err, ok := panicObj.(error)
+		if !ok {
+			// Not an error object. Definitely unexpected.
+			retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", panicObj)
+			return
+		}
+		retErr = err
+
+		if _, ok := panicObj.(*StorageError); ok {
+			// A StorageError was caused by something below SQL, and represents
+			// an error that we'd simply like to propagate along.
+			// Do nothing.
+			return
+		}
+
+		annotateErrorWithoutCode := true
+		var nvie *notVectorizedInternalError
+		if errors.As(err, &nvie) {
+			// A notVectorizedInternalError was not caused by the
+			// vectorized engine and represents an error that we don't
+			// want to annotate in case it doesn't have a valid PG code.
+			annotateErrorWithoutCode = false
+		}
+		if code := pgerror.GetPGCode(err); annotateErrorWithoutCode && code == pgcode.Uncategorized {
+			// Any error without a code already is "surprising" and
+			// needs to be annotated to indicate that it was
+			// unexpected.
+			retErr = errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error from the vectorized runtime")
+		}
 	}()
 	operation()
 	return retErr
@@ -142,11 +146,38 @@ func NewStorageError(err error) *StorageError {
 // notVectorizedInternalError will be returned to the client not as an
 // "internal error" and without the stack trace.
 type notVectorizedInternalError struct {
-	error
+	cause error
 }
 
 func newNotVectorizedInternalError(err error) *notVectorizedInternalError {
-	return &notVectorizedInternalError{error: err}
+	return &notVectorizedInternalError{cause: err}
+}
+
+var (
+	_ causer.Causer  = &notVectorizedInternalError{}
+	_ errors.Wrapper = &notVectorizedInternalError{}
+)
+
+func (e *notVectorizedInternalError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *notVectorizedInternalError) Cause() error {
+	return e.cause
+}
+
+func (e *notVectorizedInternalError) Unwrap() error {
+	return e.Cause()
+}
+
+func decodeNotVectorizedInternalError(
+	_ context.Context, cause error, _ string, _ []string, _ protoutil.SimpleMessage,
+) error {
+	return newNotVectorizedInternalError(cause)
+}
+
+func init() {
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*notVectorizedInternalError)(nil)), decodeNotVectorizedInternalError)
 }
 
 // VectorizedInternalPanic simply panics with the provided object. It will

--- a/pkg/sql/colexec/overloads_test.go
+++ b/pkg/sql/colexec/overloads_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,10 +26,10 @@ func TestIntegerAddition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The addition overload is the same for all integer widths, so we only test
 	// one of them.
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(1, math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(-1, math.MinInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MaxInt16, 1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MinInt16, -1) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(1, math.MaxInt16) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(-1, math.MinInt16) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MaxInt16, 1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MinInt16, -1) }), tree.ErrIntOutOfRange))
 
 	require.Equal(t, int16(math.MaxInt16), performPlusInt16Int16(1, math.MaxInt16-1))
 	require.Equal(t, int16(math.MinInt16), performPlusInt16Int16(-1, math.MinInt16+1))
@@ -45,10 +46,10 @@ func TestIntegerSubtraction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The subtraction overload is the same for all integer widths, so we only
 	// test one of them.
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(1, -math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(-2, math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MaxInt16, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MinInt16, 1) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(1, -math.MaxInt16) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(-2, math.MaxInt16) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MaxInt16, -1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MinInt16, 1) }), tree.ErrIntOutOfRange))
 
 	require.Equal(t, int16(math.MaxInt16), performMinusInt16Int16(1, -math.MaxInt16+1))
 	require.Equal(t, int16(math.MinInt16), performMinusInt16Int16(-1, math.MaxInt16))
@@ -77,9 +78,9 @@ func TestIntegerDivision(t *testing.T) {
 	}
 	require.Equal(t, 0, res.Cmp(d))
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Int16(10, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Int32(10, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(10, 0) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt16Int16(10, 0) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt32Int32(10, 0) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(10, 0) }), tree.ErrDivByZero))
 
 	res = performDivInt16Int16(math.MaxInt16, -1)
 	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt16, 0)))
@@ -91,24 +92,24 @@ func TestIntegerDivision(t *testing.T) {
 
 func TestIntegerMultiplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 100) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 100) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 100) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 100) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 100) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 100) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 100) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 3) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 100) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64, -1) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16, -1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32, -1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64, -1) }), tree.ErrIntOutOfRange))
 
 	require.Equal(t, int16(-math.MaxInt16), performMultInt16Int16(math.MaxInt16, -1))
 	require.Equal(t, int32(-math.MaxInt32), performMultInt32Int32(math.MaxInt32, -1))
@@ -159,15 +160,15 @@ func TestDecimalDivByZero(t *testing.T) {
 	nonZeroDec.SetFinite(4, 0)
 	zeroDec.SetFinite(0, 0)
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt16(nonZeroDec, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt32(nonZeroDec, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt64(nonZeroDec, 0) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt16(nonZeroDec, 0) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt32(nonZeroDec, 0) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt64(nonZeroDec, 0) }), tree.ErrDivByZero))
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Decimal(2, zeroDec) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Decimal(2, zeroDec) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Decimal(2, zeroDec) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt64Decimal(2, zeroDec) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt32Decimal(2, zeroDec) }), tree.ErrDivByZero))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivInt16Decimal(2, zeroDec) }), tree.ErrDivByZero))
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalDecimal(nonZeroDec, zeroDec) }))
+	require.True(t, errors.Is(execerror.CatchVectorizedRuntimeError(func() { performDivDecimalDecimal(nonZeroDec, zeroDec) }), tree.ErrDivByZero))
 }
 
 func TestDecimalComparison(t *testing.T) {


### PR DESCRIPTION
Backport 1/2 commits from #45673.

/cc @cockroachdb/release

---

execerror: use errors package

We previously would unwrap a notVectorizedInternalError when first catching it,
which mean that we would lose that information and be unable to propagate its
underlying cause without annotating it if caught again (since we only check
for a *notVectorizedInternal wrapper). Instead, this patch changes the
CatchVectorizedRuntimeError function to leave the error object unwrapped when
doing its annotation. *notVectorizedInternalError is now enhanced so that it
can be sent over the wire unwrapped and propagated as many times as necessary
through CatchVectorizedRuntimeError without losing information.

Release note (bug fix): expected errors from the vectorized execution engine
are no longer mistakenly annotated as unexpected errors.