### PR TITLE
release-19.1: sql: fix bug with decoding descending collated strings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -319,3 +319,10 @@ query T
 SELECT * FROM foo WHERE a = 'abcd' COLLATE en_u_ks_level2
 ----
 aBcD
+
+# Regression for #46570.
+statement ok
+CREATE TABLE t46570(c0 BOOL, c1 STRING COLLATE en);
+CREATE INDEX ON t46570(rowid, c1 DESC);
+INSERT INTO t46570(c1, rowid) VALUES('' COLLATE en, 0);
+UPSERT INTO t46570(rowid) VALUES (0), (1)

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -327,7 +327,11 @@ func DecodeTableKey(
 		switch t := valType.(type) {
 		case types.TCollatedString:
 			var r string
-			rkey, r, err = encoding.DecodeUnsafeStringAscending(key, nil)
+			if dir == encoding.Ascending {
+				rkey, r, err = encoding.DecodeUnsafeStringAscending(key, nil)
+			} else {
+				rkey, r, err = encoding.DecodeUnsafeStringDescending(key, nil)
+			}
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Backport 1/1 commits from #46570.

/cc @cockroachdb/release

---

Fixes #46394.

Fixes a bug where the decoding logic for collated strings
would assume the collated string was always in encoded
to be sorted in ascending order.

Release justification: fixes a bug
Release note (bug fix): Fixes a bug where operations on an index
that contained a collated string in descending order would fail.
