### PR TITLE
ui: (fix) OOM exception on ui-test build

### DIFF
--- a/pkg/ui/karma.conf.js
+++ b/pkg/ui/karma.conf.js
@@ -44,11 +44,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      "dist/protos.ccl.dll.js",
-      "dist/vendor.oss.dll.js",
       "src/polyfills.ts",
-      "src/**/*.spec.*",
-      "ccl/src/**/*.spec.*",
+      "tests-loader.js",
     ],
 
     // frameworks to use
@@ -70,14 +67,14 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "ccl/src/**": ["webpack"],
-      "src/**": ["webpack"],
+      "src/polyfills.ts": ["webpack"],
+      "tests-loader.js": ["webpack", "sourcemap"],
     },
 
     // test results reporter to use
     // possible values: "dots", "progress"
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ["mocha", "progress"],
+    reporters: ["mocha"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
@@ -85,8 +82,8 @@ module.exports = function(config) {
 
     // https://github.com/airbnb/enzyme/blob/master/docs/guides/webpack.md
     webpack: {
-      devtool: "eval",
-      mode: "none",
+      devtool: "eval-cheap-source-map",
+      mode: "development",
       module: webpackConfig.module,
       resolve: webpackConfig.resolve,
     },

--- a/pkg/ui/tests-loader.js
+++ b/pkg/ui/tests-loader.js
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+const testsContext = require.context("./src", true, /\.spec\.(ts|tsx)$/);
+const cclTestsContext = require.context("./ccl/src", true, /\.spec\.(ts|tsx)$/);
+
+testsContext.keys().forEach(testsContext);
+cclTestsContext.keys().forEach(cclTestsContext);


### PR DESCRIPTION
It is one more attempt to fix OOM issue on ui test runs.
Previous fixes were based mainly on suggestion that the
root cause of issue is source maps generated during builds
by karma.

Actually the problem was in webpack and the way it preprocess
files by karma `preprocessors: [...]`.
Before we provided a bunch of files (source and test files) and
webpack processed each matched file separately what caused
memory consumption overhead.

Current solution:
- removes source files from karma configuration entirely.
Required sources are already imported in test files so they
will be included as well.
- added `tests-loader` file as a single entry point for all
test files. It allows us to provide and preprocess one file
with all required test file at once.

Current fix is based on found work around:
https://github.com/karma-runner/karma/issues/1868#issuecomment-296071567

Release note: None

Release justification: non-production code changes