### PR TITLE
roachprod: distinguish infra and crdb errors

### DIFF
--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -173,6 +173,26 @@ OK
 
 See `roachprod help <command>` for further details.
 
+## Return Codes
+
+`roachprod` uses return codes to provide information about the exit status.
+These are the codes and what they mean:
+
+- 0: everything ran as expected
+- 1: an unclassified roachprod error
+- 10: a problem with an SSH connection to a server in the cluster
+- 20: a problem running a non-cockroach command on a remote cluster server or on a local node
+- 30: a problem running a cockroach command on a remote cluster server or a local node
+
+Each of these codes has a corresponding easy-to-search-for string that is
+emitted to output when an error of that type occurs. The strings are emitted
+near the end of output and for each error that happens during an ssh
+connection to a remote cluster node. The strings for each error code are:
+
+- 1:  `UNCLASSIFIED_PROBLEM`
+- 10: `SSH_PROBLEM`
+- 20: `COMMAND_PROBLEM`
+- 30: `DEAD_ROACH_PROBLEM`
 
 # Future improvements
 

--- a/pkg/cmd/roachprod/errors/errors.go
+++ b/pkg/cmd/roachprod/errors/errors.go
@@ -1,0 +1,233 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package errors
+
+import (
+	"fmt"
+	"os/exec"
+
+	crdberrors "github.com/cockroachdb/errors"
+)
+
+// Error is an interface for error types used by the main.wrap() function
+// to output correctly classified log messages and exit codes.
+type Error interface {
+	error
+
+	// The exit code for the error when exiting roachprod.
+	ExitCode() int
+}
+
+// Exit codes for the errors
+const (
+	cmdExitCode          = 20
+	cockroachExitCode    = 30
+	sshExitCode          = 10
+	unclassifiedExitCode = 1
+)
+
+// Cmd wraps errors that result from a non-cockroach command run against
+// the cluster.
+//
+// For errors coming from a cockroach command, use Cockroach.
+type Cmd struct {
+	Err error
+}
+
+func (e Cmd) Error() string {
+	return fmt.Sprintf("COMMAND_PROBLEM: %s", e.Err.Error())
+}
+
+// ExitCode gives the process exit code to return for non-cockroach command
+// errors.
+func (e Cmd) ExitCode() int {
+	return cmdExitCode
+}
+
+// Format passes formatting responsibilities to cockroachdb/errors
+func (e Cmd) Format(s fmt.State, verb rune) {
+	crdberrors.FormatError(e, s, verb)
+}
+
+// Unwrap the wrapped the non-cockroach command error.
+func (e Cmd) Unwrap() error {
+	return e.Err
+}
+
+// Cockroach wraps errors that result from a cockroach command run against the cluster.
+//
+// For non-cockroach commands, use Cmd.
+type Cockroach struct {
+	Err error
+}
+
+func (e Cockroach) Error() string {
+	return fmt.Sprintf("DEAD_ROACH_PROBLEM: %s", e.Err.Error())
+}
+
+// ExitCode gives the process exit code to return for cockroach errors.
+func (e Cockroach) ExitCode() int {
+	return cockroachExitCode
+}
+
+// Format passes formatting responsibilities to cockroachdb/errors
+func (e Cockroach) Format(s fmt.State, verb rune) {
+	crdberrors.FormatError(e, s, verb)
+}
+
+// Unwrap the wrapped cockroach error.
+func (e Cockroach) Unwrap() error {
+	return e.Err
+}
+
+// SSH wraps ssh-specific errors from connections to remote hosts.
+type SSH struct {
+	Err error
+}
+
+func (e SSH) Error() string {
+	return fmt.Sprintf("SSH_PROBLEM: %s", e.Err.Error())
+}
+
+// ExitCode gives the process exit code to return for SSH errors.
+func (e SSH) ExitCode() int {
+	return sshExitCode
+}
+
+// Format passes formatting responsibilities to cockroachdb/errors
+func (e SSH) Format(s fmt.State, verb rune) {
+	crdberrors.FormatError(e, s, verb)
+}
+
+// Unwrap the wrapped SSH error.
+func (e SSH) Unwrap() error {
+	return e.Err
+}
+
+// Unclassified wraps roachprod and unclassified errors.
+type Unclassified struct {
+	Err error
+}
+
+func (e Unclassified) Error() string {
+	return fmt.Sprintf("UNCLASSIFIED_PROBLEM: %s", e.Err.Error())
+}
+
+// ExitCode gives the process exit code to return for unclassified errors.
+func (e Unclassified) ExitCode() int {
+	return unclassifiedExitCode
+}
+
+// Format passes formatting responsibilities to cockroachdb/errors
+func (e Unclassified) Format(s fmt.State, verb rune) {
+	crdberrors.FormatError(e, s, verb)
+}
+
+// Unwrap the wrapped unclassified error.
+func (e Unclassified) Unwrap() error {
+	return e.Err
+}
+
+// ClassifyCmdError classifies an error received while executing a
+// non-cockroach command remotely over an ssh connection to the right Error
+// type.
+func ClassifyCmdError(err error) Error {
+	if err == nil {
+		return nil
+	}
+
+	if exitErr, ok := asExitError(err); ok {
+		if exitErr.ExitCode() == 255 {
+			return SSH{err}
+		}
+		return Cmd{err}
+	}
+
+	return Unclassified{err}
+}
+
+// ClassifyCockroachError classifies an error received while executing a
+// cockroach command remotely over an ssh connection to the right Error type.
+func ClassifyCockroachError(err error) Error {
+	if err == nil {
+		return nil
+	}
+
+	if exitErr, ok := asExitError(err); ok {
+		if exitErr.ExitCode() == 255 {
+			return SSH{err}
+		}
+		return Cockroach{err}
+	}
+
+	return Unclassified{err}
+}
+
+// Extract the an ExitError from err's error tree or (nil, false) if none exists.
+func asExitError(err error) (*exec.ExitError, bool) {
+	if exitErr, ok := crdberrors.If(err, func(err error) (interface{}, bool) {
+		if err, ok := err.(*exec.ExitError); ok {
+			return err, true
+		}
+		return nil, false
+	}); ok {
+		return exitErr.(*exec.ExitError), true
+	}
+	return nil, false
+}
+
+// AsError extracts the Error from err's error tree or (nil, false) if none exists.
+func AsError(err error) (Error, bool) {
+	if rpErr, ok := crdberrors.If(err, func(err error) (interface{}, bool) {
+		if rpErr, ok := err.(Error); ok {
+			return rpErr, true
+		}
+		return nil, false
+	}); ok {
+		return rpErr.(Error), true
+	}
+	return nil, false
+}
+
+// SelectPriorityError selects an error from the list in this priority order:
+//
+// - the Error with the highest exit code
+// - one of the `error`s
+// - nil
+func SelectPriorityError(errors []error) error {
+	var result Error
+	for _, err := range errors {
+		if err == nil {
+			continue
+		}
+
+		rpErr, _ := AsError(err)
+		if result == nil {
+			result = rpErr
+			continue
+		}
+
+		if rpErr.ExitCode() > result.ExitCode() {
+			result = rpErr
+		}
+	}
+
+	if result != nil {
+		return result
+	}
+
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -31,11 +31,13 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
+	rperrors "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/ui"
 	clog "github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	crdberrors "github.com/cockroachdb/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -78,6 +80,26 @@ type SyncedCluster struct {
 
 	// Used to stash debug information.
 	DebugDir string
+}
+
+// CmdKind is the kind of command passed to SyncedCluster.Run().
+type CmdKind int
+
+// The kinds of commands passed to SyncedCluster.Run().
+const (
+	// A cockroach command is passed.
+	CockroachCmd CmdKind = iota
+
+	// A non-classified command is passed.
+	OtherCmd
+)
+
+func (ck CmdKind) classifyError(err error) rperrors.Error {
+	if ck == CockroachCmd {
+		return rperrors.ClassifyCockroachError(err)
+	}
+
+	return rperrors.ClassifyCmdError(err)
 }
 
 func (c *SyncedCluster) host(index int) string {
@@ -428,8 +450,21 @@ done
 	return ch
 }
 
-// Run TODO(peter): document
-func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd string) error {
+// Run a command on >= 1 node in the cluster.
+//
+// When running on just one node, the command output is streamed to stdout.
+// When running on multiple nodes, the commands run in parallel, their output
+// is cached and then emitted all together once all commands are completed.
+//
+// stdout: Where stdout messages are written
+// stderr: Where stderr messages are written
+// nodes: The cluster nodes where the command will be run.
+// cmdKind: Which type of command is being run? This allows refined error reporting.
+// title: A description of the command being run that is output to the logs.
+// cmd: The command to run.
+func (c *SyncedCluster) Run(
+	stdout, stderr io.Writer, nodes []int, cmdKind CmdKind, title, cmd string,
+) error {
 	// Stream output if we're running the command on only 1 node.
 	stream := len(nodes) == 1
 	var display string
@@ -475,12 +510,21 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 			sess.SetStdout(stdout)
 			sess.SetStderr(stderr)
 			errors[i] = sess.Run(nodeCmd)
+			if errors[i] != nil {
+				detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
+				err = crdberrors.WithDetail(errors[i], detailMsg)
+				err = cmdKind.classifyError(err)
+				errors[i] = err
+			}
 			return nil, nil
 		}
 
 		out, err := sess.CombinedOutput(nodeCmd)
 		msg := strings.TrimSpace(string(out))
 		if err != nil {
+			detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
+			err = crdberrors.WithDetail(err, detailMsg)
+			err = cmdKind.classifyError(err)
 			errors[i] = err
 			msg += fmt.Sprintf("\n%v", err)
 		}
@@ -494,12 +538,7 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 		}
 	}
 
-	for _, err := range errors {
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return rperrors.SelectPriorityError(errors)
 }
 
 // Wait TODO(peter): document

--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -163,7 +163,7 @@ func SortedCmds() []string {
 func Install(c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.Run(&buf, &buf, c.Nodes, "installing "+title, cmd)
+		err := c.Run(&buf, &buf, c.Nodes, OtherCmd, "installing "+title, cmd)
 		if err != nil {
 			fmt.Print(buf.String())
 		}

--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -64,7 +64,8 @@ func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA, arch 
 		`curl -sfSL -o %s "%s" && chmod 755 ./%s`, applicationName, binURL, applicationName,
 	)
 	return c.Run(
-		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+		os.Stdout, os.Stderr, c.Nodes, OtherCmd,
+		fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
 }
 
@@ -95,6 +96,6 @@ mv ${tmpdir}/cockroach ./cockroach && \
 chmod 755 ./cockroach
 `, binURL)
 	return c.Run(
-		os.Stdout, os.Stderr, c.Nodes, "staging cockroach release binary", cmdStr,
+		os.Stdout, os.Stderr, c.Nodes, OtherCmd, "staging cockroach release binary", cmdStr,
 	)
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -29,6 +29,7 @@ import (
 
 	cld "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
+	rperrors "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/ui"
@@ -260,12 +261,25 @@ func verifyClusterName(clusterName string) (string, error) {
 		clusterName, suggestions)
 }
 
+// Provide `cobra.Command` functions with a standard return code handler.
+// Exit codes come from rperrors.Error.ExitCode().
+//
+// If the wrapped error tree of an error does not contain an instance of
+// rperrors.Error, the error will automatically be wrapped with
+// rperrors.Unclassified.
 func wrap(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		err := f(cmd, args)
 		if err != nil {
-			cmd.Println("Error: ", err.Error())
-			os.Exit(1)
+			roachprodError, ok := rperrors.AsError(err)
+			if !ok {
+				roachprodError = rperrors.Unclassified{Err: err}
+				err = roachprodError
+			}
+
+			cmd.Printf("Error: %+v\n", err)
+
+			os.Exit(roachprodError.ExitCode())
 		}
 	}
 }
@@ -1182,7 +1196,7 @@ the 'zfs rollback' command:
 			return fmt.Errorf("unknown filesystem %q", fs)
 		}
 
-		err = c.Run(os.Stdout, os.Stderr, c.Nodes, "reformatting", fmt.Sprintf(`
+		err = c.Run(os.Stdout, os.Stderr, c.Nodes, install.OtherCmd, "reformatting", fmt.Sprintf(`
 set -euo pipefail
 if sudo zpool list -Ho name 2>/dev/null | grep ^data1$; then
   sudo zpool destroy -f data1
@@ -1224,7 +1238,7 @@ var runCmd = &cobra.Command{
 		if len(title) > 30 {
 			title = title[:27] + "..."
 		}
-		return c.Run(os.Stdout, os.Stderr, c.Nodes, title, cmd)
+		return c.Run(os.Stdout, os.Stderr, c.Nodes, install.CockroachCmd, title, cmd)
 	}),
 }
 

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -81,7 +81,7 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 				case -1:
 					// Received SIGINT before setting up our own signal handlers or
 					// SIGKILL.
-				case 1:
+				case 30:
 					// Exit code from a SIGINT received by our signal handlers.
 				default:
 					t.Fatalf("unexpected exit status %d", status)


### PR DESCRIPTION
Before: there are many reasons why roachprod might fail for a given command
and it didn't differentiate between the different types of errors.

Why change?

- The lack of detail for why an error happened made debugging problems harder
  than needed.

- We couldn't use automated methods to aggregate error reporting or direct
  errors to the right team when it's used by roachtest.

- We want to gather metrics on specific types of errors and it's wasn't
  possible without more granular error reporting from roachprod.

Now:

- roachprod exits with different codes depending on type of error:

    0: all OK
    1: an unclassified roachprod error
    10: a problem with an SSH connection to a server in the cluster
    20: a problem running a non-cockroach command on a remote server in the
       cluster
    30: a problem running a cockroach command on a remote server in the cluster

- for each error type, an easily-searchable string is emitted by roachprod at
  or near the end of output. The string will also be emitted for each error
  that happens during an ssh connection to a remote cluster node. The strings
  for each error code are:

    1: UNCLASSIFIED_PROBLEM
    10: SSH_PROBLEM
    20: COMMAND_PROBLEM
    30: DEAD_ROACH_PROBLEM

- Refined error handling for remote ssh connections only for commands that use
  SyncedCluster.Run().

Release justification: This dosn't affect CRDB itself, only internal tools.

Release note: None