### PR TITLE
opt: fix buggy EliminateUpsertDistinctOnNoColumns rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1001,6 +1001,18 @@ statement ok
 DROP TABLE t44466
 
 # ------------------------------------------------------------------------------
+# Regression for #46395.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE t46395(c0 INT UNIQUE DEFAULT 0, c1 INT);
+
+statement ok
+INSERT INTO t46395(c1) VALUES (0), (1) ON CONFLICT (c0) DO NOTHING;
+
+statement ok
+DROP TABLE t46395
+
+# ------------------------------------------------------------------------------
 # Duplicate primary key inputs.
 # ------------------------------------------------------------------------------
 # Start with no secondary index present.
@@ -1180,6 +1192,21 @@ SELECT * FROM target
 5  1     NULL
 6  NULL  NULL
 7  NULL  NULL
+
+statement ok
+INSERT INTO target SELECT 8, y, z FROM (VALUES (2, 2), (2, 3)) s(y, z)
+ON CONFLICT (x) DO NOTHING
+
+query III rowsort
+SELECT * FROM target
+----
+1  1     2
+2  3     3
+4  1     NULL
+5  1     NULL
+6  NULL  NULL
+7  NULL  NULL
+8  2     2
 
 statement ok
 DROP TABLE source

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -28,6 +28,12 @@ func (c *CustomFuncs) NullsAreDistinct(distinctOp opt.Operator) bool {
 	return distinctOp == opt.UpsertDistinctOnOp
 }
 
+// RaisesErrorOnDup returns true if an UpsertDistinct operator raises an error
+// when duplicate values are detected.
+func (c *CustomFuncs) RaisesErrorOnDup(private *memo.GroupingPrivate) bool {
+	return private.ErrorOnDup
+}
+
 // RemoveGroupingCols returns a new grouping private struct with the given
 // columns removed from the grouping column set.
 func (c *CustomFuncs) RemoveGroupingCols(

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -140,19 +140,19 @@
     $groupingPrivate
 )
 
-# EliminateDistinctOnNoColumns eliminates a DistinctOn with no grouping columns,
-# replacing it with a projection and a LIMIT 1. For example:
+# EliminateDistinctNoColumns eliminates a distinct operator with no grouping
+# columns, replacing it with a projection and a LIMIT 1. For example:
 #   SELECT DISTINCT ON (a) a, b FROM ab WHERE a=1
 # is equivalent to:
 #   SELECT a, b FROM ab WHERE a=1 LIMIT 1
 #
-# Note that this rule does not apply to UpsertDistinctOn, since that will raise
-# an error if there are duplicate rows.
-[EliminateDistinctOnNoColumns, Normalize]
-(DistinctOn
+# Note that this rule does not apply to UpsertDistinctOn with ErrorOnDup = true,
+# since that will raise an error if there are duplicate rows.
+[EliminateDistinctNoColumns, Normalize]
+(DistinctOn | UpsertDistinctOn
     $input:*
     $aggregations:*
-    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate)
+    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate) & ^(RaisesErrorOnDup $groupingPrivate)
 )
 =>
 (ConstructProjectionFromDistinctOn
@@ -161,16 +161,16 @@
     $aggregations
 )
 
-# EliminateUpsertDistinctOnNoColumns is similar to EliminateDistinctOnNoColumns,
-# except that it will raise an error if there are no grouping columns and the
-# input has more than one row. No grouping columns means there is at most one
-# group. And the Max1Row operator is needed to raise an error if that group has
-# more than one row, which is a requirement of the Upsert operator.
-[EliminateUpsertDistinctOnNoColumns, Normalize]
+# EliminateErrorDistinctNoColumns is similar to EliminateDistinctNoColumns,
+# except that Max1Row will raise an error if there are no grouping columns and
+# the input has more than one row. No grouping columns means there is at most
+# one group. And the Max1Row operator is needed to raise an error if that group
+# has more than one row, which is a requirement of the Upsert operator.
+[EliminateErrorDistinctNoColumns, Normalize]
 (UpsertDistinctOn
     $input:*
     $aggregations:*
-    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate)
+    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate) & (RaisesErrorOnDup $groupingPrivate)
 )
 =>
 (ConstructProjectionFromDistinctOn

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1055,10 +1055,10 @@ project
                 └── column10:10
 
 # --------------------------------------------------
-# EliminateDistinctOnNoColumns
+# EliminateDistinctNoColumns
 # --------------------------------------------------
 
-norm expect=EliminateDistinctOnNoColumns
+norm expect=EliminateDistinctNoColumns
 SELECT DISTINCT ON (a) a, b FROM abc WHERE a = 1
 ----
 limit
@@ -1077,7 +1077,7 @@ limit
  │         └── a:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  └── 1
 
-norm expect=EliminateDistinctOnNoColumns
+norm expect=EliminateDistinctNoColumns
 SELECT DISTINCT ON (b) b, c FROM abc WHERE b = 1 ORDER BY b, c
 ----
 limit
@@ -1100,10 +1100,72 @@ limit
  │              └── b:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
  └── 1
 
+norm expect=EliminateDistinctNoColumns
+INSERT INTO a (k, i, s) SELECT 1, i, 'foo' FROM a WHERE i = 1
+ON CONFLICT (s, i) DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── "?column?":11 => k:1
+ │    ├── i:7 => i:2
+ │    ├── column13:13 => f:3
+ │    ├── "?column?":12 => s:4
+ │    └── column14:14 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,11-14)
+      └── limit
+           ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 i:16 s:18
+           ├── cardinality: [0 - 1]
+           ├── key: ()
+           ├── fd: ()-->(7,11-14,16,18)
+           ├── select
+           │    ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 i:16 s:18
+           │    ├── fd: ()-->(7,11-14,18)
+           │    ├── limit hint: 1.00
+           │    ├── left-join (hash)
+           │    │    ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 i:16 s:18
+           │    │    ├── fd: ()-->(7,11-14)
+           │    │    ├── limit hint: 1.00
+           │    │    ├── project
+           │    │    │    ├── columns: column13:13 column14:14 "?column?":11!null "?column?":12!null i:7!null
+           │    │    │    ├── fd: ()-->(7,11-14)
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: i:7!null
+           │    │    │    │    ├── fd: ()-->(7)
+           │    │    │    │    ├── scan a
+           │    │    │    │    │    └── columns: i:7!null
+           │    │    │    │    └── filters
+           │    │    │    │         └── i:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+           │    │    │    └── projections
+           │    │    │         ├── CAST(NULL AS FLOAT8) [as=column13:13]
+           │    │    │         ├── CAST(NULL AS JSONB) [as=column14:14]
+           │    │    │         ├── 1 [as="?column?":11]
+           │    │    │         └── 'foo' [as="?column?":12]
+           │    │    ├── select
+           │    │    │    ├── columns: i:16!null s:18!null
+           │    │    │    ├── key: (16)
+           │    │    │    ├── fd: ()-->(18)
+           │    │    │    ├── scan a
+           │    │    │    │    ├── columns: i:16!null s:18!null
+           │    │    │    │    └── key: (16,18)
+           │    │    │    └── filters
+           │    │    │         └── s:18 = 'foo' [outer=(18), constraints=(/18: [/'foo' - /'foo']; tight), fd=()-->(18)]
+           │    │    └── filters
+           │    │         └── i:7 = i:16 [outer=(7,16), constraints=(/7: (/NULL - ]; /16: (/NULL - ]), fd=(7)==(16), (16)==(7)]
+           │    └── filters
+           │         └── s:18 IS NULL [outer=(18), constraints=(/18: [/NULL - /NULL]; tight), fd=()-->(18)]
+           └── 1
+
 # --------------------------------------------------
-# EliminateUpsertDistinctOnNoColumns
+# EliminateErrorDistinctNoColumns
 # --------------------------------------------------
-norm expect=EliminateUpsertDistinctOnNoColumns
+norm expect=EliminateErrorDistinctNoColumns
 INSERT INTO a (k, i, s) SELECT 1, i, 'foo' FROM a WHERE i = 1
 ON CONFLICT (s, i) DO UPDATE SET f=1.1
 ----

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -914,7 +914,8 @@ func (o *Optimizer) disableRules(probability float64) {
 		// Needed to prevent execbuilder error.
 		// TODO(radu): the DistinctOn execution path should be fixed up so it
 		// supports distinct on an empty column set.
-		int(opt.EliminateDistinctOnNoColumns),
+		int(opt.EliminateDistinctNoColumns),
+		int(opt.EliminateErrorDistinctNoColumns),
 	)
 
 	for i := opt.RuleName(1); i < opt.NumRuleNames; i++ {


### PR DESCRIPTION
The fix for #37880 added a new ErrorOnDup field to the UpsertDistinctOn
operator. However, the EliminateErrorDistinctNoColumns rule wasn't changed
to respect this flag, and so there's still a case where ON CONFLICT DO
NOTHING returns an error.

This commit eliminates the error by separating out the ErrorOnDup=True case
from the EliminateErrorDistinctNoColumns rule (which raises an error) and
adding it instead to the EliminateDistinctNoColumns rule (which does not
raise an error).

Fixes #46395

Release justification: Bug fixes and low-risk updates to new functionality.
This was always an error, so it's low-risk to make it a non-error.

Release note: None