### PR TITLE
build: do not fail RocksDB build on compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,8 +642,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | bin/.submodules-initial
 	  -DSNAPPY_LIBRARIES=$(LIBSNAPPY) -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(use-stdmalloc),,-DJEMALLOC_LIBRARIES=$(LIBJEMALLOC) -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
 	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release) \
-	  -DFAIL_ON_WARNINGS=$(if $(findstring windows,$(XGOOS)),0,1) \
-	  -DUSE_RTTI=1
+	  -DUSE_RTTI=1 -DFAIL_ON_WARNINGS=0
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild | bin/.submodules-initialized
 	rm -rf $(SNAPPY_DIR)

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-13
+14


### PR DESCRIPTION
Disable `-Werror` for the RocksDB build which has recently started
complaining about a missing exception specification in a jemalloc header
with the newest version of Xcode.

Release justification: low risk change to remove developer build
irritation. Should be a no-op for production builds.

Release note: None