### PR TITLE
opt: allow qualified star without FROM clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1431,21 +1431,21 @@ query error pq: cos\(\): cannot use "\*" in this context
 SELECT cos(*) FROM system.namespace
 
 # Don't panic with invalid names (#8045)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT TRIM(TRAILING nonexistent.*[1])
 
 query error rtrim\(\): cannot subscript type tuple
 SELECT TRIM(TRAILING foo.*[1]) FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8044)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT OVERLAY(nonexistent.* PLACING 'string' FROM 'string')
 
 query error unknown signature
 SELECT OVERLAY(foo.* PLACING 'string' FROM 'string') FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8023)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT nonexistent.* IS NOT TRUE
 
 query error unsupported comparison operator: <tuple{int AS x}> IS DISTINCT FROM <bool>

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -218,6 +218,25 @@ project
       └── ((k:1, v:2) AS k, v) [as=r:3]
 
 build
+SELECT (SELECT t.*) FROM (VALUES (1)) AS t(x)
+----
+project
+ ├── columns: "?column?":3
+ ├── values
+ │    ├── columns: column1:1!null
+ │    └── (1,)
+ └── projections
+      └── subquery [as="?column?":3]
+           └── max1-row
+                ├── columns: x:2
+                └── project
+                     ├── columns: x:2
+                     ├── values
+                     │    └── ()
+                     └── projections
+                          └── column1:1 [as=x:2]
+
+build
 SELECT foo.* FROM kv
 ----
 error (42P01): no data source matches pattern: foo.*


### PR DESCRIPTION
We incorrectly error out if we have a qualified star without a FROM clause; the
star can refer to an outer table. We also incorrectly take the columns from the
input scope which is not necessarily the scope that the star is referring to.

Unfortunately, in the specific case in #45855 (`SELECT (SELECT t.*)`) we don't
get the nice column name `x` like in postgres; we get `?column?`. This is
because in our code the aliases are determined before building the expressions;
this seems complicated to change.

Fixes #45855.

Release note (bug fix): queries with qualified stars that refer to tables
in outer scopes now work.

Release justification: low risk changes to existing functionality.