### PR TITLE
release-19.2: colexec: fix a seek error with interleaved tables in the cfetcher

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -501,10 +501,10 @@ const (
 	//     -> fetchNextKVWithUnfinishedRow
 	stateDecodeFirstKVOfRow
 
-	// stateSeekPrefix is the state of skipping all keys that sort before a
-	// prefix. s.machine.seekPrefix must be set to the prefix to seek to.
-	// state[1] must be set, and seekPrefix will transition to that state once it
-	// finds the first key with that prefix.
+	// stateSeekPrefix is the state of skipping all keys that sort before
+	// (or after, in the case of a reverse scan) a prefix. s.machine.seekPrefix
+	// must be set to the prefix to seek to. state[1] must be set, and seekPrefix
+	// will transition to that state once it finds the first key with that prefix.
 	//   1. fetch next kv into nextKV buffer
 	//   2. kv doesn't match seek prefix?
 	//     -> seekPrefix
@@ -681,9 +681,18 @@ func (rf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 					rf.machine.state[1] = stateEmitLastBatch
 					break
 				}
+				// The order we perform the comparison in depends on whether we are
+				// performing a reverse scan or not. If we are performing a reverse
+				// scan, then we want to seek until we find a key less than seekPrefix.
+				var comparison int
+				if rf.reverse {
+					comparison = bytes.Compare(rf.machine.seekPrefix, kv.Key)
+				} else {
+					comparison = bytes.Compare(kv.Key, rf.machine.seekPrefix)
+				}
 				// TODO(jordan): if nextKV returns newSpan = true, set the new span
-				// prefix and indicate that it needs decoding.
-				if bytes.Compare(kv.Key, rf.machine.seekPrefix) >= 0 {
+				//  prefix and indicate that it needs decoding.
+				if comparison >= 0 {
 					rf.machine.nextKV = kv
 					break
 				}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1084,3 +1084,16 @@ CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0)
 query I
 SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_user(), '')) THEN 0 ELSE t44726.c0 END)
 ----
+
+# Regression for 46140.
+statement ok
+DROP TABLE IF EXISTS t0, t1;
+CREATE TABLE t0(c0 INT);
+CREATE TABLE t1(c0 BOOL) INTERLEAVE IN PARENT t0(rowid);
+INSERT INTO t0(c0) VALUES (0);
+INSERT INTO t1(rowid, c0) VALUES(0, TRUE)
+
+query I
+SELECT max(t1.rowid) FROM t1 WHERE t1.c0
+----
+0


### PR DESCRIPTION
Backport 1/1 commits from #46456.

/cc @cockroachdb/release

---

Fixes #46140.

This PR fixes a bug where the cfetcher was using an incorrect
predicate to skip interleaved child rows when performing
a reverse scan.

Release justification: bug fix
Release note (bug fix): Fix a bug where the vectorized engine
could sometimes give an incorrect result when reading from
interleaved parents or children.
