### PR TITLE
release-19.2: opt: fix histogram type assertion error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1056,3 +1056,40 @@ EXECUTE change_rename_2
 ----
 a  b
 1  10
+
+# Regression test for #46217. Histogram type doesn't match column type.
+statement ok
+CREATE TABLE ts (d DATE PRIMARY KEY, x INT);
+
+statement ok
+ALTER TABLE ts INJECT STATISTICS '[
+  {
+    "columns": ["d"],
+    "created_at": "2020-03-24 15:34:22.863634+00:00",
+    "distinct_count": 1000,
+    "histo_buckets": [
+      {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "2020-03-24 15:16:12.117516+00:00"
+      },
+      {
+        "distinct_range": 501.60499999999996,
+        "num_eq": 10,
+        "num_range": 9999,
+        "upper_bound": "2020-03-25 00:05:28.117516+00:00"
+      }
+    ],
+    "histo_col_type": "TIMESTAMP",
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 100000
+  }
+]';
+
+statement ok
+PREPARE q AS DELETE FROM ts WHERE ts.d <= $1
+
+statement ok
+EXECUTE q ('2020-03-25')


### PR DESCRIPTION
Backport 1/1 commits from #46552.

/cc @cockroachdb/release

---

It is possible in certain edge cases that we need to filter a histogram
using a constraint with a different data type. For example, we may need
to filter a histogram of timestamps with a constraint of type date.

Prior to this commit, filtering a histogram with mismatched types
would cause an assertion error. This commit fixes the issue by avoiding
the calculations requiring a type assertion if the types don't match.

In order to easily perform this check, this commit includes a small
refactoring of the `getFilteredBucket` function in `histogram.go`.
Specifically, it pulls out the code for calculating bucket range sizes
and for determining whether a data type is discrete into two separate
functions.

Fixes #46217

Release justification: This change is a low risk, high benefit change
to existing functionality.

Release note (bug fix): Fixed an internal error that could happen
during planning when a column with a histogram was filtered with a
predicate of a different data type.
