### PR TITLE
sql, workload, compose: miscellaneous cleanups

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -151,6 +151,12 @@
 </span></td></tr>
 <tr><td><a name="stddev"></a><code>stddev(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
 </span></td></tr>
+<tr><td><a name="stddev_samp"></a><code>stddev_samp(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
+<tr><td><a name="stddev_samp"></a><code>stddev_samp(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
+<tr><td><a name="stddev_samp"></a><code>stddev_samp(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
 <tr><td><a name="string_agg"></a><code>string_agg(arg1: <a href="bytes.html">bytes</a>, arg2: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.</p>
 </span></td></tr>
 <tr><td><a name="string_agg"></a><code>string_agg(arg1: <a href="string.html">string</a>, arg2: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.</p>

--- a/pkg/cmd/smithcmp/tpch.toml
+++ b/pkg/cmd/smithcmp/tpch.toml
@@ -524,7 +524,7 @@ set vectorize=auto;
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
 allowmutations = true
 initsql = """
-set vectorize=experimental_on;
+set vectorize=on;
 """
 
 [databases.postgres]

--- a/pkg/cmd/smithcmp/vec.toml
+++ b/pkg/cmd/smithcmp/vec.toml
@@ -32,5 +32,5 @@ set vectorize=off;
 addr = "postgresql://root@localhost:26257?sslmode=disable"
 allowmutations = true
 initsql = """
-set vectorize=experimental_on;
+set vectorize=on;
 """

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -144,14 +143,6 @@ func TestCompare(t *testing.T) {
 				default:
 				}
 				query := smither.Generate()
-				// #44029
-				if strings.Contains(query, "FULL JOIN") {
-					continue
-				}
-				// #44079
-				if strings.Contains(query, "|| NULL::") {
-					continue
-				}
 				query, _ = mutations.ApplyString(rng, query, mutations.PostgresMutator)
 				if err := cmpconn.CompareConns(ctx, time.Second*30, conns, "" /* prep */, query); err != nil {
 					path := filepath.Join(*flagArtifacts, confName+".log")

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -10,10 +10,10 @@ CREATE TABLE kv (
 )
 
 # Aggregate functions return NULL if there are no rows.
-query IIIIRRRRBBTII
-SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), variance(1), bool_and(true), bool_and(false), xor_agg(b'\x01'), bit_and(1), bit_or(1) FROM kv
+query IIIIRRRRRBBTII
+SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), stddev_samp(1), variance(1), bool_and(true), bool_and(false), xor_agg(b'\x01'), bit_and(1), bit_or(1) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
 
 # Regression test for #29695
 query T
@@ -64,7 +64,7 @@ NULL
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 query IIIIRRRRBBT
-SELECT min(1), count(1), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
+SELECT min(1), count(1), max(1), sum_int(1), avg(1)::float, sum(1), stddev_samp(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
 1 1 1 1 1 1 NULL NULL true true 01
 
@@ -789,7 +789,7 @@ SELECT variance(x) FROM xyz WHERE x = 1
 NULL
 
 query RRR
-SELECT stddev(x), stddev(y::decimal), round(stddev(z), 14) FROM xyz
+SELECT stddev_samp(x), stddev(y::decimal), round(stddev_samp(z), 14) FROM xyz
 ----
 3  2.1213203435596425732  2.51661147842358
 
@@ -834,7 +834,7 @@ SELECT round(variance(n), 2), round(variance(n), 2), round(variance(p)) FROM mno
 
 
 query RRR
-SELECT round(stddev(n), 2), round(stddev(n), 2), round(stddev(p)) FROM mnop
+SELECT round(stddev_samp(n), 2), round(stddev(n), 2), round(stddev_samp(p)) FROM mnop
 ----
 0.29 0.29 3
 
@@ -859,7 +859,7 @@ SELECT variance(1::int), variance(1::float), variance(1::decimal)
 NULL NULL NULL
 
 query RRR
-SELECT stddev(1::int), stddev(1::float), stddev(1::decimal)
+SELECT stddev(1::int), stddev_samp(1::float), stddev(1::decimal)
 ----
 NULL NULL NULL
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -774,7 +774,7 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 		return b.factory.ConstructSqrDiff(args[0])
 	case "variance":
 		return b.factory.ConstructVariance(args[0])
-	case "stddev":
+	case "stddev", "stddev_samp":
 		return b.factory.ConstructStdDev(args[0])
 	case "xor_agg":
 		return b.factory.ConstructXorAgg(args[0])

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -292,14 +292,9 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the variance of the selected values."),
 	),
 
-	"stddev": makeBuiltin(aggProps(),
-		makeAggOverload([]*types.T{types.Int}, types.Decimal, newIntStdDevAggregate,
-			"Calculates the standard deviation of the selected values."),
-		makeAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalStdDevAggregate,
-			"Calculates the standard deviation of the selected values."),
-		makeAggOverload([]*types.T{types.Float}, types.Float, newFloatStdDevAggregate,
-			"Calculates the standard deviation of the selected values."),
-	),
+	// stddev is a historical alias for stddev_samp.
+	"stddev":      makeStdDevBuiltin(),
+	"stddev_samp": makeStdDevBuiltin(),
 
 	"xor_agg": makeBuiltin(aggProps(),
 		makeAggOverload([]*types.T{types.Bytes}, types.Bytes, newBytesXorAggregate,
@@ -407,6 +402,17 @@ func makeAggOverloadWithReturnType(
 		},
 		Info: info,
 	}
+}
+
+func makeStdDevBuiltin() builtinDefinition {
+	return makeBuiltin(aggProps(),
+		makeAggOverload([]*types.T{types.Int}, types.Decimal, newIntStdDevAggregate,
+			"Calculates the standard deviation of the selected values."),
+		makeAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalStdDevAggregate,
+			"Calculates the standard deviation of the selected values."),
+		makeAggOverload([]*types.T{types.Float}, types.Float, newFloatStdDevAggregate,
+			"Calculates the standard deviation of the selected values."),
+	)
 }
 
 var _ tree.AggregateFunc = &arrayAggregate{}


### PR DESCRIPTION
**sql: add stddev_samp alias for stddev aggregate builtin**

Release justification: low-risk new functionality.

Addresses: #37464.

Release note (sql change): CockroachDB now supports `stddev_samp`
aggregate builtin function which is the same as `stddev` (actually, the
latter is the historical alias of the former, according to Postgres
documentation).

**workload, compose: miscellaneous cleanups**

Release justification: non-production code changes.

This commit cleans up a few things:
1. we recently renamed `experimental_on` vectorize setting to `on`, but
a couple of places were missed.
2. compose-compare test (of randomized land) was skipping some queries
due to bugs which have been fixed.
3. `tpcds` workload has been slightly enhanced (added `vectorize` option
and refactored the way statement timeout is set).

Release note: None