### PR TITLE
opt: include distsql diagrams in EXPLAIN BUNDLE

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -322,6 +322,7 @@ func wrapWithVectorizedStatsCollector(
 // outputs their stats to the trace contained in the ctx's span.
 func finishVectorizedStatsCollectors(
 	ctx context.Context,
+	flowID execinfrapb.FlowID,
 	deterministicStats bool,
 	vectorizedStatsCollectors []*colexec.VectorizedStatsCollector,
 	procIDs []int32,
@@ -335,6 +336,7 @@ func finishVectorizedStatsCollectors(
 		// away which is not the way they are supposed to be used, so this
 		// should be fixed.
 		_, spansByProcID[pid] = tracing.ChildSpan(ctx, fmt.Sprintf("operator for processor %d", pid))
+		spansByProcID[pid].SetTag(execinfrapb.FlowIDTagKey, flowID.String())
 		spansByProcID[pid].SetTag(execinfrapb.ProcessorIDTagKey, pid)
 	}
 	for _, vsc := range vectorizedStatsCollectors {
@@ -799,7 +801,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
 						ctx, span := tracing.ChildSpanSeparateRecording(ctx, "")
-						finishVectorizedStatsCollectors(ctx, flowCtx.Cfg.TestingKnobs.DeterministicStats, vscs, s.procIDs)
+						finishVectorizedStatsCollectors(ctx, flowCtx.ID, flowCtx.Cfg.TestingKnobs.DeterministicStats, vscs, s.procIDs)
 						return []execinfrapb.ProducerMetadata{{TraceData: tracing.GetRecording(span)}}
 					},
 				},
@@ -828,7 +830,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			vscq := append([]*colexec.VectorizedStatsCollector(nil), s.vectorizedStatsCollectorsQueue...)
 			outputStatsToTrace = func() {
 				finishVectorizedStatsCollectors(
-					ctx, flowCtx.Cfg.TestingKnobs.DeterministicStats, vscq, s.procIDs,
+					ctx, flowCtx.ID, flowCtx.Cfg.TestingKnobs.DeterministicStats, vscq, s.procIDs,
 				)
 			}
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -836,6 +837,11 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	planCtx.isLocal = !distribute
 	planCtx.planner = planner
 	planCtx.stmtType = recv.stmtType
+	if planner.collectBundle {
+		planCtx.saveDiagram = func(diagram execinfrapb.FlowDiagram) {
+			planner.curPlan.distSQLDiagrams = append(planner.curPlan.distSQLDiagrams, diagram)
+		}
+	}
 
 	var evalCtxFactory func() *extendedEvalContext
 	if len(planner.curPlan.subqueryPlans) != 0 || len(planner.curPlan.postqueryPlans) != 0 {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -536,6 +536,13 @@ type PlanningCtx struct {
 	// noEvalSubqueries indicates that the plan expects any subqueries to not
 	// be replaced by evaluation. Should only be set by EXPLAIN.
 	noEvalSubqueries bool
+
+	// If set, a diagram for the plan will be generated and passed to this
+	// function.
+	saveDiagram func(execinfrapb.FlowDiagram)
+	// If set, the diagram passed to saveDiagram will show the types of each
+	// stream.
+	saveDiagramShowInputTypes bool
 }
 
 var _ physicalplan.ExprContext = &PlanningCtx{}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -324,8 +324,24 @@ func (dsp *DistSQLPlanner) Run(
 		return func() {}
 	}
 
-	if logPlanDiagram {
+	if planCtx.saveDiagram != nil {
 		log.VEvent(ctx, 1, "creating plan diagram")
+		var stmtStr string
+		if planCtx.planner != nil && planCtx.planner.stmt != nil {
+			stmtStr = planCtx.planner.stmt.String()
+		}
+		diagram, err := execinfrapb.GeneratePlanDiagram(
+			stmtStr, flows, planCtx.saveDiagramShowInputTypes,
+		)
+		if err != nil {
+			recv.SetError(err)
+			return func() {}
+		}
+		planCtx.saveDiagram(diagram)
+	}
+
+	if logPlanDiagram {
+		log.VEvent(ctx, 1, "creating plan diagram for logging")
 		var stmtStr string
 		if planCtx.planner != nil && planCtx.planner.stmt != nil {
 			stmtStr = planCtx.planner.stmt.String()
@@ -858,10 +874,14 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryPlanCtx.isLocal = !distributeSubquery
 	subqueryPlanCtx.planner = planner
 	subqueryPlanCtx.stmtType = tree.Rows
+	if planner.collectBundle {
+		subqueryPlanCtx.saveDiagram = func(diagram execinfrapb.FlowDiagram) {
+			planner.curPlan.distSQLDiagrams = append(planner.curPlan.distSQLDiagrams, diagram)
+		}
+	}
 	// Don't close the top-level plan from subqueries - someone else will handle
 	// that.
 	subqueryPlanCtx.ignoreClose = true
-
 	subqueryPhysPlan, err := dsp.createPlanForNode(subqueryPlanCtx, subqueryPlan.plan)
 	if err != nil {
 		return err
@@ -1063,6 +1083,11 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryPlanCtx.planner = planner
 	postqueryPlanCtx.stmtType = tree.Rows
 	postqueryPlanCtx.ignoreClose = true
+	if planner.collectBundle {
+		postqueryPlanCtx.saveDiagram = func(diagram execinfrapb.FlowDiagram) {
+			planner.curPlan.distSQLDiagrams = append(planner.curPlan.distSQLDiagrams, diagram)
+		}
+	}
 
 	postqueryPhysPlan, err := dsp.createPlanForNode(postqueryPlanCtx, postqueryPlan.plan)
 	if err != nil {

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -823,8 +823,9 @@ func ProcessorSpan(ctx context.Context, name string) (context.Context, opentraci
 func (pb *ProcessorBase) StartInternal(ctx context.Context, name string) context.Context {
 	pb.origCtx = ctx
 	pb.Ctx, pb.span = ProcessorSpan(ctx, name)
-	if pb.span != nil {
-		pb.span.SetTag(tracing.TagPrefix+"processorid", pb.processorID)
+	if pb.span != nil && tracing.IsRecording(pb.span) {
+		pb.span.SetTag(execinfrapb.FlowIDTagKey, pb.FlowCtx.ID.String())
+		pb.span.SetTag(execinfrapb.ProcessorIDTagKey, pb.processorID)
 	}
 	pb.EvalCtx.Context = pb.Ctx
 	return pb.Ctx

--- a/pkg/sql/execinfrapb/stats.go
+++ b/pkg/sql/execinfrapb/stats.go
@@ -12,6 +12,9 @@ package execinfrapb
 
 import "github.com/cockroachdb/cockroach/pkg/util/tracing"
 
+// FlowIDTagKey is the key used for flow id tags in tracing spans.
+const FlowIDTagKey = tracing.TagPrefix + "flowid"
+
 // StreamIDTagKey is the key used for stream id tags in tracing spans.
 const StreamIDTagKey = tracing.TagPrefix + "streamid"
 

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -207,6 +207,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 	ctx, span = execinfra.ProcessorSpan(ctx, "outbox")
 	if span != nil && tracing.IsRecording(span) {
 		m.statsCollectionEnabled = true
+		span.SetTag(execinfrapb.FlowIDTagKey, m.flowCtx.ID.String())
 		span.SetTag(execinfrapb.StreamIDTagKey, m.streamID)
 	}
 	// spanFinished specifies whether we called tracing.FinishSpan on the span.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -315,6 +316,9 @@ type planTop struct {
 	avoidBuffering bool
 
 	instrumentation planInstrumentation
+
+	// If we are collecting query diagnostics, flow diagrams are saved here.
+	distSQLDiagrams []execinfrapb.FlowDiagram
 }
 
 // postquery is a query tree that is executed after the main one. It can only

--- a/pkg/sql/statement_diagnostics.go
+++ b/pkg/sql/statement_diagnostics.go
@@ -490,7 +490,7 @@ func getTraceAndBundle(
 	trace tracing.Recording, plan *planTop,
 ) (traceJSON tree.Datum, bundle *bytes.Buffer, _ error) {
 	traceJSON, traceStr, err := traceToJSON(trace)
-	bundle, bundleErr := buildStatementBundle(plan, traceStr)
+	bundle, bundleErr := buildStatementBundle(plan, trace, traceStr)
 	if bundleErr != nil {
 		if err == nil {
 			err = bundleErr


### PR DESCRIPTION
#### opt: include distsql diagrams in EXPLAIN BUNDLE

This change adds EXPLAIN ANALYZE diagrams in the statement diagnostics bundle.
Each subquery or postquery gets its own diagram. The added infrastructure is
also used to improve the existing EXPLAIN ANALYZE code - we can get a diagram
without having to generate the flow specs twice.

Release note (sql change): EXPLAIN BUNDLE now contains distsql diagrams.

Release justification: bug fixes and low-risk updates to new functionality.

#### sql: disambiguate distsql stats for subqueries/postqueries

EXPLAIN ANALYZE collects execution stats through span tags. Processor and outbox
streams contain an ID as their tag. This is insufficient when the same trace
covers multiple flows, as is the case with EXPLAIN BUNDLE and a statement that
has subqueries / postqueries.

This change adds the FlowID as a tag as well, allowing us to select the correct
subset of spans for each diagram.

Release note: None

Release justification: Bug fixes and low-risk updates to new functionality