### PR TITLE
sql: allow DROP DATABASE to work over active temporary schemas

### DIFF
--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -166,11 +166,20 @@ func (p *planner) prepareDrop(
 	if tableDesc == nil {
 		return nil, err
 	}
-
-	if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
+	if err := p.prepareDropWithTableDesc(ctx, tableDesc); err != nil {
 		return nil, err
 	}
 	return tableDesc, nil
+}
+
+// prepareDropWithTableDesc behaves as prepareDrop, except it assumes the
+// table descriptor is already fetched. This is useful for DropDatabase,
+// as prepareDrop requires resolving a TableName when DropDatabase already
+// has it resolved.
+func (p *planner) prepareDropWithTableDesc(
+	ctx context.Context, tableDesc *sqlbase.MutableTableDescriptor,
+) error {
+	return p.CheckPrivilege(ctx, tableDesc, privilege.DROP)
 }
 
 // canRemoveFKBackReference returns an error if the input backreference isn't


### PR DESCRIPTION
Resolves #46393.

Previously, DROP DATABASE whilst a temporary schema was active (or not
cleaned up) would result in failure as the DROP DATABASE session may not
have access to the temporary schema in the SearchPath. Fix this by
making DROP DATABASE not rely on searching by SearchPath.

Furthermore, we make sure DROP DATABASE cleans up any leftover schemas
that have been dangling as well.

Test is done as a regular go test as logic tests cannot simulate this
scenario so well.

Release justification: bug fixes and low-risk updates to new
functionality

Release note: None

