### PR TITLE
server: fix misleading TestJemalloc result for ppc64le

### DIFF
--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -122,6 +122,6 @@ func getJemallocStats(ctx context.Context) (uint, uint, error) {
 
 // Used to force allocation in tests. 'import "C"' is not supported in tests.
 func allocateMemory() {
-	// Empirically, 8KiB is not enough, but 16KiB is.
-	C.malloc(16 << 10)
+	// Empirically, 8KiB is not enough, but 16KiB is except for ppc64le, where 256KiB is needed.
+	C.malloc(256 << 10)
 }


### PR DESCRIPTION
Fixes #43522

The test failed on ppc64le since the 16KiB constant in allocateMemory
didn't exceed the thread cache on ppc64le. Brief failure log shown below:
```
=== RUN   TestJemalloc
--- FAIL: TestJemalloc (0.00s)
    jemalloc_test.go:37: allocated stat not incremented on allocation: 2322976
```
Configuring jemalloc with `--disable-tcache to disable the thread cache` or
flushing thread cache as `mallctl("thread.tcache.flush", NULL, NULL, NULL, 0);`
showed expected behavior. But had performance and code clutter trade-offs resp.
So, updated the constant to suit ppc64le which also works for x86 and others.

Release justification: Fixes misleading test result for jemalloc stat on PPC
Release note: None