### PR TITLE
release-19.2: sql: fix bug where some session vars couldn't be set to "on" or "off"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -319,3 +319,14 @@ SET DATESTYLE = ISO;
   SET lock_timeout = 0;
   SET idle_in_transaction_session_timeout = 0;
   SET row_security = off;
+
+# Ensure that we can set variables to on/off.
+statement ok
+SET enable_zigzag_join = 'on';
+SET enable_zigzag_join = 'off';
+SET enable_zigzag_join = 'true';
+SET enable_zigzag_join = 'false';
+SET enable_zigzag_join = on;
+SET enable_zigzag_join = off;
+SET enable_zigzag_join = true;
+SET enable_zigzag_join = false


### PR DESCRIPTION
Backport 1/1 commits from #46163.

/cc @cockroachdb/release

---

Session variables were incorrectly erroring out on
string inputs even though string values of "on" and
"off" are accepted.

Fixes #46161.

Release justification: bug fix
Release note (bug fix): This PR fixes a bug where various session
variables whose value would display as "on" or "off" could not be
set to the values "on" or "off", only true or false.
