### PR TITLE
ui: Persistent dismissal of Release notes signup form

### DIFF
--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -60,6 +60,10 @@ export const VERSION_DISMISSED_KEY = "version_dismissed";
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY = "clusterviz_instructions_box_collapsed";
 
+// RELEASE_NOTES_SIGNUP_DISMISSED_KEY is the uiData key on the server that tracks when the user
+// dismisses Release Nodes signup form.
+export const RELEASE_NOTES_SIGNUP_DISMISSED_KEY = "release_notes_signup_dismissed";
+
 export enum UIDataStatus {
   UNINITIALIZED, // Data has not been loaded yet.
   LOADING,

--- a/pkg/ui/src/redux/uiDataSelectors.spec.ts
+++ b/pkg/ui/src/redux/uiDataSelectors.spec.ts
@@ -1,0 +1,50 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { assert } from "chai";
+import { dismissReleaseNotesSignupForm } from "./uiDataSelectors";
+import { UIData, UIDataStatus } from "src/redux/uiData";
+
+describe("uiDataSelectors", () => {
+  describe("dismissReleaseNotesSignupForm selector", () => {
+    const selector = dismissReleaseNotesSignupForm.resultFunc;
+
+    it("returns `false` if uiData status is VALID and has no data", () => {
+      const uiData: UIData = {
+        status: UIDataStatus.VALID,
+        error: null,
+        data: undefined,
+      };
+      assert.isFalse(selector(uiData));
+    });
+
+    it("returns `true` if uiData status is VALID and data = true", () => {
+      const uiData: UIData = {
+        status: UIDataStatus.VALID,
+        error: null,
+        data: true,
+      };
+      assert.isTrue(selector(uiData));
+    });
+
+    it("returns `true` if uiData status is UNINITIALIZED", () => {
+      const uiData: UIData = {
+        status: UIDataStatus.UNINITIALIZED,
+        error: null,
+        data: undefined,
+      };
+      assert.isTrue(selector(uiData));
+    });
+
+    it("returns `true` if uiData state is undefined", () => {
+      assert.isTrue(selector(undefined));
+    });
+  });
+});

--- a/pkg/ui/src/redux/uiDataSelectors.ts
+++ b/pkg/ui/src/redux/uiDataSelectors.ts
@@ -1,0 +1,36 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+
+import { AdminUIState } from "src/redux/state";
+import { RELEASE_NOTES_SIGNUP_DISMISSED_KEY, UIDataStatus } from "src/redux/uiData";
+
+export const dismissReleaseNotesSignupForm = createSelector(
+  (state: AdminUIState) => state.uiData[RELEASE_NOTES_SIGNUP_DISMISSED_KEY],
+  (hideFormData) => {
+    // Do not show subscription form if data is not initialized yet.
+    // It avoids form flickering in case value is set to `false` (hide form) and it
+    // is shown for a moment before response is received back.
+    if (!hideFormData) {
+      return true;
+    }
+    if (hideFormData.status === UIDataStatus.VALID) {
+      // If data is successfully loaded and have no values,
+      // return default `false` value (do not hide subscription form)
+      if (hideFormData?.data === undefined) {
+        return false;
+      }
+      return hideFormData?.data;
+    }
+    // Do not show subscription form if request is loading
+    return true;
+  },
+);

--- a/pkg/ui/src/views/dashboard/emailSubscription.tsx
+++ b/pkg/ui/src/views/dashboard/emailSubscription.tsx
@@ -15,14 +15,19 @@ import { EmailSubscriptionForm } from "src/views/shared/components/emailSubscrip
 import { signUpForEmailSubscription } from "src/redux/customAnalytics";
 import { AdminUIState } from "src/redux/state";
 import { clusterIdSelector } from "src/redux/nodes";
-import { LocalSetting } from "src/redux/localsettings";
 
 import "./emailSubscription.styl";
+import { loadUIData, RELEASE_NOTES_SIGNUP_DISMISSED_KEY, saveUIData } from "src/redux/uiData";
+import { dismissReleaseNotesSignupForm } from "src/redux/uiDataSelectors";
 import { emailSubscriptionAlertLocalSetting } from "oss/src/redux/alerts";
 
 type EmailSubscriptionProps = MapDispatchToProps & MapStateToProps;
 
 class EmailSubscription extends React.Component<EmailSubscriptionProps> {
+  componentDidMount() {
+    this.props.refresh();
+  }
+
   handleEmailSubscriptionSubmit = (email: string) => {
     this.props.signUpForEmailSubscription(this.props.clusterId, email);
   }
@@ -67,19 +72,22 @@ class EmailSubscription extends React.Component<EmailSubscriptionProps> {
   }
 }
 
-const hidePanelLocalSetting = new LocalSetting<AdminUIState, boolean>(
-  "dashboard/release_notes_signup/hide", (s) => s.localSettings, false,
-);
-
 interface MapDispatchToProps {
   signUpForEmailSubscription: (clusterId: string, email: string) => void;
   hidePanel: () => void;
+  refresh: () => void;
   dismissAlertMessage: () => void;
 }
 
 const mapDispatchToProps = {
   signUpForEmailSubscription,
-  hidePanel: () => hidePanelLocalSetting.set(true),
+  refresh: () => loadUIData(RELEASE_NOTES_SIGNUP_DISMISSED_KEY),
+  hidePanel: () => {
+    return saveUIData({
+      key: RELEASE_NOTES_SIGNUP_DISMISSED_KEY,
+      value: true,
+    });
+  },
   dismissAlertMessage: () => emailSubscriptionAlertLocalSetting.set(false),
 };
 
@@ -88,7 +96,7 @@ interface MapStateToProps {
   clusterId: string;
 }
 const mapStateToProps = (state: AdminUIState) => ({
-  isHiddenPanel: hidePanelLocalSetting.selector(state),
+  isHiddenPanel: dismissReleaseNotesSignupForm(state),
   clusterId: clusterIdSelector(state),
 });
 


### PR DESCRIPTION
Resolves: #45624 

Before, Release notes signup could be dismissed by user
and this setting was stored in local storage regardless for
any user in the browser.

Now, this setting is stored in DB as ui data setting.
When user dismisses form this option persisted per user.

Release note: None

Release justification: bug fixes and low-risk updates to new functionality

<img width="978" alt="Screenshot 2020-03-24 at 21 29 43" src="https://user-images.githubusercontent.com/3106437/77468749-b39d7c80-6e16-11ea-9f35-9d742b2a5905.png">
