### PR TITLE
opt: fix infinite cost estimate for lookup join with limit hint

### DIFF
--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -792,6 +792,10 @@ func localityMatchScore(zone cat.Zone, locality roachpb.Locality) float64 {
 // lookupJoinInputLimitHint calculates an appropriate limit hint for the input
 // to a lookup join.
 func lookupJoinInputLimitHint(inputRowCount, outputRowCount, outputLimitHint float64) float64 {
+	if outputRowCount == 0 {
+		return 0
+	}
+
 	// Estimate the number of lookups needed to output LimitHint rows.
 	expectedLookupCount := outputLimitHint * inputRowCount / outputRowCount
 

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -532,3 +532,66 @@ limit
  │         │    └── -1
  │         └── filters (true)
  └── -1
+
+exec-ddl
+CREATE TABLE t0(c0 INT UNIQUE)
+----
+
+exec-ddl
+CREATE TABLE t1(c0 INT)
+----
+
+exec-ddl
+CREATE VIEW v0(c0) AS SELECT 0 FROM t1 LIMIT -1
+----
+
+# Regression test for #46187. Ensure that the estimated cost of a lookup join
+# with a limit hint is finite when the number of output rows is 0.
+opt
+SELECT * FROM v0, t0 NATURAL JOIN t1 LIMIT -1
+----
+project
+ ├── columns: c0:3!null c0:4!null
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3,4)
+ └── limit
+      ├── columns: "?column?":3!null t0.c0:4!null t1.c0:6!null
+      ├── cardinality: [0 - 0]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(3,4,6)
+      ├── inner-join (lookup t0@t0_c0_key)
+      │    ├── columns: "?column?":3!null t0.c0:4!null t1.c0:6!null
+      │    ├── key columns: [6] = [4]
+      │    ├── lookup columns are key
+      │    ├── cardinality: [0 - 0]
+      │    ├── side-effects
+      │    ├── fd: ()-->(3), (4)==(6), (6)==(4)
+      │    ├── limit hint: 1.00
+      │    ├── inner-join (cross)
+      │    │    ├── columns: "?column?":3!null t1.c0:6
+      │    │    ├── cardinality: [0 - 0]
+      │    │    ├── side-effects
+      │    │    ├── fd: ()-->(3)
+      │    │    ├── scan t1
+      │    │    │    └── columns: t1.c0:6
+      │    │    ├── project
+      │    │    │    ├── columns: "?column?":3!null
+      │    │    │    ├── cardinality: [0 - 0]
+      │    │    │    ├── side-effects
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(3)
+      │    │    │    ├── limit
+      │    │    │    │    ├── cardinality: [0 - 0]
+      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── scan t1
+      │    │    │    │    │    └── limit hint: 1.00
+      │    │    │    │    └── -1
+      │    │    │    └── projections
+      │    │    │         └── 0 [as="?column?":3]
+      │    │    └── filters (true)
+      │    └── filters (true)
+      └── -1


### PR DESCRIPTION
Due to a divide-by-zero error, the coster estimated an infinite limit hint --
and therefore an infinite cost -- for lookup joins that had a limit hint and
zero output rows. This caused an internal error during planning.

This commit fixes the problem by fixing the divide-by-zero error. Instead of
an infinite limit hint, it estimates a limit hint of 0.

Fixes #46187

Release justification: This is a low risk, high benefit change to existing
functionality.

Release note (bug fix): Fixed an internal error that could occur during
planning for some queries with a join and negative LIMIT.