### PR TITLE
colexec: release discarded memory in external sort

### DIFF
--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -105,7 +105,7 @@ const (
 	// - The 2 partitions that need to be sorted + merged will use an FD each: 2
 	//   FDs. Meanwhile, each sorter will use up to externalSorterMinPartitions to
 	//   sort and partition this input. At this stage 2 + 2 *
-	//   externalMinPartitions FDs are used.
+	//   externalSorterMinPartitions FDs are used.
 	// - Once the inputs (the hash joiner partitions) are finished, both FDs will
 	//   be released. The merge joiner will now be in use, which uses two
 	//   spillingQueues with 1 FD each for a total of 2. Since each sorter will

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -140,7 +140,7 @@ func TestRouterOutputAddBatch(t *testing.T) {
 		for _, mtc := range memoryTestCases {
 			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 				// Clear the testAllocator for use.
-				testAllocator.Clear()
+				testAllocator.ReleaseMemory(testAllocator.Used())
 				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, []coltypes.T{coltypes.Int64}, unblockEventsChan, mtc.bytes, queueCfg, NewTestingSemaphore(2), tc.blockedThreshold, tc.outputBatchSize, testDiskAcc)
 				in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
 				out := newOpTestOutput(o, data[:len(tc.selection)])
@@ -708,7 +708,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 	for _, mtc := range memoryTestCases {
 		t.Run(fmt.Sprintf("memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 			// Clear the testAllocator for use.
-			testAllocator.Clear()
+			testAllocator.ReleaseMemory(testAllocator.Used())
 			diskAcc := testDiskMonitor.MakeBoundAccount()
 			defer diskAcc.Close(ctx)
 			r, routerOutputs := NewHashRouter(


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

External sorter uses an unlimited allocator. Previously, the allocator
would only be growing and never shrunk, even if some memory is
"discarded". Namely, when we're merging partitions and spilling the
result into a new partition, we're using a new ordered synchronizer
every time which will be registering its "working memory" with the
unlimited allocator. However, we should also unregister that memory once
we have spilled.

The previous situation was problematic in case when we needed to
"recursively merge" many partitions, in which case the unlimited
allocator could actually hit the limit imposed by root SQL monitor, but
now it should be fixed.

Release note: None