### PR TITLE
release-19.2: sem/builtins: account for internal memory of some aggregates

### DIFF
--- a/pkg/sql/sem/tree/aggregate_funcs.go
+++ b/pkg/sql/sem/tree/aggregate_funcs.go
@@ -38,7 +38,7 @@ type AggregateFunc interface {
 	// aggregation.
 	Close(context.Context)
 
-	// Size returns the size of the AggregateFunc implementation in bytes. It does
-	// not account for additional memory used during accumulation.
+	// Size returns the size of the AggregateFunc implementation in bytes. It
+	// does *not* account for additional memory used during accumulation.
 	Size() int64
 }


### PR DESCRIPTION
Backport 1/1 commits from #46545.

/cc @cockroachdb/release

---

Release justification: fixes for high-priority or high-severity bugs in
existing functionality.

Previously, we were not accounting for the memory of the first non-null
datum in `anyNotNull` aggregate. Similarly, we were not accounting for
the byte slice in `bytesXor` aggregate. This is now fixed.

This commit also fixes an issue with double accounting for the current
datum in `min` and `max` aggregates on fixed size types (previously, it
was reported in `Size()` method as well as separately on the first
non-null datum).

Addresses: #45812.

Release note (bug fix): CockroachDB previously was incorrectly
accounting for some RAM usage when computing aggregate functions which
results in an underestimation of it and could cause an out of memory
crash. Now this has been fixed.
