### PR TITLE
opt: fix for subquery that uses view and refers to outer table

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -89,3 +89,31 @@ scalar-group-by
  └── aggregations
       └── array-agg [as=array_agg:6]
            └── f:3
+
+# Verify that an outer table is visible from a subquery that uses
+# a view (#46180).
+exec-ddl
+CREATE VIEW v AS SELECT x FROM (VALUES (1), (2)) AS foo(x);
+----
+
+build
+SELECT (SELECT x FROM v WHERE x=t.a) FROM (VALUES (3), (4)) AS t(a);
+----
+project
+ ├── columns: x:3
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── (3,)
+ │    └── (4,)
+ └── projections
+      └── subquery [as=x:3]
+           └── max1-row
+                ├── columns: column1:2!null
+                └── select
+                     ├── columns: column1:2!null
+                     ├── values
+                     │    ├── columns: column1:2!null
+                     │    ├── (1,)
+                     │    └── (2,)
+                     └── filters
+                          └── column1:2 = column1:1


### PR DESCRIPTION
When a subquery uses a view, the higher scopes are lost and the subquery can't
refer to outer tables. This change fixes this by passing the inScope when we
build the view.

Fixes #46180.

Release note (bug fix): fixed incorrect "no data source matches prefix" error in
some cases involving subqueries that use views.

Release justification: low risk change to existing functionality.