### PR TITLE
sql: improve SHOW TABLES to show schema and type

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1314,7 +1314,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 		// still present. Also ensure that the table that was being restored (bank)
 		// is not.
 		sqlDB.Exec(t, `USE data;`)
-		sqlDB.CheckQueryResults(t, `SHOW TABLES;`, [][]string{{"new_table"}})
+		sqlDB.CheckQueryResults(t, `SHOW TABLES;`, [][]string{{"public", "new_table", "table"}})
 	})
 
 	t.Run("cancel", func(t *testing.T) {

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -749,7 +749,7 @@ COPY t (a, b, c) FROM stdin;
 			typ:  "PGDUMP",
 			data: testPgdumpFk,
 			query: map[string][][]string{
-				`SHOW TABLES`:              {{"cities"}, {"weather"}},
+				`SHOW TABLES`:              {{"public", "cities", "table"}, {"public", "weather", "table"}},
 				`SELECT city FROM cities`:  {{"Berkeley"}},
 				`SELECT city FROM weather`: {{"Berkeley"}},
 
@@ -773,7 +773,7 @@ COPY t (a, b, c) FROM stdin;
 			typ:  "PGDUMP",
 			data: testPgdumpFkCircular,
 			query: map[string][][]string{
-				`SHOW TABLES`:        {{"a"}, {"b"}},
+				`SHOW TABLES`:        {{"public", "a", "table"}, {"public", "b", "table"}},
 				`SELECT i, k FROM a`: {{"2", "2"}},
 				`SELECT j FROM b`:    {{"2"}},
 
@@ -823,7 +823,7 @@ COPY t (a, b, c) FROM stdin;
 			data: testPgdumpFk,
 			with: `WITH skip_foreign_keys`,
 			query: map[string][][]string{
-				`SHOW TABLES`: {{"cities"}, {"weather"}},
+				`SHOW TABLES`: {{"public", "cities", "table"}, {"public", "weather", "table"}},
 				// Verify the constraint is skipped.
 				`SELECT dependson_name FROM crdb_internal.backward_dependencies`: {},
 				`SHOW CONSTRAINTS FROM weather`:                                  {},
@@ -841,7 +841,7 @@ COPY t (a, b, c) FROM stdin;
 			data: testPgdumpFk,
 			with: `WITH skip_foreign_keys`,
 			query: map[string][][]string{
-				`SHOW TABLES`: {{"weather"}},
+				`SHOW TABLES`: {{"public", "weather", "table"}},
 			},
 		},
 		{
@@ -897,7 +897,7 @@ COPY t (a, b, c) FROM stdin;
 				CREATE TABLE t (i INT8);
 			`,
 			query: map[string][][]string{
-				`SHOW TABLES`: {{"t"}},
+				`SHOW TABLES`: {{"public", "t", "table"}},
 			},
 		},
 		{

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -51,22 +51,24 @@ func TestZipContainsAllInternalTables(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	rows, err := db.Query(`
-SELECT concat('crdb_internal.', table_name) as name FROM [ SHOW TABLES FROM crdb_internal ] WHERE
-    table_name NOT IN (
--- whitelisted tables that don't need to be in debug zip
-'backward_dependencies',
-'builtin_functions',
-'create_statements',
-'forward_dependencies',
-'index_columns',
-'table_columns',
-'table_indexes',
-'ranges',
-'ranges_no_leases',
-'predefined_comments',
-'session_trace',
-'session_variables',
-'tables'
+SELECT concat('crdb_internal.', table_name) as name
+FROM [ SELECT table_name FROM [ SHOW TABLES FROM crdb_internal ] ]
+WHERE
+table_name NOT IN (
+	-- whitelisted tables that don't need to be in debug zip
+	'backward_dependencies',
+	'builtin_functions',
+	'create_statements',
+	'forward_dependencies',
+	'index_columns',
+	'table_columns',
+	'table_indexes',
+	'ranges',
+	'ranges_no_leases',
+	'predefined_comments',
+	'session_trace',
+	'session_variables',
+	'tables'
 )
 ORDER BY name ASC`)
 	assert.NoError(t, err)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -194,7 +194,10 @@ func registerBackup(r *testRegistry) {
 					var b strings.Builder
 
 					var tables []string
-					rows, err := conn.QueryContext(ctx, fmt.Sprintf("SHOW TABLES FROM %s", db))
+					rows, err := conn.QueryContext(
+						ctx,
+						fmt.Sprintf("SELECT table_name FROM [SHOW TABLES FROM %s] ORDER BY table_name", db),
+					)
 					if err != nil {
 						return "", err
 					}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -318,14 +318,19 @@ func (s *adminServer) DatabaseDetails(
 
 	// Marshal table names.
 	{
-		const nameCol = "table_name"
 		scanner := makeResultScanner(cols)
-		if a, e := len(cols), 1; a != e {
+		if a, e := len(cols), 3; a != e {
 			return nil, s.serverErrorf("show tables columns mismatch: %d != expected %d", a, e)
 		}
 		for _, row := range rows {
-			var tableName string
-			if err := scanner.Scan(row, nameCol, &tableName); err != nil {
+			var schemaName, tableName string
+			if err := scanner.Scan(row, "schema_name", &schemaName); err != nil {
+				return nil, err
+			}
+			if schemaName != "public" {
+				continue
+			}
+			if err := scanner.Scan(row, "table_name", &tableName); err != nil {
 				return nil, err
 			}
 			resp.TableNames = append(resp.TableNames, tableName)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -36,10 +36,10 @@ DROP TABLE t
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 TRUNCATE TABLE t
 
-query T
+query TTT
 SHOW TABLES
 ----
-t
+public  t  table
 
 subtest columns
 
@@ -143,10 +143,10 @@ CREATE TABLE db.t (a INT)
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 DROP DATABASE db
 
-query T
+query TTT
 SHOW TABLES FROM db
 ----
-t
+public  t  table
 
 subtest non_backfill_schema_changes
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -7,46 +7,46 @@ CREATE TABLE crdb_internal.t (x INT)
 query error database "crdb_internal" does not exist
 DROP DATABASE crdb_internal
 
-query T
+query TTT
 SHOW TABLES FROM crdb_internal
 ----
-backward_dependencies
-builtin_functions
-cluster_queries
-cluster_sessions
-cluster_settings
-cluster_transactions
-create_statements
-feature_usage
-forward_dependencies
-gossip_alerts
-gossip_liveness
-gossip_network
-gossip_nodes
-index_columns
-jobs
-kv_node_status
-kv_store_status
-leases
-node_build_info
-node_metrics
-node_queries
-node_runtime_info
-node_sessions
-node_statement_statistics
-node_transactions
-node_txn_stats
-partitions
-predefined_comments
-ranges
-ranges_no_leases
-schema_changes
-session_trace
-session_variables
-table_columns
-table_indexes
-tables
-zones
+crdb_internal  backward_dependencies      table
+crdb_internal  builtin_functions          table
+crdb_internal  cluster_queries            table
+crdb_internal  cluster_sessions           table
+crdb_internal  cluster_settings           table
+crdb_internal  cluster_transactions       table
+crdb_internal  create_statements          table
+crdb_internal  feature_usage              table
+crdb_internal  forward_dependencies       table
+crdb_internal  gossip_alerts              table
+crdb_internal  gossip_liveness            table
+crdb_internal  gossip_network             table
+crdb_internal  gossip_nodes               table
+crdb_internal  index_columns              table
+crdb_internal  jobs                       table
+crdb_internal  kv_node_status             table
+crdb_internal  kv_store_status            table
+crdb_internal  leases                     table
+crdb_internal  node_build_info            table
+crdb_internal  node_metrics               table
+crdb_internal  node_queries               table
+crdb_internal  node_runtime_info          table
+crdb_internal  node_sessions              table
+crdb_internal  node_statement_statistics  table
+crdb_internal  node_transactions          table
+crdb_internal  node_txn_stats             table
+crdb_internal  partitions                 table
+crdb_internal  predefined_comments        table
+crdb_internal  ranges                     view
+crdb_internal  ranges_no_leases           table
+crdb_internal  schema_changes             table
+crdb_internal  session_trace              table
+crdb_internal  session_variables          table
+crdb_internal  table_columns              table
+crdb_internal  table_indexes              table
+crdb_internal  tables                     table
+crdb_internal  zones                      table
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -170,12 +170,12 @@ users       foo         true        2             id           ASC        false 
 statement ok
 CREATE VIEW v2 AS SELECT name FROM v
 
-query T
+query TTT
 SHOW TABLES
 ----
-users
-v
-v2
+public  users  table
+public  v      view
+public  v2     view
 
 statement ok
 GRANT ALL ON users to testuser
@@ -199,10 +199,10 @@ SHOW INDEXES FROM users
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
 users       primary     false       1             id           ASC        false    false
 
-query T
+query TTT
 SHOW TABLES
 ----
-users
+public  users  table
 
 # Test the syntax without a '@'
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -6,11 +6,11 @@ CREATE TABLE a (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-a
-b
+public  a  table
+public  b  table
 
 statement ok
 INSERT INTO a VALUES (3),(7),(2)
@@ -35,10 +35,10 @@ SELECT job_type, status FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' OR 
 SCHEMA CHANGE     succeeded
 SCHEMA CHANGE GC  running
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-b
+public  b  table
 
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -12,12 +12,12 @@ CREATE VIEW b AS SELECT k,v from a
 statement ok
 CREATE VIEW c AS SELECT k,v from b
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-a
-b
-c
+public  a  table
+public  b  view
+public  c  view
 
 statement error cannot drop relation "a" because view "b" depends on it
 DROP TABLE a
@@ -40,14 +40,14 @@ DROP VIEW d
 statement ok
 GRANT ALL ON d TO testuser
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-a
-b
-c
-d
-diamond
+public  a        table
+public  b        view
+public  c        view
+public  d        view
+public  diamond  view
 
 user testuser
 
@@ -77,29 +77,26 @@ GRANT ALL ON testuser2 to testuser
 statement ok
 GRANT ALL ON testuser3 to testuser
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-a
-b
-c
-d
-diamond
-testuser1
-testuser2
-testuser3
+public  a          table
+public  b          view
+public  c          view
+public  d          view
+public  diamond    view
+public  testuser1  view
+public  testuser2  view
+public  testuser3  view
 
 user testuser
 
 statement ok
 DROP VIEW testuser3
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-d
-testuser1
-testuser2
 
 statement error cannot drop relation "testuser1" because view "testuser2" depends on it
 DROP VIEW testuser1
@@ -110,10 +107,9 @@ DROP VIEW testuser1 RESTRICT
 statement ok
 DROP VIEW testuser1 CASCADE
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-d
 
 statement error pgcode 42P01 relation "testuser2" does not exist
 DROP VIEW testuser2
@@ -142,7 +138,7 @@ user root
 statement ok
 DROP TABLE a CASCADE
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -828,26 +828,26 @@ statement ok
 DROP INDEX refers@another_idx
 
 # refers is not visible because it is in the ADD state.
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-bar
-child
-customers
-delivery
-domain_modules
-domains
-foo
-grandchild
-modules
-pairs
-referee
-refpairs
-refpairs_c_between
-refpairs_wrong_order
-tx
-tx_leg
-unindexed
+public  bar                   table
+public  child                 table
+public  customers             table
+public  delivery              table
+public  domain_modules        table
+public  domains               table
+public  foo                   table
+public  grandchild            table
+public  modules               table
+public  pairs                 table
+public  referee               table
+public  refpairs              table
+public  refpairs_c_between    table
+public  refpairs_wrong_order  table
+public  tx                    table
+public  tx_leg                table
+public  unindexed             table
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -1072,26 +1072,26 @@ statement ok
 DROP INDEX refers@another_idx
 
 # refers is not visible because it is in the ADD state.
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-bar
-child
-customers
-delivery
-domain_modules
-domains
-foo
-grandchild
-modules
-pairs
-referee
-refpairs
-refpairs_c_between
-refpairs_wrong_order
-tx
-tx_leg
-unindexed
+public  bar                   table
+public  child                 table
+public  customers             table
+public  delivery              table
+public  domain_modules        table
+public  domains               table
+public  foo                   table
+public  grandchild            table
+public  modules               table
+public  pairs                 table
+public  referee               table
+public  refpairs              table
+public  refpairs_c_between    table
+public  refpairs_wrong_order  table
+public  tx                    table
+public  tx_leg                table
+public  unindexed             table
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -11,30 +11,30 @@ CREATE TABLE information_schema.t (x INT)
 query error database "information_schema" does not exist
 DROP DATABASE information_schema
 
-query T
+query TTT
 SHOW TABLES FROM information_schema
 ----
-administrable_role_authorizations
-applicable_roles
-check_constraints
-column_privileges
-columns
-constraint_column_usage
-enabled_roles
-key_column_usage
-parameters
-referential_constraints
-role_table_grants
-routines
-schema_privileges
-schemata
-sequences
-statistics
-table_constraints
-table_privileges
-tables
-user_privileges
-views
+information_schema  administrable_role_authorizations  table
+information_schema  applicable_roles                   table
+information_schema  check_constraints                  table
+information_schema  column_privileges                  table
+information_schema  columns                            table
+information_schema  constraint_column_usage            table
+information_schema  enabled_roles                      table
+information_schema  key_column_usage                   table
+information_schema  parameters                         table
+information_schema  referential_constraints            table
+information_schema  role_table_grants                  table
+information_schema  routines                           table
+information_schema  schema_privileges                  table
+information_schema  schemata                           table
+information_schema  sequences                          table
+information_schema  statistics                         table
+information_schema  table_constraints                  table
+information_schema  table_privileges                   table
+information_schema  tables                             table
+information_schema  user_privileges                    table
+information_schema  views                              table
 
 # Verify that the name is not special for databases.
 
@@ -118,30 +118,30 @@ postgres
 system
 test
 
-query T
+query TTT
 SHOW TABLES FROM test.information_schema
 ----
-administrable_role_authorizations
-applicable_roles
-check_constraints
-column_privileges
-columns
-constraint_column_usage
-enabled_roles
-key_column_usage
-parameters
-referential_constraints
-role_table_grants
-routines
-schema_privileges
-schemata
-sequences
-statistics
-table_constraints
-table_privileges
-tables
-user_privileges
-views
+information_schema  administrable_role_authorizations  table
+information_schema  applicable_roles                   table
+information_schema  check_constraints                  table
+information_schema  column_privileges                  table
+information_schema  columns                            table
+information_schema  constraint_column_usage            table
+information_schema  enabled_roles                      table
+information_schema  key_column_usage                   table
+information_schema  parameters                         table
+information_schema  referential_constraints            table
+information_schema  role_table_grants                  table
+information_schema  routines                           table
+information_schema  schema_privileges                  table
+information_schema  schemata                           table
+information_schema  sequences                          table
+information_schema  statistics                         table
+information_schema  table_constraints                  table
+information_schema  table_privileges                   table
+information_schema  tables                             table
+information_schema  user_privileges                    table
+information_schema  views                              table
 
 query TT colnames
 SHOW CREATE TABLE information_schema.tables

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -5,27 +5,27 @@ statement ok
 CREATE DATABASE public; CREATE TABLE public.public.t(a INT)
 
 # "public" with the current database designates the public schema
-query T
+query TTT
 SHOW TABLES FROM public
 ----
-a
+public  a  table
 
 # To access all tables in database "public", one must specify
 # its public schema explicitly.
-query T
+query TTT
 SHOW TABLES FROM public.public
 ----
-t
+public  t  table
 
 # Of course one can also list the tables in "public" by making it the
 # current database.
 statement ok
 SET database = public
 
-query T
+query TTT
 SHOW TABLES
 ----
-t
+public  t  table
 
 statement ok
 SET database = test; DROP DATABASE public

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -14,58 +14,58 @@ CREATE TABLE pg_catalog.t (x INT)
 query error database "pg_catalog" does not exist
 DROP DATABASE pg_catalog
 
-query T
+query TTT
 SHOW TABLES FROM pg_catalog
 ----
-pg_am
-pg_attrdef
-pg_attribute
-pg_auth_members
-pg_authid
-pg_available_extensions
-pg_cast
-pg_class
-pg_collation
-pg_constraint
-pg_conversion
-pg_database
-pg_default_acl
-pg_depend
-pg_description
-pg_enum
-pg_extension
-pg_foreign_data_wrapper
-pg_foreign_server
-pg_foreign_table
-pg_index
-pg_indexes
-pg_inherits
-pg_language
-pg_locks
-pg_matviews
-pg_namespace
-pg_operator
-pg_prepared_statements
-pg_prepared_xacts
-pg_proc
-pg_range
-pg_rewrite
-pg_roles
-pg_seclabel
-pg_seclabels
-pg_sequence
-pg_settings
-pg_shdepend
-pg_shdescription
-pg_shseclabel
-pg_stat_activity
-pg_tables
-pg_tablespace
-pg_trigger
-pg_type
-pg_user
-pg_user_mapping
-pg_views
+pg_catalog  pg_am                    table
+pg_catalog  pg_attrdef               table
+pg_catalog  pg_attribute             table
+pg_catalog  pg_auth_members          table
+pg_catalog  pg_authid                table
+pg_catalog  pg_available_extensions  table
+pg_catalog  pg_cast                  table
+pg_catalog  pg_class                 table
+pg_catalog  pg_collation             table
+pg_catalog  pg_constraint            table
+pg_catalog  pg_conversion            table
+pg_catalog  pg_database              table
+pg_catalog  pg_default_acl           table
+pg_catalog  pg_depend                table
+pg_catalog  pg_description           table
+pg_catalog  pg_enum                  table
+pg_catalog  pg_extension             table
+pg_catalog  pg_foreign_data_wrapper  table
+pg_catalog  pg_foreign_server        table
+pg_catalog  pg_foreign_table         table
+pg_catalog  pg_index                 table
+pg_catalog  pg_indexes               table
+pg_catalog  pg_inherits              table
+pg_catalog  pg_language              table
+pg_catalog  pg_locks                 table
+pg_catalog  pg_matviews              table
+pg_catalog  pg_namespace             table
+pg_catalog  pg_operator              table
+pg_catalog  pg_prepared_statements   table
+pg_catalog  pg_prepared_xacts        table
+pg_catalog  pg_proc                  table
+pg_catalog  pg_range                 table
+pg_catalog  pg_rewrite               table
+pg_catalog  pg_roles                 table
+pg_catalog  pg_seclabel              table
+pg_catalog  pg_seclabels             table
+pg_catalog  pg_sequence              table
+pg_catalog  pg_settings              table
+pg_catalog  pg_shdepend              table
+pg_catalog  pg_shdescription         table
+pg_catalog  pg_shseclabel            table
+pg_catalog  pg_stat_activity         table
+pg_catalog  pg_tables                table
+pg_catalog  pg_tablespace            table
+pg_catalog  pg_trigger               table
+pg_catalog  pg_type                  table
+pg_catalog  pg_user                  table
+pg_catalog  pg_user_mapping          table
+pg_catalog  pg_views                 table
 
 # Verify "pg_catalog" is a regular db name
 
@@ -89,58 +89,58 @@ SELECT * FROM pg_catalog.pg_class c WHERE nonexistent_function()
 
 # Verify pg_catalog handles reflection correctly.
 
-query T
+query TTT
 SHOW TABLES FROM test.pg_catalog
 ----
-pg_am
-pg_attrdef
-pg_attribute
-pg_auth_members
-pg_authid
-pg_available_extensions
-pg_cast
-pg_class
-pg_collation
-pg_constraint
-pg_conversion
-pg_database
-pg_default_acl
-pg_depend
-pg_description
-pg_enum
-pg_extension
-pg_foreign_data_wrapper
-pg_foreign_server
-pg_foreign_table
-pg_index
-pg_indexes
-pg_inherits
-pg_language
-pg_locks
-pg_matviews
-pg_namespace
-pg_operator
-pg_prepared_statements
-pg_prepared_xacts
-pg_proc
-pg_range
-pg_rewrite
-pg_roles
-pg_seclabel
-pg_seclabels
-pg_sequence
-pg_settings
-pg_shdepend
-pg_shdescription
-pg_shseclabel
-pg_stat_activity
-pg_tables
-pg_tablespace
-pg_trigger
-pg_type
-pg_user
-pg_user_mapping
-pg_views
+pg_catalog  pg_am                    table
+pg_catalog  pg_attrdef               table
+pg_catalog  pg_attribute             table
+pg_catalog  pg_auth_members          table
+pg_catalog  pg_authid                table
+pg_catalog  pg_available_extensions  table
+pg_catalog  pg_cast                  table
+pg_catalog  pg_class                 table
+pg_catalog  pg_collation             table
+pg_catalog  pg_constraint            table
+pg_catalog  pg_conversion            table
+pg_catalog  pg_database              table
+pg_catalog  pg_default_acl           table
+pg_catalog  pg_depend                table
+pg_catalog  pg_description           table
+pg_catalog  pg_enum                  table
+pg_catalog  pg_extension             table
+pg_catalog  pg_foreign_data_wrapper  table
+pg_catalog  pg_foreign_server        table
+pg_catalog  pg_foreign_table         table
+pg_catalog  pg_index                 table
+pg_catalog  pg_indexes               table
+pg_catalog  pg_inherits              table
+pg_catalog  pg_language              table
+pg_catalog  pg_locks                 table
+pg_catalog  pg_matviews              table
+pg_catalog  pg_namespace             table
+pg_catalog  pg_operator              table
+pg_catalog  pg_prepared_statements   table
+pg_catalog  pg_prepared_xacts        table
+pg_catalog  pg_proc                  table
+pg_catalog  pg_range                 table
+pg_catalog  pg_rewrite               table
+pg_catalog  pg_roles                 table
+pg_catalog  pg_seclabel              table
+pg_catalog  pg_seclabels             table
+pg_catalog  pg_sequence              table
+pg_catalog  pg_settings              table
+pg_catalog  pg_shdepend              table
+pg_catalog  pg_shdescription         table
+pg_catalog  pg_shseclabel            table
+pg_catalog  pg_stat_activity         table
+pg_catalog  pg_tables                table
+pg_catalog  pg_tablespace            table
+pg_catalog  pg_trigger               table
+pg_catalog  pg_type                  table
+pg_catalog  pg_user                  table
+pg_catalog  pg_user_mapping          table
+pg_catalog  pg_views                 table
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -119,10 +119,10 @@ user root
 statement ok
 CREATE VIEW t.v AS SELECT k,v FROM u.kv
 
-query T
+query TTT
 SHOW TABLES FROM u
 ----
-kv
+public  kv  table
 
 statement error cannot rename database because relation "t.public.v" depends on relation "u.public.kv"
 ALTER DATABASE u RENAME TO v

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -19,10 +19,10 @@ SELECT * FROM kv
 1 2
 3 4
 
-query T
+query TTT
 SHOW TABLES
 ----
-kv
+public  kv  table
 
 statement ok
 ALTER TABLE kv RENAME TO new_kv
@@ -36,10 +36,10 @@ SELECT * FROM new_kv
 1 2
 3 4
 
-query T
+query TTT
 SHOW TABLES
 ----
-new_kv
+public  new_kv  table
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -95,11 +95,11 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER TABLE test.t RENAME TO t2
 
-query T
+query TTT
 SHOW TABLES
 ----
-new_kv
-t2
+public  new_kv  table
+public  t2      table
 
 user testuser
 
@@ -122,15 +122,15 @@ ALTER TABLE test.new_kv RENAME TO test2.t
 statement ok
 ALTER TABLE test.t2 RENAME TO test2.t2
 
-query T
+query TTT
 SHOW TABLES
 ----
 
-query T
+query TTT
 SHOW TABLES FROM test2
 ----
-t
-t2
+public  t   table
+public  t2  table
 
 user root
 
@@ -263,10 +263,10 @@ INSERT INTO d.kv2 (k,v) VALUES ('c', 'd')
 statement ok
 USE d
 
-query T
+query TTT
 SHOW TABLES
 ----
-kv
+public  kv  table
 
 query TTT
 EXPLAIN ALTER TABLE kv RENAME TO kv2
@@ -276,7 +276,7 @@ EXPLAIN ALTER TABLE kv RENAME TO kv2
 rename table  ·            ·
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
-query T
+query TTT
 SHOW TABLES
 ----
-kv
+public  kv  table

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -22,11 +22,11 @@ SELECT * FROM v
 1 2
 3 4
 
-query T
+query TTT
 SHOW TABLES
 ----
-kv
-v
+public  kv  table
+public  v   view
 
 statement error pgcode 42809 "kv" is not a view
 ALTER VIEW kv RENAME TO new_kv
@@ -44,11 +44,11 @@ SELECT * FROM new_v
 1 2
 3 4
 
-query T
+query TTT
 SHOW TABLES
 ----
-kv
-new_v
+public  kv     table
+public  new_v  view
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -107,13 +107,13 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER VIEW test.v RENAME TO v2
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
-kv
-new_v
-t
-v2
+public  kv     table
+public  new_v  view
+public  t      table
+public  v2     view
 
 user testuser
 
@@ -136,15 +136,15 @@ ALTER VIEW test.new_v RENAME TO test2.v
 statement ok
 ALTER VIEW test.v2 RENAME TO test2.v2
 
-query T
+query TTT
 SHOW TABLES FROM test
 ----
 
-query T
+query TTT
 SHOW TABLES FROM test2
 ----
-v
-v2
+public  v   view
+public  v2  view
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1146,15 +1146,14 @@ SHOW DATABASES
 ----
 publicdb
 
-query T
+query TTT
 SHOW TABLES FROM publicdb
 ----
-publictable
+public  publictable  table
 
-query T
+query TTT
 SHOW TABLES FROM privatedb
 ----
-publictable
 
 statement ok
 SELECT * FROM publicdb.publictable
@@ -1195,6 +1194,6 @@ SELECT * FROM publicdb.publictable
 statement error user testuser does not have INSERT privilege on relation publictable
 INSERT INTO publicdb.publictable VALUES (1)
 
-query T
+query TTT
 SHOW TABLES FROM publicdb
 ----

--- a/pkg/sql/logictest/testdata/logic_test/save_table
+++ b/pkg/sql/logictest/testdata/logic_test/save_table
@@ -77,20 +77,20 @@ key  val
 9    nine
 10   one-zero
 
-query T rowsort
+query TTT rowsort
 SHOW TABLES
 ----
-save_table_test_scan_1
-st_lookup_join_2
-st_project_1
-st_scan_4
-st_select_3
-st_test_merge_join_2
-st_test_project_1
-st_test_scan_3
-st_test_scan_4
-t
-u
+public  save_table_test_scan_1  table
+public  st_lookup_join_2        table
+public  st_project_1            table
+public  st_scan_4               table
+public  st_select_3             table
+public  st_test_merge_join_2    table
+public  st_test_project_1       table
+public  st_test_scan_3          table
+public  st_test_scan_4          table
+public  t                       table
+public  u                       table
 
 # Only root may use the saveTableNode.
 

--- a/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
+++ b/pkg/sql/logictest/testdata/logic_test/secondary_index_column_families
@@ -117,4 +117,3 @@ query II
 SELECT y, z FROM t42992@i
 ----
 NULL 2
-

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -1,7 +1,7 @@
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.
 
-query T
+query TTT
 SHOW TABLES
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -25,10 +25,10 @@ statement ok
 CREATE TABLE bar (k INT PRIMARY KEY)
 
 # Verify that the table is indeed in "foo".
-query T
+query TTT
 SHOW TABLES FROM foo
 ----
-bar
+public  bar  table
 
 # Verify set to empty string.
 statement ok
@@ -44,10 +44,10 @@ statement error no database specified
 SHOW TABLES
 
 # Verify SHOW TABLES FROM works when there is no current database.
-query T
+query TTT
 SHOW TABLES FROM foo
 ----
-bar
+public  bar  table
 
 # SET statement succeeds, CREATE TABLE fails.
 statement error pgcode 42P07 relation \"bar\" already exists
@@ -60,10 +60,10 @@ database
 foo
 
 # SET succeeds
-query T
+query TTT
 SHOW TABLES from foo
 ----
-bar
+public  bar  table
 
 statement error invalid variable name: ""
 SET ROW (1, TRUE, NULL)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -172,67 +172,67 @@ SELECT * FROM [SHOW SEQUENCES FROM system]
 ----
 sequence_name
 
-query T colnames,rowsort
+query TTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
-table_name
-namespace_deprecated
-descriptor
-users
-zones
-settings
-lease
-eventlog
-rangelog
-ui
-jobs
-web_sessions
-table_statistics
-locations
-role_members
-comments
-replication_constraint_stats
-replication_critical_localities
-replication_stats
-reports_meta
-namespace
-protected_ts_meta
-protected_ts_records
-statement_bundle_chunks
-statement_diagnostics_requests
-statement_diagnostics
-role_options
+schema_name  table_name                       type
+public       namespace_deprecated             table
+public       descriptor                       table
+public       users                            table
+public       zones                            table
+public       settings                         table
+public       lease                            table
+public       eventlog                         table
+public       rangelog                         table
+public       ui                               table
+public       jobs                             table
+public       web_sessions                     table
+public       table_statistics                 table
+public       locations                        table
+public       role_members                     table
+public       comments                         table
+public       replication_constraint_stats     table
+public       replication_critical_localities  table
+public       replication_stats                table
+public       reports_meta                     table
+public       namespace                        table
+public       protected_ts_meta                table
+public       protected_ts_records             table
+public       role_options                     table
+public       statement_bundle_chunks          table
+public       statement_diagnostics_requests   table
+public       statement_diagnostics            table
 
-query TT colnames,rowsort
+query TTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
-table_name                       comment
-namespace_deprecated             ·
-descriptor                       ·
-users                            ·
-zones                            ·
-settings                         ·
-lease                            ·
-eventlog                         ·
-rangelog                         ·
-ui                               ·
-jobs                             ·
-web_sessions                     ·
-table_statistics                 ·
-locations                        ·
-role_members                     ·
-comments                         ·
-replication_constraint_stats     ·
-replication_critical_localities  ·
-replication_stats                ·
-reports_meta                     ·
-namespace                        ·
-protected_ts_meta                ·
-protected_ts_records             ·
-statement_bundle_chunks          ·
-statement_diagnostics_requests   ·
-statement_diagnostics            ·
-role_options                     ·
+schema_name  table_name                       type   comment
+public       namespace_deprecated             table  ·
+public       descriptor                       table  ·
+public       users                            table  ·
+public       zones                            table  ·
+public       settings                         table  ·
+public       lease                            table  ·
+public       eventlog                         table  ·
+public       rangelog                         table  ·
+public       ui                               table  ·
+public       jobs                             table  ·
+public       web_sessions                     table  ·
+public       table_statistics                 table  ·
+public       locations                        table  ·
+public       role_members                     table  ·
+public       comments                         table  ·
+public       replication_constraint_stats     table  ·
+public       replication_critical_localities  table  ·
+public       replication_stats                table  ·
+public       reports_meta                     table  ·
+public       namespace                        table  ·
+public       protected_ts_meta                table  ·
+public       protected_ts_records             table  ·
+public       role_options                     table  ·
+public       statement_bundle_chunks          table  ·
+public       statement_diagnostics_requests   table  ·
+public       statement_diagnostics            table  ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries
@@ -258,11 +258,11 @@ information_schema
 pg_catalog
 public
 
-query T colnames
+query TTT colnames
 CREATE TABLE foo(x INT); SELECT * FROM [SHOW TABLES]
 ----
-table_name
-foo
+schema_name  table_name  type
+public       foo         table
 
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -6,35 +6,35 @@ postgres
 system
 test
 
-query T
+query TTT
 SHOW TABLES FROM system
 ----
-comments
-descriptor
-eventlog
-jobs
-lease
-locations
-namespace
-namespace_deprecated
-protected_ts_meta
-protected_ts_records
-rangelog
-replication_constraint_stats
-replication_critical_localities
-replication_stats
-reports_meta
-role_members
-role_options
-settings
-statement_bundle_chunks
-statement_diagnostics
-statement_diagnostics_requests
-table_statistics
-ui
-users
-web_sessions
-zones
+public  comments                         table
+public  descriptor                       table
+public  eventlog                         table
+public  jobs                             table
+public  lease                            table
+public  locations                        table
+public  namespace                        table
+public  namespace_deprecated             table
+public  protected_ts_meta                table
+public  protected_ts_records             table
+public  rangelog                         table
+public  replication_constraint_stats     table
+public  replication_critical_localities  table
+public  replication_stats                table
+public  reports_meta                     table
+public  role_members                     table
+public  role_options                     table
+public  settings                         table
+public  statement_bundle_chunks          table
+public  statement_diagnostics            table
+public  statement_diagnostics_requests   table
+public  table_statistics                 table
+public  ui                               table
+public  users                            table
+public  web_sessions                     table
+public  zones                            table
 
 query I rowsort
 SELECT id FROM system.descriptor

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -40,11 +40,11 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 statement ok
 COMMENT ON TABLE a IS 'a_comment'
 
-query T colnames
+query TTT colnames
 SHOW TABLES FROM test
 ----
-table_name
-a
+schema_name  table_name  type
+public       a           table
 
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
@@ -135,15 +135,15 @@ a            INT8       false        NULL            ·                      {pr
 b            INT8       false        NULL            ·                      {primary}  false
 c            INT8       false        NULL            ·                      {primary}  false
 
-query TT
+query TTTT
 SHOW TABLES FROM test WITH COMMENT
 ----
-a  a_comment
-b  ·
-c  ·
-d  ·
-e  ·
-f  ·
+public  a  table  a_comment
+public  b  table  ·
+public  c  table  ·
+public  d  table  ·
+public  e  table  ·
+public  f  table  ·
 
 statement ok
 SET DATABASE = ""

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -4,6 +4,19 @@ CREATE TEMP TABLE a_temp(a INT PRIMARY KEY)
 statement ok
 SET experimental_enable_temp_tables=true
 
+subtest show_tables
+
+statement ok
+CREATE TEMP TABLE tbl (a int)
+
+query TT rowsort
+SELECT table_name, type FROM [SHOW TABLES]
+----
+tbl  table
+
+statement ok
+DROP TABLE tbl
+
 subtest test_meta_tables
 
 statement ok
@@ -35,11 +48,11 @@ SELECT count(1) FROM pg_namespace WHERE nspname LIKE 'pg_temp_%'
 ----
 1
 
-query T
-SELECT * FROM [SHOW TABLES FROM pg_temp] ORDER BY 1
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
 ----
-temp_table_ref
 temp_table_test
+temp_table_ref
 
 statement ok
 DROP TABLE temp_table_ref CASCADE; DROP TABLE temp_table_test CASCADE

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -182,40 +182,51 @@ sort                          ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-sort                          ·            ·
- │                            order        +table_name
- └── render                   ·            ·
-      └── filter              ·            ·
-           │                  filter       table_schema = 'public'
-           └── virtual table  ·            ·
-·                             source       ·
+·                                       distributed  false
+·                                       vectorized   false
+render                                  ·            ·
+ └── sort                               ·            ·
+      │                                 order        +nspname,+relname
+      └── render                        ·            ·
+           └── hash-join                ·            ·
+                │                       type         inner
+                │                       equality     (oid) = (relnamespace)
+                ├── filter              ·            ·
+                │    │                  filter       nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog')
+                │    └── virtual table  ·            ·
+                │                       source       ·
+                └── filter              ·            ·
+                     │                  filter       relkind IN ('S', 'r', 'v')
+                     └── virtual table  ·            ·
+·                                       source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-·                                  distributed  false
-·                                  vectorized   false
-render                             ·            ·
- └── hash-join                     ·            ·
-      │                            type         left outer
-      │                            equality     (oid) = (objoid)
-      ├── hash-join                ·            ·
-      │    │                       type         inner
-      │    │                       equality     (relnamespace) = (oid)
-      │    ├── filter              ·            ·
-      │    │    │                  filter       relkind IN ('r', 'v')
-      │    │    └── virtual table  ·            ·
-      │    │                       source       ·
-      │    └── filter              ·            ·
-      │         │                  filter       nspname = 'public'
-      │         └── virtual table  ·            ·
-      │                            source       ·
-      └── filter                   ·            ·
-           │                       filter       objsubid = 0
-           └── virtual table       ·            ·
-·                                  source       ·
+·                                            distributed  false
+·                                            vectorized   false
+render                                       ·            ·
+ └── sort                                    ·            ·
+      │                                      order        +nspname,+relname
+      └── render                             ·            ·
+           └── hash-join                     ·            ·
+                │                            type         left outer
+                │                            equality     (oid) = (objoid)
+                ├── hash-join                ·            ·
+                │    │                       type         inner
+                │    │                       equality     (oid) = (relnamespace)
+                │    ├── filter              ·            ·
+                │    │    │                  filter       nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog')
+                │    │    └── virtual table  ·            ·
+                │    │                       source       ·
+                │    └── filter              ·            ·
+                │         │                  filter       relkind IN ('S', 'r', 'v')
+                │         └── virtual table  ·            ·
+                │                            source       ·
+                └── filter                   ·            ·
+                     │                       filter       objsubid = 0
+                     └── virtual table       ·            ·
+·                                            source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -556,7 +556,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
-			baseTest.Results("comments").Others(25),
+			baseTest.Results("public", "comments", "table").Others(25),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
 			baseTest.Results("crdb_internal").Others(3),

--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -494,7 +494,7 @@ func (w *worker) generatePlaceholders(
 // getTableNames fetches the names of all the tables in db and stores them in
 // w.state.
 func (w *querylog) getTableNames(db *gosql.DB) error {
-	rows, err := db.Query(`SHOW TABLES`)
+	rows, err := db.Query(`SELECT table_name FROM [SHOW TABLES] ORDER BY table_name`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/46553. 

Release justification: none - aiming for 20.2 release.

Release note (sql change): This change modifies SHOW TABLES to return
schema and table type. Furthermore, sequences will now appear in SHOW
TABLES. Any user who relies on SHOW TABLES to return one column can use
`SELECT table_name FROM [SHOW TABLES]` to get compatible behavior
between versions.