### PR TITLE
opt: treat outer column as constant when grouping

### DIFF
--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -74,11 +74,12 @@ func (b *Builder) buildScalar(
 			// of a larger grouping expression would have been detected by the
 			// groupStrs checking code above.
 			// Normally this would be a "column must appear in the GROUP BY clause"
-			// error. The only case where we allow this (for compatibility with
-			// Postgres) is when this column is part of a table and we are already
+			// error. The only cases where we allow this (for compatibility with
+			// Postgres) is when this column is an outer column (and therefore
+			// effectively constant) or it is part of a table and we are already
 			// grouping on the entire PK of that table.
 			g := inScope.groupby
-			if !b.allowImplicitGroupingColumn(t.id, g) {
+			if !inScope.isOuterColumn(t.id) && !b.allowImplicitGroupingColumn(t.id, g) {
 				panic(newGroupingError(&t.name))
 			}
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3799,3 +3799,43 @@ project
                           │    └── columns: t3.a:9!null t3.b:10!null t3.x:11 t3.y:12
                           └── filters
                                └── sum:14 = t3.x:11
+
+# Regression test for #45631.
+build
+SELECT
+  (SELECT (max(b), unnest) FROM ab WHERE a = unnest)
+FROM
+  ROWS FROM (unnest(ARRAY[1, 2]))
+----
+project
+ ├── columns: "?column?":7
+ ├── project-set
+ │    ├── columns: unnest:1
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── unnest(ARRAY[1,2])
+ └── projections
+      └── subquery [as="?column?":7]
+           └── max1-row
+                ├── columns: "?column?":6
+                └── project
+                     ├── columns: "?column?":6
+                     ├── group-by
+                     │    ├── columns: max:4 unnest:5
+                     │    ├── grouping columns: unnest:5
+                     │    ├── project
+                     │    │    ├── columns: unnest:5 b:3
+                     │    │    ├── select
+                     │    │    │    ├── columns: a:2!null b:3
+                     │    │    │    ├── scan ab
+                     │    │    │    │    └── columns: a:2!null b:3
+                     │    │    │    └── filters
+                     │    │    │         └── a:2 = unnest:1
+                     │    │    └── projections
+                     │    │         └── unnest:1 [as=unnest:5]
+                     │    └── aggregations
+                     │         └── max [as=max:4]
+                     │              └── b:3
+                     └── projections
+                          └── (max:4, unnest:1) [as="?column?":6]


### PR DESCRIPTION
Prior to this commit, using an outer column in the `SELECT` list of
an aggregation or grouping expression would cause an error. However,
Postgres allows it because the outer column is effectively constant
in the subquery context. This commit fixes CRDB to behave like Postgres
in this scenario, and adds an implicit `GROUP BY` column for the outer
column.

Fixes #45631

Release justification: This bug fix is a low risk, high benefit change
to existing functionality.
Release note (sql change): To improve compatibility with Postgres, outer
columns (columns in a subquery that reference a higher scope) can now be used
in the SELECT list of an aggregation or grouping expression without explicitly
including them in the GROUP BY list.