### PR TITLE
build: upgrade to go 1.13.9 and cmake 3.17.0

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -36,13 +36,21 @@ echo 'export COCKROACH_BUILDER_CCACHE=1' >> ~/.bashrc_bootstrap
 echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 . ~/.bashrc_bootstrap
 
+# Upgrade cmake.
+trap 'rm -f /tmp/cmake.tgz' EXIT
+curl https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz > /tmp/cmake.tgz
+sha256sum -c - <<EOF
+b44685227b9f9be103e305efa2075a8ccf2415807fbcf1fc192da4d36aacc9f5  /tmp/cmake.tgz
+EOF
+sudo tar -C /usr -zxf /tmp/cmake.tgz && rm /tmp/cmake.tgz
+
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569  /tmp/go.tgz
+34bb19d806e0bc4ad8f508ae24bade5e9fedfa53d09be63b488a9314d2d4f31d  /tmp/go.tgz
 EOF
-sudo tar -C /usr/local -zxf /tmp/go.tgz
+sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 
 # Clone CockroachDB.
 git clone https://github.com/cockroachdb/cockroach "$(go env GOPATH)/src/github.com/cockroachdb/cockroach"

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200115-154509
+version=20200326-092324
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -189,6 +189,13 @@ RUN git clone git://git.sv.gnu.org/sed \
  && cd .. \
  && rm -rf sed
 
+# xenial installs cmake 3.5.1. We need a newer version. Run this step
+# after the llvm/cross-compile step which is exceedingly slow.
+RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz -o cmake.tar.gz \
+ && echo 'b44685227b9f9be103e305efa2075a8ccf2415807fbcf1fc192da4d36aacc9f5 cmake.tar.gz' | sha256sum -c - \
+ && tar --strip-components=1 -C /usr -xzf cmake.tar.gz \
+ && rm cmake.tar.gz
+
 # Compile Go from source so that CC defaults to clang instead of gcc. This
 # requires a Go toolchain to bootstrap.
 #
@@ -196,8 +203,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.13.5.src.tar.gz -o golang.tar.gz \
- && echo '27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.13.9.src.tar.gz -o golang.tar.gz \
+ && echo '34bb19d806e0bc4ad8f508ae24bade5e9fedfa53d09be63b488a9314d2d4f31d golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \


### PR DESCRIPTION
Upgrade from go 1.13.5 to go 1.13.9 which picks up a number of security
fixes.

Upgrade cmake from 3.5.1 to 3.17.0. The newer cmake is needed by libgeos
which the geospatial folks want to use. 3.5.1 is very out of date.

Fixes cockroachdb/dev-inf#60

Release note (build change): CockroachDB is now built against go1.13.19.

Release justification: low risk, high benefit change to use the latest
minor release of go1.13 in order to pick up security fixes.