### PR TITLE
scripts: Add Windows download link to generated release note files

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -829,6 +829,7 @@ if not hidedownloads:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 """)


### PR DESCRIPTION
Previously, the script for generating release note files would not
include a Windows binary download link. The link was removed at a point
when the Windows binary was not functioning properly. The Windows
binary has been fine a while now. This commit adds the link back in so
Docs writes don't have to do that manually as a part of editing
generated release note files.

Release justification: This commit is safe for this release because
it has nothing to do with cockroach.

Release note: None