### PR TITLE
sql: implement the client_min_messages session var

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1204,6 +1204,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.notice"></a><code>crdb_internal.notice(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.notice"></a><code>crdb_internal.notice(severity: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.num_inverted_index_entries"></a><code>crdb_internal.num_inverted_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -19,12 +19,13 @@ eexpect root@
 # Ditto with multiple result sets. Notices after all result sets.
 send "SELECT crdb_internal.notice('hello') AS STAGE1;"
 send "SELECT crdb_internal.notice('world') AS STAGE2;\r"
+send "SELECT crdb_internal.notice('warning', 'stay indoors') AS STAGE3;\r"
 eexpect stage1
 eexpect stage2
 eexpect "NOTICE: hello"
 eexpect "NOTICE: world"
+eexpect "WARNING: stay indoors"
 eexpect root@
-end_test
-
-send "\\q\r"
+interrupt
 eexpect eof
+end_test

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -317,8 +318,9 @@ func (p *planner) AlterPrimaryKey(
 
 	// Send a notice to users about the async cleanup jobs.
 	// TODO(knz): Mention the job ID in the client notice.
-	p.SendClientNotice(ctx,
-		pgerror.Noticef(
+	p.SendClientNotice(
+		ctx,
+		pgnotice.Newf(
 			"primary key changes are finalized asynchronously; "+
 				"further schema changes on this table may be restricted until the job completes"),
 	)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -313,7 +314,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	if n.n.Concurrently {
 		params.p.SendClientNotice(
 			params.ctx,
-			pgerror.Noticef("CONCURRENTLY is not required as all indexes are created concurrently"),
+			pgnotice.Newf("CONCURRENTLY is not required as all indexes are created concurrently"),
 		)
 	}
 
@@ -323,7 +324,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 		params.p.SendClientNotice(
 			params.ctx,
 			errors.WithHint(
-				pgerror.Noticef("creating non-partitioned index on partitioned table may not be performant"),
+				pgnotice.Newf("creating non-partitioned index on partitioned table may not be performant"),
 				"Consider modifying the index such that it is also partitioned.",
 			),
 		)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/schema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -243,7 +244,7 @@ func (n *createTableNode) startExec(params runParams) error {
 					params.p.SendClientNotice(
 						params.ctx,
 						errors.WithHint(
-							pgerror.Noticef("creating non-partitioned index on partitioned table may not be performant"),
+							pgnotice.Newf("creating non-partitioned index on partitioned table may not be performant"),
 							"Consider modifying the index such that it is also partitioned.",
 						),
 					)

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -65,8 +66,9 @@ func (n *createViewNode) startExec(params runParams) error {
 		}
 		if !isTemporary && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
-			params.p.SendClientNotice(params.ctx,
-				pgerror.Noticef(`view "%s" will be a temporary view`, viewName),
+			params.p.SendClientNotice(
+				params.ctx,
+				pgnotice.Newf(`view "%s" will be a temporary view`, viewName),
 			)
 			isTemporary = true
 		}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -73,7 +74,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 	if n.n.Concurrently {
 		params.p.SendClientNotice(
 			params.ctx,
-			pgerror.Noticef("CONCURRENTLY is not required as all indexes are dropped concurrently"),
+			pgnotice.Newf("CONCURRENTLY is not required as all indexes are dropped concurrently"),
 		)
 	}
 
@@ -477,10 +478,13 @@ func (p *planner) dropIndexByName(
 	if err := p.writeSchemaChange(ctx, tableDesc, mutationID, jobDesc); err != nil {
 		return err
 	}
-	p.SendClientNotice(ctx,
+	p.SendClientNotice(
+		ctx,
 		errors.WithHint(
-			pgerror.Noticef("the data for dropped indexes is reclaimed asynchronously"),
-			"The reclamation delay can be customized in the zone configuration for the table."))
+			pgnotice.Newf("the data for dropped indexes is reclaimed asynchronously"),
+			"The reclamation delay can be customized in the zone configuration for the table.",
+		),
+	)
 	// Record index drop in the event log. This is an auditable log event
 	// and is recorded in the same transaction as the table descriptor
 	// update.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -1968,6 +1969,11 @@ func (m *sessionDataMutator) SetHashShardedIndexesEnabled(val bool) {
 // a sequence.
 func (m *sessionDataMutator) RecordLatestSequenceVal(seqID uint32, val int64) {
 	m.data.SequenceState.RecordValue(seqID, val)
+}
+
+// SetNoticeDisplaySeverity sets the NoticeDisplaySeverity for the given session.
+func (m *sessionDataMutator) SetNoticeDisplaySeverity(severity pgnotice.DisplaySeverity) {
+	m.data.NoticeDisplaySeverity = severity
 }
 
 type sqlStatsCollector struct {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1113,7 +1113,7 @@ func (t *logicTest) setUser(user string) func() {
 	}
 
 	connector := pq.ConnectorWithNoticeHandler(base, func(notice *pq.Error) {
-		t.noticeBuffer = append(t.noticeBuffer, "NOTICE: "+notice.Message)
+		t.noticeBuffer = append(t.noticeBuffer, notice.Severity+": "+notice.Message)
 		if notice.Detail != "" {
 			t.noticeBuffer = append(t.noticeBuffer, "DETAIL: "+notice.Detail)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -7,3 +7,19 @@ SELECT crdb_internal.notice('hi'), crdb_internal.notice('i am....'), crdb_intern
 NOTICE: hi
 NOTICE: i am....
 NOTICE: otan!!!
+
+subtest test_notice_severity
+
+query T noticetrace
+SELECT crdb_internal.notice('debug1', 'do not see this'), crdb_internal.notice('warning', 'but you see this'), crdb_internal.notice('debug2', 'and never this')
+----
+WARNING: but you see this
+
+statement ok
+SET client_min_messages = 'debug1'
+
+query T noticetrace
+SELECT crdb_internal.notice('debug1', 'now you see this'), crdb_internal.notice('warning', 'and you see this'), crdb_internal.notice('debug2', 'and never this')
+----
+DEBUG1: now you see this
+WARNING: and you see this

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -115,7 +115,7 @@ statement error 123 is outside the valid range for parameter "extra_float_digits
 SET extra_float_digits = 123
 
 statement ok
-SET client_min_messages = 'debug'
+SET client_min_messages = 'debug1'
 
 statement ok
 SET standard_conforming_strings = 'on'

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -206,7 +206,9 @@ func (r *commandResult) AppendParamStatusUpdate(param string, val string) {
 func (r *commandResult) AppendNotice(noticeErr error) {
 	r.flushBeforeCloseFuncs = append(
 		r.flushBeforeCloseFuncs,
-		func(ctx context.Context) error { return r.conn.bufferNotice(ctx, noticeErr) },
+		func(ctx context.Context) error {
+			return r.conn.bufferNotice(ctx, noticeErr)
+		},
 	)
 }
 

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -99,14 +99,6 @@ func Newf(code string, format string, args ...interface{}) error {
 	return err
 }
 
-// Noticef generates a Notice with a format string.
-func Noticef(format string, args ...interface{}) error {
-	err := errors.NewWithDepthf(1, format, args...)
-	err = WithCandidateCode(err, pgcode.SuccessfulCompletion)
-	err = WithSeverity(err, "NOTICE")
-	return err
-}
-
 // DangerousStatementf creates a new error for "rejected dangerous
 // statements".
 func DangerousStatementf(format string, args ...interface{}) error {

--- a/pkg/sql/pgwire/pgerror/severity_test.go
+++ b/pkg/sql/pgwire/pgerror/severity_test.go
@@ -24,7 +24,6 @@ func TestSeverity(t *testing.T) {
 		err              error
 		expectedSeverity string
 	}{
-		{Noticef("notice me"), "NOTICE"},
 		{WithSeverity(fmt.Errorf("notice me"), "NOTICE ME"), "NOTICE ME"},
 		{WithSeverity(WithSeverity(fmt.Errorf("notice me"), "IGNORE ME"), "NOTICE ME"), "NOTICE ME"},
 		{WithSeverity(WithCandidateCode(fmt.Errorf("notice me"), pgcode.FeatureNotSupported), "NOTICE ME"), "NOTICE ME"},

--- a/pkg/sql/pgwire/pgnotice/display_severity.go
+++ b/pkg/sql/pgwire/pgnotice/display_severity.go
@@ -1,0 +1,100 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgnotice
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DisplaySeverity indicates the severity of a given error for the
+// purposes of displaying notices.
+// This corresponds to the allowed values for the `client_min_messages`
+// variable in postgres.
+type DisplaySeverity int
+
+// It is important to keep the same order here as Postgres.
+// See https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-CLIENT-MIN-MESSAGES.
+
+const (
+	// DisplaySeverityError is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityError to display.
+	DisplaySeverityError = iota
+	// DisplaySeverityWarning is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityWarning to display.
+	DisplaySeverityWarning
+	// DisplaySeverityNotice is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityNotice to display.
+	DisplaySeverityNotice
+	// DisplaySeverityLog is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityLog.g to display.
+	DisplaySeverityLog
+	// DisplaySeverityDebug1 is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityDebug1 to display.
+	DisplaySeverityDebug1
+	// DisplaySeverityDebug2 is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityDebug2 to display.
+	DisplaySeverityDebug2
+	// DisplaySeverityDebug3 is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityDebug3 to display.
+	DisplaySeverityDebug3
+	// DisplaySeverityDebug4 is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityDebug4 to display.
+	DisplaySeverityDebug4
+	// DisplaySeverityDebug5 is a DisplaySeverity value allowing all notices
+	// of value <= DisplaySeverityDebug5 to display.
+	DisplaySeverityDebug5
+)
+
+// ParseDisplaySeverity translates a string to a DisplaySeverity.
+// Returns the severity, and a bool indicating whether the severity exists.
+func ParseDisplaySeverity(k string) (DisplaySeverity, bool) {
+	s, ok := namesToDisplaySeverity[strings.ToLower(k)]
+	return s, ok
+}
+
+func (ns DisplaySeverity) String() string {
+	if ns < 0 || ns > DisplaySeverity(len(noticeDisplaySeverityNames)-1) {
+		return fmt.Sprintf("DisplaySeverity(%d)", ns)
+	}
+	return noticeDisplaySeverityNames[ns]
+}
+
+// noticeDisplaySeverityNames maps a DisplaySeverity into it's string representation.
+var noticeDisplaySeverityNames = [...]string{
+	DisplaySeverityDebug5:  "debug5",
+	DisplaySeverityDebug4:  "debug4",
+	DisplaySeverityDebug3:  "debug3",
+	DisplaySeverityDebug2:  "debug2",
+	DisplaySeverityDebug1:  "debug1",
+	DisplaySeverityLog:     "log",
+	DisplaySeverityNotice:  "notice",
+	DisplaySeverityWarning: "warning",
+	DisplaySeverityError:   "error",
+}
+
+// namesToDisplaySeverity is the reverse mapping from string to DisplaySeverity.
+var namesToDisplaySeverity = map[string]DisplaySeverity{}
+
+// ValidDisplaySeverities returns a list of all valid severities.
+func ValidDisplaySeverities() []string {
+	ret := make([]string, 0, len(namesToDisplaySeverity))
+	for _, s := range noticeDisplaySeverityNames {
+		ret = append(ret, s)
+	}
+	return ret
+}
+
+func init() {
+	for k, v := range noticeDisplaySeverityNames {
+		namesToDisplaySeverity[v] = DisplaySeverity(k)
+	}
+}

--- a/pkg/sql/pgwire/pgnotice/pgnotice.go
+++ b/pkg/sql/pgwire/pgnotice/pgnotice.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgnotice
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/errors"
+)
+
+// Newf generates a Notice with a format string.
+func Newf(format string, args ...interface{}) error {
+	err := errors.NewWithDepthf(1, format, args...)
+	err = pgerror.WithCandidateCode(err, pgcode.SuccessfulCompletion)
+	err = pgerror.WithSeverity(err, "NOTICE")
+	return err
+}
+
+// NewWithSeverityf generates a Notice with a format string and severity.
+func NewWithSeverityf(severity string, format string, args ...interface{}) error {
+	err := errors.NewWithDepthf(1, format, args...)
+	err = pgerror.WithCandidateCode(err, pgcode.SuccessfulCompletion)
+	err = pgerror.WithSeverity(err, severity)
+	return err
+}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -1,7 +1,5 @@
-# Test notices work as expected by creating a VIEW on a TEMP TABLE.
-
 send
-Parse {"Query": "CREATE TABLE t(x INT, y INT, INDEX (x), INDEX (y))"}
+Parse {"Query": "SELECT crdb_internal.notice('hello')"}
 Bind
 Execute
 Sync
@@ -12,25 +10,9 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-
-
-send
-Parse {"Query": "DROP INDEX t@t_x_idx"}
-Bind
-Execute
-Sync
-----
-
-until
-ReadyForQuery
-----
-{"Type":"ParseComplete"}
-{"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":482,"Routine":"dropIndexByName","UnknownFields":null}
-{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
+{"Type":"DataRow","Values":[{"text":"0"}]}
+{"Severity":"NOTICE","Code":"00000","Message":"hello","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"notice.go","Line":32,"Routine":"crdbInternalSendNotice","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Disable notices and assert now it is not sent.
@@ -50,7 +32,7 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Parse {"Query": "DROP INDEX t@t_y_idx"}
+Parse {"Query": "SELECT crdb_internal.notice('goodbye')"}
 Bind
 Execute
 Sync
@@ -61,5 +43,6 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
+{"Type":"DataRow","Values":[{"text":"0"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -3360,12 +3361,21 @@ may increase either contention or retry errors, or both.`,
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if ctx.ClientNoticeSender == nil {
-					return nil, errors.AssertionFailedf("notice sender not set")
-				}
 				msg := string(*args[0].(*tree.DString))
-				ctx.ClientNoticeSender.SendClientNotice(ctx.Context, pgerror.Noticef("%s", msg))
-				return tree.NewDInt(0), nil
+				return crdbInternalSendNotice(ctx, "NOTICE", msg)
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"severity", types.String}, {"msg", types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				severityString := string(*args[0].(*tree.DString))
+				msg := string(*args[1].(*tree.DString))
+				if _, ok := pgnotice.ParseDisplaySeverity(severityString); !ok {
+					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "severity %s is invalid", severityString)
+				}
+				return crdbInternalSendNotice(ctx, severityString, msg)
 			},
 			Info: "This function is used only by CockroachDB's developers for testing purposes.",
 		},

--- a/pkg/sql/sem/builtins/notice.go
+++ b/pkg/sql/sem/builtins/notice.go
@@ -1,0 +1,35 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// crdbInternalSendNotice sends a notice.
+// Note this is extracted to a different file to prevent churn on the pgwire
+// test, which records line numbers.
+func crdbInternalSendNotice(
+	ctx *tree.EvalContext, severity string, msg string,
+) (tree.Datum, error) {
+	if ctx.ClientNoticeSender == nil {
+		return nil, errors.AssertionFailedf("notice sender not set")
+	}
+	ctx.ClientNoticeSender.SendClientNotice(
+		ctx.Context,
+		pgnotice.NewWithSeverityf(strings.ToUpper(severity), "%s", msg),
+	)
+	return tree.NewDInt(0), nil
+}

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 )
 
 // SessionData contains session parameters. They are all user-configurable.
@@ -106,6 +107,9 @@ type SessionData struct {
 	// InsertFastPath is true if the fast path for insert (with VALUES input) may
 	// be used.
 	InsertFastPath bool
+	// NoticeDisplaySeverity indicates the level of Severity to send notices for the given
+	// session.
+	NoticeDisplaySeverity pgnotice.DisplaySeverity
 }
 
 // DataConversionConfig contains the parameters that influence

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -163,4 +163,4 @@ type DummyClientNoticeSender struct{}
 var _ tree.ClientNoticeSender = &DummyClientNoticeSender{}
 
 // SendClientNotice is part of the tree.ClientNoticeSender interface.
-func (c *DummyClientNoticeSender) SendClientNotice(_ context.Context, _ error) {}
+func (c *DummyClientNoticeSender) SendClientNotice(context.Context, error) {}


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/44711

PostgreSQL supports notices of varying severity to display to the user.
This is achieved through the `client_min_messages` session var. The
strings it accepts is different than the Severity value.

As such, we create a new pgnotice package that has a `DisplaySeverity`
setting that encodes this value. Severities from pgerror will get
translated into a DisplaySeverity and compared to the
`client_min_messages` value before displaying.

In addition, we have created the `pgnotice` package which
contains the Severity constants as well as moving `pgerror.Noticef` to
`pgnotice.Newf`.

Release note (sql change): Users now have the ability to control which
level of NOTICE output with the session variable `client_min_messages`.

