### PR TITLE
sql: disable stats injection within an explicit transaction

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -707,6 +707,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if !ok {
 				return errors.AssertionFailedf("missing stats data")
 			}
+			if !params.p.EvalContext().TxnImplicit {
+				return errors.New("cannot inject statistics in an explicit transaction")
+			}
 			if err := injectTableStats(params, n.tableDesc.TableDesc(), sd); err != nil {
 				return err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1107,3 +1107,16 @@ sql.schema.new_column.qualification.default_expr
 
 statement ok
 DROP TABLE telemetry_test
+
+# Disable stats injection in explicit transactions.
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE inject_stats (k CHAR PRIMARY KEY, v TIMESTAMPTZ)
+
+statement error pq: cannot inject statistics in an explicit transaction
+ALTER TABLE inject_stats INJECT STATISTICS '[]'
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Fixes #42421.

Release justification: Disables a situation that could lead to a
deadlock.

Release note (sql change): Disables to ability to inject stats
within an explicit transaction.