### PR TITLE
release-19.2: cli/sql: fix multi-line input with ROLLBACK TO SAVEPOINT

### DIFF
--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -74,6 +74,15 @@ eexpect "1 row"
 eexpect "root@"
 end_test
 
+start_test "Test that BEGIN .. without COMMIT begins a multi-line stmt even when ROLLBACK TO SAVEPOINT is present."
+send "begin; savepoint cockroach_restart; select 1; rollback to savepoint cockroach_restart;\r"
+eexpect " ->"
+
+send "commit;\r"
+eexpect "1 row"
+eexpect "root@"
+end_test
+
 start_test "Test that BEGIN .. without COMMIT does not begin a multi-line statement with smart_prompt disabled."
 send "\\unset smart_prompt\r"
 send "begin;\r"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -729,13 +729,16 @@ func (c *cliState) refreshDatabaseName() string {
 // endsWithIncompleteTxn returns true if and only if its
 // argument ends with an incomplete transaction prefix (BEGIN without
 // ROLLBACK/COMMIT).
+// TODO(knz): Remove this in 20.2, see
+// https://github.com/cockroachdb/cockroach/issues/46074
 func endsWithIncompleteTxn(stmts []string) bool {
 	txnStarted := false
 	for _, stmt := range stmts {
 		if strings.HasPrefix(stmt, "BEGIN TRANSACTION") {
 			txnStarted = true
 		} else if strings.HasPrefix(stmt, "COMMIT TRANSACTION") ||
-			strings.HasPrefix(stmt, "ROLLBACK TRANSACTION") {
+			(strings.HasPrefix(stmt, "ROLLBACK TRANSACTION") &&
+				!strings.HasPrefix(stmt, "ROLLBACK TRANSACTION TO SAVEPOINT")) {
 			txnStarted = false
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #46119.

/cc @cockroachdb/release

---

(backporting because there will be 19.2 clients connecting to 20.1 nodes)


Release justification: Bug fix to existing functionality

Release note: None
