### PR TITLE
sql: update index backfill validation for primary key changes

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3283,7 +3283,10 @@ func (desc *ImmutableTableDescriptor) MakeFirstMutationPublic(
 			// of mutations if they have the mutation ID we're looking for.
 			break
 		}
-		if includeConstraints || mutation.GetConstraint() == nil {
+		// Don't include the primary key swap, or constraint mutations if
+		// they were not requested.
+		if mutation.GetPrimaryKeySwap() == nil &&
+			(includeConstraints || mutation.GetConstraint() == nil) {
 			if err := table.MakeMutationComplete(mutation); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This PR updates the index backfill validation step of the
schema changer for primary key changes. Originally, the index
validator applies all mutations with id = current mutation ID
before running a validation. However, that includes the
primary key swap mutation. This makes the newly created index
the index that is used as "ground truth" for the validation,
rather than the existing primary index. This PR updates
that logic to ensure that the existing primary key
is used to validate against.

Release justification: important validation update
Release note: None