### PR TITLE
build: remove TestSqlLiteCorrelatedLogic

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -11,16 +11,9 @@ mkdir -p artifacts
 # the all-on/all-off strategy BUILDER_HIDE_GOPATH_SRC gives us.
 export BUILDER_HIDE_GOPATH_SRC=0
 
-# Run SqlLite tests that do not contain correlated subqueries first, since the
-# heuristic planner does not support that feature. Afterwards, run additional
-# tests that do require correlated subquery support, but only with the cost-
-# based optimizer.
-run_json_test build/builder.sh \
-  stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$'
-
+# Run SqlLite tests.
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -config local,fakedist -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$'
+  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$'

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -32,12 +32,8 @@ func TestLogic(t *testing.T) {
 	RunLogicTest(t, "testdata/logic_test/[^.]*")
 }
 
-// TestSqlLiteLogic runs the subset of SqlLite logic tests that do not require
-// support for correlated subqueries. The heuristic planner does not support
-// correlated subqueries, so until that is fully deprecated, it can only run
-// this subset.
-//
-// See the comments for runSQLLiteLogicTest for more detail on these tests.
+// TestSqlLiteLogic runs the supported SqlLite logic tests. See the comments
+// for runSQLLiteLogicTest for more detail on these tests.
 func TestSqlLiteLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	runSQLLiteLogicTest(t,
@@ -49,6 +45,14 @@ func TestSqlLiteLogic(t *testing.T) {
 		"/test/index/orderby_nosort/*/*.test",
 		"/test/index/view/*/*.test",
 
+		"/test/select1.test",
+		"/test/select2.test",
+		"/test/select3.test",
+		"/test/select4.test",
+
+		// TODO(andyk): No support for join ordering yet, so this takes too long.
+		// "/test/select5.test",
+
 		// TODO(pmattis): Incompatibilities in numeric types.
 		// For instance, we type SUM(int) as a decimal since all of our ints are
 		// int64.
@@ -59,24 +63,6 @@ func TestSqlLiteLogic(t *testing.T) {
 		// "/test/random/aggregates/*.test",
 		// "/test/random/groupby/*.test",
 		// "/test/random/select/*.test",
-	)
-}
-
-// TestSqlLiteCorrelatedLogic runs the subset of SqlLite logic tests that
-// require support for correlated subqueries. The cost-based optimizer has this
-// support, whereas the heuristic planner does not.
-//
-// See the comments for runSQLLiteLogicTest for more detail on these tests.
-func TestSqlLiteCorrelatedLogic(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	runSQLLiteLogicTest(t,
-		"/test/select1.test",
-		"/test/select2.test",
-		"/test/select3.test",
-		"/test/select4.test",
-
-		// TODO(andyk): No support for join ordering yet, so this takes too long.
-		// "/test/select5.test",
 	)
 }
 


### PR DESCRIPTION
Release justification: non-production code change. This commit changes testing
code.

This test was introduced to separate the SQLLite logic tests with
non-correlated subqueries in TestSqlLiteLogic from those with correlated
subqueries in TestSqlLiteCorrelatedLogic. The idea was to run the latter test
without the heuristic planner. Now that the heuristic planner is gone, this
commit merges the two tests back into one that is run using all configs.

Release note: None (testing change)