### PR TITLE
cli/demo: make `cockroach demo` use secure mode by default

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -190,6 +190,9 @@ type Config struct {
 	// HTTPAddr is the configured HTTP listen address.
 	HTTPAddr string
 
+	// DisableTLSForHTTP, if set, disables TLS for the HTTP listener.
+	DisableTLSForHTTP bool
+
 	// HTTPAdvertiseAddr is the advertised HTTP address.
 	// This is computed from HTTPAddr if specified otherwise Addr.
 	HTTPAdvertiseAddr string
@@ -230,6 +233,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.Addr = defaultAddr
 	cfg.AdvertiseAddr = cfg.Addr
 	cfg.HTTPAddr = defaultHTTPAddr
+	cfg.DisableTLSForHTTP = false
 	cfg.HTTPAdvertiseAddr = ""
 	cfg.SplitListenSQL = false
 	cfg.SQLAddr = defaultSQLAddr
@@ -241,9 +245,10 @@ func (cfg *Config) InitDefaults() {
 	cfg.DisableClusterNameVerification = false
 }
 
-// HTTPRequestScheme returns "http" or "https" based on the value of Insecure.
+// HTTPRequestScheme returns "http" or "https" based on the value of
+// Insecure and DisableTLSForHTTP.
 func (cfg *Config) HTTPRequestScheme() string {
-	if cfg.Insecure {
+	if cfg.Insecure || cfg.DisableTLSForHTTP {
 		return httpScheme
 	}
 	return httpsScheme
@@ -444,7 +449,7 @@ func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
 // manager for a server UI TLS config.
 func (cfg *Config) GetUIServerTLSConfig() (*tls.Config, error) {
 	// Early out.
-	if cfg.Insecure {
+	if cfg.Insecure || cfg.DisableTLSForHTTP {
 		return nil, nil
 	}
 

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -50,6 +50,8 @@ type TestServerArgs struct {
 	SQLAddr string
 	// HTTPAddr (if nonempty) is the HTTP address to use for the test server.
 	HTTPAddr string
+	// DisableTLSForHTTP if set, disables TLS for the HTTP interface.
+	DisableTLSForHTTP bool
 
 	// JoinAddr is the address of a node we are joining.
 	//

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -413,10 +413,10 @@ func Example_demo() {
 		{`demo`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
 		{`demo`, `startrek`, `-e`, `show databases`},
 		{`demo`, `startrek`, `-e`, `show databases`, `--format=table`},
-		// Test that if we start with --insecure=false we can perform
+		// Test that if we start with --insecure we cannot perform
 		// commands that require a secure cluster.
-		{`demo`, `--insecure=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 		{`demo`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
+		{`demo`, `--insecure`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 		{`demo`, `--geo-partitioned-replicas`, `--disable-demo-license`},
 	}
 	setCLIDefaultsForTests()
@@ -471,9 +471,9 @@ func Example_demo() {
 	//   startrek
 	//   system
 	// (4 rows)
-	// demo --insecure=false -e CREATE USER test WITH PASSWORD 'testpass'
-	// CREATE ROLE 1
 	// demo -e CREATE USER test WITH PASSWORD 'testpass'
+	// CREATE ROLE 1
+	// demo --insecure -e CREATE USER test WITH PASSWORD 'testpass'
 	// ERROR: setting or updating a password is not supported in insecure mode
 	// SQLSTATE: 28P01
 	// demo --geo-partitioned-replicas --disable-demo-license

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -506,6 +506,15 @@ An IPv6 address can also be specified with the notation [...], for
 example [::1]:8080 or [fe80::f6f2:::]:8080.`,
 	}
 
+	UnencryptedLocalhostHTTP = FlagInfo{
+		Name: "unencrypted-localhost-http",
+		Description: `
+When specified, restricts HTTP connections to localhost-only and disables
+TLS for the HTTP interface. The hostname part of --http-addr, if specified,
+is then ignored. This flag is intended for use to facilitate
+local testing without requiring certificate setups in web browsers.`,
+	}
+
 	LocalityAdvertiseAddr = FlagInfo{
 		Name: "locality-advertise-addr",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -121,6 +121,7 @@ func initCLIDefaults() {
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
 	startCtx.serverCertPrincipalMap = nil
 	startCtx.serverListenAddr = ""
+	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""
 	startCtx.externalIODir = ""
 	startCtx.listeningURLFile = ""
@@ -298,6 +299,10 @@ var startCtx struct {
 	serverSSLCertsDir      string
 	serverCertPrincipalMap []string
 	serverListenAddr       string
+
+	// if specified, this forces the HTTP listen addr to localhost
+	// and disables TLS on the HTTP listener.
+	unencryptedLocalhostHTTP bool
 
 	// temporary directory to use to spill computation results to disk.
 	tempDir string

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -166,7 +166,7 @@ func initCLIDefaults() {
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
-	demoCtx.insecure = true
+	demoCtx.insecure = false
 
 	authCtx.validityPeriod = 1 * time.Hour
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -298,6 +298,7 @@ func testServerArgsForTransientCluster(nodeID roachpb.NodeID, joinAddr string) b
 			fmt.Sprintf("%s/demo-node%d", startCtx.backtraceOutputDir, nodeID),
 		),
 		JoinAddr:          joinAddr,
+		DisableTLSForHTTP: true,
 		StoreSpecs:        []base.StoreSpec{storeSpec},
 		SQLMemoryPoolSize: demoCtx.sqlPoolMemorySize,
 		CacheSize:         demoCtx.cacheSize,

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -39,6 +39,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			expected: base.TestServerArgs{
 				PartOfCluster:     true,
 				JoinAddr:          "127.0.0.1",
+				DisableTLSForHTTP: true,
 				SQLMemoryPoolSize: 2 << 10,
 				CacheSize:         1 << 10,
 			},
@@ -51,6 +52,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			expected: base.TestServerArgs{
 				PartOfCluster:     true,
 				JoinAddr:          "127.0.0.1",
+				DisableTLSForHTTP: true,
 				SQLMemoryPoolSize: 4 << 10,
 				CacheSize:         4 << 10,
 			},

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -323,6 +324,7 @@ func init() {
 		// TODO(knz): remove in 20.2.
 		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
 		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
+		BoolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP, startCtx.unencryptedLocalhostHTTP)
 
 		// Backward-compatibility flags.
 
@@ -783,6 +785,29 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	// Fill in the defaults for --http-addr.
 	if serverHTTPAddr == "" {
 		serverHTTPAddr = startCtx.serverListenAddr
+	}
+	if startCtx.unencryptedLocalhostHTTP {
+		// If --unencrypted-localhost-http was specified, we want to
+		// override whatever was specified or derived from other flags for
+		// the host part of --http-addr.
+		//
+		// Before we do so, we'll check whether the user explicitly
+		// specified something contradictory, and tell them that's no
+		// good.
+		if (fs.Lookup(cliflags.ListenHTTPAddr.Name).Changed ||
+			fs.Lookup(cliflags.ListenHTTPAddrAlias.Name).Changed) &&
+			(serverHTTPAddr != "" && serverHTTPAddr != "localhost") {
+			return errors.WithHintf(
+				errors.Newf("--unencrypted-localhost-http is incompatible with --http-addr=%s:%s",
+					serverHTTPAddr, serverHTTPPort),
+				`When --unencrypted-localhost-http is specified, use --http-addr=:%s or omit --http-addr entirely.`, serverHTTPPort)
+		}
+
+		// Now do the override proper.
+		serverHTTPAddr = "localhost"
+		// We then also tell the server to disable TLS for the HTTP
+		// listener.
+		serverCfg.DisableTLSForHTTP = true
 	}
 	serverCfg.HTTPAddr = net.JoinHostPort(serverHTTPAddr, serverHTTPPort)
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -627,7 +627,7 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
 	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
-	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, true)
+	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, false)
 	BoolFlag(demoFlags, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense, false)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -712,7 +712,16 @@ func registerEnvVarDefault(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
 	}
 }
 
+// extraServerFlagInit configures the server.Config based on the command-line flags.
+// It is only called when the command being ran is one of the start commands.
 func extraServerFlagInit(cmd *cobra.Command) error {
+	if err := security.SetCertPrincipalMap(startCtx.serverCertPrincipalMap); err != nil {
+		return err
+	}
+	serverCfg.User = security.NodeUser
+	serverCfg.Insecure = startCtx.serverInsecure
+	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
+
 	// Construct the main RPC listen address.
 	serverCfg.Addr = net.JoinHostPort(startCtx.serverListenAddr, serverListenPort)
 

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -2,8 +2,8 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-start_test "Check that demo says hello properly"
-spawn $argv demo
+start_test "Check that demo insecure says hello properly"
+spawn $argv demo --insecure
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
@@ -20,14 +20,14 @@ eexpect root@
 eexpect "movr>"
 end_test
 
-start_test "Check that demo secure mode says hello properly"
-spawn $argv demo --insecure=false
+start_test "Check that demo secure says hello properly"
+spawn $argv demo
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
-eexpect "Web UI: https:"
+eexpect "Web UI: http:"
 # Ensure that user login information is present.
 eexpect "The user \"root\" with password \"admin\" has been created."
 # Ensure same messages as cockroach sql.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -120,7 +120,8 @@ type Config struct {
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
 	LeaseManagerConfig *base.LeaseManagerConfig
 
-	// Unix socket: for postgres only.
+	// SocketFile, if non-empty, sets up a TLS-free local listener using
+	// a unix datagram socket at the specified path.
 	SocketFile string
 
 	// Stores is specified to enable durable key-value storage.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2005,7 +2005,7 @@ func (s *Server) startServeUI(
 	}
 
 	// Serve the HTTP endpoint. This will be the original httpLn
-	// listening on --http-listen-addr without TLS if uiTLSConfig was
+	// listening on --http-addr without TLS if uiTLSConfig was
 	// nil, or overridden above if uiTLSConfig was not nil to come from
 	// the TLS negotiation over the HTTP port.
 	s.stopper.RunWorker(workersCtx, func(context.Context) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -195,6 +195,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.HTTPAddr != "" {
 		cfg.HTTPAddr = params.HTTPAddr
 	}
+	cfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	if params.DisableWebSessionAuthentication {
 		cfg.EnableWebSessionAuthentication = false
 	}


### PR DESCRIPTION
First two commits from #46471 - please ignore those two

When `cockroach demo` was updated to support secure mode, secure mode
was not enabled *by default* because the certificate story for a web
browser accessing the UI wasn't clear and would cause unnecessary
friction.

Now that test servers support non-TLS listeners for HTTP,
`cockroach demo` can use that unconditionally.

Release note (cli change): `cockroach demo` now starts
a secure cluster by default. An insecure demo session can
be started via `cockroach demo --insecure`.

Release justification: low risk, high benefit changes to existing functionality