### PR TITLE
sql: change it's to its in alter primary key error message

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -49,7 +49,7 @@ func (p *planner) AlterPrimaryKey(
 
 	if tableDesc.IsNewTable() {
 		return pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot create table and change it's primary key in the same transaction")
+			"cannot create table and change its primary key in the same transaction")
 	}
 
 	// Ensure that other schema changes on this table are not currently

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -472,7 +472,7 @@ BEGIN
 statement ok
 CREATE TABLE t44782 (x INT PRIMARY KEY, y INT NOT NULL)
 
-statement error pq: cannot create table and change it's primary key in the same transaction
+statement error pq: cannot create table and change its primary key in the same transaction
 ALTER TABLE t44782 ALTER PRIMARY KEY USING COLUMNS (y)
 
 statement ok


### PR DESCRIPTION
I'm pretty sure this should be its :)

Release justification: better english in error message, no user defining
difference.

Release note: None