### PR TITLE
opt: support EXPLAIN BUNDLE as a prepared statement

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -215,6 +215,11 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.AST = explainBundle.Statement
 		// TODO(radu): should we trim the "EXPLAIN BUNDLE" part from stmt.SQL?
 
+		// Clear any ExpectedTypes we set if we prepared this statement (they
+		// reflect the column types of the EXPLAIN itself and not those of the inner
+		// statement).
+		stmt.ExpectedTypes = nil
+
 		// EXPLAIN BUNDLE does not return the rows for the given query; instead it
 		// returns some text which includes a URL.
 		// TODO(radu): maybe capture some of the rows and include them in the

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -303,6 +303,10 @@ func (b *Builder) buildStmt(
 	case *tree.Export:
 		return b.buildExport(stmt, inScope)
 
+	case *tree.ExplainBundle:
+		// This statement should have been handled by the executor.
+		panic(errors.Errorf("%s can only be used as a top-level statement", stmt.StatementTag()))
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.
@@ -325,7 +329,7 @@ func (b *Builder) buildStmt(
 			b.DisableMemoReuse = true
 			return outScope
 		}
-		panic(unimplementedWithIssueDetailf(34848, stmt.StatementTag(), "unsupported statement: %T", stmt))
+		panic(errors.AssertionFailedf("unexpected statement: %T", stmt))
 	}
 }
 


### PR DESCRIPTION
Some clients / drivers might issue EXPLAIN BUNDLE with the parse/bind/exec
protocol (e.g. DBeaver).

This change also fixes an error message in the optimizer - it was left over from
when we would fall back on HP; now this condition is an internal error.

Fixes #46020.

Release note (bug fix): EXPLAIN BUNDLE now works when the client driver prepares
the statement (as is the case with DBeaver).

Release justification: Bug fixes and low-risk updates to new functionality.