### PR TITLE
kv: deflake TestRangeInfo by using a manual clock

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1454,6 +1454,7 @@ func TestRangeInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
 	storeCfg.TestingKnobs.DisableMergeQueue = true
+	storeCfg.Clock = nil // manual clock
 	mtc := &multiTestContext{
 		storeConfig: &storeCfg,
 		// This test was written before the multiTestContext started creating many


### PR DESCRIPTION
Fixes #46215.

Fallout from https://github.com/cockroachdb/cockroach/pull/45984.

Release justification: testing only
Release note: None.