### PR TITLE
sql: fix metric logging for temporary objects cleaner

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -905,6 +905,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.temporaryObjectCleaner = sql.NewTemporaryObjectCleaner(
 		s.st,
 		s.db,
+		s.registry,
 		s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory,
 		s.status,
 		s.node.stores.IsMeta1Leaseholder,

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -387,11 +387,14 @@ func (m *temporaryObjectCleanerMetrics) MetricStruct() {}
 func NewTemporaryObjectCleaner(
 	settings *cluster.Settings,
 	db *kv.DB,
+	registry *metric.Registry,
 	makeSessionBoundInternalExecutor sqlutil.SessionBoundInternalExecutorFactory,
 	statusServer serverpb.StatusServer,
 	isMeta1LeaseholderFunc isMeta1LeaseholderFunc,
 	testingKnobs ExecutorTestingKnobs,
 ) *TemporaryObjectCleaner {
+	metrics := makeTemporaryObjectCleanerMetrics()
+	registry.AddMetricStruct(metrics)
 	return &TemporaryObjectCleaner{
 		settings:                         settings,
 		db:                               db,
@@ -399,7 +402,7 @@ func NewTemporaryObjectCleaner(
 		statusServer:                     statusServer,
 		isMeta1LeaseholderFunc:           isMeta1LeaseholderFunc,
 		testingKnobs:                     testingKnobs,
-		metrics:                          makeTemporaryObjectCleanerMetrics(),
+		metrics:                          metrics,
 	}
 }
 


### PR DESCRIPTION
Was benchmarking temporary tables and found we didn't actually log these
metrics properly. There was a bit of plumbing that I missed doing. This
has been resolved and verified in this PR.

Release justification: bug fixes and low-risk updates to new
functionality
Release note: None