### PR TITLE
backup: re-enable fast incremental BACKUP via TBI

### DIFF
--- a/c-deps/libroach/incremental_iterator.cc
+++ b/c-deps/libroach/incremental_iterator.cc
@@ -113,7 +113,7 @@ void DBIncrementalIterator::maybeSkipKeys() {
       // phantom MVCCKey.Keys. These keys may not be seen by the main iterator
       // due to aborted transactions and keys which have been subsumed due to
       // range tombstones. In this case we can SeekGE() the TBI to the main iterator.
-      DBKey seek_to;
+      DBKey seek_to = {};
       // NB: We don't ToDBKey as iter_key is already split.
       seek_to.key = ToDBSlice(iter_key);
       state = DBIterSeek(time_bound_iter.get(), seek_to);
@@ -134,7 +134,7 @@ void DBIncrementalIterator::maybeSkipKeys() {
       // keys. The main iterator is seeked to the TBI in hopes that many keys
       // were skipped. Note that a Seek() is an order of magnitude more
       // expensive than a Next().
-      DBKey seek_to;
+      DBKey seek_to = {};
       // NB: We don't ToDBKey as iter_key is already split.
       seek_to.key = ToDBSlice(tbi_key);
       state = DBIterSeek(iter.get(), seek_to);

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -67,7 +67,7 @@ var fullClusterSystemTables = []string{
 var useTBI = settings.RegisterBoolSetting(
 	"kv.bulk_io_write.experimental_incremental_export_enabled",
 	"use experimental time-bound file filter when exporting in BACKUP",
-	false,
+	true,
 )
 
 var backupOptionExpectValues = map[string]sql.KVStringOptValidate{


### PR DESCRIPTION
Add correct zero-initialization of DBKey fields that should have been in #46068.

Un-revert #46385.

Fixes #43394.

Release note (enterprise change): Incremental BACKUP can quickly skip of unchanged data making frequent incremental BACKUPs 10-100x faster depending on data-size and frequency.

Release justification: high-impact.