### PR TITLE
kv: unskip TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2877,7 +2877,6 @@ func TestStoreRangeMergeSlowWatcher(t *testing.T) {
 // range.
 func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#46192")
 
 	// We will be testing the SSTs written on store2's engine.
 	var receivingEng storage.Engine


### PR DESCRIPTION
This test has been deflaked so undo #46337.

Release justification: testing only.

Release note: None.