### PR TITLE
release-19.2: opt: fix detection of correlated subqueries in complex filters

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -213,6 +213,19 @@ func (m *Memo) checkExpr(e opt.Expr) {
 		}
 
 		if opt.IsJoinOp(e) {
+			left := e.Child(0).(RelExpr)
+			right := e.Child(1).(RelExpr)
+			// The left side cannot depend on the right side columns.
+			if left.Relational().OuterCols.Intersects(right.Relational().OutputCols) {
+				panic(errors.AssertionFailedf("%s left side has outer cols in right side", e.Op()))
+			}
+
+			// The reverse is allowed but only for apply variants.
+			if !opt.IsJoinApplyOp(e) {
+				if right.Relational().OuterCols.Intersects(left.Relational().OutputCols) {
+					panic(errors.AssertionFailedf("%s is correlated", e.Op()))
+				}
+			}
 			checkFilters(*e.Child(2).(*FiltersExpr))
 		}
 	}

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1,3 +1,6 @@
+import file=tpcc_schema
+----
+
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT NOT NULL, s STRING, j JSON)
 ----
@@ -1128,6 +1131,89 @@ inner-join (merge)
                 │    └── projections
                 │         └── const: 5 [type=int]
                 └── variable: k [type=int]
+
+# Regression test for #46151. Do not push down a filter with a correlated
+# subquery.
+norm expect-not=PushFilterIntoJoinLeftAndRight
+SELECT (SELECT i_name FROM item LIMIT 1)
+  FROM history INNER JOIN order_line ON h_data = ol_dist_info
+ WHERE (
+        EXISTS(
+            SELECT *
+              FROM history
+             WHERE h_data IS NOT NULL AND ol_dist_info IS NOT NULL
+        )
+       )
+    OR (SELECT ol_i_id FROM order_line LIMIT 1) IS NOT NULL;
+----
+project
+ ├── columns: i_name:47(varchar)
+ ├── fd: ()-->(47)
+ ├── inner-join (hash)
+ │    ├── columns: h_data:9(varchar!null) ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null) ol_dist_info:19(char!null) true_agg:40(bool)
+ │    ├── fd: (10-13)-->(19,40), (9)==(19), (19)==(9)
+ │    ├── scan history
+ │    │    └── columns: h_data:9(varchar)
+ │    ├── select
+ │    │    ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null) ol_dist_info:19(char) true_agg:40(bool)
+ │    │    ├── key: (10-13)
+ │    │    ├── fd: (10-13)-->(19,40)
+ │    │    ├── group-by
+ │    │    │    ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null) ol_dist_info:19(char) true_agg:40(bool)
+ │    │    │    ├── grouping columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null)
+ │    │    │    ├── key: (10-13)
+ │    │    │    ├── fd: (10-13)-->(19,40)
+ │    │    │    ├── left-join (cross)
+ │    │    │    │    ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null) ol_dist_info:19(char) true:39(bool)
+ │    │    │    │    ├── fd: (10-13)-->(19)
+ │    │    │    │    ├── scan order_line
+ │    │    │    │    │    ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_number:13(int!null) ol_dist_info:19(char)
+ │    │    │    │    │    ├── key: (10-13)
+ │    │    │    │    │    └── fd: (10-13)-->(19)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: true:39(bool!null)
+ │    │    │    │    │    ├── fd: ()-->(39)
+ │    │    │    │    │    ├── select
+ │    │    │    │    │    │    ├── columns: h_data:28(varchar!null)
+ │    │    │    │    │    │    ├── scan history
+ │    │    │    │    │    │    │    └── columns: h_data:28(varchar)
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── h_data IS NOT NULL [type=bool, outer=(28), constraints=(/28: (/NULL - ]; tight)]
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── true [type=bool]
+ │    │    │    │    └── filters
+ │    │    │    │         └── ol_dist_info IS NOT NULL [type=bool, outer=(19), constraints=(/19: (/NULL - ]; tight)]
+ │    │    │    └── aggregations
+ │    │    │         ├── const-not-null-agg [type=bool, outer=(39)]
+ │    │    │         │    └── variable: true [type=bool]
+ │    │    │         └── const-agg [type=char, outer=(19)]
+ │    │    │              └── variable: ol_dist_info [type=char]
+ │    │    └── filters
+ │    │         └── or [type=bool, outer=(40), subquery]
+ │    │              ├── true_agg IS NOT NULL [type=bool]
+ │    │              └── is-not [type=bool]
+ │    │                   ├── subquery [type=int]
+ │    │                   │    └── limit
+ │    │                   │         ├── columns: ol_i_id:33(int!null)
+ │    │                   │         ├── cardinality: [0 - 1]
+ │    │                   │         ├── key: ()
+ │    │                   │         ├── fd: ()-->(33)
+ │    │                   │         ├── scan order_line
+ │    │                   │         │    └── columns: ol_i_id:33(int!null)
+ │    │                   │         └── const: 1 [type=int]
+ │    │                   └── null [type=unknown]
+ │    └── filters
+ │         └── h_data = ol_dist_info [type=bool, outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+ └── projections
+      └── subquery [type=varchar, subquery]
+           └── limit
+                ├── columns: item.i_name:44(varchar)
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(44)
+                ├── scan item
+                │    └── columns: item.i_name:44(varchar)
+                └── const: 1 [type=int]
 
 # --------------------------------------------------
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight


### PR DESCRIPTION
Backport 1/1 commits from #46153.

/cc @cockroachdb/release

---

Prior to this commit, it was possible for a correlated subquery to
go undetected if it was buried in a complex filter. In particular,
a filter of the form:
```
  <correlated subquery> OR <non-correlated subquery>
```
would incorrectly be marked as *not* containing a correlated subquery.
This was because although the logical property `HasCorrelatedSubquery`
was initially set to true upon encountering the first (correlated)
subquery, the left-to-right recursive traversal of the `OR` expression
caused `HasCorrelatedSubquery` to be overwritten to false upon encountering
the second (non-correlated) subquery.

This commit fixes the issue by never overwriting `HasCorrelatedSubquery`
to false.

Fixes #46151

Release note (bug fix): Fixed an internal error that could occur in the
optimizer when a WHERE filter contained at least one correlated subquery
and one non-correlated subquery.

Release justification: This bug fix falls into the category "low risk,
high benefit changes to existing functionality".
