### PR TITLE
ui: Statements truncated header

### DIFF
--- a/pkg/ui/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/src/views/app/containers/layout/layout.styl
@@ -44,7 +44,6 @@ $subnav-background  = $background-color
 
   z-index $z-index-page-config
   background-color $background-color
-  max-width $max-window-width
 
   &__list
     display flex


### PR DESCRIPTION
Statements grey header extended all the way to the right edge.

![header](https://user-images.githubusercontent.com/12850886/78563427-9e1b5000-7823-11ea-81d2-e68c3722f738.png)

Resolves: #46572

Release justification: bug fixes and low-risk updates to new functionality

Release note (ui): layout sizes update