### PR TITLE
sql: require a valid KV txn to be open for privilege checks

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -191,9 +191,15 @@ func (txn *Txn) status() roachpb.TransactionStatus {
 	return txn.mu.sender.TxnStatus()
 }
 
-// IsCommitted returns true if the transaction has the committed status.
+// IsCommitted returns true iff the transaction has the committed status.
 func (txn *Txn) IsCommitted() bool {
 	return txn.status() == roachpb.COMMITTED
+}
+
+// IsOpen returns true iff the transaction is in the open state where
+// it can accept further commands.
+func (txn *Txn) IsOpen() bool {
+	return txn.status() == roachpb.PENDING
 }
 
 // SetUserPriority sets the transaction's user priority. Transactions default to


### PR DESCRIPTION
Requested by @dt 

Prior to this change, the APIs from `authorization.go` contained
a shortcut for the `root` principal, causing them to tolerate
an invalidly-unset `planner.txn`.

This was a productivity hurdle, because *even though the API
is meant to require a valid KV txn object*, this was not
actually asserted in all the tests that use the `root` principal
by default.

This change makes it so that the `txn` object is always checked
for validity.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None