### PR TITLE
release-19.2: sql: omit certain foreign key checks after cascade when deleting

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -621,3 +621,41 @@ SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %
 # Clean up after the test.
 statement ok
 DROP TABLE c3, c2, c1, b2, b1, a;
+
+# Regression for #46094.
+
+statement ok
+CREATE TABLE parent (x INT PRIMARY KEY);
+CREATE TABLE child1 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE CASCADE,
+  FAMILY (id, x)
+);
+CREATE TABLE child2 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE SET NULL,
+  FAMILY (id, x)
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child1 VALUES (1, 1), (2, 1);
+INSERT INTO child2 VALUES (1, 1), (2, 1)
+
+# Here we ensure that after the cascaded deletes we don't need
+# to perform additional and unneeded FKScan operations after
+# cascade deleting or setting null to referencing rows.
+statement ok
+SET tracing=on,kv,results;
+DELETE FROM parent WHERE x = 1;
+SET tracing=off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
+  message LIKE 'Del%' OR message LIKE 'FKScan%'
+----
+Del /Table/109/1/1/0
+Del /Table/110/2/1/1/0
+Del /Table/110/1/1/0
+Del /Table/110/2/1/2/0
+Del /Table/110/1/2/0
+Del /Table/111/2/1/1/0
+Del /Table/111/2/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -345,7 +345,6 @@ Del /Table/61/1/1/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/1/#/62/{1-2}
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
@@ -354,7 +353,6 @@ Del /Table/61/1/2/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/2/#/62/{1-2}
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
@@ -363,7 +361,6 @@ Del /Table/61/1/3/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/3/#/62/{1-2}
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
@@ -372,7 +369,6 @@ Del /Table/61/1/4/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/4/#/62/{1-2}
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
@@ -381,7 +377,6 @@ Del /Table/61/1/5/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/5/#/62/{1-2}
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
@@ -390,7 +385,6 @@ Del /Table/61/1/6/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/6/#/62/{1-2}
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
@@ -399,7 +393,6 @@ Del /Table/61/1/7/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/7/#/62/{1-2}
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
@@ -408,7 +401,6 @@ Del /Table/61/1/8/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/8/#/62/{1-2}
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
@@ -417,7 +409,6 @@ Del /Table/61/1/9/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/9/#/62/{1-2}
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
@@ -426,7 +417,6 @@ Del /Table/61/1/10/#/62/1/1/0
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-FKScan /Table/61/1/10/#/62/{1-2}
 output row: [1]
 output row: [2]
 output row: [3]

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -58,6 +58,28 @@ func MakeDeleter(
 		if err != nil {
 			return Deleter{}, err
 		}
+		// If we are performing a cascade operation for a particular foreign
+		// key constraint, we don't also need to perform a foreign key
+		// existence check after the delete for the same foreign key
+		// constraint. This pass removes unnecessary existence helpers.
+		// In particular, we omit checks for CASCADE and SET NULL because
+		// after the cascader has finished deleting or setting rows to
+		// NULL, we don't need to verify the result of those operations.
+		// TODO (rohany): This code will be removed once the optimizer
+		//  handles cascade operations.
+		for k, helpers := range rowDeleter.Fks.fks {
+			index := 0
+			for i := range helpers {
+				helper := &helpers[i]
+				if helper.ref.OnDelete == sqlbase.ForeignKeyReference_CASCADE ||
+					helper.ref.OnDelete == sqlbase.ForeignKeyReference_SET_NULL {
+					continue
+				}
+				helpers[index] = *helper
+				index++
+			}
+			rowDeleter.Fks.fks[k] = helpers[:index]
+		}
 	}
 	return rowDeleter, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #46121.

/cc @cockroachdb/release

---

We still perform FK existence checks after cascading for
`CASCADE` and `SET NULL` operations after a delete. However,
we don't need to perform an additional read after performing
these operations, because the rows that would be queried for
the check are not present anymore after the cascade.

Release justification: low risk change with high benefit

Release note: None
