### PR TITLE
deflake TestStoreRangeMergeRaftSnapshot by using a manual clock

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2888,6 +2888,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	storeCfg := kvserver.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	storeCfg.TestingKnobs.DisableReplicaGCQueue = true
+	storeCfg.Clock = nil // manual clock
 	storeCfg.TestingKnobs.BeforeSnapshotSSTIngestion = func(
 		inSnap kvserver.IncomingSnapshot,
 		snapType kvserver.SnapshotRequest_Type,


### PR DESCRIPTION
This test became flaky after #45984, which changed the behavior of multiTestContext to use a real-time clock if it wasn't explicitly set to a manual clock.

Fixes #46192.

Release justification: Deflake test in non-production code.

Release note: None.