### PR TITLE
sql: fix the COPY <-> conn executor API

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1772,9 +1772,7 @@ func (ex *connExecutor) execCopyIn(
 		ex.state.mon.Start(ctx, ex.sessionMon, mon.BoundAccount{} /* reserved */)
 		monToStop = ex.state.mon
 	}
-	var cm copyMachineInterface
-	var err error
-	resetPlanner := func(p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time) {
+	txnOpt.resetPlanner = func(ctx context.Context, p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time) {
 		// HACK: We're reaching inside ex.state and changing sqlTimestamp by hand.
 		// It is used by resetPlanner. Normally sqlTimestamp is updated by the
 		// state machine, but the copyMachine manages its own transactions without
@@ -1785,11 +1783,13 @@ func (ex *connExecutor) execCopyIn(
 		ex.initPlanner(ctx, p)
 		ex.resetPlanner(ctx, p, txn, stmtTS, 0 /* numAnnotations */)
 	}
+	var cm copyMachineInterface
+	var err error
 	if table := cmd.Stmt.Table; table.Table() == fileUploadTable && table.Schema() == crdbInternalName {
-		cm, err = newFileUploadMachine(cmd.Conn, cmd.Stmt, ex.server.cfg, resetPlanner)
+		cm, err = newFileUploadMachine(ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg)
 	} else {
 		cm, err = newCopyMachine(
-			ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg, resetPlanner,
+			ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg,
 			// execInsertPlan
 			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
 				_, _, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, false /* distribute */, nil /* progressAtomic */)

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -15,10 +15,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/blobs"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -47,10 +45,11 @@ type fileUploadMachine struct {
 }
 
 func newFileUploadMachine(
+	ctx context.Context,
 	conn pgwirebase.Conn,
 	n *tree.CopyFrom,
+	txnOpt copyTxnOpt,
 	execCfg *ExecutorConfig,
-	resetPlanner func(p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time),
 ) (f *fileUploadMachine, retErr error) {
 	if len(n.Columns) != 0 {
 		return nil, errors.New("expected 0 columns specified for file uploads")
@@ -58,13 +57,20 @@ func newFileUploadMachine(
 	c := &copyMachine{
 		conn: conn,
 		// The planner will be prepared before use.
-		p:            planner{execCfg: execCfg},
-		resetPlanner: resetPlanner,
+		p: planner{execCfg: execCfg},
 	}
 	f = &fileUploadMachine{
 		c:  c,
 		wg: &sync.WaitGroup{},
 	}
+
+	// We need a planner to do the initial planning, even if a planner
+	// is not required after that.
+	cleanup := c.p.preparePlannerForCopy(ctx, txnOpt)
+	defer func() {
+		retErr = cleanup(ctx, retErr)
+	}()
+	c.parsingEvalCtx = c.p.EvalContext()
 
 	optsFn, err := f.c.p.TypeAsStringOpts(n.Options, copyFileOptionExpectValues)
 	if err != nil {
@@ -100,7 +106,6 @@ func newFileUploadMachine(
 		_ = localStorage.Delete(opts[copyOptionDest])
 	}
 
-	c.resetPlanner(&c.p, nil /* txn */, time.Time{} /* txnTS */, time.Time{} /* stmtTS */)
 	c.resultColumns = make(sqlbase.ResultColumns, 1)
 	c.resultColumns[0] = sqlbase.ResultColumn{Typ: types.Bytes}
 	c.parsingEvalCtx = c.p.EvalContext()


### PR DESCRIPTION
@dt needed this.

Prior to this patch, there was an inconsistent API between
the conn executor and the two separate variants of COPY.
This made it impossible to e.g. perform privilege
checks in the "COPY file" variant.

This patch fixes the API and incidentally fixes the planner
initialization in the second COPY variant.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None