### PR TITLE
sql: fix race caused by reporting active txn info in session data

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2264,7 +2264,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		kvTxnID = &id
 		activeTxnInfo = &serverpb.TxnInfo{
 			ID:             id,
-			Start:          ex.phaseTimes[transactionStart],
+			Start:          ex.state.mu.txnStart,
 			TxnDescription: txn.String(),
 		}
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1279,20 +1279,15 @@ func payloadHasError(payload fsm.EventPayload) bool {
 // recordTransactionStart records the start of the transaction and returns a
 // closure to be called once the transaction finishes.
 func (ex *connExecutor) recordTransactionStart() func(txnEvent) {
-	// We don't need to write down the transaction start time into
-	// ex.statsCollector.phaseTimes because it will be overwritten in
-	// ex.statsCollector.reset() before executing the statements of the
-	// transaction.
-	ex.phaseTimes[transactionStart] = timeutil.Now()
+	ex.state.mu.RLock()
+	txnStart := ex.state.mu.txnStart
+	ex.state.mu.RUnlock()
 	implicit := ex.implicitTxn()
-	return func(ev txnEvent) { ex.recordTransaction(ev, implicit) }
+	return func(ev txnEvent) { ex.recordTransaction(ev, implicit, txnStart) }
 }
 
-func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool) {
-	phaseTimes := &ex.statsCollector.phaseTimes
-	phaseTimes[transactionEnd] = timeutil.Now()
-	txnStart := phaseTimes[transactionStart]
-	txnEnd := phaseTimes[transactionEnd]
+func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart time.Time) {
+	txnEnd := timeutil.Now()
 	txnTime := txnEnd.Sub(txnStart)
 	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
 	ex.statsCollector.recordTransaction(

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -47,10 +47,6 @@ const (
 	plannerStartExecStmt    // Execution starts.
 	plannerEndExecStmt      // Execution ends.
 
-	// Transaction phases.
-	transactionStart // Transaction starts.
-	transactionEnd   // Transaction ends.
-
 	// sessionNumPhases must be listed last so that it can be used to
 	// define arrays sufficiently large to hold all the other values.
 	sessionNumPhases

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -50,6 +50,9 @@ type txnState struct {
 		syncutil.RWMutex
 
 		txn *kv.Txn
+
+		// txnStart records the time that txn started.
+		txnStart time.Time
 	}
 
 	// connCtx is the connection's context. This is the parent of Ctx.
@@ -201,6 +204,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	} else {
 		ts.mu.txn = txn
 	}
+	ts.mu.txnStart = timeutil.Now()
 	ts.mu.Unlock()
 	if historicalTimestamp != nil {
 		ts.setHistoricalTimestamp(ts.Ctx, *historicalTimestamp)
@@ -245,6 +249,7 @@ func (ts *txnState) finishSQLTxn() {
 	ts.Ctx = nil
 	ts.mu.Lock()
 	ts.mu.txn = nil
+	ts.mu.txnStart = time.Time{}
 	ts.mu.Unlock()
 	ts.recordingThreshold = 0
 }


### PR DESCRIPTION
Fixes #46368.
Fixes #46351.
Fixes #46428.
Fixes #46448.

This PR fixes a newly introduced race between the conn_executor
recording the start of a transaction and reading the recorded
transaction start time in a ListSessions RPC query.

Release justification: bug fix

Release note: None