### PR TITLE
roachtest/ycsb: tune concurrency for each benchmark workload

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -16,8 +16,29 @@ import (
 )
 
 func registerYCSB(r *testRegistry) {
+	workloads := []string{"A", "B", "C", "D", "E", "F"}
+	cpusConfigs := []int{8, 32}
+
+	// concurrencyConfigs contains near-optimal concurrency levels for each
+	// (workload, cpu count) combination. All of these figures were tuned on GCP
+	// n1-standard instance types. We should consider implementing a search for
+	// the optimal concurrency level in the roachtest itself (see kvbench).
+	concurrencyConfigs := map[string] /* workload */ map[int] /* cpus */ int{
+		"A": {8: 96, 32: 144},
+		"B": {8: 144, 32: 192},
+		"C": {8: 144, 32: 192},
+		"D": {8: 96, 32: 144},
+		"E": {8: 96, 32: 144},
+		"F": {8: 96, 32: 144},
+	}
+
 	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string, cpus int) {
 		nodes := c.spec.NodeCount - 1
+
+		conc, ok := concurrencyConfigs[wl][cpus]
+		if !ok {
+			t.Fatalf("missing concurrency for (workload, cpus) = (%s, %d)", wl, cpus)
+		}
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -31,18 +52,18 @@ func registerYCSB(r *testRegistry) {
 			ramp := " --ramp=" + ifLocal("0s", "1m")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"./workload run ycsb --init --insert-count=1000000 --splits=100"+
-					" --workload=%s --concurrency=64 --histograms="+perfArtifactsDir+"/stats.json"+
-					sfu+ramp+duration+" {pgurl:1-%d}",
-				wl, nodes)
+				"./workload run ycsb --init --insert-count=1000000 --workload=%s --concurrency=%d"+
+					" --splits=%d --histograms="+perfArtifactsDir+"/stats.json"+sfu+ramp+duration+
+					" {pgurl:1-%d}",
+				wl, conc, nodes, nodes)
 			c.Run(ctx, c.Node(nodes+1), cmd)
 			return nil
 		})
 		m.Wait()
 	}
 
-	for _, wl := range []string{"A", "B", "C", "D", "E", "F"} {
-		for _, cpus := range []int{8, 32} {
+	for _, wl := range workloads {
+		for _, cpus := range cpusConfigs {
 			var name string
 			if cpus == 8 { // support legacy test name which didn't include cpu
 				name = fmt.Sprintf("ycsb/%s/nodes=3", wl)


### PR DESCRIPTION
This commit updates the ycsb roachtest suite to use more optimal concurrency levels for each of its tests. Part of the reason why recent changes around SELECT FOR UPDATE and improved queueing haven't shown up in roachperf is because the concurrency used was so far from optimal that the workload was not saturating the system.

With this change, a run of the entire YCSB roachtest suite on GCP n1-standard instances looks like:
```
=== RUN   ycsb/A/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       10233047        17055.1      5.6      3.9     15.2     39.8    453.0

=== RUN   ycsb/B/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       18656983        31095.0      4.6      3.1     14.7     28.3    469.8

=== RUN   ycsb/C/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       25652802        42754.7      3.4      3.1      8.9     14.2    285.2

=== RUN   ycsb/D/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       19480698        32467.8      3.0      2.2      9.4     16.3    352.3

=== RUN   ycsb/E/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0        1469048         2448.4     39.2     25.2    121.6    176.2    436.2

=== RUN   ycsb/F/nodes=3
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0        4424966         7375.1     13.0      7.9     33.6    159.4    771.8

=== RUN   ycsb/A/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       19027657        31712.8      4.5      2.5      9.4     65.0    352.3

=== RUN   ycsb/B/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       62467489       104112.5      1.8      1.2      6.3     11.5    184.5

=== RUN   ycsb/C/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       76910448       128184.0      1.5      1.2      4.5      7.1    302.0

=== RUN   ycsb/D/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0       56500181        94166.9      1.5      1.1      5.0      7.6    302.0

=== RUN   ycsb/E/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0        4790570         7984.3     18.0     15.2     44.0     60.8    251.7

=== RUN   ycsb/F/nodes=3/cpu=32
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
  600.0s        0        8977638        14962.7      9.6      6.0     18.9    159.4    906.0
```

We should consider implementing a search for the optimal concurrency level in the roachtest itself (see kvbench). For now, though, we just hard-code it.

Release justification: testing only.