### PR TITLE
colexec: fix interaction between projectingBatch and ArrowBatchConverter

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -229,29 +229,36 @@ func (m *MemBatch) ReplaceCol(col Vec, colIdx int) {
 
 // Reset implements the Batch interface.
 func (m *MemBatch) Reset(types []coltypes.T, length int) {
+	ResetNoTruncation(m, types, length)
+	m.b = m.b[:len(types)]
+}
+
+// ResetNoTruncation is the same as Reset, but if the batch has enough
+// capacity for length and has more columns than the given coltypes, yet
+// the prefix of already present columns matches the desired type schema,
+// the batch will be reused (meaning this method does *not* truncate the
+// type schema).
+func ResetNoTruncation(m *MemBatch, types []coltypes.T, length int) {
 	// The columns are always sized the same as the selection vector, so use it as
 	// a shortcut for the capacity (like a go slice, the batch's `Length` could be
 	// shorter than the capacity). We could be more defensive and type switch
 	// every column to verify its capacity, but that doesn't seem necessary yet.
-	hasColCapacity := len(m.sel) >= length
-	if m == nil || !hasColCapacity || m.Width() < len(types) {
+	cannotReuse := m == nil || len(m.sel) < length || m.Width() < len(types)
+	for i := 0; i < len(types) && !cannotReuse; i++ {
+		if m.ColVec(i).Type() != types[i] {
+			cannotReuse = true
+		}
+	}
+	if cannotReuse {
 		*m = *NewMemBatchWithSize(types, length).(*MemBatch)
 		m.SetLength(length)
 		return
-	}
-	for i := range types {
-		if m.ColVec(i).Type() != types[i] {
-			*m = *NewMemBatchWithSize(types, length).(*MemBatch)
-			m.SetLength(length)
-			return
-		}
 	}
 	// Yay! We can reuse m. NB It's not specified in the Reset contract, but
 	// probably a good idea to keep all modifications below this line.
 	m.SetLength(length)
 	m.SetSelection(false)
 	m.sel = m.sel[:length]
-	m.b = m.b[:len(types)]
 	for _, col := range m.ColVecs() {
 		col.Nulls().UnsetNulls()
 		if col.Type() == coltypes.Bytes {

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -260,10 +260,10 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 	}
 	// Assume > 0 length data.
 	n := data[0].Len()
-	// Reset reuses the passed-in Batch when possible, saving allocations but
-	// overwriting it. If the passed-in Batch is not suitable for use, a new one
-	// is allocated.
-	b.Reset(c.typs, n)
+	// ResetNoTruncation reuses the passed-in Batch when possible, saving
+	// allocations but overwriting it. If the passed-in Batch is not suitable
+	// for use, a new one is allocated.
+	coldata.ResetNoTruncation(b.(*coldata.MemBatch), c.typs, n)
 	b.SetLength(n)
 	// Reset the batch, this resets the selection vector as well.
 	b.ResetInternalBatch()

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -209,7 +209,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 			data, err := c.BatchToArrow(batch)
 			require.NoError(b, err)
 			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
-			result := coldata.NewMemBatch(typs)
+			result := coldata.NewMemBatch([]coltypes.T{typ})
 			b.Run(testPrefix+"/ArrowToBatch", func(b *testing.B) {
 				b.SetBytes(numBytes[typIdx])
 				for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/simple_project.go
+++ b/pkg/sql/colexec/simple_project.go
@@ -46,9 +46,12 @@ type projectingBatch struct {
 }
 
 func newProjectionBatch(projection []uint32) *projectingBatch {
-	return &projectingBatch{
-		projection: projection,
+	p := &projectingBatch{
+		projection: make([]uint32, len(projection)),
 	}
+	// We make a copy of projection to be safe.
+	copy(p.projection, projection)
+	return p
 }
 
 func (b *projectingBatch) ColVec(i int) coldata.Vec {
@@ -59,7 +62,7 @@ func (b *projectingBatch) ColVecs() []coldata.Vec {
 	if b.Batch == coldata.ZeroBatch {
 		return nil
 	}
-	if b.colVecs == nil {
+	if b.colVecs == nil || len(b.colVecs) != len(b.projection) {
 		b.colVecs = make([]coldata.Vec, len(b.projection))
 	}
 	for i := range b.colVecs {
@@ -75,6 +78,10 @@ func (b *projectingBatch) Width() int {
 func (b *projectingBatch) AppendCol(col coldata.Vec) {
 	b.Batch.AppendCol(col)
 	b.projection = append(b.projection, uint32(b.Batch.Width())-1)
+}
+
+func (b *projectingBatch) ReplaceCol(col coldata.Vec, idx int) {
+	b.Batch.ReplaceCol(col, int(b.projection[idx]))
 }
 
 // NewSimpleProjectOp returns a new simpleProjectOp that applies a simple
@@ -94,12 +101,15 @@ func NewSimpleProjectOp(input Operator, numInputCols int, projection []uint32) O
 			return input
 		}
 	}
-	return &simpleProjectOp{
+	s := &simpleProjectOp{
 		OneInputNode:               NewOneInputNode(input),
-		projection:                 projection,
+		projection:                 make([]uint32, len(projection)),
 		batches:                    make(map[coldata.Batch]*projectingBatch),
 		numBatchesLoggingThreshold: 128,
 	}
+	// We make a copy of projection to be safe.
+	copy(s.projection, projection)
+	return s
 }
 
 func (d *simpleProjectOp) Init() {
@@ -110,8 +120,7 @@ func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
 	batch := d.input.Next(ctx)
 	projBatch, found := d.batches[batch]
 	if !found {
-		// We pass in a copy of d.projection just to be safe.
-		projBatch = newProjectionBatch(append([]uint32{}, d.projection...))
+		projBatch = newProjectionBatch(d.projection)
 		d.batches[batch] = projBatch
 		if len(d.batches) == d.numBatchesLoggingThreshold {
 			if log.V(1) {


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality.

With our recent work, `simpleProjectOp` relies on creating a separate
`projectingBatch` for each "new" batch it sees (where "new" is tracked
by the pointer address). This works ok, but the interaction with
ArrowBatchConverter has been messed up - the converter `Reset`s the
batch which truncates its type schema. As a result, we end up in
a situation where `projectingBatch` that wraps the batch created in the
converter thinks that there are more columns than `MemBatch.b` actually
contains after the truncation which can lead to an internal error. This
problem is now fixed by introducing another variation of `Reset` method
(`ResetNoTruncation`) that doesn't truncate the schema. Only
ArrowBatchConverter is using this method.

Fixes: #46533.

Release note: None (this is a follow-up fix to a PR that has been merged
three weeks ago with a release note)