### PR TITLE
kv/concurrency: never regress timestamp in lockTable on lock acquisition

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -53,15 +53,15 @@ import (
 //
 // new-txn      name=<txn-name> ts=<int>[,<int>] epoch=<int> [maxts=<int>[,<int>]]
 // new-request  name=<req-name> txn=<txn-name>|none ts=<int>[,<int>] [priority] [consistency]
-//   <proto-name> [<field-name>=<field-value>...]
+//   <proto-name> [<field-name>=<field-value>...] (hint: see scanSingleRequest)
 // sequence     req=<req-name>
 // finish       req=<req-name>
 //
 // handle-write-intent-error  req=<req-name> txn=<txn-name> key=<key>
 // handle-txn-push-error      req=<req-name> txn=<txn-name> key=<key>  TODO(nvanbenschoten): implement this
 //
-// on-lock-acquired  txn=<txn-name> key=<key>
-// on-lock-updated   txn=<txn-name> key=<key> status=[committed|aborted|pending] [ts=<int>[,<int>]]
+// on-lock-acquired  req=<req-name> key=<key>
+// on-lock-updated   req=<req-name> txn=<txn-name> key=<key> status=[committed|aborted|pending] [ts=<int>[,<int>]]
 // on-txn-updated    txn=<txn-name> status=[committed|aborted|pending] [ts=<int>[,<int>]]
 //
 // on-lease-updated  leaseholder=<bool>
@@ -136,8 +136,10 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				}
 
 				ts := scanTimestamp(t, d)
-				if txn != nil && txn.ReadTimestamp != ts {
-					d.Fatalf(t, "txn read timestamp != timestamp")
+				if txn != nil {
+					txn = txn.Clone()
+					txn.ReadTimestamp = ts
+					txn.WriteTimestamp = ts
 				}
 
 				readConsistency := roachpb.CONSISTENT
@@ -149,7 +151,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				var reqs []roachpb.Request
 				singleReqLines := strings.Split(d.Input, "\n")
 				for _, line := range singleReqLines {
-					req := scanSingleRequest(t, d, line)
+					req := scanSingleRequest(t, d, line, c.txnsByName)
 					reqs = append(reqs, req)
 				}
 				reqUnions := make([]roachpb.RequestUnion, len(reqs))
@@ -257,18 +259,34 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				return c.waitAndCollect(t, mon)
 
 			case "on-lock-acquired":
-				var txnName string
-				d.ScanArgs(t, "txn", &txnName)
-				txn, ok := c.txnsByName[txnName]
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				guard, ok := c.guardsByReqName[reqName]
 				if !ok {
-					d.Fatalf(t, "unknown txn %s", txnName)
+					d.Fatalf(t, "unknown request: %s", reqName)
 				}
+				txn := guard.Req.Txn
 
 				var key string
 				d.ScanArgs(t, "key", &key)
 
+				// Confirm that the request has a corresponding write request.
+				found := false
+				for _, ru := range guard.Req.Requests {
+					req := ru.GetInner()
+					keySpan := roachpb.Span{Key: roachpb.Key(key)}
+					if roachpb.IsLocking(req) &&
+						req.Header().Span().Contains(keySpan) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					d.Fatalf(t, "missing corresponding write request")
+				}
+
 				mon.runSync("acquire lock", func(ctx context.Context) {
-					log.Eventf(ctx, "%s @ %s", txnName, key)
+					log.Eventf(ctx, "txn %s @ %s", txn.ID.Short(), key)
 					span := roachpb.Span{Key: roachpb.Key(key)}
 					up := roachpb.MakeLockUpdateWithDur(txn, span, lock.Unreplicated)
 					m.OnLockAcquired(ctx, &up)
@@ -276,6 +294,13 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				return c.waitAndCollect(t, mon)
 
 			case "on-lock-updated":
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				guard, ok := c.guardsByReqName[reqName]
+				if !ok {
+					d.Fatalf(t, "unknown request: %s", reqName)
+				}
+
 				var txnName string
 				d.ScanArgs(t, "txn", &txnName)
 				txn, ok := c.txnsByName[txnName]
@@ -292,12 +317,27 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					ts = scanTimestamp(t, d)
 				}
 
+				// Confirm that the request has a corresponding ResolveIntent.
+				found := false
+				for _, ru := range guard.Req.Requests {
+					if riReq := ru.GetResolveIntent(); riReq != nil &&
+						riReq.IntentTxn.ID == txn.ID &&
+						riReq.Key.Equal(roachpb.Key(key)) &&
+						riReq.Status == status {
+						found = true
+						break
+					}
+				}
+				if !found {
+					d.Fatalf(t, "missing corresponding resolve intent request")
+				}
+
 				txnUpdate := txn.Clone()
 				txnUpdate.Status = status
 				txnUpdate.WriteTimestamp.Forward(ts)
 
 				mon.runSync("update lock", func(ctx context.Context) {
-					log.Eventf(ctx, "%s %s @ %s", verb, txnName, key)
+					log.Eventf(ctx, "%s txn %s @ %s", verb, txn.ID.Short(), key)
 					span := roachpb.Span{Key: roachpb.Key(key)}
 					up := roachpb.MakeLockUpdate(txnUpdate, span)
 					m.OnLockUpdated(ctx, &up)

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -50,9 +50,9 @@ sequence req=req2
 [1] sequence req2: scanning lock table for conflicting locks
 [1] sequence req2: sequencing complete, returned guard
 
-on-lock-acquired txn=txn2 key=k
+on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn2 @ k
+[-] acquire lock: txn 00000002 @ k
 
 debug-lock-table
 ----
@@ -90,9 +90,20 @@ local: num=0
 # 6. Requests proceed in order
 # -------------------------------------------------------------
 
-on-lock-acquired txn=txn2 key=k
+sequence req=req2
 ----
-[-] acquire lock: txn2 @ k
+[1] sequence req2: sequencing request
+[1] sequence req2: acquiring latches
+[1] sequence req2: scanning lock table for conflicting locks
+[1] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=k
+----
+[-] acquire lock: txn 00000002 @ k
+
+finish req=req2
+----
+[-] finish req2: finishing request
 
 new-request name=req3 txn=txn3 ts=14,1
   get  key=k
@@ -101,20 +112,20 @@ new-request name=req3 txn=txn3 ts=14,1
 
 sequence req=req3
 ----
-[1] sequence req3: sequencing request
-[1] sequence req3: acquiring latches
-[1] sequence req3: scanning lock table for conflicting locks
-[1] sequence req3: waiting in lock wait-queues
-[1] sequence req3: pushing timestamp of txn 00000002 above 0.000000014,1
-[1] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
+[2] sequence req3: sequencing request
+[2] sequence req3: acquiring latches
+[2] sequence req3: scanning lock table for conflicting locks
+[2] sequence req3: waiting in lock wait-queues
+[2] sequence req3: pushing timestamp of txn 00000002 above 0.000000014,1
+[2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[1] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
-[1] sequence req3: acquiring latches
-[1] sequence req3: scanning lock table for conflicting locks
-[1] sequence req3: sequencing complete, returned guard
+[2] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
+[2] sequence req3: acquiring latches
+[2] sequence req3: scanning lock table for conflicting locks
+[2] sequence req3: sequencing complete, returned guard
 
 debug-lock-table
 ----
@@ -127,9 +138,9 @@ new-request name=req4 txn=txn1 ts=10,1
 
 sequence req=req4
 ----
-[2] sequence req4: sequencing request
-[2] sequence req4: acquiring latches
-[2] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
+[3] sequence req4: sequencing request
+[3] sequence req4: acquiring latches
+[3] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
 ----
@@ -139,8 +150,8 @@ write count: 1
 finish req=req3
 ----
 [-] finish req3: finishing request
-[2] sequence req4: scanning lock table for conflicting locks
-[2] sequence req4: sequencing complete, returned guard
+[3] sequence req4: scanning lock table for conflicting locks
+[3] sequence req4: sequencing complete, returned guard
 
 finish req=req4
 ----
@@ -160,9 +171,20 @@ reset
 # 8. Requests proceed in order
 # -------------------------------------------------------------
 
-on-lock-acquired txn=txn2 key=k
+sequence req=req2
 ----
-[-] acquire lock: txn2 @ k
+[1] sequence req2: sequencing request
+[1] sequence req2: acquiring latches
+[1] sequence req2: scanning lock table for conflicting locks
+[1] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=k
+----
+[-] acquire lock: txn 00000002 @ k
+
+finish req=req2
+----
+[-] finish req2: finishing request
 
 new-request name=req5 txn=none ts=14,1
   scan key=a endkey=m
@@ -170,12 +192,12 @@ new-request name=req5 txn=none ts=14,1
 
 sequence req=req5
 ----
-[1] sequence req5: sequencing request
-[1] sequence req5: acquiring latches
-[1] sequence req5: scanning lock table for conflicting locks
-[1] sequence req5: waiting in lock wait-queues
-[1] sequence req5: pushing timestamp of txn 00000002 above 0.000000014,1
-[1] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
+[2] sequence req5: sequencing request
+[2] sequence req5: acquiring latches
+[2] sequence req5: scanning lock table for conflicting locks
+[2] sequence req5: waiting in lock wait-queues
+[2] sequence req5: pushing timestamp of txn 00000002 above 0.000000014,1
+[2] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 new-request name=req6 txn=none ts=16,1
   scan key=c endkey=z
@@ -183,22 +205,22 @@ new-request name=req6 txn=none ts=16,1
 
 sequence req=req6
 ----
-[2] sequence req6: sequencing request
-[2] sequence req6: acquiring latches
-[2] sequence req6: scanning lock table for conflicting locks
-[2] sequence req6: waiting in lock wait-queues
-[2] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+[3] sequence req6: sequencing request
+[3] sequence req6: acquiring latches
+[3] sequence req6: scanning lock table for conflicting locks
+[3] sequence req6: waiting in lock wait-queues
+[3] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-txn-updated txn=txn2 status=pending ts=18,1
 ----
 [-] update txn: increasing timestamp of txn2
-[1] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
-[1] sequence req5: acquiring latches
-[1] sequence req5: scanning lock table for conflicting locks
-[1] sequence req5: sequencing complete, returned guard
-[2] sequence req6: acquiring latches
-[2] sequence req6: scanning lock table for conflicting locks
-[2] sequence req6: sequencing complete, returned guard
+[2] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
+[2] sequence req5: acquiring latches
+[2] sequence req5: scanning lock table for conflicting locks
+[2] sequence req5: sequencing complete, returned guard
+[3] sequence req6: acquiring latches
+[3] sequence req6: scanning lock table for conflicting locks
+[3] sequence req6: sequencing complete, returned guard
 
 new-request name=req7 txn=none ts=12,1
   put key=k value=v
@@ -206,9 +228,9 @@ new-request name=req7 txn=none ts=12,1
 
 sequence req=req7
 ----
-[3] sequence req7: sequencing request
-[3] sequence req7: acquiring latches
-[3] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
+[4] sequence req7: sequencing request
+[4] sequence req7: acquiring latches
+[4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req5
 ----
@@ -217,18 +239,18 @@ finish req=req5
 finish req=req6
 ----
 [-] finish req6: finishing request
-[3] sequence req7: scanning lock table for conflicting locks
-[3] sequence req7: waiting in lock wait-queues
-[3] sequence req7: pushing txn 00000002 to abort
-[3] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
+[4] sequence req7: scanning lock table for conflicting locks
+[4] sequence req7: waiting in lock wait-queues
+[4] sequence req7: pushing txn 00000002 to abort
+[4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
-[3] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
-[3] sequence req7: acquiring latches
-[3] sequence req7: scanning lock table for conflicting locks
-[3] sequence req7: sequencing complete, returned guard
+[4] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
+[4] sequence req7: acquiring latches
+[4] sequence req7: scanning lock table for conflicting locks
+[4] sequence req7: sequencing complete, returned guard
 
 finish req=req7
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -53,17 +53,17 @@ sequence req=req3w
 [3] sequence req3w: scanning lock table for conflicting locks
 [3] sequence req3w: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=a
+on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn1 @ a
+[-] acquire lock: txn 00000001 @ a
 
-on-lock-acquired txn=txn2 key=b
+on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn2 @ b
+[-] acquire lock: txn 00000002 @ b
 
-on-lock-acquired txn=txn3 key=c
+on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn3 @ c
+[-] acquire lock: txn 00000003 @ c
 
 finish req=req1w
 ----
@@ -250,17 +250,17 @@ sequence req=req3w
 [3] sequence req3w: scanning lock table for conflicting locks
 [3] sequence req3w: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=a
+on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn1 @ a
+[-] acquire lock: txn 00000001 @ a
 
-on-lock-acquired txn=txn2 key=b
+on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn2 @ b
+[-] acquire lock: txn 00000002 @ b
 
-on-lock-acquired txn=txn3 key=c
+on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn3 @ c
+[-] acquire lock: txn 00000003 @ c
 
 finish req=req1w
 ----
@@ -474,17 +474,17 @@ sequence req=req3w
 [3] sequence req3w: scanning lock table for conflicting locks
 [3] sequence req3w: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=a
+on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn1 @ a
+[-] acquire lock: txn 00000001 @ a
 
-on-lock-acquired txn=txn2 key=b
+on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn2 @ b
+[-] acquire lock: txn 00000002 @ b
 
-on-lock-acquired txn=txn3 key=c
+on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn3 @ c
+[-] acquire lock: txn 00000003 @ c
 
 finish req=req1w
 ----
@@ -694,17 +694,17 @@ sequence req=req3w
 [3] sequence req3w: scanning lock table for conflicting locks
 [3] sequence req3w: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=a
+on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn1 @ a
+[-] acquire lock: txn 00000001 @ a
 
-on-lock-acquired txn=txn2 key=b
+on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn2 @ b
+[-] acquire lock: txn 00000002 @ b
 
-on-lock-acquired txn=txn3 key=c
+on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn3 @ c
+[-] acquire lock: txn 00000003 @ c
 
 finish req=req1w
 ----
@@ -921,17 +921,17 @@ sequence req=req3w
 [3] sequence req3w: scanning lock table for conflicting locks
 [3] sequence req3w: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=a
+on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn1 @ a
+[-] acquire lock: txn 00000001 @ a
 
-on-lock-acquired txn=txn2 key=b
+on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn2 @ b
+[-] acquire lock: txn 00000002 @ b
 
-on-lock-acquired txn=txn3 key=c
+on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn3 @ c
+[-] acquire lock: txn 00000003 @ c
 
 finish req=req1w
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -61,13 +61,13 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=k
+on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn1 @ k
+[-] acquire lock: txn 00000001 @ k
 
-on-lock-acquired txn=txn1 key=k2
+on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn1 @ k2
+[-] acquire lock: txn 00000001 @ k2
 
 finish req=req1
 ----
@@ -160,9 +160,9 @@ sequence req=req2
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
 
-on-lock-acquired txn=txn2 key=k
+on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn2 @ k
+[-] acquire lock: txn 00000002 @ k
 
 debug-lock-table
 ----
@@ -221,10 +221,25 @@ global: num=1
    distinguished req: 3
 local: num=0
 
-on-lock-updated txn=txn2 key=k status=committed
+new-request name=reqRes2 txn=none ts=10,1
+  resolve-intent txn=txn2 key=k status=committed
 ----
-[-] update lock: committing txn2 @ k
+
+sequence req=reqRes2
+----
+[10] sequence reqRes2: sequencing request
+[10] sequence reqRes2: acquiring latches
+[10] sequence reqRes2: sequencing complete, returned guard
+
+on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
+----
+[-] update lock: committing txn 00000002 @ k
 [9] sequence req3: acquiring latches
+[9] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
+
+finish req=reqRes2
+----
+[-] finish reqRes2: finishing request
 [9] sequence req3: scanning lock table for conflicting locks
 [9] sequence req3: sequencing complete, returned guard
 
@@ -235,9 +250,9 @@ global: num=1
   res: req: 3, txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
 local: num=0
 
-on-lock-acquired txn=txn3 key=k
+on-lock-acquired req=req3 key=k
 ----
-[-] acquire lock: txn3 @ k
+[-] acquire lock: txn 00000003 @ k
 
 debug-lock-table
 ----
@@ -293,9 +308,9 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=k
+on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn1 @ k
+[-] acquire lock: txn 00000001 @ k
 
 finish req=req1
 ----
@@ -363,10 +378,25 @@ sequence req=req2
 [4] sequence req2: waiting in lock wait-queues
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
-on-lock-updated txn=txn1 key=k status=committed
+new-request name=reqRes1 txn=none ts=10,1
+  resolve-intent txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn1 @ k
+
+sequence req=reqRes1
+----
+[5] sequence reqRes1: sequencing request
+[5] sequence reqRes1: acquiring latches
+[5] sequence reqRes1: sequencing complete, returned guard
+
+on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
+----
+[-] update lock: committing txn 00000001 @ k
 [4] sequence req2: acquiring latches
+[4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
+
+finish req=reqRes1
+----
+[-] finish reqRes1: finishing request
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
@@ -377,9 +407,9 @@ global: num=1
   res: req: 5, txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
 local: num=0
 
-on-lock-acquired txn=txn2 key=k
+on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn2 @ k
+[-] acquire lock: txn 00000002 @ k
 
 debug-lock-table
 ----
@@ -439,13 +469,13 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=k
+on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn1 @ k
+[-] acquire lock: txn 00000001 @ k
 
-on-lock-acquired txn=txn1 key=k2
+on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn1 @ k2
+[-] acquire lock: txn 00000001 @ k2
 
 finish req=req1
 ----
@@ -537,9 +567,9 @@ sequence req=req2
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
 
-on-lock-acquired txn=txn2 key=k
+on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn2 @ k
+[-] acquire lock: txn 00000002 @ k
 
 debug-lock-table
 ----
@@ -593,9 +623,9 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-on-lock-acquired txn=txn1 key=k
+on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn1 @ k
+[-] acquire lock: txn 00000001 @ k
 
 finish req=req1
 ----
@@ -663,10 +693,25 @@ sequence req=req2
 [4] sequence req2: waiting in lock wait-queues
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
-on-lock-updated txn=txn1 key=k status=committed
+new-request name=reqRes1 txn=none ts=10,1
+  resolve-intent txn=txn1 key=k status=committed
 ----
-[-] update lock: committing txn1 @ k
+
+sequence req=reqRes1
+----
+[5] sequence reqRes1: sequencing request
+[5] sequence reqRes1: acquiring latches
+[5] sequence reqRes1: sequencing complete, returned guard
+
+on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
+----
+[-] update lock: committing txn 00000001 @ k
 [4] sequence req2: acquiring latches
+[4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
+
+finish req=reqRes1
+----
+[-] finish reqRes1: finishing request
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
@@ -677,9 +722,9 @@ global: num=1
   res: req: 9, txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
 local: num=0
 
-on-lock-acquired txn=txn2 key=k
+on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn2 @ k
+[-] acquire lock: txn 00000002 @ k
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -1,0 +1,240 @@
+# -------------------------------------------------------------
+# A transaction writes an intent. The intent is pushed to a
+# higher timestamp by a second transaction. The transaction then
+# returns to re-acquire the intent at a new sequence number but
+# still at the original timestamp. This is permitted but the
+# lock's timestamp should not regress.
+#
+# Setup: txn1 acquire lock k
+#        txn2 reads k and waits
+#        txn2 pushes txn1
+#
+# Test:  txn2 succeeds in pushing txn1's ts forward
+#        txn2 proceeds
+#        txn1 re-acquires lock k at new seq num, lower ts
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  put key=k value=v
+----
+
+new-request name=req2 txn=txn2 ts=12,1
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: pushing timestamp of txn 00000001 above 0.000000012,1
+[2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 2, txn: 00000002-0000-0000-0000-000000000000
+   distinguished req: 2
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+on-txn-updated txn=txn1 status=pending ts=12,2
+----
+[-] update txn: increasing timestamp of txn1
+[2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000012,2, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# Issue another write to the same key for txn1 at its initial
+# timestamp. The timestamp in the lock table does not regress.
+
+new-request name=req3 txn=txn1 ts=10,1
+  put key=k value=v2 seq=1
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=k seq=1
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000012,2, info: unrepl epoch: 0, seqs: [0, 1]
+local: num=0
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A transaction writes an intent. The intent is pushed to a
+# higher timestamp by a second transaction. The transaction then
+# returns to re-acquire the intent at a new epoch but still at
+# the original timestamp. This is permitted but the lock's
+# timestamp should not regress.
+#
+# Setup: txn1 acquire lock k
+#        txn2 reads k and waits
+#
+# Test:  txn2 pushes txn1's timestamp forward
+#        txn2 proceeds
+#        txn1 re-acquires lock k at new epoch, lower ts
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  put key=k value=v
+----
+
+new-request name=req2 txn=txn2 ts=12,1
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: pushing timestamp of txn 00000001 above 0.000000012,1
+[2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, info: unrepl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 5, txn: 00000002-0000-0000-0000-000000000000
+   distinguished req: 5
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+on-txn-updated txn=txn1 status=pending ts=12,2
+----
+[-] update txn: increasing timestamp of txn1
+[2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000012,2, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# The txn restarts at a new timestamp, but below the pushed
+# timestamp. It re-issues the same write at the new epoch. The
+# timestamp in the lock table does not regress.
+
+new-txn name=txn1 ts=11,1 epoch=1
+----
+
+new-request name=req3 txn=txn1 ts=11,1
+  put key=k value=v2
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=k
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000012,2, info: unrepl epoch: 1, seqs: [0]
+local: num=0
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -31,16 +31,35 @@ global: num=1
 local: num=0
 
 # ---------------------------------------------------------------------------------
+# Lock is reacquired at same epoch with lower timestamp. This is allowed,
+# see TestMVCCHistories/put_out_of_order. The new sequence number is added
+# but the timestamp is not regressed.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=8 epoch=0 seq=3
+----
+
+new-request r=req2 txn=txn1 ts=8 spans=w@a
+----
+
+acquire r=req2 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2, 3]
+local: num=0
+
+# ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch. The old sequence numbers are discarded.
 # ---------------------------------------------------------------------------------
 
 new-txn txn=txn1 ts=10 epoch=1 seq=0
 ----
 
-new-request r=req2 txn=txn1 ts=10 spans=w@a
+new-request r=req3 txn=txn1 ts=10 spans=w@a
 ----
 
-acquire r=req2 k=a durability=u
+acquire r=req3 k=a durability=u
 ----
 global: num=1
  lock: "a"
@@ -48,17 +67,36 @@ global: num=1
 local: num=0
 
 # ---------------------------------------------------------------------------------
+# Lock is reacquired at a different epoch with lower timestamp. This is allowed,
+# see TestMVCCHistories/put_new_epoch_lower_timestamp. The old sequence numbers are
+# discarded but the timestamp is not regressed.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=8 epoch=2 seq=0
+----
+
+new-request r=req4 txn=txn1 ts=8 spans=w@a
+----
+
+acquire r=req4 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 2, seqs: [0]
+local: num=0
+
+# ---------------------------------------------------------------------------------
 # Reader waits until the timestamp of the lock is updated.
 # ---------------------------------------------------------------------------------
 
-new-request r=req3 txn=txn2 ts=12 spans=r@a
+new-request r=req5 txn=txn2 ts=12 spans=r@a
 ----
 
-scan r=req3
+scan r=req5
 ----
 start-waiting: true
 
-guard-state r=req3
+guard-state r=req5
 ----
 new: state=waitForDistinguished txn=txn1 ts=10 key="a" held=true guard-access=read
 
@@ -66,7 +104,7 @@ print
 ----
 global: num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 1, seqs: [0]
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 2, seqs: [0]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 1
@@ -75,17 +113,17 @@ local: num=0
 new-txn txn=txn1 ts=14 epoch=1 seq=1
 ----
 
-new-request r=req4 txn=txn1 ts=14 spans=w@a
+new-request r=req6 txn=txn1 ts=14 spans=w@a
 ----
 
-acquire r=req4 k=a durability=u
+acquire r=req6 k=a durability=u
 ----
 global: num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000014,0, info: unrepl epoch: 1, seqs: [0, 1]
 local: num=0
 
-guard-state r=req3
+guard-state r=req5
 ----
 new: state=doneWaiting
 
@@ -96,18 +134,18 @@ new: state=doneWaiting
 # that the lock table is used.
 # ---------------------------------------------------------------------------------
 
-new-request r=req5 txn=txn2 ts=17 spans=r@a
+new-request r=req7 txn=txn2 ts=17 spans=r@a
 ----
 
-scan r=req5
+scan r=req7
 ----
 start-waiting: true
 
-guard-state r=req5
+guard-state r=req7
 ----
 new: state=waitForDistinguished txn=txn1 ts=14 key="a" held=true guard-access=read
 
-add-discovered r=req5 k=a txn=txn1
+add-discovered r=req7 k=a txn=txn1
 ----
 global: num=1
  lock: "a"
@@ -117,6 +155,6 @@ global: num=1
    distinguished req: 2
 local: num=0
 
-guard-state r=req5
+guard-state r=req7
 ----
 new: state=waitForDistinguished txn=txn1 ts=14 key="a" held=true guard-access=read

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
@@ -4,10 +4,6 @@
 # from the old epoch.
 
 # Additionally the intent history is blown away when a transaction restarts.
-#
-# TODO(knz): This last sentence is dubious. The test, as-is, does not
-# create an intent history because there is just 1 put.
-# See: https://github.com/cockroachdb/cockroach/issues/42310
 
 # Populate a txn and make the intent have an intent history by using
 # two puts.
@@ -15,15 +11,17 @@
 run ok
 with t=A
   txn_begin ts=1
-  txn_step  n=5
+  txn_step  n=4
   put  k=k v=v
+  txn_step
+  put  k=k v=v2
   get  k=k ts=3
 ----
-get: "k" -> /BYTES/v @0.000000001,0
+get: "k" -> /BYTES/v2 @0.000000001,0
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} ts=0.000000001,0 del=false klen=12 vlen=6
-data: "k"/0.000000001,0 -> /BYTES/v
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=5} ts=0.000000001,0 del=false klen=12 vlen=7 ih={{4 /BYTES/v}}
+data: "k"/0.000000001,0 -> /BYTES/v2
 
 run ok
 with t=A
@@ -38,25 +36,21 @@ txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000001,0 min=0,
 
 # The following will blow the intent history because the epoch is now
 # higher. However the intent is preserved.
-#
-# TODO(knz): This last sentence is dubious. The test, as-is, does not
-# create an intent history because there is just 1 put.
-# See: https://github.com/cockroachdb/cockroach/issues/42310
 
 run ok
 with t=A k=k
-  put v=v2
+  put v=v3
   check_intent exists
 ----
 meta: "k" -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000001,0 min=0,0 seq=4} ts=0.000000001,0 del=false klen=12 vlen=7
 >> at end:
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000001,0 min=0,0 seq=4} ts=0.000000001,0 del=false klen=12 vlen=7
-data: "k"/0.000000001,0 -> /BYTES/v2
+data: "k"/0.000000001,0 -> /BYTES/v3
 
-# We're expecting v2 here.
+# We're expecting v3 here.
 
 run ok
 with t=A
   get k=k
 ----
-get: "k" -> /BYTES/v2 @0.000000001,0
+get: "k" -> /BYTES/v3 @0.000000001,0

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
@@ -1,0 +1,46 @@
+# Tests a scenario where a put operation of an older timestamp but a
+# higher epoch comes after a put operation of a newer timestamp but an
+# older epoch. The timestamp of the resulting intent remains equal to
+# the higher timestamp - it does not regress.
+#
+# Transaction coordinators shouldn't issue this series of operations
+# directly, but it is possible to create such a situation if the
+# transaction is pushed.
+
+# Populate a txn and an intent.
+
+run ok
+with t=A
+  txn_begin   ts=1
+  txn_advance ts=5
+  txn_step    n=4
+  put  k=k v=v
+  get  k=k ts=3
+----
+get: "k" -> /BYTES/v @0.000000005,0
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=4} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000005,0 min=0,0 seq=4} ts=0.000000005,0 del=false klen=12 vlen=6
+data: "k"/0.000000005,0 -> /BYTES/v
+
+run ok
+with t=A
+  txn_advance ts=3
+  txn_restart
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
+
+
+# We're operating at a higher epoch but a lower timestamp.
+# We're expecting v2 here, but still at timestamp 5.
+
+run ok
+with t=A
+  put k=k v=v2
+  get k=k
+----
+get: "k" -> /BYTES/v2 @0.000000005,0
+>> at end:
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=0} ts=0.000000005,0 del=false klen=12 vlen=7
+data: "k"/0.000000005,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/put_out_of_order
+++ b/pkg/storage/testdata/mvcc_histories/put_out_of_order
@@ -1,5 +1,7 @@
-# tests a scenario where a put operation of an
-# older timestamp comes after a put operation of a newer timestamp.
+# Tests a scenario where a put operation of an older timestamp comes
+# after a put operation of a newer timestamp. The timestamp of the
+# resulting intent remains equal to the higher timestamp - it does not
+# regress.
 
 run ok
 with t=A


### PR DESCRIPTION
Fixes #46290.
Fixes #43735.
Fixes #41425.
Fixes #43809.

This change adjusts the lockTable to be more lenient to the timestamp of new lock acquisitions. Specifically, it lifts the restriction that all calls to AcquireLock use monotonically increasing timestamps. Instead, it properly handles apparent timestamp regressions by ratcheting lock timestamps instead of replacing them directly.

This matches the corresponding behavior in MVCC: https://github.com/cockroachdb/cockroach/blob/92107b551bbafe54fddb496442c590cb6feb5d65/pkg/storage/mvcc.go#L1631

This leniency is needed for sequences of events like the following:
- txn A acquires lock at epoch 1, ts 10
- txn B pushes txn A to ts 20
- txn B updates lock to ts 20
- txn A restarts at ts 15 without noticing that it has been pushes
- txn A re-acquires lock at epoch 2, ts 15
- we hit the lock timestamp regression assertion

We see this frequently in CDC roachtests because the rangefeed processor performs high-priority timestamp pushes on long-running transactions. Outside of CDC, this is rare in our system.

Release note (bug fix): CDC no longer combines with long running transactions to trigger an assertion.

Release justification: fixes a high-priority bug in existing functionality. The bug could crash a server if the right sequence of events occurred. This was typically rare, but was much more common when CDC was in use. This is a fairly large PR, but there's only a single line of non-testing code touched.