### PR TITLE
cli/sql: fix multi-line input with ROLLBACK TO SAVEPOINT

### DIFF
--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -74,6 +74,15 @@ eexpect "1 row"
 eexpect "root@"
 end_test
 
+start_test "Test that BEGIN .. without COMMIT begins a multi-line stmt even when ROLLBACK TO SAVEPOINT is present."
+send "begin; select 1; savepoint foo; rollback to savepoint foo;\r"
+eexpect " ->"
+
+send "commit;\r"
+eexpect "1 row"
+eexpect "root@"
+end_test
+
 start_test "Test that BEGIN .. without COMMIT does not begin a multi-line statement with smart_prompt disabled."
 send "\\unset smart_prompt\r"
 send "begin;\r"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -786,13 +786,16 @@ func (c *cliState) refreshDatabaseName() string {
 // endsWithIncompleteTxn returns true if and only if its
 // argument ends with an incomplete transaction prefix (BEGIN without
 // ROLLBACK/COMMIT).
+// TODO(knz): Remove this in 20.2, see
+// https://github.com/cockroachdb/cockroach/issues/46074
 func endsWithIncompleteTxn(stmts []string) bool {
 	txnStarted := false
 	for _, stmt := range stmts {
 		if strings.HasPrefix(stmt, "BEGIN TRANSACTION") {
 			txnStarted = true
 		} else if strings.HasPrefix(stmt, "COMMIT TRANSACTION") ||
-			strings.HasPrefix(stmt, "ROLLBACK TRANSACTION") {
+			(strings.HasPrefix(stmt, "ROLLBACK TRANSACTION") &&
+				!strings.HasPrefix(stmt, "ROLLBACK TRANSACTION TO SAVEPOINT")) {
 			txnStarted = false
 		}
 	}


### PR DESCRIPTION
Fixes #45816

(Note that this functionality will be removed later - see  #46074 )

Release justification: Bug fix to existing functionality

Release note: None