### PR TITLE
colexec: fix agg function incorrect handling of apd.Decimal

### DIFF
--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -200,14 +200,8 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// If we haven't seen any non-nulls for the current group yet, and the
 		// current value is non-null, then we can pick the current value to be the
 		// output.
-		// {{ if eq .LTyp.String "Bytes" }}
-		// Bytes type is special - we actually need to copy the value that we're
-		// getting in an "unsafe" way because col might be reused (and the
-		// underlying memory overwritten) on the next batches.
-		a.curAgg = append(a.curAgg[:0], execgen.UNSAFEGET(col, i)...)
-		// {{ else }}
-		a.curAgg = execgen.UNSAFEGET(col, i)
-		// {{ end }}
+		val := execgen.UNSAFEGET(col, i)
+		execgen.COPYVAL(a.curAgg, val)
 		a.foundNonNullForCurrentGroup = true
 	}
 	// {{end}}

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -231,14 +231,15 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 	// {{ end }}
 	if !isNull {
 		if !a.foundNonNullForCurrentGroup {
-			a.curAgg = execgen.UNSAFEGET(col, i)
+			val := execgen.UNSAFEGET(col, i)
+			execgen.COPYVAL(a.curAgg, val)
 			a.foundNonNullForCurrentGroup = true
 		} else {
 			var cmp bool
 			candidate := execgen.UNSAFEGET(col, i)
 			_ASSIGN_CMP(cmp, candidate, a.curAgg)
 			if cmp {
-				a.curAgg = candidate
+				execgen.COPYVAL(a.curAgg, candidate)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, some agg functions directly assign the intermediate
value to its curAgg field. This does not work for apd.Decimal
since its assignment should be handled using .Set method.

Closes #46421

Release justification: bug fix
Release note: None
