### PR TITLE
ui: removed metric function `setDefaultTime`

### DIFF
--- a/pkg/ui/src/redux/timewindow.ts
+++ b/pkg/ui/src/redux/timewindow.ts
@@ -136,10 +136,10 @@ export class TimeWindowState {
   currentWindow: TimeWindow;
   // True if scale has changed since currentWindow was generated.
   scaleChanged: boolean;
-  useTimeRage: boolean;
+  useTimeRange: boolean;
   constructor() {
     this.scale = availableTimeScales["Past 10 Minutes"];
-    this.useTimeRage = false;
+    this.useTimeRange = false;
     this.scaleChanged = false;
   }
 }
@@ -156,16 +156,16 @@ export function timeWindowReducer(state = new TimeWindowState(), action: Action)
       const { payload: data } = action as PayloadAction<TimeWindow>;
       state = _.clone(state);
       state.currentWindow = data;
-      state.useTimeRage = true;
+      state.useTimeRange = true;
       state.scaleChanged = false;
       return state;
     case SET_SCALE:
       const { payload: scale } = action as PayloadAction<TimeScale>;
       state = _.clone(state);
       if (scale.key === "Custom") {
-        state.useTimeRage = true;
+        state.useTimeRange = true;
       } else {
-        state.useTimeRage = false;
+        state.useTimeRange = false;
       }
       state.scale = scale;
       state.scaleChanged = true;

--- a/pkg/ui/src/views/app/containers/timewindow/index.tsx
+++ b/pkg/ui/src/views/app/containers/timewindow/index.tsx
@@ -89,7 +89,7 @@ class TimeWindowManager extends React.Component<TimeWindowManagerProps, TimeWind
    */
   setWindow(props: TimeWindowManagerProps) {
     if (!props.timeWindow.scale.windowEnd) {
-      if (!props.timeWindow.useTimeRage) {
+      if (!props.timeWindow.useTimeRange) {
         const now = props.now ? props.now() : moment();
         props.setTimeWindow({
           start: now.clone().subtract(props.timeWindow.scale.windowSize),


### PR DESCRIPTION
Removed setter the default graph time window based on the age of the older node in the cluster because we have default redux scale. That fixed our problem when we using the time dropdown on the metrics page and clicking on "10m" we get result with "6h" duration.

Resolves: #46145

Release justification: bug fixes and low-risk updates to new functionality

Release note (ui): default timescale on metrics page is always 10m. previously it defaulted to the age of the longest running node