### PR TITLE
delegate: fix SHOW INDEXES ... WITH COMMENT showing extraneous data

### DIFF
--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -47,8 +47,8 @@ func (d *delegator) delegateShowIndexes(n *tree.ShowIndexes) (tree.Statement, er
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Indexes)
 	getIndexesQuery := `
 SELECT
-	table_name,
-	index_name,
+	s.table_name,
+	s.index_name,
 	non_unique::BOOL,
 	seq_in_index,
 	column_name,
@@ -58,17 +58,19 @@ SELECT
 
 	if n.WithComment {
 		getIndexesQuery += `,
-	obj_description(pg_class.oid) AS comment`
+	obj_description(pg_indexes.crdb_oid) AS comment`
 	}
 
 	getIndexesQuery += `
 FROM
-	%[4]s.information_schema.statistics`
+	%[4]s.information_schema.statistics AS s`
 
 	if n.WithComment {
 		getIndexesQuery += `
-	LEFT JOIN pg_class ON
-		statistics.index_name = pg_class.relname`
+	LEFT JOIN pg_indexes ON
+		pg_indexes.tablename = s.table_name AND
+		pg_indexes.indexname = s.index_name
+	`
 	}
 
 	getIndexesQuery += `

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -454,3 +454,47 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.jobs' AND usage_count > 0
 ----
 sql.show.jobs
+
+# Tests identically named indexes do not show up twice with SHOW INDEXES.
+subtest regression_46333
+
+statement ok
+CREATE TABLE t (
+  x INT,
+  y INT,
+  z INT,
+  INDEX i1 (x),
+  INDEX i2 (y),
+  INDEX i3 (z)
+); CREATE TABLE t2 (
+  x INT,
+  y INT,
+  z INT,
+  INDEX i1 (x),
+  INDEX i2 (y),
+  INDEX i3 (z)
+); COMMENT ON COLUMN t.x IS 'comment1';
+COMMENT ON COLUMN t.z IS 'comm"en"t2';
+COMMENT ON INDEX t@i2 IS 'comm''ent3'
+
+query TTBITTBBT
+SHOW INDEXES FROM t WITH COMMENT
+----
+t  primary  false  1  rowid  ASC  false  false  NULL
+t  i1       true   1  x      ASC  false  false  NULL
+t  i1       true   2  rowid  ASC  false  true   NULL
+t  i2       true   1  y      ASC  false  false  comm'ent3
+t  i2       true   2  rowid  ASC  false  true   comm'ent3
+t  i3       true   1  z      ASC  false  false  NULL
+t  i3       true   2  rowid  ASC  false  true   NULL
+
+query TTBITTBBT
+SHOW INDEXES FROM t2 WITH COMMENT
+----
+t2  primary  false  1  rowid  ASC  false  false  NULL
+t2  i1       true   1  x      ASC  false  false  NULL
+t2  i1       true   2  rowid  ASC  false  true   NULL
+t2  i2       true   1  y      ASC  false  false  NULL
+t2  i2       true   2  rowid  ASC  false  true   NULL
+t2  i3       true   1  z      ASC  false  false  NULL
+t2  i3       true   2  rowid  ASC  false  true   NULL

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -83,8 +83,6 @@ SHOW INDEXES FROM c WITH COMMENT
 ----
 table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  comment
 c           primary        false       1             id           ASC        false    false     NULL
-c           primary        false       1             id           ASC        false    false     NULL
-c           primary        false       1             id           ASC        false    false     NULL
 c           c_foo_idx      true        1             foo          ASC        false    false     index_comment
 c           c_foo_idx      true        2             id           ASC        false    true      index_comment
 c           c_foo_idx1     true        1             foo          ASC        false    false     NULL


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/46333

Release justification: low risk, high benefit changes to existing
functionality
Release note (bug fix): Previously, SHOW INDEXES ... WITH COMMENT would
show duplicate rows for certain tables if indexes were identically
named. This has been fixed.