### PR TITLE
github-pull-request-make: set minimum testrace duration per test

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -256,15 +256,17 @@ func main() {
 			log.Fatal(err)
 		}
 		if len(pkgs) > 0 {
-			// 10 minutes total seems OK, but at least a minute per test.
-			duration := (10 * time.Minute) / time.Duration(len(pkgs))
-			if duration < time.Minute {
-				duration = time.Minute
-			}
-			// Use a timeout shorter than the duration so that hanging tests don't
-			// get a free pass.
-			timeout := (3 * duration) / 4
 			for name, pkg := range pkgs {
+				// 10 minutes total seems OK, but at least a minute per test.
+				duration := (10 * time.Minute) / time.Duration(len(pkgs))
+				minDuration := time.Minute * time.Duration(len(pkg.tests))
+				if duration < minDuration {
+					duration = minDuration
+				}
+				// Use a timeout shorter than the duration so that hanging tests don't
+				// get a free pass.
+				timeout := (3 * duration) / 4
+
 				tests := "-"
 				if len(pkg.tests) > 0 {
 					tests = "(" + strings.Join(pkg.tests, "$$|") + "$$)"


### PR DESCRIPTION
This change updates the minimum allowed duration for a test run under
race in CI to be configured on a per-test basis, rather than a
per-package basis.

When there are a lot of tests in a given package that need to be
stressed by testrace, the entire package may not be given sufficient
time to complete. For example, #45962 was not passing CI since many
tests were changed within one package.

Release justification: Non-production code changes.
Release note: None