### PR TITLE
server: Add engine_type tag to sentry reports

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1613,9 +1613,10 @@ func (s *Server) Start(ctx context.Context) error {
 	s.refreshSettings()
 
 	raven.SetTagsContext(map[string]string{
-		"cluster":   s.ClusterID().String(),
-		"node":      s.NodeID().String(),
-		"server_id": fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
+		"cluster":     s.ClusterID().String(),
+		"node":        s.NodeID().String(),
+		"server_id":   fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
+		"engine_type": s.cfg.StorageEngine.String(),
 	})
 
 	// We can now add the node registry.

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -113,7 +113,7 @@ func TestCrashReportingPacket(t *testing.T) {
 			message += ": " + panicPre
 			return message
 		}()},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 10, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 11, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {


### PR DESCRIPTION
Adds `engine_type` to the list of tags set in raven during
initialization. These tags are reported with all sentry reports made
on that node.

Fixes #46719.

Release justification: Low-risk sentry report change, makes
investigations easier.

Release note: None.