### PR TITLE
cli/quit: bump the default for --drain-wait

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -129,7 +129,7 @@ func initCLIDefaults() {
 	startCtx.inBackground = false
 
 	quitCtx.serverDecommission = false
-	quitCtx.drainWait = time.Minute
+	quitCtx.drainWait = 10 * time.Minute
 
 	nodeCtx.nodeDecommissionWait = nodeDecommissionWaitAll
 	nodeCtx.statusShowRanges = false


### PR DESCRIPTION
Release note (cli change): The default value of the paramater
`--drain-wait` for `cockroach quit` has been increased from 1 minute
to 10 minutes, to give more time for nodes with thousands of range to
migrate their leases away.