### PR TITLE
Revert "backup: re-enable fast incremental BACKUP via TBI"

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -67,7 +67,7 @@ var fullClusterSystemTables = []string{
 var useTBI = settings.RegisterBoolSetting(
 	"kv.bulk_io_write.experimental_incremental_export_enabled",
 	"use experimental time-bound file filter when exporting in BACKUP",
-	true,
+	false,
 )
 
 var backupOptionExpectValues = map[string]sql.KVStringOptValidate{


### PR DESCRIPTION
This reverts commit 347243e8d32418c40a4493d57e7964a8ef993913.

Release justification: bug fix
Release note (bug fix): Reverts performance improvements to incremental backups until a potential correctness issue is addressed.