### PR TITLE
ui: Preserve search/sorting on Statements page

### DIFF
--- a/pkg/ui/src/views/app/components/Search/index.tsx
+++ b/pkg/ui/src/views/app/components/Search/index.tsx
@@ -18,6 +18,7 @@ import "./search.styl";
 interface ISearchProps {
   onSubmit: (value: string) => void;
   onClear?: () => void;
+  defaultValue?: string;
 }
 
 interface ISearchState {
@@ -30,7 +31,7 @@ type TSearchProps = ISearchProps & InputProps;
 
 export class Search extends React.Component<TSearchProps, ISearchState> {
   state = {
-    value: "",
+    value: this.props.defaultValue || "",
     submitted: false,
   };
 

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -73,24 +73,38 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
 
   constructor(props: StatementsPageProps & RouteComponentProps<any>) {
     super(props);
+    const { history } = props;
+    const searchParams = new URLSearchParams(history.location.search);
+    const sortKey = searchParams.get("sortKey");
+    const ascending = searchParams.get("ascending");
+    const searchQuery = searchParams.get("q");
+
     this.state = {
       sortSetting: {
-        sortKey: 6,  // Latency
-        ascending: false,
+        sortKey: sortKey || 6,  // Latency column is default for sorting
+        ascending: Boolean(ascending) || false,
       },
       pagination: {
         pageSize: 20,
         current: 1,
       },
-      search: "",
+      search: searchQuery || "",
     };
     this.activateDiagnosticsRef = React.createRef();
   }
 
   changeSortSetting = (ss: SortSetting) => {
+    const { history } = this.props;
+
     this.setState({
       sortSetting: ss,
     });
+
+    const searchParams = new URLSearchParams(history.location.search);
+    searchParams.set("sortKey", ss.sortKey);
+    searchParams.set("ascending", Boolean(ss.ascending).toString());
+    history.location.search = searchParams.toString();
+    history.replace(history.location);
   }
 
   selectApp = (app: DropdownOption) => {
@@ -125,7 +139,15 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     return data;
   }
 
-  onSubmitSearchField = (search: string) => this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
+  onSubmitSearchField = (search: string) => {
+    const { history } = this.props;
+    this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
+
+    const searchParams = new URLSearchParams(history.location.search);
+    searchParams.set("q", search);
+    history.location.search = searchParams.toString();
+    history.replace(history.location);
+  }
 
   onClearSearchField = () => this.setState({ search: "" });
 
@@ -201,6 +223,7 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
             <Search
               onSubmit={this.onSubmitSearchField as any}
               onClear={this.onClearSearchField}
+              defaultValue={search}
             />
           </PageConfigItem>
           <PageConfigItem>

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -151,7 +151,14 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
     history.replace(history.location);
   }
 
-  onClearSearchField = () => this.setState({ search: "" });
+  onClearSearchField = () => {
+    const { history } = this.props;
+    this.setState({ search: "" });
+    const searchParams = new URLSearchParams(history.location.search);
+    searchParams.delete("q");
+    history.location.search = searchParams.toString();
+    history.replace(history.location);
+  }
 
   filteredStatementsData = () => {
     const { search } = this.state;

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -108,7 +108,9 @@ export class StatementsPage extends React.Component<StatementsPageProps & RouteC
   }
 
   selectApp = (app: DropdownOption) => {
-    this.props.history.push(`/statements/${app.value}`);
+    const { history } = this.props;
+    history.location.pathname = `/statements/${app.value}`;
+    history.replace(history.location);
   }
 
   componentWillMount() {


### PR DESCRIPTION
Resolves: #45404

Search query and sorting params are preserved as URL search
params. It doesn't break existing routing configuration and
allows restore custom state from URL.

Release justification: bug fixes and low-risk updates to new functionality