### PR TITLE
release-19.2: sql: run postqueries with EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -26,8 +26,9 @@ import (
 type explainDistSQLNode struct {
 	optColumnsSlot
 
-	plan          planNode
-	subqueryPlans []subquery
+	plan           planNode
+	subqueryPlans  []subquery
+	postqueryPlans []postquery
 
 	stmtType tree.StatementType
 
@@ -194,6 +195,45 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		diagram.AddSpans(spans)
 	}
 
+	if n.analyze && len(n.postqueryPlans) > 0 {
+		outerPostqueries := planCtx.planner.curPlan.postqueryPlans
+		defer func() {
+			planCtx.planner.curPlan.postqueryPlans = outerPostqueries
+		}()
+		planCtx.planner.curPlan.postqueryPlans = n.postqueryPlans
+
+		// Discard rows that are returned.
+		rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
+			return nil
+		})
+		execCfg := params.p.ExecCfg()
+		recv := MakeDistSQLReceiver(
+			planCtx.ctx,
+			rw,
+			tree.Rows,
+			execCfg.RangeDescriptorCache,
+			execCfg.LeaseHolderCache,
+			params.p.txn,
+			func(ts hlc.Timestamp) {
+				_ = execCfg.Clock.Update(ts)
+			},
+			params.extendedEvalCtx.Tracing,
+		)
+		if !distSQLPlanner.PlanAndRunPostqueries(
+			planCtx.ctx,
+			params.p,
+			params.extendedEvalCtx.copy,
+			n.postqueryPlans,
+			recv,
+			true,
+		) {
+			if err := rw.Err(); err != nil {
+				return err
+			}
+			return recv.commErr
+		}
+	}
+
 	planJSON, planURL, err := diagram.ToURL()
 	if err != nil {
 		return err
@@ -219,11 +259,17 @@ func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
 func (n *explainDistSQLNode) Close(ctx context.Context) {
 	n.plan.Close(ctx)
 	for i := range n.subqueryPlans {
-		// Once a subquery plan has been evaluated, it already closes its
-		// plan.
+		// Once a subquery plan has been evaluated, it already closes its plan.
 		if n.subqueryPlans[i].plan != nil {
 			n.subqueryPlans[i].plan.Close(ctx)
 			n.subqueryPlans[i].plan = nil
+		}
+	}
+	for i := range n.postqueryPlans {
+		// Once a postquery plan has been evaluated, it already closes its plan.
+		if n.postqueryPlans[i].plan != nil {
+			n.postqueryPlans[i].plan.Close(ctx)
+			n.postqueryPlans[i].plan = nil
 		}
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -65,3 +65,17 @@ EXECUTE x(1, 1)
 # Regression test for #34927.
 statement ok
 EXPLAIN ANALYZE (DISTSQL) DELETE FROM a WHERE true
+
+# Regression test for #45099 (not running postqueries with EXPLAIN ANALYZE).
+statement ok
+CREATE TABLE p (p INT8 PRIMARY KEY);
+CREATE TABLE c (c INT8 PRIMARY KEY, p INT8 REFERENCES p (p))
+
+statement ok
+SET experimental_optimizer_foreign_keys = true
+
+query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)
+
+statement ok
+RESET experimental_optimizer_foreign_keys

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1181,10 +1181,11 @@ func (ef *execFactory) ConstructExplain(
 	switch options.Mode {
 	case tree.ExplainDistSQL:
 		return &explainDistSQLNode{
-			plan:          p.plan,
-			subqueryPlans: p.subqueryPlans,
-			analyze:       analyzeSet,
-			stmtType:      stmtType,
+			plan:           p.plan,
+			subqueryPlans:  p.subqueryPlans,
+			postqueryPlans: p.postqueryPlans,
+			analyze:        analyzeSet,
+			stmtType:       stmtType,
 		}, nil
 
 	case tree.ExplainVec:


### PR DESCRIPTION
Backport 1/1 commits from #45155.

/cc @cockroachdb/release

---

Previously, postqueries didn't run when executing a query with EXPLAIN
ANALYZE. This is incorrect (for example, this allows for circumventing
foreign key checks) and is now fixed.

Fixes: #45099.

Release note: None (the bug is present only with experimental settings).
