### PR TITLE
tree: fix cast to VARBIT adding extraneous padding

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3261,7 +3261,16 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				return d, nil
 			}
 			var a DBitArray
-			a.BitArray = v.BitArray.ToWidth(uint(t.Width()))
+			switch t.Oid() {
+			case oid.T_varbit:
+				// VARBITs do not have padding attached.
+				a.BitArray = v.BitArray.Clone()
+				if uint(t.Width()) < a.BitArray.BitLen() {
+					a.BitArray = a.BitArray.ToWidth(uint(t.Width()))
+				}
+			default:
+				a.BitArray = v.BitArray.Clone().ToWidth(uint(t.Width()))
+			}
 			return &a, nil
 		case *DInt:
 			return NewDBitArrayFromInt(int64(*v), uint(t.Width()))

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1023,3 +1023,24 @@ eval
 ARRAY['hello','world']::char(2)[]
 ----
 ARRAY['he','wo']
+
+# regression for #45850
+eval
+cast(B'11011' || B'00' as bit varying(8))
+----
+B'1101100'
+
+eval
+cast(B'11011' || B'00' as bit varying(6))
+----
+B'110110'
+
+eval
+cast(B'11011' || B'00' as bit(8))
+----
+B'11011000'
+
+eval
+cast(B'11011' || B'00' as bit(6))
+----
+B'110110'


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/45850.

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): Previously, casting a bit array to a bigger
varbit array added extra 0 padding at the end. This is not expected
behavior, which is resolved in this PR.