### PR TITLE
ui: Generic sorting functionality for Table component

### DIFF
--- a/pkg/ui/src/components/table/columnSorterFactory.spec.ts
+++ b/pkg/ui/src/components/table/columnSorterFactory.spec.ts
@@ -1,0 +1,102 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { assert } from "chai";
+import { columnSorterFactory } from "./columnSorterFactory";
+
+describe("columnSorterFactory", () => {
+  type SomeValue = {
+    field1?: string;
+    field2?: number;
+    field3?: number;
+  };
+
+  const valueA: SomeValue = {
+    field1: "a",
+    field2: 1,
+    field3: 5,
+  };
+
+  const valueB: SomeValue = {
+    field1: "b",
+    field2: 2,
+    field3: 20,
+  };
+
+  describe("when field passed as a value", () => {
+    const sorter = columnSorterFactory<SomeValue>("field1");
+
+    it("properly sort values", () => {
+      assert.equal(sorter(valueA, valueB), -1);
+      assert.equal(sorter(valueB, valueA), 1);
+    });
+
+    it("properly sort values if one field is undefined", () => {
+      assert.equal(sorter(valueA, { ...valueB, field1: undefined }), 1);
+      assert.equal(sorter({ ...valueB, field1: undefined }, valueA), -1);
+    });
+
+    it("properly sort values if both fields are undefined", () => {
+      assert.equal(sorter({ ...valueA, field1: undefined }, { ...valueB, field1: undefined }), 0);
+    });
+
+    it("properly sort values if both fields are equal", () => {
+      assert.equal(sorter(valueA, valueA), 0);
+    });
+  });
+
+  describe("when field passed as a transformation function", () => {
+
+    const transformFunc = (value: SomeValue) => {
+      if (!value.field2 || !value.field3) {
+        return undefined;
+      }
+      return value.field2 + value.field3;
+    };
+
+    const sorter = columnSorterFactory<SomeValue>(transformFunc);
+
+    it("properly sort values", () => {
+      assert.equal(sorter(valueA, valueB), -1);
+      assert.equal(sorter(valueB, valueA), 1);
+    });
+
+    it("properly sort values if one field is undefined", () => {
+      assert.equal(
+        sorter(
+          valueA,
+          { ...valueB, field2: undefined },
+          ),
+        1,
+      );
+      assert.equal(
+        sorter(
+          { ...valueB, field2: undefined },
+          valueA,
+        ),
+        -1,
+      );
+    });
+
+    it("properly sort values if both fields are undefined", () => {
+      assert.equal(
+        sorter(
+        { ...valueA, field2: undefined },
+        { ...valueB, field2: undefined },
+        ),
+        0,
+      );
+    });
+
+    it("properly sort values if both fields are equal", () => {
+      assert.equal(sorter(valueA, valueA), 0);
+    });
+  });
+});

--- a/pkg/ui/src/components/table/columnSorterFactory.ts
+++ b/pkg/ui/src/components/table/columnSorterFactory.ts
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { isFunction, isUndefined } from "lodash";
+
+export function columnSorterFactory<T>(field: keyof T | ((column: T) => string|number)) {
+  return (a: T, b: T) => {
+    let fieldA, fieldB;
+    if (isFunction(field)) {
+      fieldA = field(a);
+      fieldB = field(b);
+    } else {
+      fieldA = a[field];
+      fieldB = b[field];
+    }
+
+    if (isUndefined(fieldA) && !isUndefined(fieldB)) { return -1; }
+    if (!isUndefined(fieldA) && isUndefined(fieldB)) { return 1; }
+    if (isUndefined(fieldA) || isUndefined(fieldB)) { return 0; }
+
+    if (fieldA < fieldB) { return -1; }
+    if (fieldA > fieldB) { return 1; }
+    return 0;
+  };
+}

--- a/pkg/ui/src/components/table/index.ts
+++ b/pkg/ui/src/components/table/index.ts
@@ -9,3 +9,4 @@
 // licenses/APL.txt.
 
 export * from "./table";
+export * from "./columnSorterFactory";

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -28,7 +28,7 @@ import { LocalSetting } from "src/redux/localsettings";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { LongToMoment } from "src/util/convert";
 import { INodeStatus, MetricConstants } from "src/util/proto";
-import { ColumnsConfig, Table, Text, TextTypes, Tooltip } from "src/components";
+import { ColumnsConfig, columnSorterFactory, Table, Text, TextTypes, Tooltip } from "src/components";
 import { Percentage } from "src/util/format";
 import { FixLong } from "src/util/fixLong";
 import { getNodeLocalityTiers } from "src/util/localities";
@@ -173,24 +173,14 @@ export class NodeList extends React.Component<LiveNodeListProps> {
           return <NodeLocalityColumn record={record} />;
         }
       },
-      sorter: (a, b) => {
-        if (!_.isUndefined(a.nodeId) && !_.isUndefined(b.nodeId)) { return 0; }
-        if (a.region < b.region) { return -1; }
-        if (a.region > b.region) { return 1; }
-        return 0;
-      },
+      sorter: columnSorterFactory<NodeStatusRow>("region"),
       className: "column--border-right",
       width: "20%",
     },
     {
       key: "nodesCount",
       title: "node count",
-      sorter: (a, b) => {
-        if (_.isUndefined(a.nodesCount) || _.isUndefined(b.nodesCount)) { return 0; }
-        if (a.nodesCount < b.nodesCount) { return -1; }
-        if (a.nodesCount > b.nodesCount) { return 1; }
-        return 0;
-      },
+      sorter: columnSorterFactory<NodeStatusRow>("nodesCount"),
       render: (_text, record) => record.nodesCount,
       sortDirections: ["ascend", "descend"],
       className: "column--align-right",
@@ -200,7 +190,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "uptime",
       dataIndex: "uptime",
       title: "uptime",
-      sorter: true,
+      sorter: columnSorterFactory<NodeStatusRow>("uptime"),
       className: "column--align-right",
       width: "10%",
       ellipsis: true,
@@ -209,7 +199,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "replicas",
       dataIndex: "replicas",
       title: "replicas",
-      sorter: true,
+      sorter: columnSorterFactory<NodeStatusRow>("replicas"),
       className: "column--align-right",
       width: "10%",
     },
@@ -217,8 +207,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "capacityUse",
       title: "capacity use",
       render: (_text, record) => Percentage(record.usedCapacity, record.availableCapacity),
-      sorter: (a, b) =>
-        a.usedCapacity / a.availableCapacity - b.usedCapacity / b.availableCapacity,
+      sorter: columnSorterFactory<NodeStatusRow>(value => value.usedCapacity / value.availableCapacity),
       className: "column--align-right",
       width: "10%",
     },
@@ -226,8 +215,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "memoryUse",
       title: "memory use",
       render: (_text, record) => Percentage(record.usedMemory, record.availableMemory),
-      sorter: (a, b) =>
-        a.usedMemory / a.availableMemory - b.usedMemory / b.availableMemory,
+      sorter: columnSorterFactory<NodeStatusRow>(value => value.usedMemory / value.availableMemory),
       className: "column--align-right",
       width: "10%",
     },
@@ -235,7 +223,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "numCpus",
       title: "cpus",
       dataIndex: "numCpus",
-      sorter: true,
+      sorter: columnSorterFactory<NodeStatusRow>("numCpus"),
       className: "column--align-right",
       width: "8%",
     },
@@ -243,7 +231,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "version",
       dataIndex: "version",
       title: "version",
-      sorter: true,
+      sorter: columnSorterFactory<NodeStatusRow>("version"),
       width: "8%",
       ellipsis: true,
     },
@@ -272,7 +260,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
         );
       },
       title: "status",
-      sorter: (a, b) => a.status - b.status,
+      sorter: columnSorterFactory<NodeStatusRow>("status"),
       width: "13%",
     },
     {

--- a/pkg/ui/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
@@ -27,7 +27,7 @@ import { SortSetting } from "src/views/shared/components/sortabletable";
 import { LocalSetting } from "src/redux/localsettings";
 
 import "./decommissionedNodeHistory.styl";
-import { ColumnsConfig, Table, Text } from "src/components";
+import { ColumnsConfig, columnSorterFactory, Table, Text } from "src/components";
 import { createSelector } from "reselect";
 
 const decommissionedNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
@@ -47,24 +47,12 @@ export interface DecommissionedNodeHistoryProps {
   dataSource: DecommissionedNodeStatusRow[];
 }
 
-const sortByNodeId = (a: DecommissionedNodeStatusRow, b: DecommissionedNodeStatusRow) => {
-  if (a.nodeId < b.nodeId) { return -1; }
-  if (a.nodeId > b.nodeId) { return 1; }
-  return 0;
-};
-
-const sortByDecommissioningDate = (a: DecommissionedNodeStatusRow, b: DecommissionedNodeStatusRow) => {
-  if (a.decommissionedDate.isBefore(b.decommissionedDate)) { return -1; }
-  if (a.decommissionedDate.isAfter(b.decommissionedDate)) { return 1; }
-  return 0;
-};
-
 export class DecommissionedNodeHistory extends React.Component<DecommissionedNodeHistoryProps> {
   columns: ColumnsConfig<DecommissionedNodeStatusRow> = [
     {
       key: "id",
       title: "ID",
-      sorter: sortByNodeId,
+      sorter: columnSorterFactory<DecommissionedNodeStatusRow>("nodeId"),
       render: (_text, record) => (
         <Text>{`n${record.nodeId}`}</Text>
       ),
@@ -72,7 +60,7 @@ export class DecommissionedNodeHistory extends React.Component<DecommissionedNod
     {
       key: "address",
       title: "Address",
-      sorter: true,
+      sorter: columnSorterFactory<DecommissionedNodeStatusRow>("address"),
       render: (_text, record) => (
         <Link to={`/node/${record.nodeId}`}>
           <Text>{record.address}</Text>
@@ -81,7 +69,7 @@ export class DecommissionedNodeHistory extends React.Component<DecommissionedNod
     {
       key: "decommissionedOn",
       title: "Decommissioned On",
-      sorter: sortByDecommissioningDate,
+      sorter: columnSorterFactory<DecommissionedNodeStatusRow>(value => value?.decommissionedDate?.toDate().getTime()),
       render: (_text, record) => {
         return record.decommissionedDate.format("LL[ at ]h:mm a");
       },

--- a/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -15,7 +15,16 @@ import moment from "moment";
 import { Action, Dispatch } from "redux";
 import Long from "long";
 
-import { Button, ColumnsConfig, DownloadFile, DownloadFileRef, Table, Text, TextTypes } from "src/components";
+import {
+  Button,
+  ColumnsConfig,
+  columnSorterFactory,
+  DownloadFile,
+  DownloadFileRef,
+  Table,
+  Text,
+  TextTypes,
+} from "src/components";
 import HeaderSection from "src/views/shared/components/headerSection";
 import { AdminUIState } from "src/redux/state";
 import { getStatementDiagnostics } from "src/util/api";
@@ -33,12 +42,7 @@ import "./statementDiagnosticsHistoryView.styl";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnosticsRequest;
-import {
-  getDiagnosticsStatus,
-  sortByCompletedField,
-  sortByRequestedAtField,
-  sortByStatementFingerprintField,
-} from "src/views/statements/diagnostics";
+import { getDiagnosticsStatus } from "src/views/statements/diagnostics";
 
 type StatementDiagnosticsHistoryViewProps = MapStateToProps & MapDispatchToProps;
 
@@ -47,7 +51,7 @@ class StatementDiagnosticsHistoryView extends React.Component<StatementDiagnosti
     {
       key: "activatedOn",
       title: "Activated on",
-      sorter: sortByRequestedAtField,
+      sorter: columnSorterFactory<IStatementDiagnosticsReport>(value => value?.requested_at?.seconds?.toNumber()),
       defaultSortOrder: "descend",
       width: "240px",
       render: (_text, record) => {
@@ -58,7 +62,7 @@ class StatementDiagnosticsHistoryView extends React.Component<StatementDiagnosti
     {
       key: "statement",
       title: "statement",
-      sorter: sortByStatementFingerprintField,
+      sorter: columnSorterFactory<IStatementDiagnosticsReport>("statement_fingerprint"),
       render: (_text, record) => (
         <Text textType={TextTypes.Code}>{record.statement_fingerprint}</Text>
       ),
@@ -66,7 +70,7 @@ class StatementDiagnosticsHistoryView extends React.Component<StatementDiagnosti
     {
       key: "status",
       title: "status",
-      sorter: sortByCompletedField,
+      sorter: columnSorterFactory<IStatementDiagnosticsReport>(value => value?.completed ? 1 : -1),
       width: "160px",
       render: (_text, record) => (
         <Text>

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsUtils.ts
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsUtils.ts
@@ -8,8 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { isUndefined } from "lodash";
-
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import {DiagnosticStatuses} from "src/views/statements/diagnostics/diagnosticStatuses";
@@ -20,30 +18,4 @@ export function getDiagnosticsStatus(diagnosticsRequest: IStatementDiagnosticsRe
   }
 
   return "WAITING FOR QUERY";
-}
-
-export function sortByRequestedAtField(a: IStatementDiagnosticsReport, b: IStatementDiagnosticsReport) {
-  const activatedOnA = a.requested_at?.seconds?.toNumber();
-  const activatedOnB = b.requested_at?.seconds?.toNumber();
-  if (isUndefined(activatedOnA) && isUndefined(activatedOnB)) { return 0; }
-  if (activatedOnA < activatedOnB) { return -1; }
-  if (activatedOnA > activatedOnB) { return 1; }
-  return 0;
-}
-
-export function sortByCompletedField(a: IStatementDiagnosticsReport, b: IStatementDiagnosticsReport) {
-  const completedA = a.completed ? 1 : -1;
-  const completedB = b.completed ? 1 : -1;
-  if (completedA < completedB) { return -1; }
-  if (completedA > completedB) { return 1; }
-  return 0;
-}
-
-export function sortByStatementFingerprintField(a: IStatementDiagnosticsReport, b: IStatementDiagnosticsReport) {
-  const statementFingerprintA = a.statement_fingerprint;
-  const statementFingerprintB = b.statement_fingerprint;
-  if (isUndefined(statementFingerprintA) && isUndefined(statementFingerprintB)) { return 0; }
-  if (statementFingerprintA < statementFingerprintB) { return -1; }
-  if (statementFingerprintA > statementFingerprintB) { return 1; }
-  return 0;
 }

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -23,6 +23,7 @@ import {
   Anchor,
   DownloadFile,
   DownloadFileRef,
+  columnSorterFactory,
 } from "src/components";
 import { AdminUIState } from "src/redux/state";
 import { getStatementDiagnostics } from "src/util/api";
@@ -40,7 +41,7 @@ import "./diagnosticsView.styl";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnosticsRequest;
-import { getDiagnosticsStatus, sortByCompletedField, sortByRequestedAtField } from "./diagnosticsUtils";
+import { getDiagnosticsStatus } from "./diagnosticsUtils";
 import { statementDiagnostics } from "src/util/docs";
 import { createStatementDiagnosticsAlertLocalSetting } from "oss/src/redux/alerts";
 
@@ -61,7 +62,7 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
     {
       key: "activatedOn",
       title: "Activated on",
-      sorter: sortByRequestedAtField,
+      sorter: columnSorterFactory<IStatementDiagnosticsReport>(value => value?.requested_at?.seconds?.toNumber()),
       defaultSortOrder: "descend",
       render: (_text, record) => {
         const timestamp = record.requested_at.seconds.toNumber() * 1000;
@@ -71,7 +72,7 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
     {
       key: "status",
       title: "status",
-      sorter: sortByCompletedField,
+      sorter: columnSorterFactory<IStatementDiagnosticsReport>(value => value?.completed ? 1 : -1),
       width: "160px",
       render: (_text, record) => {
         const status = getDiagnosticsStatus(record);


### PR DESCRIPTION
Table component requires `sorter` function to be passed
in `columnConfiguration` for every column.
It makes code to be almost identical for many columns
except those ones which require to perform sorting on
adjusted (transformed somehow) values.

Before, sorter function was provided for every column
configuration and made it difficult to validate that
all columns can be sorted. As result: some columns had
miss configured sorting.

To make this functionality DRY, with current changes
generic factory function allows to create sorter func
with no code duplication.

`columnSorterFactory` factory function accepts inputs
of two types:

1) column name by which value sorting will be performed
2) map function which allows perform sorting on some
computed value based on row object.

Those two cases cover current implementation.

Following pages were refactored to use generic sorting functionality:
- Node Overview page. Live and Decommissioned node lists
- Decommissioned node history table
- Statement diagnostics tab > Diagnostics table