### PR TITLE
ui: remove "oss/" prefix from imports

### DIFF
--- a/pkg/ui/src/components/dropdown/dropdown.tsx
+++ b/pkg/ui/src/components/dropdown/dropdown.tsx
@@ -14,7 +14,7 @@ import cn from "classnames";
 import { OutsideEventHandler } from "../outsideEventHandler";
 import "./dropdown.styl";
 import { Icon } from "antd";
-import { Button } from "oss/src/components/button";
+import { Button } from "src/components/button";
 
 export interface Item {
   value: string;

--- a/pkg/ui/src/components/pagination/pagination.tsx
+++ b/pkg/ui/src/components/pagination/pagination.tsx
@@ -10,7 +10,7 @@
 
 import { Icon, Pagination } from "antd";
 import * as React from "react";
-import { getMatchParamByName } from "oss/src/util/query";
+import { getMatchParamByName } from "src/util/query";
 import { match } from "react-router";
 
 export interface PaginationSettings {

--- a/pkg/ui/src/util/analytics/trackTableSort.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 import { analytics } from "src/redux/analytics";
-import { SortableColumn, SortSetting } from "oss/src/views/shared/components/sortabletable";
+import { SortableColumn, SortSetting } from "src/views/shared/components/sortabletable";
 
 export const track = (fn: Function) => (
   name?: String,

--- a/pkg/ui/src/views/cluster/components/controls/index.tsx
+++ b/pkg/ui/src/views/cluster/components/controls/index.tsx
@@ -12,7 +12,7 @@ import { Button, Tooltip } from "antd";
 import CaretLeft from "assets/caret-left.svg";
 import CaretRight from "assets/caret-right.svg";
 import _ from "lodash";
-import { ArrowDirection } from "oss/src/views/shared/components/dropdown";
+import { ArrowDirection } from "src/views/shared/components/dropdown";
 import React from "react";
 import "./controls.styl";
 

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -23,7 +23,7 @@ import { Bytes, DATE_FORMAT, Percentage } from "src/util/format";
 import { INodeStatus, MetricConstants, StatusMetrics } from "src/util/proto";
 import { getMatchParamByName } from "src/util/query";
 import { SummaryBar, SummaryLabel, SummaryValue } from "src/views/shared/components/summaryBar";
-import { Button, BackIcon } from "oss/src/components/button";
+import { Button, BackIcon } from "src/components/button";
 import "./nodeOverview.styl";
 
 /**

--- a/pkg/ui/src/views/cluster/containers/timescale/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/timescale/index.tsx
@@ -10,7 +10,7 @@
 
 import _ from "lodash";
 import moment from "moment";
-import { queryByName, queryToObj, queryToString } from "oss/src/util/query";
+import { queryByName, queryToObj, queryToString } from "src/util/query";
 import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";

--- a/pkg/ui/src/views/dashboard/emailSubscription.tsx
+++ b/pkg/ui/src/views/dashboard/emailSubscription.tsx
@@ -19,7 +19,7 @@ import { clusterIdSelector } from "src/redux/nodes";
 import "./emailSubscription.styl";
 import { loadUIData, RELEASE_NOTES_SIGNUP_DISMISSED_KEY, saveUIData } from "src/redux/uiData";
 import { dismissReleaseNotesSignupForm } from "src/redux/uiDataSelectors";
-import { emailSubscriptionAlertLocalSetting } from "oss/src/redux/alerts";
+import { emailSubscriptionAlertLocalSetting } from "src/redux/alerts";
 
 type EmailSubscriptionProps = MapDispatchToProps & MapStateToProps;
 

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -25,7 +25,7 @@ import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconf
 import { SortSetting} from "src/views/shared/components/sortabletable";
 import "./index.styl";
 import { statusOptions } from "./jobStatusOptions";
-import { JobTable} from "oss/src/views/jobs/jobTable";
+import { JobTable } from "src/views/jobs/jobTable";
 import { trackFilter } from "src/util/analytics";
 import JobType = cockroach.sql.jobs.jobspb.Type;
 import JobsRequest = cockroach.server.serverpb.JobsRequest;

--- a/pkg/ui/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/src/views/jobs/jobDetails.tsx
@@ -10,7 +10,7 @@
 
 import { Col, Row } from "antd";
 import _ from "lodash";
-import { TimestampToMoment } from "oss/src/util/convert";
+import { TimestampToMoment } from "src/util/convert";
 import React from "react";
 import Helmet from "react-helmet";
 import { connect } from "react-redux";

--- a/pkg/ui/src/views/jobs/jobStatusCell.tsx
+++ b/pkg/ui/src/views/jobs/jobStatusCell.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import {cockroach} from "src/js/protos";
-import {HighwaterTimestamp} from "oss/src/views/jobs/highwaterTimestamp";
+import {HighwaterTimestamp} from "src/views/jobs/highwaterTimestamp";
 import {JobStatus} from "./jobStatus";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 

--- a/pkg/ui/src/views/jobs/jobTable.spec.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.spec.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { assert } from "chai";
-import {JobTable, JobTableProps} from "oss/src/views/jobs/jobTable";
+import {JobTable, JobTableProps} from "src/views/jobs/jobTable";
 
 import "src/enzymeInit";
 

--- a/pkg/ui/src/views/jobs/progressBar.tsx
+++ b/pkg/ui/src/views/jobs/progressBar.tsx
@@ -14,7 +14,7 @@ import {
 } from "src/views/jobs/jobStatusOptions";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import {cockroach} from "src/js/protos";
-import { Badge } from "oss/src/components";
+import { Badge } from "src/components";
 import { Line } from "rc-progress";
 
 export class JobStatusBadge extends React.PureComponent<{jobStatus: string}> {

--- a/pkg/ui/src/views/reports/containers/network/legend/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/legend/index.tsx
@@ -9,8 +9,8 @@
 // licenses/APL.txt.
 
 import { Divider, Icon, Tooltip } from "antd";
-import { Chip } from "oss/src/views/app/components/chip";
-import Modal from "oss/src/views/app/components/modal";
+import { Chip } from "src/views/app/components/chip";
+import Modal from "src/views/app/components/modal";
 import { getDisplayName } from "src/redux/nodes";
 import React from "react";
 import { NoConnection } from "..";

--- a/pkg/ui/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/sort/index.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { Checkbox, Divider } from "antd";
-import Dropdown, { DropdownOption } from "oss/src/views/shared/components/dropdown";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import React from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 

--- a/pkg/ui/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/src/views/shared/components/dropdown/index.tsx
@@ -18,7 +18,7 @@ import "./dropdown.styl";
 import {leftArrow, rightArrow} from "src/views/shared/components/icons";
 import { trustIcon } from "src/util/trust";
 import ReactSelectClass from "react-select";
-import { CaretDown } from "oss/src/components/icon/caretDown";
+import { CaretDown } from "src/components/icon/caretDown";
 
 export interface DropdownOption {
   value: string;

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -10,17 +10,17 @@
 
 import React from "react";
 import classNames from "classnames";
+import getHighlightedText from "src/util/highlightedText";
 import map from "lodash/map";
 import isUndefined from "lodash/isUndefined";
 import times from "lodash/times";
 
-import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
 import { trackTableSort } from "src/util/analytics";
 
 import "./sortabletable.styl";
 import { Spin, Icon } from "antd";
-import SpinIcon from "oss/src/components/icon/spin";
+import SpinIcon from "src/components/icon/spin";
 import { Empty, IEmptyProps } from "src/components/empty";
 
 /**

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -14,7 +14,7 @@ import { Moment } from "moment";
 import React from "react";
 import { createSelector } from "reselect";
 import { ExpandableConfig, SortableColumn, SortableTable, SortSetting } from "src/views/shared/components/sortabletable";
-import { IEmptyProps } from "oss/src/components/empty";
+import { IEmptyProps } from "src/components/empty";
 
 export interface ISortedTablePagination {
   current: number;

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.spec.tsx
@@ -16,7 +16,7 @@ import Long from "long";
 
 import "src/enzymeInit";
 import { DiagnosticsView, EmptyDiagnosticsView } from "./diagnosticsView";
-import { Table } from "oss/src/components";
+import { Table } from "src/components";
 import { connectedMount } from "src/test-utils";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -47,7 +47,7 @@ import classNames from "classnames";
 import {
   selectDiagnosticsReportsCountByStatementFingerprint,
 } from "src/redux/statements/statementsSelectors";
-import { Button, BackIcon } from "oss/src/components/button";
+import { Button, BackIcon } from "src/components/button";
 import { trackSubnavSelection } from "src/util/analytics";
 
 const { TabPane } = Tabs;

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import getHighlightedText from "oss/src/util/highlightedText";
+import getHighlightedText from "src/util/highlightedText";
 import React from "react";
 import { Link } from "react-router-dom";
 


### PR DESCRIPTION
This import is inserted when automating imports from an IDE and
should generally be omitted.

Currently, our tsconfig differentiates between `oss` and `ccl`
imports by allowing the `ccl` directory to override any file in the
main `src` dir.

This change reverts all explicit `oss` imports in the `pkg/ui/src` dir,
since they are redundant and confusing.

Release note: none