### PR TITLE
colexec: improve test coverage for joiners

### DIFF
--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -973,24 +973,26 @@ func TestHashJoiner(t *testing.T) {
 		}
 		for _, tcs := range [][]joinTestCase{hjTestCases, mjTestCases} {
 			for _, tc := range tcs {
-				runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
-					spec := createSpecForHashJoiner(tc)
-					args := NewColOperatorArgs{
-						Spec:                spec,
-						Inputs:              sources,
-						StreamingMemAccount: testMemAcc,
-					}
-					args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-					args.TestingKnobs.DiskSpillingDisabled = true
-					result, err := NewColOperator(ctx, flowCtx, args)
-					if err != nil {
-						return nil, err
-					}
-					if hj, ok := result.Op.(*hashJoiner); ok {
-						hj.outputBatchSize = outputBatchSize
-					}
-					return result.Op, nil
-				})
+				for _, tc := range tc.mutateTypes() {
+					runHashJoinTestCase(t, tc, func(sources []Operator) (Operator, error) {
+						spec := createSpecForHashJoiner(tc)
+						args := NewColOperatorArgs{
+							Spec:                spec,
+							Inputs:              sources,
+							StreamingMemAccount: testMemAcc,
+						}
+						args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+						args.TestingKnobs.DiskSpillingDisabled = true
+						result, err := NewColOperator(ctx, flowCtx, args)
+						if err != nil {
+							return nil, err
+						}
+						if hj, ok := result.Op.(*hashJoiner); ok {
+							hj.outputBatchSize = outputBatchSize
+						}
+						return result.Op, nil
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
All Int64-specific merge join and hash join test cases are now
duplicated for Decimals and Bytes types.

Release note: None
Release justification: test-only change