### PR TITLE
sql: fix inverted index display on pg_catalog.pg_indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2124,3 +2124,16 @@ SELECT  pg_catalog.set_config('woo', 'woo', false)
 
 query error configuration setting.*not supported
 SELECT  pg_catalog.set_config('vacuum_cost_delay', '0', false)
+
+subtest regression_46450
+
+statement ok
+CREATE TABLE regression_46450 (id UUID PRIMARY KEY, json JSONB)
+
+statement ok
+CREATE INDEX regression_46450_idx ON regression_46450 USING gin(json)
+
+query TTTTTT
+select * from pg_indexes where indexname = 'regression_46450_idx'
+----
+3047862654  public  regression_46450  regression_46450_idx  NULL  CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json ASC)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1586,11 +1586,12 @@ func indexDefFromDescriptor(
 	tableLookup tableLookupFn,
 ) (string, error) {
 	indexDef := tree.CreateIndex{
-		Name:    tree.Name(index.Name),
-		Table:   tree.MakeTableName(tree.Name(db.Name), tree.Name(table.Name)),
-		Unique:  index.Unique,
-		Columns: make(tree.IndexElemList, len(index.ColumnNames)),
-		Storing: make(tree.NameList, len(index.StoreColumnNames)),
+		Name:     tree.Name(index.Name),
+		Table:    tree.MakeTableName(tree.Name(db.Name), tree.Name(table.Name)),
+		Unique:   index.Unique,
+		Columns:  make(tree.IndexElemList, len(index.ColumnNames)),
+		Storing:  make(tree.NameList, len(index.StoreColumnNames)),
+		Inverted: index.Type == sqlbase.IndexDescriptor_INVERTED,
 	}
 	for i, name := range index.ColumnNames {
 		elem := tree.IndexElem{


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/46450

Intending to backport this.

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): Fix a bug where pg_catalog.pg_indexes
showed the wrong index definition for inverted indexes.