### PR TITLE
sql: omit certain foreign key checks after cascade when deleting

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -621,3 +621,35 @@ SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %
 # Clean up after the test.
 statement ok
 DROP TABLE c3, c2, c1, b2, b1, a;
+
+# Regression for #46094.
+
+statement ok
+CREATE TABLE parent (x INT PRIMARY KEY);
+CREATE TABLE child1 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE CASCADE,
+  FAMILY (id, x)
+);
+CREATE TABLE child2 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE SET NULL,
+  FAMILY (id, x)
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child1 VALUES (1, 1), (2, 1);
+INSERT INTO child2 VALUES (1, 1), (2, 1)
+
+# Here we ensure that after the cascaded deletes we don't need
+# to perform additional and unneeded FKScan operations after
+# cascade deleting or setting null to referencing rows.
+query T kvtrace(Del,FKScan)
+DELETE FROM parent WHERE x = 1
+----
+Del /Table/109/1/1/0
+Del /Table/110/2/1/1/0
+Del /Table/110/1/1/0
+Del /Table/110/2/1/2/0
+Del /Table/110/1/2/0
+Del /Table/111/2/1/1/0
+Del /Table/111/2/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -348,7 +348,6 @@ Del /Table/61/1/1/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/1/#/62/{1-2}
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
@@ -357,7 +356,6 @@ Del /Table/61/1/2/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/2/#/62/{1-2}
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
@@ -366,7 +364,6 @@ Del /Table/61/1/3/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/3/#/62/{1-2}
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
@@ -375,7 +372,6 @@ Del /Table/61/1/4/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/4/#/62/{1-2}
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
@@ -384,7 +380,6 @@ Del /Table/61/1/5/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/5/#/62/{1-2}
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
@@ -393,7 +388,6 @@ Del /Table/61/1/6/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/6/#/62/{1-2}
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
@@ -402,7 +396,6 @@ Del /Table/61/1/7/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/7/#/62/{1-2}
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
@@ -411,7 +404,6 @@ Del /Table/61/1/8/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/8/#/62/{1-2}
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
@@ -420,7 +412,6 @@ Del /Table/61/1/9/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/9/#/62/{1-2}
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
@@ -429,7 +420,6 @@ Del /Table/61/1/10/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/10/#/62/{1-2}
 output row: [1]
 output row: [2]
 output row: [3]


### PR DESCRIPTION
We still perform FK existence checks after cascading for
`CASCADE` and `SET NULL` operations after a delete. However,
we don't need to perform an additional read after performing
these operations, because the rows that would be queried for
the check are not present anymore after the cascade.

Release justification: low risk change with high benefit

Release note: None