### PR TITLE
opt: eliminate LIMIT in right side of semi or anti join

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -651,42 +651,32 @@ project
       └── filters (true)
 
 # Calculate semi-join-apply cardinality.
-opt
-SELECT * FROM (SELECT * FROM xysd LIMIT 10) WHERE EXISTS(SELECT * FROM uv WHERE x=u LIMIT 5)
+expr
+(SemiJoinApply
+    (FakeRel
+        [
+            (OutputCols [ (NewColumn "a" "int") ])
+            (Cardinality "0-10")
+        ]
+    )
+    (FakeRel
+        [
+            (OutputCols [ (NewColumn "a" "int") ])
+        ]
+    )
+    [ ]
+    [ ]
+)
 ----
 semi-join-apply
- ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── columns: a:1(int)
  ├── cardinality: [0 - 10]
- ├── key: (1)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1)
- ├── scan xysd
- │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── limit: 10
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │    ├── prune: (1-4)
- │    └── interesting orderings: (+1) (-3,+4,+1)
- ├── limit
- │    ├── columns: u:5(int!null)
- │    ├── outer: (1)
- │    ├── cardinality: [0 - 5]
- │    ├── fd: ()-->(5)
- │    ├── select
- │    │    ├── columns: u:5(int!null)
- │    │    ├── outer: (1)
- │    │    ├── fd: ()-->(5)
- │    │    ├── limit hint: 5.00
- │    │    ├── scan uv
- │    │    │    ├── columns: u:5(int)
- │    │    │    ├── limit hint: 5.05
- │    │    │    └── prune: (5)
- │    │    └── filters
- │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
- │    │              ├── variable: x:1 [type=int]
- │    │              └── variable: u:5 [type=int]
- │    └── const: 5 [type=int]
+ ├── fake-rel
+ │    ├── columns: a:1(int)
+ │    └── cardinality: [0 - 10]
+ ├── fake-rel
+ │    ├── columns: a:2(int)
+ │    └── cardinality: [0 - 0]
  └── filters (true)
 
 # Calculate anti-join cardinality when left side has non-zero cardinality.
@@ -713,42 +703,32 @@ anti-join (hash)
            └── variable: column1:1 [type=int]
 
 # Calculate anti-join-apply cardinality.
-opt
-SELECT * FROM (SELECT * FROM xysd LIMIT 10) WHERE NOT EXISTS(SELECT * FROM uv WHERE x=u LIMIT 5)
+expr
+(AntiJoinApply
+    (FakeRel
+        [
+            (OutputCols [ (NewColumn "a" "int") ])
+            (Cardinality "0-10")
+        ]
+    )
+    (FakeRel
+        [
+            (OutputCols [ (NewColumn "a" "int") ])
+        ]
+    )
+    [ ]
+    [ ]
+)
 ----
 anti-join-apply
- ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── columns: a:1(int)
  ├── cardinality: [0 - 10]
- ├── key: (1)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1)
- ├── scan xysd
- │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── limit: 10
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │    ├── prune: (1-4)
- │    └── interesting orderings: (+1) (-3,+4,+1)
- ├── limit
- │    ├── columns: u:5(int!null)
- │    ├── outer: (1)
- │    ├── cardinality: [0 - 5]
- │    ├── fd: ()-->(5)
- │    ├── select
- │    │    ├── columns: u:5(int!null)
- │    │    ├── outer: (1)
- │    │    ├── fd: ()-->(5)
- │    │    ├── limit hint: 5.00
- │    │    ├── scan uv
- │    │    │    ├── columns: u:5(int)
- │    │    │    ├── limit hint: 5.05
- │    │    │    └── prune: (5)
- │    │    └── filters
- │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
- │    │              ├── variable: x:1 [type=int]
- │    │              └── variable: u:5 [type=int]
- │    └── const: 5 [type=int]
+ ├── fake-rel
+ │    ├── columns: a:1(int)
+ │    └── cardinality: [0 - 10]
+ ├── fake-rel
+ │    ├── columns: a:2(int)
+ │    └── cardinality: [0 - 0]
  └── filters (true)
 
 # Calculate inner-join cardinality.

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -112,11 +112,11 @@
 # rule expands to an Exists pattern that's also a valid input pattern
 # and it would recurse otherwise.
 #
-# We avoid this rule if the query is decorrelated because the
-# decorrelation rules get confused by the presence of a limit.
-# (It will be worth re-considering this when a general-purpose apply
-# operator is supported - in that case it can be definitely worthwhile
-# pushing down a LIMIT 1 to limit the amount of work done on every row.)
+# We avoid this rule if the query is correlated because the decorrelation rules
+# get confused by the presence of a limit. (It will be worth re-considering this
+# when a general-purpose apply operator is supported - in that case it can be
+# definitely worthwhile pushing down a LIMIT 1 to limit the amount of work done
+# on every row.)
 [IntroduceExistsLimit, Normalize]
 (Exists
     $input:* & ^(HasOuterCols $input) & ^(HasZeroOrOneRow $input)
@@ -128,6 +128,27 @@
     (MakeLimited $subqueryPrivate)
 )
 
+# EliminateExistsLimit discards a Limit operator with a positive limit inside an
+# Exist operator.
+#
+# The Limit operator prevents decorrelation rules from being applied. By
+# discarding the Limit, which is a no-op inside of Exist operators, the query
+# can be decorrelated into a more efficient SemiJoin or AntiJoin.
+#
+# Note that this rule uses HasOuterCols to ensure that it only matches
+# correlated Exists subqueries. There is no need to discard limits from
+# non-correlated Exists subqueries. Limits are preferred for non-correlated
+# Exists subqueries. See IntroduceExistsLimit above for details.
+[EliminateExistsLimit, Normalize]
+(Exists
+    (Limit
+        $input:* & (HasOuterCols $input)
+        (Const $limit:*) & (IsPositiveLimit $limit)
+    )
+    $subqueryPrivate:*
+)
+=>
+(Exists $input $subqueryPrivate)
 
 # NormalizeJSONFieldAccess transforms field access into a containment with a
 # simpler LHS. This allows inverted index constraints to be generated in some

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -104,7 +104,7 @@
 [EliminateExistsGroupBy, Normalize]
 (Exists (GroupBy | DistinctOn $input:*) $subqueryPrivate:*) => (Exists $input $subqueryPrivate)
 
-# ExistsLimit inserts a LIMIT 1 "under" Exists so as to save resources
+# IntroduceExistsLimit inserts a LIMIT 1 "under" Exists so as to save resources
 # to make the EXISTS determination.
 #
 # This rule uses and sets a boolean "WasLimited" on the Exists
@@ -119,7 +119,7 @@
 # pushing down a LIMIT 1 to limit the amount of work done on every row.)
 [IntroduceExistsLimit, Normalize]
 (Exists
-    $input:^(Project | GroupBy | DistinctOn) & ^(HasOuterCols $input) & ^(HasZeroOrOneRow $input)
+    $input:* & ^(HasOuterCols $input) & ^(HasZeroOrOneRow $input)
     $subqueryPrivate:* & ^(IsLimited $subqueryPrivate)
 )
 =>

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2031,86 +2031,71 @@ with &1 (w0)
       │    ├── columns: t0._string:6
       │    ├── scan t0
       │    │    └── columns: t0._string:6
-      │    ├── limit
-      │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19!null t1.rowid:21!null t2._bool:25!null t2._decimal:26 t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null t5._decimal:54!null
-      │    │    ├── internal-ordering: +26 opt(25)
+      │    ├── inner-join (hash)
+      │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19!null t1.rowid:21!null t2._bool:25!null t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null t5._decimal:54!null
       │    │    ├── outer: (6)
-      │    │    ├── cardinality: [0 - 66]
-      │    │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
-      │    │    ├── sort
-      │    │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19!null t1.rowid:21!null t2._bool:25!null t2._decimal:26 t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null t5._decimal:54!null
+      │    │    ├── fd: ()-->(25), (21)-->(19), (35)-->(29,31), (14,21,28,35)-->(19,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
+      │    │    ├── inner-join (hash)
+      │    │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null
       │    │    │    ├── outer: (6)
-      │    │    │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
-      │    │    │    ├── ordering: +26 opt(25) [actual: +26]
-      │    │    │    ├── limit hint: 66.00
-      │    │    │    └── inner-join (hash)
-      │    │    │         ├── columns: tab_orig.rowid:14!null t1._decimal:19!null t1.rowid:21!null t2._bool:25!null t2._decimal:26 t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null t5._decimal:54!null
-      │    │    │         ├── outer: (6)
-      │    │    │         ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
-      │    │    │         ├── inner-join (hash)
-      │    │    │         │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2._decimal:26 t2.rowid:28!null t3._int2:29!null t3._timestamptz:31!null t3.rowid:35!null t4._int8:44!null t4._timestamptz:45!null
-      │    │    │         │    ├── outer: (6)
-      │    │    │         │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31), (14,21,28,35)-->(19,25,26,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
-      │    │    │         │    ├── group-by
-      │    │    │         │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2._decimal:26 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
-      │    │    │         │    │    ├── grouping columns: tab_orig.rowid:14!null t1.rowid:21!null t2.rowid:28!null t3.rowid:35!null
-      │    │    │         │    │    ├── outer: (6)
-      │    │    │         │    │    ├── key: (14,21,28,35)
-      │    │    │         │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31), (14,21,28,35)-->(19,25,26,29,31)
-      │    │    │         │    │    ├── inner-join (cross)
-      │    │    │         │    │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2._decimal:26 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
-      │    │    │         │    │    │    ├── outer: (6)
-      │    │    │         │    │    │    ├── key: (14,21,28,35)
-      │    │    │         │    │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31)
-      │    │    │         │    │    │    ├── scan tab_orig
-      │    │    │         │    │    │    │    ├── columns: tab_orig.rowid:14!null
-      │    │    │         │    │    │    │    └── key: (14)
-      │    │    │         │    │    │    ├── inner-join (cross)
-      │    │    │         │    │    │    │    ├── columns: t1._decimal:19 t1.rowid:21!null t2._bool:25 t2._decimal:26 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
-      │    │    │         │    │    │    │    ├── key: (21,28,35)
-      │    │    │         │    │    │    │    ├── fd: (21)-->(19), (28)-->(25,26), (35)-->(29,31)
-      │    │    │         │    │    │    │    ├── scan t1
-      │    │    │         │    │    │    │    │    ├── columns: t1._decimal:19 t1.rowid:21!null
-      │    │    │         │    │    │    │    │    ├── key: (21)
-      │    │    │         │    │    │    │    │    └── fd: (21)-->(19)
-      │    │    │         │    │    │    │    ├── inner-join (cross)
-      │    │    │         │    │    │    │    │    ├── columns: t2._bool:25 t2._decimal:26 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
-      │    │    │         │    │    │    │    │    ├── key: (28,35)
-      │    │    │         │    │    │    │    │    ├── fd: (28)-->(25,26), (35)-->(29,31)
-      │    │    │         │    │    │    │    │    ├── scan t2
-      │    │    │         │    │    │    │    │    │    ├── columns: t2._bool:25 t2._decimal:26 t2.rowid:28!null
-      │    │    │         │    │    │    │    │    │    ├── key: (28)
-      │    │    │         │    │    │    │    │    │    └── fd: (28)-->(25,26)
-      │    │    │         │    │    │    │    │    ├── scan t3
-      │    │    │         │    │    │    │    │    │    ├── columns: t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
-      │    │    │         │    │    │    │    │    │    ├── key: (35)
-      │    │    │         │    │    │    │    │    │    └── fd: (35)-->(29,31)
-      │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │         │    │    │    │    └── filters (true)
-      │    │    │         │    │    │    └── filters
-      │    │    │         │    │    │         └── t0._string:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
-      │    │    │         │    │    └── aggregations
-      │    │    │         │    │         ├── const-agg [as=t2._bool:25, outer=(25)]
-      │    │    │         │    │         │    └── t2._bool:25
-      │    │    │         │    │         ├── const-agg [as=t2._decimal:26, outer=(26)]
-      │    │    │         │    │         │    └── t2._decimal:26
-      │    │    │         │    │         ├── const-agg [as=t3._int2:29, outer=(29)]
-      │    │    │         │    │         │    └── t3._int2:29
-      │    │    │         │    │         ├── const-agg [as=t3._timestamptz:31, outer=(31)]
-      │    │    │         │    │         │    └── t3._timestamptz:31
-      │    │    │         │    │         └── const-agg [as=t1._decimal:19, outer=(19)]
-      │    │    │         │    │              └── t1._decimal:19
-      │    │    │         │    ├── scan t4
-      │    │    │         │    │    └── columns: t4._int8:44 t4._timestamptz:45
-      │    │    │         │    └── filters
-      │    │    │         │         ├── t3._timestamptz:31 = t4._timestamptz:45 [outer=(31,45), constraints=(/31: (/NULL - ]; /45: (/NULL - ]), fd=(31)==(45), (45)==(31)]
-      │    │    │         │         └── t3._int2:29 = t4._int8:44 [outer=(29,44), constraints=(/29: (/NULL - ]; /44: (/NULL - ]), fd=(29)==(44), (44)==(29)]
-      │    │    │         ├── scan t5
-      │    │    │         │    └── columns: t5._decimal:54
-      │    │    │         └── filters
-      │    │    │              ├── t2._bool:25 [outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
-      │    │    │              └── t1._decimal:19 = t5._decimal:54 [outer=(19,54), constraints=(/19: (/NULL - ]; /54: (/NULL - ]), fd=(19)==(54), (54)==(19)]
-      │    │    └── 66
+      │    │    │    ├── fd: (21)-->(19), (28)-->(25), (35)-->(29,31), (14,21,28,35)-->(19,25,29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
+      │    │    │    ├── group-by
+      │    │    │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
+      │    │    │    │    ├── grouping columns: tab_orig.rowid:14!null t1.rowid:21!null t2.rowid:28!null t3.rowid:35!null
+      │    │    │    │    ├── outer: (6)
+      │    │    │    │    ├── key: (14,21,28,35)
+      │    │    │    │    ├── fd: (21)-->(19), (28)-->(25), (35)-->(29,31), (14,21,28,35)-->(19,25,29,31)
+      │    │    │    │    ├── inner-join (cross)
+      │    │    │    │    │    ├── columns: tab_orig.rowid:14!null t1._decimal:19 t1.rowid:21!null t2._bool:25 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
+      │    │    │    │    │    ├── outer: (6)
+      │    │    │    │    │    ├── key: (14,21,28,35)
+      │    │    │    │    │    ├── fd: (21)-->(19), (28)-->(25), (35)-->(29,31)
+      │    │    │    │    │    ├── scan tab_orig
+      │    │    │    │    │    │    ├── columns: tab_orig.rowid:14!null
+      │    │    │    │    │    │    └── key: (14)
+      │    │    │    │    │    ├── inner-join (cross)
+      │    │    │    │    │    │    ├── columns: t1._decimal:19 t1.rowid:21!null t2._bool:25 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
+      │    │    │    │    │    │    ├── key: (21,28,35)
+      │    │    │    │    │    │    ├── fd: (21)-->(19), (28)-->(25), (35)-->(29,31)
+      │    │    │    │    │    │    ├── scan t1
+      │    │    │    │    │    │    │    ├── columns: t1._decimal:19 t1.rowid:21!null
+      │    │    │    │    │    │    │    ├── key: (21)
+      │    │    │    │    │    │    │    └── fd: (21)-->(19)
+      │    │    │    │    │    │    ├── inner-join (cross)
+      │    │    │    │    │    │    │    ├── columns: t2._bool:25 t2.rowid:28!null t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
+      │    │    │    │    │    │    │    ├── key: (28,35)
+      │    │    │    │    │    │    │    ├── fd: (28)-->(25), (35)-->(29,31)
+      │    │    │    │    │    │    │    ├── scan t2
+      │    │    │    │    │    │    │    │    ├── columns: t2._bool:25 t2.rowid:28!null
+      │    │    │    │    │    │    │    │    ├── key: (28)
+      │    │    │    │    │    │    │    │    └── fd: (28)-->(25)
+      │    │    │    │    │    │    │    ├── scan t3
+      │    │    │    │    │    │    │    │    ├── columns: t3._int2:29 t3._timestamptz:31 t3.rowid:35!null
+      │    │    │    │    │    │    │    │    ├── key: (35)
+      │    │    │    │    │    │    │    │    └── fd: (35)-->(29,31)
+      │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── t0._string:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-agg [as=t2._bool:25, outer=(25)]
+      │    │    │    │         │    └── t2._bool:25
+      │    │    │    │         ├── const-agg [as=t3._int2:29, outer=(29)]
+      │    │    │    │         │    └── t3._int2:29
+      │    │    │    │         ├── const-agg [as=t3._timestamptz:31, outer=(31)]
+      │    │    │    │         │    └── t3._timestamptz:31
+      │    │    │    │         └── const-agg [as=t1._decimal:19, outer=(19)]
+      │    │    │    │              └── t1._decimal:19
+      │    │    │    ├── scan t4
+      │    │    │    │    └── columns: t4._int8:44 t4._timestamptz:45
+      │    │    │    └── filters
+      │    │    │         ├── t3._timestamptz:31 = t4._timestamptz:45 [outer=(31,45), constraints=(/31: (/NULL - ]; /45: (/NULL - ]), fd=(31)==(45), (45)==(31)]
+      │    │    │         └── t3._int2:29 = t4._int8:44 [outer=(29,44), constraints=(/29: (/NULL - ]; /44: (/NULL - ]), fd=(29)==(44), (44)==(29)]
+      │    │    ├── scan t5
+      │    │    │    └── columns: t5._decimal:54
+      │    │    └── filters
+      │    │         ├── t2._bool:25 [outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
+      │    │         └── t1._decimal:19 = t5._decimal:54 [outer=(19,54), constraints=(/19: (/NULL - ]; /54: (/NULL - ]), fd=(19)==(54), (54)==(19)]
       │    └── filters (true)
       └── projections
            └── NULL [as="?column?":58]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -465,20 +465,13 @@ project
       │              │    │         │    ├── true
       │              │    │         │    ├── when
       │              │    │         │    │    ├── exists
-      │              │    │         │    │    │    └── limit
+      │              │    │         │    │    │    └── select
       │              │    │         │    │    │         ├── columns: ref_1.config_yaml:10!null
       │              │    │         │    │    │         ├── outer: (6)
-      │              │    │         │    │    │         ├── cardinality: [0 - 52]
-      │              │    │         │    │    │         ├── select
-      │              │    │         │    │    │         │    ├── columns: ref_1.config_yaml:10!null
-      │              │    │         │    │    │         │    ├── outer: (6)
-      │              │    │         │    │    │         │    ├── limit hint: 52.00
-      │              │    │         │    │    │         │    ├── scan ref_1
-      │              │    │         │    │    │         │    │    ├── columns: ref_1.config_yaml:10!null
-      │              │    │         │    │    │         │    │    └── limit hint: 52.00
-      │              │    │         │    │    │         │    └── filters
-      │              │    │         │    │    │         │         └── c0:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]
-      │              │    │         │    │    │         └── 52
+      │              │    │         │    │    │         ├── scan ref_1
+      │              │    │         │    │    │         │    └── columns: ref_1.config_yaml:10!null
+      │              │    │         │    │    │         └── filters
+      │              │    │         │    │    │              └── c0:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]
       │              │    │         │    │    └── version()
       │              │    │         │    └── version()
       │              │    │         └── current_date()

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -909,12 +909,15 @@ WHERE EXISTS (
 project
  ├── columns: "?column?":22!null
  ├── fd: ()-->(22)
- ├── semi-join-apply
- │    ├── columns: s:4
- │    ├── scan a
- │    │    └── columns: s:4
+ ├── semi-join (cross)
+ │    ├── columns: s:4!null
+ │    ├── select
+ │    │    ├── columns: s:4!null
+ │    │    ├── scan a
+ │    │    │    └── columns: s:4
+ │    │    └── filters
+ │    │         └── s:4 >= 'foo' [outer=(4), constraints=(/4: [/'foo' - ]; tight)]
  │    ├── inner-join (cross)
- │    │    ├── outer: (4)
  │    │    ├── inner-join (cross)
  │    │    │    ├── select
  │    │    │    │    ├── scan xy
@@ -945,17 +948,20 @@ project
  │    │    │    │              │              └── columns: s:19
  │    │    │    │              └── 'foo'
  │    │    │    └── filters (true)
- │    │    ├── limit
- │    │    │    ├── outer: (4)
- │    │    │    ├── cardinality: [0 - 10]
- │    │    │    ├── select
- │    │    │    │    ├── outer: (4)
- │    │    │    │    ├── limit hint: 10.00
- │    │    │    │    ├── scan b
- │    │    │    │    │    └── limit hint: 10.00
- │    │    │    │    └── filters
- │    │    │    │         └── s:4 >= 'foo' [outer=(4), constraints=(/4: [/'foo' - ]; tight)]
- │    │    │    └── 10
+ │    │    ├── select
+ │    │    │    ├── scan b
+ │    │    │    └── filters
+ │    │    │         └── eq [subquery]
+ │    │    │              ├── subquery
+ │    │    │              │    └── max1-row
+ │    │    │              │         ├── columns: s:19
+ │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │              │         ├── cardinality: [0 - 1]
+ │    │    │              │         ├── key: ()
+ │    │    │              │         ├── fd: ()-->(19)
+ │    │    │              │         └── scan a
+ │    │    │              │              └── columns: s:19
+ │    │    │              └── 'foo'
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -442,6 +442,87 @@ select
                 └── (1,)
 
 # --------------------------------------------------
+# EliminateExistsLimit
+# --------------------------------------------------
+norm expect=EliminateExistsLimit
+SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 1)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a1
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ ├── scan a2
+ │    └── columns: a2.i:8
+ └── filters
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+norm expect=EliminateExistsLimit
+SELECT * FROM a a1 WHERE NOT EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 1)
+----
+anti-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a1
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ ├── scan a2
+ │    └── columns: a2.i:8
+ └── filters
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+# Don't eliminate a non-positive limit.
+norm expect-not=EliminateExistsLimit
+SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i LIMIT 0)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a1
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [subquery]
+           └── values
+                ├── columns: a2.i:8!null
+                ├── cardinality: [0 - 0]
+                ├── key: ()
+                └── fd: ()-->(8)
+
+# Don't eliminate a limit from a non-correlated subquery.
+norm expect-not=EliminateExistsLimit
+SELECT * FROM a WHERE EXISTS(SELECT * FROM a LIMIT 1)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [subquery]
+           └── limit
+                ├── columns: k:7!null i:8 f:9 s:10 j:11 arr:12
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7-12)
+                ├── scan a
+                │    ├── columns: k:7!null i:8 f:9 s:10 j:11 arr:12
+                │    ├── key: (7)
+                │    ├── fd: (7)-->(8-12)
+                │    └── limit hint: 1.00
+                └── 1
+
+# --------------------------------------------------
 # NormalizeJSONFieldAccess
 # --------------------------------------------------
 norm expect=NormalizeJSONFieldAccess

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -378,6 +378,70 @@ select
                 └── 1
 
 # --------------------------------------------------
+# IntroduceExistsLimit
+# --------------------------------------------------
+norm expect=IntroduceExistsLimit
+SELECT * FROM a WHERE EXISTS(SELECT i FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [subquery]
+           └── limit
+                ├── columns: i:8
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(8)
+                ├── scan a
+                │    ├── columns: i:8
+                │    └── limit hint: 1.00
+                └── 1
+
+# Don't introduce a limit on correlated subqueries (when HasOuterCols is true).
+norm expect-not=IntroduceExistsLimit
+SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a1
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.j:5 a1.arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ ├── scan a2
+ │    └── columns: a2.i:8
+ └── filters
+      └── a1.i:2 = a2.i:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+# Don't introduce a limit when the subquery has one row.
+norm expect-not=IntroduceExistsLimit
+SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (1)))
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [subquery]
+           └── values
+                ├── columns: column1:7!null
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7)
+                └── (1,)
+
+# --------------------------------------------------
 # NormalizeJSONFieldAccess
 # --------------------------------------------------
 norm expect=NormalizeJSONFieldAccess


### PR DESCRIPTION
#### opt: add tests for IntroduceExistsLimit normalization rule

This change adds tests for the IntroduceExistsLimit normalization rule,
which were previously not present. These tests should catch any
regressions of this rule.

Release note: None

#### opt: match all children node types in IntroduceExistsLimit

This change removes the ^(Project | GroupBy | DistinctOn) name match
pattern on the Exists input for the IntroduceExistsLimit rule.

Expression trees that match the Project, GroupBy, or DistinctOn patterns
already having the IntroduceExistsLimit rule applied after the
EliminateExistsProject and EliminateExistsGroupBy rules discard nodes.
Therefore this change simplifies the IntroduceExistsLimit rule without
changing the normalization process.

Release note: None

#### opt: eliminate LIMIT in right side of semi or anti join

A Limit expression with a positive limit is a no-op when used with a
SemiJoin or AntiJoin operator that has a True filter. By eliminating
this no-op Limit expression, the query can be decorrelated.

Fixes #45852

Release note (performance improvement): The query planner can now
decorrelate correlated exists subqueries with LIMIT expressions, leading
to better query plans.