### PR TITLE
cli/start: fix the heap & goroutine dumps

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -38,6 +38,10 @@ const (
 	// when there is a potential OOM situation.
 	HeapProfileDir = "heap_profiler"
 
+	// GoroutineDumpDir is the directory name where the goroutine dumper
+	// stores dump when one of the dump heuristics is triggered.
+	GoroutineDumpDir = "goroutine_dump"
+
 	// MinRangeMaxBytes is the minimum value for range max bytes.
 	MinRangeMaxBytes = 64 << 10 // 64 KB
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -104,6 +104,8 @@ func initCLIDefaults() {
 	debugCtx.maxResults = 1000
 	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
 
+	serverCfg.GoroutineDumpDirName = ""
+	serverCfg.HeapProfileDirName = ""
 	serverCfg.ReadyFn = nil
 	serverCfg.DelayedBootstrapFn = nil
 	serverCfg.SocketFile = ""

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -524,10 +524,6 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 		return err
 	}
 
-	serverCfg.GoroutineDumpDirName = logOutputDirectory()
-
-	heapProfileDir := filepath.Join(logOutputDirectory(), base.HeapProfileDir)
-	serverCfg.HeapProfileDirName = heapProfileDir
 	// We don't care about GRPCs fairly verbose logs in most client commands,
 	// but when actually starting a server, we enable them.
 	grpcutil.SetSeverity(log.Severity_WARNING)
@@ -1201,11 +1197,15 @@ func setupAndInitializeLoggingAndProfiling(
 		}()
 	}
 
+	// We want to be careful to still produce useful debug dumps if the
+	// server configuration has disabled logging to files.
 	outputDirectory := "."
 	if p := logOutputDirectory(); p != "" {
 		outputDirectory = p
 	}
 	startCtx.backtraceOutputDir = outputDirectory
+	serverCfg.GoroutineDumpDirName = filepath.Join(outputDirectory, base.GoroutineDumpDir)
+	serverCfg.HeapProfileDirName = filepath.Join(outputDirectory, base.HeapProfileDir)
 
 	if ambiguousLogDirs {
 		// Note that we can't report this message earlier, because the log directory

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -474,8 +474,10 @@ requesting data for debug/nodes/1/enginestats... writing: debug/nodes/1/enginest
 requesting stacks for node 1... writing: debug/nodes/1/stacks.txt
 requesting threads for node 1... writing: debug/nodes/1/threads.txt
 requesting heap profile for node 1... writing: debug/nodes/1/heap.pprof
-requesting heap files for node 1... 0 found
-requesting goroutine files for node 1... 0 found
+requesting heap files for node 1... writing: debug/nodes/1/heapprof
+  ^- resulted in ...
+requesting goroutine files for node 1... writing: debug/nodes/1/goroutines
+  ^- resulted in ...
 requesting log file ...
 requesting list of SQL databases... writing: debug/schema
   ^- resulted in ...
@@ -582,8 +584,10 @@ requesting data for debug/nodes/1/enginestats... writing: debug/nodes/1/enginest
 requesting stacks for node 1... writing: debug/nodes/1/stacks.txt
 requesting threads for node 1... writing: debug/nodes/1/threads.txt
 requesting heap profile for node 1... writing: debug/nodes/1/heap.pprof
-requesting heap files for node 1... 0 found
-requesting goroutine files for node 1... 0 found
+requesting heap files for node 1... writing: debug/nodes/1/heapprof
+  ^- resulted in ...
+requesting goroutine files for node 1... writing: debug/nodes/1/goroutines
+  ^- resulted in ...
 requesting log file ...
 requesting ranges... 32 found
 writing: debug/nodes/1/ranges/1.json
@@ -690,8 +694,10 @@ requesting data for debug/nodes/3/enginestats... writing: debug/nodes/3/enginest
 requesting stacks for node 3... writing: debug/nodes/3/stacks.txt
 requesting threads for node 3... writing: debug/nodes/3/threads.txt
 requesting heap profile for node 3... writing: debug/nodes/3/heap.pprof
-requesting heap files for node 3... 0 found
-requesting goroutine files for node 3... 0 found
+requesting heap files for node 3... writing: debug/nodes/3/heapprof
+  ^- resulted in ...
+requesting goroutine files for node 3... writing: debug/nodes/3/goroutines
+  ^- resulted in ...
 requesting log file ...
 requesting ranges... 32 found
 writing: debug/nodes/3/ranges/1.json

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -113,10 +113,6 @@ func NewGoroutineDumper(dir string) (*GoroutineDumper, error) {
 	if dir == "" {
 		return nil, errors.New("directory to store dumps could not be determined")
 	}
-	dir = filepath.Join(dir, "goroutine_dump")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return nil, err
-	}
 	gd := &GoroutineDumper{
 		heuristics: []heuristic{
 			doubleSinceLastDumpHeuristic,

--- a/pkg/server/goroutinedumper/goroutinedumper_test.go
+++ b/pkg/server/goroutinedumper/goroutinedumper_test.go
@@ -174,19 +174,6 @@ func TestNewGoroutineDumper(t *testing.T) {
 		assert.EqualError(t, err, "directory to store dumps could not be determined")
 	})
 
-	t.Run("fails because goroutine_dump already exists as a file", func(t *testing.T) {
-		tempDir, dirCleanupFn := testutils.TempDir(t)
-		defer dirCleanupFn()
-		path := filepath.Join(tempDir, "goroutine_dump")
-		emptyFile, err := os.Create(path)
-		assert.NoError(t, err, "failed to create goroutine_dump file")
-		err = emptyFile.Close()
-		assert.NoError(t, err, "failed to close goroutine_dump file")
-
-		_, err = NewGoroutineDumper(tempDir)
-		assert.IsType(t, &os.PathError{}, err)
-	})
-
 	t.Run("succeeds", func(t *testing.T) {
 		tempDir, dirCleanupFn := testutils.TempDir(t)
 		defer dirCleanupFn()
@@ -194,7 +181,7 @@ func TestNewGoroutineDumper(t *testing.T) {
 		assert.NoError(t, err, "unexpected error in NewGoroutineDumper")
 		assert.Equal(t, int64(0), gd.goroutinesThreshold)
 		assert.Equal(t, int64(0), gd.maxGoroutinesDumped)
-		assert.Equal(t, filepath.Join(tempDir, "goroutine_dump"), gd.dir)
+		assert.Equal(t, tempDir, gd.dir)
 	})
 }
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -92,10 +92,6 @@ const (
 	// omittedKeyStr is the string returned in place of a key when keys aren't
 	// permitted in responses.
 	omittedKeyStr = "omitted (due to the 'server.remote_debugging.mode' setting)"
-
-	// goroutineDir is the directory name where the goroutinedumper stores
-	// goroutine dumps.
-	goroutinesDir = "goroutine_dump"
 )
 
 var (
@@ -718,11 +714,14 @@ func (s *statusServer) GetFiles(
 	//TODO(ridwanmsharif): Serve logfiles so debug-zip can fetch them
 	// intead of reading indididual entries.
 	case serverpb.FileType_HEAP: // Requesting for saved Heap Profiles.
-		dir = filepath.Join(s.admin.server.cfg.HeapProfileDirName, base.HeapProfileDir)
+		dir = s.admin.server.cfg.HeapProfileDirName
 	case serverpb.FileType_GOROUTINES: // Requesting for saved Goroutine dumps.
-		dir = filepath.Join(s.admin.server.cfg.GoroutineDumpDirName, goroutinesDir)
+		dir = s.admin.server.cfg.GoroutineDumpDirName
 	default:
 		return nil, grpcstatus.Errorf(codes.InvalidArgument, "unknown file type: %s", req.Type)
+	}
+	if dir == "" {
+		return nil, grpcstatus.Errorf(codes.Unimplemented, "dump directory not configured: %s", req.Type)
 	}
 	var resp serverpb.GetFilesResponse
 	for _, pattern := range req.Patterns {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -425,8 +425,12 @@ func TestStatusGetFiles(t *testing.T) {
 	t.Run("goroutines", func(t *testing.T) {
 		const testFilesNo = 3
 		for i := 0; i < testFilesNo; i++ {
-			testFile := filepath.Join(storeSpec.Path, "logs", goroutinesDir, fmt.Sprintf("goroutine_dump%d.txt.gz", i))
-			if err := ioutil.WriteFile(testFile, []byte(fmt.Sprintf("Goroutine dump %d", i)), 0644); err != nil {
+			testGoroutineDir := filepath.Join(storeSpec.Path, "logs", base.GoroutineDumpDir)
+			testGoroutineFile := filepath.Join(testGoroutineDir, fmt.Sprintf("goroutine_dump%d.txt.gz", i))
+			if err := os.MkdirAll(testGoroutineDir, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+			if err := ioutil.WriteFile(testGoroutineFile, []byte(fmt.Sprintf("Goroutine dump %d", i)), 0644); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -220,10 +220,10 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 			// HeapProfileDirName and GoroutineDumpDirName are normally set by the
 			// cli, once, to the path of the first store.
 			if cfg.HeapProfileDirName == "" {
-				cfg.HeapProfileDirName = filepath.Join(storeSpec.Path, "logs")
+				cfg.HeapProfileDirName = filepath.Join(storeSpec.Path, "logs", base.HeapProfileDir)
 			}
 			if cfg.GoroutineDumpDirName == "" {
-				cfg.GoroutineDumpDirName = filepath.Join(storeSpec.Path, "logs")
+				cfg.GoroutineDumpDirName = filepath.Join(storeSpec.Path, "logs", base.GoroutineDumpDir)
 			}
 		}
 	}


### PR DESCRIPTION
Three fixes here:

1) the status endpoint was looking the heap profiles
   in (approximately) `logdir/heap_profiles/heap_profiles/` and
   obviously never finding anything. This patch fixes the double
   append. This also ensures that `cockroach debug zip` finds the
   files.

2) The code that was setting the destination directory for goroutine
   dumps did not account for cases where logging to files is disabled
   by setting `--log-dir` to the empty string. This patch fixes
   it by dumping to the current dir, like heap profiles already do.

3) The intent of the code was to disable dumping things to files
   when using only in-memory stores. This intent was violated
   for goroutine dumps, because of an ad-hoc (inconsistent)
   initialization code path.

Release note (bug fix): `cockroach debug zip` now properly collects
heap profiles, as originally intended.

Release note (bug fix): the goroutine dump facility now functions
properly when logging to files is disabled, e.g. via `--log-dir=""` or
`--logtostderr`.

Release justification: fixes for high-priority or high-severity bugs in existing functionality