### PR TITLE
sql: add 192auto to the hint for vectorize session variable

### DIFF
--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -392,7 +392,7 @@ var varGen = map[string]sessionVar{
 			mode, ok := sessiondata.VectorizeExecModeFromString(s)
 			if !ok {
 				return newVarValueError(`vectorize`, s,
-					"off", "auto", "on", "experimental_always")
+					"off", "192auto", "auto", "on", "experimental_always")
 			}
 			m.SetVectorize(mode)
 			return nil


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new
functionality (only hint change).

`192auto` was forgotten to be added to the hint for `vectorize` session
variable.

Release note: None