### PR TITLE
sql: fix license acquisition bug and add a flag to disable acquisition

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -417,6 +417,7 @@ func Example_demo() {
 		// commands that require a secure cluster.
 		{`demo`, `--insecure=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 		{`demo`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
+		{`demo`, `--geo-partitioned-replicas`, `--disable-demo-license`},
 	}
 	setCLIDefaultsForTests()
 	// We must reset the security asset loader here, otherwise the dummy
@@ -475,6 +476,8 @@ func Example_demo() {
 	// demo -e CREATE USER test WITH PASSWORD 'testpass'
 	// ERROR: setting or updating a password is not supported in insecure mode
 	// SQLSTATE: 28P01
+	// demo --geo-partitioned-replicas --disable-demo-license
+	// ERROR: enterprise features are needed for this demo (--geo-partitioned-replicas)
 }
 
 func Example_sql() {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1007,6 +1007,12 @@ https://www.cockroachlabs.com/docs/v19.1/topology-geo-partitioned-replicas.html
 		`,
 	}
 
+	DemoNoLicense = FlagInfo{
+		Name: "disable-demo-license",
+		Description: `
+If set, disable cockroach demo from attempting to obtain a temporary license.`,
+	}
+
 	UseEmptyDatabase = FlagInfo{
 		Name: "empty",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -626,6 +626,7 @@ func init() {
 	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
 	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, true)
+	BoolFlag(demoFlags, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense, false)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
 	_ = demoFlags.MarkHidden(cliflags.Global.Name)

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -83,6 +83,18 @@ interrupt
 eexpect eof
 end_test
 
+# Test interaction of -e and license acquisition.
+start_test "Ensure we can run licensed commands with -e"
+spawn $argv demo -e "ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))"
+eexpect "ALTER TABLE"
+eexpect eof
+end_test
+
+start_test "Ensure that licensed commands with -e error when license acquisition is disabled"
+spawn $argv demo --disable-demo-license -e "ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))"
+eexpect "ERROR: use of partitions requires an enterprise license"
+eexpect eof
+end_test
 
 start_test "Expect an error if geo-partitioning is requested and a license cannot be acquired"
 set env(COCKROACH_DEMO_LICENSE_URL) "https://127.0.0.1:9999/"


### PR DESCRIPTION
Fixes #46117.

Release justification: bug fix

Release note (bug fix): This PR fixes a bug where sometimes using
`cockroach demo -e` would display a `connection refused` error.

Release note (cli change): This PR adds the flag `--disable-demo-license`
to provide another option to disable `cockroach demo` from attempting
to acquire a demo license.