### PR TITLE
colexec: fix merge joiner in some cases

### DIFF
--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -87,10 +87,6 @@ func (u unknown) Window(colType coltypes.T, start int, end int) Vec {
 	panic("Vec is of unknown type and should not be accessed")
 }
 
-func (u unknown) PrettyValueAt(idx int, colType coltypes.T) string {
-	panic("Vec is of unknown type and should not be accessed")
-}
-
 func (u unknown) MaybeHasNulls() bool {
 	panic("Vec is of unknown type and should not be accessed")
 }

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -112,10 +112,6 @@ type Vec interface {
 	// behavior).
 	Window(colType coltypes.T, start int, end int) Vec
 
-	// PrettyValueAt returns a "pretty"value for the idx'th value in this Vec.
-	// It uses the reflect package and is not suitable for calling in hot paths.
-	PrettyValueAt(idx int, colType coltypes.T) string
-
 	// MaybeHasNulls returns true if the column possibly has any null values, and
 	// returns false if the column definitely has no null values.
 	MaybeHasNulls() bool

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -189,22 +189,6 @@ func (m *memColumn) Window(colType coltypes.T, start int, end int) Vec {
 	}
 }
 
-func (m *memColumn) PrettyValueAt(colIdx int, colType coltypes.T) string {
-	if m.nulls.NullAt(colIdx) {
-		return "NULL"
-	}
-	switch colType {
-	// {{range .}}
-	case _TYPES_T:
-		col := m._TemplateType()
-		v := execgen.UNSAFEGET(col, colIdx)
-		return fmt.Sprintf("%v", v)
-	// {{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-}
-
 // SetValueAt is an inefficient helper to set the value in a Vec when the type
 // is unknown.
 func SetValueAt(v Vec, elem interface{}, rowIdx int, colType coltypes.T) {

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -410,6 +410,8 @@ func (o *mergeJoinBase) reset(ctx context.Context) {
 	o.proberState.rBatch = nil
 	o.proberState.lBufferedGroup.reset(ctx)
 	o.proberState.rBufferedGroup.reset(ctx)
+	o.proberState.lBufferedGroupNeedToReset = false
+	o.proberState.rBufferedGroupNeedToReset = false
 	o.resetBuilderCrossProductState()
 }
 

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -802,6 +802,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftBufferedGroup(
 		}
 		o.builderState.lBufferedGroupBatch = currentBatch
 		o.builderState.left.curSrcStartIdx = 0
+		o.builderState.left.numRepeatsIdx = 0
 	}
 	initialBuilderState := o.builderState.left
 	o.unlimitedAllocator.PerformOperation(
@@ -856,6 +857,9 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftBufferedGroup(
 									o.builderState.left.numRepeatsIdx += toAppend
 									return
 								}
+								// We need to start building the next column
+								// with the same initial builder state as the
+								// current column.
 								o.builderState.left.setBuilderColumnState(initialBuilderState)
 								continue LeftColLoop
 							}
@@ -884,11 +888,15 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftBufferedGroup(
 				}
 				o.builderState.lBufferedGroupBatch = currentBatch
 				batchLength = currentBatch.Length()
-				// Note that here we're not resetting the builder state to
-				// initialBuilderState because we have transitioned to building from a
-				// new batch.
+				// We have transitioned to building from a new batch, so we
+				// need to update the builder state to build from the beginning
+				// of the new batch.
 				o.builderState.left.curSrcStartIdx = 0
 				o.builderState.left.numRepeatsIdx = 0
+				// We also need to update 'initialBuilderState' so that the
+				// builder state gets reset correctly in-between different
+				// columns in the loop above.
+				initialBuilderState = o.builderState.left
 			}
 			o.builderState.lBufferedGroupBatch = nil
 			o.builderState.left.reset()


### PR DESCRIPTION
**colexec: fix merge joiner in some cases**

Release justification: bug fixes and low-risk updates to new
functionality.

The cross product builder in the merge joiner was not correctly reset
when building from the left buffered group. The issue was that we were
correctly resetting `builderState` for the first column but then could
be incorrectly overwriting it to `initialBuilderState` (which hasn't
been properly reset) on the consequent columns. For the problem to
appear we needed to have such buffered group that its built output would
not fit into a single batch and that the "building" would stop somewhere
in the middle.

Fixes: #46106.

Release note: None

**colexec, coldata: miscellaneous cleanups**

Release justification: bug fixes and low-risk updates to new
functionality.

This commit cleans up a few things:
- removes coldata.Batch.PrettyValueAt method since it is no longer used
- fixes the calculation of the partition sizes on the right side in the
external hash joiner
- fixes the calculation of RAM dedicated in the external sort to the
cache of disk queues.

Release note: None