### PR TITLE
sql,cli: improve the handling of notices

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1103,6 +1103,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.node_executable_version"></a><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.notice"></a><code>crdb_internal.notice(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -318,7 +318,7 @@ func (p *planner) AlterPrimaryKey(
 	// until the primary key swap actually occurs. Deletions will get enqueued in the phase when the swap happens.
 
 	// Send a notice to users about the async cleanup jobs.
-	p.noticeSender.AppendNotice(
+	p.SendClientNotice(ctx,
 		pgerror.Noticef(
 			"primary key changes spawn async cleanup jobs. Future schema changes on %q may be delayed as these jobs finish",
 			tableDesc.Name,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1987,6 +1987,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			SessionData:        ex.sessionData,
 			SessionAccessor:    p,
 			PrivilegedAccessor: p,
+			ClientNoticeSender: p,
 			Settings:           ex.server.cfg.Settings,
 			TestingKnobs:       ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:          ex.server.cfg.ClusterID(),
@@ -2060,7 +2061,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	ex.initEvalCtx(ctx, &p.extendedEvalCtx, p)
 
 	p.sessionDataMutator = ex.dataMutator
-	p.noticeSender = noopNoticeSender
+	p.noticeSender = nil
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 
 	p.queryCacheSession.Init()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -37,28 +36,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/opentracing/opentracing-go"
 )
-
-// NoticesEnabled is the cluster setting that allows users
-// to enable notices.
-var NoticesEnabled = settings.RegisterPublicBoolSetting(
-	"sql.notices.enabled",
-	"enable notices in the server/client protocol being sent",
-	true,
-)
-
-// gatedNoticeSender is a noticeSender which can be gated by a cluster setting.
-type gatedNoticeSender struct {
-	noticeSender
-	sv *settings.Values
-}
-
-// AppendNotice implements the noticeSender interface.
-func (s *gatedNoticeSender) AppendNotice(notice error) {
-	if !NoticesEnabled.Get(s.sv) {
-		return
-	}
-	s.noticeSender.AppendNotice(notice)
-}
 
 // execStmt executes one statement by dispatching according to the current
 // state. Returns an Event to be passed to the state machine, or nil if no
@@ -388,7 +365,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS, stmt.NumAnnotations)
 	p.sessionDataMutator.paramStatusUpdater = res
-	p.noticeSender = &gatedNoticeSender{noticeSender: res, sv: &ex.server.cfg.Settings.SV}
+	p.noticeSender = res
 	stmtDiagPlan = &p.curPlan
 
 	if os.ImplicitTxn.Get() {

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -62,7 +62,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		}
 		if !isTemporary && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
-			params.p.noticeSender.AppendNotice(
+			params.p.SendClientNotice(params.ctx,
 				pgerror.Noticef(`view "%s" will be a temporary view`, viewName),
 			)
 			isTemporary = true

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -307,6 +307,7 @@ func (ds *ServerImpl) setupFlow(
 			SessionAccessor:    &sqlbase.DummySessionAccessor{},
 			PrivilegedAccessor: &sqlbase.DummyPrivilegedAccessor{},
 			Sequence:           &sqlbase.DummySequenceOperators{},
+			ClientNoticeSender: &sqlbase.DummyClientNoticeSender{},
 			InternalExecutor:   ie,
 			Txn:                leafTxn,
 		}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -470,7 +470,7 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID, jobDesc); err != nil {
 		return err
 	}
-	p.noticeSender.AppendNotice(pgerror.Noticef(
+	p.SendClientNotice(ctx, pgerror.Noticef(
 		"index %q will be dropped asynchronously and will be complete after the GC TTL",
 		idxName.String(),
 	))

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1769,19 +1769,6 @@ var _ paramStatusUpdater = (*noopParamStatusUpdater)(nil)
 
 func (noopParamStatusUpdater) AppendParamStatusUpdate(string, string) {}
 
-// noticeSender is a subset of RestrictedCommandResult which allows sending
-// notices.
-type noticeSender interface {
-	AppendNotice(error)
-}
-
-// noopNoticeSender implements noticeSender by performing a no-op.
-type noopNoticeSenderImpl struct{}
-
-var noopNoticeSender noticeSender = &noopNoticeSenderImpl{}
-
-func (noopNoticeSenderImpl) AppendNotice(error) {}
-
 // sessionDataMutator is the interface used by sessionVars to change the session
 // state. It mostly mutates the Session's SessionData, but not exclusively (e.g.
 // see curTxnReadOnly).

--- a/pkg/sql/notices.go
+++ b/pkg/sql/notices.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// NoticesEnabled is the cluster setting that allows users
+// to enable notices.
+var NoticesEnabled = settings.RegisterPublicBoolSetting(
+	"sql.notices.enabled",
+	"enable notices in the server/client protocol being sent",
+	true,
+)
+
+// noticeSender is a subset of RestrictedCommandResult which allows
+// sending notices.
+type noticeSender interface {
+	AppendNotice(error)
+}
+
+// SendClientNotice implements the tree.ClientNoticeSender interface.
+func (p *planner) SendClientNotice(ctx context.Context, err error) {
+	if log.V(2) {
+		log.Infof(ctx, "out-of-band notice: %+v", err)
+	}
+	if p.noticeSender == nil ||
+		!NoticesEnabled.Get(&p.execCfg.Settings.SV) {
+		// Notice cannot flow to the client - either because there is no
+		// client, or the notice protocol was disabled.
+		return
+	}
+	p.noticeSender.AppendNotice(err)
+}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -189,6 +189,8 @@ type planner struct {
 	optPlanningCtx optPlanningCtx
 
 	// noticeSender allows the sending of notices.
+	// Do not use this object directly; use the SendClientNotice() method
+	// instead.
 	noticeSender noticeSender
 
 	queryCacheSession querycache.Session
@@ -289,6 +291,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Planner = p
 	p.extendedEvalCtx.PrivilegedAccessor = p
 	p.extendedEvalCtx.SessionAccessor = p
+	p.extendedEvalCtx.ClientNoticeSender = p
 	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.ClusterID = execCfg.ClusterID()
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3342,6 +3342,26 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.notice": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+			Impure:   true,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"msg", types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if ctx.ClientNoticeSender == nil {
+					return nil, errors.AssertionFailedf("notice sender not set")
+				}
+				msg := string(*args[0].(*tree.DString))
+				ctx.ClientNoticeSender.SendClientNotice(ctx.Context, pgerror.Noticef("%s", msg))
+				return tree.NewDInt(0), nil
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	),
+
 	"crdb_internal.force_assertion_error": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2630,6 +2630,17 @@ type EvalSessionAccessor interface {
 	HasAdminRole(ctx context.Context) (bool, error)
 }
 
+// ClientNoticeSender is a limited interface to send notices to the
+// client.
+//
+// TODO(knz): as of this writing, the implementations of this
+// interface only work on the gateway node (i.e. not from
+// distributed processors).
+type ClientNoticeSender interface {
+	// SendClientNotice sends a notice out-of-band to the client.
+	SendClientNotice(ctx context.Context, notice error)
+}
+
 // InternalExecutor is a subset of sqlutil.InternalExecutor (which, in turn, is
 // implemented by sql.InternalExecutor) used by this sem/tree package which
 // can't even import sqlutil.
@@ -2804,6 +2815,8 @@ type EvalContext struct {
 	PrivilegedAccessor PrivilegedAccessor
 
 	SessionAccessor EvalSessionAccessor
+
+	ClientNoticeSender ClientNoticeSender
 
 	Sequence SequenceOperators
 

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -156,3 +156,11 @@ func (ep *DummySessionAccessor) SetSessionVar(_ context.Context, _, _ string) er
 func (ep *DummySessionAccessor) HasAdminRole(_ context.Context) (bool, error) {
 	return false, errors.WithStack(errEvalSessionVar)
 }
+
+// DummyClientNoticeSender implements the tree.ClientNoticeSender interface.
+type DummyClientNoticeSender struct{}
+
+var _ tree.ClientNoticeSender = &DummyClientNoticeSender{}
+
+// SendClientNotice is part of the tree.ClientNoticeSender interface.
+func (c *DummyClientNoticeSender) SendClientNotice(_ context.Context, _ error) {}


### PR DESCRIPTION
Fixes #45833.

tldr:
- notices printed at end in SQL shell (requested by @RaduBerinde),
- new built-in function `crdb_internal.notice()`,
- notices can now be logged with vmodule `notices=2`,
- code simplification.

Details:

The main purpose of this patch was to delay the printing
of notices in the crdb SQL shell to the end, after the results.

The motivation for that is that if there are many (e.g. thousands) of
result rows, a notice printed at the beginning or "in the middle"
would get drowned and missed by the human observer.

This patch achieves that with a straightforward, local change to the
CLI SQL code.

To unit test the change, a way to introduce notices at an arbitrary
point of query execution was also needed. To achieve this, the patch
introduces a new SQL built-in function `crdb_internal.notice()` with
the corresponding plumbing throughout the execution layers. This makes
it possible to send an out-of-band notice in the middle of SQL
execution. The unit test for the first changes already uses this new
built-in; I also foresee that we will discover that our users will
start using that in fancy ways that we are not envisioning yet.

To troubleshoot the implementation of the above, a way to inspect
the notices inside the SQL execution layer was needed; so this
patch also ensures notices are logged when the vmodule config
includes `notices=2`.

Finally, the various changes discussed here revealed that
the notice code in the SQL execution package could be simplified, so
this patch does this too.

Release justification: Category 4: Low risk, high reward changes to existing functionality

Release note (cli change): The `sql` and `demo` client commands now
display out-of-band server notices at the end of execution.