### PR TITLE
c-deps/geos: do not compile if using Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,8 +493,8 @@ LIBGEOS     := $(DYN_LIB_DIR)/libgeos.$(DYN_EXT)
 
 C_LIBS_COMMON = \
 	$(if $(use-stdmalloc),,$(LIBJEMALLOC)) \
-	$(if $(target-is-windows),,$(LIBEDIT)) \
-	$(LIBPROTOBUF) $(LIBSNAPPY) $(LIBGEOS) $(LIBROCKSDB)
+	$(if $(target-is-windows),,$(LIBEDIT) $(LIBGEOS)) \
+	$(LIBPROTOBUF) $(LIBSNAPPY) $(LIBROCKSDB)
 C_LIBS_OSS = $(C_LIBS_COMMON) $(LIBROACH)
 C_LIBS_CCL = $(C_LIBS_COMMON) $(LIBCRYPTOPP) $(LIBROACHCCL)
 


### PR DESCRIPTION
Not sure what's causing the errors (guess I'd need to set a Windows
machine up to find out), but since we're not able planning to support
Windows (we don't have the right extensions set up anyway!) I'd move to
just not compile c-deps/geos on it.

Release note: None