### PR TITLE
sql: crdb_internal.jobs memory usage improvements

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -432,7 +432,6 @@ func tsOrNull(micros int64) tree.Datum {
 
 // TODO(tbg): prefix with kv_.
 var crdbInternalJobsTable = virtualSchemaTable{
-	comment: `decoded job metadata from system.jobs (KV scan)`,
 	schema: `
 CREATE TABLE crdb_internal.jobs (
 	job_id             		INT,
@@ -452,14 +451,23 @@ CREATE TABLE crdb_internal.jobs (
 	error              		STRING,
 	coordinator_id     		INT
 )`,
-	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	comment: `decoded job metadata from system.jobs (KV scan)`,
+	generator: func(ctx context.Context, p *planner, _ *DatabaseDescriptor) (virtualTableGenerator, error) {
+		currentUser := p.SessionData().User
+		isAdmin, err := p.HasAdminRole(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Beware: we're querying system.jobs as root; we need to be careful to filter
+		// out results that the current user is not able to see.
 		query := `SELECT id, status, created, payload, progress FROM system.jobs`
 		rows, _ /* cols */, err :=
 			p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryWithUser(
 				ctx, "crdb-internal-jobs-table", p.txn,
 				p.SessionData().User, query)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Attempt to account for the memory of the retrieved rows and the data
@@ -472,106 +480,121 @@ CREATE TABLE crdb_internal.jobs (
 		// and other virtual table queries but that's a bigger task.
 		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount()
 		defer ba.Close(ctx)
+		var totalMem int64
 		for _, r := range rows {
-			var rowSize int64
 			for _, d := range r {
-				// NB: Add the datum size twice to count the fact that we already allocated
-				// it once and we're about to unmarshal it and keep that around.
-				rowSize += int64(d.Size()) * 2
-			}
-			if err := ba.Grow(ctx, rowSize); err != nil {
-				return err
+				totalMem += int64(d.Size())
 			}
 		}
+		if err := ba.Grow(ctx, totalMem); err != nil {
+			return nil, err
+		}
 
-		for _, r := range rows {
-			id, status, created, payloadBytes, progressBytes := r[0], r[1], r[2], r[3], r[4]
-
-			var jobType, description, statement, username, descriptorIDs, started, runningStatus,
-				finished, modified, fractionCompleted, highWaterTimestamp, errorStr, leaseNode = tree.DNull,
-				tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull,
-				tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull
-
-			// Extract data from the payload.
-			payload, err := jobs.UnmarshalPayload(payloadBytes)
-			if err != nil {
-				errorStr = tree.NewDString(fmt.Sprintf("error decoding payload: %v", err))
-			} else {
-				jobType = tree.NewDString(payload.Type().String())
-				description = tree.NewDString(payload.Description)
-				statement = tree.NewDString(payload.Statement)
-				username = tree.NewDString(payload.Username)
-				descriptorIDsArr := tree.NewDArray(types.Int)
-				for _, descID := range payload.DescriptorIDs {
-					if err := descriptorIDsArr.Append(tree.NewDInt(tree.DInt(int(descID)))); err != nil {
-						return err
-					}
+		// We'll reuse this container on each loop.
+		container := make(tree.Datums, 0, 16)
+		return func() (datums tree.Datums, e error) {
+			// Loop while we need to skip a row.
+			for {
+				if len(rows) == 0 {
+					return nil, nil
 				}
-				descriptorIDs = descriptorIDsArr
-				started = tsOrNull(payload.StartedMicros)
-				finished = tsOrNull(payload.FinishedMicros)
-				if payload.Lease != nil {
-					leaseNode = tree.NewDInt(tree.DInt(payload.Lease.NodeID))
-				}
-				errorStr = tree.NewDString(payload.Error)
-			}
+				r := rows[0]
+				rows = rows[1:]
+				id, status, created, payloadBytes, progressBytes := r[0], r[1], r[2], r[3], r[4]
 
-			// Extract data from the progress field.
-			if progressBytes != tree.DNull {
-				progress, err := jobs.UnmarshalProgress(progressBytes)
+				var jobType, description, statement, username, descriptorIDs, started, runningStatus,
+					finished, modified, fractionCompleted, highWaterTimestamp, errorStr, leaseNode = tree.DNull,
+					tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull,
+					tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull
+
+				// Extract data from the payload.
+				payload, err := jobs.UnmarshalPayload(payloadBytes)
+
+				// We filter out masked rows before we allocate all the
+				// datums. Needless allocate when not necessary.
+				sameUser := payload != nil && payload.Username == currentUser
+				if canAccess := isAdmin || sameUser; !canAccess {
+					// This user is neither an admin nor the user who created the
+					// job. They cannot see this row.
+					continue
+				}
+
 				if err != nil {
-					baseErr := ""
-					if s, ok := errorStr.(*tree.DString); ok {
-						baseErr = string(*s)
-						if baseErr != "" {
-							baseErr += "\n"
+					errorStr = tree.NewDString(fmt.Sprintf("error decoding payload: %v", err))
+				} else {
+					jobType = tree.NewDString(payload.Type().String())
+					description = tree.NewDString(payload.Description)
+					statement = tree.NewDString(payload.Statement)
+					username = tree.NewDString(payload.Username)
+					descriptorIDsArr := tree.NewDArray(types.Int)
+					for _, descID := range payload.DescriptorIDs {
+						if err := descriptorIDsArr.Append(tree.NewDInt(tree.DInt(int(descID)))); err != nil {
+							return nil, err
 						}
 					}
-					errorStr = tree.NewDString(fmt.Sprintf("%serror decoding progress: %v", baseErr, err))
-				} else {
-					// Progress contains either fractionCompleted for traditional jobs,
-					// or the highWaterTimestamp for change feeds.
-					if highwater := progress.GetHighWater(); highwater != nil {
-						highWaterTimestamp = tree.TimestampToDecimal(*highwater)
-					} else {
-						fractionCompleted = tree.NewDFloat(tree.DFloat(progress.GetFractionCompleted()))
+					descriptorIDs = descriptorIDsArr
+					started = tsOrNull(payload.StartedMicros)
+					finished = tsOrNull(payload.FinishedMicros)
+					if payload.Lease != nil {
+						leaseNode = tree.NewDInt(tree.DInt(payload.Lease.NodeID))
 					}
-					modified = tsOrNull(progress.ModifiedMicros)
+					errorStr = tree.NewDString(payload.Error)
+				}
 
-					if len(progress.RunningStatus) > 0 {
-						if s, ok := status.(*tree.DString); ok {
-							if jobs.Status(string(*s)) == jobs.StatusRunning {
-								runningStatus = tree.NewDString(progress.RunningStatus)
+				// Extract data from the progress field.
+				if progressBytes != tree.DNull {
+					progress, err := jobs.UnmarshalProgress(progressBytes)
+					if err != nil {
+						baseErr := ""
+						if s, ok := errorStr.(*tree.DString); ok {
+							baseErr = string(*s)
+							if baseErr != "" {
+								baseErr += "\n"
+							}
+						}
+						errorStr = tree.NewDString(fmt.Sprintf("%serror decoding progress: %v", baseErr, err))
+					} else {
+						// Progress contains either fractionCompleted for traditional jobs,
+						// or the highWaterTimestamp for change feeds.
+						if highwater := progress.GetHighWater(); highwater != nil {
+							highWaterTimestamp = tree.TimestampToDecimal(*highwater)
+						} else {
+							fractionCompleted = tree.NewDFloat(tree.DFloat(progress.GetFractionCompleted()))
+						}
+						modified = tsOrNull(progress.ModifiedMicros)
+
+						if len(progress.RunningStatus) > 0 {
+							if s, ok := status.(*tree.DString); ok {
+								if jobs.Status(string(*s)) == jobs.StatusRunning {
+									runningStatus = tree.NewDString(progress.RunningStatus)
+								}
 							}
 						}
 					}
 				}
-			}
 
-			// Report the data.
-			if err := addRow(
-				id,
-				jobType,
-				description,
-				statement,
-				username,
-				descriptorIDs,
-				status,
-				runningStatus,
-				created,
-				started,
-				finished,
-				modified,
-				fractionCompleted,
-				highWaterTimestamp,
-				errorStr,
-				leaseNode,
-			); err != nil {
-				return err
+				container = container[:0]
+				container = append(container,
+					id,
+					jobType,
+					description,
+					statement,
+					username,
+					descriptorIDs,
+					status,
+					runningStatus,
+					created,
+					started,
+					finished,
+					modified,
+					fractionCompleted,
+					highWaterTimestamp,
+					errorStr,
+					leaseNode,
+				)
+				return container, nil
 			}
-		}
-
-		return nil
+		}, nil
 	},
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -462,6 +462,28 @@ CREATE TABLE crdb_internal.jobs (
 			return err
 		}
 
+		// Attempt to account for the memory of the retrieved rows and the data
+		// we're going to unmarshal and keep bufferred in RAM.
+		//
+		// TODO(ajwerner): This is a pretty terrible hack. Instead the internal
+		// executor should be hooked into the memory monitor associated with this
+		// conn executor. If we did that we would still want to account for the
+		// unmarshaling. Additionally, it's probably a good idea to paginate this
+		// and other virtual table queries but that's a bigger task.
+		ba := p.ExtendedEvalContext().Mon.MakeBoundAccount()
+		defer ba.Close(ctx)
+		for _, r := range rows {
+			var rowSize int64
+			for _, d := range r {
+				// NB: Add the datum size twice to count the fact that we already allocated
+				// it once and we're about to unmarshal it and keep that around.
+				rowSize += int64(d.Size()) * 2
+			}
+			if err := ba.Grow(ctx, rowSize); err != nil {
+				return err
+			}
+		}
+
 		for _, r := range rows {
 			id, status, created, payloadBytes, progressBytes := r[0], r[1], r[2], r[3], r[4]
 

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -272,7 +272,7 @@ func TestCrdbInternalJobsOOM(t *testing.T) {
 	// connection, but small enough to overflow easily. It's set to be comfortably
 	// large enough that the server can start up with a bit of
 	// extra space to overflow.
-	const lowMemoryBudget = 500000
+	const lowMemoryBudget = 250000
 	const fieldSize = 10000
 	const numRows = 10
 	const statement = "SELECT count(*) FROM crdb_internal.jobs"
@@ -294,8 +294,12 @@ VALUES ($1, 'StatusRunning', repeat('a', $2)::BYTES, repeat('a', $2)::BYTES)`, i
 		defer s.Stopper().Stop(context.Background())
 
 		insertRows(sqlDB)
-		if _, err := sqlDB.Exec(statement); err.(*pq.Error).Code != pgcode.OutOfMemory {
-			t.Fatalf("Expected \"%s\" to consume too much memory", statement)
+		_, err := sqlDB.Exec(statement)
+		if err == nil {
+			t.Fatalf("Expected \"%s\" to consume too much memory, found no error", statement)
+		}
+		if pErr, ok := err.(*pq.Error); !ok || pErr.Code != pgcode.OutOfMemory {
+			t.Fatalf("Expected \"%s\" to consume too much memory, found unexpected error %+v", statement, pErr)
 		}
 	})
 

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -12,6 +12,7 @@ package sql_test
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -32,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgx/pgtype"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -258,5 +261,53 @@ SELECT column_name, character_maximum_length, numeric_precision, numeric_precisi
 	if !found {
 		t.Fatal("column disappeared")
 	}
+}
 
+// TestCrdbInternalJobsOOM verifies that the memory budget works correctly for
+// crdb_internal.jobs.
+func TestCrdbInternalJobsOOM(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The budget needs to be large enough to establish the initial database
+	// connection, but small enough to overflow easily. It's set to be comfortably
+	// large enough that the server can start up with a bit of
+	// extra space to overflow.
+	const lowMemoryBudget = 500000
+	const fieldSize = 10000
+	const numRows = 10
+	const statement = "SELECT count(*) FROM crdb_internal.jobs"
+
+	insertRows := func(sqlDB *gosql.DB) {
+		for i := 0; i < numRows; i++ {
+			if _, err := sqlDB.Exec(`
+INSERT INTO system.jobs(id, status, payload, progress)
+VALUES ($1, 'StatusRunning', repeat('a', $2)::BYTES, repeat('a', $2)::BYTES)`, i, fieldSize); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("over budget jobs table", func(t *testing.T) {
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			SQLMemoryPoolSize: lowMemoryBudget,
+		})
+		defer s.Stopper().Stop(context.Background())
+
+		insertRows(sqlDB)
+		if _, err := sqlDB.Exec(statement); err.(*pq.Error).Code != pgcode.OutOfMemory {
+			t.Fatalf("Expected \"%s\" to consume too much memory", statement)
+		}
+	})
+
+	t.Run("under budget jobs table", func(t *testing.T) {
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			SQLMemoryPoolSize: 2 * lowMemoryBudget,
+		})
+		defer s.Stopper().Stop(context.Background())
+
+		insertRows(sqlDB)
+		if _, err := sqlDB.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	})
 }


### PR DESCRIPTION
This backports two commits: 4355ae8 and c20cbef.

sql: attempt to account for memory in crdb_internal.jobs
This is a stop-gap PR to do _some_ memory accounting during the
execution of `crdb_internal.jobs`. It turns out that with hundreds of
databases and hours backups per database, one can easily get to 100k jobs
which are roughly 2-3Kb each. Given the total lack of memory monitoring here,
this situation can lead to OOMs.

Ideally we'd track the memory usage by the internal executor. That's a
bigger change left for later. Also ideally we'd paginate the output.

Touches #44166.

sql: load crdb_internal.jobs protobufs lazily
Previously, crdb_internal.jobs did two things eagerly:

1. Load all serialized rows into memory from system.jobs
2. Unmarshal all serialized rows into inflated protobuf structs

Now, crdb_internal.jobs loads all serialized rows into memory only, and
does the unmarshalling lazily, throwing away the memory for each
unmarshalled job after each row is emitted.

This should lead to somewhat less memory usage.

Release note (performance improvement): load less data into memory for
crdb_internal.jobs.