### PR TITLE
storage: remove TODO about MaxKeys on MVCCScanOptions

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2429,11 +2429,6 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 
 // MVCCScanOptions bundles options for the MVCCScan family of functions.
 type MVCCScanOptions struct {
-	// TODO(benesch): The max parameter should be moved into this struct. Its
-	// semantics make that tricky, though, as the zero value for this struct
-	// naturally represents an unbounded scan, but a max of zero currently means
-	// to return no results.
-
 	// See the documentation for MVCCScan for information on these parameters.
 	Inconsistent     bool
 	Tombstones       bool


### PR DESCRIPTION
This TODO was addressed by #45069.

Release justification: comment only
Release note: None