### PR TITLE
colexec: fix bug where vectorized engine couldn't use inverted indexes

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -150,7 +150,7 @@ func DecodeKeyValsToCols(
 		i := indexColIdx[j]
 		if i == -1 {
 			// Don't need the coldata - skip it.
-			key, err = sqlbase.SkipTableKey(&types[j], key, enc)
+			key, err = sqlbase.SkipTableKey(key)
 		} else {
 			if unseen != nil {
 				unseen.Remove(i)

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -714,19 +714,10 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 				prefixLen := len(rf.machine.lastRowPrefix)
 				remainingBytes := rf.machine.nextKV.Key[prefixLen:]
 				origRemainingBytesLen := len(remainingBytes)
-				for _, colID := range rf.table.index.ExtraColumnIDs {
-					colIdx, ok := rf.table.colIdxMap.get(colID)
-					if !ok {
-						return nil, errors.Errorf("column id %d was in index.ExtraColumnIDs but not in colIdxMap", colID)
-					}
+				for range rf.table.index.ExtraColumnIDs {
 					var err error
 					// Slice off an extra encoded column from remainingBytes.
-					remainingBytes, err = sqlbase.SkipTableKey(
-						&rf.table.cols[colIdx].Type,
-						remainingBytes,
-						// Extra columns are always stored in ascending order.
-						sqlbase.IndexDescriptor_ASC,
-					)
+					remainingBytes, err = sqlbase.SkipTableKey(remainingBytes)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1188,3 +1188,13 @@ query I
 SELECT max(t1.rowid) FROM t1 WHERE t1.c0
 ----
 0
+
+# Regression for #46183.
+statement ok
+CREATE TABLE t46183 (x INT PRIMARY KEY, y JSONB, INVERTED INDEX (y));
+INSERT INTO t46183 VALUES (1, '{"y": "hello"}')
+
+query I
+SELECT count(*) FROM t46183 WHERE y->'y' = to_jsonb('hello')
+----
+1

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -690,16 +690,10 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 		// is that the extra columns are not always there, and are used to unique-ify
 		// the index key, rather than provide the primary key column values.
 		if foundNull && rf.currentTable.isSecondaryIndex && rf.currentTable.index.Unique && len(rf.currentTable.desc.Families) != 1 {
-			for _, colID := range rf.currentTable.index.ExtraColumnIDs {
-				colIdx := rf.currentTable.colIdxMap[colID]
+			for range rf.currentTable.index.ExtraColumnIDs {
 				var err error
 				// Slice off an extra encoded column from rf.keyRemainingBytes.
-				rf.keyRemainingBytes, err = sqlbase.SkipTableKey(
-					&rf.currentTable.cols[colIdx].Type,
-					rf.keyRemainingBytes,
-					// Extra columns are always stored in ascending order.
-					sqlbase.IndexDescriptor_ASC,
-				)
+				rf.keyRemainingBytes, err = sqlbase.SkipTableKey(rf.keyRemainingBytes)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -164,74 +163,12 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 
 // SkipTableKey skips a value of type valType in key, returning the remainder
 // of the key.
-// TODO(jordan): each type could be optimized here.
-func SkipTableKey(valType *types.T, key []byte, dir IndexDescriptor_Direction) ([]byte, error) {
-	if (dir != IndexDescriptor_ASC) && (dir != IndexDescriptor_DESC) {
-		return nil, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
-	}
-	var isNull bool
-	if key, isNull = encoding.DecodeIfNull(key); isNull {
-		return key, nil
-	}
-	var rkey []byte
-	var err error
-	switch valType.Family() {
-	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily, types.TimeFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeVarintAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeVarintDescending(key)
-		}
-	case types.FloatFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeFloatAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeFloatDescending(key)
-		}
-	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.INetFamily, types.CollatedStringFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
-		}
-	case types.DecimalFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
-		}
-	case types.TimestampFamily, types.TimestampTZFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeTimeAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeTimeDescending(key)
-		}
-	case types.TimeTZFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeTimeTZAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeTimeTZDescending(key)
-		}
-	case types.IntervalFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeDurationAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeDurationDescending(key)
-		}
-	case types.BitFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeBitArrayAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeBitArrayDescending(key)
-		}
-	default:
-		// Tuples and arrays aren't indexable types right now, so we don't have cases for them.
-		return key, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
-	}
+func SkipTableKey(key []byte) ([]byte, error) {
+	skipLen, err := encoding.PeekLength(key)
 	if err != nil {
-		return key, err
+		return nil, err
 	}
-	return rkey, nil
+	return key[skipLen:], nil
 }
 
 // DecodeTableKey decodes a value encoded by EncodeTableKey.

--- a/pkg/sql/sqlbase/column_type_encoding_test.go
+++ b/pkg/sql/sqlbase/column_type_encoding_test.go
@@ -181,15 +181,11 @@ func TestSkipTableKey(t *testing.T) {
 	properties := gopter.NewProperties(parameters)
 	properties.Property("correctness", prop.ForAll(
 		func(d tree.Datum, dir encoding.Direction) string {
-			descDir := IndexDescriptor_ASC
-			if dir == encoding.Descending {
-				descDir = IndexDescriptor_DESC
-			}
 			b, err := EncodeTableKey(nil, d, dir)
 			if err != nil {
 				return "error: " + err.Error()
 			}
-			res, err := SkipTableKey(d.ResolvedType(), b, descDir)
+			res, err := SkipTableKey(b)
 			if err != nil {
 				return "error: " + err.Error()
 			}

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -1366,7 +1366,7 @@ func getMultiNonsortingVarintLen(b []byte, num int) (int, error) {
 
 // PeekLength returns the length of the encoded value at the start of b.  Note:
 // if this function succeeds, it's not a guarantee that decoding the value will
-// succeed.
+// succeed. PeekLength is meant to be used on key encoded data only.
 func PeekLength(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, errors.Errorf("empty slice")


### PR DESCRIPTION
Fixes #46183.

Release justification: bug fix

Release note (bug fix): This PR fixes a bug where the vectorized
engine would throw an internal error when executing a query that
utilized an inverted index.