### PR TITLE
rowexec: make tableReader implement execinfra.OpNode interface

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -91,3 +91,16 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN
 querying next range at /Table/56/1/0
 === SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/56/1/10
+
+# Regression test for #46123 (rowexec.TableReader not implementing
+# execinfra.OpNode interface).
+statement ok
+CREATE TABLE t46123(c0 INT)
+
+query T
+EXPLAIN (VEC) SELECT stddev(0) FROM t46123 WHERE ('' COLLATE en)::BOOL
+----
+│
+└ Node 1
+└ *rowexec.orderedAggregator
+  └ *rowexec.tableReader

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -60,6 +60,7 @@ var _ execinfra.Processor = &tableReader{}
 var _ execinfra.RowSource = &tableReader{}
 var _ execinfrapb.MetadataSource = &tableReader{}
 var _ execinfra.Releasable = &tableReader{}
+var _ execinfra.OpNode = &tableReader{}
 
 const tableReaderProcName = "table reader"
 
@@ -293,4 +294,14 @@ func (tr *tableReader) generateMeta(ctx context.Context) []execinfrapb.ProducerM
 // DrainMeta is part of the MetadataSource interface.
 func (tr *tableReader) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	return tr.generateMeta(ctx)
+}
+
+// ChildCount is part of the execinfra.OpNode interface.
+func (tr *tableReader) ChildCount(bool) int {
+	return 0
+}
+
+// Child is part of the execinfra.OpNode interface.
+func (tr *tableReader) Child(nth int, _ bool) execinfra.OpNode {
+	panic(fmt.Sprintf("invalid index %d", nth))
 }


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

In #42873 we started wrapping most processors into the vectorized flow,
and most of the processors implemented execinfra.OpNode interface at
that time. However, we missed tableReader (I thought there would be no
vectorized flows with them, only with colBatchScans, and as it turns
out, it is now possible to have such a flow), and this commit fixes it.

Fixes: #46123.

Release note: None