### PR TITLE
build: require go 1.13

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -6,8 +6,7 @@
 # To bump the required version of Go, edit the appropriate variables:
 
 required_version_major=1
-minimum_version_minor=12
-minimum_version_12_patch=10
+minimum_version_minor=13
 minimum_version_13_patch=4
 
 go=${1-go}

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -32,7 +32,7 @@ run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:1.12-stretch ./verify-archive.sh
+  golang:1.13-stretch ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"


### PR DESCRIPTION
Some parts of the tree no longer build with go1.12; update the
go-version-check script to not allow it anymore.

Release note: None

Release justification: Not a code change.