### PR TITLE
release-19.2: colexec: fix bug where vectorized engine couldn't use inverted indexes

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -947,6 +947,37 @@ func runBenchmarkWideTable(b *testing.B, db *sqlutils.SQLRunner, count int, bigC
 	b.StopTimer()
 }
 
+// BenchmarkVecSkipScan benchmarks the vectorized engine's performance
+// when skipping unneeded key values in the decoding process.
+func BenchmarkVecSkipScan(b *testing.B) {
+	benchmarkCockroach(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		create := `
+CREATE TABLE bench.scan(
+	x INT, y INT, z INT, 
+	a INT, w INT, v INT, 
+	PRIMARY KEY (x, y, z, a, w, v)
+)
+`
+		db.Exec(b, create)
+		const count = 1000
+		for i := 0; i < count; i++ {
+			db.Exec(
+				b,
+				fmt.Sprintf(
+					"INSERT INTO bench.scan VALUES (%d, %d, %d, %d, %d, %d)",
+					i, i, i, i, i, i,
+				),
+			)
+		}
+		b.ResetTimer()
+		b.Run("Bench scan with skip", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				db.Exec(b, `SET vectorize=experimental_on; SELECT y FROM bench.scan`)
+			}
+		})
+	})
+}
+
 func BenchmarkWideTable(b *testing.B) {
 	if testing.Short() {
 		b.Skip("short flag")

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -141,7 +141,7 @@ func DecodeKeyValsToCols(
 		i := indexColIdx[j]
 		if i == -1 {
 			// Don't need the coldata - skip it.
-			key, err = sqlbase.SkipTableKey(&types[j], key, enc)
+			key, err = sqlbase.SkipTableKey(key)
 		} else {
 			if unseen != nil {
 				unseen.Remove(i)

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1097,3 +1097,13 @@ query I
 SELECT max(t1.rowid) FROM t1 WHERE t1.c0
 ----
 0
+
+# Regression for #46183.
+statement ok
+CREATE TABLE t46183 (x INT PRIMARY KEY, y JSONB, INVERTED INDEX (y));
+INSERT INTO t46183 VALUES (1, '{"y": "hello"}')
+
+query I
+SELECT count(*) FROM t46183 WHERE y->'y' = to_jsonb('hello')
+----
+1

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -167,68 +166,12 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 
 // SkipTableKey skips a value of type valType in key, returning the remainder
 // of the key.
-// TODO(jordan): each type could be optimized here.
-func SkipTableKey(valType *types.T, key []byte, dir IndexDescriptor_Direction) ([]byte, error) {
-	if (dir != IndexDescriptor_ASC) && (dir != IndexDescriptor_DESC) {
-		return nil, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
-	}
-	var isNull bool
-	if key, isNull = encoding.DecodeIfNull(key); isNull {
-		return key, nil
-	}
-	var rkey []byte
-	var err error
-	switch valType.Family() {
-	case types.BoolFamily, types.IntFamily, types.DateFamily, types.OidFamily, types.TimeFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeVarintAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeVarintDescending(key)
-		}
-	case types.FloatFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeFloatAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeFloatDescending(key)
-		}
-	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.INetFamily, types.CollatedStringFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
-		}
-	case types.DecimalFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
-		} else {
-			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
-		}
-	case types.TimestampFamily, types.TimestampTZFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeTimeAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeTimeDescending(key)
-		}
-	case types.IntervalFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeDurationAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeDurationDescending(key)
-		}
-	case types.BitFamily:
-		if dir == IndexDescriptor_ASC {
-			rkey, _, err = encoding.DecodeBitArrayAscending(key)
-		} else {
-			rkey, _, err = encoding.DecodeBitArrayDescending(key)
-		}
-	default:
-		// Tuples and arrays aren't indexable types right now, so we don't have cases for them.
-		return key, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
-	}
+func SkipTableKey(key []byte) ([]byte, error) {
+	skipLen, err := encoding.PeekLength(key)
 	if err != nil {
-		return key, err
+		return nil, err
 	}
-	return rkey, nil
+	return key[skipLen:], nil
 }
 
 // DecodeTableKey decodes a value encoded by EncodeTableKey.

--- a/pkg/sql/sqlbase/column_type_encoding_test.go
+++ b/pkg/sql/sqlbase/column_type_encoding_test.go
@@ -181,15 +181,11 @@ func TestSkipTableKey(t *testing.T) {
 	properties := gopter.NewProperties(parameters)
 	properties.Property("correctness", prop.ForAll(
 		func(d tree.Datum, dir encoding.Direction) string {
-			descDir := IndexDescriptor_ASC
-			if dir == encoding.Descending {
-				descDir = IndexDescriptor_DESC
-			}
 			b, err := EncodeTableKey(nil, d, dir)
 			if err != nil {
 				return "error: " + err.Error()
 			}
-			res, err := SkipTableKey(d.ResolvedType(), b, descDir)
+			res, err := SkipTableKey(b)
 			if err != nil {
 				return "error: " + err.Error()
 			}

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -1293,7 +1293,7 @@ func getMultiNonsortingVarintLen(b []byte, num int) (int, error) {
 
 // PeekLength returns the length of the encoded value at the start of b.  Note:
 // if this function succeeds, it's not a guarantee that decoding the value will
-// succeed.
+// succeed. PeekLength is meant to be used on key encoded data only.
 func PeekLength(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, errors.Errorf("empty slice")


### PR DESCRIPTION
Backport 1/1 commits from #46267.

/cc @cockroachdb/release

---

Fixes #46183.

Release justification: bug fix

Release note (bug fix): This PR fixes a bug where the vectorized
engine would throw an internal error when executing a query that
utilized an inverted index.
