### PR TITLE
Revert "sql: add support for max/min aggregates on collated strings"

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -97,8 +97,6 @@
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
-<tr><td><a name="max"></a><code>max(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
-</span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: oid) &rarr; oid</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
@@ -132,8 +130,6 @@
 <tr><td><a name="min"></a><code>min(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
-</span></td></tr>
-<tr><td><a name="min"></a><code>min(arg1: collatedstring{*}) &rarr; collatedstring{*}</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -61,11 +61,11 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version execinfrapb.DistSQLVersion = 29
+const Version execinfrapb.DistSQLVersion = 28
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 29
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 27
 
 // SettingUseTempStorageJoins is a cluster setting that configures whether
 // joins are allowed to spill to disk.

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -363,13 +363,3 @@ CREATE TABLE t46570(c0 BOOL, c1 STRING COLLATE en);
 CREATE INDEX ON t46570(rowid, c1 DESC);
 INSERT INTO t46570(c1, rowid) VALUES('' COLLATE en, 0);
 UPSERT INTO t46570(rowid) VALUES (0), (1)
-
-query T
-SELECT max(x) FROM (VALUES ('foo' COLLATE en), ('bar' COLLATE en)) t(x)
-----
-foo
-
-query T
-SELECT min(x) FROM (VALUES ('foo' COLLATE en), ('bar' COLLATE en)) t(x)
-----
-bar

--- a/pkg/sql/rowexec/version_history.txt
+++ b/pkg/sql/rowexec/version_history.txt
@@ -109,6 +109,3 @@
     - The CORR aggregate function has been added which will not be recognized
       by older nodes. However, new nodes can process plans from older nodes,
       so MinAcceptedVersion is unchanged.
-- Version: 29 (MinAcceptedVersion: 29)
-    - The Max and Min aggregate functions have been extended to support collated
-      strings. Old nodes won't have this ability, so we bump the version.

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -76,13 +76,6 @@ func aggPropsNullableArgs() tree.FunctionProperties {
 	return f
 }
 
-// allMaxMinAggregateTypes contains extra types that aren't in
-// types.Scalar that the max/min aggregate functions are defined on.
-var allMaxMinAggregateTypes = append(
-	[]*types.T{types.AnyCollatedString},
-	types.Scalar...,
-)
-
 // aggregates are a special class of builtin functions that are wrapped
 // at execution in a bucketing layer to combine (aggregate) the result
 // of the function being run over many rows.
@@ -204,13 +197,13 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the boolean value of `AND`ing all selected values."),
 	),
 
-	"max": collectOverloads(aggProps(), allMaxMinAggregateTypes,
+	"max": collectOverloads(aggProps(), types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeAggOverload([]*types.T{t}, t, newMaxAggregate,
 				"Identifies the maximum selected value.")
 		}),
 
-	"min": collectOverloads(aggProps(), allMaxMinAggregateTypes,
+	"min": collectOverloads(aggProps(), types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeAggOverload([]*types.T{t}, t, newMinAggregate,
 				"Identifies the minimum selected value.")


### PR DESCRIPTION
Reverts cockroachdb/cockroach#46647

As brought up by #46685, the simple change in #46647 is not enough. An investigation into why makes it seem like we need a decent refactor of the overload return type system. Because we type this aggregate with `types.AnyCollatedStringFamily`, we don't end up propagating the correct return type (the collation of the input) through to receivers of the aggregate's output. I think it is too late in the release to attempt such a refactor, so I'm going to revert this PR.

Release justification: Reverts a bug.
Release note (sql change): Remove the ability to perform min/max aggregates on collated strings.