### PR TITLE
release-19.2: rowcontainer: make some logging tunable when spilled to disk

### DIFF
--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -689,7 +689,7 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 		if f.idxRowIter > pos {
 			// The iterator has been advanced further than we need, so we need to
 			// start iterating from the beginning.
-			log.Infof(ctx, "rewinding: cache contains indices [%d, %d) but index %d requested", f.firstCachedRowPos, f.nextPosToCache, pos)
+			log.VEventf(ctx, 1, "rewinding: cache contains indices [%d, %d) but index %d requested", f.firstCachedRowPos, f.nextPosToCache, pos)
 			f.idxRowIter = 0
 			f.diskRowIter.Rewind()
 			f.resetCache(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #46109.

/cc @cockroachdb/release

---

Release justification: bug fixes and low-risk updates to new
functionality (only reducing some logging).

Previously, we would log every time the disk-backed row container
"misses its cache", but now we will do so only with the verbosity level
of 1 or higher.

Release note: None
