### PR TITLE
ui: Hide Activate button while waiting for query status

### DIFF
--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.spec.tsx
@@ -84,7 +84,7 @@ describe("DiagnosticsView", () => {
       activateFn.calledOnceWith(statementFingerprint);
     });
 
-    it("Activate button is disabled if diagnostics is requested and waiting query", () => {
+    it("Activate button is hidden if diagnostics is requested and waiting query", () => {
       const diagnosticsRequests: IStatementDiagnosticsReport[] = [
         generateDiagnosticsRequest({ completed: false }),
         generateDiagnosticsRequest(),
@@ -99,11 +99,8 @@ describe("DiagnosticsView", () => {
         />),
       );
 
-      const activateButtonComponent = wrapper.find(".crl-button").first();
-      assert.isTrue(wrapper.find(".crl-button.crl-button--disabled").exists());
-
-      activateButtonComponent.simulate("click");
-      assert.isTrue(activateFn.notCalled, "Activate button is called when diagnostic is already requested");
+      const activateButtonComponent = wrapper.find(".crl-statements-diagnostics-view__activate-button").first();
+      assert.isFalse(activateButtonComponent.exists());
     });
   });
 });

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -159,13 +159,18 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
           >
             Statement diagnostics
           </Text>
-          <Button
-            onClick={this.onActivateButtonClick}
-            disabled={!canRequestDiagnostics}
-            type="secondary"
-          >
-            Activate diagnostics
-          </Button>
+          {
+            canRequestDiagnostics && (
+              <Button
+                onClick={this.onActivateButtonClick}
+                disabled={!canRequestDiagnostics}
+                type="secondary"
+                className="crl-statements-diagnostics-view__activate-button"
+              >
+                Activate diagnostics
+              </Button>
+            )
+          }
         </div>
         <Table
           dataSource={dataSource}


### PR DESCRIPTION
Resolves: #46079

Before Activate diagnostics button (on Statements page > Diagnostics tab)
has been disabled after user requested.
Now to avoid user confusion, we hide this button instead of disabling it.

Release justification: bug fixes and low-risk updates to new functionality

Release note (admin ui change): Hide Activate diagnostics button
on Statements > Diagnostics tab

<img width="1440" alt="76773934-e955bc00-67ab-11ea-8194-c94ea3e7c79b" src="https://user-images.githubusercontent.com/3106437/76958824-12e42400-6921-11ea-88ce-ec950c98f4cb.png">
