### PR TITLE
sql: resolve databases in high-priority transactions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1777,13 +1777,24 @@ COMMIT
 # namespace entries could block the schema resolution after the rollback (schema
 # resolution uses different transactions to do its reads). We've fixed it by having those
 # other transactions run at high priority, thus pushing the intents out of their way.
-subtest no_schemachange_deadlock_after_savepoint_rollback
+subtest no_table_schemachange_deadlock_after_savepoint_rollback
 
 statement ok
 begin; savepoint s; create table t(x int); rollback to savepoint s;
 
 query error relation "t" does not exist
 select * from t;
+
+statement ok
+commit;
+
+subtest no_database_schemachange_deadlock_after_savepoint_rollback
+
+statement ok
+begin; savepoint s; create database d46224; rollback to savepoint s;
+
+query error  relation "d46224.t" does not exist
+select * from d46224.t;
 
 statement ok
 commit;


### PR DESCRIPTION
This commit is a follow up to #46170. That PR dealt with the table resolution
self-deadlock and additionally ensures that lease acquisition is not blocked.
That commit did not deal with the fact that schema changes which mutate
databases can deadlock themselves on retry because a separate transaction
is used to resolve database descriptors during planning.

This patch makes reading the system.namespace table and reading database
descriptors in high-priority transactions. The transactions will push
locks owned by schema changes out of their way. The idea is that regular
SQL transactions reading schema don't want to wait for the transactions
performing DDL statements. Instead, those DDLs will be pushed and forced
to refresh.

Besides the benefit to regular transactions, this patch also prevents
deadlocks for the transactions performing DDL. Before this patch, the
final select in the following sequence would deadlock:

begin; savepoint s; create database d; rollback to savepoint s;
select * from d.t;

The select is reading the namespace table, using a different txn from
its own. That read would block on the intent laid down by the prior
create. With this patch, the transaction effectively pushes itself, but
gets to otherwise run.

Fixes #46224

Release justification: Fix for an old bug that became more preminent
when we introduced SAVEPOINTs recently.

Release note (bug fix): A rare bug causing transactions that have performed
schema changes to deadlock after they restart has been fixed.