### PR TITLE
opt: fix some aggregate scoping issues

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1072,7 +1072,7 @@ NULL  NULL
 query error generator functions are not allowed in ON
 SELECT * FROM foo JOIN bar ON generate_series(0, 1) < 2
 
-query error aggregate functions are not allowed in ON
+query error aggregate functions are not allowed in JOIN conditions
 SELECT * FROM foo JOIN bar ON max(foo.c) < 2
 
 # Regression test for #44029 (outer join on two single-row clauses, with two

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -53,12 +53,12 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 	// Build the expiration scalar.
 	var expiration opt.ScalarExpr
 	if split.ExpireExpr != nil {
-		emptyScope.context = "ALTER TABLE SPLIT AT"
+		emptyScope.context = exprKindAlterTableSplitAt
 		// We need to save and restore the previous value of the field in
 		// semaCtx in case we are recursively called within a subquery
 		// context.
 		defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-		b.semaCtx.Properties.Require(emptyScope.context, tree.RejectSpecial)
+		b.semaCtx.Properties.Require(emptyScope.context.String(), tree.RejectSpecial)
 
 		texpr := emptyScope.resolveType(split.ExpireExpr, types.String)
 		expiration = b.buildScalar(texpr, emptyScope, nil /* outScope */, nil /* outCol */, nil /* colRefs */)

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -178,8 +178,8 @@ func (b *Builder) analyzeDistinctOnArgs(
 	// semaCtx in case we are recursively called within a subquery
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require("DISTINCT ON", tree.RejectGenerators)
-	inScope.context = "DISTINCT ON"
+	b.semaCtx.Properties.Require(exprKindDistinctOn.String(), tree.RejectGenerators)
+	inScope.context = exprKindDistinctOn
 
 	for i := range distinctOn {
 		b.analyzeExtraArgument(distinctOn[i], inScope, projectionsScope, distinctOnScope)

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -434,8 +434,10 @@ func (b *Builder) analyzeHaving(having *tree.Where, fromScope *scope) tree.Typed
 	// We need to save and restore the previous value of the field in semaCtx
 	// in case we are recursively called within a subquery context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require("HAVING", tree.RejectWindowApplications|tree.RejectGenerators)
-	fromScope.context = "HAVING"
+	b.semaCtx.Properties.Require(
+		exprKindHaving.String(), tree.RejectWindowApplications|tree.RejectGenerators,
+	)
+	fromScope.context = exprKindHaving
 	return fromScope.resolveAndRequireType(having.Expr, types.Bool)
 }
 
@@ -589,8 +591,8 @@ func (b *Builder) buildGrouping(
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 
 	// Make sure the GROUP BY columns have no special functions.
-	b.semaCtx.Properties.Require("GROUP BY", tree.RejectSpecial)
-	fromScope.context = "GROUP BY"
+	b.semaCtx.Properties.Require(exprKindGroupBy.String(), tree.RejectSpecial)
+	fromScope.context = exprKindGroupBy
 
 	// Resolve types, expand stars, and flatten tuples.
 	exprs := b.expandStarAndResolveType(groupBy, fromScope)

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -26,14 +26,14 @@ func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
 	if limit.Offset != nil {
 		input := inScope.expr.(memo.RelExpr)
 		offset := b.resolveAndBuildScalar(
-			limit.Offset, types.Int, "OFFSET", tree.RejectSpecial, parentScope,
+			limit.Offset, types.Int, exprKindOffset, tree.RejectSpecial, parentScope,
 		)
 		inScope.expr = b.factory.ConstructOffset(input, offset, inScope.makeOrderingChoice())
 	}
 	if limit.Count != nil {
 		input := inScope.expr.(memo.RelExpr)
 		limit := b.resolveAndBuildScalar(
-			limit.Count, types.Int, "LIMIT", tree.RejectSpecial, parentScope,
+			limit.Count, types.Int, exprKindLimit, tree.RejectSpecial, parentScope,
 		)
 		inScope.expr = b.factory.ConstructLimit(input, limit, inScope.makeOrderingChoice())
 	}

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -36,8 +36,8 @@ func (b *Builder) analyzeOrderBy(
 	// semaCtx in case we are recursively called within a subquery
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require("ORDER BY", tree.RejectGenerators)
-	inScope.context = "ORDER BY"
+	b.semaCtx.Properties.Require(exprKindOrderBy.String(), tree.RejectGenerators)
+	inScope.context = exprKindOrderBy
 
 	for i := range orderBy {
 		b.analyzeOrderByArg(orderBy[i], inScope, projectionsScope, orderByScope)
@@ -231,12 +231,12 @@ func (b *Builder) analyzeExtraArgument(
 	//    e.g. SELECT a, b FROM t ORDER by a+b
 
 	// First, deal with projection aliases.
-	idx := colIdxByProjectionAlias(expr, inScope.context, projectionsScope)
+	idx := colIdxByProjectionAlias(expr, inScope.context.String(), projectionsScope)
 
 	// If the expression does not refer to an alias, deal with
 	// column ordinals.
 	if idx == -1 {
-		idx = colIndex(len(projectionsScope.cols), expr, inScope.context)
+		idx = colIndex(len(projectionsScope.cols), expr, inScope.context.String())
 	}
 
 	var exprs tree.TypedExprs

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -77,8 +77,8 @@ func (b *Builder) analyzeProjectionList(
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 	defer func(replaceSRFs bool) { inScope.replaceSRFs = replaceSRFs }(inScope.replaceSRFs)
 
-	b.semaCtx.Properties.Require("SELECT", tree.RejectNestedGenerators)
-	inScope.context = "SELECT"
+	b.semaCtx.Properties.Require(exprKindSelect.String(), tree.RejectNestedGenerators)
+	inScope.context = exprKindSelect
 	inScope.replaceSRFs = true
 
 	b.analyzeSelectList(selects, desiredTypes, inScope, outScope)
@@ -96,8 +96,8 @@ func (b *Builder) analyzeReturningList(
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 
 	// Ensure there are no special functions in the RETURNING clause.
-	b.semaCtx.Properties.Require("RETURNING", tree.RejectSpecial)
-	inScope.context = "RETURNING"
+	b.semaCtx.Properties.Require(exprKindReturning.String(), tree.RejectSpecial)
+	inScope.context = exprKindReturning
 
 	b.analyzeSelectList(tree.SelectExprs(returning), desiredTypes, inScope, outScope)
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -572,7 +572,7 @@ func (b *Builder) checkSubqueryOuterCols(
 		aggCols := inScope.groupby.aggregateResultCols()
 		for i := range aggCols {
 			if subqueryOuterCols.Contains(aggCols[i].id) {
-				panic(tree.NewInvalidFunctionUsageError(tree.AggregateClass, inScope.context))
+				panic(tree.NewInvalidFunctionUsageError(tree.AggregateClass, inScope.context.String()))
 			}
 		}
 	}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1036,7 +1036,13 @@ func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
 		return
 	}
 
-	filter := b.resolveAndBuildScalar(where.Expr, types.Bool, "WHERE", tree.RejectSpecial, inScope)
+	filter := b.resolveAndBuildScalar(
+		where.Expr,
+		types.Bool,
+		exprKindWhere,
+		tree.RejectGenerators|tree.RejectWindowApplications,
+		inScope,
+	)
 
 	// Wrap the filter in a FiltersOp.
 	inScope.expr = b.factory.ConstructSelect(
@@ -1140,6 +1146,7 @@ func (b *Builder) buildFromWithLateral(
 		// have been built already.
 		if b.exprIsLateral(tables[i]) {
 			scope = outScope
+			scope.context = exprKindLateralJoin
 		}
 		tableScope := b.buildDataSource(tables[i], nil /* indexFlags */, locking, scope)
 

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -75,9 +75,9 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// semaCtx in case we are recursively called within a subquery
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require("FROM",
+	b.semaCtx.Properties.Require(exprKindFrom.String(),
 		tree.RejectAggregates|tree.RejectWindowApplications|tree.RejectNestedGenerators)
-	inScope.context = "FROM"
+	inScope.context = exprKindFrom
 
 	// Build each of the provided expressions.
 	zip := make(memo.ZipExpr, len(exprs))

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -549,7 +549,7 @@ error (42803): column "v" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT k FROM kv WHERE avg(k) > 1
 ----
-error (42803): avg(): aggregate functions are not allowed in WHERE
+error (42803): aggregate functions are not allowed in WHERE
 
 build
 SELECT max(avg(k)) FROM kv
@@ -3651,3 +3651,151 @@ project
            │    └── column5:5
            └── sum [as=sum:8]
                 └── column7:7
+
+# Regression test for #44724.
+build
+SELECT *
+  FROM (SELECT 1 AS one, v FROM kv) AS kv
+  JOIN LATERAL (
+        SELECT b, sum(one) FROM abxy
+       ) AS abxy ON kv.v = abxy.b
+----
+error (42803): aggregate functions are not allowed in FROM clause of their own query level
+
+# Regression test for #45838. The aggregate should be allowed in the WHERE
+# clause since it's scoped at the outer level.
+build
+  SELECT sum(x)
+    FROM abxy AS t
+GROUP BY y
+  HAVING EXISTS(SELECT 1 FROM abxy AS t2 WHERE sum(t.x) = 1)
+----
+project
+ ├── columns: sum:5
+ └── select
+      ├── columns: t.y:4 sum:5
+      ├── group-by
+      │    ├── columns: t.y:4 sum:5
+      │    ├── grouping columns: t.y:4
+      │    ├── project
+      │    │    ├── columns: t.x:3 t.y:4
+      │    │    └── scan t
+      │    │         └── columns: t.a:1!null t.b:2!null t.x:3 t.y:4
+      │    └── aggregations
+      │         └── sum [as=sum:5]
+      │              └── t.x:3
+      └── filters
+           └── exists
+                └── project
+                     ├── columns: "?column?":11!null
+                     ├── select
+                     │    ├── columns: t2.a:6!null t2.b:7!null t2.x:8 t2.y:9
+                     │    ├── scan t2
+                     │    │    └── columns: t2.a:6!null t2.b:7!null t2.x:8 t2.y:9
+                     │    └── filters
+                     │         └── sum:5 = 1
+                     └── projections
+                          └── 1 [as="?column?":11]
+
+exec-ddl
+CREATE TABLE onek (
+        unique1         int,
+        unique2         int,
+        two                     int,
+        four            int,
+        ten                     int,
+        twenty          int,
+        hundred         int,
+        thousand        int,
+        twothousand     int,
+        fivethous       int,
+        tenthous        int,
+        odd                     int,
+        even            int,
+        stringu1        string,
+        stringu2        string,
+        string4         string
+)
+----
+
+# Regression tests for #30652.
+build
+  SELECT ten, sum(DISTINCT four)
+    FROM onek AS a
+GROUP BY ten
+  HAVING EXISTS(
+            SELECT 1 FROM onek AS b WHERE sum(DISTINCT a.four) = b.four
+         )
+----
+select
+ ├── columns: ten:5 sum:18
+ ├── group-by
+ │    ├── columns: a.ten:5 sum:18
+ │    ├── grouping columns: a.ten:5
+ │    ├── project
+ │    │    ├── columns: a.four:4 a.ten:5
+ │    │    └── scan a
+ │    │         └── columns: a.unique1:1 a.unique2:2 a.two:3 a.four:4 a.ten:5 a.twenty:6 a.hundred:7 a.thousand:8 a.twothousand:9 a.fivethous:10 a.tenthous:11 a.odd:12 a.even:13 a.stringu1:14 a.stringu2:15 a.string4:16 a.rowid:17!null
+ │    └── aggregations
+ │         └── agg-distinct [as=sum:18]
+ │              └── sum
+ │                   └── a.four:4
+ └── filters
+      └── exists
+           └── project
+                ├── columns: "?column?":37!null
+                ├── select
+                │    ├── columns: b.unique1:19 b.unique2:20 b.two:21 b.four:22!null b.ten:23 b.twenty:24 b.hundred:25 b.thousand:26 b.twothousand:27 b.fivethous:28 b.tenthous:29 b.odd:30 b.even:31 b.stringu1:32 b.stringu2:33 b.string4:34 b.rowid:35!null
+                │    ├── scan b
+                │    │    └── columns: b.unique1:19 b.unique2:20 b.two:21 b.four:22 b.ten:23 b.twenty:24 b.hundred:25 b.thousand:26 b.twothousand:27 b.fivethous:28 b.tenthous:29 b.odd:30 b.even:31 b.stringu1:32 b.stringu2:33 b.string4:34 b.rowid:35!null
+                │    └── filters
+                │         └── sum:18 = b.four:22
+                └── projections
+                     └── 1 [as="?column?":37]
+
+build
+  SELECT ten, sum(DISTINCT four)
+    FROM onek AS a
+GROUP BY ten
+  HAVING EXISTS(
+            SELECT 1
+              FROM onek AS b
+             WHERE sum(DISTINCT a.four + b.four) = b.four
+         )
+----
+error (42803): aggregate functions are not allowed in WHERE
+
+build
+SELECT (
+        SELECT t2.a
+          FROM abxy AS t2 JOIN abxy AS t3 ON sum(t1.x) = t3.x
+       )
+  FROM abxy AS t1
+----
+project
+ ├── columns: a:15
+ ├── scalar-group-by
+ │    ├── columns: sum:14
+ │    ├── project
+ │    │    ├── columns: x:13
+ │    │    ├── scan t1
+ │    │    │    └── columns: t1.a:1!null t1.b:2!null t1.x:3 t1.y:4
+ │    │    └── projections
+ │    │         └── t1.x:3 [as=x:13]
+ │    └── aggregations
+ │         └── sum [as=sum:14]
+ │              └── x:13
+ └── projections
+      └── subquery [as=a:15]
+           └── max1-row
+                ├── columns: t2.a:5!null
+                └── project
+                     ├── columns: t2.a:5!null
+                     └── inner-join (cross)
+                          ├── columns: t2.a:5!null t2.b:6!null t2.x:7 t2.y:8 t3.a:9!null t3.b:10!null t3.x:11!null t3.y:12
+                          ├── scan t2
+                          │    └── columns: t2.a:5!null t2.b:6!null t2.x:7 t2.y:8
+                          ├── scan t3
+                          │    └── columns: t3.a:9!null t3.b:10!null t3.x:11 t3.y:12
+                          └── filters
+                               └── sum:14 = t3.x:11

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -2380,7 +2380,7 @@ error (0A000): generate_series(): generator functions are not allowed in ON
 build
 SELECT * FROM foo JOIN bar ON max(foo.c) < 2
 ----
-error (42803): max(): aggregate functions are not allowed in ON
+error (42803): aggregate functions are not allowed in JOIN conditions
 
 # Verify join hints get populated.
 build

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -423,13 +423,17 @@ func colsToColList(cols []scopeColumn) opt.ColList {
 
 // resolveAndBuildScalar is used to build a scalar with a required type.
 func (b *Builder) resolveAndBuildScalar(
-	expr tree.Expr, requiredType *types.T, context string, flags tree.SemaRejectFlags, inScope *scope,
+	expr tree.Expr,
+	requiredType *types.T,
+	context exprKind,
+	flags tree.SemaRejectFlags,
+	inScope *scope,
 ) opt.ScalarExpr {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require(context, flags)
+	b.semaCtx.Properties.Require(context.String(), flags)
 
 	inScope.context = context
 	texpr := inScope.resolveAndRequireType(expr, requiredType)

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -40,8 +40,8 @@ func (b *Builder) buildValuesClause(
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 
 	// Ensure there are no special functions in the clause.
-	b.semaCtx.Properties.Require("VALUES", tree.RejectSpecial)
-	inScope.context = "VALUES"
+	b.semaCtx.Properties.Require(exprKindValues.String(), tree.RejectSpecial)
+	inScope.context = exprKindValues
 
 	// Typing a VALUES clause is not trivial; consider:
 	//   VALUES (NULL), (1)


### PR DESCRIPTION
Prior to this commit, some aggregate functions were either incorrectly
rejected or incorrectly accepted when they were scoped at a higher
level than their position in the query. For example, aggregate functions
are not normally allowed in `WHERE`, but if the aggregate is actually scoped
at a higher level, then the aggregate should be allowed. Prior to this
commit, these aggregate functions were rejected and caused an error.

This commit fixes the issue by validating the context of the aggregate's
scope rather than the aggregate's position in the query. In order to
avoid adding another field to the scope struct, this commit re-uses
the existing `context` field which was previously only used for error
messages. To make comparisons more efficient, the field is now an enum
rather than a string.

Fixes #44724
Fixes #45838
Fixes #30652

Release justification: This bug fix is a low risk, high benefit change
to existing functionality, since it fixes internal errors and increases
compatibility with Postgres.

Release note (bug fix): Fixed an internal error that could occur when
an aggregate inside the right-hand side of a LATERAL join was scoped at
the level of the left-hand side.

Release note (bug fix): Fixed an error that incorrectly occurred when
an aggregate was used inside the WHERE or ON clause of a subquery but
was scoped at an outer level of the query.