### PR TITLE
release-19.2: opt: fix for subquery that uses view and refers to outer table

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -219,7 +219,15 @@ func (b *Builder) buildView(
 		defer func() { b.trackViewDeps = true }()
 	}
 
-	outScope = b.buildSelect(sel, nil /* desiredTypes */, &scope{builder: b})
+	// We don't want the view to be able to refer to any outer scopes in the
+	// query. This shouldn't happen if the view is valid but there may be
+	// cornercases (e.g. renaming tables referenced by the view). To be safe, we
+	// build the view with an empty scope. But after that, we reattach the scope
+	// to the existing scope chain because we want the rest of the query to be
+	// able to refer to the higher scopes (see #46180).
+	emptyScope := b.allocScope()
+	outScope = b.buildSelect(sel, nil /* desiredTypes */, emptyScope)
+	emptyScope.parent = inScope
 
 	// Update data source name to be the name of the view. And if view columns
 	// are specified, then update names of output columns.

--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -95,3 +95,37 @@ scalar-group-by
  └── aggregations
       └── array-agg [type=float[]]
            └── variable: f [type=float]
+
+# Verify that an outer table is visible from a subquery that uses
+# a view (#46180).
+exec-ddl
+CREATE VIEW v AS SELECT x FROM (VALUES (1), (2)) AS foo(x);
+----
+
+build
+SELECT (SELECT x FROM v WHERE x=t.a) FROM (VALUES (3), (4)) AS t(a);
+----
+project
+ ├── columns: x:3(int)
+ ├── values
+ │    ├── columns: column1:1(int!null)
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 3 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 4 [type=int]
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: column1:2(int!null)
+                └── select
+                     ├── columns: column1:2(int!null)
+                     ├── values
+                     │    ├── columns: column1:2(int!null)
+                     │    ├── tuple [type=tuple{int}]
+                     │    │    └── const: 1 [type=int]
+                     │    └── tuple [type=tuple{int}]
+                     │         └── const: 2 [type=int]
+                     └── filters
+                          └── eq [type=bool]
+                               ├── variable: column1 [type=int]
+                               └── variable: column1 [type=int]


### PR DESCRIPTION
Backport 1/1 commits from #46226.

/cc @cockroachdb/release

---

When a subquery uses a view, the higher scopes are lost and the subquery can't
refer to outer tables. This change fixes this by passing the inScope when we
build the view.

Fixes #46180.

Release note (bug fix): fixed incorrect "no data source matches prefix" error in
some cases involving subqueries that use views.

Release justification: low risk change to existing functionality.
