### PR TITLE
release-20.1: gcjob: ensure GC job timer fires appropriately when tables are expired

### DIFF
--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -97,6 +97,9 @@ func (r schemaChangeGCResumer) Resume(
 	tableDropTimes, indexDropTimes := getDropTimes(details)
 
 	allTables := getAllTablesWaitingForGC(details, progress)
+	if len(allTables) == 0 {
+		return nil
+	}
 	expired, earliestDeadline := refreshTables(ctx, execCfg, allTables, tableDropTimes, indexDropTimes, r.jobID, progress)
 	timerDuration := timeutil.Until(earliestDeadline)
 	if expired {
@@ -121,6 +124,9 @@ func (r schemaChangeGCResumer) Resume(
 			// that this job is responsible for, and computing the earliest deadline
 			// from our set of cached TTL values.
 			remainingTables := getAllTablesWaitingForGC(details, progress)
+			if len(remainingTables) == 0 {
+				return nil
+			}
 			expired, earliestDeadline = refreshTables(ctx, execCfg, remainingTables, tableDropTimes, indexDropTimes, r.jobID, progress)
 			timerDuration := time.Until(earliestDeadline)
 			if expired {

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -132,8 +132,8 @@ func isDoneGC(progress *jobspb.SchemaChangeGCProgress) bool {
 }
 
 // getAllTablesWaitingForGC returns a slice with all of the table IDs which have
-// note yet been scheduled to be GC'd or have not yet been GC'd. This is used to
-// determine which tables' statuses need to be updated.
+// note yet been been GC'd. This is used to determine which tables' statuses
+// need to be updated.
 func getAllTablesWaitingForGC(
 	details *jobspb.SchemaChangeGCDetails, progress *jobspb.SchemaChangeGCProgress,
 ) []sqlbase.ID {
@@ -142,7 +142,7 @@ func getAllTablesWaitingForGC(
 		allRemainingTableIDs = append(allRemainingTableIDs, details.ParentID)
 	}
 	for _, table := range progress.Tables {
-		if table.Status == jobspb.SchemaChangeGCProgress_WAITING_FOR_GC {
+		if table.Status != jobspb.SchemaChangeGCProgress_DELETED {
 			allRemainingTableIDs = append(allRemainingTableIDs, table.ID)
 		}
 	}

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -146,7 +146,7 @@ func updateTableStatus(
 
 	for i, t := range progress.Tables {
 		droppedTable := &progress.Tables[i]
-		if droppedTable.ID != table.ID || droppedTable.Status != jobspb.SchemaChangeGCProgress_WAITING_FOR_GC {
+		if droppedTable.ID != table.ID || droppedTable.Status == jobspb.SchemaChangeGCProgress_DELETED {
 			continue
 		}
 
@@ -191,6 +191,9 @@ func updateIndexesStatus(
 	soonestDeadline = timeutil.Unix(0, int64(math.MaxInt64))
 	for i := 0; i < len(progress.Indexes); i++ {
 		idxProgress := &progress.Indexes[i]
+		if idxProgress.Status == jobspb.SchemaChangeGCProgress_DELETED {
+			continue
+		}
 
 		sp := table.IndexSpan(idxProgress.IndexID)
 


### PR DESCRIPTION
Backport 1/1 commits from #46715.

/cc @cockroachdb/release

---

Previously, if a table should have already been GC'd there were cases
where the GC job would schedule the timer to fire after 5 minutes rather
than immediately. In particular, when a gossip update is triggered and
all tables have been moved to the DELETING state, the timer may be
rescheduled to fire at MaxSQLGCInterval (5 min), rather than
immediately. This lead to the possible starvation of GC jobs due to
gossip updates and generally delayed GC.

Release justification: bug fixes
Release note (bug fix): Ensure that index and table GC happen closer to
their GC deadline.
