### PR TITLE
sql: clean up the preliminary notices

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1103,6 +1103,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.node_executable_version"></a><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.notice"></a><code>crdb_internal.notice(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -29,16 +29,21 @@ end_test
 start_test "Test creating a view without TEMP set on a TEMP TABLE notifies it will become a TEMP VIEW."
 send "SET experimental_enable_temp_tables = true; CREATE TEMP TABLE temp_view_test_tbl(a int); CREATE VIEW temp_view_test AS SELECT a FROM temp_view_test_tbl;\r"
 eexpect "NOTICE: view \"temp_view_test\" will be a temporary view"
+eexpect root@
 end_test
 
 start_test "Check dropping an index prints a message about GC TTL."
 send "CREATE TABLE drop_index_test(a int); CREATE INDEX drop_index_test_index ON drop_index_test(a); DROP INDEX drop_index_test_index;\r"
-eexpect "NOTICE: index \"drop_index_test_index\" will be dropped asynchronously and will be complete after the GC TTL"
+eexpect "NOTICE: the data for dropped indexes is reclaimed asynchronously"
+eexpect "HINT: The reclamation delay can be customized in the zone configuration for the table."
+eexpect root@
 end_test
 
 start_test "Check that altering the primary key of a table prints a message about async jobs."
 send "CREATE TABLE alterpk (x INT NOT NULL); ALTER TABLE alterpk ALTER PRIMARY KEY USING COLUMNS (x);\r"
-eexpect "NOTICE: primary key changes spawn async cleanup jobs. Future schema changes on \"alterpk\" may be delayed as these jobs finish"
+
+eexpect "NOTICE: primary key changes are finalized asynchronously; further schema changes on this table may be restricted"
+eexpect root@
 end_test
 
 send "\\q\r"

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -314,15 +314,17 @@ func (p *planner) AlterPrimaryKey(
 	// Mark the primary key of the table as valid.
 	tableDesc.PrimaryIndex.Disabled = false
 
-	// N.B. We don't schedule index deletions here because the existing indexes need to be visible to the user
-	// until the primary key swap actually occurs. Deletions will get enqueued in the phase when the swap happens.
+	// N.B. We don't schedule index deletions here because the existing
+	// indexes need to be visible to the user until the primary key swap
+	// actually occurs. Deletions will get enqueued in the phase when
+	// the swap happens.
 
 	// Send a notice to users about the async cleanup jobs.
+	// TODO(knz): Mention the job ID in the client notice.
 	p.SendClientNotice(ctx,
 		pgerror.Noticef(
-			"primary key changes spawn async cleanup jobs. Future schema changes on %q may be delayed as these jobs finish",
-			tableDesc.Name,
-		),
+			"primary key changes are finalized asynchronously; "+
+				"further schema changes on this table may be restricted until the job completes"),
 	)
 
 	return nil

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -318,7 +318,7 @@ func (p *planner) AlterPrimaryKey(
 	// until the primary key swap actually occurs. Deletions will get enqueued in the phase when the swap happens.
 
 	// Send a notice to users about the async cleanup jobs.
-	p.noticeSender.AppendNotice(
+	p.SendClientNotice(ctx,
 		pgerror.Noticef(
 			"primary key changes spawn async cleanup jobs. Future schema changes on %q may be delayed as these jobs finish",
 			tableDesc.Name,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1987,6 +1987,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			SessionData:        ex.sessionData,
 			SessionAccessor:    p,
 			PrivilegedAccessor: p,
+			ClientNoticeSender: p,
 			Settings:           ex.server.cfg.Settings,
 			TestingKnobs:       ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:          ex.server.cfg.ClusterID(),
@@ -2060,7 +2061,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	ex.initEvalCtx(ctx, &p.extendedEvalCtx, p)
 
 	p.sessionDataMutator = ex.dataMutator
-	p.noticeSender = noopNoticeSender
+	p.noticeSender = nil
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 
 	p.queryCacheSession.Init()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -37,28 +36,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/opentracing/opentracing-go"
 )
-
-// NoticesEnabled is the cluster setting that allows users
-// to enable notices.
-var NoticesEnabled = settings.RegisterPublicBoolSetting(
-	"sql.notices.enabled",
-	"enable notices in the server/client protocol being sent",
-	true,
-)
-
-// gatedNoticeSender is a noticeSender which can be gated by a cluster setting.
-type gatedNoticeSender struct {
-	noticeSender
-	sv *settings.Values
-}
-
-// AppendNotice implements the noticeSender interface.
-func (s *gatedNoticeSender) AppendNotice(notice error) {
-	if !NoticesEnabled.Get(s.sv) {
-		return
-	}
-	s.noticeSender.AppendNotice(notice)
-}
 
 // execStmt executes one statement by dispatching according to the current
 // state. Returns an Event to be passed to the state machine, or nil if no
@@ -388,7 +365,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS, stmt.NumAnnotations)
 	p.sessionDataMutator.paramStatusUpdater = res
-	p.noticeSender = &gatedNoticeSender{noticeSender: res, sv: &ex.server.cfg.Settings.SV}
+	p.noticeSender = res
 	stmtDiagPlan = &p.curPlan
 
 	if os.ImplicitTxn.Get() {

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -62,7 +62,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		}
 		if !isTemporary && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
-			params.p.noticeSender.AppendNotice(
+			params.p.SendClientNotice(params.ctx,
 				pgerror.Noticef(`view "%s" will be a temporary view`, viewName),
 			)
 			isTemporary = true

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -307,6 +307,7 @@ func (ds *ServerImpl) setupFlow(
 			SessionAccessor:    &sqlbase.DummySessionAccessor{},
 			PrivilegedAccessor: &sqlbase.DummyPrivilegedAccessor{},
 			Sequence:           &sqlbase.DummySequenceOperators{},
+			ClientNoticeSender: &sqlbase.DummyClientNoticeSender{},
 			InternalExecutor:   ie,
 			Txn:                leafTxn,
 		}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -470,7 +470,7 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID, jobDesc); err != nil {
 		return err
 	}
-	p.noticeSender.AppendNotice(pgerror.Noticef(
+	p.SendClientNotice(ctx, pgerror.Noticef(
 		"index %q will be dropped asynchronously and will be complete after the GC TTL",
 		idxName.String(),
 	))

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -470,10 +470,10 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID, jobDesc); err != nil {
 		return err
 	}
-	p.SendClientNotice(ctx, pgerror.Noticef(
-		"index %q will be dropped asynchronously and will be complete after the GC TTL",
-		idxName.String(),
-	))
+	p.SendClientNotice(ctx,
+		errors.WithHint(
+			pgerror.Noticef("the data for dropped indexes is reclaimed asynchronously"),
+			"The reclamation delay can be customized in the zone configuration for the table."))
 	// Record index drop in the event log. This is an auditable log event
 	// and is recorded in the same transaction as the table descriptor
 	// update.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1769,19 +1769,6 @@ var _ paramStatusUpdater = (*noopParamStatusUpdater)(nil)
 
 func (noopParamStatusUpdater) AppendParamStatusUpdate(string, string) {}
 
-// noticeSender is a subset of RestrictedCommandResult which allows sending
-// notices.
-type noticeSender interface {
-	AppendNotice(error)
-}
-
-// noopNoticeSender implements noticeSender by performing a no-op.
-type noopNoticeSenderImpl struct{}
-
-var noopNoticeSender noticeSender = &noopNoticeSenderImpl{}
-
-func (noopNoticeSenderImpl) AppendNotice(error) {}
-
 // sessionDataMutator is the interface used by sessionVars to change the session
 // state. It mostly mutates the Session's SessionData, but not exclusively (e.g.
 // see curTxnReadOnly).

--- a/pkg/sql/notices.go
+++ b/pkg/sql/notices.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// NoticesEnabled is the cluster setting that allows users
+// to enable notices.
+var NoticesEnabled = settings.RegisterPublicBoolSetting(
+	"sql.notices.enabled",
+	"enable notices in the server/client protocol being sent",
+	true,
+)
+
+// noticeSender is a subset of RestrictedCommandResult which allows
+// sending notices.
+type noticeSender interface {
+	AppendNotice(error)
+}
+
+// SendClientNotice implements the tree.ClientNoticeSender interface.
+func (p *planner) SendClientNotice(ctx context.Context, err error) {
+	if log.V(2) {
+		log.Infof(ctx, "out-of-band notice: %+v", err)
+	}
+	if p.noticeSender == nil ||
+		!NoticesEnabled.Get(&p.execCfg.Settings.SV) {
+		// Notice cannot flow to the client - either because there is no
+		// client, or the notice protocol was disabled.
+		return
+	}
+	p.noticeSender.AppendNotice(err)
+}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -1,22 +1,7 @@
 # Test notices work as expected by creating a VIEW on a TEMP TABLE.
 
 send
-Parse {"Query": "SET experimental_enable_temp_tables = true"}
-Bind
-Execute
-Sync
-----
-
-until
-ReadyForQuery
-----
-{"Type":"ParseComplete"}
-{"Type":"BindComplete"}
-{"Type":"CommandComplete","CommandTag":"SET"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-send
-Parse {"Query": "CREATE TEMP TABLE a (a int)"}
+Parse {"Query": "CREATE TABLE t(x INT, y INT, INDEX (x), INDEX (y))"}
 Bind
 Execute
 Sync
@@ -30,8 +15,10 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+
+
 send
-Parse {"Query": "CREATE VIEW a_view AS SELECT a FROM a"}
+Parse {"Query": "DROP INDEX t@t_x_idx"}
 Bind
 Execute
 Sync
@@ -42,8 +29,8 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"view \"a_view\" will be a temporary view","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"create_view.go","Line":66,"Routine":"startExec","UnknownFields":null}
-{"Type":"CommandComplete","CommandTag":"CREATE VIEW"}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":475,"Routine":"dropIndexByName","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Disable notices and assert now it is not sent.
@@ -63,7 +50,7 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Parse {"Query": "CREATE VIEW a_view_notice_disabled AS SELECT a FROM a"}
+Parse {"Query": "DROP INDEX t@t_y_idx"}
 Bind
 Execute
 Sync
@@ -74,5 +61,5 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"CommandComplete","CommandTag":"CREATE VIEW"}
+{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -189,6 +189,8 @@ type planner struct {
 	optPlanningCtx optPlanningCtx
 
 	// noticeSender allows the sending of notices.
+	// Do not use this object directly; use the SendClientNotice() method
+	// instead.
 	noticeSender noticeSender
 
 	queryCacheSession querycache.Session
@@ -289,6 +291,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Planner = p
 	p.extendedEvalCtx.PrivilegedAccessor = p
 	p.extendedEvalCtx.SessionAccessor = p
+	p.extendedEvalCtx.ClientNoticeSender = p
 	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.ClusterID = execCfg.ClusterID()
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3342,6 +3342,26 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.notice": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+			Impure:   true,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"msg", types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if ctx.ClientNoticeSender == nil {
+					return nil, errors.AssertionFailedf("notice sender not set")
+				}
+				msg := string(*args[0].(*tree.DString))
+				ctx.ClientNoticeSender.SendClientNotice(ctx.Context, pgerror.Noticef("%s", msg))
+				return tree.NewDInt(0), nil
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	),
+
 	"crdb_internal.force_assertion_error": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2630,6 +2630,17 @@ type EvalSessionAccessor interface {
 	HasAdminRole(ctx context.Context) (bool, error)
 }
 
+// ClientNoticeSender is a limited interface to send notices to the
+// client.
+//
+// TODO(knz): as of this writing, the implementations of this
+// interface only work on the gateway node (i.e. not from
+// distributed processors).
+type ClientNoticeSender interface {
+	// SendClientNotice sends a notice out-of-band to the client.
+	SendClientNotice(ctx context.Context, notice error)
+}
+
 // InternalExecutor is a subset of sqlutil.InternalExecutor (which, in turn, is
 // implemented by sql.InternalExecutor) used by this sem/tree package which
 // can't even import sqlutil.
@@ -2804,6 +2815,8 @@ type EvalContext struct {
 	PrivilegedAccessor PrivilegedAccessor
 
 	SessionAccessor EvalSessionAccessor
+
+	ClientNoticeSender ClientNoticeSender
 
 	Sequence SequenceOperators
 

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -156,3 +156,11 @@ func (ep *DummySessionAccessor) SetSessionVar(_ context.Context, _, _ string) er
 func (ep *DummySessionAccessor) HasAdminRole(_ context.Context) (bool, error) {
 	return false, errors.WithStack(errEvalSessionVar)
 }
+
+// DummyClientNoticeSender implements the tree.ClientNoticeSender interface.
+type DummyClientNoticeSender struct{}
+
+var _ tree.ClientNoticeSender = &DummyClientNoticeSender{}
+
+// SendClientNotice is part of the tree.ClientNoticeSender interface.
+func (c *DummyClientNoticeSender) SendClientNotice(_ context.Context, _ error) {}


### PR DESCRIPTION
First commit from #46124.

In the lead up to 20.1, we want the first impression of client notices
by users to be clean and positive. Random notice messages with
inconsistent casing, non-standard terminology and unscoped identifiers
would likely not delight developers.

To achieve this, this commit streamlines the messages for DROP INDEX
and PK changes.


Release justification: Category 4: Low risk, high reward changes to existing functionality

Release note: None