### PR TITLE
colexec: fix a seek error with interleaved tables in the cfetcher

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1175,3 +1175,16 @@ SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (n
 
 statement ok
 RESET vectorize
+
+# Regression for 46140.
+statement ok
+DROP TABLE IF EXISTS t0, t1;
+CREATE TABLE t0(c0 INT);
+CREATE TABLE t1(c0 BOOL) INTERLEAVE IN PARENT t0(rowid);
+INSERT INTO t0(c0) VALUES (0);
+INSERT INTO t1(rowid, c0) VALUES(0, TRUE)
+
+query I
+SELECT max(t1.rowid) FROM t1 WHERE t1.c0
+----
+0


### PR DESCRIPTION
Fixes #46140.

This PR fixes a bug where the cfetcher was using an incorrect
predicate to skip interleaved child rows when performing
a reverse scan.

Release justification: bug fix
Release note (bug fix): Fix a bug where the vectorized engine
could sometimes give an incorrect result when reading from
interleaved parents or children.