### PR TITLE
cli,server: support non-TLS localhost-only HTTP

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -190,6 +190,9 @@ type Config struct {
 	// HTTPAddr is the configured HTTP listen address.
 	HTTPAddr string
 
+	// DisableTLSForHTTP, if set, disables TLS for the HTTP listener.
+	DisableTLSForHTTP bool
+
 	// HTTPAdvertiseAddr is the advertised HTTP address.
 	// This is computed from HTTPAddr if specified otherwise Addr.
 	HTTPAdvertiseAddr string
@@ -230,6 +233,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.Addr = defaultAddr
 	cfg.AdvertiseAddr = cfg.Addr
 	cfg.HTTPAddr = defaultHTTPAddr
+	cfg.DisableTLSForHTTP = false
 	cfg.HTTPAdvertiseAddr = ""
 	cfg.SplitListenSQL = false
 	cfg.SQLAddr = defaultSQLAddr
@@ -241,9 +245,10 @@ func (cfg *Config) InitDefaults() {
 	cfg.DisableClusterNameVerification = false
 }
 
-// HTTPRequestScheme returns "http" or "https" based on the value of Insecure.
+// HTTPRequestScheme returns "http" or "https" based on the value of
+// Insecure and DisableTLSForHTTP.
 func (cfg *Config) HTTPRequestScheme() string {
-	if cfg.Insecure {
+	if cfg.Insecure || cfg.DisableTLSForHTTP {
 		return httpScheme
 	}
 	return httpsScheme
@@ -444,7 +449,7 @@ func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
 // manager for a server UI TLS config.
 func (cfg *Config) GetUIServerTLSConfig() (*tls.Config, error) {
 	// Early out.
-	if cfg.Insecure {
+	if cfg.Insecure || cfg.DisableTLSForHTTP {
 		return nil, nil
 	}
 

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -50,6 +50,8 @@ type TestServerArgs struct {
 	SQLAddr string
 	// HTTPAddr (if nonempty) is the HTTP address to use for the test server.
 	HTTPAddr string
+	// DisableTLSForHTTP if set, disables TLS for the HTTP interface.
+	DisableTLSForHTTP bool
 
 	// JoinAddr is the address of a node we are joining.
 	//

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -506,6 +506,15 @@ An IPv6 address can also be specified with the notation [...], for
 example [::1]:8080 or [fe80::f6f2:::]:8080.`,
 	}
 
+	UnencryptedLocalhostHTTP = FlagInfo{
+		Name: "unencrypted-localhost-http",
+		Description: `
+When specified, restricts HTTP connections to localhost-only and disables
+TLS for the HTTP interface. The hostname part of --http-addr, if specified,
+is then ignored. This flag is intended for use to facilitate
+local testing without requiring certificate setups in web browsers.`,
+	}
+
 	LocalityAdvertiseAddr = FlagInfo{
 		Name: "locality-advertise-addr",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -121,6 +121,7 @@ func initCLIDefaults() {
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
 	startCtx.serverCertPrincipalMap = nil
 	startCtx.serverListenAddr = ""
+	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""
 	startCtx.externalIODir = ""
 	startCtx.listeningURLFile = ""
@@ -298,6 +299,10 @@ var startCtx struct {
 	serverSSLCertsDir      string
 	serverCertPrincipalMap []string
 	serverListenAddr       string
+
+	// if specified, this forces the HTTP listen addr to localhost
+	// and disables TLS on the HTTP listener.
+	unencryptedLocalhostHTTP bool
 
 	// temporary directory to use to spill computation results to disk.
 	tempDir string

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -323,6 +324,7 @@ func init() {
 		// TODO(knz): remove in 20.2.
 		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
 		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
+		BoolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP, startCtx.unencryptedLocalhostHTTP)
 
 		// Backward-compatibility flags.
 
@@ -783,6 +785,29 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	// Fill in the defaults for --http-addr.
 	if serverHTTPAddr == "" {
 		serverHTTPAddr = startCtx.serverListenAddr
+	}
+	if startCtx.unencryptedLocalhostHTTP {
+		// If --unencrypted-localhost-http was specified, we want to
+		// override whatever was specified or derived from other flags for
+		// the host part of --http-addr.
+		//
+		// Before we do so, we'll check whether the user explicitly
+		// specified something contradictory, and tell them that's no
+		// good.
+		if (fs.Lookup(cliflags.ListenHTTPAddr.Name).Changed ||
+			fs.Lookup(cliflags.ListenHTTPAddrAlias.Name).Changed) &&
+			(serverHTTPAddr != "" && serverHTTPAddr != "localhost") {
+			return errors.WithHintf(
+				errors.Newf("--unencrypted-localhost-http is incompatible with --http-addr=%s:%s",
+					serverHTTPAddr, serverHTTPPort),
+				`When --unencrypted-localhost-http is specified, use --http-addr=:%s or omit --http-addr entirely.`, serverHTTPPort)
+		}
+
+		// Now do the override proper.
+		serverHTTPAddr = "localhost"
+		// We then also tell the server to disable TLS for the HTTP
+		// listener.
+		serverCfg.DisableTLSForHTTP = true
 	}
 	serverCfg.HTTPAddr = net.JoinHostPort(serverHTTPAddr, serverHTTPPort)
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -712,7 +712,16 @@ func registerEnvVarDefault(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
 	}
 }
 
+// extraServerFlagInit configures the server.Config based on the command-line flags.
+// It is only called when the command being ran is one of the start commands.
 func extraServerFlagInit(cmd *cobra.Command) error {
+	if err := security.SetCertPrincipalMap(startCtx.serverCertPrincipalMap); err != nil {
+		return err
+	}
+	serverCfg.User = security.NodeUser
+	serverCfg.Insecure = startCtx.serverInsecure
+	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
+
 	// Construct the main RPC listen address.
 	serverCfg.Addr = net.JoinHostPort(startCtx.serverListenAddr, serverListenPort)
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -120,7 +120,8 @@ type Config struct {
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
 	LeaseManagerConfig *base.LeaseManagerConfig
 
-	// Unix socket: for postgres only.
+	// SocketFile, if non-empty, sets up a TLS-free local listener using
+	// a unix datagram socket at the specified path.
 	SocketFile string
 
 	// Stores is specified to enable durable key-value storage.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2005,7 +2005,7 @@ func (s *Server) startServeUI(
 	}
 
 	// Serve the HTTP endpoint. This will be the original httpLn
-	// listening on --http-listen-addr without TLS if uiTLSConfig was
+	// listening on --http-addr without TLS if uiTLSConfig was
 	// nil, or overridden above if uiTLSConfig was not nil to come from
 	// the TLS negotiation over the HTTP port.
 	s.stopper.RunWorker(workersCtx, func(context.Context) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -195,6 +195,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.HTTPAddr != "" {
 		cfg.HTTPAddr = params.HTTPAddr
 	}
+	cfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	if params.DisableWebSessionAuthentication {
 		cfg.EnableWebSessionAuthentication = false
 	}


### PR DESCRIPTION
Fixes #46420. 

tldr: this patch makes it possible to disable TLS for the HTTP
endpoint and thus facilitate UI access for testing, when proper cert
setup in the web browser is complicated.

Use with: `cockroach start` (or `start-single-node`)
and flag `--unencrypted-localhost-http`. The resulting HTTP URL
uses `http://` and thus no TLS.

**Motivation**

We distinguish two user journeys to discover CockroachDB and "try it
out": setting up a node in the Cloud, and setting up a node on a
personal computer.

The first case requires good TLS security, but then setting up TLS
certificates for a cloud host is relatively straightforward: the Cloud
provider's own cert management interface, Let's Encrypt or manual
configuration using the cloud host's stable hostname are reliable and
well-documented methods.

The second case (own computer) is complicated.

Personal computers typically do not have stable addresses and setting
up a trusted TLS cert for their network address is thus difficult.
Configuring a TLS cert for `localhost` is theoretically possible but
troublesome for the web UI. Indeed, certain OS/browser combinations
have become very agressive at preventing dubious TLS certs over
time (e.g. Chrome on macOS Catalina)—for good reasons from a general
Internet security perspective, but in a way impractical to
CockroachDB.

On the other hand, running a server on the local machine does not
usually come with the requirement that the service is available over
the network for other users. When there is no actual network
communication, transport-level security (i.e. encryption and server
authentication) is not useful.

We're thus interested to acknowledge this last point and this patch
provides this, a feature to *disable TLS for HTTP connections and
restrict the HTTP listener to the loopback interface*, while keeping
the other security mechanisms active (i.e. not force `--insecure`).

**Detail of the changes**

- a new boolean field on `base.Config`: `DisableTLSForHTTP`
- when set, disables loading the UI TLS configuration
  upon `(*Server) Start()`, and thus disables the TLS
  wrapper for the HTTP listener.
- new CLI flag `--unencrypted-localhost-http` forces
  both `base.HTTPAddr` to use `localhost` and
  sets `DisableTLSForHTTP`.
- the TLS-less URL is also advertised in the `NodeInfo`'s
  `AdminURL` field.

Release justification: fixes for high-priority or high-severity bugs in existing functionality

Release note (ui change): a server started with
`--unencrypted-localhost-http` is now reachable with a `http://` URL
in the web browser and does not require certificate or CA setup for
HTTP accesses.

Release note (security update): the new command-line argument
`--unencrypted-localhost-http`, when specified on either `cockroach
start` or `cockroach start-single-node`, forces the HTTP listener to
bind to `localhost` addresses only and disables the TLS protocol. This
effectively disables transport-level security and server
authentication for the HTTP interface.