### PR TITLE
opt: fix incorrect upserter check column ordinal

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -337,7 +337,7 @@ type checkSet = util.FastIntSet
 func checkMutationInput(
 	tabDesc *sqlbase.ImmutableTableDescriptor, checkOrds checkSet, checkVals tree.Datums,
 ) error {
-	if len(checkVals) != checkOrds.Len() {
+	if len(checkVals) < checkOrds.Len() {
 		return errors.AssertionFailedf(
 			"mismatched check constraint columns: expected %d, got %d", checkOrds.Len(), len(checkVals))
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -853,3 +853,27 @@ count                  ·            ·
 ·                      auto commit  ·
 ·                      FK check     nonunique_idx_parent@nonunique_idx_parent_k2_idx
 ·                      size         3 columns, 1 row
+
+# Regression test for #46397: upserter was looking at the incorrect ordinal for
+# the check because of an extra input column used by the FK check.
+statement ok
+CREATE TABLE t46397_parent(p INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE t46397_child (
+  c INT PRIMARY KEY,
+  p INT DEFAULT 0 REFERENCES t46397_parent (p),
+  CONSTRAINT foo CHECK (c != 1)
+)
+
+statement error failed to satisfy CHECK constraint
+UPSERT INTO t46397_child(c) VALUES (1)
+
+statement error upsert on table "t46397_child" violates foreign key constraint "fk_p_ref_t46397_parent"
+UPSERT INTO t46397_child(c) VALUES (2)
+
+statement ok
+INSERT INTO t46397_parent VALUES (0)
+
+statement ok
+UPSERT INTO t46397_child(c) VALUES (2)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -152,11 +152,13 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 		return err
 	}
 
-	// Run the CHECK constraints, if any. CheckHelper will either evaluate the
-	// constraints itself, or else inspect boolean columns from the input that
+	// Verify the CHECK constraints by inspecting boolean columns from the input that
 	// contain the results of evaluation.
 	if !n.run.checkOrds.Empty() {
-		ord := len(rowVals) - n.run.checkOrds.Len()
+		ord := len(n.run.insertCols) + len(n.run.tw.fetchCols) + len(n.run.tw.updateCols)
+		if n.run.tw.canaryOrdinal != -1 {
+			ord++
+		}
 		checkVals := rowVals[ord:]
 		if err := checkMutationInput(n.run.tw.tableDesc(), n.run.checkOrds, checkVals); err != nil {
 			return err


### PR DESCRIPTION
Unlike the other operators, the upserter assumes that the input has no extra
columns following the check columns. This is incorrect in some cases when
optimizer FK checks are enabled: the input may contain extra input columns that
are used only by the FK checks.

Fixes #46397.

Release note (bug fix): fixed an internal error or incorrect evaluation of check
constraints in certain cases involving UPSERT and foreign key checks.

Release justification: fix regression in existing functionality