### PR TITLE
kvcoord: assert that the txn is clean after commit

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -195,6 +195,7 @@ func (tc *txnCommitter) SendLocked(
 		// the EndTxn request, either because canCommitInParallel returned false
 		// or because there were no unproven in-flight writes (see txnPipeliner)
 		// and there were no writes in the batch request.
+		assertTxnCleanWhenCommitted(ctx, br.Txn)
 		return br, nil
 	default:
 		return nil, roachpb.NewErrorf("unexpected response status without error: %v", br.Txn)
@@ -211,6 +212,8 @@ func (tc *txnCommitter) SendLocked(
 		return nil, pErr
 	}
 
+	assertTxnCleanWhenCommitted(ctx, br.Txn)
+
 	// If the transaction doesn't need to retry then it is implicitly committed!
 	// We're the only ones who know that though -- other concurrent transactions
 	// will need to go through the full status resolution process to make a
@@ -225,6 +228,29 @@ func (tc *txnCommitter) SendLocked(
 	// transaction proto in the STAGING state.
 	br.Txn = cloneWithStatus(br.Txn, roachpb.COMMITTED)
 	return br, nil
+}
+
+// assertTxnCleanWhenCommitted checks that a COMMITTED or STAGING txn is sane.
+//
+// In particular, in the STAGING state, the WriteTooOld flag shouldn't be set.
+// If the wto flag were set, it'd be a problem since the refresher interceptor
+// would attempt to retry the request, which is problematic after a txn is
+// implicitly committed (which it now is since the EndTxn batch succeeded). The
+// WriteTooOld flag shouldn't be set, however, even if the batch was split by
+// the DistSender and some of the sub-batches returned with this flag set: since
+// needTxnRetryAfterStaging() above didn't force a retry, we know that, even if
+// some sub-batches were pushed, the EndTxn sub-batch was pushed higher than all
+// the others and it also succeeded in performing a server-side refresh - so it
+// couldn't return the wto flag. Having the highest read timestamp, the response
+// from the EndTxn sub-batch gets to dictate the wto flag of the combined
+// response (see Transaction.Update()).
+func assertTxnCleanWhenCommitted(ctx context.Context, txn *roachpb.Transaction) {
+	if txn.WriteTooOld {
+		log.Fatalf(ctx, "unexpected WriteTooOld set on %s txn: %s", txn.Status, txn)
+	}
+	if !txn.ReadTimestamp.Equal(txn.WriteTimestamp) {
+		log.Fatalf(ctx, "unexpected diverged timestamps on %s txn: %s", txn.Status, txn)
+	}
 }
 
 // sendLockedWithElidedEndTxn sends the provided batch without its EndTxn


### PR DESCRIPTION
This patch adds a couple of assertions about the state in which a txn
proto can be after a successful commit (explicit commit or implicit).
The assertions are about how the multiple updates to a txn done by
sub-batches of the commit batch (as split by the DistSender) must have
been collapsed in a sane way when merging their responses together.

I spent the morning thinking that we have a problem with the WriteTooOld
flag being set on the result for an implicitly-committed txn. The
scenario that I was worried about is that the
EndTxn(CanCommitAtHigherTimestamp:true) batch gets split
into two, and both halves get pushed. The EndTxn half gets pushed higher
than the other half (otherwise, we wouldn't end up in an implicit commit
state), but it performs a server-side refresh and succeeds. I was
worried that the other half can still return a WriteTooOld flag, which
would make it into the combined response, and would trick the span
refresher into retrying. This would be bad, since retrying after an
implicit commit is problematic.
However, I believe this situation is not possible. We're saved by the
fact that combining the transaction updates (Transaction.Update()) is
smart enough to not treat the WriteTooOld flag as cummulative; instead,
the response with the highest read timestamp gets to dictate the wto,
and the EndTxn response should not have it set.

Release note: None
Release justification: Only an assertion. It would be indicative of a
dangerous bug if it fires.