### PR TITLE
jobs: slow workload for test job creation

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/querylog"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/queue"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/rand"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/slow"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlsmith"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpccchecks"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples" // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"       // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/movr"     // registers workloads
+	_ "github.com/cockroachdb/cockroach/pkg/workload/slow"     // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"     // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"     // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"     // registers workloads

--- a/pkg/storage/cloud/workload_storage.go
+++ b/pkg/storage/cloud/workload_storage.go
@@ -113,7 +113,7 @@ func ParseWorkloadConfig(uri *url.URL) (*roachpb.ExternalStorage_Workload, error
 	}
 	c.Format, c.Generator, c.Table = pathParts[0], pathParts[1], pathParts[2]
 	q := uri.Query()
-	if _, ok := q[`version`]; !ok {
+	if _, ok := q[`version`]; !ok && c.Generator != "slow" {
 		return nil, errors.New(`parameter version is required`)
 	}
 	c.Version = q.Get(`version`)
@@ -131,6 +131,10 @@ func ParseWorkloadConfig(uri *url.URL) (*roachpb.ExternalStorage_Workload, error
 		if c.BatchEnd, err = strconv.ParseInt(e, 10, 64); err != nil {
 			return nil, err
 		}
+	} else {
+		// Make the default 1, so that the user does not need to set it
+		// every time.
+		c.BatchEnd = 1
 	}
 	for k, vs := range q {
 		for _, v := range vs {

--- a/pkg/workload/slow/slow.go
+++ b/pkg/workload/slow/slow.go
@@ -1,0 +1,127 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package slow
+
+import (
+	"context"
+	gosql "database/sql"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+const (
+	slowSchema = `(
+		ts TIMESTAMPTZ
+	)`
+
+	defaultRows  = 10
+	defaultDelay = 1
+)
+
+type slow struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	rows, delay int
+}
+
+func init() {
+	workload.Register(slowMeta)
+}
+
+var slowMeta = workload.Meta{
+	Name:         `slow`,
+	Description:  `Slow models a slow producer that creates a row after delay seconds`,
+	Version:      `1.0.0`,
+	PublicFacing: false,
+	New: func() workload.Generator {
+		g := &slow{}
+		g.flags.FlagSet = pflag.NewFlagSet(`slow`, pflag.ContinueOnError)
+		g.flags.IntVar(&g.rows, `rows`, defaultRows, `Number of rows to produce.`)
+		g.flags.IntVar(&g.delay, `delay`, 0, /* no delay to prevent test timeout */
+			`Delay in seconds before producing next row.`)
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		return g
+	},
+}
+
+// Meta implements the Generator interface.
+func (s *slow) Meta() workload.Meta { return slowMeta }
+
+// Flags implements the Flagser interface.
+func (s *slow) Flags() workload.Flags { return s.flags }
+
+// Hooks implements the Hookser interface.
+func (s *slow) Hooks() workload.Hooks {
+	return workload.Hooks{
+		Validate: func() error {
+			if s.delay < 0 {
+				return errors.Errorf(`Value of delay must be zero or greater; was %d`, s.delay)
+			}
+			return nil
+		},
+	}
+}
+
+var slowColTypes = []coltypes.T{coltypes.Timestamp}
+
+// Tables implements the Generator interface.
+func (s *slow) Tables() []workload.Table {
+	table := workload.Table{
+		Name:   `slow`,
+		Schema: slowSchema,
+		InitialRows: workload.BatchedTuples{
+			NumBatches: s.rows,
+			FillBatch: func(batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
+				cb.Reset(slowColTypes, 1)
+				tsCol := cb.ColVec(0).Timestamp()
+				time.Sleep(time.Duration(s.delay) * time.Second)
+				tsCol[0] = timeutil.Now()
+			},
+		},
+	}
+	return []workload.Table{table}
+}
+
+// Ops implements the Opser interface.
+func (s *slow) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+	sqlDatabase, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+
+	insertStmt, err := db.Prepare(`INSERT INTO slow VALUES (now())`)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+
+	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	workerFn := func(ctx context.Context) error {
+		time.Sleep(time.Duration(s.delay) * time.Second)
+		_, err := insertStmt.Exec()
+		return err
+	}
+	ql.WorkerFns = append(ql.WorkerFns, workerFn)
+	return ql, nil
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -289,6 +289,12 @@ func ColBatchToRows(cb coldata.Batch) [][]interface{} {
 					datums[rowIdx*numCols+colIdx] = datum
 				}
 			}
+		case coltypes.Timestamp:
+			for rowIdx, datum := range col.Timestamp()[:numRows] {
+				if !nulls.NullAt(rowIdx) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
 		case coltypes.Bytes:
 			// HACK: workload's Table schemas are SQL schemas, but the initial data is
 			// returned as a coldata.Batch, which has a more limited set of coltypes.


### PR DESCRIPTION
It is useful for testing or SRE/sysadmins to create jobs
that last a fixed amount of time. To that end we introduce
a new workload generator `slow`. This can be used together
with `IMPORT` to create such jobs.

Usage example:
```
IMPORT table foo (ts timestamp) CSV DATA
('workload:///csv/slow/slow?rows=5&delay=2');
```

This will produce 5 rows with a delay of 2 seconds between
rows. The table will contain the timestamp of each row
created.

Touches #45218.

Release justification: This is a very simple change that
introduces a new workload.
Release note (cli change): a new workload generator that produces
timestamps at a given interval.