### PR TITLE
opt: fix logical properties for aggregates which can be NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2223,3 +2223,12 @@ query B
 SELECT every (x) FROM t_every
 ----
 NULL
+
+# Regression test for #46423: this query should return no rows.
+statement ok
+CREATE TABLE t46423(c0 INT);
+INSERT INTO t46423(c0) VALUES(0)
+
+query T
+SELECT c0 FROM t46423 GROUP BY c0 HAVING NOT (variance(0) IS NULL);
+----

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -486,11 +486,13 @@ func (b *logicalPropsBuilder) buildGroupingExprProps(groupExpr RelExpr, rel *pro
 			continue
 		}
 
-		// All PG aggregate functions return a non-NULL result if they have at
-		// least one input row, and if all argument values are non-NULL.
-		inputCols := ExtractAggInputColumns(agg)
-		if inputCols.SubsetOf(inputProps.NotNullCols) {
-			rel.NotNullCols.Add(item.Col)
+		// Most aggregate functions return a non-NULL result if they have at least
+		// one input row with non-NULL argument value, and if all argument values are non-NULL.
+		if opt.AggregateIsNeverNullOnNonNullInput(agg.Op()) {
+			inputCols := ExtractAggInputColumns(agg)
+			if inputCols.SubsetOf(inputProps.NotNullCols) {
+				rel.NotNullCols.Add(item.Col)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -308,3 +308,41 @@ group-by
       │    └── variable: z:3 [type=float]
       └── const-agg [as=x:1, type=int, outer=(1)]
            └── variable: x:1 [type=int]
+
+
+# Even with non-NULL input, some aggregates can still be NULL.
+build
+SELECT variance(x), stddev(x), corr(x, y)
+FROM xyzs
+GROUP BY x, y
+----
+project
+ ├── columns: variance:5(decimal) stddev:6(decimal) corr:7(float)
+ ├── prune: (5-7)
+ └── group-by
+      ├── columns: x:1(int!null) y:2(int) variance:5(decimal) stddev:6(decimal) corr:7(float)
+      ├── grouping columns: x:1(int!null) y:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2,5-7)
+      ├── prune: (5-7)
+      ├── interesting orderings: (+1)
+      ├── project
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── prune: (1,2)
+      │    ├── interesting orderings: (+1)
+      │    └── scan xyzs
+      │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      │         ├── prune: (1-4)
+      │         └── interesting orderings: (+1) (-4,+3,+1)
+      └── aggregations
+           ├── variance [as=variance:5, type=decimal, outer=(1)]
+           │    └── variable: x:1 [type=int]
+           ├── std-dev [as=stddev:6, type=decimal, outer=(1)]
+           │    └── variable: x:1 [type=int]
+           └── corr [as=corr:7, type=float, outer=(1,2)]
+                ├── variable: x:1 [type=int]
+                └── variable: y:2 [type=int]

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -482,7 +482,11 @@ func (c *CustomFuncs) AggsCanBeDecorrelated(aggs memo.AggregationsExpr) bool {
 	for i := range aggs {
 		agg := aggs[i].Agg
 		op := agg.Op()
-		if op != opt.CountRowsOp && !opt.AggregateIgnoresNulls(op) && !opt.AggregateIsNullOnEmpty(op) {
+		if op == opt.AggFilterOp || op == opt.AggDistinctOp {
+			// TODO(radu): investigate if we can do better here
+			return false
+		}
+		if !(op == opt.CountRowsOp || opt.AggregateIgnoresNulls(op) || opt.AggregateIsNullOnEmpty(op)) {
 			return false
 		}
 	}

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -820,9 +820,9 @@ norm expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT u), stddev(DISTINCT w), avg(DISTINCT z) FROM uvwz GROUP BY v
 ----
 project
- ├── columns: sum:6!null stddev:7!null avg:8!null
+ ├── columns: sum:6!null stddev:7 avg:8!null
  └── group-by
-      ├── columns: v:2!null sum:6!null stddev:7!null avg:8!null
+      ├── columns: v:2!null sum:6!null stddev:7 avg:8!null
       ├── grouping columns: v:2!null
       ├── key: (2)
       ├── fd: (2)-->(6-8)


### PR DESCRIPTION
There are a few aggregates which can return NULL even if they have a
non-NULL input: variance, stddev, corr require at least two not-null
input values.

This change fixes the logical props builder to not set the columns as
not-nullable in these cases. It also improves the code around the
functions describing various properties of aggregates to make sure we
didn't miss any aggregates (and we don't miss adding any future new
ones).

Fixes #46412.

Release note (bug fix): fixed incorrect query results in some
cornercases involving variance/stddev/corr.

Release justification: high benefit, low risk change to existing
functionality.