### PR TITLE
colflow: add testing cluster setting to change batch size

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -14,8 +14,10 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/errors"
 )
 
 // Batch is the type that columnar operators receive and produce. It
@@ -64,37 +66,33 @@ type Batch interface {
 
 var _ Batch = &MemBatch{}
 
-const (
-	// MinBatchSize is the minimum acceptable size of batches.
-	MinBatchSize = 3
-	// MaxBatchSize is the maximum acceptable size of batches.
-	MaxBatchSize = 4096
-)
-
 // TODO(jordan): tune.
-var batchSize = 1024
+const defaultBatchSize = 1024
+
+var batchSize int64 = defaultBatchSize
 
 // BatchSize is the maximum number of tuples that fit in a column batch.
 func BatchSize() int {
-	return batchSize
+	return int(atomic.LoadInt64(&batchSize))
 }
 
+// MaxBatchSize is the maximum acceptable size of batches.
+const MaxBatchSize = 4096
+
 // SetBatchSizeForTests modifies batchSize variable. It should only be used in
-// tests.
-func SetBatchSizeForTests(newBatchSize int) {
+// tests. batch sizes greater than MaxBatchSize will return an error.
+func SetBatchSizeForTests(newBatchSize int) error {
 	if newBatchSize > MaxBatchSize {
-		panic(
-			fmt.Sprintf("requested batch size %d is greater than MaxBatchSize %d",
-				newBatchSize, MaxBatchSize),
-		)
+		return errors.Errorf("batch size %d greater than maximum allowed batch size %d", newBatchSize, MaxBatchSize)
 	}
-	if newBatchSize < MinBatchSize {
-		panic(
-			fmt.Sprintf("requested batch size %d is smaller than MinBatchSize %d",
-				newBatchSize, MinBatchSize),
-		)
-	}
-	batchSize = newBatchSize
+	atomic.SwapInt64(&batchSize, int64(newBatchSize))
+	return nil
+}
+
+// ResetBatchSizeForTests resets the batchSize variable to the default batch
+// size. It should only be used in tests.
+func ResetBatchSizeForTests() {
+	atomic.SwapInt64(&batchSize, defaultBatchSize)
 }
 
 // NewMemBatch allocates a new in-memory Batch. A coltypes.Unknown type

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -305,9 +305,9 @@ func TestRouterOutputNext(t *testing.T) {
 				// If a full batch is smaller than our small batch size, reduce it, since
 				// this test relies on multiple batches returned from the input.
 				smallBatchSize = 2
-				if smallBatchSize >= coldata.MinBatchSize {
+				if smallBatchSize >= minBatchSize {
 					// Sanity check.
-					t.Fatalf("smallBatchSize=%d still too large (must be less than MinBatchSize=%d)", smallBatchSize, coldata.MinBatchSize)
+					t.Fatalf("smallBatchSize=%d still too large (must be less than minBatchSize=%d)", smallBatchSize, minBatchSize)
 				}
 				blockThreshold = 1
 			}
@@ -538,8 +538,8 @@ func TestHashRouterComputesDestination(t *testing.T) {
 	const expectedBatchSize = 1024
 	batchSize := coldata.BatchSize()
 	if batchSize != expectedBatchSize {
-		coldata.SetBatchSizeForTests(expectedBatchSize)
-		defer func(batchSize int) { coldata.SetBatchSizeForTests(batchSize) }(batchSize)
+		require.NoError(t, coldata.SetBatchSizeForTests(expectedBatchSize))
+		defer func(batchSize int) { require.NoError(t, coldata.SetBatchSizeForTests(batchSize)) }(batchSize)
 		batchSize = expectedBatchSize
 	}
 	data := make(tuples, batchSize)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -20,8 +20,10 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
@@ -30,6 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -136,6 +140,21 @@ func NewVectorizedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 	return vf
 }
 
+// VectorizeTestingBatchSize is a testing cluster setting that sets the default
+// batch size used by the vectorized execution engine. A low batch size is
+// useful to test batch reuse.
+var VectorizeTestingBatchSize = settings.RegisterValidatedIntSetting(
+	"sql.testing.vectorize.batch_size",
+	fmt.Sprintf("the size of a batch of rows in the vectorized engine (0=default, value must be less than %d)", coldata.MaxBatchSize),
+	0,
+	func(newBatchSize int64) error {
+		if newBatchSize > coldata.MaxBatchSize {
+			return pgerror.Newf(pgcode.InvalidParameterValue, "batch size %d may not be larger than %d", newBatchSize, coldata.MaxBatchSize)
+		}
+		return nil
+	},
+)
+
 // Setup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
@@ -151,6 +170,19 @@ func (f *vectorizedFlow) Setup(
 		recordingStats = true
 	}
 	helper := &vectorizedFlowCreatorHelper{f: f.FlowBase}
+
+	testingBatchSize := int64(0)
+	if f.FlowCtx.Cfg.Settings != nil {
+		testingBatchSize = VectorizeTestingBatchSize.Get(&f.FlowCtx.Cfg.Settings.SV)
+	}
+	if testingBatchSize != 0 {
+		if err := coldata.SetBatchSizeForTests(int(testingBatchSize)); err != nil {
+			return ctx, err
+		}
+	} else {
+		coldata.ResetBatchSizeForTests()
+	}
+
 	// Create a name for this flow's temporary directory. Note that this directory
 	// is lazily created when necessary and cleaned up in Cleanup(). The directory
 	// name is the flow's ID in most cases apart from when the flow's ID is unset


### PR DESCRIPTION
Release justification: non-production code change. This change adds a cluster
setting for increased testing coverage.

This setting allows us to easily set a batch size of 1 cluster-wide in order to
stress the vectorized execution engine.

Release note: None (testing change)