### PR TITLE
sql: add support for max/min aggregates on collated strings

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -97,6 +97,8 @@
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
+<tr><td><a name="max"></a><code>max(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: oid) &rarr; oid</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
@@ -130,6 +132,8 @@
 <tr><td><a name="min"></a><code>min(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><a name="min"></a><code>min(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -61,11 +61,11 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 28
+const Version execinfrapb.DistSQLVersion = 29
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 27
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 29
 
 // SettingUseTempStorageJoins is a cluster setting that configures whether
 // joins are allowed to spill to disk.

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -363,3 +363,13 @@ CREATE TABLE t46570(c0 BOOL, c1 STRING COLLATE en);
 CREATE INDEX ON t46570(rowid, c1 DESC);
 INSERT INTO t46570(c1, rowid) VALUES('' COLLATE en, 0);
 UPSERT INTO t46570(rowid) VALUES (0), (1)
+
+query T
+SELECT max(x) FROM (VALUES ('foo' COLLATE en), ('bar' COLLATE en)) t(x)
+----
+foo
+
+query T
+SELECT min(x) FROM (VALUES ('foo' COLLATE en), ('bar' COLLATE en)) t(x)
+----
+bar

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -109,3 +109,6 @@
     - The CORR aggregate function has been added which will not be recognized
       by older nodes. However, new nodes can process plans from older nodes,
       so MinAcceptedVersion is unchanged.
+- Version: 29 (MinAcceptedVersion: 29)
+    - The Max and Min aggregate functions have been extended to support collated
+      strings. Old nodes won't have this ability, so we bump the version.

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -76,6 +76,13 @@ func aggPropsNullableArgs() tree.FunctionProperties {
 	return f
 }
 
+// allMaxMinAggregateTypes contains extra types that aren't in
+// types.Scalar that the max/min aggregate functions are defined on.
+var allMaxMinAggregateTypes = append(
+	[]*types.T{types.AnyCollatedString},
+	types.Scalar...,
+)
+
 // aggregates are a special class of builtin functions that are wrapped
 // at execution in a bucketing layer to combine (aggregate) the result
 // of the function being run over many rows.
@@ -197,13 +204,13 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the boolean value of `AND`ing all selected values."),
 	),
 
-	"max": collectOverloads(aggProps(), types.Scalar,
+	"max": collectOverloads(aggProps(), allMaxMinAggregateTypes,
 		func(t *types.T) tree.Overload {
 			return makeAggOverload([]*types.T{t}, t, newMaxAggregate,
 				"Identifies the maximum selected value.")
 		}),
 
-	"min": collectOverloads(aggProps(), types.Scalar,
+	"min": collectOverloads(aggProps(), allMaxMinAggregateTypes,
 		func(t *types.T) tree.Overload {
 			return makeAggOverload([]*types.T{t}, t, newMinAggregate,
 				"Identifies the minimum selected value.")


### PR DESCRIPTION
Fixes #45846.

Release justification: low risk update to existing functionality
Release note (sql change): The max/min aggregates now work on collated
strings.