### PR TITLE
Makefile: update "make help" text for specifying files to test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ help: ## Print help for targets with comments.
 		"make testccllogic" "Run all CCL SQL logic tests." \
 		"make testoptlogic" "Run all opt exec builder SQL logic tests." \
 		"make testbaselogic" "Run all the baseSQL SQL logic tests." \
-		"make testlogic FILES='prepare fk'" "Run the logic tests in the files named prepare and fk." \
+		"make testlogic FILES='prepare|fk'" "Run the logic tests in the files named prepare and fk (the full path is not required)." \
 		"make testlogic FILES=fk SUBTESTS='20042|20045'" "Run the logic tests within subtests 20042 and 20045 in the file named fk." \
 		"make testlogic TESTCONFIG=local" "Run the logic tests for the cluster configuration 'local'." \
 		"make fuzz" "Run all fuzz tests for 12m each (or whatever the default TESTTIMEOUT is)." \


### PR DESCRIPTION
Just to add a little specificity to help the next poor dev.

Screenshot of how it looks on my terminal:

![image](https://user-images.githubusercontent.com/1438493/77261409-b8baca00-6c64-11ea-9603-1214d03f22a0.png)

Release justification: non-production change