### PR TITLE
colexec: populate batches for projecting operators upfront

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 )
@@ -112,7 +111,6 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	if origLen == 0 {
 		return coldata.ZeroBatch
 	}
-	o.allocator.MaybeAddColumn(batch, coltypes.Bool, o.outputIdx)
 	usesSel := false
 	if sel := batch.Selection(); sel != nil {
 		copy(o.origSel[:origLen], sel[:origLen])

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -28,28 +29,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Mock typing context for the typechecker.
-type mockTypeContext struct {
-	typs []types.T
-}
-
-func (p *mockTypeContext) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	return tree.DNull.Eval(ctx)
-}
-
-func (p *mockTypeContext) IndexedVarResolvedType(idx int) *types.T {
-	return &p.typs[idx]
-}
-
-func (p *mockTypeContext) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	n := tree.Name(fmt.Sprintf("$%d", idx))
-	return &n
-}
-
 func TestBasicBuiltinFunctions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Trick to get the init() for the builtins package to run.
 	_ = builtins.AllBuiltinNames
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
 
 	testCases := []struct {
 		desc         string
@@ -57,17 +50,15 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		inputCols    []int
 		inputTuples  tuples
 		inputTypes   []types.T
-		outputTypes  []types.T
 		outputTuples tuples
 	}{
 		{
 			desc:         "AbsVal",
 			expr:         "abs(@1)",
 			inputCols:    []int{0},
-			inputTuples:  tuples{{1}, {-1}},
+			inputTuples:  tuples{{1}, {-2}},
 			inputTypes:   []types.T{*types.Int},
-			outputTuples: tuples{{1, 1}, {-1, 1}},
-			outputTypes:  []types.T{*types.Int, *types.Int},
+			outputTuples: tuples{{1, 1}, {-2, 2}},
 		},
 		{
 			desc:         "StringLen",
@@ -76,28 +67,17 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 			inputTuples:  tuples{{"Hello"}, {"The"}},
 			inputTypes:   []types.T{*types.String},
 			outputTuples: tuples{{"Hello", 5}, {"The", 3}},
-			outputTypes:  []types.T{*types.String, *types.Int},
 		},
 	}
-
-	tctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			runTests(t, []tuples{tc.inputTuples}, tc.outputTuples, orderedVerifier,
 				func(input []Operator) (Operator, error) {
-					expr, err := parser.ParseExpr(tc.expr)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					p := &mockTypeContext{typs: tc.inputTypes}
-					typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					return NewBuiltinFunctionOperator(testAllocator, tctx, typedExpr.(*tree.FuncExpr), tc.outputTypes, tc.inputCols, 1, input[0])
+					return createTestProjectingOperator(
+						ctx, flowCtx, input[0], tc.inputTypes,
+						tc.expr, false, /* canFallbackToRowexec */
+					)
 				})
 		})
 	}
@@ -105,7 +85,15 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 
 func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
-	tctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
 
 	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Int64})
 	col := batch.ColVec(0).Int64()
@@ -137,19 +125,12 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	}
 
 	source := NewRepeatableBatchSource(testAllocator, batch)
-	source.Init()
-
-	expr, err := parser.ParseExpr("abs(@1)")
-	if err != nil {
-		b.Fatal(err)
-	}
-	p := &mockTypeContext{typs: []types.T{*types.Int}}
-	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
-	if err != nil {
-		b.Fatal(err)
-	}
-	op, err := NewBuiltinFunctionOperator(testAllocator, tctx, typedExpr.(*tree.FuncExpr), []types.T{*types.Int}, []int{0}, 1, source)
+	op, err := createTestProjectingOperator(
+		ctx, flowCtx, source, []types.T{*types.Int},
+		"abs(@1)" /* projectingExpr */, false, /* canFallbackToRowexec */
+	)
 	require.NoError(b, err)
+	op.Init()
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
@@ -176,6 +157,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	tctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	batch := testAllocator.NewMemBatch([]coltypes.T{coltypes.Bytes, coltypes.Int64, coltypes.Int64})
+	outputIdx := 3
 	bCol := batch.ColVec(0).Bytes()
 	sCol := batch.ColVec(1).Int64()
 	eCol := batch.ColVec(2).Int64()
@@ -185,7 +167,9 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		eCol[i] = 4
 	}
 	batch.SetLength(coldata.BatchSize())
-	source := NewRepeatableBatchSource(testAllocator, batch)
+	var source Operator
+	source = NewRepeatableBatchSource(testAllocator, batch)
+	source = newVectorTypeEnforcer(testAllocator, source, coltypes.Bytes, outputIdx)
 
 	// Set up the default operator.
 	expr, err := parser.ParseExpr("substring(@1, @2, @3)")
@@ -204,19 +188,19 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		allocator:      testAllocator,
 		evalCtx:        tctx,
 		funcExpr:       typedExpr.(*tree.FuncExpr),
-		outputIdx:      3,
+		outputIdx:      outputIdx,
 		columnTypes:    typs,
 		outputType:     types.String,
 		outputPhysType: coltypes.Bytes,
 		converter:      typeconv.GetDatumToPhysicalFn(types.String),
-		row:            make(tree.Datums, 3),
+		row:            make(tree.Datums, outputIdx),
 		argumentCols:   inputCols,
 	}
 	defaultOp.Init()
 
 	// Set up the specialized substring operator.
 	specOp := newSubstringOperator(
-		testAllocator, typs, inputCols, 3 /* outputIdx */, source,
+		testAllocator, typs, inputCols, outputIdx, source,
 	)
 	specOp.Init()
 
@@ -227,7 +211,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 			b := defaultOp.Next(ctx)
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
-			b.ColVec(3).Bytes().Reset()
+			b.ColVec(outputIdx).Bytes().Reset()
 		}
 	})
 
@@ -238,7 +222,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 			b := specOp.Next(ctx)
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
-			b.ColVec(3).Bytes().Reset()
+			b.ColVec(outputIdx).Bytes().Reset()
 		}
 	})
 }

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -113,7 +113,6 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	if origLen == 0 {
 		return coldata.ZeroBatch
 	}
-	c.allocator.MaybeAddColumn(c.buffer.batch, c.typ, c.outputIdx)
 	var origHasSel bool
 	if sel := c.buffer.batch.Selection(); sel != nil {
 		origHasSel = true

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -27,11 +27,10 @@ package colexec
 
 import (
 	"bytes"
-  "context"
+	"context"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
 {{range .}}

--- a/pkg/sql/colexec/is_null_ops.go
+++ b/pkg/sql/colexec/is_null_ops.go
@@ -31,6 +31,7 @@ type isNullProjOp struct {
 func newIsNullProjOp(
 	allocator *Allocator, input Operator, colIdx, outputIdx int, negate bool,
 ) Operator {
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Bool, outputIdx)
 	return &isNullProjOp{
 		OneInputNode: NewOneInputNode(input),
 		allocator:    allocator,
@@ -52,7 +53,6 @@ func (o *isNullProjOp) Next(ctx context.Context) coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	o.allocator.MaybeAddColumn(batch, coltypes.Bool, o.outputIdx)
 	vec := batch.ColVec(o.colIdx)
 	nulls := vec.Nulls()
 	projCol := batch.ColVec(o.outputIdx).Bool()

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -87,29 +87,10 @@ func TestIsNullProjOp(t *testing.T) {
 				if c.negate {
 					projExpr = "IS NOT NULL"
 				}
-				spec := &execinfrapb.ProcessorSpec{
-					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []types.T{*types.Int}}},
-					Core: execinfrapb.ProcessorCoreUnion{
-						Noop: &execinfrapb.NoopCoreSpec{},
-					},
-					Post: execinfrapb.PostProcessSpec{
-						RenderExprs: []execinfrapb.Expression{
-							{Expr: "@1"},
-							{Expr: fmt.Sprintf("@1 %s", projExpr)},
-						},
-					},
-				}
-				args := NewColOperatorArgs{
-					Spec:                spec,
-					Inputs:              input,
-					StreamingMemAccount: testMemAcc,
-				}
-				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-				result, err := NewColOperator(ctx, flowCtx, args)
-				if err != nil {
-					return nil, err
-				}
-				return result.Op, nil
+				return createTestProjectingOperator(
+					ctx, flowCtx, input[0], []types.T{*types.Int},
+					fmt.Sprintf("@1 %s", projExpr), false, /* canFallbackToRowexec */
+				)
 			}
 			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
 		})

--- a/pkg/sql/colexec/like_ops.go
+++ b/pkg/sql/colexec/like_ops.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
@@ -184,6 +185,7 @@ func GetLikeProjectionOperator(
 		return nil, err
 	}
 	pat := []byte(pattern)
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Bool, resultIdx)
 	base := projConstOpBase{
 		OneInputNode: NewOneInputNode(input),
 		allocator:    allocator,

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 )
@@ -285,3 +286,105 @@ func (o *feedOperator) Next(context.Context) coldata.Batch {
 }
 
 var _ Operator = &feedOperator{}
+
+// vectorTypeEnforcer is a utility Operator that on every call to Next
+// enforces that non-zero length batch from the input has a vector of the
+// desired type in the desired position. If the width of the batch is less than
+// the desired position, a new vector will be appended; if the batch has a
+// well-typed vector of an undesired type in the desired position, an error
+// will occur.
+//
+// This Operator is designed to be planned as a wrapper on the input to a
+// "projecting" Operator (such Operator that has a single column as its output
+// and does not touch other columns by simply passing them along).
+//
+// The intended diagram is as follows:
+//
+//       original input                (with schema [t1, ..., tN])
+//       --------------
+//             |
+//             ↓
+//     vectorTypeEnforcer              (will enforce that tN+1 = outputType)
+//     ------------------
+//             |
+//             ↓
+//   "projecting" operator             (projects its output of type outputType
+//   ---------------------              in column at position of N+1)
+//
+type vectorTypeEnforcer struct {
+	OneInputNode
+	NonExplainable
+
+	allocator *Allocator
+	typ       coltypes.T
+	idx       int
+}
+
+var _ Operator = &vectorTypeEnforcer{}
+
+func newVectorTypeEnforcer(allocator *Allocator, input Operator, typ coltypes.T, idx int) Operator {
+	return &vectorTypeEnforcer{
+		OneInputNode: NewOneInputNode(input),
+		allocator:    allocator,
+		typ:          typ,
+		idx:          idx,
+	}
+}
+
+func (e *vectorTypeEnforcer) Init() {
+	e.input.Init()
+}
+
+func (e *vectorTypeEnforcer) Next(ctx context.Context) coldata.Batch {
+	b := e.input.Next(ctx)
+	if b.Length() == 0 {
+		return b
+	}
+	e.allocator.maybeAppendColumn(b, e.typ, e.idx)
+	return b
+}
+
+// batchSchemaPrefixEnforcer is similar to vectorTypeEnforcer in its purpose,
+// but it enforces that the prefix of the columns of the non-zero length batch
+// satisfies the desired schema. It needs to wrap the input to a "projecting"
+// operator that internally uses other "projecting" operators (for example,
+// caseOp and logical projection operators). This operator supports type
+// schemas with coltypes.Unhandled type in which case in the corresponding
+// position an "unknown" vector can be appended.
+//
+// NOTE: the type schema passed into batchSchemaPrefixEnforcer *must* include
+// the output type of the Operator that the enforcer will be the input to.
+type batchSchemaPrefixEnforcer struct {
+	OneInputNode
+	NonExplainable
+
+	allocator *Allocator
+	typs      []coltypes.T
+}
+
+var _ Operator = &batchSchemaPrefixEnforcer{}
+
+func newBatchSchemaPrefixEnforcer(
+	allocator *Allocator, input Operator, typs []coltypes.T,
+) *batchSchemaPrefixEnforcer {
+	return &batchSchemaPrefixEnforcer{
+		OneInputNode: NewOneInputNode(input),
+		allocator:    allocator,
+		typs:         typs,
+	}
+}
+
+func (e *batchSchemaPrefixEnforcer) Init() {
+	e.input.Init()
+}
+
+func (e *batchSchemaPrefixEnforcer) Next(ctx context.Context) coldata.Batch {
+	b := e.input.Next(ctx)
+	if b.Length() == 0 {
+		return b
+	}
+	for i, typ := range e.typs {
+		e.allocator.maybeAppendColumn(b, typ, i)
+	}
+	return b
+}

--- a/pkg/sql/colexec/ordinality.go
+++ b/pkg/sql/colexec/ordinality.go
@@ -34,6 +34,7 @@ var _ Operator = &ordinalityOp{}
 
 // NewOrdinalityOp returns a new WITH ORDINALITY operator.
 func NewOrdinalityOp(allocator *Allocator, input Operator, outputIdx int) Operator {
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Int64, outputIdx)
 	c := &ordinalityOp{
 		OneInputNode: NewOneInputNode(input),
 		allocator:    allocator,
@@ -52,7 +53,6 @@ func (c *ordinalityOp) Next(ctx context.Context) coldata.Batch {
 	if bat.Length() == 0 {
 		return coldata.ZeroBatch
 	}
-	c.allocator.MaybeAddColumn(bat, coltypes.Int64, c.outputIdx)
 
 	vec := bat.ColVec(c.outputIdx).Int64()
 	sel := bat.Selection()

--- a/pkg/sql/colexec/partitioner.go
+++ b/pkg/sql/colexec/partitioner.go
@@ -48,6 +48,7 @@ func NewWindowSortingPartitioner(
 		return nil, err
 	}
 
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Bool, partitionColIdx)
 	return &windowSortingPartitioner{
 		OneInputNode:    NewOneInputNode(input),
 		allocator:       allocator,
@@ -76,7 +77,6 @@ func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
 	if b.Length() == 0 {
 		return coldata.ZeroBatch
 	}
-	p.allocator.MaybeAddColumn(b, coltypes.Bool, p.partitionColIdx)
 	partitionVec := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()
 	if sel != nil {

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -100,7 +100,6 @@ func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	p.allocator.MaybeAddColumn(batch, coltypes._RET_TYP, p.outputIdx)
 	vec := batch.ColVec(p.colIdx)
 	// {{if _IS_CONST_LEFT}}
 	col := vec._R_TYP()
@@ -204,12 +203,14 @@ func GetProjection_CONST_SIDEConstOperator(
 	allocator *Allocator,
 	leftColType *types.T,
 	rightColType *types.T,
+	outputPhysType coltypes.T,
 	op tree.Operator,
 	input Operator,
 	colIdx int,
 	constArg tree.Datum,
 	outputIdx int,
 ) (Operator, error) {
+	input = newVectorTypeEnforcer(allocator, input, outputPhysType, outputIdx)
 	projConstOpBase := projConstOpBase{
 		OneInputNode: NewOneInputNode(input),
 		allocator:    allocator,

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -122,7 +122,6 @@ func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	p.allocator.MaybeAddColumn(batch, coltypes._RET_TYP, p.outputIdx)
 	projVec := batch.ColVec(p.outputIdx)
 	projCol := projVec._RET_TYP()
 	vec1 := batch.ColVec(p.col1Idx)
@@ -230,12 +229,14 @@ func GetProjectionOperator(
 	allocator *Allocator,
 	leftColType *types.T,
 	rightColType *types.T,
+	outputPhysType coltypes.T,
 	op tree.Operator,
 	input Operator,
 	col1Idx int,
 	col2Idx int,
 	outputIdx int,
 ) (Operator, error) {
+	input = newVectorTypeEnforcer(allocator, input, outputPhysType, outputIdx)
 	projOpBase := projOpBase{
 		OneInputNode: NewOneInputNode(input),
 		allocator:    allocator,

--- a/pkg/sql/colexec/rank_tmpl.go
+++ b/pkg/sql/colexec/rank_tmpl.go
@@ -49,6 +49,7 @@ func NewRankOperator(
 	if len(orderingCols) == 0 {
 		return NewConstOp(allocator, input, coltypes.Int64, int64(1), outputColIdx)
 	}
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Int64, outputColIdx)
 	initFields := rankInitFields{
 		OneInputNode:    NewOneInputNode(input),
 		allocator:       allocator,
@@ -126,7 +127,6 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	r.allocator.MaybeAddColumn(batch, coltypes.Int64, r.outputColIdx)
 	// {{if .HasPartition}}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{end}}

--- a/pkg/sql/colexec/row_number_tmpl.go
+++ b/pkg/sql/colexec/row_number_tmpl.go
@@ -34,6 +34,7 @@ import (
 func NewRowNumberOperator(
 	allocator *Allocator, input Operator, outputColIdx int, partitionColIdx int,
 ) Operator {
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Int64, outputColIdx)
 	base := rowNumberBase{
 		OneInputNode:    NewOneInputNode(input),
 		allocator:       allocator,
@@ -75,10 +76,6 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
-	// {{ if .HasPartition }}
-	r.allocator.MaybeAddColumn(batch, coltypes.Bool, r.partitionColIdx)
-	// {{ end }}
-	r.allocator.MaybeAddColumn(batch, coltypes.Int64, r.outputColIdx)
 
 	// {{ if .HasPartition }}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -18,6 +18,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -151,61 +158,57 @@ func BenchmarkSelectInInt64(b *testing.B) {
 
 func TestProjectInInt64(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
 	testCases := []struct {
 		desc         string
 		inputTuples  tuples
 		outputTuples tuples
-		filterRow    []int64
-		hasNulls     bool
-		negate       bool
+		inClause     string
 	}{
 		{
 			desc:         "Simple in test",
 			inputTuples:  tuples{{0}, {1}},
 			outputTuples: tuples{{0, true}, {1, true}},
-			filterRow:    []int64{0, 1},
-			hasNulls:     false,
-			negate:       false,
+			inClause:     "IN (0, 1)",
 		},
 		{
 			desc:         "Simple not in test",
 			inputTuples:  tuples{{2}},
 			outputTuples: tuples{{2, true}},
-			filterRow:    []int64{0, 1},
-			hasNulls:     false,
-			negate:       true,
+			inClause:     "NOT IN (0, 1)",
 		},
 		{
 			desc:         "In test with NULLs",
 			inputTuples:  tuples{{1}, {2}, {nil}},
 			outputTuples: tuples{{1, true}, {2, nil}, {nil, nil}},
-			filterRow:    []int64{1},
-			hasNulls:     true,
-			negate:       false,
+			inClause:     "IN (1, NULL)",
 		},
 		{
 			desc:         "Not in test with NULLs",
 			inputTuples:  tuples{{1}, {2}, {nil}},
 			outputTuples: tuples{{1, false}, {2, nil}, {nil, nil}},
-			filterRow:    []int64{1},
-			hasNulls:     true,
-			negate:       true,
+			inClause:     "NOT IN (1, NULL)",
 		},
 		{
 			desc:         "Not in test with NULLs and no nulls in filter",
 			inputTuples:  tuples{{1}, {2}, {nil}},
 			outputTuples: tuples{{1, false}, {2, true}, {nil, nil}},
-			filterRow:    []int64{1},
-			hasNulls:     false,
-			negate:       true,
+			inClause:     "NOT IN (1)",
 		},
 		{
 			desc:         "Test with false values",
 			inputTuples:  tuples{{1}, {2}},
 			outputTuples: tuples{{1, false}, {2, false}},
-			filterRow:    []int64{3},
-			hasNulls:     false,
-			negate:       false,
+			inClause:     "IN (3)",
 		},
 	}
 
@@ -213,16 +216,44 @@ func TestProjectInInt64(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier,
 				func(input []Operator) (Operator, error) {
-					op := projectInOpInt64{
-						OneInputNode: NewOneInputNode(input[0]),
-						allocator:    testAllocator,
-						colIdx:       0,
-						outputIdx:    1,
-						filterRow:    c.filterRow,
-						negate:       c.negate,
-						hasNulls:     c.hasNulls,
+					expr, err := parser.ParseExpr(fmt.Sprintf("@1 %s", c.inClause))
+					if err != nil {
+						return nil, err
 					}
-					return &op, nil
+					p := &mockTypeContext{typs: []types.T{*types.Int, *types.MakeTuple([]types.T{*types.Int})}}
+					typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
+					if err != nil {
+						return nil, err
+					}
+					spec := &execinfrapb.ProcessorSpec{
+						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []types.T{*types.Int}}},
+						Core: execinfrapb.ProcessorCoreUnion{
+							Noop: &execinfrapb.NoopCoreSpec{},
+						},
+						Post: execinfrapb.PostProcessSpec{
+							RenderExprs: []execinfrapb.Expression{
+								{Expr: "@1"},
+								{LocalExpr: typedExpr},
+							},
+						},
+					}
+					args := NewColOperatorArgs{
+						Spec:                spec,
+						Inputs:              input,
+						StreamingMemAccount: testMemAcc,
+						// TODO(yuzefovich): figure out how to make the second
+						// argument of IN comparison as DTuple not Tuple.
+						// TODO(yuzefovich): reuse createTestProjectingOperator
+						// once we don't need to provide the processor
+						// constructor.
+						ProcessorConstructor: rowexec.NewProcessor,
+					}
+					args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+					result, err := NewColOperator(ctx, flowCtx, args)
+					if err != nil {
+						return nil, err
+					}
+					return result.Op, nil
 				})
 		})
 	}

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -86,6 +86,7 @@ func GetInProjectionOperator(
 	datumTuple *tree.DTuple,
 	negate bool,
 ) (Operator, error) {
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Bool, resultIdx)
 	var err error
 	switch t := typeconv.FromColumnType(ct); t {
 	// {{range .}}
@@ -271,7 +272,6 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
-	pi.allocator.MaybeAddColumn(batch, coltypes.Bool, pi.outputIdx)
 
 	vec := batch.ColVec(pi.colIdx)
 	col := vec._TemplateType()

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -30,6 +30,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// {{/*
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "coltypes" package.
+var _ coltypes.T
+
+// */}}
+
 func newSubstringOperator(
 	allocator *Allocator, columnTypes []types.T, argumentCols []int, outputIdx int, input Operator,
 ) Operator {
@@ -88,7 +96,6 @@ func (s *substring_StartType_LengthTypeOperator) Next(ctx context.Context) colda
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	s.allocator.MaybeAddColumn(batch, coltypes.Bytes, s.outputIdx)
 
 	sel := batch.Selection()
 	runeVec := batch.ColVec(s.argumentCols[0]).Bytes()

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -25,7 +25,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1447,4 +1451,79 @@ type sortTestCase struct {
 	ordCols     []execinfrapb.Ordering_Column
 	matchLen    int
 	k           uint16
+}
+
+// Mock typing context for the typechecker.
+type mockTypeContext struct {
+	typs []types.T
+}
+
+func (p *mockTypeContext) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
+	return tree.DNull.Eval(ctx)
+}
+
+func (p *mockTypeContext) IndexedVarResolvedType(idx int) *types.T {
+	return &p.typs[idx]
+}
+
+func (p *mockTypeContext) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	n := tree.Name(fmt.Sprintf("$%d", idx))
+	return &n
+}
+
+// createTestProjectingOperator creates a projecting operator that performs
+// projectingExpr on input that has inputTypes as its output columns. It does
+// so by making a noop processor core with post-processing step that passes
+// through all input columns and renders an additional column using
+// projectingExpr to create the render; then, the processor core is used to
+// plan all necessary infrastructure using NewColOperator call.
+// - canFallbackToRowexec determines whether NewColOperator will be able to use
+// rowexec.NewProcessor to instantiate a wrapped rowexec processor. This should
+// be false unless we expect that for some unit tests we will not be able to
+// plan the "pure" vectorized operators.
+func createTestProjectingOperator(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	input Operator,
+	inputTypes []types.T,
+	projectingExpr string,
+	canFallbackToRowexec bool,
+) (Operator, error) {
+	expr, err := parser.ParseExpr(projectingExpr)
+	if err != nil {
+		return nil, err
+	}
+	p := &mockTypeContext{typs: inputTypes}
+	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
+	if err != nil {
+		return nil, err
+	}
+	renderExprs := make([]execinfrapb.Expression, len(inputTypes)+1)
+	for i := range inputTypes {
+		renderExprs[i].Expr = fmt.Sprintf("@%d", i+1)
+	}
+	renderExprs[len(inputTypes)].LocalExpr = typedExpr
+	spec := &execinfrapb.ProcessorSpec{
+		Input: []execinfrapb.InputSyncSpec{{ColumnTypes: inputTypes}},
+		Core: execinfrapb.ProcessorCoreUnion{
+			Noop: &execinfrapb.NoopCoreSpec{},
+		},
+		Post: execinfrapb.PostProcessSpec{
+			RenderExprs: renderExprs,
+		},
+	}
+	args := NewColOperatorArgs{
+		Spec:                spec,
+		Inputs:              []Operator{input},
+		StreamingMemAccount: testMemAcc,
+	}
+	if canFallbackToRowexec {
+		args.ProcessorConstructor = rowexec.NewProcessor
+	}
+	args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+	result, err := NewColOperator(ctx, flowCtx, args)
+	if err != nil {
+		return nil, err
+	}
+	return result.Op, nil
 }

--- a/pkg/sql/colexec/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/window_peer_grouper_tmpl.go
@@ -57,6 +57,7 @@ func NewWindowPeerGrouper(
 			return nil, err
 		}
 	}
+	input = newVectorTypeEnforcer(allocator, input, coltypes.Bool, outputColIdx)
 	initFields := windowPeerGrouperInitFields{
 		OneInputNode:    NewOneInputNode(input),
 		allocator:       allocator,
@@ -117,7 +118,6 @@ func (p *_PEER_GROUPER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if n == 0 {
 		return b
 	}
-	p.allocator.MaybeAddColumn(b, coltypes.Bool, p.outputColIdx)
 	// {{if .HasPartition}}
 	partitionCol := b.ColVec(p.partitionColIdx).Bool()
 	// {{end}}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -1,4 +1,4 @@
-# LogicTest: local-vec
+# LogicTest: local-vec fakedist-vec
 
 # Check that all types supported by the vectorized engine can be read correctly.
 statement ok
@@ -135,3 +135,18 @@ SELECT sum(c) FROM (SELECT CAST((IF(IF(false, false, c0 IS NULL), NULL, NULL)) B
 
 statement ok
 RESET default_int_size
+
+# Regression test for #46714 (mismatched expected logical and actual physical
+# integer types "inside" of the vectorized flow).
+statement ok
+CREATE TABLE t46714_0(c0 INT4); CREATE TABLE t46714_1(c0 INT4); INSERT INTO t46714_0 VALUES (0); INSERT INTO t46714_1 VALUES (0)
+
+query I
+SELECT 1 FROM t46714_0, t46714_1 GROUP BY t46714_0.c0 * t46714_1.c0
+----
+1
+
+query I
+SELECT * FROM t46714_0 ORDER BY c0 + c0
+----
+0


### PR DESCRIPTION
**colexec: populate batches for projecting operators upfront**

Release justification: bug fix (without this, vectorized engine could
hit internal errors in some cases).

This commit introduces two utility operators `vectorTypeEnforcer` and
`batchSchemaPrefixEnforcer` which all "projecting" operators that do not
output their own batches need to use. This utility operators are planned
in a such way that they wrap the input to the projecting operator and
make sure that there is an output column of the appropriate type for
corresponding projecting operator. For most operators, enforcing
a single column is sufficient, however, `caseOp`, `andProjOp`, and
`orProjOp` use side chains of projecting operators, so they need to
enforce the vector types on the prefix of the columns from the batch, so
they use `batchSchemaPrefixEnforcer`. Such design allows us to have
short-circuiting logic in all operators on zero-length batches, yet it
enforces that all vectors are correctly appended upfront.

Additionally, this commit refactors several unit tests to use
`NewColOperator` to plan the operators to test rather than instantiating
them directly. This is done so that planning code is being tested as
well, and it already found a deficiency in planning casts to decimals
(namely, currently we're prohibiting all possible casts except between
decimals of the same precision).

Fixes: #46646.

Release note: None

**colexec: fix width mismatch for integer types in some cases**

We have a limitation of our SQL type system that it doesn't respect the
width of integer columns, however, the vectorized projecting operators
do, and this can lead to a mismatch between expected logical and actual
physical types in the vectorized flow. This is now fixed by planning
a cast that "synchronizes" the reality and the expectations.

Fixes: #46714.

Release note (bug fix): Previously, CockroachDB could hit an internal
error when queries with projections only of `INT2` and/or `INT4` columns
were executed via the vectorized engine, and this has been fixed.