### PR TITLE
sql: trace execution stats for query diagnostics

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -169,8 +169,9 @@ func (ex *connExecutor) prepare(
 
 	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	p := &ex.planner
-	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */, stmt.NumAnnotations)
+	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
 	p.stmt = &stmt
+	p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {
 		txn.CleanupOnError(ctx, err)


### PR DESCRIPTION
The distsql processors are initialized with the Context in the eval context. If
this context contains a tracing span that is recording, the processors will set
up statistics collection and put them in the span as tags.

The statement diagnostics code sets up a span but doesn't change this context,
so statistics collection doesn't happen. We want these statistics in the trace,
as they will soon be used to generate EXPLAIN ANALYZE diagrams for the bundles.

This change fixes this issue and moves up the initialization of the planner so
we can tweak it directly, which simplifies code.

Release note (bug fix): statement diagnostics traces now contain processor
statistics.

Release justification: Bug fixes and low-risk updates to new functionality