### PR TITLE
colexec: optimize resetting of buffered groups in merge joiner

### DIFF
--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -102,8 +102,8 @@ type mjBufferedGroup struct {
 }
 
 func (bg *mjBufferedGroup) reset(ctx context.Context) {
-	if err := bg.close(ctx); err != nil {
-		execerror.VectorizedInternalPanic(err)
+	if bg.spillingQueue != nil {
+		bg.spillingQueue.reset(ctx)
 	}
 	bg.numTuples = 0
 }
@@ -441,10 +441,18 @@ func (o *mergeJoinBase) initWithOutputBatchSize(outBatchSize int) {
 		o.outputBatchSize = 1<<16 - 1
 	}
 
+	o.proberState.lBufferedGroup.spillingQueue = newSpillingQueue(
+		o.unlimitedAllocator, o.left.sourceTypes, o.memoryLimit,
+		o.diskQueueCfg, o.fdSemaphore, coldata.BatchSize(), o.diskAcc,
+	)
 	o.proberState.lBufferedGroup.firstTuple = make([]coldata.Vec, len(o.left.sourceTypes))
 	for colIdx, colType := range o.left.sourceTypes {
 		o.proberState.lBufferedGroup.firstTuple[colIdx] = o.unlimitedAllocator.NewMemColumn(colType, 1)
 	}
+	o.proberState.rBufferedGroup.spillingQueue = newRewindableSpillingQueue(
+		o.unlimitedAllocator, o.right.sourceTypes, o.memoryLimit,
+		o.diskQueueCfg, o.fdSemaphore, coldata.BatchSize(), o.diskAcc,
+	)
 	o.proberState.rBufferedGroup.firstTuple = make([]coldata.Vec, len(o.right.sourceTypes))
 	for colIdx, colType := range o.right.sourceTypes {
 		o.proberState.rBufferedGroup.firstTuple[colIdx] = o.unlimitedAllocator.NewMemColumn(colType, 1)
@@ -485,12 +493,6 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	if input == &o.left {
 		sourceTypes = o.left.sourceTypes
 		bufferedGroup = &o.proberState.lBufferedGroup
-		if bufferedGroup.spillingQueue == nil {
-			bufferedGroup.spillingQueue = newSpillingQueue(
-				o.unlimitedAllocator, o.left.sourceTypes, o.memoryLimit,
-				o.diskQueueCfg, o.fdSemaphore, coldata.BatchSize(), o.diskAcc,
-			)
-		}
 		// TODO(yuzefovich): uncomment when spillingQueue actually copies the
 		// enqueued batches when those are kept in memory.
 		//if o.scratch.lBufferedGroupBatch == nil {
@@ -500,12 +502,6 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	} else {
 		sourceTypes = o.right.sourceTypes
 		bufferedGroup = &o.proberState.rBufferedGroup
-		if bufferedGroup.spillingQueue == nil {
-			bufferedGroup.spillingQueue = newRewindableSpillingQueue(
-				o.unlimitedAllocator, o.right.sourceTypes, o.memoryLimit,
-				o.diskQueueCfg, o.fdSemaphore, coldata.BatchSize(), o.diskAcc,
-			)
-		}
 		// TODO(yuzefovich): uncomment when spillingQueue actually copies the
 		// enqueued batches when those are kept in memory.
 		//if o.scratch.rBufferedGroupBatch == nil {
@@ -703,17 +699,11 @@ func (o *mergeJoinBase) Close(ctx context.Context) error {
 			}
 		}
 	}
-	if o.proberState.lBufferedGroup.spillingQueue != nil {
-		if err := o.proberState.lBufferedGroup.close(ctx); err != nil {
-			lastErr = err
-		}
-		o.proberState.lBufferedGroup.spillingQueue = nil
+	if err := o.proberState.lBufferedGroup.close(ctx); err != nil {
+		lastErr = err
 	}
-	if o.proberState.rBufferedGroup.spillingQueue != nil {
-		if err := o.proberState.rBufferedGroup.close(ctx); err != nil {
-			lastErr = err
-		}
-		o.proberState.rBufferedGroup.spillingQueue = nil
+	if err := o.proberState.rBufferedGroup.close(ctx); err != nil {
+		lastErr = err
 	}
 	return lastErr
 }

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1487,11 +1487,15 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				return o.output
 			}
 		case mjDone:
-			if err := o.proberState.lBufferedGroup.close(ctx); err != nil {
-				execerror.VectorizedInternalPanic(err)
+			// Note that resetting of buffered groups will close disk queues
+			// (if there are any).
+			if o.proberState.lBufferedGroupNeedToReset {
+				o.proberState.lBufferedGroup.reset(ctx)
+				o.proberState.lBufferedGroupNeedToReset = false
 			}
-			if err := o.proberState.rBufferedGroup.close(ctx); err != nil {
-				execerror.VectorizedInternalPanic(err)
+			if o.proberState.rBufferedGroupNeedToReset {
+				o.proberState.rBufferedGroup.reset(ctx)
+				o.proberState.rBufferedGroupNeedToReset = false
 			}
 			return coldata.ZeroBatch
 		default:

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -11,7 +11,7 @@ statement ok
 INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)
 
 query II
-SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a LIMIT 6
+SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a ORDER BY 1, 2 LIMIT 6
 ----
 0  0
 0  0
@@ -71,7 +71,7 @@ SELECT count(*) FROM (SELECT DISTINCT a FROM a)
 1001
 
 query III
-SELECT * FROM a LIMIT 10
+SELECT * FROM a ORDER BY 1, 2 LIMIT 10
 ----
 0  0  0
 0  1  1
@@ -85,7 +85,7 @@ SELECT * FROM a LIMIT 10
 4  9  9
 
 query II
-SELECT DISTINCT(a), b FROM a LIMIT 10
+SELECT DISTINCT(a), b FROM a ORDER BY 1, 2 LIMIT 10
 ----
 0  0
 0  1
@@ -99,7 +99,7 @@ SELECT DISTINCT(a), b FROM a LIMIT 10
 4  9
 
 # Simple filter.
-query I
+query I rowsort
 SELECT b FROM a WHERE b < 3
 ----
 0
@@ -107,7 +107,7 @@ SELECT b FROM a WHERE b < 3
 2
 
 # Mixed type comparison
-query IB
+query IB rowsort
 SELECT c, c > 1 FROM a LIMIT 3
 ----
 0  false
@@ -129,7 +129,7 @@ SELECT a, b FROM nulls WHERE a <= b
 
 # Filter on the result of a projection.
 query II
-SELECT a, b FROM a WHERE a * 2 < b LIMIT 5
+SELECT a, b FROM a WHERE a * 2 < b ORDER BY 1, 2 LIMIT 5
 ----
 0  1
 1  3
@@ -182,7 +182,7 @@ SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
 
 # Operations with constants on the left work.
 query I
-SELECT 5 - a FROM a LIMIT 3
+SELECT 5 - a FROM a ORDER BY 1 DESC LIMIT 3
 ----
 5
 5
@@ -190,7 +190,7 @@ SELECT 5 - a FROM a LIMIT 3
 
 # Constant projections.
 query II
-SELECT 5, a FROM a LIMIT 3
+SELECT 5, a FROM a ORDER BY 2 LIMIT 3
 ----
 5  0
 5  0


### PR DESCRIPTION
**colexec: fix resetting of buffered groups**

Release justification: bug fixes and low-risk updates to new
functionality.

Previously, whenever we needed to reset the buffered groups, we would
close the spilling queue and would create a new one when needed. This is
an overkill since we could simply reset the spilling queues that we have
which reduces amount of allocations and improves the performance.

Addresses: #46502.

Release note: None

**logictest: make results of queries in vectorize test deterministic**

Release justification: non-production code changes.

Several queries in `vectorize` logic test could have produced different
results, and this is now fixed.

Fixes: #46630.

Release note: None