### PR TITLE
[dnm] concurrency: reproduce panic observed in scaledata tests

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1230,7 +1230,9 @@ func (l *lockState) discoveredLock(
 
 	if l.holder.locked {
 		if !l.isLockedBy(txn.ID) {
-			panic("bug in caller or lockTable")
+			meta, ts, d := l.getLockerInfo()
+			msg := fmt.Sprintf("bug: meta=%v, ts=%v, d=%v", meta, ts, d)
+			panic(msg)
 		}
 	} else {
 		l.holder.locked = true

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -54,3 +54,123 @@ finish req=req1
 
 reset
 ----
+
+# Consider txns 1-3. There's an intent on "k" left by txn1, and both txn2 and
+# txn3 will 'discover' it concurrently.
+# - AddDiscovered, as called by txn2, goes through first. It returns to caller
+# which then retries the txn, now waiting on lock (from txn1's intent on 'k') to
+# get released. When it does, txn2 proceeds and ends up acquiring an
+# unreplicated lock.
+# - AddDiscovered, as called by txn3, goes through, but with the intent it first
+# observed from txn1. It expects the lock on 'k' to be held by txn1. When adding
+# the discovered lock, it asserts against that expectation but finds txn2 to be
+# holding it.
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-request name=req2 txn=txn2 ts=10,1
+  get key=k
+----
+
+new-request name=req3 txn=txn3 ts=10,1
+  get key=k
+----
+
+sequence req=req2
+----
+[1] sequence req2: sequencing request
+[1] sequence req2: acquiring latches
+[1] sequence req2: scanning lock table for conflicting locks
+[1] sequence req2: sequencing complete, returned guard
+
+sequence req=req3
+----
+[2] sequence req3: sequencing request
+[2] sequence req3: acquiring latches
+[2] sequence req3: scanning lock table for conflicting locks
+[2] sequence req3: sequencing complete, returned guard
+
+handle-write-intent-error req=req2 txn=txn1 key=k
+----
+[-] handle write intent error req2: handling conflicting intents on "k"
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req2
+----
+[3] sequence req2: re-sequencing request
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: waiting in lock wait-queues
+[3] sequence req2: pushing txn 00000001
+[3] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# XXX: I don't understand the safety around possible concurrency between the
+# following three commands. I'm trying to simulate handle-write-intent-error
+# being concurrently called with the resolution of the intent "k" by txn2 + lock
+# acquisition by txn2 on k.
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[3] sequence req2: resolving intent "k" for txn 00000001 with ABORTED status
+[3] sequence req2: acquiring latches
+[3] sequence req2: scanning lock table for conflicting locks
+[3] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired txn=txn2 key=k
+----
+[-] acquire lock: txn2 @ k
+
+# XXX: This is where we panic. Because we're handling the write intent we saw
+# left by txn1, and are asserting that the lock is in fact still held by txn1,
+# we don't account for the possibility that txn2 could've acquired the lock
+# between when we first saw the intent, and when we get to actually tell the
+# concurrency manager about it.
+handle-write-intent-error req=req3 txn=txn1 key=k
+----
+[-] handle write intent error req3: handling conflicting intents on "k"
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req3
+----
+[4] sequence req3: re-sequencing request
+[4] sequence req3: acquiring latches
+[4] sequence req3: scanning lock table for conflicting locks
+[4] sequence req3: waiting in lock wait-queues
+[4] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+[4] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
+[4] sequence req3: acquiring latches
+[4] sequence req3: scanning lock table for conflicting locks
+[4] sequence req3: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+reset
+----


### PR DESCRIPTION
In attempting to debug #43273, I ran into the panic [here](
https://github.com/cockroachdb/cockroach/blob/6e991cb2/pkg/kv/kvserver/concurrency/lock_table.go#L1233).

The workload running against it was heavy UPDATEs and concurrent
SELECTs. This PR is my reconstruction of why I think it may have
happened, and I'm not sure if the sequence of operations I've defined in
the testdata file is an allowed one, but it hits the same panic I
observed. Looking to understand it better. Reproducing the text below:

```
Consider txns 1-3. There's an intent on "k" left by txn1, and both txn2
and txn3 will 'discover' it concurrently.
  - AddDiscovered, as called by txn2, goes through first. It returns to caller
  which then retries the txn, now waiting on lock (from txn1's intent on 'k') to
  get released. When it does, txn2 proceeds.
  txn2 also now acquires a lock on 'k' (Is this allowed?)
  - AddDiscovered, as called by txn3, goes through, but with the intent it first
  observed from txn1. It expects the lock on 'k' to be held by txn1. When adding
  the discovered lock, it asserts against that expectation but finds txn2 to be
  holding it.
```

Release justification: None
Release note: None