### PR TITLE
opt: detect and extract projected tuple equalities

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -520,6 +520,60 @@ $left
     $private
 )
 
+# ExtractProjectedTupleEqualityLeft detects joins which contain equalities between 
+# projected tuple variables and tuples, splits these tuples out into multiple 
+# equalities on the underlying columns, and hoists the project above the join. 
+# This can allow further simplification of project operators.
+[ExtractProjectedTupleEqualityLeft, Normalize]
+(InnerJoin | LeftJoin | SemiJoin
+    $left: (Project  $input:* $projections:* $passthrough:*)
+    $right:*
+    $on:[
+        ...
+            (FiltersItem (Eq (Variable) (Tuple))) &
+            (CanExtractTupleEquality $projections $on) 
+        ...
+    ]
+    $private:*
+)
+=>
+(Project 
+    ((OpName)
+        $input
+        $right
+        (RewriteTupleEquality $on $projections)
+        $private
+    )
+    $projections 
+    (UnionCols $passthrough (OutputCols $right))
+)
+
+# ExtractProjectedTupleEqualityRight like ExtractProjectedTupleEqualityLeft, but 
+# for the right side of the join
+[ExtractProjectedTupleEqualityRight, Normalize]
+(InnerJoin | LeftJoin | SemiJoin
+    $left: *
+    $right:(Project $input:* $projections:* $passthrough:*)
+    $on:[
+        ...
+            (FiltersItem (Eq (Variable) (Tuple))) &
+            (CanExtractTupleEquality $projections $on) 
+        ...
+    ]
+    $private:*
+)
+=>
+(Project 
+    ((OpName)
+        $left
+        $input
+        (RewriteTupleEquality $on $projections)
+        $private
+    )
+    $projections 
+    (UnionCols $passthrough (OutputCols $left))
+)
+
 # ExtractJoinEqualities finds equality conditions such that one side only
 # depends on left columns and the other only on right columns and pushes the
 # expressions down into Project operators. The result is a join that has an
@@ -567,4 +621,9 @@ $left
     $private:*
 )
 =>
-(InnerJoin $left $right (SortFilters $on) $private)
+(InnerJoin
+    $left
+    $right
+    (SortFilters $on)
+    $private
+)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2929,3 +2929,39 @@ full-join (cross)
  │    └── fd: (3)-->(4)
  └── filters
       └── (substring('', ')') = '') = (u:3 > 0) [outer=(3)]
+
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  PRIMARY KEY (a,b)
+)
+----
+
+
+exec-ddl
+CREATE TABLE cd (
+  c INT,
+  d INT
+)
+----
+
+norm expect=ExtractProjectedTupleEqualityLeft
+SELECT * FROM ab WHERE (a, b) IN (SELECT c, d FROM cd)
+----
+project
+ ├── columns: a:1!null b:2!null
+ ├── key: (1,2)
+ └── inner-join (lookup ab)
+      ├── columns: a:1!null b:2!null c:3!null d:4!null
+      ├── key columns: [3 4] = [1 2]
+      ├── lookup columns are key
+      ├── key: (3,4)
+      ├── fd: (1)==(3), (3)==(1), (2)==(4), (4)==(2)
+      ├── distinct-on
+      │    ├── columns: c:3 d:4
+      │    ├── grouping columns: c:3 d:4
+      │    ├── key: (3,4)
+      │    └── scan cd
+      │         └── columns: c:3 d:4
+      └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1244,32 +1244,23 @@ project
  ├── columns: k:1!null
  ├── key: (1)
  └── semi-join (hash)
-      ├── columns: k:1!null column10:10
+      ├── columns: k:1!null i:2
       ├── key: (1)
-      ├── fd: (1)-->(10)
-      ├── project
-      │    ├── columns: column10:10 k:1!null
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
       │    ├── key: (1)
-      │    ├── fd: (1)-->(10)
-      │    ├── scan a
-      │    │    ├── columns: k:1!null i:2
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2)
-      │    └── projections
-      │         └── (k:1, i:2) [as=column10:10, outer=(1,2)]
-      ├── project
-      │    ├── columns: column9:9!null
+      │    └── fd: (1)-->(2)
+      ├── values
+      │    ├── columns: column1:7!null column2:8!null
       │    ├── cardinality: [3 - 3]
-      │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null
-      │    │    ├── cardinality: [3 - 3]
-      │    │    ├── (1, 1)
-      │    │    ├── (2, 2)
-      │    │    └── (3, 3)
-      │    └── projections
-      │         └── (column2:8, column1:7) [as=column9:9, outer=(7,8)]
+      │    ├── (1, 1)
+      │    ├── (2, 2)
+      │    └── (3, 3)
       └── filters
-           └── column10:10 = column9:9 [outer=(9,10), constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
+           ├── column2:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+           └── column1:7 = i:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
 
 # --------------------------------------------------
 # SimplifyEqualsAnyTuple


### PR DESCRIPTION
This commit adds a new rule to join normalisation that detects joins on tuple equalities between a tuple and a variable that is a projected tuple and splits them out into multiple equalities on the underlying columns, and hoists the project above the join. This allows us to simplify a number of queries where previously the projected tuple was preventing us merging projections.

Resolves: #43198