### PR TITLE
changefeedccl,jobs: add behavior on PauseRequest, protect CHANGEFEED data

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -26,17 +26,18 @@ type SchemaChangePolicy string
 
 // Constants for the options.
 const (
-	OptConfluentSchemaRegistry = `confluent_schema_registry`
-	OptCursor                  = `cursor`
-	OptEnvelope                = `envelope`
-	OptFormat                  = `format`
-	OptKeyInValue              = `key_in_value`
-	OptResolvedTimestamps      = `resolved`
-	OptUpdatedTimestamps       = `updated`
-	OptDiff                    = `diff`
-	OptCompression             = `compression`
-	OptSchemaChangeEvents      = `schema_change_events`
-	OptSchemaChangePolicy      = `schema_change_policy`
+	OptConfluentSchemaRegistry  = `confluent_schema_registry`
+	OptCursor                   = `cursor`
+	OptEnvelope                 = `envelope`
+	OptFormat                   = `format`
+	OptKeyInValue               = `key_in_value`
+	OptResolvedTimestamps       = `resolved`
+	OptUpdatedTimestamps        = `updated`
+	OptDiff                     = `diff`
+	OptCompression              = `compression`
+	OptSchemaChangeEvents       = `schema_change_events`
+	OptSchemaChangePolicy       = `schema_change_policy`
+	OptProtectDataFromGCOnPause = `protect_data_from_gc_on_pause`
 
 	// OptSchemaChangeEventClassColumnChange corresponds to all schema change
 	// events which add or remove any column.
@@ -94,17 +95,18 @@ const (
 // ChangefeedOptionExpectValues is used to parse changefeed options using
 // PlanHookState.TypeAsStringOpts().
 var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
-	OptConfluentSchemaRegistry: sql.KVStringOptRequireValue,
-	OptCursor:                  sql.KVStringOptRequireValue,
-	OptEnvelope:                sql.KVStringOptRequireValue,
-	OptFormat:                  sql.KVStringOptRequireValue,
-	OptKeyInValue:              sql.KVStringOptRequireNoValue,
-	OptResolvedTimestamps:      sql.KVStringOptAny,
-	OptUpdatedTimestamps:       sql.KVStringOptRequireNoValue,
-	OptDiff:                    sql.KVStringOptRequireNoValue,
-	OptCompression:             sql.KVStringOptRequireValue,
-	OptSchemaChangeEvents:      sql.KVStringOptRequireValue,
-	OptSchemaChangePolicy:      sql.KVStringOptRequireValue,
-	OptInitialScan:             sql.KVStringOptRequireNoValue,
-	OptNoInitialScan:           sql.KVStringOptRequireNoValue,
+	OptConfluentSchemaRegistry:  sql.KVStringOptRequireValue,
+	OptCursor:                   sql.KVStringOptRequireValue,
+	OptEnvelope:                 sql.KVStringOptRequireValue,
+	OptFormat:                   sql.KVStringOptRequireValue,
+	OptKeyInValue:               sql.KVStringOptRequireNoValue,
+	OptResolvedTimestamps:       sql.KVStringOptAny,
+	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,
+	OptDiff:                     sql.KVStringOptRequireNoValue,
+	OptCompression:              sql.KVStringOptRequireValue,
+	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,
+	OptSchemaChangePolicy:       sql.KVStringOptRequireValue,
+	OptInitialScan:              sql.KVStringOptRequireNoValue,
+	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
+	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
 }

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -54,3 +54,33 @@ func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
 }
 
 var _ Resumer = FakeResumer{}
+
+// Started is a wrapper around the internal function that moves a job to the
+// started state.
+func (j *Job) Started(ctx context.Context) error {
+	return j.started(ctx)
+}
+
+// Created is a wrapper around the internal function that creates the initial
+// job state.
+func (j *Job) Created(ctx context.Context) error {
+	return j.created(ctx)
+}
+
+// Paused is a wrapper around the internal function that moves a job to the
+// paused state.
+func (j *Job) Paused(ctx context.Context) error {
+	return j.paused(ctx, nil /* fn */)
+}
+
+// Failed is a wrapper around the internal function that moves a job to the
+// failed state.
+func (j *Job) Failed(ctx context.Context, causingErr error) error {
+	return j.failed(ctx, causingErr, nil /* fn */)
+}
+
+// Succeeded is a wrapper around the internal function that moves a job to the
+// succeeded state.
+func (j *Job) Succeeded(ctx context.Context) error {
+	return j.succeeded(ctx, nil /* fn */)
+}

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -30,7 +31,10 @@ type FakeResumer struct {
 	OnResume     func(context.Context, chan<- tree.Datums) error
 	FailOrCancel func(context.Context) error
 	Success      func() error
+	PauseRequest onPauseRequestFunc
 }
+
+var _ Resumer = FakeResumer{}
 
 func (d FakeResumer) Resume(
 	ctx context.Context, _ interface{}, resultsCh chan<- tree.Datums,
@@ -53,7 +57,19 @@ func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
 	return nil
 }
 
-var _ Resumer = FakeResumer{}
+// OnPauseRequestFunc forwards the definition for use in tests.
+type OnPauseRequestFunc = onPauseRequestFunc
+
+var _ PauseRequester = FakeResumer{}
+
+func (d FakeResumer) OnPauseRequest(
+	ctx context.Context, phs interface{}, txn *kv.Txn, details *jobspb.Progress,
+) error {
+	if d.PauseRequest == nil {
+		return nil
+	}
+	return d.PauseRequest(ctx, phs, txn, details)
+}
 
 // Started is a wrapper around the internal function that moves a job to the
 // started state.

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -183,7 +183,7 @@ func (j *Job) ID() *int64 {
 // Created records the creation of a new job in the system.jobs table and
 // remembers the assigned ID of the job in the Job. The job information is read
 // from the Record field at the time Created is called.
-func (j *Job) Created(ctx context.Context) error {
+func (j *Job) created(ctx context.Context) error {
 	if j.ID() != nil {
 		return errors.Errorf("job already created with ID %v", *j.ID())
 	}
@@ -191,7 +191,7 @@ func (j *Job) Created(ctx context.Context) error {
 }
 
 // Started marks the tracked job as started.
-func (j *Job) Started(ctx context.Context) error {
+func (j *Job) started(ctx context.Context) error {
 	return j.Update(ctx, func(_ *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		if md.Status != StatusPending && md.Status != StatusRunning {
 			return errors.Errorf("job with status %s cannot be marked started", md.Status)
@@ -341,10 +341,10 @@ func (j *Job) HighWaterProgressed(ctx context.Context, progressedFn HighWaterPro
 	})
 }
 
-// Paused sets the status of the tracked job to paused. It does not directly
-// pause the job; instead, it expects the job to call job.Progressed soon,
-// observe a "job is paused" error, and abort further work.
-func (j *Job) Paused(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
+// paused sets the status of the tracked job to paused. It is called by the
+// registry adoption loop by the node currently running a job to move it from
+// pauseRequested to paused.
+func (j *Job) paused(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		if md.Status == StatusPaused {
 			// Already paused - do nothing.
@@ -363,7 +363,7 @@ func (j *Job) Paused(ctx context.Context, fn func(context.Context, *kv.Txn) erro
 	})
 }
 
-// Resumed sets the status of the tracked job to running or reverting iff the
+// resumed sets the status of the tracked job to running or reverting iff the
 // job is currently paused. It does not directly resume the job; rather, it
 // expires the job's lease so that a Registry adoption loop detects it and
 // resumes it.
@@ -473,8 +473,8 @@ func (j *Job) pauseRequested(ctx context.Context, fn func(context.Context, *kv.T
 	})
 }
 
-// Reverted sets the status of the tracked job to reverted.
-func (j *Job) Reverted(
+// reverted sets the status of the tracked job to reverted.
+func (j *Job) reverted(
 	ctx context.Context, err error, fn func(context.Context, *kv.Txn) error,
 ) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
@@ -527,7 +527,7 @@ func (j *Job) canceled(ctx context.Context, fn func(context.Context, *kv.Txn) er
 }
 
 // Failed marks the tracked job as having failed with the given error.
-func (j *Job) Failed(
+func (j *Job) failed(
 	ctx context.Context, err error, fn func(context.Context, *kv.Txn) error,
 ) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
@@ -549,9 +549,9 @@ func (j *Job) Failed(
 	})
 }
 
-// Succeeded marks the tracked job as having succeeded and sets its fraction
+// succeeded marks the tracked job as having succeeded and sets its fraction
 // completed to 1.0.
-func (j *Job) Succeeded(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
+func (j *Job) succeeded(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		if md.Status == StatusSucceeded {
 			return nil
@@ -817,7 +817,7 @@ func (sj *StartableJob) Start(ctx context.Context) (errCh <-chan error, err erro
 	if !sj.txn.IsCommitted() {
 		return nil, fmt.Errorf("cannot resume %T job which is not committed", sj.resumer)
 	}
-	if err := sj.Started(ctx); err != nil {
+	if err := sj.started(ctx); err != nil {
 		return nil, err
 	}
 	errCh, err = sj.registry.resume(sj.resumerCtx, sj.resumer, sj.resultsCh, sj.Job)

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -435,11 +435,17 @@ func (j *Job) cancelRequested(ctx context.Context, fn func(context.Context, *kv.
 	})
 }
 
+// onPauseRequestFunc is a function used to perform action on behalf of a job
+// implementation when a pause is requested.
+type onPauseRequestFunc func(
+	ctx context.Context, planHookState interface{}, txn *kv.Txn, progress *jobspb.Progress,
+) error
+
 // pauseRequested sets the status of the tracked job to pause-requested. It does
 // not directly pause the job; it expects the node that runs the job will
 // actively cancel it when it notices that it is in state StatusPauseRequested
 // and will move it to state StatusPaused.
-func (j *Job) pauseRequested(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
+func (j *Job) pauseRequested(ctx context.Context, fn onPauseRequestFunc) error {
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		// Don't allow 19.2-style schema change jobs to undergo changes in job state
 		// before they undergo a migration to make them properly runnable in 20.1 and
@@ -464,9 +470,12 @@ func (j *Job) pauseRequested(ctx context.Context, fn func(context.Context, *kv.T
 			return fmt.Errorf("job with status %s cannot be requested to be paused", md.Status)
 		}
 		if fn != nil {
-			if err := fn(ctx, txn); err != nil {
+			phs, cleanup := j.registry.planFn("pause request", j.Payload().Username)
+			defer cleanup()
+			if err := fn(ctx, phs, txn, md.Progress); err != nil {
 				return err
 			}
+			ju.UpdateProgress(md.Progress)
 		}
 		ju.UpdateStatus(StatusPauseRequested)
 		return nil

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -162,9 +162,16 @@ type registryTestSuite struct {
 	failOrCancelCh      chan error
 	resumeCheckCh       chan struct{}
 	failOrCancelCheckCh chan struct{}
+	onPauseRequest      jobs.OnPauseRequestFunc
 	// Instead of a ch for success, use a variable because it can retry since it
 	// is in a transaction.
 	successErr error
+}
+
+func noopPauseRequestFunc(
+	ctx context.Context, planHookState interface{}, txn *kv.Txn, progress *jobspb.Progress,
+) error {
+	return nil
 }
 
 func (rts *registryTestSuite) setUp(t *testing.T) {
@@ -182,6 +189,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 	rts.failOrCancelCh = make(chan error)
 	rts.resumeCheckCh = make(chan struct{})
 	rts.failOrCancelCheckCh = make(chan struct{})
+	rts.onPauseRequest = noopPauseRequestFunc
 
 	jobs.RegisterConstructor(jobspb.TypeImport, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
@@ -214,7 +222,6 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 					}
 				}
 			},
-
 			FailOrCancel: func(ctx context.Context) error {
 				t.Log("Starting FailOrCancel")
 				rts.mu.Lock()
@@ -247,6 +254,9 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				}()
 				rts.mu.a.Success = true
 				return rts.successErr
+			},
+			PauseRequest: func(ctx context.Context, execCfg interface{}, txn *kv.Txn, progress *jobspb.Progress) error {
+				return rts.onPauseRequest(ctx, execCfg, txn, progress)
 			},
 		}
 	})
@@ -741,6 +751,74 @@ func TestRegistryLifecycle(t *testing.T) {
 			return nil
 		})
 		rts.check(t, jobs.StatusFailed)
+	})
+
+	t.Run("OnPauseRequest", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		madeUpSpans := []roachpb.Span{
+			{Key: roachpb.Key("foo")},
+		}
+		rts.onPauseRequest = func(ctx context.Context, planHookState interface{}, txn *kv.Txn, progress *jobspb.Progress) error {
+			progress.GetImport().SpanProgress = madeUpSpans
+			return nil
+		}
+
+		job, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		require.NoError(t, err)
+		rts.job = job
+
+		rts.resumeCheckCh <- struct{}{}
+		rts.mu.e.ResumeStart = true
+		rts.check(t, jobs.StatusRunning)
+
+		// Request that the job is paused.
+		pauseErrCh := make(chan error)
+		go func() {
+			_, err := rts.outerDB.Exec("PAUSE JOB $1", *job.ID())
+			pauseErrCh <- err
+		}()
+
+		// Ensure that the pause went off without a problem.
+		require.NoError(t, <-pauseErrCh)
+		rts.check(t, jobs.StatusPaused)
+		{
+			// Make sure the side-effects of our pause function occurred.
+			j, err := rts.registry.LoadJob(rts.ctx, *job.ID())
+			require.NoError(t, err)
+			progress := j.Progress()
+			require.Equal(t, madeUpSpans, progress.GetImport().SpanProgress)
+		}
+	})
+	t.Run("OnPauseRequest failure does not pause", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+
+		rts.onPauseRequest = func(ctx context.Context, planHookState interface{}, txn *kv.Txn, progress *jobspb.Progress) error {
+			return errors.New("boom")
+		}
+
+		job, _, err := rts.registry.CreateAndStartJob(rts.ctx, nil, rts.mockJob)
+		require.NoError(t, err)
+		rts.job = job
+
+		// Allow the job to start.
+		rts.resumeCheckCh <- struct{}{}
+		rts.mu.e.ResumeStart = true
+		rts.check(t, jobs.StatusRunning)
+
+		// Request that the job is paused and ensure that the pause hit the error
+		// and failed to pause.
+		_, err = rts.outerDB.Exec("PAUSE JOB $1", *job.ID())
+		require.Regexp(t, "boom", err)
+
+		// Allow the job to complete.
+		rts.resumeCh <- nil
+		rts.mu.e.Success = true
+		rts.mu.e.ResumeExit++
+		rts.check(t, jobs.StatusSucceeded)
 	})
 }
 
@@ -1296,6 +1374,7 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
 }
 
 // TestShowJobs manually inserts a row into system.jobs and checks that the

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -864,7 +864,7 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := woodyJob.Succeeded(ctx, nil); err != nil {
+		if err := woodyJob.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if err := woodyExp.verify(woodyJob.ID(), jobs.StatusSucceeded); err != nil {
@@ -910,7 +910,7 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := buzzJob.Failed(ctx, errors.New("Buzz Lightyear can't fly"), nil); err != nil {
+		if err := buzzJob.Failed(ctx, errors.New("Buzz Lightyear can't fly")); err != nil {
 			t.Fatal(err)
 		}
 		if err := buzzExp.verify(buzzJob.ID(), jobs.StatusFailed); err != nil {
@@ -935,7 +935,7 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := sidJob.Failed(ctx, errors.New("Sid is a total failure"), nil); err != nil {
+		if err := sidJob.Failed(ctx, errors.New("Sid is a total failure")); err != nil {
 			t.Fatal(err)
 		}
 		sidExp.Error = "Sid is a total failure"
@@ -959,7 +959,7 @@ func TestJobLifecycle(t *testing.T) {
 			if err := job.Started(ctx); err != nil {
 				t.Fatal(err)
 			}
-			if err := job.Succeeded(ctx, nil); err != nil {
+			if err := job.Succeeded(ctx); err != nil {
 				t.Fatal(err)
 			}
 			if err := exp.verify(job.ID(), jobs.StatusSucceeded); err != nil {
@@ -970,7 +970,7 @@ func TestJobLifecycle(t *testing.T) {
 		t.Run("non-nil error marks job as failed", func(t *testing.T) {
 			job, exp := createDefaultJob()
 			exp.Error = "boom"
-			if err := job.Failed(ctx, errors.New(exp.Error), nil); err != nil {
+			if err := job.Failed(ctx, errors.New(exp.Error)); err != nil {
 				t.Fatal(err)
 			}
 			if err := exp.verify(job.ID(), jobs.StatusFailed); err != nil {
@@ -985,7 +985,7 @@ func TestJobLifecycle(t *testing.T) {
 			); err != nil {
 				t.Fatal(err)
 			}
-			if err := job.Succeeded(ctx, nil); !testutils.IsError(err, "wrong wireType") {
+			if err := job.Succeeded(ctx); !testutils.IsError(err, "wrong wireType") {
 				t.Fatalf("unexpected: %v", err)
 			}
 		})
@@ -997,7 +997,7 @@ func TestJobLifecycle(t *testing.T) {
 			); err != nil {
 				t.Fatal(err)
 			}
-			if err := job.Failed(ctx, errors.New("boom"), nil); !testutils.IsError(err, "wrong wireType") {
+			if err := job.Failed(ctx, errors.New("boom")); !testutils.IsError(err, "wrong wireType") {
 				t.Fatalf("unexpected: %v", err)
 			}
 		})
@@ -1009,7 +1009,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := registry.PauseRequested(ctx, nil, *job.ID()); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.Paused(ctx, nil); err != nil {
+		if err := job.Paused(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if err := exp.verify(job.ID(), jobs.StatusPaused); err != nil {
@@ -1018,6 +1018,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := registry.Resume(ctx, nil, *job.ID()); err != nil {
 			t.Fatal(err)
 		}
+		// Resume the job again to ensure that the resumption is idempotent.
 		if err := registry.Resume(ctx, nil, *job.ID()); err != nil {
 			t.Fatal(err)
 		}
@@ -1026,7 +1027,7 @@ func TestJobLifecycle(t *testing.T) {
 		}
 
 		// PauseRequested fails after job is successful.
-		if err := job.Succeeded(ctx, nil); err != nil {
+		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if err := registry.PauseRequested(ctx, nil, *job.ID()); !testutils.IsError(err, "cannot be requested to be paused") {
@@ -1063,7 +1064,7 @@ func TestJobLifecycle(t *testing.T) {
 			if err := registry.PauseRequested(ctx, nil, *job.ID()); err != nil {
 				t.Fatal(err)
 			}
-			if err := job.Paused(ctx, nil); err != nil {
+			if err := job.Paused(ctx); err != nil {
 				t.Fatal(err)
 			}
 			if err := registry.CancelRequested(ctx, nil, *job.ID()); err != nil {
@@ -1076,7 +1077,7 @@ func TestJobLifecycle(t *testing.T) {
 
 		{
 			job, _ := startLeasedJob(t, defaultRecord)
-			if err := job.Succeeded(ctx, nil); err != nil {
+			if err := job.Succeeded(ctx); err != nil {
 				t.Fatal(err)
 			}
 			expectedErr := "job with status succeeded cannot be requested to be canceled"
@@ -1099,7 +1100,7 @@ func TestJobLifecycle(t *testing.T) {
 
 		{
 			job, _ := startLeasedJob(t, defaultRecord)
-			if err := job.Succeeded(ctx, nil); err != nil {
+			if err := job.Succeeded(ctx); err != nil {
 				t.Fatal(err)
 			}
 			expectedErr := fmt.Sprintf("job with status %s cannot be resumed", jobs.StatusSucceeded)
@@ -1140,10 +1141,10 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.Succeeded(ctx, nil); err != nil {
+		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.Succeeded(ctx, nil); err != nil {
+		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -1209,7 +1210,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.Succeeded(ctx, nil); err != nil {
+		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if err := job.FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
@@ -1251,7 +1252,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.FractionProgressed(ctx, jobs.FractionUpdater(0.2)); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.Succeeded(ctx, nil); err != nil {
+		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
 		exp.FractionCompleted = 1.0

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1985,7 +1985,6 @@ func TestStartableJob(t *testing.T) {
 		return nil
 	})
 	setResumeFunc := func(f func(ctx context.Context, _ chan<- tree.Datums) error) (cleanup func()) {
-		fmt.Println("hi")
 		prev := resumeFunc.Load()
 		resumeFunc.Store(f)
 		return func() { resumeFunc.Store(prev) }
@@ -1993,7 +1992,6 @@ func TestStartableJob(t *testing.T) {
 	jobs.RegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
 		return jobs.FakeResumer{
 			OnResume: func(ctx context.Context, resultsCh chan<- tree.Datums) error {
-				fmt.Println("hey")
 				return resumeFunc.Load().(func(ctx context.Context, _ chan<- tree.Datums) error)(ctx, resultsCh)
 			},
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -407,12 +407,7 @@ func (p *planner) initiateDropTable(
 		}
 	}
 	for jobID := range jobIDs {
-		job, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.txn)
-		if err != nil {
-			return err
-		}
-
-		if err := job.WithTxn(p.txn).Succeeded(ctx, nil); err != nil {
+		if err := p.ExecCfg().JobRegistry.Succeeded(ctx, p.txn, jobID); err != nil {
 			return errors.Wrapf(err,
 				"failed to mark job %d as as successful", errors.Safe(jobID))
 		}


### PR DESCRIPTION
This PR comes in several commits. 

1) Unexport a number of internal state transitions from the `*jobs.Job` struct. 
2) Remove some debugging Printlns
3) Add an extension to `jobs.Resumer` to control behavior when a pause is requested
4) Use that extension to install a protected timestamp record when pausing a CHANGEFEED.

Release justification: bug fixes and low-risk updates to new functionality
