### PR TITLE
colexec: optimize hash aggregator

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -31,7 +31,7 @@ func registerTPCHVec(r *testRegistry) {
 		// if vec ON is slower that vec OFF, meaning that if
 		// vec_on_time > vecOnSlowerFailFactor * vec_off_time, the test is failed.
 		// This will help catch any regressions.
-		vecOnSlowerFailFactor = 1.5
+		vecOnSlowerFailFactor = 1.15
 	)
 
 	// queriesToSkipByVersionPrefix is a map from version prefix to another map


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

This commit optimizes the resetting of `op.scratch.sels` slices to
improve the performance of hash aggregator. The key insight here is that
not all of slices in this map have been changed, so we only need to
reset those that have. In fact, since we're processing at most
`batchTupleLimit` tuples at once, we can have at most the same number of
different hash codes, so we could use `[][]int` and `map[int64]int`
instead of `map[int64][]int`, but this change is left as TODO since it
might be destabilizing.

This commit also reduces the "slowness" threshold in `tpchvec/perf` test
from 50% slower to 15% slower (meaning if we're slower by 15% or more
with `vectorize=on`, the test fails). In the last several runs only
queries 15 and 20 would have exceeded that threshold, but with this
commit they should stay under it. Let's see whether the test becomes
unnecessarily noisy.

Fixes: #45614.

Release note: None