### PR TITLE
colexec: remove batch width check in invariant checker 

### DIFF
--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -23,17 +22,14 @@ import (
 // should be planned between other Operators in tests.
 type invariantsChecker struct {
 	OneInputNode
-
-	expectedBatchWidth int
 }
 
 var _ Operator = invariantsChecker{}
 
 // NewInvariantsChecker creates a new invariantsChecker.
-func NewInvariantsChecker(input Operator, expectedBatchWidth int) Operator {
+func NewInvariantsChecker(input Operator) Operator {
 	return &invariantsChecker{
-		OneInputNode:       OneInputNode{input: input},
-		expectedBatchWidth: expectedBatchWidth,
+		OneInputNode: OneInputNode{input: input},
 	}
 }
 
@@ -46,12 +42,6 @@ func (i invariantsChecker) Next(ctx context.Context) coldata.Batch {
 	n := b.Length()
 	if n == 0 {
 		return b
-	}
-	if i.expectedBatchWidth != b.Width() {
-		panic(
-			fmt.Sprintf("unexpected batch width: expected %d, got %d",
-				i.expectedBatchWidth, b.Width(),
-			))
 	}
 	for colIdx := 0; colIdx < b.Width(); colIdx++ {
 		v := b.ColVec(colIdx)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -936,7 +936,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, errors.Wrapf(err, "unable to vectorize execution plan")
 		}
 		if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.EnableVectorizedInvariantsChecker {
-			result.Op = colexec.NewInvariantsChecker(result.Op, len(result.ColumnTypes))
+			result.Op = colexec.NewInvariantsChecker(result.Op)
 		}
 		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.Vectorize192Auto &&
 			!result.IsStreaming {


### PR DESCRIPTION
The batch width check in invariant checker is removed since
this assumption is no longer true. This fixes the issue that
ordinality operator fails the batch width check in logictest
when batch size is 1.

Release justification: bug fix
Release note: None
