### PR TITLE
kvserver: remove dead code

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -279,11 +279,6 @@ func EndTxn(
 		if retry, reason, extraMsg := IsEndTxnTriggeringRetryError(reply.Txn, args); retry {
 			return result.Result{}, roachpb.NewTransactionRetryError(reason, extraMsg)
 		}
-		// Update the read timestamp in case we've essentially refreshed. This
-		// update is important because reply.Txn.ReadTimestamp will make its way
-		// into BatchResponse.Timestamp, which is used to update the timestamp
-		// cache.
-		reply.Txn.ReadTimestamp = reply.Txn.WriteTimestamp
 
 		// If the transaction needs to be staged as part of an implicit commit
 		// before being explicitly committed, write the staged transaction


### PR DESCRIPTION
This patch removes an assignment that had become a noop when the EndTxn
evaluation stopped dealing with bumping the request's timestamp. It used
to do that, but a while ago we switched to having the higher-level
server-side refresh loop do it instead.

Release note: None
Release justification: low-risk update to new functionality. This is a
no-op cleanup after some recent changes.