### PR TITLE
sql: update TestPrimaryKeyChangeWithCancel to run pk change synchronously

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2962,11 +2962,8 @@ CREATE TABLE t.test (k INT NOT NULL, v INT);
 		t.Fatal(err)
 	}
 
-	// Run a primary key change in a background thread.
-	go func() {
-		// This will fail, so we don't want to check the error.
-		_, _ = sqlDB.Exec(`ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`)
-	}()
+	// This will fail, so we don't want to check the error.
+	_, _ = sqlDB.Exec(`ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`)
 
 	// Ensure that the mutations corresponding to the primary key change are cleaned up and
 	// that the job did not succeed even though it was canceled.


### PR DESCRIPTION
This PR fixes a race in TestPrimaryKeyChangeWithCancel by running the
primary key change synchronously rather than asynchronously. There
was no real reasong it was in a goroutine.

Release justification: test only change
Release note: None