### PR TITLE
colexec: fix a bug with relative rank operators

### DIFF
--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -430,6 +430,9 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// {{if .HasPartition}}
 			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 			var runningPartitionsSizesCol []int64
+			if r.partitionsState.runningSizes != nil {
+				runningPartitionsSizesCol = r.partitionsState.runningSizes.ColVec(0).Int64()
+			}
 			if sel != nil {
 				for _, i := range sel[:n] {
 					_COMPUTE_PARTITIONS_SIZES()
@@ -448,6 +451,9 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// Next, we need to update the sizes of the peer groups.
 			peersCol := batch.ColVec(r.peersColIdx).Bool()
 			var runningPeerGroupsSizesCol []int64
+			if r.peerGroupsState.runningSizes != nil {
+				runningPeerGroupsSizesCol = r.peerGroupsState.runningSizes.ColVec(0).Int64()
+			}
 			if sel != nil {
 				for _, i := range sel[:n] {
 					_COMPUTE_PEER_GROUPS_SIZES()


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

Previously, we could leave the vectors that we put partitions' and peer
groups' sizes uninitialized. This is now fixed. Our unit tests caught
this bug with low batch size.

Fixes: #46474.

Release note: None