### PR TITLE
cli: allow `demo` to work if TZ db not available

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -909,7 +909,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 
 	ctx := context.Background()
 
-	if err := checkTzDatabaseAvailability(ctx); err != nil {
+	if err := checkTzDatabaseAvailability(ctx, true /* onlyLog */); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR is a follow-up to #45680 to re-enable `cockroach demo` even if the
tz db is not available. Demo should not force users into workarounds that
are vague and poorly documented.

Release justification: low risk, high benefit changes to existing functionality

Release note: None