### PR TITLE
server: ensure that the auth cookie works over non-TLS HTTP

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -69,11 +69,11 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(stderr, `#
 # Example uses:
 #
-#     curl [-k] --cookie '%s' https://...
+#     curl [-k] --cookie '%[1]s' https://...
 #
-#     wget [--no-check-certificate] --header='Cookie: %s' https://...
+#     wget [--no-check-certificate] --header='Cookie: %[1]s' https://...
 #
-`, hC, hC)
+`, hC)
 		}
 	}
 
@@ -132,7 +132,7 @@ RETURNING id
 
 	// Spell out the cookie.
 	sCookie := &serverpb.SessionCookie{ID: id, Secret: secret}
-	httpCookie, err = server.EncodeSessionCookie(sCookie)
+	httpCookie, err = server.EncodeSessionCookie(sCookie, false /* forHTTPSOnly */)
 	return id, httpCookie, err
 }
 

--- a/pkg/cli/interactive_tests/test_auth_cookie.py
+++ b/pkg/cli/interactive_tests/test_auth_cookie.py
@@ -11,7 +11,7 @@ ctx.check_hostname = False
 ctx.verify_mode = ssl.CERT_NONE
 
 # Load the cookie.
-cookie = file('cookie.txt').read().strip()
+cookie = file(cookiefile).read().strip()
 
 # Perform the HTTP request.
 httpReq = urllib2.Request(url, "", {"Cookie": cookie})

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -162,7 +162,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 							// The actual contents of the cookie don't matter; the presence of
 							// a valid encoded cookie is enough to trigger the authentication
 							// code paths.
-						})
+						}, false /* forHTTPSOnly - cluster is insecure */)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -581,7 +581,7 @@ func TestLogout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	encodedCookie, err := EncodeSessionCookie(cookie)
+	encodedCookie, err := EncodeSessionCookie(cookie, false /* forHTTPSOnly */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -525,7 +525,7 @@ func (ts *TestServer) getAuthenticatedHTTPClientAndCookie(
 				Secret: secret,
 			}
 			// Encode a session cookie and store it in a cookie jar.
-			cookie, err := EncodeSessionCookie(rawCookie)
+			cookie, err := EncodeSessionCookie(rawCookie, false /* forHTTPSOnly */)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #46550. Kudos for @awoods187 for finding the problem.

When non-TLS HTTP listeners were introduced, the auth cookie remained
with the "Secure" flag attached (which broke auth over non-TLS).

This patch fixes that by removing the "Secure" flag for cookies
generated over non-TLS listeners.

(Note that the name of this HTTP cookie flag, "Secure", is not really
a security concept. Removing the flag in that case does not reduce
security.)

Release justification: fixes for high-priority or high-severity bugs in existing functionality

Release note: None