### PR TITLE
pgwire: add telemetry for portal related requests

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -324,6 +324,7 @@ func (c *conn) newCommandResult(
 	if limit == 0 {
 		return r
 	}
+	telemetry.Inc(sqltelemetry.PortalWithLimitRequestCounter)
 	return &limitedCommandResult{
 		limit:         limit,
 		portalName:    portalName,

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -40,3 +40,7 @@ var UncategorizedErrorCounter = telemetry.GetCounterOnce("othererror." + pgcode.
 // InterleavedPortalRequestCounter is to be incremented every time an open
 // portal attempts to interleave work with another portal.
 var InterleavedPortalRequestCounter = telemetry.GetCounterOnce("pgwire.#40195.interleaved_portal")
+
+// PortalWithLimitRequestCounter is to be incremented every time a portal request is
+// made.
+var PortalWithLimitRequestCounter = telemetry.GetCounterOnce("pgwire.portal_with_limit_request")


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/43763 by covering the happy case.

This PR adds telemetry everytime a "limitedCommandResult" is made, which
signifies jdbc streaming.

Release justification: simply telemetry.

Release note: None