### PR TITLE
release-19.2: rowexec: fix some issues with aggregation

### DIFF
--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -211,6 +211,17 @@ func (ag *aggregatorBase) outputStatsToTrace() {
 	}
 }
 
+const (
+	// hashAggregatorBucketsInitialLen is a guess on how many "items" the
+	// 'buckets' map of hashAggregator has the capacity for initially.
+	hashAggregatorBucketsInitialLen = 8
+	// hashAggregatorSizeOfBucketsItem is a guess on how much space (in bytes)
+	// each item added to 'buckets' map of hashAggregator takes up in the map
+	// (i.e. it is memory internal to the map, orthogonal to "key-value" pair
+	// that we're adding to the map).
+	hashAggregatorSizeOfBucketsItem = 64
+)
+
 // hashAggregator is a specialization of aggregatorBase that must keep track of
 // multiple grouping buckets at a time.
 type hashAggregator struct {
@@ -221,6 +232,14 @@ type hashAggregator struct {
 	// bucketsIter for iteration.
 	buckets     map[string]aggregateFuncs
 	bucketsIter []string
+	// bucketsLenGrowThreshold is the threshold which, when reached by the
+	// number of items in 'buckets', will trigger the update to memory
+	// accounting. It will start out at hashAggregatorBucketsInitialLen and
+	// then will be doubling in size.
+	bucketsLenGrowThreshold int
+	// alreadyAccountedFor tracks the number of items in 'buckets' memory for
+	// which we have already accounted for.
+	alreadyAccountedFor int
 }
 
 // orderedAggregator is a specialization of aggregatorBase that only needs to
@@ -274,7 +293,10 @@ func newAggregator(
 		return newOrderedAggregator(flowCtx, processorID, spec, input, post, output)
 	}
 
-	ag := &hashAggregator{buckets: make(map[string]aggregateFuncs)}
+	ag := &hashAggregator{
+		buckets:                 make(map[string]aggregateFuncs),
+		bucketsLenGrowThreshold: hashAggregatorBucketsInitialLen,
+	}
 
 	if err := ag.init(
 		ag,
@@ -421,7 +443,7 @@ func (ag *hashAggregator) accumulateRows() (
 				return aggStateUnknown, nil, nil
 			}
 			if !matched {
-				ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
+				copy(ag.lastOrdGroupCols, row)
 				break
 			}
 		}
@@ -442,6 +464,12 @@ func (ag *hashAggregator) accumulateRows() (
 		ag.buckets[""] = bucket
 	}
 
+	// Note that, for simplicity, we're ignoring the overhead of the slice of
+	// strings.
+	if err := ag.bucketsAcc.Grow(ag.Ctx, int64(len(ag.buckets))*sizeOfString); err != nil {
+		ag.MoveToDraining(err)
+		return aggStateUnknown, nil, nil
+	}
 	ag.bucketsIter = make([]string, 0, len(ag.buckets))
 	for bucket := range ag.buckets {
 		ag.bucketsIter = append(ag.bucketsIter, bucket)
@@ -484,7 +512,7 @@ func (ag *orderedAggregator) accumulateRows() (
 				return aggStateUnknown, nil, nil
 			}
 			if !matched {
-				ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
+				copy(ag.lastOrdGroupCols, row)
 				break
 			}
 		}
@@ -561,8 +589,16 @@ func (ag *hashAggregator) emitRow() (
 			ag.MoveToDraining(err)
 			return aggStateUnknown, nil, nil
 		}
+		// Before we create a new 'buckets' map below, we need to "release" the
+		// already accounted for memory of the current map.
+		ag.bucketsAcc.Shrink(ag.Ctx, int64(ag.alreadyAccountedFor)*hashAggregatorSizeOfBucketsItem)
+		// Note that, for simplicity, we're ignoring the overhead of the slice of
+		// strings.
+		ag.bucketsAcc.Shrink(ag.Ctx, int64(len(ag.buckets))*sizeOfString)
 		ag.bucketsIter = nil
 		ag.buckets = make(map[string]aggregateFuncs)
+		ag.bucketsLenGrowThreshold = hashAggregatorBucketsInitialLen
+		ag.alreadyAccountedFor = 0
 		for _, f := range ag.funcs {
 			if f.seen != nil {
 				f.seen = make(map[string]struct{})
@@ -687,6 +723,7 @@ func (ag *orderedAggregator) ConsumerClosed() {
 func (ag *aggregatorBase) accumulateRowIntoBucket(
 	row sqlbase.EncDatumRow, groupKey []byte, bucket aggregateFuncs,
 ) error {
+	var err error
 	// Feed the func holders for this bucket the non-grouping datums.
 	for i, a := range ag.aggregations {
 		if a.FilterColIdx != nil {
@@ -722,9 +759,12 @@ func (ag *aggregatorBase) accumulateRowIntoBucket(
 			otherArgs[j-1] = row[c].Datum
 		}
 
-		canAdd, err := ag.funcs[i].canAdd(ag.Ctx, groupKey, firstArg, otherArgs)
-		if err != nil {
-			return err
+		canAdd := true
+		if a.Distinct {
+			canAdd, err = ag.funcs[i].isDistinct(ag.Ctx, groupKey, firstArg, otherArgs)
+			if err != nil {
+				return err
+			}
 		}
 		if !canAdd {
 			continue
@@ -762,6 +802,14 @@ func (ag *hashAggregator) accumulateRow(row sqlbase.EncDatumRow) error {
 			return err
 		}
 		ag.buckets[s] = bucket
+		if len(ag.buckets) == ag.bucketsLenGrowThreshold {
+			toAccountFor := ag.bucketsLenGrowThreshold - ag.alreadyAccountedFor
+			if err := ag.bucketsAcc.Grow(ag.Ctx, int64(toAccountFor)*hashAggregatorSizeOfBucketsItem); err != nil {
+				return err
+			}
+			ag.alreadyAccountedFor = ag.bucketsLenGrowThreshold
+			ag.bucketsLenGrowThreshold *= 2
+		}
 	}
 
 	return ag.accumulateRowIntoBucket(row, encoded, bucket)
@@ -797,7 +845,11 @@ type aggregateFuncHolder struct {
 	arena *stringarena.Arena
 }
 
-const sizeOfAggregateFunc = int64(unsafe.Sizeof(tree.AggregateFunc(nil)))
+const (
+	sizeOfString         = int64(unsafe.Sizeof(""))
+	sizeOfAggregateFuncs = int64(unsafe.Sizeof(aggregateFuncs{}))
+	sizeOfAggregateFunc  = int64(unsafe.Sizeof(tree.AggregateFunc(nil)))
+)
 
 func (ag *aggregatorBase) newAggregateFuncHolder(
 	create func(*tree.EvalContext, tree.Datums) tree.AggregateFunc, arguments tree.Datums,
@@ -810,33 +862,35 @@ func (ag *aggregatorBase) newAggregateFuncHolder(
 	}
 }
 
-func (a *aggregateFuncHolder) canAdd(
+// isDistinct returns whether this aggregateFuncHolder has not already seen the
+// encoding of grouping columns and argument columns. It should be used *only*
+// when we have DISTINCT aggregation so that we can aggregate only the "first"
+// row in the group.
+func (a *aggregateFuncHolder) isDistinct(
 	ctx context.Context, encodingPrefix []byte, firstArg tree.Datum, otherArgs tree.Datums,
 ) (bool, error) {
-	if a.seen != nil {
-		encoded, err := sqlbase.EncodeDatumKeyAscending(encodingPrefix, firstArg)
+	encoded, err := sqlbase.EncodeDatumKeyAscending(encodingPrefix, firstArg)
+	if err != nil {
+		return false, err
+	}
+	// Encode additional arguments if necessary.
+	if otherArgs != nil {
+		encoded, err = sqlbase.EncodeDatumsKeyAscending(encoded, otherArgs)
 		if err != nil {
 			return false, err
 		}
-		// Encode additional arguments if necessary.
-		if otherArgs != nil {
-			encoded, err = sqlbase.EncodeDatumsKeyAscending(encoded, otherArgs)
-			if err != nil {
-				return false, err
-			}
-		}
-
-		if _, ok := a.seen[string(encoded)]; ok {
-			// skip
-			return false, nil
-		}
-		s, err := a.arena.AllocBytes(ctx, encoded)
-		if err != nil {
-			return false, err
-		}
-		a.seen[s] = struct{}{}
 	}
 
+	if _, ok := a.seen[string(encoded)]; ok {
+		// We have already seen a row with such combination of grouping and
+		// argument columns.
+		return false, nil
+	}
+	s, err := a.arena.AllocBytes(ctx, encoded)
+	if err != nil {
+		return false, err
+	}
+	a.seen[s] = struct{}{}
 	return true, nil
 }
 
@@ -856,7 +910,7 @@ func (ag *aggregatorBase) encode(
 }
 
 func (ag *aggregatorBase) createAggregateFuncs() (aggregateFuncs, error) {
-	if err := ag.bucketsAcc.Grow(ag.Ctx, sizeOfAggregateFunc*int64(len(ag.funcs))); err != nil {
+	if err := ag.bucketsAcc.Grow(ag.Ctx, sizeOfAggregateFuncs+sizeOfAggregateFunc*int64(len(ag.funcs))); err != nil {
 		return nil, err
 	}
 	bucket := make(aggregateFuncs, len(ag.funcs))


### PR DESCRIPTION
Backport 1/1 commits from #46162.

/cc @cockroachdb/release

---

Release justification: fixes for high-priority or high-severity bugs in
existing functionality (we were incorrectly doing memory accounting plus
performing some unnecessary copies and allocations).

This commit fixes a couple of problems with aggregation in row-by-row
engine:
1. the memory under the "lastOrdGroupCols" row is not accounted for, and
a new row was always allocated. This leads to significant drift in memory
accounting. This is now fixed by allocating the row only once and
reusing the same memory later (with the memory being not accounted for,
but that's ok).
2. the overhead of `aggregateFuncs` slice hasn't been accounted for.
3. `bucketIter` slice of strings (which captures a particular order of
items in `buckets` map making it fixed) hasn't been accounted for.
4. memory internal to Golang's map (for `buckets`) hasn't been accounted
for. I don't think we can reliably get that memory's size, so we're
employing some heuristics to get the estimate. The updates to memory
accounts occur only on logarithmic scale in order to not degrade the
performance.

Also, this commit refactors `canAdd` function to make its purpose more
clear.

Fixes: #45975.

Release note: None
