### PR TITLE
importccl: Do not crash when missing table definition.

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1141,6 +1141,7 @@ func TestImportCSVStmt(t *testing.T) {
 		t.Fatal(err)
 	}
 	empty := []string{"'nodelocal://0/empty.csv'"}
+	emptySchema := []interface{}{"nodelocal://0/empty.schema"}
 
 	// Support subtests by keeping track of the number of jobs that are executed.
 	testNum := -1
@@ -1340,6 +1341,14 @@ func TestImportCSVStmt(t *testing.T) {
 			testFiles.files,
 			``,
 			"invalid option",
+		},
+		{
+			"empty-schema-in-file",
+			`IMPORT TABLE t CREATE USING $1 CSV DATA (%s)`,
+			emptySchema,
+			testFiles.files,
+			``,
+			"expected 1 create table statement",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -54,11 +54,14 @@ func readCreateTableFromStore(
 	if err != nil {
 		return nil, err
 	}
-	stmt, err := parser.ParseOne(string(tableDefStr))
+	stmts, err := parser.Parse(string(tableDefStr))
 	if err != nil {
 		return nil, err
 	}
-	create, ok := stmt.AST.(*tree.CreateTable)
+	if len(stmts) != 1 {
+		return nil, errors.Errorf("expected 1 create table statement, found %d", len(stmts))
+	}
+	create, ok := stmts[0].AST.(*tree.CreateTable)
 	if !ok {
 		return nil, errors.New("expected CREATE TABLE statement in table file")
 	}

--- a/pkg/ccl/importccl/testdata/csv/empty.schema
+++ b/pkg/ccl/importccl/testdata/csv/empty.schema
@@ -1,0 +1,2 @@
+/* non-zero length file without any statements */
+


### PR DESCRIPTION
Fixes #41731

Do not crash when running "IMPORT TABLE _ CREATE USING (_)...." when
the external file, which supposed to contain table definition, does
not contain table definition.

Release notes (bug fix): Fix crash when importing table without
table definition.

Release justification: A low/no-impact bug fix.