### PR TITLE
opt: add safe logging to new test code

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -214,13 +214,15 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 			right := e.Child(1).(RelExpr)
 			// The left side cannot depend on the right side columns.
 			if left.Relational().OuterCols.Intersects(right.Relational().OutputCols) {
-				panic(errors.AssertionFailedf("%s left side has outer cols in right side", e.Op()))
+				panic(errors.AssertionFailedf(
+					"%s left side has outer cols in right side", log.Safe(e.Op()),
+				))
 			}
 
 			// The reverse is allowed but only for apply variants.
 			if !opt.IsJoinApplyOp(e) {
 				if right.Relational().OuterCols.Intersects(left.Relational().OutputCols) {
-					panic(errors.AssertionFailedf("%s is correlated", e.Op()))
+					panic(errors.AssertionFailedf("%s is correlated", log.Safe(e.Op())))
 				}
 			}
 			checkFilters(*e.Child(2).(*FiltersExpr))


### PR DESCRIPTION
In a small oversight, #46153 added some new checks to the
`check_expr.go file`, but did not wrap the error messages with
`log.Safe`. This commit fixes these error messages to match
the rest of the file.

Release justification: This is a low-risk bug fix to new functionality.
Release note: None