### PR TITLE
build: increase testtimeout from 20 to 30 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ SUBTESTS :=
 LINTTIMEOUT := 20m
 
 ## Test timeout to use for regular tests.
-TESTTIMEOUT := 20m
+TESTTIMEOUT := 30m
 
 ## Test timeout to use for race tests.
 RACETIMEOUT := 30m


### PR DESCRIPTION
Release justification: non-production code changes.

I have seen multiple timeouts of logic test runs in CI, so I think it's
time to bump up the timeout limit.

Release note: None