### PR TITLE
sql, jobs: schema change job upgrade migration

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1706,6 +1706,7 @@ func (s *Server) Start(ctx context.Context) error {
 		mmKnobs,
 		s.NodeID().String(),
 		s.ClusterSettings(),
+		s.jobRegistry,
 	)
 
 	// Start garbage collecting system events.
@@ -1788,6 +1789,10 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Start serving SQL clients.
 	if err := s.startServeSQL(ctx, workersCtx, connManager, pgL); err != nil {
+		return err
+	}
+
+	if err := migMgr.StartSchemaChangeJobMigration(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -44,6 +44,10 @@ import (
 )
 
 const (
+	// RunningStatusDrainingNames used to indicate that the job was draining names
+	// for dropped descriptors. This constant is now deprecated and only exists
+	// to be used for migrating old jobs.
+	RunningStatusDrainingNames jobs.RunningStatus = "draining names"
 	// RunningStatusWaitingGC is for jobs that are currently in progress and
 	// are waiting for the GC interval to expire
 	RunningStatusWaitingGC jobs.RunningStatus = "waiting for GC TTL"
@@ -1615,7 +1619,11 @@ func (r schemaChangeResumer) Resume(
 
 	// If a database is being dropped, handle this separately by draining names
 	// for all the tables.
-	if details.DroppedDatabaseID != sqlbase.InvalidID {
+	//
+	// This also covers other cases where we have a leftover 19.2 job that drops
+	// multiple tables in a single job (e.g., TRUNCATE on multiple tables), so
+	// it's possible for DroppedDatabaseID to be unset.
+	if len(details.DroppedTables) > 1 {
 		for i := range details.DroppedTables {
 			droppedTable := &details.DroppedTables[i]
 			if err := execSchemaChange(droppedTable.ID, sqlbase.InvalidMutationID, details.DroppedDatabaseID); err != nil {
@@ -1627,14 +1635,14 @@ func (r schemaChangeResumer) Resume(
 		for i, table := range details.DroppedTables {
 			tablesToGC[i] = jobspb.SchemaChangeGCDetails_DroppedID{ID: table.ID, DropTime: dropTime}
 		}
-		databaseGCDetails := jobspb.SchemaChangeGCDetails{
+		multiTableGCDetails := jobspb.SchemaChangeGCDetails{
 			Tables:   tablesToGC,
 			ParentID: details.DroppedDatabaseID,
 		}
-		return startGCJob(ctx, p.ExecCfg().DB, p.ExecCfg().JobRegistry, r.job.Payload().Username, r.job.Payload().Description, databaseGCDetails)
+		return startGCJob(ctx, p.ExecCfg().DB, p.ExecCfg().JobRegistry, r.job.Payload().Username, r.job.Payload().Description, multiTableGCDetails)
 	}
 	if details.TableID == sqlbase.InvalidID {
-		return errors.AssertionFailedf("job has no database ID or table ID")
+		return errors.AssertionFailedf("schema change has no specified database or table(s)")
 	}
 	return execSchemaChange(details.TableID, details.MutationID, details.DroppedDatabaseID)
 }


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/46152.

To do:

- This needs tests. (I've been manually testing as I go so far, and the extent of that is that I've confirmed that we can set up GC jobs for dropping indexes, tables, and DBs and for truncating tables, and that we can upgrade in the middle of a column backfill. Excepting rollbacks/cancellations, this probably covers all the most common cases. Obviously, though, there are a lot of possible states besides these.)


Done:
- ~DROP TABLE/DATABASE is not yet supported.~
- ~In the WIP commit, the approach for preventing 19.2 schema change jobs from being run in 20.1 is to have the resumer return a retry error upon encountering a 19.2-style job payload, so the job will keep being adopted and retried until it actually sees a 20.1-style payload. But I think this is inadequate, because it still allows users to pause or cancel the job, etc., and that we need to have the registry refuse to perform any operations on a 19.2-style schema change payload.~ Done in #46214.
- ~#46018 needs to be fixed before we can successfully migrate jobs that are rolling back.~
- ~We should probably keep retrying this indefinitely in the background until we succeed.~
- ~We should record when the migration completes successfully (by writing a KV like other migrations) so that we don't redo it every time a node joins or restarts (though it is idempotent).~
- ~We need another step where we iterate through all the descriptors and make new jobs for every schema change that has a non-trivial job in 20.1 (i.e., not merely waiting for table leases) but has no job in 19.2. This means (1) tables in the `ADD` state, which need to transition to the `PUBLIC` state; and (2) (maybe?) dropped views, sequences, etc., that need to have their names drained. It's very unlikely that anyone would get their table stuck in one of these states, but they should be covered for completeness. This is annoying to implement because we need to ensure that exactly one job is created for each table that needs a job, and there's no obviously good place to store that state.~