### PR TITLE
ui: (fix) Enable vertical scrolling for Node map page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -28,7 +28,7 @@
   height 100%
   display flex
   flex-direction column
-  overflow hidden
+  overflow auto
 
 .cluster-overview
   .cluster-summary
@@ -257,4 +257,3 @@
   max-width $max-window-width
   position relative
   padding $spacing-smaller $spacing-medium
-  overflow hidden


### PR DESCRIPTION
Resolves: #46516

Before, main panel on Cluster Overview > Node Map page
didn't have vertical scroll bar and the remaining part of
the bottom section with map couldn't be scrolled down.

Now with enabled vertical scrollbar for main panel it is
possible to scroll Map section.

<img width="1206" alt="Screenshot 2020-03-30 at 21 21 50" src="https://user-images.githubusercontent.com/3106437/77949137-230be400-72cf-11ea-9183-e7300353ec54.png">
<img width="1213" alt="Screenshot 2020-03-30 at 21 23 04" src="https://user-images.githubusercontent.com/3106437/77949143-256e3e00-72cf-11ea-9888-9d96b0cc2cab.png">

Release note (admin ui change): Add verticall scroll bar on
Cluster Overview main panel
- allows scroll down to Node Map section
- allows scroll down Node list table

Release justification: bug fixes and low-risk updates to new functionality