### PR TITLE
roachtest: make alterpk roachtest run on smaller machines

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -179,7 +179,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		// TODO (rohany): This should be bumped to cpu(16) if 500 warehouses are used.
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Cluster: makeClusterSpec(4),
 		Run:     runAlterPKTPCC,
 	})
 }


### PR DESCRIPTION
This PR makes the machines that the alterpk roachtest run
on smaller in order to diagnose the deadlock failure.]]

I realized I accidentally included bumping up the machine size in my previous PR, which was an accident. This PR reverts that change.

Release justification: non-production code change
Release note: None