### PR TITLE
ui: Sortable sort per page

### DIFF
--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -121,16 +121,6 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
     return `${count} of ${total} jobs`;
   }
 
-  getData = () => {
-    const { pagination: { current, pageSize } } = this.state;
-    const jobs = this.props.jobs.data.jobs;
-    const currentDefault = current - 1;
-    const start = (currentDefault * pageSize);
-    const end = (currentDefault * pageSize + pageSize);
-    const data = jobs.slice(start, end);
-    return data;
-  }
-
   noJobResult = () => (
     <>
       <p>There are no jobs that match your search in filter.</p>
@@ -159,13 +149,14 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
         </div>
         <section className="cl-table-wrapper">
           <JobsSortedTable
-            data={this.getData()}
+            data={jobs}
             sortSetting={this.props.sort}
             onChangeSortSetting={this.props.setSort}
             className="jobs-table"
             rowClass={job => "jobs-table__row--" + job.status}
             columns={jobsTableColumns}
             renderNoResult={this.noJobResult()}
+            pagination={pagination}
           />
         </section>
         <Pagination

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -115,7 +115,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
     },
   );
 
-  sorted = createSelector(
+  sortedAndPaginated = createSelector(
     (props: SortedTableProps<T>) => props.data,
     (props: SortedTableProps<T>) => props.sortSetting,
     (props: SortedTableProps<T>) => props.columns,
@@ -136,7 +136,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
    * sortableTable.
    */
   columns = createSelector(
-    this.sorted,
+    this.sortedAndPaginated,
     this.rollups,
     (props: SortedTableProps<T>) => props.columns,
     (sorted: T[], rollups: React.ReactNode[], columns: ColumnDescriptor<T>[]) => {
@@ -153,7 +153,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
     });
 
   rowClass = createSelector(
-    this.sorted,
+    this.sortedAndPaginated,
     (props: SortedTableProps<T>) => props.rowClass,
     (sorted: T[], rowClass: (obj: T) => string) => {
       return (index: number) => rowClass(sorted[index]);
@@ -167,7 +167,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
   };
 
   getItemAt(rowIndex: number): T {
-    const sorted = this.sorted(this.props);
+    const sorted = this.sortedAndPaginated(this.props);
     return sorted[rowIndex];
   }
 

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -15,6 +15,11 @@ import React from "react";
 import { createSelector } from "reselect";
 import { ExpandableConfig, SortableColumn, SortableTable, SortSetting } from "src/views/shared/components/sortabletable";
 
+export interface ISortedTablePagination {
+  current: number;
+  pageSize: number;
+}
+
 /**
  * ColumnDescriptor is used to describe metadata about an individual column
  * in a SortedTable.
@@ -74,10 +79,7 @@ interface SortedTableProps<T> {
   drawer?: boolean;
   firstCellBordered?: boolean;
   renderNoResult?: React.ReactNode;
-  pagination?: {
-    current: number;
-    pageSize: number;
-  };
+  pagination?: ISortedTablePagination;
 }
 
 interface SortedTableState {
@@ -199,7 +201,7 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, SortedT
   paginatedData = (sortData?: T[]) => {
     const { pagination, data } = this.props;
     if (!pagination) {
-      return data;
+      return sortData || data;
     }
     const currentDefault = pagination.current - 1;
     const start = (currentDefault * pagination.pageSize);

--- a/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
@@ -15,7 +15,7 @@ import { mount } from "enzyme";
 import * as sinon from "sinon";
 
 import "src/enzymeInit";
-import { SortedTable, ColumnDescriptor } from "src/views/shared/components/sortedtable";
+import { SortedTable, ColumnDescriptor, ISortedTablePagination } from "src/views/shared/components/sortedtable";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 
 class TestRow {
@@ -39,11 +39,12 @@ const columns: ColumnDescriptor<TestRow>[] = [
 class TestSortedTable extends SortedTable<TestRow> {}
 
 function makeTable(
-  data: TestRow[], sortSetting?: SortSetting, onChangeSortSetting?: (ss: SortSetting) => void,
+  data: TestRow[], sortSetting?: SortSetting, onChangeSortSetting?: (ss: SortSetting) => void, pagination?: ISortedTablePagination,
 ) {
   return mount(<TestSortedTable data={data}
                                 sortSetting={sortSetting}
                                 onChangeSortSetting={onChangeSortSetting}
+                                pagination={pagination}
                                 columns={columns}/>);
 }
 
@@ -134,5 +135,32 @@ describe("<SortedTable>", function() {
       wrapper.find(".sort-table__cell__expansion-control").simulate("click");
       assert.lengthOf(wrapper.find(".sort-table__row--expanded-area"), 0, "row collapsed again");
     });
+  });
+
+  it("should correctly render rows with pagination and sort settings", function() {
+    const data = [
+      new TestRow("c", 3),
+      new TestRow("d", 4),
+      new TestRow("a", 1),
+      new TestRow("b", 2),
+    ];
+    let wrapper = makeTable(data, undefined, undefined, { current: 1, pageSize: 2});
+    let rows = wrapper.find("tbody");
+    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
+    assert.equal(rows.childAt(1).childAt(0).text(), "d", "second row column at first page match");
+
+    wrapper = makeTable(data, undefined, undefined, { current: 2, pageSize: 2});
+    rows = wrapper.find("tbody");
+    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
+    assert.equal(rows.childAt(0).childAt(0).text(), "a", "first row column at seconds page match");
+
+    wrapper = makeTable(data, {sortKey: 0, ascending: true}, undefined, { current: 1, pageSize: 2});
+    rows = wrapper.find("tbody");
+    assert.equal(rows.childAt(1).childAt(0).text(), "b", "second row column at first page match");
+
+    wrapper = makeTable(data, {sortKey: 0, ascending: true}, undefined, { current: 2, pageSize: 2});
+    rows = wrapper.find("tbody");
+    assert.equal(rows.childAt(0).childAt(0).text(), "c", "first row column at seconds page match");
+
   });
 });

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -158,16 +158,6 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current }});
   }
-
-  getStatementsData = () => {
-    const { pagination: { current, pageSize } } = this.state;
-    const currentDefault = current - 1;
-    const start = (currentDefault * pageSize);
-    const end = (currentDefault * pageSize + pageSize);
-    const data = this.filteredStatementsData().slice(start, end);
-    return data;
-  }
-
   onSubmitSearchField = (search: string) => {
     this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
     this.syncHistory({
@@ -246,7 +236,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     const selectedApp = appAttrValue || "";
     const appOptions = [{ value: "", label: "All" }];
     this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
-    const data = this.getStatementsData();
+    const data = this.filteredStatementsData();
     return (
       <div>
         <PageConfig>
@@ -298,6 +288,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
                 sortSetting={this.state.sortSetting}
                 onChangeSortSetting={this.changeSortSetting}
                 renderNoResult={this.noStatementResult()}
+                pagination={pagination}
               />
             </div>
           )}
@@ -307,7 +298,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
           itemRender={this.renderPage as (page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next") => React.ReactNode}
           pageSize={pagination.pageSize}
           current={pagination.current}
-          total={this.filteredStatementsData().length}
+          total={data.length}
           onChange={this.onChangePage}
           hideOnSinglePage
         />


### PR DESCRIPTION
moved pagination logic to `Sortedtable` component for fixed an issue with sort settings when sorting is worked out for one page

Resolves: #46173

Release justification: bug fix

Release note (ui): this fixes a bug where sort columns were only being applied per-page instead of for the entire multi-page list of statements