### PR TITLE
kvcoord: don't disable the merge queue needlessly in test

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1523,8 +1523,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			}
 			return nil
 		}
-	// Don't clobber the test's splits.
-	storeKnobs.DisableMergeQueue = true
 
 	s, _, _ := serverutils.StartServer(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})


### PR DESCRIPTION
A test was disabling the queue to not interfere with its AdminSplit, but
since the test was written, the AdminSplit got a TTL.

Release note: None
Release justification: test only