### PR TITLE
tpccbench: bump EstimatedMax for tpccbench/nodes=9/cpu=4/multi-region

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -365,7 +365,7 @@ func registerTPCC(r *testRegistry) {
 		LoadConfig:   multiLoadgen,
 
 		LoadWarehouses: 5000,
-		EstimatedMax:   2200,
+		EstimatedMax:   3000,
 
 		MinVersion: "v19.1.0",
 	})


### PR DESCRIPTION
Closes #41876.

Searching from 2200 up to around 3000 each time this test runs takes a long
time and can lead to test timeouts. Now that we're more efficient, we can
bump the estimated max and limit the max warehouse search.

Release justification: testing only