### PR TITLE
kv: immediately push on WriteIntentError when lock-table disabled

### DIFF
--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -29,9 +29,13 @@ func nextUUID(counter *uint32) uuid.UUID {
 }
 
 func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
+	return scanTimestampWithName(t, d, "ts")
+}
+
+func scanTimestampWithName(t *testing.T, d *datadriven.TestData, name string) hlc.Timestamp {
 	var ts hlc.Timestamp
 	var tsS string
-	d.ScanArgs(t, "ts", &tsS)
+	d.ScanArgs(t, name, &tsS)
 	parts := strings.Split(tsS, ",")
 
 	// Find the wall time part.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1663,17 +1663,12 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTa
 	if guard == nil {
 		g = newLockTableGuardImpl()
 		g.seqNum = atomic.AddUint64(&t.seqNum, 1)
+		g.txn = req.txnMeta()
 		g.spans = req.LockSpans
-		g.readTS = req.Timestamp
-		g.writeTS = req.Timestamp
+		g.readTS = req.readConflictTimestamp()
+		g.writeTS = req.writeConflictTimestamp()
 		g.sa = spanset.NumSpanAccess - 1
 		g.index = -1
-		if req.Txn != nil {
-			g.txn = &req.Txn.TxnMeta
-			g.readTS = req.Txn.ReadTimestamp
-			g.readTS.Forward(req.Txn.MaxTimestamp)
-			g.writeTS = req.Txn.WriteTimestamp
-		}
 	} else {
 		g = guard.(*lockTableGuardImpl)
 		g.key = nil

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -333,7 +333,7 @@ func TestLockTableBasic(t *testing.T) {
 					d.Fatalf(t, "unknown txn %s", txnName)
 				}
 				intent := roachpb.MakeIntent(txnMeta, roachpb.Key(key))
-				if err := lt.AddDiscoveredLock(&intent, g); err != nil {
+				if _, err := lt.AddDiscoveredLock(&intent, g); err != nil {
 					return err.Error()
 				}
 				return lt.(*lockTableImpl).String()

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -78,7 +79,6 @@ var LockTableDeadlockDetectionPushDelay = settings.RegisterDurationSetting(
 
 // lockTableWaiterImpl is an implementation of lockTableWaiter.
 type lockTableWaiterImpl struct {
-	nodeID  roachpb.NodeID
 	st      *cluster.Settings
 	stopper *stop.Stopper
 	ir      IntentResolver
@@ -319,15 +319,17 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 	// under the lock. For write-write conflicts, try to abort the lock holder
 	// entirely so the write request can revoke and replace the lock with its
 	// own lock.
+	h := w.pushHeader(req)
 	var pushType roachpb.PushTxnType
 	switch ws.guardAccess {
 	case spanset.SpanReadOnly:
 		pushType = roachpb.PUSH_TIMESTAMP
+		log.VEventf(ctx, 3, "pushing timestamp of txn %s above %s", ws.txn.ID.Short(), h.Timestamp)
 	case spanset.SpanReadWrite:
 		pushType = roachpb.PUSH_ABORT
+		log.VEventf(ctx, 3, "pushing txn %s to abort", ws.txn.ID.Short())
 	}
 
-	h := w.pushHeader(req)
 	pusheeTxn, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
 	if err != nil {
 		return err
@@ -397,9 +399,10 @@ func (w *lockTableWaiterImpl) pushRequestTxn(
 	// because it wants to block until either a) the pushee or the pusher is
 	// aborted due to a deadlock or b) the request exits the lock wait-queue and
 	// the caller of this function cancels the push.
-	pushType := roachpb.PUSH_ABORT
-
 	h := w.pushHeader(req)
+	pushType := roachpb.PUSH_ABORT
+	log.VEventf(ctx, 3, "pushing txn %s to detect request deadlock", ws.txn.ID.Short())
+
 	_, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
 	// Even if the push succeeded and aborted the other transaction to break a
 	// deadlock, there's nothing for the pusher to clean up. The conflicting
@@ -413,26 +416,15 @@ func (w *lockTableWaiterImpl) pushRequestTxn(
 
 func (w *lockTableWaiterImpl) pushHeader(req Request) roachpb.Header {
 	h := roachpb.Header{
-		Timestamp:    req.Timestamp,
+		Timestamp:    req.readConflictTimestamp(),
 		UserPriority: req.Priority,
 	}
 	if req.Txn != nil {
-		// We are going to hand the header (and thus the transaction proto)
-		// to the RPC framework, after which it must not be changed (since
-		// that could race). Since the subsequent execution of the original
-		// request might mutate the transaction, make a copy here.
-		//
-		// See #9130.
+		// We are going to hand the header (and thus the transaction proto) to
+		// the RPC framework, after which it must not be changed (since that
+		// could race). Since the subsequent execution of the original request
+		// might mutate the transaction, make a copy here. See #9130.
 		h.Txn = req.Txn.Clone()
-
-		// We must push at least to h.Timestamp, but in fact we want to
-		// go all the way up to a timestamp which was taken off the HLC
-		// after our operation started. This allows us to not have to
-		// restart for uncertainty as we come back and read.
-		obsTS, ok := h.Txn.GetObservedTimestamp(w.nodeID)
-		if ok {
-			h.Timestamp.Forward(obsTS)
-		}
 	}
 	return h
 }

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -105,7 +105,7 @@ sequence req=req3
 [1] sequence req3: acquiring latches
 [1] sequence req3: scanning lock table for conflicting locks
 [1] sequence req3: waiting in lock wait-queues
-[1] sequence req3: pushing txn 00000002
+[1] sequence req3: pushing timestamp of txn 00000002 above 0.000000014,1
 [1] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
@@ -174,7 +174,7 @@ sequence req=req5
 [1] sequence req5: acquiring latches
 [1] sequence req5: scanning lock table for conflicting locks
 [1] sequence req5: waiting in lock wait-queues
-[1] sequence req5: pushing txn 00000002
+[1] sequence req5: pushing timestamp of txn 00000002 above 0.000000014,1
 [1] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 new-request name=req6 txn=none ts=16,1
@@ -219,7 +219,7 @@ finish req=req6
 [-] finish req6: finishing request
 [3] sequence req7: scanning lock table for conflicting locks
 [3] sequence req7: waiting in lock wait-queues
-[3] sequence req7: pushing txn 00000002
+[3] sequence req7: pushing txn 00000002 to abort
 [3] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -110,7 +110,7 @@ sequence req=req1r
 [4] sequence req1r: acquiring latches
 [4] sequence req1r: scanning lock table for conflicting locks
 [4] sequence req1r: waiting in lock wait-queues
-[4] sequence req1r: pushing txn 00000002
+[4] sequence req1r: pushing timestamp of txn 00000002 above 0.000000010,1
 [4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req2r
@@ -119,7 +119,7 @@ sequence req=req2r
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: waiting in lock wait-queues
-[5] sequence req2r: pushing txn 00000003
+[5] sequence req2r: pushing timestamp of txn 00000003 above 0.000000010,1
 [5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req3r
@@ -130,7 +130,7 @@ sequence req=req3r
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: waiting in lock wait-queues
-[6] sequence req3r: pushing txn 00000001
+[6] sequence req3r: pushing timestamp of txn 00000001 above 0.000000010,1
 [6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3r: dependency cycle detected 00000003->00000001->00000002->00000003
 
@@ -311,7 +311,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: pushing txn 00000001
+[4] sequence req4w: pushing txn 00000001 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req1w2
@@ -320,7 +320,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: pushing txn 00000002
+[5] sequence req1w2: pushing txn 00000002 to abort
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req2w2
@@ -329,7 +329,7 @@ sequence req=req2w2
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: waiting in lock wait-queues
-[6] sequence req2w2: pushing txn 00000003
+[6] sequence req2w2: pushing txn 00000003 to abort
 [6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req3w2
@@ -340,7 +340,7 @@ sequence req=req3w2
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: waiting in lock wait-queues
-[7] sequence req3w2: pushing txn 00000001
+[7] sequence req3w2: pushing txn 00000001 to abort
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [7] sequence req3w2: dependency cycle detected 00000003->00000001->00000002->00000003
 
@@ -376,7 +376,7 @@ on-txn-updated txn=txn1 status=aborted
 [5] sequence req1w2: detected pusher aborted
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
-[7] sequence req3w2: pushing txn 00000004
+[7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 # Txn4 can proceed.
@@ -520,14 +520,14 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: pushing txn 00000002
+[4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req4w: pushing txn 00000003
+[4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 debug-lock-table
@@ -562,7 +562,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: pushing txn 00000004
+[5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req3w2
@@ -573,7 +573,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: pushing txn 00000001
+[6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
 
@@ -740,14 +740,14 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: pushing txn 00000002
+[4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req4w: pushing txn 00000003
+[4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 debug-lock-table
@@ -782,7 +782,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: pushing txn 00000004
+[5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req3w2
@@ -793,7 +793,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: pushing txn 00000001
+[6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
 
@@ -972,7 +972,7 @@ sequence req=req5w
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: waiting in lock wait-queues
-[4] sequence req5w: pushing txn 00000002
+[4] sequence req5w: pushing txn 00000002 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 sequence req=req4w
@@ -981,24 +981,24 @@ sequence req=req4w
 [5] sequence req4w: acquiring latches
 [5] sequence req4w: scanning lock table for conflicting locks
 [5] sequence req4w: waiting in lock wait-queues
-[5] sequence req4w: pushing txn 00000001
+[5] sequence req4w: pushing txn 00000001 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
-[5] sequence req4w: pushing txn 00000002
+[5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
-[4] sequence req5w: pushing txn 00000003
+[4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
-[5] sequence req4w: pushing txn 00000005
+[5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 debug-lock-table
@@ -1034,7 +1034,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: pushing txn 00000004
+[6] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000004->00000005->00000003
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------
 # Read-only request runs into replicated intent. It informs the
-# lock table and waits for the intent to be resolved.
+# lock-table and waits for the intent to be resolved.
 # -------------------------------------------------------------
 
 new-txn name=txn1 ts=10,1 epoch=0
@@ -22,7 +22,7 @@ sequence req=req1
 
 handle-write-intent-error req=req1 txn=txn1 key=k
 ----
-[-] handle write intent error req1: handling conflicting intents on "k"
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -33,24 +33,185 @@ local: num=0
 
 sequence req=req1
 ----
-[2] sequence req1: re-sequencing request
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: waiting in lock wait-queues
-[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000012,1
-[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000001 above 0.000000012,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
-[2] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: sequencing complete, returned guard
+[3] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
 
 finish req=req1
 ----
 [-] finish req1: finishing request
 
-reset
+reset namespace
+----
+
+# -------------------------------------------------------------
+# Read-only request runs into replicated intent while the
+# lock-table is disabled. The lock-table cannot store the lock,
+# so the request is forced to push (PUSH_TIMESTAMP) immediately.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  get key=k
+----
+
+on-lease-updated leaseholder=false
+----
+[-] transfer lease: released
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1
+[2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[2] handle write intent error req1: resolving intent "k" for txn 00000001 with ABORTED status
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# Read-write request runs into replicated intent while the
+# lock-table is disabled. The lock-table cannot store the lock,
+# so the request is forced to push (PUSH_ABORT) immediately.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  put key=k value=v
+----
+
+on-lease-updated leaseholder=false
+----
+[-] transfer lease: released
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[2] handle write intent error req1: pushing txn 00000001 to abort
+[2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[2] handle write intent error req1: resolving intent "k" for txn 00000001 with ABORTED status
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# Read-write request runs into replicated intent while the
+# lock-table is disabled. The lock-table cannot store the lock,
+# so the request is forced to push (PUSH_ABORT) immediately.
+# The request's own transaction is aborted while pushing.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  get key=k
+----
+
+on-lease-updated leaseholder=false
+----
+[-] transfer lease: released
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1
+[2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[2] handle write intent error req1: detected pusher aborted
+[2] handle write intent error req1: handled conflicting intents on "k", returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+reset namespace
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -37,7 +37,7 @@ sequence req=req1
 [2] sequence req1: acquiring latches
 [2] sequence req1: scanning lock table for conflicting locks
 [2] sequence req1: waiting in lock wait-queues
-[2] sequence req1: pushing txn 00000001
+[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000012,1
 [2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=aborted

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -10,12 +10,14 @@ debug-disable-txn-pushes
 # OnRangeLeaseUpdated - losing this lease disables the
 # lock-table and acquiring the lease enables the lock-table.
 #
-# Setup: txn1 acquires lock
+# Setup: txn1 acquires locks on k and k2
 #        
 # Test:  txn2 enters lock's wait-queue
 #        replica loses lease
 #        txn2 proceeds
-#        txn2 discovers txn1's lock      (ignored)
+#        txn2 discovers txn1's lock on k  while writing (not ignored, waits)
+#        txn2 re-sequences
+#        txn2 discovers txn1's lock on k2 while reading (not ignored, waits)
 #        txn2 re-sequences
 #        txn1 lock is released           (ignored)
 #        txn2 proceeds and acquires lock (ignored)
@@ -39,11 +41,13 @@ new-txn name=txn3 ts=10,1 epoch=0
 ----
 
 new-request name=req1 txn=txn1 ts=10,1
-  put key=k value=v
+  put key=k  value=v
+  put key=k2 value=v
 ----
 
 new-request name=req2 txn=txn2 ts=10,1
-  put key=k value=v
+  put key=k  value=v
+  get key=k2
 ----
 
 new-request name=req3 txn=txn3 ts=10,1
@@ -61,14 +65,20 @@ on-lock-acquired txn=txn1 key=k
 ----
 [-] acquire lock: txn1 @ k
 
+on-lock-acquired txn=txn1 key=k2
+----
+[-] acquire lock: txn1 @ k2
+
 finish req=req1
 ----
 [-] finish req1: finishing request
 
 debug-lock-table
 ----
-global: num=1
+global: num=2
  lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
@@ -86,12 +96,14 @@ sequence req=req2
 
 debug-lock-table
 ----
-global: num=1
+global: num=2
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
+ lock: "k2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 # Replica loses lease.
@@ -109,7 +121,14 @@ local: num=0
 
 handle-write-intent-error req=req2 txn=txn1 key=k
 ----
-[-] handle write intent error req2: handling conflicting intents on "k"
+[3] handle write intent error req2: pushing txn 00000001 to abort
+[3] handle write intent error req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=committed
+----
+[-] update txn: committing txn1
+[3] handle write intent error req2: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] handle write intent error req2: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -118,19 +137,28 @@ local: num=0
 
 sequence req=req2
 ----
-[3] sequence req2: re-sequencing request
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: sequencing complete, returned guard
+[4] sequence req2: re-sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
 
-on-lock-updated txn=txn1 key=k status=committed
+handle-write-intent-error req=req2 txn=txn1 key=k2
 ----
-[-] update lock: committing txn1 @ k
+[5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
+[5] handle write intent error req2: resolving intent "k2" for txn 00000001 with COMMITTED status
+[5] handle write intent error req2: handled conflicting intents on "k2", released latches
 
 debug-lock-table
 ----
 global: num=0
 local: num=0
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
 
 on-lock-acquired txn=txn2 key=k
 ----
@@ -157,14 +185,14 @@ local: num=0
 
 sequence req=req3
 ----
-[4] sequence req3: sequencing request
-[4] sequence req3: acquiring latches
-[4] sequence req3: scanning lock table for conflicting locks
-[4] sequence req3: sequencing complete, returned guard
+[7] sequence req3: sequencing request
+[7] sequence req3: acquiring latches
+[7] sequence req3: scanning lock table for conflicting locks
+[7] sequence req3: sequencing complete, returned guard
 
 handle-write-intent-error req=req3 txn=txn2 key=k
 ----
-[-] handle write intent error req3: handling conflicting intents on "k"
+[8] handle write intent error req3: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -177,11 +205,11 @@ local: num=0
 
 sequence req=req3
 ----
-[5] sequence req3: re-sequencing request
-[5] sequence req3: acquiring latches
-[5] sequence req3: scanning lock table for conflicting locks
-[5] sequence req3: waiting in lock wait-queues
-[5] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+[9] sequence req3: re-sequencing request
+[9] sequence req3: acquiring latches
+[9] sequence req3: scanning lock table for conflicting locks
+[9] sequence req3: waiting in lock wait-queues
+[9] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
 ----
@@ -196,9 +224,9 @@ local: num=0
 on-lock-updated txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn2 @ k
-[5] sequence req3: acquiring latches
-[5] sequence req3: scanning lock table for conflicting locks
-[5] sequence req3: sequencing complete, returned guard
+[9] sequence req3: acquiring latches
+[9] sequence req3: scanning lock table for conflicting locks
+[9] sequence req3: sequencing complete, returned guard
 
 debug-lock-table
 ----
@@ -316,7 +344,7 @@ local: num=0
 
 handle-write-intent-error req=req2 txn=txn1 key=k
 ----
-[-] handle write intent error req2: handling conflicting intents on "k"
+[3] handle write intent error req2: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -329,18 +357,18 @@ local: num=0
 
 sequence req=req2
 ----
-[3] sequence req2: re-sequencing request
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: waiting in lock wait-queues
-[3] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+[4] sequence req2: re-sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: waiting in lock wait-queues
+[4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-lock-updated txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn1 @ k
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: sequencing complete, returned guard
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
 
 debug-lock-table
 ----
@@ -373,12 +401,14 @@ subtest end
 # OnRangeMerge - a Range merge clears the lock-table and
 # disables it.
 #
-# Setup: txn1 acquires lock
+# Setup: txn1 acquires lock on k and k2
 #        
 # Test:  txn2 enters lock's wait-queue
 #        range is merged
 #        txn2 proceeds
-#        txn2 discovers txn1's lock      (ignored)
+#        txn2 discovers txn1's lock on k  while writing (not ignored, waits)
+#        txn2 re-sequences
+#        txn2 discovers txn1's lock on k2 while reading (not ignored, waits)
 #        txn2 re-sequences
 #        txn1 lock is released           (ignored)
 #        txn2 proceeds and acquires lock (ignored)
@@ -393,11 +423,13 @@ new-txn name=txn2 ts=10,1 epoch=0
 ----
 
 new-request name=req1 txn=txn1 ts=10,1
-  put key=k value=v
+  put key=k  value=v
+  put key=k2 value=v
 ----
 
 new-request name=req2 txn=txn2 ts=10,1
-  put key=k value=v
+  put key=k  value=v
+  get key=k2
 ----
 
 sequence req=req1
@@ -411,14 +443,20 @@ on-lock-acquired txn=txn1 key=k
 ----
 [-] acquire lock: txn1 @ k
 
+on-lock-acquired txn=txn1 key=k2
+----
+[-] acquire lock: txn1 @ k2
+
 finish req=req1
 ----
 [-] finish req1: finishing request
 
 debug-lock-table
 ----
-global: num=1
+global: num=2
  lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
@@ -436,12 +474,14 @@ sequence req=req2
 
 debug-lock-table
 ----
-global: num=1
+global: num=2
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
    queued writers:
     active: true req: 7, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 7
+ lock: "k2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
 on-merge
@@ -458,7 +498,14 @@ local: num=0
 
 handle-write-intent-error req=req2 txn=txn1 key=k
 ----
-[-] handle write intent error req2: handling conflicting intents on "k"
+[3] handle write intent error req2: pushing txn 00000001 to abort
+[3] handle write intent error req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=committed
+----
+[-] update txn: committing txn1
+[3] handle write intent error req2: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] handle write intent error req2: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -467,19 +514,28 @@ local: num=0
 
 sequence req=req2
 ----
-[3] sequence req2: re-sequencing request
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: sequencing complete, returned guard
+[4] sequence req2: re-sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
 
-on-lock-updated txn=txn1 key=k status=committed
+handle-write-intent-error req=req2 txn=txn1 key=k2
 ----
-[-] update lock: committing txn1 @ k
+[5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
+[5] handle write intent error req2: resolving intent "k2" for txn 00000001 with COMMITTED status
+[5] handle write intent error req2: handled conflicting intents on "k2", released latches
 
 debug-lock-table
 ----
 global: num=0
 local: num=0
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
 
 on-lock-acquired txn=txn2 key=k
 ----
@@ -588,7 +644,7 @@ local: num=0
 
 handle-write-intent-error req=req2 txn=txn1 key=k
 ----
-[-] handle write intent error req2: handling conflicting intents on "k"
+[3] handle write intent error req2: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -601,18 +657,18 @@ local: num=0
 
 sequence req=req2
 ----
-[3] sequence req2: re-sequencing request
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: waiting in lock wait-queues
-[3] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+[4] sequence req2: re-sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: waiting in lock wait-queues
+[4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-lock-updated txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn1 @ k
-[3] sequence req2: acquiring latches
-[3] sequence req2: scanning lock table for conflicting locks
-[3] sequence req2: sequencing complete, returned guard
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -24,7 +24,7 @@ sequence req=req1
 
 handle-write-intent-error req=req1 txn=txn1 key=k
 ----
-[-] handle write intent error req1: handling conflicting intents on "k"
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -35,20 +35,20 @@ local: num=0
 
 sequence req=req1
 ----
-[2] sequence req1: re-sequencing request
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: waiting in lock wait-queues
-[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
-[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=pending ts=15,2
 ----
 [-] update txn: increasing timestamp of txn1
-[2] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: sequencing complete, returned guard
+[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
 
 finish req=req1
 ----
@@ -84,7 +84,7 @@ sequence req=req1
 
 handle-write-intent-error req=req1 txn=txn1 key=k
 ----
-[-] handle write intent error req1: handling conflicting intents on "k"
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -95,20 +95,20 @@ local: num=0
 
 sequence req=req1
 ----
-[2] sequence req1: re-sequencing request
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: waiting in lock wait-queues
-[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
-[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn1 status=pending ts=15,2
 ----
 [-] update txn: increasing timestamp of txn1
-[2] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
-[2] sequence req1: acquiring latches
-[2] sequence req1: scanning lock table for conflicting locks
-[2] sequence req1: sequencing complete, returned guard
+[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
 
 finish req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -1,0 +1,118 @@
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request runs into replicated
+# intent below its read timestamp. It informs the lock table and
+# pushes the intent's transaction (txn1) above its uncertainty
+# window. The push succeeds and the request is able to proceed.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0 maxts=15,1
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[-] handle write intent error req1: handling conflicting intents on "k"
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[2] sequence req1: re-sequencing request
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: waiting in lock wait-queues
+[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
+[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[2] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request runs into replicated
+# intent above its read timestamp but in its uncertainty window.
+# It informs the lock table and pushes the intent's transaction
+# (txn1) above its uncertainty window. The push succeeds and the
+# request is able to proceed.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=14,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0 maxts=15,1
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 txn=txn1 key=k
+----
+[-] handle write intent error req1: handling conflicting intents on "k"
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000014,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[2] sequence req1: re-sequencing request
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: waiting in lock wait-queues
+[2] sequence req1: pushing timestamp of txn 00000001 above 0.000000015,1
+[2] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[2] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req1: acquiring latches
+[2] sequence req1: scanning lock table for conflicting locks
+[2] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -242,7 +242,7 @@ type replicaInQueue interface {
 	IsDestroyed() (DestroyReason, error)
 	Desc() *roachpb.RangeDescriptor
 	maybeInitializeRaftGroup(context.Context)
-	redirectOnOrAcquireLease(context.Context) (storagepb.LeaseStatus, hlc.Timestamp, *roachpb.Error)
+	redirectOnOrAcquireLease(context.Context) (storagepb.LeaseStatus, *roachpb.Error)
 	IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool
 	GetLease() (roachpb.Lease, roachpb.Lease)
 }
@@ -932,7 +932,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			// order to be processed, check whether this replica has range lease
 			// and renew or acquire if necessary.
 			if bq.needsLease {
-				if _, _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+				if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 					switch v := pErr.GetDetail().(type) {
 					case *roachpb.NotLeaseHolderError, *roachpb.RangeNotFoundError:
 						log.VEventf(ctx, 3, "%s; skipping", v)

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -169,9 +169,9 @@ func (fr *fakeReplica) Desc() *roachpb.RangeDescriptor {
 func (fr *fakeReplica) maybeInitializeRaftGroup(context.Context) {}
 func (fr *fakeReplica) redirectOnOrAcquireLease(
 	context.Context,
-) (storagepb.LeaseStatus, hlc.Timestamp, *roachpb.Error) {
+) (storagepb.LeaseStatus, *roachpb.Error) {
 	// baseQueue only checks that the returned error is nil.
-	return storagepb.LeaseStatus{}, hlc.Timestamp{}, nil
+	return storagepb.LeaseStatus{}, nil
 }
 func (fr *fakeReplica) IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool { return true }
 func (fr *fakeReplica) GetLease() (roachpb.Lease, roachpb.Lease) {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -525,7 +525,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 		// Without the lease, a replica's local descriptor can be arbitrarily
 		// stale, which will result in a ConditionFailedError. To avoid this, we
 		// make sure that we still have the lease before each attempt.
-		if _, _, pErr := r.redirectOnOrAcquireLease(ctx); pErr != nil {
+		if _, pErr := r.redirectOnOrAcquireLease(ctx); pErr != nil {
 			return pErr
 		}
 

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -31,32 +31,34 @@ var FollowerReadsEnabled = settings.RegisterPublicBoolSetting(
 	true,
 )
 
-// canServeFollowerRead tests, when a range lease could not be
-// acquired, whether the read only batch can be served as a follower
-// read despite the error.
+// canServeFollowerRead tests, when a range lease could not be acquired, whether
+// the batch can be served as a follower read despite the error. Only
+// non-locking, read-only requests can be served as follower reads. The batch
+// must be composed exclusively only this kind of request to be accepted as a
+// follower read.
 func (r *Replica) canServeFollowerRead(
 	ctx context.Context, ba *roachpb.BatchRequest, pErr *roachpb.Error,
 ) *roachpb.Error {
-	// There's no known reason that a non-VOTER_FULL replica couldn't serve follower
-	// reads (or RangeFeed), but as of the time of writing, these are expected
-	// to be short-lived, so it's not worth working out the edge-cases. Revisit if
-	// we add long-lived learners or feel that incoming/outgoing voters also need
-	// to be able to serve follower reads.
-	repDesc, err := r.GetReplicaDescriptor()
-	if err != nil {
-		return roachpb.NewError(err)
-	}
-	if typ := repDesc.GetType(); typ != roachpb.VOTER_FULL {
-		log.Eventf(ctx, "%s replicas cannot serve follower reads", typ)
-		return pErr
-	}
-
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
 		(!ba.IsLocking() && ba.IsAllTransactional()) && // followerreadsccl.batchCanBeEvaluatedOnFollower
 		(ba.Txn == nil || !ba.Txn.IsLocking()) && // followerreadsccl.txnCanPerformFollowerRead
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) {
+
+		// There's no known reason that a non-VOTER_FULL replica couldn't serve follower
+		// reads (or RangeFeed), but as of the time of writing, these are expected
+		// to be short-lived, so it's not worth working out the edge-cases. Revisit if
+		// we add long-lived learners or feel that incoming/outgoing voters also need
+		// to be able to serve follower reads.
+		repDesc, err := r.GetReplicaDescriptor()
+		if err != nil {
+			return roachpb.NewError(err)
+		}
+		if typ := repDesc.GetType(); typ != roachpb.VOTER_FULL {
+			log.Eventf(ctx, "%s replicas cannot serve follower reads", typ)
+			return pErr
+		}
 
 		ts := ba.Timestamp
 		if ba.Txn != nil {
@@ -91,6 +93,7 @@ func (r *Replica) canServeFollowerRead(
 	// TODO(tschottdorf): once a read for a timestamp T has been served, the replica may
 	// serve reads for that and smaller timestamps forever.
 	log.Event(ctx, "serving via follower read")
+	r.store.metrics.FollowerReadsCount.Inc(1)
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -216,7 +216,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 		ctx, "storage.Replica: acquiring lease to gossip",
 		func(ctx context.Context) {
 			// Check for or obtain the lease, if none active.
-			_, _, pErr = r.redirectOnOrAcquireLease(ctx)
+			_, pErr = r.redirectOnOrAcquireLease(ctx)
 			hasLease = pErr == nil
 			if pErr != nil {
 				switch e := pErr.GetDetail().(type) {

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -144,7 +144,7 @@ func (r *Replica) protectedTimestampRecordCurrentlyApplies(
 	// record or we're not and if we don't then we'll push the cache and re-assert
 	// that we're still the leaseholder. If somebody else becomes the leaseholder
 	// then they will have to go through the same process.
-	ls, _, pErr := r.redirectOnOrAcquireLease(ctx)
+	ls, pErr := r.redirectOnOrAcquireLease(ctx)
 	if pErr != nil {
 		return false, false, pErr.GoError()
 	}

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -657,7 +657,7 @@ func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Err
 	// Make sure there's a leaseholder. If there's no leaseholder, there's no
 	// closed timestamp updates.
 	var leaseholderNodeID roachpb.NodeID
-	_, _, err := r.redirectOnOrAcquireLease(ctx)
+	_, err := r.redirectOnOrAcquireLease(ctx)
 	if err == nil {
 		// We have the lease. Request is essentially a wrapper for calling EmitMLAI
 		// on a remote node, so cut out the middleman.

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/kr/pretty"
 )
@@ -37,16 +36,15 @@ func (r *Replica) executeReadOnlyBatch(
 	// If the read is not inconsistent, the read requires the range lease or
 	// permission to serve via follower reads.
 	var status storagepb.LeaseStatus
-	var now hlc.Timestamp
 	if ba.ReadConsistency.RequiresReadLease() {
-		if status, now, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
+		if status, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
 			if nErr := r.canServeFollowerRead(ctx, ba, pErr); nErr != nil {
 				return nil, g, nErr
 			}
 			r.store.metrics.FollowerReadsCount.Inc(1)
 		}
 	} else {
-		now = r.Clock().Now() // get a clock reading for checkExecutionCanProceed
+		status.Timestamp = r.Clock().Now() // get a clock reading for checkExecutionCanProceed
 	}
 	r.limitTxnMaxTimestamp(ctx, ba, status)
 
@@ -55,7 +53,7 @@ func (r *Replica) executeReadOnlyBatch(
 	defer r.readOnlyCmdMu.RUnlock()
 
 	// Verify that the batch can be executed.
-	if err := r.checkExecutionCanProceed(ba, g, now, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, g, &status); err != nil {
 		return nil, g, roachpb.NewError(err)
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -290,7 +290,7 @@ func (r *Replica) handleWriteIntentError(
 		return g, pErr
 	}
 	// g's latches will be dropped, but it retains its spot in lock wait-queues.
-	return r.concMgr.HandleWriterIntentError(ctx, g, t), nil
+	return r.concMgr.HandleWriterIntentError(ctx, g, t)
 }
 
 func (r *Replica) handleTransactionPushError(

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -366,7 +366,7 @@ func (r *Replica) executeAdminBatch(
 	}
 
 	// Admin commands always require the range lease.
-	status, now, pErr := r.redirectOnOrAcquireLease(ctx)
+	status, pErr := r.redirectOnOrAcquireLease(ctx)
 	if pErr != nil {
 		return nil, pErr
 	}
@@ -376,7 +376,7 @@ func (r *Replica) executeAdminBatch(
 	// NB: we pass nil for the spanlatch guard because we haven't acquired
 	// latches yet. This is ok because each individual request that the admin
 	// request sends will acquire latches.
-	if err := r.checkExecutionCanProceed(ba, nil /* g */, now, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, nil /* g */, &status); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -118,9 +118,9 @@ func (r *Replica) sendWithRangeID(
 }
 
 // batchExecutionFn is a method on Replica that is able to execute a
-// BatchRequest. It is called with the batch, along with the span bounds that
-// the batch will operate over and a guard for the latches protecting the span
-// bounds.
+// BatchRequest. It is called with the batch, along with the status of
+// the lease that the batch is operating under and a guard for the
+// latches protecting the request.
 //
 // The function will return either a batch response or an error. The function
 // also has the option to pass ownership of the concurrency guard back to the
@@ -138,7 +138,7 @@ func (r *Replica) sendWithRangeID(
 //    the replicated state machine. In all of these cases, responsibility
 //    for releasing the concurrency guard is handed to Raft.
 type batchExecutionFn func(
-	*Replica, context.Context, *roachpb.BatchRequest, *concurrency.Guard,
+	*Replica, context.Context, *roachpb.BatchRequest, storagepb.LeaseStatus, *concurrency.Guard,
 ) (*roachpb.BatchResponse, *concurrency.Guard, *roachpb.Error)
 
 var _ batchExecutionFn = (*Replica).executeWriteBatch
@@ -184,6 +184,27 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			return nil, roachpb.NewError(errors.Wrap(err, "aborted during Replica.Send"))
 		}
 
+		// Determine the lease under which to evaluate the request.
+		var status storagepb.LeaseStatus
+		if !ba.ReadConsistency.RequiresReadLease() {
+			// Get a clock reading for checkExecutionCanProceed.
+			status.Timestamp = r.Clock().Now()
+		} else if ba.IsSingleSkipLeaseCheckRequest() {
+			// For lease commands, use the provided previous lease for verification.
+			status.Lease = ba.GetPrevLeaseForLeaseRequest()
+			status.Timestamp = r.Clock().Now()
+		} else {
+			// If the request is a write or a consistent read, it requires the
+			// range lease or permission to serve via follower reads.
+			if status, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
+				if nErr := r.canServeFollowerRead(ctx, ba, pErr); nErr != nil {
+					return nil, nErr
+				}
+			}
+		}
+		// Limit the transaction's maximum timestamp using observed timestamps.
+		r.limitTxnMaxTimestamp(ctx, ba, status)
+
 		// Acquire latches to prevent overlapping requests from executing until
 		// this request completes. After latching, wait on any conflicting locks
 		// to ensure that the request has full isolation during evaluation. This
@@ -212,7 +233,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			}
 		}
 
-		br, g, pErr = fn(r, ctx, ba, g)
+		br, g, pErr = fn(r, ctx, ba, status, g)
 		switch t := pErr.GetDetail().(type) {
 		case nil:
 			// Success.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -923,7 +923,7 @@ func TestReplicaRangeBoundsChecking(t *testing.T) {
 	key := roachpb.RKey("a")
 	firstRepl := tc.store.LookupReplica(key)
 	newRepl := splitTestRange(tc.store, key, key, t)
-	if _, _, pErr := newRepl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
+	if _, pErr := newRepl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -1012,7 +1012,7 @@ func TestReplicaLease(t *testing.T) {
 	}
 
 	{
-		_, _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background())
+		_, pErr := tc.repl.redirectOnOrAcquireLease(context.Background())
 		if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok || lErr == nil {
 			t.Fatalf("wanted NotLeaseHolderError, got %s", pErr)
 		}
@@ -1028,7 +1028,7 @@ func TestReplicaLease(t *testing.T) {
 	filterErr.Store(roachpb.NewError(&roachpb.LeaseRejectedError{Message: "replica not found"}))
 
 	{
-		_, _, err := tc.repl.redirectOnOrAcquireLease(context.Background())
+		_, err := tc.repl.redirectOnOrAcquireLease(context.Background())
 		if _, ok := err.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 			t.Fatalf("expected %T, got %s", &roachpb.NotLeaseHolderError{}, err)
 		}
@@ -1410,7 +1410,7 @@ func TestReplicaDrainLease(t *testing.T) {
 
 	// Acquire initial lease.
 	ctx := context.Background()
-	status, _, pErr := tc.repl.redirectOnOrAcquireLease(ctx)
+	status, pErr := tc.repl.redirectOnOrAcquireLease(ctx)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1425,7 +1425,7 @@ func TestReplicaDrainLease(t *testing.T) {
 	}
 	tc.store.SetDraining(false)
 	// Newly undrained, leases work again.
-	if _, _, pErr := tc.repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+	if _, pErr := tc.repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 		t.Fatal(pErr)
 	}
 }
@@ -1558,7 +1558,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 
 	// Make sure the information for db1 is not gossiped. Since obtaining
 	// a lease updates the gossiped information, we do that.
-	if _, _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
+	if _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)
 	}
 	// Fetch the raw gossip info. GetSystemConfig is based on callbacks at

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -68,20 +68,17 @@ func (r *Replica) executeWriteBatch(
 	startTime := timeutil.Now()
 
 	// Determine the lease under which to evaluate the write.
-	var now hlc.Timestamp
-	var lease roachpb.Lease
 	var status storagepb.LeaseStatus
-	// For lease commands, use the provided previous lease for verification.
 	if ba.IsSingleSkipLeaseCheckRequest() {
-		lease = ba.GetPrevLeaseForLeaseRequest()
-		now = r.Clock().Now()
+		// For lease commands, use the provided previous lease for verification.
+		status.Lease = ba.GetPrevLeaseForLeaseRequest()
+		status.Timestamp = r.Clock().Now()
 	} else {
 		// Other write commands require that this replica has the range
 		// lease.
-		if status, now, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
+		if status, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
 			return nil, g, pErr
 		}
-		lease = status.Lease
 	}
 	r.limitTxnMaxTimestamp(ctx, ba, status)
 
@@ -90,7 +87,7 @@ func (r *Replica) executeWriteBatch(
 	// at proposal time, not at application time, because the spanlatch manager
 	// will synchronize all requests (notably EndTxn with SplitTrigger) that may
 	// cause this condition to change.
-	if err := r.checkExecutionCanProceed(ba, g, now, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, g, &status); err != nil {
 		return nil, g, roachpb.NewError(err)
 	}
 
@@ -129,7 +126,7 @@ func (r *Replica) executeWriteBatch(
 	// If the command is proposed to Raft, ownership of and responsibility for
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose.
-	ch, abandon, maxLeaseIndex, g, pErr := r.evalAndPropose(ctx, ba, g, &lease)
+	ch, abandon, maxLeaseIndex, g, pErr := r.evalAndPropose(ctx, ba, g, &status.Lease)
 	if pErr != nil {
 		if maxLeaseIndex != 0 {
 			log.Fatalf(
@@ -144,7 +141,7 @@ func (r *Replica) executeWriteBatch(
 	// cannot communicate under the lease's epoch. Instead the code calls EmitMLAI explicitly
 	// as a side effect of stepping up as leaseholder.
 	if maxLeaseIndex != 0 {
-		untrack(ctx, ctpb.Epoch(lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
+		untrack(ctx, ctpb.Epoch(status.Lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}
 
 	// If the command was accepted by raft, wait for the range to apply it.

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -63,31 +63,22 @@ import (
 // as this method makes the assumption that it operates on a shallow copy (see
 // call to applyTimestampCache).
 func (r *Replica) executeWriteBatch(
-	ctx context.Context, ba *roachpb.BatchRequest, g *concurrency.Guard,
+	ctx context.Context, ba *roachpb.BatchRequest, st storagepb.LeaseStatus, g *concurrency.Guard,
 ) (br *roachpb.BatchResponse, _ *concurrency.Guard, pErr *roachpb.Error) {
 	startTime := timeutil.Now()
 
-	// Determine the lease under which to evaluate the write.
-	var status storagepb.LeaseStatus
-	if ba.IsSingleSkipLeaseCheckRequest() {
-		// For lease commands, use the provided previous lease for verification.
-		status.Lease = ba.GetPrevLeaseForLeaseRequest()
-		status.Timestamp = r.Clock().Now()
-	} else {
-		// Other write commands require that this replica has the range
-		// lease.
-		if status, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
-			return nil, g, pErr
-		}
-	}
-	r.limitTxnMaxTimestamp(ctx, ba, status)
+	// TODO(nvanbenschoten): unlike on the read-path (executeReadOnlyBatch), we
+	// don't synchronize with r.readOnlyCmdMu here. Is that ok? What if the
+	// replica is destroyed concurrently with a write? We won't be able to
+	// successfully propose as the lease will presumably have changed, but what
+	// if we hit an error during evaluation (e.g. a ConditionFailedError)?
 
 	// Verify that the batch can be executed.
 	// NB: we only need to check that the request is in the Range's key bounds
 	// at proposal time, not at application time, because the spanlatch manager
 	// will synchronize all requests (notably EndTxn with SplitTrigger) that may
 	// cause this condition to change.
-	if err := r.checkExecutionCanProceed(ba, g, &status); err != nil {
+	if err := r.checkExecutionCanProceed(ba, g, &st); err != nil {
 		return nil, g, roachpb.NewError(err)
 	}
 
@@ -123,10 +114,23 @@ func (r *Replica) executeWriteBatch(
 		return nil, g, roachpb.NewError(errors.Wrap(err, "aborted before proposing"))
 	}
 
+	// Check that the lease is still valid before proposing to avoid discovering
+	// this after replication and potentially missing out on the chance to retry
+	// if the request is using AsyncConsensus. This is best-effort, but can help
+	// in cases where the request waited arbitrarily long for locks acquired by
+	// other transactions to be released while sequencing in the concurrency
+	// manager.
+	if curLease, _ := r.GetLease(); curLease.Sequence > st.Lease.Sequence {
+		curLeaseCpy := curLease // avoid letting curLease escape
+		err := newNotLeaseHolderError(&curLeaseCpy, r.store.StoreID(), r.Desc())
+		log.VEventf(ctx, 2, "%s before proposing: %s", err, ba.Summary())
+		return nil, g, roachpb.NewError(err)
+	}
+
 	// If the command is proposed to Raft, ownership of and responsibility for
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose.
-	ch, abandon, maxLeaseIndex, g, pErr := r.evalAndPropose(ctx, ba, g, &status.Lease)
+	ch, abandon, maxLeaseIndex, g, pErr := r.evalAndPropose(ctx, ba, g, &st.Lease)
 	if pErr != nil {
 		if maxLeaseIndex != 0 {
 			log.Fatalf(
@@ -141,7 +145,7 @@ func (r *Replica) executeWriteBatch(
 	// cannot communicate under the lease's epoch. Instead the code calls EmitMLAI explicitly
 	// as a side effect of stepping up as leaseholder.
 	if maxLeaseIndex != 0 {
-		untrack(ctx, ctpb.Epoch(status.Lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
+		untrack(ctx, ctpb.Epoch(st.Lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}
 
 	// If the command was accepted by raft, wait for the range to apply it.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -311,7 +311,7 @@ func (rq *replicateQueue) processOneChange(
 	if _, err := repl.IsDestroyed(); err != nil {
 		return false, err
 	}
-	if _, _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+	if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
 		return false, pErr.GoError()
 	}
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1587,7 +1587,7 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 			s.renewableLeases.Range(func(k int64, v unsafe.Pointer) bool {
 				repl := (*Replica)(v)
 				annotatedCtx := repl.AnnotateCtx(ctx)
-				if _, _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
+				if _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
 					if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 						log.Warningf(annotatedCtx, "failed to proactively renew lease: %s", pErr)
 					}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -704,8 +704,8 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal("replica was not marked as destroyed")
 	}
 
-	now := repl1.Clock().Now()
-	if err = repl1.checkExecutionCanProceed(&roachpb.BatchRequest{}, nil /* g */, now, nil /* st */); err != expErr {
+	st := &storagepb.LeaseStatus{Timestamp: repl1.Clock().Now()}
+	if err = repl1.checkExecutionCanProceed(&roachpb.BatchRequest{}, nil /* g */, st); err != expErr {
 		t.Fatalf("expected error %s, but got %v", expErr, err)
 	}
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -1499,7 +1499,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	manual := hlc.NewManualClock(123)
-	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
+	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, 1000*time.Nanosecond))
 	cfg.TestingKnobs.EvalKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			pr, ok := filterArgs.Req.(*roachpb.PushTxnRequest)


### PR DESCRIPTION
Fixes #46148.

This commit fixes a bug where follower reads that hit intents could get stuck in an indefinite loop of running into the intent during evaluation, not adding the intent to the lock-table because the lock table was disabled, sequencing in the concurrency manager without issue, and repeating. The new TestClosedTimestampCanServeWithConflictingIntent test hits exactly this issue before this commit.

The fix implemented here is to immediately push the transaction responsible for an intent when serving a follower read (i.e. when a replica's lock-table is disabled). This ensures that the intent gets cleaned up if it was abandoned and avoids the busy loop we see today. If/when lockTables are maintained on follower replicas by propagating lockTable state transitions through the Raft log in the ReplicatedEvalResult instead of through the (leaseholder-only) LocalResult, we should be able to remove the lockTable "disabled" state and, in turn, remove this special-case.

The alternative approach floated to address this was to simply pass a NotLeaseHolderError back to the client when an intent is hit on a follower. This would have worked to avoid the infinite loop, but it seems like a short-term patch that doesn't get to the root of the issue. As we push further on follower reads (or even consistent read replicas), we want non-leaseholders to be able to perform conflict resolution. Falling back to the leaseholder works counter to this goal. The approach implemented by this commit works towards this goal, simply falling back to the previous sub-optimal approach of pushing immediately during conflicts.

Release note (bug fix): Follower reads that hit intents no longer have a chance of entering an infinite loop. This bug was present in earlier versions of the v20.1 release.

Release justification: fixes a high-priority bug where follower reads could get stuck indefinitely if they hit an abandoned intent.