### PR TITLE
kv/kvserver: don't bump ReadTimestamp on EndTxn batch with bounded read latches

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -13,7 +13,6 @@ package batcheval
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -115,13 +114,13 @@ func Subsume(
 	_, intent, err := storage.MVCCGet(ctx, readWriter, descKey, cArgs.Header.Timestamp,
 		storage.MVCCGetOptions{Inconsistent: true})
 	if err != nil {
-		return result.Result{}, fmt.Errorf("fetching local range descriptor: %s", err)
+		return result.Result{}, errors.Errorf("fetching local range descriptor: %s", err)
 	} else if intent == nil {
 		return result.Result{}, errors.New("range missing intent on its local descriptor")
 	}
 	val, _, err := storage.MVCCGetAsTxn(ctx, readWriter, descKey, cArgs.Header.Timestamp, intent.Txn)
 	if err != nil {
-		return result.Result{}, fmt.Errorf("fetching local range descriptor as txn: %s", err)
+		return result.Result{}, errors.Errorf("fetching local range descriptor as txn: %s", err)
 	} else if val != nil {
 		return result.Result{}, errors.New("non-deletion intent on local range descriptor")
 	}

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -86,7 +86,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 	rw storage.ReadWriter,
 	rec batcheval.EvalContext,
 	ba *roachpb.BatchRequest,
-	spans *spanset.SpanSet,
+	latchSpans *spanset.SpanSet,
 ) (br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
 	for retries := 0; ; retries++ {
 		if retries > 0 {
@@ -96,7 +96,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 
 		// If we can retry, set a higher batch timestamp and continue.
 		// Allow one retry only.
-		if pErr == nil || retries > 0 || !canDoServersideRetry(ctx, pErr, ba, br, spans, nil /* deadline */) {
+		if pErr == nil || retries > 0 || !canDoServersideRetry(ctx, pErr, ba, br, latchSpans, nil /* deadline */) {
 			break
 		}
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -559,7 +559,7 @@ func TestIsOnePhaseCommit(t *testing.T) {
 				// Emulate what a server actually does and bump the write timestamp when
 				// possible. This makes some batches with diverged read and write
 				// timestamps pass isOnePhaseCommit().
-				maybeBumpReadTimestampToWriteTimestamp(ctx, &ba)
+				maybeBumpReadTimestampToWriteTimestamp(ctx, &ba, &spanset.SpanSet{})
 
 				if is1PC := isOnePhaseCommit(&ba); is1PC != c.exp1PC {
 					t.Errorf("expected 1pc=%t; got %t", c.exp1PC, is1PC)


### PR DESCRIPTION
This commit prevents an error-prone situation where requests with an
EndTxn request that acquire read-latches at bounded timestamps were
allowed to move their ReadTimestamp to their WriteTimestamp without
re-acquiring new latches. This could allow the request to read at an
unprotected timestamp and forgo proper synchronization with writes with
respect to its lock-table scan and timestamp cache update.

This relates to 11bffb2, which made a similar fix to server-side
refreshes, but not to this new (as of this release) pre-emptive
ReadTimestamp update mechanism.

This bug was triggering the following assertion when stressing
`TestKVNemesisSingleNode`:

```
F200326 15:56:11.350743 1199 kv/kvserver/concurrency/concurrency_manager.go:261  [n1,s1,r33/1:/{Table/50/"60…-Max}] caller violated contract: discovered non-conflicting lock
```

The batch that hit this issue looked like:
```
Get [/Table/50/"a1036fd0",/Min),
Get [/Table/50/"e54a51a8",/Min),
QueryIntent [/Table/50/"aafccb40",/Min),
QueryIntent [/Table/50/"be7f37c9",/Min),
EndTxn(commit:true tsflex:true)
```

This commit adds two subtests to `TestTxnCoordSenderRetries` that
create this scenario.

Release note (bug fix): A rare bug causing an assertion failure was
fixed. The assertion error message was "caller violated contract:
discovered non-conflicting lock".

Release justification: fixes a series bug that could crash a server.
Additionally, the bug could have theoretically allowed isolation
violations between transactions without hitting the assertion, though
this was never observed in practice.

cc. @danhhz 