### PR TITLE
importccl: GC imported data when dropping table

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -10,6 +10,7 @@ package importccl
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"sort"
@@ -1234,8 +1235,9 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 // stuff to delete the keys in the background.
 func (r *importResumer) OnFailOrCancel(ctx context.Context, phs interface{}) error {
 	cfg := phs.(sql.PlanHookState).ExecCfg()
+	jr := cfg.JobRegistry
 	return cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		if err := r.dropTables(ctx, txn); err != nil {
+		if err := r.dropTables(ctx, jr, txn); err != nil {
 			return err
 		}
 		return r.releaseProtectedTimestamp(ctx, txn, cfg.ProtectedTimestampProvider)
@@ -1262,7 +1264,7 @@ func (r *importResumer) releaseProtectedTimestamp(
 }
 
 // dropTables implements the OnFailOrCancel logic.
-func (r *importResumer) dropTables(ctx context.Context, txn *kv.Txn) error {
+func (r *importResumer) dropTables(ctx context.Context, jr *jobs.Registry, txn *kv.Txn) error {
 	details := r.job.Details().(jobspb.ImportDetails)
 
 	// Needed to trigger the schema change manager.
@@ -1304,6 +1306,8 @@ func (r *importResumer) dropTables(ctx context.Context, txn *kv.Txn) error {
 	}
 
 	b := txn.NewBatch()
+	dropTime := int64(1)
+	tablesToGC := make([]sqlbase.ID, 0, len(details.Tables))
 	for _, tbl := range details.Tables {
 		tableDesc := *tbl.Desc
 		tableDesc.Version++
@@ -1315,9 +1319,8 @@ func (r *importResumer) dropTables(ctx context.Context, txn *kv.Txn) error {
 			// (that is, 1ns past the epoch) to allow this to be cleaned up as soon as
 			// possible. This is safe since the table data was never visible to users,
 			// and so we don't need to preserve MVCC semantics.
-			tableDesc.DropTime = 1
-			err := sqlbase.RemovePublicTableNamespaceEntry(ctx, txn, tableDesc.ParentID, tableDesc.Name)
-			if err != nil {
+			tableDesc.DropTime = dropTime
+			if err := sqlbase.RemovePublicTableNamespaceEntry(ctx, txn, tableDesc.ParentID, tableDesc.Name); err != nil {
 				return err
 			}
 		} else {
@@ -1337,6 +1340,27 @@ func (r *importResumer) dropTables(ctx context.Context, txn *kv.Txn) error {
 			sqlbase.WrapDescriptor(&tableDesc),
 			existingDesc)
 	}
+
+	// Queue a GC job.
+	gcDetails := jobspb.SchemaChangeGCDetails{}
+	for _, tableID := range tablesToGC {
+		gcDetails.Tables = append(gcDetails.Tables, jobspb.SchemaChangeGCDetails_DroppedID{
+			ID:       tableID,
+			DropTime: dropTime,
+		})
+	}
+	gcJobRecord := jobs.Record{
+		Description:   fmt.Sprintf("GC for %s", r.job.Payload().Description),
+		Username:      r.job.Payload().Username,
+		DescriptorIDs: tablesToGC,
+		Details:       gcDetails,
+		Progress:      jobspb.SchemaChangeGCProgress{},
+		NonCancelable: true,
+	}
+	if _, err := jr.CreateJobWithTxn(ctx, gcJobRecord, txn); err != nil {
+		return err
+	}
+
 	return errors.Wrap(txn.Run(ctx, b), "rolling back tables")
 }
 


### PR DESCRIPTION
When an import fails or is canceled, it marks the table as dropped. But
it should also create a GC job so that the data in that dropped table is
deleted.

Partially addresses #46684 (the IMPORT portion).

Release justification: bug fix
Release note (bug fix): Failed or canceled imports may have not cleaned
up partially imported data. This is now fixed for future imports.