### PR TITLE
release-19.1: cli: fix `--url` with `sslmode` omitted but other options presents

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -175,7 +175,7 @@ func (u urlParser) Set(v string) error {
 		cliCtx.extraConnURLOptions = options
 
 		switch sslMode := options.Get("sslmode"); sslMode {
-		case "disable":
+		case "", "disable":
 			if err := fl.Set(cliflags.ClientInsecure.Name, "true"); err != nil {
 				return errors.Wrapf(err, "setting insecure connection based on --url")
 			}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -214,6 +214,7 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 		{anySQL, []string{"--url=postgresql://a@b:c"}, []string{"--user=a", "--host=b", "--port=c"}, ""},
 		{anyNonSQL, []string{"--url=postgresql://b:c"}, []string{"--host=b", "--port=c"}, ""},
 
+		{anyCmd, []string{"--url=postgresql://foo?application_name=abc"}, []string{"--host=foo", "--insecure"}, ""},
 		{anyCmd, []string{"--url=postgresql://foo?sslmode=disable"}, []string{"--host=foo", "--insecure"}, ""},
 		{anySQL, []string{"--url=postgresql://foo?sslmode=require"}, []string{"--host=foo", "--insecure=false"}, ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=require"}, nil, "command .* only supports sslmode=disable or sslmode=verify-full"},


### PR DESCRIPTION
Backport 1/1 commits from #44113.

/cc @cockroachdb/release

---

Fixes #44088.

Release justification: backport of stable fix to previous release