### PR TITLE
rowexec: fix bug with distinct aggregations on JSONB columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -210,3 +210,17 @@ query I
 SELECT COUNT (*) FROM (SELECT DISTINCT (array[x]) FROM t)
 ----
 1
+
+# Regression for #46709.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (i INT, x INT, y INT, z STRING);
+INSERT INTO t VALUES
+  (1, 1, 2, 'hello'),
+  (2, 1, 2, 'hello'),
+  (3, 1, 2, 'hello there')
+
+query IT
+SELECT x, jsonb_agg(DISTINCT jsonb_build_object('y', y, 'z', z)) FROM (SELECT * FROM t ORDER BY i) GROUP BY x
+----
+1 [{"y": 2, "z": "hello"}, {"y": 2, "z": "hello there"}]

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -555,32 +555,6 @@ func decodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 	}
 }
 
-// EncodeDatumKeyAscending encodes a datum using an order-preserving
-// encoding.
-// The encoding is lossy: some datums need composite encoding where
-// the key part only contains part of the datum's information.
-func EncodeDatumKeyAscending(b []byte, d tree.Datum) ([]byte, error) {
-	if values, ok := d.(*tree.DTuple); ok {
-		return EncodeDatumsKeyAscending(b, values.D)
-	}
-	return EncodeTableKey(b, d, encoding.Ascending)
-}
-
-// EncodeDatumsKeyAscending encodes a Datums (tuple) using an
-// order-preserving encoding.
-// The encoding is lossy: some datums need composite encoding where
-// the key part only contains part of the datum's information.
-func EncodeDatumsKeyAscending(b []byte, d tree.Datums) ([]byte, error) {
-	for _, val := range d {
-		var err error
-		b, err = EncodeDatumKeyAscending(b, val)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return b, nil
-}
-
 // MarshalColumnValue produces the value encoding of the given datum,
 // constrained by the given column type, into a roachpb.Value.
 //


### PR DESCRIPTION
Fixes #46709.

A recent change (#45229) was made to fix encodings to perform aggregations
on JSONB and ARRAY columns. That change missed a case in for
DISTINCT aggregations, causing a runtime error when executing
these queries.

Release justification: fixes a bug

Release note (bug fix): This PR fixes a bug with distinct aggregations
on JSONB columns.