### PR TITLE
build: use golang:1.13-buster for verify archive

### DIFF
--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -32,7 +32,7 @@ run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:1.13-stretch ./verify-archive.sh
+  golang:1.13-buster ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"


### PR DESCRIPTION
`verify archive` uses an older version of debian, which has an
older version of cmake (3.7). To fix this, we can upgrade the
version of debian to buster which has cmake 3.13.

Release justification: non-production code changes

Release note: None