### PR TITLE
ui: Tooltips for statements list page

### DIFF
--- a/pkg/ui/src/components/tooltip/tooltip.styl
+++ b/pkg/ui/src/components/tooltip/tooltip.styl
@@ -27,3 +27,24 @@
       background $colors--neutral-6
     .ant-tooltip-arrow
       color $colors--neutral-6
+
+.tooltip__table--title
+  font-family $font-family--base
+  font-weight 600
+  font-size $font-size--small
+  line-height $line-height--small
+  letter-spacing 0.3px
+  color $colors--neutral-0
+  a
+    color $colors--neutral-0
+    text-decoration underline
+    &:hover
+      opacity 0.7
+      color $colors--neutral-0
+  code
+    font-family $font-family--monospace
+    line-height $line-height--medium
+    color $colors--neutral-8
+    background $colors--neutral-4 
+    border-radius 3px
+    padding 2px 5px

--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -38,6 +38,9 @@ export const databaseTable = docsURL("admin-ui-databases-page.html");
 export const jobTable = docsURL("admin-ui-jobs-page.html");
 export const statementsTable = docsURL("admin-ui-statements-page.html");
 
+export const statementsSql = docsURL("admin-ui-statements-page.html#sql-statement-fingerprints");
+export const statementsRetries = docsURL("transactions.html#transaction-retries");
+export const statementsTimeInterval = docsURL("admin-ui-statements-page.html#time-interval");
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion = "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -117,8 +117,7 @@
   color $colors--neutral-1
   white-space pre-wrap
   margin-bottom 0
-  line-height 22px
-  color $colors--neutral-6
+  cursor pointer
   span
     margin-right 6px
   a

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -30,6 +30,7 @@
       line-height 1.17
       letter-spacing 1.5px
       color $placeholder
+      cursor pointer
       .sortable__actions
         position relative
         padding 11px

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticStatusBadge.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticStatusBadge.tsx
@@ -37,34 +37,35 @@ function mapStatusToDescription(diagnosticsStatus: DiagnosticStatuses) {
   switch (diagnosticsStatus) {
     case "READY":
       return (
-        <div>
-          {`Go to the detail page for this statement and click the ‘diagnostics’ tab.
-           The statement diagnostics download will include EXPLAIN plans, table statistics, and traces. `}
-          <Anchor
-            href={statementDiagnostics}
-            target="_blank"
-          >
-            Learn more
-          </Anchor>
-        </div>
-      );
-    case "WAITING FOR QUERY":
-      return (
-        <div>
-          <span>
-            CockroachDB is waiting for the next query that matches this statement fingerprint.
-          </span>
-          <p/>
-          <span>
-            {`A download button will appear on the statement list and detail pages when the query is ready.
-            The download will include EXPLAIN plans, table statistics, and traces. `}
+        <div className="tooltip__table--title">
+          <p>
+            {"The most recent "}
             <Anchor
               href={statementDiagnostics}
               target="_blank"
             >
-              Learn more
+              diagnostics
             </Anchor>
-          </span>
+            {" for this SQL statement fingerprint are ready to download. Access the full history of diagnostics for the fingerprint in the Statement Details page."}
+          </p>
+        </div>
+      );
+    case "WAITING FOR QUERY":
+      return (
+        <div className="tooltip__table--title">
+          <p>
+            CockroachDB is waiting for the next SQL statement that matches this fingerprint.
+          </p>
+          <p>
+            {"When the most recent "}
+            <Anchor
+              href={statementDiagnostics}
+              target="_blank"
+            >
+              diagnostics
+            </Anchor>
+            {" are ready to download, a link will appear in this row."}
+          </p>
         </div>
       );
     case "ERROR":

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -8,24 +8,20 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import getHighlightedText from "src/util/highlightedText";
 import React from "react";
-import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
 
 import { StatementStatistics } from "src/util/appStats";
 import { FixLong } from "src/util/fixLong";
-import { StatementSummary, summarize } from "src/util/sql/summarize";
+import { StatementSummary } from "src/util/sql/summarize";
 import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
 import { countBarChart, latencyBarChart, retryBarChart, rowsBarChart } from "./barCharts";
-import { Anchor, Tooltip } from "src/components";
 import "./statements.styl";
-import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
 import styles from "./statementsTable.module.styl";
-import { statementsSql, transactionalPipelining, statementDiagnostics, statementsRetries, statementsTimeInterval } from "oss/src/util/docs";
+import { StatementTableTitle, StatementTableCell, NodeNames } from "./statementsTableContent";
 
 const cx = classNames.bind(styles);
 const longToInt = (d: number | Long) => FixLong(d).toInt();
@@ -41,28 +37,6 @@ export interface AggregateStatistics {
 }
 
 export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
-
-function StatementLink(props: { statement: string, app: string, implicitTxn: boolean, search: string }) {
-  const summary = summarize(props.statement);
-  const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
-  return (
-    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
-      <div className="cl-table-link__tooltip">
-        <Tooltip
-          placement="bottom"
-          title={<pre className="cl-table-link__description">
-            { getHighlightedText(props.statement, props.search) }
-          </pre>}
-          overlayClassName="cl-table-link__statement-tooltip--fixed-width"
-        >
-          <div className="cl-table-link__tooltip-hover-area">
-            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
-          </div>
-        </Tooltip>
-      </div>
-    </Link>
-  );
-}
 
 export function shortStatement(summary: StatementSummary, original: string) {
   switch (summary.statement) {
@@ -84,69 +58,13 @@ export function makeStatementsColumns(
 ): ColumnDescriptor<AggregateStatistics>[]  {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"SQL statement "}
-                <Anchor
-                  href={statementsSql}
-                  target="_blank"
-                >
-                  fingerprint.
-                </Anchor>
-              </p>
-              <p>
-                To view additional details of a SQL statement fingerprint, click this to open the Statement Details page.
-              </p>
-            </div>
-          }
-        >
-          Statements
-        </Tooltip>
-      ),
+      title: StatementTableTitle.statements,
       className: "cl-table__col-query-text",
-      cell: (stmt) => (
-        <StatementLink
-          statement={ stmt.label }
-          implicitTxn={ stmt.implicitTxn }
-          search={search}
-          app={ selectedApp }
-        />
-      ),
+      cell: StatementTableCell.statements(search, selectedApp),
       sort: (stmt) => stmt.label,
     },
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "}
-                <code>BEGIN</code>
-                {" and "}
-                <code>COMMIT</code>
-                {" statements by the client. Explicit transactions employ "}
-                <Anchor
-                  href={transactionalPipelining}
-                  target="_blank"
-                >
-                  transactional pipelining
-                </Anchor>
-                {" and therefore report latencies that do not account for replication."}
-              </p>
-              <p>
-                For statements not in explicit transactions, CockroachDB wraps each statement in individual implicit transactions.
-              </p>
-            </div>
-          }
-        >
-          TXN Type
-        </Tooltip>
-      ),
+      title: StatementTableTitle.txtType,
       className: "statements-table__col-time",
       cell: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
       sort: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
@@ -156,40 +74,8 @@ export function makeStatementsColumns(
 
   if (activateDiagnosticsRef) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"Option to activate "}
-                <Anchor
-                  href={statementDiagnostics}
-                  target="_blank"
-                >
-                  diagnostics
-                </Anchor>
-                {" for each statement. If activated, this displays the status of diagnostics collection ("}
-                <code>WAITING FOR QUERY</code>, <code>READY</code>, OR <code>ERROR</code>).
-              </p>
-            </div>
-          }
-        >
-          Diagnostics
-        </Tooltip>
-      ),
-      cell: (stmt) => {
-        if (stmt.diagnosticsReport) {
-          return <DiagnosticStatusBadge status={stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"}/>;
-        }
-        return (
-          <Anchor
-            onClick={() => activateDiagnosticsRef?.current?.showModalFor(stmt.label)}
-          >
-            Activate
-          </Anchor>
-        );
-      },
+      title: StatementTableTitle.diagnostics,
+      cell: StatementTableCell.diagnostics(activateDiagnosticsRef),
       sort: (stmt) => {
         if (stmt.diagnosticsReport) {
           return stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY";
@@ -202,20 +88,12 @@ export function makeStatementsColumns(
   return columns;
 }
 
-function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
-  return (
-    <Link to={ `/node/${props.nodeId}` }>
-      <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
-    </Link>
-  );
-}
-
-export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: { [nodeId: string]: string })
+export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: NodeNames)
     : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: null,
-      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
+      cell: StatementTableCell.nodeLink(nodeNames),
       // sort: (stmt) => stmt.label,
     },
   ];
@@ -263,112 +141,25 @@ function makeCommonColumns(statements: AggregateStatistics[])
 
   return [
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"Cumulative number of "}
-                <Anchor
-                  href={statementsRetries}
-                  target="_blank"
-                >
-                  retries
-                </Anchor>
-                {" of statements with this fingerprint within the last hour or specified time interval."}
-              </p>
-            </div>
-          }
-        >
-          Retries
-        </Tooltip>
-      ),
+      title: StatementTableTitle.retries,
       className: "statements-table__col-retries",
       cell: retryBar,
       sort: (stmt) => (longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count)),
     },
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"Cumulative number of executions of statements with this fingerprint within the last hour or specified "}
-                <Anchor
-                  href={statementsTimeInterval}
-                  target="_blank"
-                >
-                  time interval
-                </Anchor>.
-              </p>
-              <p>
-                {"The bar indicates the ratio of runtime success (gray) to "}
-                <Anchor
-                  href={statementsRetries}
-                  target="_blank"
-                >
-                  retries
-                </Anchor>
-                {" (red) for the SQL statement fingerprint."}
-              </p>
-            </div>
-          }
-        >
-          Execution Count
-        </Tooltip>
-      ),
+      title: StatementTableTitle.executionCount,
       className: "statements-table__col-count",
       cell: countBar,
       sort: (stmt) => FixLong(stmt.stats.count).toInt(),
     },
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                {"Average number of rows returned while executing statements with this fingerprint within the last hour or specified "}
-                <Anchor
-                  href={statementsTimeInterval}
-                  target="_blank"
-                >
-                  time interval
-                </Anchor>.
-              </p>
-              <p>
-                The gray bar indicates the mean number of rows returned. The blue bar indicates one standard deviation from the mean.
-              </p>
-            </div>
-          }
-        >
-          Rows Affected
-        </Tooltip>
-      ),
+      title: StatementTableTitle.rowsAffected,
       className: "statements-table__col-rows",
       cell: rowsBar,
       sort: (stmt) => stmt.stats.num_rows.mean,
     },
     {
-      title: (
-        <Tooltip
-          placement="bottom"
-          title={
-            <div className="tooltip__table--title">
-              <p>
-                Average service latency of statements with this fingerprint within the last hour or specified time interval.
-              </p>
-              <p>
-                The gray bar indicates the mean latency. The blue bar indicates one standard deviation from the mean.
-              </p>
-            </div>
-          }
-        >
-          Latency
-        </Tooltip>
-      ),
+      title: StatementTableTitle.latency,
       className: "statements-table__col-latency",
       cell: latencyBar,
       sort: (stmt) => stmt.stats.service_lat.mean,

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -25,6 +25,7 @@ import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
 import styles from "./statementsTable.module.styl";
+import { statementsSql, transactionalPipelining, statementDiagnostics, statementsRetries, statementsTimeInterval } from "oss/src/util/docs";
 
 const cx = classNames.bind(styles);
 const longToInt = (d: number | Long) => FixLong(d).toInt();
@@ -83,7 +84,29 @@ export function makeStatementsColumns(
 ): ColumnDescriptor<AggregateStatistics>[]  {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
-      title: "Statement",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"SQL statement "}
+                <Anchor
+                  href={statementsSql}
+                  target="_blank"
+                >
+                  fingerprint.
+                </Anchor>
+              </p>
+              <p>
+                To view additional details of a SQL statement fingerprint, click this to open the Statement Details page.
+              </p>
+            </div>
+          }
+        >
+          Statements
+        </Tooltip>
+      ),
       className: "cl-table__col-query-text",
       cell: (stmt) => (
         <StatementLink
@@ -96,7 +119,34 @@ export function makeStatementsColumns(
       sort: (stmt) => stmt.label,
     },
     {
-      title: "Txn Type",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "}
+                <code>BEGIN</code>
+                {" and "}
+                <code>COMMIT</code>
+                {" statements by the client. Explicit transactions employ "}
+                <Anchor
+                  href={transactionalPipelining}
+                  target="_blank"
+                >
+                  transactional pipelining
+                </Anchor>
+                {" and therefore report latencies that do not account for replication."}
+              </p>
+              <p>
+                For statements not in explicit transactions, CockroachDB wraps each statement in individual implicit transactions.
+              </p>
+            </div>
+          }
+        >
+          TXN Type
+        </Tooltip>
+      ),
       className: "statements-table__col-time",
       cell: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
       sort: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
@@ -106,7 +156,28 @@ export function makeStatementsColumns(
 
   if (activateDiagnosticsRef) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
-      title: "Diagnostics",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"Option to activate "}
+                <Anchor
+                  href={statementDiagnostics}
+                  target="_blank"
+                >
+                  diagnostics
+                </Anchor>
+                {" for each statement. If activated, this displays the status of diagnostics collection ("}
+                <code>WAITING FOR QUERY</code>, <code>READY</code>, OR <code>ERROR</code>).
+              </p>
+            </div>
+          }
+        >
+          Diagnostics
+        </Tooltip>
+      ),
       cell: (stmt) => {
         if (stmt.diagnosticsReport) {
           return <DiagnosticStatusBadge status={stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"}/>;
@@ -192,25 +263,112 @@ function makeCommonColumns(statements: AggregateStatistics[])
 
   return [
     {
-      title: "Retries",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"Cumulative number of "}
+                <Anchor
+                  href={statementsRetries}
+                  target="_blank"
+                >
+                  retries
+                </Anchor>
+                {" of statements with this fingerprint within the last hour or specified time interval."}
+              </p>
+            </div>
+          }
+        >
+          Retries
+        </Tooltip>
+      ),
       className: "statements-table__col-retries",
       cell: retryBar,
       sort: (stmt) => (longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count)),
     },
     {
-      title: "Execution Count",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"Cumulative number of executions of statements with this fingerprint within the last hour or specified "}
+                <Anchor
+                  href={statementsTimeInterval}
+                  target="_blank"
+                >
+                  time interval
+                </Anchor>.
+              </p>
+              <p>
+                {"The bar indicates the ratio of runtime success (gray) to "}
+                <Anchor
+                  href={statementsRetries}
+                  target="_blank"
+                >
+                  retries
+                </Anchor>
+                {" (red) for the SQL statement fingerprint."}
+              </p>
+            </div>
+          }
+        >
+          Execution Count
+        </Tooltip>
+      ),
       className: "statements-table__col-count",
       cell: countBar,
       sort: (stmt) => FixLong(stmt.stats.count).toInt(),
     },
     {
-      title: "Rows Affected",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                {"Average number of rows returned while executing statements with this fingerprint within the last hour or specified "}
+                <Anchor
+                  href={statementsTimeInterval}
+                  target="_blank"
+                >
+                  time interval
+                </Anchor>.
+              </p>
+              <p>
+                The gray bar indicates the mean number of rows returned. The blue bar indicates one standard deviation from the mean.
+              </p>
+            </div>
+          }
+        >
+          Rows Affected
+        </Tooltip>
+      ),
       className: "statements-table__col-rows",
       cell: rowsBar,
       sort: (stmt) => stmt.stats.num_rows.mean,
     },
     {
-      title: "Latency",
+      title: (
+        <Tooltip
+          placement="bottom"
+          title={
+            <div className="tooltip__table--title">
+              <p>
+                Average service latency of statements with this fingerprint within the last hour or specified time interval.
+              </p>
+              <p>
+                The gray bar indicates the mean latency. The blue bar indicates one standard deviation from the mean.
+              </p>
+            </div>
+          }
+        >
+          Latency
+        </Tooltip>
+      ),
       className: "statements-table__col-latency",
       cell: latencyBar,
       sort: (stmt) => stmt.stats.service_lat.mean,

--- a/pkg/ui/src/views/statements/statementsTableContent.tsx
+++ b/pkg/ui/src/views/statements/statementsTableContent.tsx
@@ -1,0 +1,240 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Link } from "react-router-dom";
+import { Anchor, Tooltip } from "src/components";
+import { statementDiagnostics, statementsRetries, statementsSql, statementsTimeInterval, transactionalPipelining } from "src/util/docs";
+import getHighlightedText from "src/util/highlightedText";
+import { summarize } from "src/util/sql/summarize";
+import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
+import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
+import { shortStatement } from "./statementsTable";
+
+export type NodeNames = { [nodeId: string]: string };
+
+export const StatementTableTitle = {
+  statements: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"SQL statement "}
+            <Anchor
+              href={statementsSql}
+              target="_blank"
+            >
+              fingerprint.
+            </Anchor>
+          </p>
+          <p>
+            To view additional details of a SQL statement fingerprint, click this to open the Statement Details page.
+          </p>
+        </div>
+      }
+    >
+      Statements
+    </Tooltip>
+  ),
+  txtType: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "}
+            <code>BEGIN</code>
+            {" and "}
+            <code>COMMIT</code>
+            {" statements by the client. Explicit transactions employ "}
+            <Anchor
+              href={transactionalPipelining}
+              target="_blank"
+            >
+              transactional pipelining
+            </Anchor>
+            {" and therefore report latencies that do not account for replication."}
+          </p>
+          <p>
+            For statements not in explicit transactions, CockroachDB wraps each statement in individual implicit transactions.
+          </p>
+        </div>
+      }
+    >
+      TXN Type
+    </Tooltip>
+  ),
+  diagnostics: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"Option to activate "}
+            <Anchor
+              href={statementDiagnostics}
+              target="_blank"
+            >
+              diagnostics
+            </Anchor>
+            {" for each statement. If activated, this displays the status of diagnostics collection ("}
+            <code>WAITING FOR QUERY</code>, <code>READY</code>, OR <code>ERROR</code>).
+          </p>
+        </div>
+      }
+    >
+      Diagnostics
+    </Tooltip>
+  ),
+  retries: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"Cumulative number of "}
+            <Anchor
+              href={statementsRetries}
+              target="_blank"
+            >
+              retries
+            </Anchor>
+            {" of statements with this fingerprint within the last hour or specified time interval."}
+          </p>
+        </div>
+      }
+    >
+      Retries
+    </Tooltip>
+  ),
+  executionCount: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"Cumulative number of executions of statements with this fingerprint within the last hour or specified "}
+            <Anchor
+              href={statementsTimeInterval}
+              target="_blank"
+            >
+              time interval
+            </Anchor>.
+          </p>
+          <p>
+            {"The bar indicates the ratio of runtime success (gray) to "}
+            <Anchor
+              href={statementsRetries}
+              target="_blank"
+            >
+              retries
+            </Anchor>
+            {" (red) for the SQL statement fingerprint."}
+          </p>
+        </div>
+      }
+    >
+      Execution Count
+    </Tooltip>
+  ),
+  rowsAffected: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            {"Average number of rows returned while executing statements with this fingerprint within the last hour or specified "}
+            <Anchor
+              href={statementsTimeInterval}
+              target="_blank"
+            >
+              time interval
+            </Anchor>.
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Rows Affected
+    </Tooltip>
+  ),
+  latency: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className="tooltip__table--title">
+          <p>
+            Average service latency of statements with this fingerprint within the last hour or specified time interval.
+          </p>
+          <p>
+            The gray bar indicates the mean latency. The blue bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Latency
+    </Tooltip>
+  ),
+};
+
+export const StatementTableCell = {
+  statements: (search?: string, selectedApp?: string) => (stmt: any) => (
+    <StatementLink
+      statement={ stmt.label }
+      implicitTxn={ stmt.implicitTxn }
+      search={search}
+      app={ selectedApp }
+    />
+  ),
+  diagnostics: (activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>) => (stmt: any) => {
+    if (stmt.diagnosticsReport) {
+      return <DiagnosticStatusBadge status={stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"}/>;
+    }
+    return (
+      <Anchor
+        onClick={() => activateDiagnosticsRef?.current?.showModalFor(stmt.label)}
+      >
+        Activate
+      </Anchor>
+    );
+  },
+  nodeLink: (nodeNames: NodeNames) => (stmt: any) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
+};
+
+export const StatementLink = (props: { statement: string, app: string, implicitTxn: boolean, search: string }) => {
+  const summary = summarize(props.statement);
+  const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
+  return (
+    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
+      <div className="cl-table-link__tooltip">
+        <Tooltip
+          placement="bottom"
+          title={<pre className="cl-table-link__description">
+            { getHighlightedText(props.statement, props.search) }
+          </pre>}
+          overlayClassName="cl-table-link__statement-tooltip--fixed-width"
+        >
+          <div className="cl-table-link__tooltip-hover-area">
+            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
+          </div>
+        </Tooltip>
+      </div>
+    </Link>
+  );
+};
+
+const NodeLink = (props: { nodeId: string, nodeNames: NodeNames }) => (
+  <Link to={ `/node/${props.nodeId}` }>
+    <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
+  </Link>
+);


### PR DESCRIPTION
Added column header tooltips statements table and for diagnostic statuses

![TXN TYPE](https://user-images.githubusercontent.com/12850886/77671645-97254f80-6f90-11ea-99c0-ea081ab76243.png)

![DIAGNOSTICS](https://user-images.githubusercontent.com/12850886/77671703-a73d2f00-6f90-11ea-9737-3dc4d579a5cd.png)

Resolves: #46211, #48075

Release justification: low risk, high benefit changes to existing functionality

Release note (ui): statements tooltips design updates