### PR TITLE
ui: Hide Activate button while waiting for query status

### DIFF
--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -159,13 +159,17 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
           >
             Statement diagnostics
           </Text>
-          <Button
-            onClick={this.onActivateButtonClick}
-            disabled={!canRequestDiagnostics}
-            type="secondary"
-          >
-            Activate diagnostics
-          </Button>
+          {
+            canRequestDiagnostics && (
+              <Button
+                onClick={this.onActivateButtonClick}
+                disabled={!canRequestDiagnostics}
+                type="secondary"
+              >
+                Activate diagnostics
+              </Button>
+            )
+          }
         </div>
         <Table
           dataSource={dataSource}


### PR DESCRIPTION
Before Activate diagnostics button (on Statements page > Diagnostics tab)
has been disabled after user requested.
Now to avoid user confusion, we hide this button instead of disabling it.

Release justification: It is minor change with low
impact on new functionality only

Release note (admin-ui change): Hide Activate diagnostics button
on Statements > Diagnostics tab

<img width="1440" alt="Screenshot 2020-03-16 at 17 29 41" src="https://user-images.githubusercontent.com/3106437/76773934-e955bc00-67ab-11ea-8194-c94ea3e7c79b.png">
