### PR TITLE
release-19.1: cli/zip: fix the naming of error reports

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -139,7 +139,7 @@ func (z *zipper) createJSON(name string, m interface{}) error {
 }
 
 func (z *zipper) createError(name string, e error) error {
-	w, err := z.create(name, time.Time{})
+	w, err := z.create(name+".err.txt", time.Time{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #46634.

/cc @cockroachdb/release

---

Fixes #46633.
