### PR TITLE
sql: fix bug where placeholders in subqueries and CTEs have incorrect

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -565,3 +565,45 @@ SET c = c
 RETURNING b
 ----
 1
+
+# Regression for #42881.
+statement ok
+DROP TABLE IF EXISTS t1
+
+statement ok
+CREATE TABLE t1 (
+bucket BYTES NOT NULL,
+fullpath BYTES NOT NULL,
+metadata BYTES NOT NULL,
+CONSTRAINT "primary" PRIMARY KEY (bucket ASC, fullpath ASC),
+FAMILY "primary" (bucket, fullpath, metadata),
+CONSTRAINT check_fullpath CHECK (fullpath != '')
+);
+
+statement ok
+prepare x as UPDATE t1
+ SET metadata = $4::BYTEA
+ FROM (SELECT * FROM t1 WHERE bucket = $1::BYTEA AND fullpath = $2::BYTEA) mk
+ WHERE t1.metadata = $3::BYTEA
+ AND t1.bucket = mk.bucket
+ AND t1.fullpath = mk.fullpath
+ RETURNING 1;
+
+statement ok
+PREPARE y AS
+WITH
+	matching_key AS (SELECT * FROM t1 WHERE bucket = $1::BYTES AND fullpath = $2::BYTES),
+	updated
+		AS (
+			UPDATE t1 SET metadata = $4::BYTES FROM matching_key AS mk WHERE
+				t1.metadata = $3::BYTES AND t1.bucket = mk.bucket AND t1.fullpath = mk.fullpath
+			RETURNING 1
+		)
+SELECT
+	EXISTS(SELECT 1 FROM matching_key) AS key_present, EXISTS(SELECT 1 FROM updated) AS value_updated;
+
+query TT rowsort
+SELECT name, parameter_types FROM pg_prepared_statements
+----
+x {bytea,bytea,bytea,bytea}
+y {bytea,bytea,bytea,bytea}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -882,6 +882,9 @@ func (*ValuesClause) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ValuesClause) StatementTag() string { return "VALUES" }
 
+func (*With) StatementType() StatementType { return Rows }
+func (*With) StatementTag() string         { return "WITH" }
+
 func (n *AlterIndex) String() string                     { return AsString(n) }
 func (n *AlterTable) String() string                     { return AsString(n) }
 func (n *AlterTableCmds) String() string                 { return AsString(n) }
@@ -995,3 +998,4 @@ func (n *Truncate) String() string                       { return AsString(n) }
 func (n *UnionClause) String() string                    { return AsString(n) }
 func (n *Update) String() string                         { return AsString(n) }
 func (n *ValuesClause) String() string                   { return AsString(n) }
+func (n *With) String() string                           { return AsString(n) }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1096,6 +1096,17 @@ func (stmt *Select) walkStmt(v Visitor) Statement {
 			}
 		}
 	}
+	if stmt.With != nil {
+		for i, cte := range stmt.With.CTEList {
+			e, changed := walkStmt(v, cte.Stmt)
+			if changed {
+				if ret == stmt {
+					ret = stmt.copyNode()
+				}
+				ret.With.CTEList[i].Stmt = e
+			}
+		}
+	}
 	return ret
 }
 
@@ -1302,6 +1313,23 @@ func (stmt *Update) walkStmt(v Visitor) Statement {
 		}
 	}
 
+	if stmt.With != nil {
+		for i, cte := range stmt.With.CTEList {
+			e, changed := walkStmt(v, cte.Stmt)
+			if changed {
+				if ret == stmt {
+					ret = stmt.copyNode()
+				}
+				ret.With.CTEList[i].Stmt = e
+			}
+		}
+	}
+
+	for i, texpr := range stmt.From {
+		// TODO (rohany): Maybe copy the node here.
+		stmt.From[i] = WalkTableExpr(texpr, v)
+	}
+
 	if stmt.Where != nil {
 		e, changed := WalkExpr(v, stmt.Where.Expr)
 		if changed {
@@ -1356,6 +1384,17 @@ func (stmt *BeginTransaction) walkStmt(v Visitor) Statement {
 	return ret
 }
 
+func (stmt *With) walkStmt(v Visitor) Statement {
+	if stmt == nil {
+		return stmt
+	}
+	for i, cte := range stmt.CTEList {
+		// TODO (rohany): handle changed here.
+		stmt.CTEList[i].Stmt, _ = walkStmt(v, cte.Stmt)
+	}
+	return stmt
+}
+
 var _ walkableStmt = &CreateTable{}
 var _ walkableStmt = &Backup{}
 var _ walkableStmt = &Delete{}
@@ -1374,6 +1413,7 @@ var _ walkableStmt = &CancelQueries{}
 var _ walkableStmt = &CancelSessions{}
 var _ walkableStmt = &ControlJobs{}
 var _ walkableStmt = &BeginTransaction{}
+var _ walkableStmt = &With{}
 
 // walkStmt walks the entire parsed stmt calling WalkExpr on each
 // expression, and replacing each expression with the one returned


### PR DESCRIPTION
type annotations

Release justification:
Release note (<category, see below>): <what> <show> <why>