### PR TITLE
sql: change messaging for non-partitioned indexes on partitioned table

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -925,19 +925,25 @@ scan ok12
 statement error null value in column "a" violates not-null constraint
 INSERT INTO ok12 (a, b, c) VALUES (NULL, 2, 3)
 
+query T noticetrace
+CREATE INDEX non_partitioned_idx ON ok1 (c)
+----
+NOTICE: creating non-partitioned index on partitioned table may not be performant
+HINT: Consider modifying the index such that it is also partitioned.
+
 statement ok
-SET sql_safe_updates = true
+DROP INDEX ok1@non_partitioned_idx
 
-statement error non-partitioned index on partitioned table
-CREATE INDEX ON ok1 (c)
-
-statement error non-partitioned index on partitioned table
+query T noticetrace
 CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX (b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1)
 )
+----
+NOTICE: creating non-partitioned index on partitioned table may not be performant
+HINT: Consider modifying the index such that it is also partitioned.
 
 statement ok
-RESET sql_safe_updates
+DROP TABLE t
 
 # regression tests for #40450
 statement ok

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -176,13 +176,19 @@ func (n *createTableNode) startExec(params runParams) error {
 		telemetry.Inc(sqltelemetry.CreateTempTableCounter)
 	}
 
-	// Guard against creating non-partitioned indexes on a partitioned table,
+	// Warn against creating non-partitioned indexes on a partitioned table,
 	// which is undesirable in most cases.
-	if params.SessionData().SafeUpdates && n.n.PartitionBy != nil {
+	if n.n.PartitionBy != nil {
 		for _, def := range n.n.Defs {
 			if d, ok := def.(*tree.IndexTableDef); ok {
 				if d.PartitionBy == nil {
-					return pgerror.DangerousStatementf("non-partitioned index on partitioned table")
+					params.p.SendClientNotice(
+						params.ctx,
+						errors.WithHint(
+							pgerror.Noticef("creating non-partitioned index on partitioned table may not be performant"),
+							"Consider modifying the index such that it is also partitioned.",
+						),
+					)
 				}
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/43359

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): Previously, when creating a non-partitioned
index on a partitioned table with "sql_safe_updates = true", we would
error out. In the new change, we instead will send a NOTICE stating that
creating a non-partitioned index on a partitioned table stating it is
not performant.