### PR TITLE
release-19.2: opt: allow qualified star without FROM clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1409,21 +1409,21 @@ query error pq: cos\(\): cannot use "\*" in this context
 SELECT cos(*) FROM system.namespace
 
 # Don't panic with invalid names (#8045)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT TRIM(TRAILING nonexistent.*[1])
 
 query error rtrim\(\): cannot subscript type tuple
 SELECT TRIM(TRAILING foo.*[1]) FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8044)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT OVERLAY(nonexistent.* PLACING 'string' FROM 'string')
 
 query error unknown signature
 SELECT OVERLAY(foo.* PLACING 'string' FROM 'string') FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8023)
-query error cannot use "nonexistent.\*" without a FROM clause
+query error no data source matches pattern: nonexistent.\*
 SELECT nonexistent.* IS NOT TRUE
 
 query error unsupported comparison operator: <tuple{int AS x}> IS DISTINCT FROM <bool>

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -240,6 +240,26 @@ project
            └── variable: v [type=char]
 
 build
+SELECT (SELECT t.*) FROM (VALUES (1)) AS t(x)
+----
+project
+ ├── columns: "?column?":3(int)
+ ├── values
+ │    ├── columns: column1:1(int!null)
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 1 [type=int]
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: x:2(int)
+                └── project
+                     ├── columns: x:2(int)
+                     ├── values
+                     │    └── tuple [type=tuple]
+                     └── projections
+                          └── variable: column1 [type=int]
+
+build
 SELECT foo.* FROM kv
 ----
 error (42P01): no data source matches pattern: foo.*

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -24,13 +24,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func checkFrom(expr tree.Expr, inScope *scope) {
-	if len(inScope.cols) == 0 {
-		panic(pgerror.Newf(pgcode.InvalidName,
-			"cannot use %q without a FROM clause", tree.ErrString(expr)))
-	}
-}
-
 // windowAggregateFrame() returns a frame that any aggregate built as a window
 // can use.
 func windowAggregateFrame() memo.WindowFrame {
@@ -99,15 +92,15 @@ func (b *Builder) expandStar(
 		}
 
 	case *tree.AllColumnsSelector:
-		checkFrom(expr, inScope)
-		src, _, err := t.Resolve(b.ctx, inScope)
+		src, srcMeta, err := t.Resolve(b.ctx, inScope)
 		if err != nil {
 			panic(err)
 		}
-		exprs = make([]tree.TypedExpr, 0, len(inScope.cols))
-		aliases = make([]string, 0, len(inScope.cols))
-		for i := range inScope.cols {
-			col := &inScope.cols[i]
+		refScope := srcMeta.(*scope)
+		exprs = make([]tree.TypedExpr, 0, len(refScope.cols))
+		aliases = make([]string, 0, len(refScope.cols))
+		for i := range refScope.cols {
+			col := &refScope.cols[i]
 			if col.table == *src && !col.hidden {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name))
@@ -115,7 +108,10 @@ func (b *Builder) expandStar(
 		}
 
 	case tree.UnqualifiedStar:
-		checkFrom(expr, inScope)
+		if len(inScope.cols) == 0 {
+			panic(pgerror.Newf(pgcode.InvalidName,
+				"cannot use %q without a FROM clause", tree.ErrString(expr)))
+		}
 		exprs = make([]tree.TypedExpr, 0, len(inScope.cols))
 		aliases = make([]string, 0, len(inScope.cols))
 		for i := range inScope.cols {


### PR DESCRIPTION
Backport 1/1 commits from #46233.

/cc @cockroachdb/release

---

We incorrectly error out if we have a qualified star without a FROM clause; the
star can refer to an outer table. We also incorrectly take the columns from the
input scope which is not necessarily the scope that the star is referring to.

Unfortunately, in the specific case in #45855 (`SELECT (SELECT t.*)`) we don't
get the nice column name `x` like in postgres; we get `?column?`. This is
because in our code the aliases are determined before building the expressions;
this seems complicated to change.

Fixes #45855.

Release note (bug fix): queries with qualified stars that refer to tables
in outer scopes now work.

Release justification: low risk changes to existing functionality.
