### PR TITLE
cli/dump: support columns less tables

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2024,11 +2024,6 @@ func Example_dump_no_visible_columns() {
 	// sql -e create table t(x int); set sql_safe_updates=false; alter table t drop x
 	// ALTER TABLE
 	// dump defaultdb
-	// CREATE TABLE t (,
-	// 	FAMILY "primary" (rowid)
+	// CREATE TABLE t (FAMILY "primary" (rowid)
 	// );
-	// ERROR: table "defaultdb.public.t" has no visible columns
-	// HINT: To proceed with the dump, either omit this table from the list of tables to dump, drop the table, or add some visible columns.
-	// --
-	// See: https://github.com/cockroachdb/cockroach/issues/37768
 }

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -226,7 +226,11 @@ func showFamilyClause(desc *sqlbase.TableDescriptor, f *tree.FmtCtx) {
 				activeColumnNames = append(activeColumnNames, fam.ColumnNames[i])
 			}
 		}
-		f.WriteString(",\n\tFAMILY ")
+		if len(desc.VisibleColumns()) == 0 {
+			f.WriteString("FAMILY ")
+		} else {
+			f.WriteString(",\n\tFAMILY ")
+		}
 		formatQuoteNames(&f.Buffer, fam.Name)
 		f.WriteString(" (")
 		formatQuoteNames(&f.Buffer, activeColumnNames...)


### PR DESCRIPTION
This commit allows to dump and treat columns less tables by explicitly
allowing to explicitly specify hidden/reserved columns.

Fixes #37768.

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note (bug fix): providing with ability to dump columns less tables