### PR TITLE
release-19.1: opt: fix detection of correlated subqueries in complex filters

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1126,6 +1126,11 @@ func (b *logicalPropsBuilder) buildZipItemProps(item *ZipItem, scalar *props.Sca
 
 // BuildSharedProps fills in the shared properties derived from the given
 // expression's subtree.
+//
+// Note that shared is an "input-output" argument, and should be assumed
+// to be partially filled in already. Boolean fields such as HasPlaceholder,
+// CanHaveSideEffects and HasCorrelatedSubquery should never be reset to false
+// once set to true.
 func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
 	switch t := e.(type) {
 	case *VariableExpr:
@@ -1143,9 +1148,11 @@ func BuildSharedProps(mem *Memo, e opt.Expr, shared *props.Shared) {
 
 	case *SubqueryExpr, *ExistsExpr, *AnyExpr, *ArrayFlattenExpr:
 		shared.HasSubquery = true
-		shared.HasCorrelatedSubquery = !e.Child(0).(RelExpr).Relational().OuterCols.Empty()
-		if t.Op() == opt.AnyOp && !shared.HasCorrelatedSubquery {
-			shared.HasCorrelatedSubquery = hasOuterCols(mem, e.Child(1))
+		if hasOuterCols(mem, e.Child(0)) {
+			shared.HasCorrelatedSubquery = true
+		}
+		if t.Op() == opt.AnyOp && hasOuterCols(mem, e.Child(1)) {
+			shared.HasCorrelatedSubquery = true
 		}
 
 	case *FunctionExpr:

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1177,6 +1177,89 @@ inner-join (merge)
                 │         └── const: 5 [type=int]
                 └── variable: k [type=int]
 
+# Regression test for #46151. Do not push down a filter with a correlated
+# subquery.
+norm expect-not=PushFilterIntoJoinLeftAndRight
+SELECT (SELECT i FROM a LIMIT 1)
+  FROM b INNER JOIN c ON b.y = c.y
+ WHERE (
+        EXISTS(
+            SELECT *
+              FROM b
+             WHERE b.y IS NOT NULL AND c.y IS NOT NULL
+        )
+       )
+    OR (SELECT c.z FROM c LIMIT 1) IS NOT NULL;
+----
+project
+ ├── columns: i:19(int)
+ ├── fd: ()-->(19)
+ ├── inner-join
+ │    ├── columns: b.y:2(int!null) c.x:3(int!null) c.y:4(int!null) true_agg:12(bool)
+ │    ├── fd: (3)-->(4,12), (2)==(4), (4)==(2)
+ │    ├── scan b
+ │    │    └── columns: b.y:2(int)
+ │    ├── select
+ │    │    ├── columns: c.x:3(int!null) c.y:4(int) true_agg:12(bool)
+ │    │    ├── key: (3)
+ │    │    ├── fd: (3)-->(4,12)
+ │    │    ├── group-by
+ │    │    │    ├── columns: c.x:3(int!null) c.y:4(int) true_agg:12(bool)
+ │    │    │    ├── grouping columns: c.x:3(int!null)
+ │    │    │    ├── key: (3)
+ │    │    │    ├── fd: (3)-->(4,12)
+ │    │    │    ├── left-join
+ │    │    │    │    ├── columns: c.x:3(int!null) c.y:4(int!null) true:11(bool)
+ │    │    │    │    ├── fd: (3)-->(4)
+ │    │    │    │    ├── scan c
+ │    │    │    │    │    ├── columns: c.x:3(int!null) c.y:4(int!null)
+ │    │    │    │    │    ├── key: (3)
+ │    │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: true:11(bool!null)
+ │    │    │    │    │    ├── fd: ()-->(11)
+ │    │    │    │    │    ├── select
+ │    │    │    │    │    │    ├── columns: b.y:7(int!null)
+ │    │    │    │    │    │    ├── scan b
+ │    │    │    │    │    │    │    └── columns: b.y:7(int)
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── b.y IS NOT NULL [type=bool, outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── true [type=bool]
+ │    │    │    │    └── filters
+ │    │    │    │         └── c.y IS NOT NULL [type=bool, outer=(4), constraints=(/4: (/NULL - ]; tight)]
+ │    │    │    └── aggregations
+ │    │    │         ├── const-not-null-agg [type=bool, outer=(11)]
+ │    │    │         │    └── variable: true [type=bool]
+ │    │    │         └── const-agg [type=int, outer=(4)]
+ │    │    │              └── variable: c.y [type=int]
+ │    │    └── filters
+ │    │         └── or [type=bool, outer=(12), subquery]
+ │    │              ├── true_agg IS NOT NULL [type=bool]
+ │    │              └── is-not [type=bool]
+ │    │                   ├── subquery [type=int]
+ │    │                   │    └── limit
+ │    │                   │         ├── columns: z:10(int!null)
+ │    │                   │         ├── cardinality: [0 - 1]
+ │    │                   │         ├── key: ()
+ │    │                   │         ├── fd: ()-->(10)
+ │    │                   │         ├── scan c
+ │    │                   │         │    └── columns: z:10(int!null)
+ │    │                   │         └── const: 1 [type=int]
+ │    │                   └── null [type=unknown]
+ │    └── filters
+ │         └── b.y = c.y [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+ └── projections
+      └── subquery [type=int, subquery]
+           └── limit
+                ├── columns: a.i:15(int)
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(15)
+                ├── scan a
+                │    └── columns: a.i:15(int)
+                └── const: 1 [type=int]
+
 # --------------------------------------------------
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #46153.

/cc @cockroachdb/release

---

Prior to this commit, it was possible for a correlated subquery to
go undetected if it was buried in a complex filter. In particular,
a filter of the form:
```
  <correlated subquery> OR <non-correlated subquery>
```
would incorrectly be marked as *not* containing a correlated subquery.
This was because although the logical property `HasCorrelatedSubquery`
was initially set to true upon encountering the first (correlated)
subquery, the left-to-right recursive traversal of the `OR` expression
caused `HasCorrelatedSubquery` to be overwritten to false upon encountering
the second (non-correlated) subquery.

This commit fixes the issue by never overwriting `HasCorrelatedSubquery`
to false.

Fixes #46151

Release note (bug fix): Fixed an internal error that could occur in the
optimizer when a WHERE filter contained at least one correlated subquery
and one non-correlated subquery.

Release justification: This bug fix falls into the category "low risk,
high benefit changes to existing functionality".
