### PR TITLE
cli: add a command to generate random data in cockroach demo

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_rand_fill.tcl
+++ b/pkg/cli/interactive_tests/test_demo_rand_fill.tcl
@@ -1,0 +1,67 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Test that \\rand_fill_table works as expected"
+
+spawn $argv demo
+
+eexpect "movr>"
+
+# Wrong number of args.
+send "\\rand_fill_table t\n"
+eexpect "Usage:"
+
+# Wrong argument types.
+send "\\rand_fill_table t a\n"
+eexpect "cannot convert a to string"
+
+# Test on a table that doesn't exist.
+send "\\rand_fill_table t 10\n"
+eexpect "pq: relation \"t\" does not exist"
+
+eexpect "movr>"
+
+# Create a table.
+send "CREATE TABLE t (x INT, y TIMESTAMPTZ, z STRING, w UUID);\n"
+eexpect "movr>"
+
+# Test that the command doesn't work within a transaction.
+send "BEGIN;\n"
+eexpect ">"
+
+send "\\rand_fill_table t 100\n"
+eexpect "\\rand_fill_table cannot be run within a transaction"
+
+send "\n"
+eexpect "OPEN>"
+
+send "\\rand_fill_table t 100\n"
+eexpect "\\rand_fill_table cannot be run within a transaction"
+
+send "SELECT * FROM t2;\n"
+eexpect "ERROR>"
+
+send "\\rand_fill_table t 100\n"
+eexpect "\\rand_fill_table cannot be run within a transaction"
+
+send "ABORT;\n"
+eexpect "movr>"
+
+# Run the command.
+send "\\rand_fill_table t 100\n"
+eexpect "Successfully loaded 100 random rows into t"
+
+eexpect "movr>"
+
+send "SELECT count(*) FROM t;\n"
+eexpect "count"
+eexpect "100"
+eexpect "(1 row)"
+
+eexpect "movr>"
+
+interrupt
+eexpect eof
+
+end_test

--- a/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
@@ -16,6 +16,10 @@ eexpect root@
 send "\\demo_node shutdown 2\n"
 eexpect "\\demo_node can only be run with cockroach demo"
 
+# Ensure rand_fill_table does not work.
+send "\\rand_fill_table t 1\n"
+eexpect "\\rand_fill_table can only be run with cockroach demo"
+
 # Exit the shell.
 interrupt
 eexpect eof

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -73,6 +72,17 @@ var randMeta = workload.Meta{
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g
 	},
+}
+
+// CreateRandWorkload initializes a workload generator for the given table
+// in the given database to produce numRows random rows of datums.
+func CreateRandWorkload(database, table string, numRows int) workload.Generator {
+	r := randMeta.New().(*random)
+	r.batchSize = numRows
+	r.tableName = table
+	r.connFlags.DBOverride = database
+	r.connFlags.Concurrency = 1
+	return r
 }
 
 // Meta implements the Generator interface.
@@ -262,10 +272,6 @@ AND    i.indisprimary`, relid)
 
 	buf.WriteString(dmlSuffix.String())
 
-	if testing.Verbose() {
-		fmt.Println(buf.String())
-	}
-
 	writeStmt, err := db.Prepare(buf.String())
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -344,6 +350,8 @@ func DatumToGoSQL(d tree.Datum) (interface{}, error) {
 		return d.UUID, nil
 	case *tree.DIPAddr:
 		return d.IPAddr.String(), nil
+	case *tree.DJSON:
+		return d.JSON.String(), nil
 	}
 	return nil, errors.Errorf("unhandled datum type: %s", reflect.TypeOf(d))
 }


### PR DESCRIPTION
Work for #46562.
Fixes #46569.

This PR adds a cockroach demo command to populate an existing
table with random data.

This introduces the demo command

```
\rand_fill_table <tablename> <numrows>
```
which fills a target table in the current database with
a target number of random rows.

Release justification: who know
Release note (cli change): This PR adds the ability for cockroach demo
to fill tables with random data.