### PR TITLE
release-19.2: colexec: fix interaction between projectingBatch and ArrowBatchConverter

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -145,29 +145,36 @@ func (m *MemBatch) AppendCol(t coltypes.T) {
 
 // Reset implements the Batch interface.
 func (m *MemBatch) Reset(types []coltypes.T, length int) {
+	ResetNoTruncation(m, types, length)
+	m.b = m.b[:len(types)]
+}
+
+// ResetNoTruncation is the same as Reset, but if the batch has enough
+// capacity for length and has more columns than the given coltypes, yet
+// the prefix of already present columns matches the desired type schema,
+// the batch will be reused (meaning this method does *not* truncate the
+// type schema).
+func ResetNoTruncation(m *MemBatch, types []coltypes.T, length int) {
 	// The columns are always sized the same as the selection vector, so use it as
 	// a shortcut for the capacity (like a go slice, the batch's `Length` could be
 	// shorter than the capacity). We could be more defensive and type switch
 	// every column to verify its capacity, but that doesn't seem necessary yet.
-	hasColCapacity := len(m.sel) >= length
-	if m == nil || !hasColCapacity || m.Width() < len(types) {
+	cannotReuse := m == nil || len(m.sel) < length || m.Width() < len(types)
+	for i := 0; i < len(types) && !cannotReuse; i++ {
+		if m.ColVec(i).Type() != types[i] {
+			cannotReuse = true
+		}
+	}
+	if cannotReuse {
 		*m = *NewMemBatchWithSize(types, length).(*MemBatch)
 		m.SetLength(uint16(length))
 		return
-	}
-	for i := range types {
-		if m.ColVec(i).Type() != types[i] {
-			*m = *NewMemBatchWithSize(types, length).(*MemBatch)
-			m.SetLength(uint16(length))
-			return
-		}
 	}
 	// Yay! We can reuse m. NB It's not specified in the Reset contract, but
 	// probably a good idea to keep all modifications below this line.
 	m.SetLength(uint16(length))
 	m.SetSelection(false)
 	m.sel = m.sel[:length]
-	m.b = m.b[:len(types)]
 	for _, col := range m.ColVecs() {
 		col.Nulls().UnsetNulls()
 		if col.Type() == coltypes.Bytes {

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -219,10 +219,10 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 	}
 	// Assume > 0 length data.
 	n := data[0].Len()
-	// Reset reuses the passed-in Batch when possible, saving allocations but
-	// overwriting it. If the passed-in Batch is not suitable for use, a new one
-	// is allocated.
-	b.Reset(c.typs, n)
+	// ResetNoTruncation reuses the passed-in Batch when possible, saving
+	// allocations but overwriting it. If the passed-in Batch is not suitable
+	// for use, a new one is allocated.
+	coldata.ResetNoTruncation(b.(*coldata.MemBatch), c.typs, n)
 	b.SetLength(uint16(n))
 	// Reset the batch, this resets the selection vector as well.
 	b.ResetInternalBatch()

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -272,7 +272,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 			data, err := c.BatchToArrow(batch)
 			require.NoError(b, err)
 			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
-			result := coldata.NewMemBatch(typs)
+			result := coldata.NewMemBatch([]coltypes.T{typ})
 			b.Run(testPrefix+"/ArrowToBatch", func(b *testing.B) {
 				b.SetBytes(numBytes[typIdx])
 				for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Backport 1/1 commits from #46543.

/cc @cockroachdb/release

---

Release justification: bug fixes and low-risk updates to new
functionality.

With our recent work, `simpleProjectOp` relies on creating a separate
`projectingBatch` for each "new" batch it sees (where "new" is tracked
by the pointer address). This works ok, but the interaction with
ArrowBatchConverter has been messed up - the converter `Reset`s the
batch which truncates its type schema. As a result, we end up in
a situation where `projectingBatch` that wraps the batch created in the
converter thinks that there are more columns than `MemBatch.b` actually
contains after the truncation which can lead to an internal error. This
problem is now fixed by introducing another variation of `Reset` method
(`ResetNoTruncation`) that doesn't truncate the schema. Only
ArrowBatchConverter is using this method.

Fixes: #46533.

Release note: None (this is a follow-up fix to a PR that has been merged
three weeks ago with a release note)
