### PR TITLE
cli: return server's errors in nodelocal upload

### DIFF
--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -43,8 +43,7 @@ func Example_nodelocal() {
 	// nodelocal upload test.csv /test/file1.csv
 	// ERROR: destination file already exists for /test/file1.csv
 	// nodelocal upload test.csv /test/../../file1.csv
-	// ERROR: current transaction is aborted, commands ignored until end of transaction block
-	// SQLSTATE: 25P02
+	// ERROR: local file access to paths outside of external-io-dir is not allowed: /test/../../file1.csv
 	// nodelocal upload notexist.csv /test/file1.csv
 	// ERROR: open notexist.csv: no such file or directory
 }
@@ -64,11 +63,9 @@ func Example_nodelocal_disabled() {
 
 	// Output:
 	// nodelocal upload empty.csv /test/file1.csv
-	// ERROR: current transaction is aborted, commands ignored until end of transaction block
-	// SQLSTATE: 25P02
+	// ERROR: local file access is disabled
 	// nodelocal upload test.csv /test/file1.csv
-	// ERROR: current transaction is aborted, commands ignored until end of transaction block
-	// SQLSTATE: 25P02
+	// ERROR: local file access is disabled
 }
 
 func TestNodeLocalFileUpload(t *testing.T) {


### PR DESCRIPTION
Previously the cli code for 'nodelocal upload'  was using the retrying helper from cockroach-go
to run its COPY-based put of the file. Somehow this meant that the error the server was sending
back to the client was getting lost and instead the 'current txn is aborted' error was all that
was printed to the user. While I am still unclear on exactly where the original error went, it
seems that by using the go db/sql interface directly we see the expected errors, and as this
code is not running traditional OLTP/transactional SQL, it likely can skip the retry loop.

Fixes #46027.

Release justification: bug fix.

Release note (cli change): ensure the correct error messages are shown to the user when using 'nodelocal upload'.