### PR TITLE
encoding: fix decimal decoding not reset properly

### DIFF
--- a/pkg/util/encoding/decimal.go
+++ b/pkg/util/encoding/decimal.go
@@ -624,6 +624,7 @@ func DecodeNonsortingDecimal(buf []byte, tmp []byte) (apd.Decimal, error) {
 // DecodeIntoNonsortingDecimal is like DecodeNonsortingDecimal, but it operates
 // on the passed-in *apd.Decimal instead of producing a new one.
 func DecodeIntoNonsortingDecimal(dec *apd.Decimal, buf []byte, tmp []byte) error {
+	*dec = apd.Decimal{}
 	switch buf[0] {
 	case decimalNaN:
 		dec.Form = apd.NaN

--- a/pkg/util/encoding/decimal_test.go
+++ b/pkg/util/encoding/decimal_test.go
@@ -472,6 +472,46 @@ func TestNonsortingEncodeDecimalRoundtrip(t *testing.T) {
 	}
 }
 
+func TestDecodeMultipleDecimalsIntoNonsortingDecimal(t *testing.T) {
+	tcs := []struct {
+		value []string
+	}{
+		{
+			[]string{"1.0", "5.0", "7.0"},
+		},
+		{
+			[]string{"1.0", "-1.0", "0.0"},
+		},
+		{
+			[]string{"1.0", "-1.0", "10.0"},
+		},
+		{
+			[]string{"nan", "1.0", "-1.0"},
+		},
+		{
+			[]string{"-1.0", "inf", "5.0"},
+		},
+	}
+
+	for _, tc := range tcs {
+		var actual apd.Decimal
+		for _, num := range tc.value {
+			expected, _, err := apd.NewFromString(num)
+			if err != nil {
+				t.Fatal(err)
+			}
+			enc := EncodeNonsortingDecimal(nil, expected)
+			err = DecodeIntoNonsortingDecimal(&actual, enc, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual.Cmp(expected) != 0 {
+				t.Errorf("unexpected mismatch for %v, got %v", expected, &actual)
+			}
+		}
+	}
+}
+
 func TestUpperBoundNonsortingDecimalUnscaledSize(t *testing.T) {
 	x := make([]byte, 100)
 	d := new(apd.Decimal)


### PR DESCRIPTION
Previously, we did not properly reset apd.Decimal when we call
DecodeIntoNonsortingDecimal(). This results in incorrect decoded
results.

Closes #46523

Release justification: bug fix
Release note: None