### PR TITLE
sql: change temp table warning message to flag experimental nature

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2599,9 +2599,6 @@ DROP TABLE person, pet
 # Temporary tables can not create FK references to persistent tables, and
 # persistent tables can not create FK references to temporary tables.
 
-statement error unimplemented: temporary tables are unsupported
-CREATE TEMP TABLE a_temp(a INT PRIMARY KEY)
-
 statement ok
 SET experimental_enable_temp_tables = true
 

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -1,3 +1,6 @@
+statement error temporary tables are only supported experimentally\nHINT:.*46260\n.*\n.*SET experimental_enable_temp_tables = 'on'
+CREATE TEMP TABLE a_temp(a INT PRIMARY KEY)
+
 statement ok
 SET experimental_enable_temp_tables=true
 


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/46248

The message is currently "unimplemented", but should probably reflect
that it is experimental instead. Kept the unimplemented internals of the
message as it displays the issue number in a consistent way.

New message:
```

root@127.0.0.1:58862/defaultdb> create temp table a ( a int);
ERROR: temporary tables are only supported experimentally
SQLSTATE: 0A000
HINT: See: https://github.com/cockroachdb/cockroach/issues/46260
--
You can enable temporary tables by running `SET experimental_enable_temp_tables = 'on'`.
```

Release justification: low risk, high benefit changes to existing
functionality

Release note: None

