### PR TITLE
sql: fix bug where some unique indexes needed cascade to be dropped

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1372,10 +1372,11 @@ func MakeTableDesc(
 			}
 		case *tree.UniqueConstraintTableDef:
 			idx := sqlbase.IndexDescriptor{
-				Name:             string(d.Name),
-				Unique:           true,
-				StoreColumnNames: d.Storing.ToStrings(),
-				Version:          indexEncodingVersion,
+				Name:              string(d.Name),
+				Unique:            true,
+				StoreColumnNames:  d.Storing.ToStrings(),
+				Version:           indexEncodingVersion,
+				CreatedExplicitly: true,
 			}
 			if d.Sharded != nil {
 				if n.Interleave != nil && d.PrimaryKey {

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -105,14 +105,8 @@ GRANT CREATE ON TABLE users TO testuser
 
 user testuser
 
-statement error in use as unique constraint
-DROP INDEX users@bar
-
-statement error in use as unique constraint
-DROP INDEX users@bar RESTRICT
-
 statement ok
-DROP INDEX users@bar CASCADE
+DROP INDEX users@bar
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users


### PR DESCRIPTION
Fixes #46147.

Release justification: bug fix
Release note (bug fix): This PR fixes a bug where unique indexes
created in `CREATE TABLE` that didn't back a constraint needed
`CASCADE` to be dropped, contrary to what our docs say.