### PR TITLE
kv: re-enable merge queue in TestSplitTriggerRaftSnapshotRace

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -477,8 +477,6 @@ func TestSplitTriggerRaftSnapshotRace(t *testing.T) {
 	ctx := context.Background()
 	const numNodes = 3
 	var args base.TestClusterArgs
-	// TODO(benesch): remove this while closing #32784.
-	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{DisableMergeQueue: true}
 	// NB: the merge queue is enabled for additional "chaos". Note that the test
 	// uses three nodes and so there is no replica movement, which would other-
 	// wise tickle Raft snapshots for unrelated reasons.


### PR DESCRIPTION
The merge queue was disabled in this test by df26cf6 due to the bug
found in #32784. That bug was fixed by #33312, so we can address the
TODO and re-enable merges in the test.

Release note: None
Release justification: test only