### PR TITLE
colexec: fallback gracefully to rowexec on cross joins in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -104,3 +104,17 @@ EXPLAIN (VEC) SELECT stddev(0) FROM t46123 WHERE ('' COLLATE en)::BOOL
 └ Node 1
 └ *rowexec.orderedAggregator
   └ *rowexec.tableReader
+
+# Regression test for #46122 (checking that we gracefully fallback to row
+# execution on cross joins).
+statement ok
+CREATE TABLE t46122_0(c0 STRING); CREATE TABLE t46122_1(c0 STRING)
+
+query T
+EXPLAIN (VEC) SELECT t46122_0.c0 FROM t46122_0, t46122_1
+----
+│
+└ Node 1
+└ *rowexec.hashJoiner
+  ├ *colexec.colBatchScan
+  └ *colexec.colBatchScan

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -301,7 +301,7 @@ EXPLAIN (VERBOSE) SELECT a.v FROM kv a, kv b GROUP BY a.v, a.w, a.s
 ]
 ----
 ·                     distributed  false
-·                     vectorized   false
+·                     vectorized   true
 render                ·            ·
  │                    render 0     v
  └── distinct         ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -83,7 +83,7 @@ EXPLAIN (VERBOSE)
     w, table39010
 ----
 ·           distributed  false               ·      ·
-·           vectorized   false               ·      ·
+·           vectorized   true                ·      ·
 cross-join  ·            ·                   (col)  ·
  │          type         cross               ·      ·
  ├── scan   ·            ·                   ()     ·


### PR DESCRIPTION
Release justification: bug fix.

Both in-memory and external hash joiners have a built-in assumption of
non-empty input schemas, however, a cross join can occur with an empty
input schema on one of the sides. Previously, this would result in an
ungraceful fallback to row execution (the "ungracefullness" could be
seen when running `EXPLAIN (VEC)` on the query, but executing the query
itself would be ok), but now we detect such cases during planning and
perform a graceful fallback.

Fixes: #46122.

Release note: None