### PR TITLE
kvclient/kvcoord: add a test for request retries across EndTxn

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -2567,6 +2568,241 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+// checkImplicitCommit checks whether the txn is implicitly committed.
+func checkImplicitCommit(ctx context.Context, db *kv.DB, txn roachpb.Transaction) (bool, error) {
+	pushReq := roachpb.PushTxnRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: txn.Key,
+		},
+		PusheeTxn: txn.TxnMeta,
+		PushTo:    hlc.Timestamp{},
+		PushType:  roachpb.PUSH_ABORT,
+		// We're going to Force the push in order to not wait for the pushee to
+		// expire.
+		Force: true,
+	}
+	ba := roachpb.BatchRequest{}
+	ba.Add(&pushReq)
+
+	recCtx, collectRec, cancel := tracing.ContextWithRecordingSpan(ctx, "test trace")
+	defer cancel()
+
+	resp, pErr := db.NonTransactionalSender().Send(recCtx, ba)
+	if pErr != nil {
+		return false, pErr.GoError()
+	}
+
+	// Verify that we're not fooling ourselves and that checking for the implicit
+	// commit actually caused the txn recovery procedure to run.
+	recording := collectRec()
+	if "" == recording.FindLogMessage(
+		fmt.Sprintf("recovered txn %s", txn.ID.Short())) {
+		return false, errors.Errorf("recovery didn't run as expected. recording: %s", recording)
+	}
+
+	pusheeStatus := resp.Responses[0].GetPushTxn().PusheeTxn.Status
+	switch pusheeStatus {
+	case roachpb.ABORTED:
+		return false, nil
+	case roachpb.COMMITTED:
+		return true, nil
+	default:
+		return false, errors.Errorf("unexpected txn status: %s", pusheeStatus)
+	}
+}
+
+// Test that, even though at the kvserver level requests are not idempotent
+// across an EndTxn, a TxnCoordSender retry after a refresh still works fine. We
+// check that a transaction is not considered implicitly committed through a
+// combination of writes from a previous attempt of the EndTxn batch and a
+// STAGING txn record written by a newer attempt of that batch.
+// Namely, the scenario is as follows:
+//
+// 1. client sends Put(a) + Put(b) + EndTxn. The Put(a) is split by the
+//    DistSender from the rest. Note that the parallel commit mechanism is in
+//    effect here.
+// 2. Put(a) succeeds, but Put(b) is pushed. The client needs to refresh.
+// 3. The refresh succeeds.
+// 4. The client resends the whole batch (note that we don't keep track of the
+//    previous partial success).
+// 5. The batch is split again. The EndTxn succeeds, the Put(a) fails.
+//
+// The point of this test is to check that the txn is not considered to be
+// implicitly committed at this point. Since there is already an intent on "a"
+// from the previous attempt and that intent has a lower timestamp than the
+// EndTxn, the txn would be considered explicitly committed if we didn't take
+// particular care. If the txn were to be considered implicitly committed, and
+// the intent on "a" was resolved, then the in-flight write on a (when it
+// eventually evaluates) might return wrong results, or be pushed, or generally
+// get very confused about how its own transaction got committed already.
+//
+// !!! explain how we prevent this
+func TestTxnCoordSenderRetriesAcrossEndTxn_EndTxnSucceedsLate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var filterFn atomic.Value
+	var storeKnobs kvserver.StoreTestingKnobs
+	storeKnobs.EvalKnobs.TestingEvalFilter =
+		func(fArgs storagebase.FilterArgs) *roachpb.Error {
+			fnVal := filterFn.Load()
+			if fn, ok := fnVal.(func(storagebase.FilterArgs) *roachpb.Error); ok && fn != nil {
+				return fn(fArgs)
+			}
+			return nil
+		}
+
+	s, _, db := serverutils.StartServer(t,
+		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	keyA, keyA1, keyB, keyB1 := roachpb.Key("a"), roachpb.Key("a1"), roachpb.Key("b"), roachpb.Key("b1")
+	require.NoError(t, setupMultipleRanges(ctx, db, string(keyB)))
+
+	txn := db.NewTxn(ctx, "test txn")
+	// Do a write to anchor the txn on b's range.
+	require.NoError(t, txn.Put(ctx, keyB1, "b1"))
+
+	// Do a read to prevent the txn for performing server-side refreshes.
+	_, err := txn.Get(ctx, keyA1)
+	require.NoError(t, err)
+
+	// After the txn started, perform another read on keyB. This will cause the
+	// txn's upcoming write to be pushed. Because the write on keyB is sent
+	// together with the EndTxn, this means that the write too old condition
+	// can't be deferred and the respective sub-batch will return a
+	// WriteTooOldError.
+	_, err = db.Get(ctx, keyB)
+	require.NoError(t, err)
+
+	b := txn.NewBatch()
+	b.Put(keyA, "a")
+	b.Put(keyB, "b")
+
+	var count int32
+	filterFn.Store(func(args storagebase.FilterArgs) *roachpb.Error {
+		put, ok := args.Req.(*roachpb.PutRequest)
+		if !ok {
+			return nil
+		}
+		if !put.Key.Equal(keyA) {
+			return nil
+		}
+		count++
+		// Reject the left request on the 2nd attempt.
+		if count == 2 {
+			return roachpb.NewErrorf("injected")
+		}
+		return nil
+	})
+
+	require.Error(t, txn.CommitInBatch(ctx, b), "injected")
+	committed, err := checkImplicitCommit(ctx, db, *txn.TestingCloneTxn())
+	require.NoError(t, err)
+	require.False(t, committed)
+}
+
+// Test that, even though at the kvserver level requests are not idempotent
+// across an EndTxn, a TxnCoordSender retry after a refresh still works fine. We
+// check that a transaction is not considered implicitly committed through a
+// combination of a STAGING txn record written by an original attempt of the
+// EndTxn batch, plus writes from a subsequent attempt.
+// Namely, the scenario is as follows:
+//
+// 1. client sends CPut(a) + Put(b) + EndTxn. The CPut(a) is split by the
+//    DistSender from the rest. Note that the parallel commit mechanism is in
+//    effect here.
+// 2. CPut(a) gets a WriteTooOldError, but Put(b), EndTxn(STAGING) is succeeds.
+// 		The client needs to refresh.
+// 3. The refresh succeeds.
+// 4. The client resends the whole batch (note that we don't keep track of the
+//    previous partial success).
+// 5. The batch is split again. The EndTxn part fails, the CPut(a) succeeds.
+//
+// The point of this test is to check that the txn is not considered to be
+// implicitly committed at this point. All the intents are in place for the txn
+// to be considered committed, but we rely on the fact that the intent on "a"
+// has a timestamp that's too high (it gets the timestamp from the 2nd attempt,
+// after a refresh, but the STAGING txn record has an older timestamp). If the
+// txn were to be considered implicitly committed, it'd be bad as we are
+// returning an error to the client telling it that the EndTxn failed.
+func TestTxnCoordSenderRetriesAcrossEndTxn_EndTxnSucceedsEarly(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var filterFn atomic.Value
+	var storeKnobs kvserver.StoreTestingKnobs
+	storeKnobs.EvalKnobs.TestingEvalFilter =
+		func(fArgs storagebase.FilterArgs) *roachpb.Error {
+			fnVal := filterFn.Load()
+			if fn, ok := fnVal.(func(storagebase.FilterArgs) *roachpb.Error); ok && fn != nil {
+				return fn(fArgs)
+			}
+			return nil
+		}
+
+	s, _, db := serverutils.StartServer(t,
+		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	keyA, keyA1, keyB, keyB1 := roachpb.Key("a"), roachpb.Key("a1"), roachpb.Key("b"), roachpb.Key("b1")
+	require.NoError(t, setupMultipleRanges(ctx, db, string(keyB)))
+
+	origVal := roachpb.MakeValueFromString("init")
+	require.NoError(t, db.Put(ctx, keyA, &origVal))
+
+	txn := db.NewTxn(ctx, "test txn")
+
+	// Do a write to anchor the txn on b's range.
+	require.NoError(t, txn.Put(ctx, keyB1, "b1"))
+
+	// Take a snapshot of the txn early. We'll use it when verifying if the txn is
+	// implicitly committed. If we didn't use this early snapshot and, instead,
+	// used the transaction with a bumped timestamp, then the push code would
+	// infer that the txn is not implicitly committed without actually running the
+	// recovery procedure. Using this snapshot mimics a pusher that ran into an
+	// old intent.
+	origTxn := txn.TestingCloneTxn()
+
+	// Do a read to prevent the txn for performing server-side refreshes.
+	_, err := txn.Get(ctx, keyA1)
+	require.NoError(t, err)
+
+	// After the txn started, do a conflicting write. This will cause the txn's
+	// upcoming left half to return a WriteTooOldError on the first attempt,
+	// causing in turn a refresh and a retry. Note that the upcoming write is a
+	// CPut, so it can't return the WriteTooOld flag instead of a
+	// WriteTooOldError.
+	_, err = db.Get(ctx, keyA)
+
+	b := txn.NewBatch()
+	b.CPut(keyA, "a", &origVal)
+	b.Put(keyB, "b")
+
+	var count int32
+	filterFn.Store(func(args storagebase.FilterArgs) *roachpb.Error {
+		put, ok := args.Req.(*roachpb.PutRequest)
+		if !ok {
+			return nil
+		}
+		if !put.Key.Equal(keyB) {
+			return nil
+		}
+		count++
+		// Reject the right request on the 2nd attempt.
+		if count == 2 {
+			return roachpb.NewErrorf("injected")
+		}
+		return nil
+	})
+
+	require.Error(t, txn.CommitInBatch(ctx, b), "injected")
+	committed, err := checkImplicitCommit(ctx, db, *origTxn)
+
+	require.NoError(t, err)
+	require.False(t, committed)
 }
 
 // Test that we're being smart about the timestamp ranges that need to be

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -259,9 +259,7 @@ func PushTxn(
 	recoverOnFailedPush := cArgs.EvalCtx.EvalKnobs().RecoverIndeterminateCommitsOnFailedPushes
 	if reply.PusheeTxn.Status == roachpb.STAGING && (pusherWins || recoverOnFailedPush) {
 		err := roachpb.NewIndeterminateCommitError(reply.PusheeTxn)
-		if log.V(1) {
-			log.Infof(ctx, "%v", err)
-		}
+		log.VEventf(ctx, 1, "%v", err)
 		return result.Result{}, err
 	}
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1495,21 +1495,6 @@ func (st *SessionTracing) TraceExecEnd(ctx context.Context, err error, count int
 	}
 }
 
-// extractMsgFromRecord extracts the message of the event, which is either in an
-// "event" or "error" field.
-func extractMsgFromRecord(rec tracing.LogRecord) string {
-	for _, f := range rec.Fields {
-		key := f.Key
-		if key == "event" {
-			return f.Value
-		}
-		if key == "error" {
-			return fmt.Sprint("error:", f.Value)
-		}
-	}
-	return "<event missing in trace message>"
-}
-
 const (
 	// span_idx    INT NOT NULL,        -- The span's index.
 	traceSpanIdxCol = iota
@@ -1761,7 +1746,7 @@ func getMessagesForSubtrace(
 			allLogs = append(allLogs,
 				logRecordRow{
 					timestamp: logTime,
-					msg:       extractMsgFromRecord(span.Logs[i]),
+					msg:       span.Logs[i].Msg(),
 					span:      span,
 					// Add 1 to the index to account for the first dummy message in a
 					// span.

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -125,7 +125,7 @@ func eventInternal(ctx context.Context, isErr, withTags bool, format string, arg
 		if sp != nil {
 			// TODO(radu): pass tags directly to sp.LogKV when LightStep supports
 			// that.
-			sp.LogFields(otlog.String("event", msg))
+			sp.LogFields(otlog.String(tracing.LogMessageField, msg))
 			// if isErr {
 			// 	// TODO(radu): figure out a way to signal that this is an error. We
 			// 	// could use a different "error" key (provided it shows up in

--- a/pkg/util/tracing/recorded_span.go
+++ b/pkg/util/tracing/recorded_span.go
@@ -10,7 +10,12 @@
 
 package tracing
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+const LogMessageField string = "event"
 
 func (s *RecordedSpan) String() string {
 	sb := strings.Builder{}
@@ -19,4 +24,19 @@ func (s *RecordedSpan) String() string {
 		sb.WriteRune('\n')
 	}
 	return sb.String()
+}
+
+// Msg extracts the message of the LogRecord, which is either in an "event" or
+// "error" field.
+func (l LogRecord) Msg() string {
+	for _, f := range l.Fields {
+		key := f.Key
+		if key == LogMessageField {
+			return f.Value
+		}
+		if key == "error" {
+			return fmt.Sprint("error:", f.Value)
+		}
+	}
+	return ""
 }

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -490,7 +490,7 @@ func (s *span) LogFields(fields ...otlog.Field) {
 		// TODO(radu): when LightStep supports arbitrary fields, we should make
 		// the formatting of the message consistent with that. Until then we treat
 		// legacy events that just have an "event" key specially.
-		if len(fields) == 1 && fields[0].Key() == "event" {
+		if len(fields) == 1 && fields[0].Key() == LogMessageField {
 			s.netTr.LazyPrintf("%s", fields[0].Value())
 		} else {
 			var buf bytes.Buffer
@@ -565,12 +565,12 @@ func (s *span) Tracer() opentracing.Tracer {
 
 // LogEvent is part of the opentracing.Span interface. Deprecated.
 func (s *span) LogEvent(event string) {
-	s.LogFields(otlog.String("event", event))
+	s.LogFields(otlog.String(LogMessageField, event))
 }
 
 // LogEventWithPayload is part of the opentracing.Span interface. Deprecated.
 func (s *span) LogEventWithPayload(event string, payload interface{}) {
-	s.LogFields(otlog.String("event", event), otlog.Object("payload", payload))
+	s.LogFields(otlog.String(LogMessageField, event), otlog.Object("payload", payload))
 }
 
 // Log is part of the opentracing.Span interface. Deprecated.

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -13,6 +13,7 @@ package tracing
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -344,6 +345,21 @@ func (r Recording) String() string {
 		last = entry.Timestamp
 	}
 	return buf.String()
+}
+
+// FindLogMessage returns the first log message in the recording that matches
+// the given regexp. If no such messages exist, returns "".
+func (r Recording) FindLogMessage(pattern string) string {
+	re := regexp.MustCompile(pattern)
+	for _, sp := range r {
+		for _, l := range sp.Logs {
+			msg := l.Msg()
+			if re.MatchString(msg) {
+				return msg
+			}
+		}
+	}
+	return ""
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given span;


### PR DESCRIPTION
This patch adds a test for a tricky scenario.

Touches #46341

Release note: None
Release justification: Test only.