### PR TITLE
sql: fix behavior for GMT/UTC prefixed time

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -221,7 +221,7 @@ SET TIME ZONE 'GMT+1'
 query T
 SELECT '2001-01-01 00:00:00'::TIMESTAMP::TIMESTAMPTZ
 ----
-2001-01-01 00:00:00 +0100 +0100
+2001-01-01 00:00:00 -0100 -0100
 
 # test that current_timestamp is correct in different timezones.
 subtest current_timestamp_correct_in_timezone

--- a/pkg/util/timeutil/time_zone_util_test.go
+++ b/pkg/util/timeutil/time_zone_util_test.go
@@ -32,7 +32,7 @@ func TestTimeZoneStringToLocation(t *testing.T) {
 		{"UTC", TimeZoneStringToLocationISO8601Standard, time.UTC, true},
 		{"Australia/Sydney", TimeZoneStringToLocationISO8601Standard, aus, true},
 		{"fixed offset:3600 (3600)", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(3600, "3600"), true},
-		{`GMT-3:00`, TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(-3*60*60, "GMT-3:00"), true},
+		{`GMT-3:00`, TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(3*60*60, "GMT-3:00"), true},
 		{"+10", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(10*60*60, "+10"), true},
 		{"-10:30", TimeZoneStringToLocationISO8601Standard, FixedOffsetTimeZoneToLocation(-(10*60*60 + 30*60), "-10:30"), true},
 		{"asdf", TimeZoneStringToLocationISO8601Standard, nil, false},
@@ -62,34 +62,57 @@ func TestTimeZoneStringToLocation(t *testing.T) {
 func TestTimeZoneOffsetStringConversion(t *testing.T) {
 	testCases := []struct {
 		timezone   string
+		std        TimeZoneStringToLocationStandard
 		offsetSecs int64
 		ok         bool
 	}{
-		{`10`, 10 * 60 * 60, true},
-		{`10:15`, 10*60*60 + 15*60, true},
-		{`-10:15`, -(10*60*60 + 15*60), true},
-		{`GMT+00:00`, 0, true},
-		{`UTC-1:00:00`, -3600, true},
-		{`UTC-1:0:00`, -3600, true},
-		{`UTC+15:59:0`, 57540, true},
-		{` GMT +167:59:00  `, 604740, true},
-		{`GMT-15:59:59`, -57599, true},
-		{`GMT-06:59`, -25140, true},
-		{`GMT+167:59:00`, 604740, true},
-		{`GMT+ 167: 59:0`, 604740, true},
-		{`GMT+5`, 18000, true},
-		{`UTC+5:9`, 5*60*60 + 9*60, true},
-		{`UTC-5:9:1`, -(5*60*60 + 9*60 + 1), true},
-		{`GMT-15:59:5Z`, 0, false},
-		{`GMT-15:99:1`, 0, false},
-		{`GMT+6:`, 0, false},
-		{`GMT-6:00:`, 0, false},
-		{`GMT+168:00:00`, 0, false},
-		{`GMT-170:00:59`, 0, false},
+		{`10`, TimeZoneStringToLocationISO8601Standard, 10 * 60 * 60, true},
+		{`10:15`, TimeZoneStringToLocationISO8601Standard, 10*60*60 + 15*60, true},
+		{`-10:15`, TimeZoneStringToLocationISO8601Standard, -(10*60*60 + 15*60), true},
+		{`GMT+00:00`, TimeZoneStringToLocationISO8601Standard, 0, true},
+		{`UTC-1:00:00`, TimeZoneStringToLocationISO8601Standard, 3600, true},
+		{`UTC-1:0:00`, TimeZoneStringToLocationISO8601Standard, 3600, true},
+		{`UTC+15:59:0`, TimeZoneStringToLocationISO8601Standard, -57540, true},
+		{` GMT +167:59:00  `, TimeZoneStringToLocationISO8601Standard, -604740, true},
+		{`GMT-15:59:59`, TimeZoneStringToLocationISO8601Standard, 57599, true},
+		{`GMT-06:59`, TimeZoneStringToLocationISO8601Standard, 25140, true},
+		{`GMT+167:59:00`, TimeZoneStringToLocationISO8601Standard, -604740, true},
+		{`GMT+ 167: 59:0`, TimeZoneStringToLocationISO8601Standard, -604740, true},
+		{`GMT+5`, TimeZoneStringToLocationISO8601Standard, -18000, true},
+		{`UTC+5:9`, TimeZoneStringToLocationISO8601Standard, -(5*60*60 + 9*60), true},
+		{`UTC-5:9:1`, TimeZoneStringToLocationISO8601Standard, (5*60*60 + 9*60 + 1), true},
+		{`GMT-15:59:5Z`, TimeZoneStringToLocationISO8601Standard, 0, false},
+		{`GMT-15:99:1`, TimeZoneStringToLocationISO8601Standard, 0, false},
+		{`GMT+6:`, TimeZoneStringToLocationISO8601Standard, 0, false},
+		{`GMT-6:00:`, TimeZoneStringToLocationISO8601Standard, 0, false},
+		{`GMT+168:00:00`, TimeZoneStringToLocationISO8601Standard, 0, false},
+		{`GMT-170:00:59`, TimeZoneStringToLocationISO8601Standard, 0, false},
+
+		{`10`, TimeZoneStringToLocationPOSIXStandard, -10 * 60 * 60, true},
+		{`10:15`, TimeZoneStringToLocationPOSIXStandard, -(10*60*60 + 15*60), true},
+		{`-10:15`, TimeZoneStringToLocationPOSIXStandard, (10*60*60 + 15*60), true},
+		{`GMT+00:00`, TimeZoneStringToLocationPOSIXStandard, 0, true},
+		{`UTC-1:00:00`, TimeZoneStringToLocationPOSIXStandard, 3600, true},
+		{`UTC-1:0:00`, TimeZoneStringToLocationPOSIXStandard, 3600, true},
+		{`UTC+15:59:0`, TimeZoneStringToLocationPOSIXStandard, -57540, true},
+		{` GMT +167:59:00  `, TimeZoneStringToLocationPOSIXStandard, -604740, true},
+		{`GMT-15:59:59`, TimeZoneStringToLocationPOSIXStandard, 57599, true},
+		{`GMT-06:59`, TimeZoneStringToLocationPOSIXStandard, 25140, true},
+		{`GMT+167:59:00`, TimeZoneStringToLocationPOSIXStandard, -604740, true},
+		{`GMT+ 167: 59:0`, TimeZoneStringToLocationPOSIXStandard, -604740, true},
+		{`GMT+5`, TimeZoneStringToLocationPOSIXStandard, -18000, true},
+		{`UTC+5:9`, TimeZoneStringToLocationPOSIXStandard, -(5*60*60 + 9*60), true},
+		{`UTC-5:9:1`, TimeZoneStringToLocationPOSIXStandard, (5*60*60 + 9*60 + 1), true},
+		{`GMT-15:59:5Z`, TimeZoneStringToLocationPOSIXStandard, 0, false},
+		{`GMT-15:99:1`, TimeZoneStringToLocationPOSIXStandard, 0, false},
+		{`GMT+6:`, TimeZoneStringToLocationPOSIXStandard, 0, false},
+		{`GMT-6:00:`, TimeZoneStringToLocationPOSIXStandard, 0, false},
+		{`GMT+168:00:00`, TimeZoneStringToLocationPOSIXStandard, 0, false},
+		{`GMT-170:00:59`, TimeZoneStringToLocationPOSIXStandard, 0, false},
 	}
 
 	for i, testCase := range testCases {
-		offset, ok := timeZoneOffsetStringConversion(testCase.timezone)
+		offset, ok := timeZoneOffsetStringConversion(testCase.timezone, testCase.std)
 		if offset != testCase.offsetSecs || ok != testCase.ok {
 			t.Errorf("%d: Expected offset: %d, success: %v for time %s, but got offset: %d, success: %v",
 				i, testCase.offsetSecs, testCase.ok, testCase.timezone, offset, ok)


### PR DESCRIPTION
sql: fix behavior for GMT/UTC prefixed time

Found this whilst trying to write the blog post!

This PR corrects `TimeZoneStringToLocation` to always use POSIX
standard for times if UTC or GMT is at the start of the string, in line
with Postgres. It is worth noting that POSIX standard means hours *west*
of UTC, i.e. 'UTC+4' would 4 hours west, i.e. in NY in this time period.
Note just `+4` is still ISO8601 for `SET TIME ZONE`, but POSIX standard
for `AT TIME ZONE`.

Release justification: bug fixes and low-risk updates to new functionality

Release note (bug fix): Fix a bug where SET TIME ZONE with a string
prefixed with `UTC` or `GMT` had it's offset inverted the wrong way.

