### PR TITLE
release-19.2: colexec: support concurrent DrainMeta and Next calls in the Columnarizer

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // Columnarizer turns an execinfra.RowSource input into an Operator output, by
@@ -29,6 +30,12 @@ import (
 type Columnarizer struct {
 	execinfra.ProcessorBase
 	NonExplainable
+
+	// mu is used to protect against concurrent DrainMeta and Next calls, which
+	// are currently allowed.
+	// TODO(asubiotto): Explore calling DrainMeta from the same goroutine as Next,
+	//  which will simplify this model.
+	mu syncutil.Mutex
 
 	input      execinfra.RowSource
 	da         sqlbase.DatumAlloc
@@ -94,6 +101,8 @@ func (c *Columnarizer) Init() {
 
 // Next is part of the Operator interface.
 func (c *Columnarizer) Next(context.Context) coldata.Batch {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.batch.ResetInternalBatch()
 	// Buffer up n rows.
 	nRows := uint16(0)
@@ -137,6 +146,8 @@ var _ execinfrapb.MetadataSource = &Columnarizer{}
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MoveToDraining(nil /* err */)
 	for {
 		meta := c.DrainHelper()

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -84,10 +84,22 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	c, err := NewColumnarizer(ctx, flowCtx, 0 /* processorID */, rb)
 	require.NoError(t, err)
 
+	c.Init()
+
 	// Calling DrainMeta from the vectorized execution engine should propagate to
 	// non-vectorized components as calling ConsumerDone and then draining their
 	// metadata.
-	meta := c.DrainMeta(ctx)
+	metaCh := make(chan []execinfrapb.ProducerMetadata)
+	go func() {
+		metaCh <- c.DrainMeta(ctx)
+	}()
+
+	// Make Next race with DrainMeta, this should be supported by the
+	// Columnarizer. If the metadata is obtained through this Next call, the
+	// Columnarizer still returns it in DrainMeta.
+	_ = c.Next(ctx)
+
+	meta := <-metaCh
 	require.True(t, len(meta) == 1)
 	require.True(t, testutils.IsError(meta[0].Err, errMsg))
 	require.True(t, rb.Done)


### PR DESCRIPTION
Backport 1/1 commits from #46360.

/cc @cockroachdb/release

---

Release justification: bug fixes to new functionality.

The Columnarizer would previously not protect against concurrent DrainMeta and
Next calls, which could lead to races that could cause panics.

Release note: None (new bug)

Fixes #46129 
Fixes #46251 
Addresses #42103 
