### PR TITLE
colexec: add Closers to NewColOperatorResult

### DIFF
--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -179,6 +179,8 @@ func newTwoInputDiskSpiller(
 type diskSpillerBase struct {
 	NonExplainable
 
+	closerHelper
+
 	inputs  []Operator
 	spilled bool
 
@@ -251,9 +253,17 @@ func (d *diskSpillerBase) reset(ctx context.Context) {
 	d.spilled = false
 }
 
-func (d *diskSpillerBase) Close(ctx context.Context) error {
-	if c, ok := d.diskBackedOp.(closer); ok {
-		return c.Close(ctx)
+// Close closes the diskSpillerBase's input.
+// TODO(asubiotto): Remove this method. It only exists so that we can call Close
+//  from some runTests subtests when not draining the input fully. The test
+//  should pass in the testing.T object used so that the caller can decide to
+//  explicitly close the input after checking the test.
+func (d *diskSpillerBase) IdempotentClose(ctx context.Context) error {
+	if !d.close() {
+		return nil
+	}
+	if c, ok := d.diskBackedOp.(IdempotentCloser); ok {
+		return c.IdempotentClose(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -71,6 +71,7 @@ func wrapRowSources(
 				&execinfrapb.PostProcessSpec{},
 				nil, /* output */
 				nil, /* metadataSourcesQueue */
+				nil, /* toClose */
 				nil, /* outputStatsToTrace */
 				nil, /* cancelFlow */
 			)
@@ -138,7 +139,10 @@ type NewColOperatorResult struct {
 	ColumnTypes      []types.T
 	InternalMemUsage int
 	MetadataSources  []execinfrapb.MetadataSource
-	IsStreaming      bool
+	// ToClose is a slice of components that need to be Closed. Close should be
+	// idempotent.
+	ToClose     []IdempotentCloser
+	IsStreaming bool
 	// CanRunInAutoMode returns whether the result can be run in auto mode if
 	// IsStreaming is false. This applies to operators that can spill to disk,
 	// but also operators such as the hash aggregator that buffer, but not
@@ -426,7 +430,7 @@ func (r *NewColOperatorResult) createDiskBackedSort(
 			if args.TestingKnobs.NumForcedRepartitions != 0 {
 				maxNumberPartitions = args.TestingKnobs.NumForcedRepartitions
 			}
-			return newExternalSorter(
+			es := newExternalSorter(
 				ctx,
 				unlimitedAllocator,
 				standaloneMemAccount,
@@ -438,6 +442,8 @@ func (r *NewColOperatorResult) createDiskBackedSort(
 				args.FDSemaphore,
 				diskAccount,
 			)
+			r.ToClose = append(r.ToClose, es.(IdempotentCloser))
+			return es
 		},
 		args.TestingKnobs.SpillingCallbackFn,
 	), nil
@@ -820,7 +826,7 @@ func NewColOperator(
 						diskQueueCfg := args.DiskQueueCfg
 						diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeClearAndReuseCache
 						diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
-						return newExternalHashJoiner(
+						ehj := newExternalHashJoiner(
 							unlimitedAllocator, hjSpec,
 							inputOne, inputTwo,
 							execinfra.GetWorkMemLimit(flowCtx.Cfg),
@@ -844,6 +850,8 @@ func NewColOperator(
 							args.TestingKnobs.DelegateFDAcquisitions,
 							diskAccount,
 						)
+						result.ToClose = append(result.ToClose, ehj.(IdempotentCloser))
+						return ehj
 					},
 					args.TestingKnobs.SpillingCallbackFn,
 				)
@@ -902,7 +910,7 @@ func NewColOperator(
 					ctx, flowCtx, monitorName,
 				))
 			diskAccount := result.createDiskAccount(ctx, flowCtx, monitorName)
-			result.Op, err = newMergeJoinOp(
+			mj, err := newMergeJoinOp(
 				unlimitedAllocator, execinfra.GetWorkMemLimit(flowCtx.Cfg),
 				args.DiskQueueCfg, args.FDSemaphore,
 				joinType, inputs[0], inputs[1], leftPhysTypes, rightPhysTypes,
@@ -913,6 +921,8 @@ func NewColOperator(
 				return result, err
 			}
 
+			result.Op = mj
+			result.ToClose = append(result.ToClose, mj.(IdempotentCloser))
 			result.ColumnTypes = append(leftLogTypes, rightLogTypes...)
 
 			if onExpr != nil {
@@ -1034,6 +1044,12 @@ func NewColOperator(
 						args.FDSemaphore, input, typs, windowFn, wf.Ordering.Columns,
 						int(wf.OutputColIdx+tempColOffset), partitionColIdx, peersColIdx, diskAcc,
 					)
+					// NewRelativeRankOperator sometimes returns a constOp when there
+					// are no ordering columns, so we check that the returned operator
+					// is an IdempotentCloser.
+					if c, ok := result.Op.(IdempotentCloser); ok {
+						result.ToClose = append(result.ToClose, c)
+					}
 					// Relative rank operators are buffering operators, and we
 					// are not comfortable running them with `auto` mode.
 					canRunInAutoMode = false

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -62,18 +62,6 @@ func TestExternalHashJoiner(t *testing.T) {
 			for _, tc := range tcs {
 				delegateFDAcquisitions := rng.Float64() < 0.5
 				t.Run(fmt.Sprintf("spillForced=%t/%s/delegateFDAcquisitions=%t", spillForced, tc.description, delegateFDAcquisitions), func(t *testing.T) {
-					// Unfortunately, there is currently no better way to check that the
-					// external hash joiner does not have leftover file descriptors other
-					// than appending each semaphore used to this slice on construction.
-					// This is because some tests don't fully drain the input, making
-					// intercepting the Close() method not a useful option, since it is
-					// impossible to check between an expected case where more than 0 FDs
-					// are open (e.g. in allNullsInjection, where the joiner is not fully
-					// drained so Close must be called explicitly) and an unexpected one.
-					// These cases happen during normal execution when a limit is
-					// satisfied, but flows will call Close explicitly on Cleanup.
-					// TODO(yuzefovich): not implemented yet, currently we rely on the
-					// flow tracking open FDs and releasing any leftovers.
 					var semsToCheck []semaphore.Semaphore
 					if !tc.onExpr.Empty() {
 						// When we have ON expression, there might be other operators (like
@@ -90,10 +78,20 @@ func TestExternalHashJoiner(t *testing.T) {
 						sem := NewTestingSemaphore(externalHJMinPartitions)
 						semsToCheck = append(semsToCheck, sem)
 						spec := createSpecForHashJoiner(tc)
-						hjOp, newAccounts, newMonitors, err := createDiskBackedHashJoiner(
+						// TODO(asubiotto): Pass in the testing.T of the caller to this
+						//  function and do substring matching on the test name to
+						//  conditionally explicitly call Close() on the hash joiner
+						//  (through result.ToClose) in cases where it is known the sorter
+						//  will not be drained.
+						hjOp, newAccounts, newMonitors, closers, err := createDiskBackedHashJoiner(
 							ctx, flowCtx, spec, sources, func() {}, queueCfg,
 							2 /* numForcedPartitions */, delegateFDAcquisitions, sem,
 						)
+						// Expect three closers. These are the external hash joiner, and
+						// one external sorter for each input.
+						// TODO(asubiotto): Explicitly Close when testing.T is passed into
+						//  this constructor and we do a substring match.
+						require.Equal(t, 3, len(closers))
 						accounts = append(accounts, newAccounts...)
 						monitors = append(monitors, newMonitors...)
 						return hjOp, err
@@ -153,10 +151,14 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	var spilled bool
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-	hj, accounts, monitors, err := createDiskBackedHashJoiner(
+	sem := NewTestingSemaphore(externalHJMinPartitions)
+	// Ignore closers since the sorter should close itself when it is drained of
+	// all tuples. We assert this by checking that the semaphore reports a count
+	// of 0.
+	hj, accounts, monitors, _, err := createDiskBackedHashJoiner(
 		ctx, flowCtx, spec, []Operator{leftSource, rightSource},
 		func() { spilled = true }, queueCfg, 0 /* numForcedRepartitions */, true, /* delegateFDAcquisitions */
-		NewTestingSemaphore(externalHJMinPartitions),
+		sem,
 	)
 	defer func() {
 		for _, acc := range accounts {
@@ -177,6 +179,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	}
 	require.True(t, spilled)
 	require.Equal(t, expectedTuplesCount, actualTuplesCount)
+	require.Equal(t, 0, sem.GetCount())
 }
 
 func BenchmarkExternalHashJoiner(b *testing.B) {
@@ -255,7 +258,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							leftSource.reset(nBatches)
 							rightSource.reset(nBatches)
-							hj, accounts, monitors, err := createDiskBackedHashJoiner(
+							hj, accounts, monitors, _, err := createDiskBackedHashJoiner(
 								ctx, flowCtx, spec, []Operator{leftSource, rightSource},
 								func() {}, queueCfg, 0 /* numForcedRepartitions */, false, /* delegateFDAcquisitions */
 								NewTestingSemaphore(VecMaxOpenFDsLimit),
@@ -295,7 +298,7 @@ func createDiskBackedHashJoiner(
 	numForcedRepartitions int,
 	delegateFDAcquisitions bool,
 	testingSemaphore semaphore.Semaphore,
-) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, error) {
+) (Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []IdempotentCloser, error) {
 	args := NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,
@@ -310,5 +313,5 @@ func createDiskBackedHashJoiner(
 	args.TestingKnobs.NumForcedRepartitions = numForcedRepartitions
 	args.TestingKnobs.DelegateFDAcquisitions = delegateFDAcquisitions
 	result, err := NewColOperator(ctx, flowCtx, args)
-	return result.Op, result.OpAccounts, result.OpMonitors, err
+	return result.Op, result.OpAccounts, result.OpMonitors, result.ToClose, err
 }

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -109,8 +110,14 @@ const externalSorterMinPartitions = 3
 type externalSorter struct {
 	OneInputNode
 	NonExplainable
+	closerHelper
 
-	closed             bool
+	// mu is used to protect against concurrent IdempotentClose and Next calls,
+	// which are currently allowed.
+	// TODO(asubiotto): Explore calling IdempotentClose from the same goroutine as
+	//  Next, which will simplify this model.
+	mu syncutil.Mutex
+
 	unlimitedAllocator *Allocator
 	state              externalSorterState
 	inputTypes         []coltypes.T
@@ -239,6 +246,8 @@ func (s *externalSorter) Init() {
 }
 
 func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for {
 		switch s.state {
 		case externalSorterNewPartition:
@@ -344,7 +353,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			}
 			return b
 		case externalSorterFinished:
-			if err := s.Close(ctx); err != nil {
+			if err := s.internalCloseLocked(ctx); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			return coldata.ZeroBatch
@@ -359,18 +368,16 @@ func (s *externalSorter) reset(ctx context.Context) {
 		r.reset(ctx)
 	}
 	s.state = externalSorterNewPartition
-	if err := s.Close(ctx); err != nil {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.internalCloseLocked(ctx); err != nil {
 		execerror.VectorizedInternalPanic(err)
 	}
-	s.closed = false
 	s.firstPartitionIdx = 0
 	s.numPartitions = 0
 }
 
-func (s *externalSorter) Close(ctx context.Context) error {
-	if s.closed {
-		return nil
-	}
+func (s *externalSorter) internalCloseLocked(ctx context.Context) error {
 	var lastErr error
 	if s.partitioner != nil {
 		lastErr = s.partitioner.Close(ctx)
@@ -383,8 +390,16 @@ func (s *externalSorter) Close(ctx context.Context) error {
 		s.fdState.fdSemaphore.Release(s.fdState.acquiredFDs)
 		s.fdState.acquiredFDs = 0
 	}
-	s.closed = true
 	return lastErr
+}
+
+func (s *externalSorter) IdempotentClose(ctx context.Context) error {
+	if !s.close() {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.internalCloseLocked(ctx)
 }
 
 // createMergerForPartitions creates an ordered synchronizer that will merge

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -20,6 +20,7 @@ import (
 // tuples from its input.
 type limitOp struct {
 	OneInputNode
+	closerHelper
 
 	limit int
 
@@ -64,17 +65,17 @@ func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 	return bat
 }
 
-// Close is a temporary method to support the specific case in which an upstream
-// operator must be Closed (e.g. an external sorter) to assert a certain state
-// during tests.
-// TODO(asubiotto): This method only exists because an external sorter is
-//  wrapped with a limit op when doing a top K sort and some tests that don't
-//  exhaust the sorter (e.g. allNullsInjection) need to close the operator
-//  explicitly. This should be removed once we have a better way of closing
-//  operators even when they are not exhausted.
-func (c *limitOp) Close(ctx context.Context) error {
-	if c, ok := c.input.(closer); ok {
-		return c.Close(ctx)
+// Close closes the limitOp's input.
+// TODO(asubiotto): Remove this method. It only exists so that we can call Close
+//  from some runTests subtests when not draining the input fully. The test
+//  should pass in the testing.T object used so that the caller can decide to
+//  explicitly close the input after checking the test.
+func (c *limitOp) IdempotentClose(ctx context.Context) error {
+	if !c.close() {
+		return nil
+	}
+	if closer, ok := c.input.(IdempotentCloser); ok {
+		return closer.IdempotentClose(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // Materializer converts an Operator input into a execinfra.RowSource.
@@ -53,6 +54,10 @@ type Materializer struct {
 	// ctxCancel in that it will cancel all components of the Materializer's flow,
 	// including those started asynchronously.
 	cancelFlow func() context.CancelFunc
+
+	// closers is a slice of IdempotentClosers that should be Closed on
+	// termination.
+	closers []IdempotentCloser
 }
 
 const materializerProcName = "materializer"
@@ -76,12 +81,14 @@ func NewMaterializer(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
+	toClose []IdempotentCloser,
 	outputStatsToTrace func(),
 	cancelFlow func() context.CancelFunc,
 ) (*Materializer, error) {
 	m := &Materializer{
-		input: input,
-		row:   make(sqlbase.EncDatumRow, len(typs)),
+		input:   input,
+		row:     make(sqlbase.EncDatumRow, len(typs)),
+		closers: toClose,
 	}
 
 	if err := m.ProcessorBase.Init(
@@ -186,6 +193,13 @@ func (m *Materializer) InternalClose() bool {
 	if m.ProcessorBase.InternalClose() {
 		if m.cancelFlow != nil {
 			m.cancelFlow()()
+		}
+		for _, closer := range m.closers {
+			if err := closer.IdempotentClose(m.Ctx); err != nil {
+				if log.V(1) {
+					log.Infof(m.Ctx, "error closing Closer: %v", err)
+				}
+			}
 		}
 		return true
 	}

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -57,6 +57,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)
@@ -142,6 +143,7 @@ func TestMaterializeTypes(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)
@@ -196,6 +198,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			&execinfrapb.PostProcessSpec{},
 			nil, /* output */
 			nil, /* metadataSourcesQueue */
+			nil, /* toClose */
 			nil, /* outputStatsToTrace */
 			nil, /* cancelFlow */
 		)

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/marusama/semaphore"
 )
 
@@ -296,7 +297,7 @@ func newMergeJoinBase(
 	leftOrdering []execinfrapb.Ordering_Column,
 	rightOrdering []execinfrapb.Ordering_Column,
 	diskAcc *mon.BoundAccount,
-) (mergeJoinBase, error) {
+) (*mergeJoinBase, error) {
 	lEqCols := make([]uint32, len(leftOrdering))
 	lDirections := make([]execinfrapb.Ordering_Column_Direction, len(leftOrdering))
 	for i, c := range leftOrdering {
@@ -313,7 +314,7 @@ func newMergeJoinBase(
 
 	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
 	diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
-	base := mergeJoinBase{
+	base := &mergeJoinBase{
 		twoInputNode:       newTwoInputNode(left, right),
 		unlimitedAllocator: unlimitedAllocator,
 		memoryLimit:        memoryLimit,
@@ -354,6 +355,13 @@ func newMergeJoinBase(
 // mergeJoinBase extracts the common logic between all merge join operators.
 type mergeJoinBase struct {
 	twoInputNode
+	closerHelper
+
+	// mu is used to protect against concurrent IdempotentClose and Next calls,
+	// which are currently allowed.
+	// TODO(asubiotto): Explore calling IdempotentClose from the same goroutine as
+	//  Next, which will simplify this model.
+	mu syncutil.Mutex
 
 	unlimitedAllocator *Allocator
 	memoryLimit        int64
@@ -395,7 +403,7 @@ type mergeJoinBase struct {
 }
 
 var _ resetter = &mergeJoinBase{}
-var _ closer = &mergeJoinBase{}
+var _ IdempotentCloser = &mergeJoinBase{}
 
 func (o *mergeJoinBase) reset(ctx context.Context) {
 	if r, ok := o.left.source.(resetter); ok {
@@ -694,11 +702,16 @@ func (o *mergeJoinBase) finishProbe(ctx context.Context) {
 	)
 }
 
-func (o *mergeJoinBase) Close(ctx context.Context) error {
+func (o *mergeJoinBase) IdempotentClose(ctx context.Context) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.close() {
+		return nil
+	}
 	var lastErr error
 	for _, op := range []Operator{o.left.source, o.right.source} {
-		if c, ok := op.(closer); ok {
-			if err := c.Close(ctx); err != nil {
+		if c, ok := op.(IdempotentCloser); ok {
+			if err := c.IdempotentClose(ctx); err != nil {
 				lastErr = err
 			}
 		}

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -106,7 +106,7 @@ const _MJ_OVERLOAD = 0
 // */}}
 
 type mergeJoin_JOIN_TYPE_STRINGOp struct {
-	mergeJoinBase
+	*mergeJoinBase
 }
 
 var _ InternalMemoryOperator = &mergeJoin_JOIN_TYPE_STRINGOp{}
@@ -1437,6 +1437,8 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
+	o.mu.Lock()
+	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -204,8 +205,8 @@ func _COMPUTE_PEER_GROUPS_SIZES() { // */}}
 
 type relativeRankInitFields struct {
 	rankInitFields
+	closerHelper
 
-	closed       bool
 	state        relativeRankState
 	memoryLimit  int64
 	diskQueueCfg colcontainer.DiskQueueCfg
@@ -239,6 +240,12 @@ const relativeRankUtilityQueueMemLimitFraction = 0.1
 
 type _RELATIVE_RANK_STRINGOp struct {
 	relativeRankInitFields
+
+	// mu is used to protect against concurrent IdempotentClose and Next calls,
+	// which are currently allowed.
+	// TODO(asubiotto): Explore calling IdempotentClose from the same goroutine as
+	//  Next, which will simplify this model.
+	mu syncutil.Mutex
 
 	// {{if .IsPercentRank}}
 	// rank indicates which rank should be assigned to the next tuple.
@@ -308,6 +315,8 @@ func (r *_RELATIVE_RANK_STRINGOp) Init() {
 }
 
 func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	var err error
 	for {
 		switch r.state {
@@ -591,7 +600,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.idempotentCloseLocked(ctx); err != nil {
 				execerror.VectorizedInternalPanic(err)
 			}
 			return coldata.ZeroBatch
@@ -604,8 +613,14 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (r *_RELATIVE_RANK_STRINGOp) Close(ctx context.Context) error {
-	if r.closed {
+func (r *_RELATIVE_RANK_STRINGOp) IdempotentClose(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.idempotentCloseLocked(ctx)
+}
+
+func (r *_RELATIVE_RANK_STRINGOp) idempotentCloseLocked(ctx context.Context) error {
+	if !r.close() {
 		return nil
 	}
 	var lastErr error
@@ -622,7 +637,6 @@ func (r *_RELATIVE_RANK_STRINGOp) Close(ctx context.Context) error {
 		lastErr = err
 	}
 	// {{end}}
-	r.closed = true
 	return lastErr
 }
 

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -94,6 +94,7 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 				&execinfrapb.PostProcessSpec{},
 				output,
 				nil, /* metadataSourcesQueue */
+				nil, /* toClose */
 				nil, /* outputStatsToTrace */
 				nil, /* cancelFlow */
 			)

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -275,11 +275,11 @@ func runTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
-		if c, ok := originalOp.(closer); ok {
-			require.NoError(t, c.Close(ctx))
+		if c, ok := originalOp.(IdempotentCloser); ok {
+			require.NoError(t, c.IdempotentClose(ctx))
 		}
-		if c, ok := opWithNulls.(closer); ok {
-			require.NoError(t, c.Close(ctx))
+		if c, ok := opWithNulls.(IdempotentCloser); ok {
+			require.NoError(t, c.IdempotentClose(ctx))
 		}
 	})
 }
@@ -402,10 +402,10 @@ func runTestsWithoutAllNullsInjection(
 						assert.False(t, maybeHasNulls(b))
 					}
 				}
-				if c, ok := op.(closer); ok {
+				if c, ok := op.(IdempotentCloser); ok {
 					// Some operators need an explicit Close if not drained completely of
 					// input.
-					assert.NoError(t, c.Close(ctx))
+					assert.NoError(t, c.IdempotentClose(ctx))
 				}
 			}
 		})

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -220,9 +220,7 @@ func TestOutboxInbox(t *testing.T) {
 
 		outboxMemAcc := testMemMonitor.MakeBoundAccount()
 		defer outboxMemAcc.Close(ctx)
-		outbox, err := NewOutbox(
-			colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, nil,
-		)
+		outbox, err := NewOutbox(colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSource */, nil /* toClose */)
 		require.NoError(t, err)
 
 		inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -460,18 +458,13 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 
 			outboxMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxMemAcc.Close(ctx)
-			outbox, err := NewOutbox(
-				colexec.NewAllocator(ctx, &outboxMemAcc),
-				input,
-				typs,
-				[]execinfrapb.MetadataSource{
-					execinfrapb.CallbackMetadataSource{
-						DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
-							return []execinfrapb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
-						},
+			outbox, err := NewOutbox(colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, []execinfrapb.MetadataSource{
+				execinfrapb.CallbackMetadataSource{
+					DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
+						return []execinfrapb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
 					},
 				},
-			)
+			}, nil /* toClose */)
 			require.NoError(t, err)
 
 			inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -539,10 +532,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err := NewOutbox(
-		colexec.NewAllocator(ctx, &outboxMemAcc),
-		input, typs, nil, /* metadataSources */
-	)
+	outbox, err := NewOutbox(colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSources */, nil /* toClose */)
 	require.NoError(b, err)
 
 	inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -606,9 +596,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err := NewOutbox(
-		colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, nil,
-	)
+	outbox, err := NewOutbox(colexec.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSources */, nil /* toClose */)
 	require.NoError(t, err)
 
 	outboxDone := make(chan struct{})

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -404,10 +404,12 @@ type flowCreatorHelper interface {
 }
 
 // opDAGWithMetaSources is a helper struct that stores an operator DAG as well
-// as the metadataSources in this DAG that need to be drained.
+// as the metadataSources and closers in this DAG that need to be drained and
+// closed.
 type opDAGWithMetaSources struct {
 	rootOperator    colexec.Operator
 	metadataSources []execinfrapb.MetadataSource
+	toClose         []colexec.IdempotentCloser
 }
 
 // remoteComponentCreator is an interface that abstracts the constructors for
@@ -418,6 +420,7 @@ type remoteComponentCreator interface {
 		input colexec.Operator,
 		typs []coltypes.T,
 		metadataSources []execinfrapb.MetadataSource,
+		toClose []colexec.IdempotentCloser,
 	) (*colrpc.Outbox, error)
 	newInbox(allocator *colexec.Allocator, typs []coltypes.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
 }
@@ -429,8 +432,9 @@ func (vectorizedRemoteComponentCreator) newOutbox(
 	input colexec.Operator,
 	typs []coltypes.T,
 	metadataSources []execinfrapb.MetadataSource,
+	toClose []colexec.IdempotentCloser,
 ) (*colrpc.Outbox, error) {
-	return colrpc.NewOutbox(allocator, input, typs, metadataSources)
+	return colrpc.NewOutbox(allocator, input, typs, metadataSources, toClose)
 }
 
 func (vectorizedRemoteComponentCreator) newInbox(
@@ -562,10 +566,11 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	outputTyps []coltypes.T,
 	stream *execinfrapb.StreamEndpointSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
+	toClose []colexec.IdempotentCloser,
 ) (execinfra.OpNode, error) {
 	outbox, err := s.remoteComponentCreator.newOutbox(
 		colexec.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
-		op, outputTyps, metadataSourcesQueue,
+		op, outputTyps, metadataSourcesQueue, toClose,
 	)
 	if err != nil {
 		return nil, err
@@ -605,6 +610,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	outputTyps []coltypes.T,
 	output *execinfrapb.OutputRouterSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
+	toClose []colexec.IdempotentCloser,
 ) error {
 	if output.Type != execinfrapb.OutputRouterSpec_BY_HASH {
 		return errors.Errorf("vectorized output router type %s unsupported", output.Type)
@@ -649,7 +655,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 			return errors.Errorf("unexpected sync response output when setting up router")
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			if _, err := s.setupRemoteOutputStream(
-				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue,
+				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue, toClose,
 			); err != nil {
 				return err
 			}
@@ -668,7 +674,9 @@ func (s *vectorizedFlowCreator) setupRouter(
 					return err
 				}
 			}
-			s.streamIDToInputOp[stream.StreamID] = opDAGWithMetaSources{rootOperator: op, metadataSources: metadataSourcesQueue}
+			s.streamIDToInputOp[stream.StreamID] = opDAGWithMetaSources{
+				rootOperator: op, metadataSources: metadataSourcesQueue, toClose: toClose,
+			}
 		}
 		// Either the metadataSourcesQueue will be drained by an outbox or we
 		// created an opDAGWithMetaSources to pass along these metadataSources. We don't need to
@@ -794,6 +802,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 	op colexec.Operator,
 	opOutputTypes []coltypes.T,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
+	toClose []colexec.IdempotentCloser,
 ) error {
 	output := &pspec.Output[0]
 	if output.Type != execinfrapb.OutputRouterSpec_PASS_THROUGH {
@@ -806,6 +815,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			// Pass in a copy of the queue to reset metadataSourcesQueue for
 			// further appends without overwriting.
 			metadataSourcesQueue,
+			toClose,
 		)
 	}
 
@@ -815,7 +825,9 @@ func (s *vectorizedFlowCreator) setupOutput(
 	outputStream := &output.Streams[0]
 	switch outputStream.Type {
 	case execinfrapb.StreamEndpointSpec_LOCAL:
-		s.streamIDToInputOp[outputStream.StreamID] = opDAGWithMetaSources{rootOperator: op, metadataSources: metadataSourcesQueue}
+		s.streamIDToInputOp[outputStream.StreamID] = opDAGWithMetaSources{
+			rootOperator: op, metadataSources: metadataSourcesQueue, toClose: toClose,
+		}
 	case execinfrapb.StreamEndpointSpec_REMOTE:
 		// Set up an Outbox. Note that we pass in a copy of metadataSourcesQueue
 		// so that we can reset it below and keep on writing to it.
@@ -839,7 +851,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 				},
 			)
 		}
-		outbox, err := s.setupRemoteOutputStream(ctx, flowCtx, op, opOutputTypes, outputStream, metadataSourcesQueue)
+		outbox, err := s.setupRemoteOutputStream(ctx, flowCtx, op, opOutputTypes, outputStream, metadataSourcesQueue, toClose)
 		if err != nil {
 			return err
 		}
@@ -874,6 +886,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			&execinfrapb.PostProcessSpec{},
 			s.syncFlowConsumer,
 			metadataSourcesQueue,
+			toClose,
 			outputStatsToTrace,
 			s.getCancelFlowFn,
 		)
@@ -934,6 +947,10 @@ func (s *vectorizedFlowCreator) setupFlow(
 		// added as part of one of the last unconnected inputDAGs in
 		// streamIDToInputOp. This is to avoid cycles.
 		metadataSourcesQueue := make([]execinfrapb.MetadataSource, 0, 1)
+		// toClose is similar to metadataSourcesQueue with the difference that these
+		// components do not produce metadata and should be Closed even during
+		// non-graceful termination.
+		toClose := make([]colexec.IdempotentCloser, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
 			input, metadataSources, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt)
@@ -979,6 +996,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, errors.Wrapf(err, "not enough memory to setup vectorized plan")
 		}
 		metadataSourcesQueue = append(metadataSourcesQueue, result.MetadataSources...)
+		toClose = append(toClose, result.ToClose...)
 
 		op := result.Op
 		if s.recordingStats {
@@ -1003,7 +1021,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, err
 		}
 		if err = s.setupOutput(
-			ctx, flowCtx, pspec, op, opOutputTypes, metadataSourcesQueue,
+			ctx, flowCtx, pspec, op, opOutputTypes, metadataSourcesQueue, toClose,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -49,6 +50,14 @@ var (
 	consumerClosed    = shutdownScenario{"ConsumerClosed"}
 	shutdownScenarios = []shutdownScenario{consumerDone, consumerClosed}
 )
+
+type callbackCloser struct {
+	closeCb func() error
+}
+
+func (c callbackCloser) IdempotentClose(_ context.Context) error {
+	return c.closeCb()
+}
 
 // TestVectorizedFlowShutdown tests that closing the materializer correctly
 // closes all the infrastructure corresponding to the flow ending in that
@@ -186,6 +195,12 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				synchronizer := colexec.NewParallelUnorderedSynchronizer(synchronizerInputs, typs, &wg)
 				flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 
+				// idToClosed keeps track of whether Close was called for a given id.
+				idToClosed := struct {
+					syncutil.Mutex
+					mapping map[int]bool
+				}{}
+				idToClosed.mapping = make(map[int]bool)
 				runOutboxInbox := func(
 					ctx context.Context,
 					cancelFn context.CancelFunc,
@@ -195,18 +210,21 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					id int,
 					outboxMetadataSources []execinfrapb.MetadataSource,
 				) {
-					outbox, err := colrpc.NewOutbox(
-						colexec.NewAllocator(ctx, outboxMemAcc),
-						outboxInput,
-						typs,
-						append(outboxMetadataSources,
-							execinfrapb.CallbackMetadataSource{
-								DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
-									return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
-								},
+					idToClosed.Lock()
+					idToClosed.mapping[id] = false
+					idToClosed.Unlock()
+					outbox, err := colrpc.NewOutbox(colexec.NewAllocator(ctx, outboxMemAcc), outboxInput, typs, append(outboxMetadataSources,
+						execinfrapb.CallbackMetadataSource{
+							DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+								return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
 							},
-						),
-					)
+						},
+					), []colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+						idToClosed.Lock()
+						idToClosed.mapping[id] = true
+						idToClosed.Unlock()
+						return nil
+					}}})
 					require.NoError(t, err)
 					wg.Add(1)
 					go func(id int) {
@@ -278,6 +296,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				}
 
 				ctxLocal, cancelLocal := context.WithCancel(ctxLocal)
+				materializerCalledClose := false
 				materializer, err := colexec.NewMaterializer(
 					flowCtx,
 					1, /* processorID */
@@ -286,6 +305,10 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					&execinfrapb.PostProcessSpec{},
 					nil, /* output */
 					materializerMetadataSources,
+					[]colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+						materializerCalledClose = true
+						return nil
+					}}}, /* toClose */
 					nil, /* outputStatsToTrace */
 					func() context.CancelFunc { return cancelLocal },
 				)
@@ -336,6 +359,11 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					}
 				}
 				wg.Wait()
+				// Ensure all the outboxes called Close.
+				for id, closed := range idToClosed.mapping {
+					require.True(t, closed, "outbox with ID %d did not call Close on closers", id)
+				}
+				require.True(t, materializerCalledClose)
 			})
 		}
 	}

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -44,6 +44,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	input colexec.Operator,
 	typs []coltypes.T,
 	metadataSources []execinfrapb.MetadataSource,
+	toClose []colexec.IdempotentCloser,
 ) (*colrpc.Outbox, error) {
 	return c.newOutboxFn(allocator, input, typs, metadataSources)
 }
@@ -198,7 +199,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			// expect from the input DAG.
 			require.Len(t, sources, 1)
 			require.Len(t, inboxToNumInputTypes[sources[0].(*colrpc.Inbox)], numInputTypesToOutbox)
-			return colrpc.NewOutbox(allocator, op, typs, sources)
+			return colrpc.NewOutbox(allocator, op, typs, sources, nil /* toClose */)
 		},
 		newInboxFn: func(allocator *colexec.Allocator, typs []coltypes.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
 			inbox, err := colrpc.NewInbox(allocator, typs, streamID)

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -79,6 +79,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		[]execinfrapb.MetadataSource{col},
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -60,6 +60,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourceQueue */
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)
@@ -107,6 +108,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourceQueue */
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -141,6 +141,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		result.MetadataSources,
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -62,6 +62,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		&execinfrapb.PostProcessSpec{},
 		&distsqlutils.RowBuffer{},
 		nil, /* metadataSourceQueue */
+		nil, /* toClose */
 		nil, /* outputStatsToTrace */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -249,6 +249,7 @@ func TestEval(t *testing.T) {
 				&execinfrapb.PostProcessSpec{},
 				nil, /* output */
 				nil, /* metadataSourcesQueue */
+				nil, /* toClose */
 				nil, /* outputStatsToTrace */
 				nil, /* cancelFlow */
 			)


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new functionality.
External operators would not be Closed if not drained completely, which is not
the case with a downstream limit. The flow would clean up disk space/file
descriptors, but this commit makes it so that Close is called on these
operators in cases where the operator is not fully drained.

These are only external storage operators that need to be explicitly told to
close when not drained of input (e.g. due to a downstream limit). When creating
a component, it can now be added to result.ToClose, which will add it to the
first downstream outbox or materializer (there must be at least one in the
flow) to close either on graceful or non-graceful termination.

Release note (bug fix): resources including disk space and file descriptors were
only being cleaned up at the end of a query's execution. This now happens as
early as possible.

Closes #44652 