### PR TITLE
sql: fix bug with operations on collated string arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -363,3 +363,13 @@ CREATE TABLE t46570(c0 BOOL, c1 STRING COLLATE en);
 CREATE INDEX ON t46570(rowid, c1 DESC);
 INSERT INTO t46570(c1, rowid) VALUES('' COLLATE en, 0);
 UPSERT INTO t46570(rowid) VALUES (0), (1)
+
+# Regression for #45703.
+statement ok
+CREATE TABLE t45703(a STRING COLLATE en_u_ks_level2);
+INSERT INTO t45703 VALUES ('foo' COLLATE en_u_ks_level2);
+
+query T
+SELECT array[a] FROM t45703
+----
+{foo}


### PR DESCRIPTION
Fixes #45703.

This PR fixes a bug caused by how we parse types of
collations. When we parse the case `expr::STRING[] COLLATE en`,
we parse this as `COLLATE(ANNOTATE(expr, STRING[]), en)`, rather
than `ANNOTATE(expr, (STRING COLLATE en)[])`. This causes various
issues in the DistSQL engine where expressions are serialized
to strings and back.

Release note (bug fix): This PR fixes bugs during query execution
related to creating expressions that are arrays of collated strings.