### PR TITLE
kv: temporarily skip TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2877,6 +2877,7 @@ func TestStoreRangeMergeSlowWatcher(t *testing.T) {
 // range.
 func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#46192")
 
 	// We will be testing the SSTs written on store2's engine.
 	var receivingEng storage.Engine


### PR DESCRIPTION
Skip until #46192 is addressed.

This seems to have gotten fairly flaky and I don't want it to disrupt others during the stability period.

Release justification: testing only