### PR TITLE
kv: don't disable the merge queue needlessly in more tests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1312,8 +1312,6 @@ func TestPropagateTxnOnError(t *testing.T) {
 			}
 			return nil
 		}
-	// Don't clobber the test's splits.
-	storeKnobs.DisableMergeQueue = true
 
 	s, _, _ := serverutils.StartServer(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})

--- a/pkg/kv/kvserver/client_status_test.go
+++ b/pkg/kv/kvserver/client_status_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -24,11 +23,7 @@ import (
 
 func TestComputeStatsForKeySpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
-	storeCfg.TestingKnobs.DisableMergeQueue = true
-	mtc := &multiTestContext{
-		storeConfig: &storeCfg,
-	}
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 


### PR DESCRIPTION
Follow up to #46383.

These tests were disabling the queue to not interfere with its
AdminSplits, but since the tests were written, AdminSplit got
a TTL.

Release note: None
Release justification: test only