### PR TITLE
sqltelemetry: add CANCEL QUERIES and CANCEL SESSIONS telemetry

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -13,12 +13,14 @@ package execbuilder
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -271,6 +273,9 @@ func (b *Builder) buildCancelQueries(cancel *memo.CancelQueriesExpr) (execPlan, 
 	if err != nil {
 		return execPlan{}, err
 	}
+	if !b.disableTelemetry {
+		telemetry.Inc(sqltelemetry.CancelQueriesUseCounter)
+	}
 	// CancelQueries returns no columns.
 	return execPlan{root: node}, nil
 }
@@ -283,6 +288,9 @@ func (b *Builder) buildCancelSessions(cancel *memo.CancelSessionsExpr) (execPlan
 	node, err := b.factory.ConstructCancelSessions(input.root, cancel.IfExists)
 	if err != nil {
 		return execPlan{}, err
+	}
+	if !b.disableTelemetry {
+		telemetry.Inc(sqltelemetry.CancelSessionsUseCounter)
 	}
 	// CancelSessions returns no columns.
 	return execPlan{root: node}, nil

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -156,6 +156,14 @@ var JoinTypeSemiUseCounter = telemetry.GetCounterOnce("sql.plan.opt.node.join.ty
 // planned.
 var JoinTypeAntiUseCounter = telemetry.GetCounterOnce("sql.plan.opt.node.join.type.anti")
 
+// CancelQueriesUseCounter is to be incremented whenever CANCEL QUERY or
+// CANCEL QUERIES is run.
+var CancelQueriesUseCounter = telemetry.GetCounterOnce("sql.session.cancel-queries")
+
+// CancelSessionsUseCounter is to be incremented whenever CANCEL SESSION or
+// CANCEL SESSIONS is run.
+var CancelSessionsUseCounter = telemetry.GetCounterOnce("sql.session.cancel-sessions")
+
 // We can't parameterize these telemetry counters, so just make a bunch of
 // buckets for setting the join reorder limit since the range of reasonable
 // values for the join reorder limit is quite small.


### PR DESCRIPTION
Release note: None (internal telemetry change)

Closes #45103

Not sure whether we want to distinguish between CANCEL QUERY vs QUERIES use and CANCEL SESSION vs SESSIONS use (or even how to). So just added one counter for each statement type which is probably good enough.

Tested this manually but holding off on writing tests since I've heard some work will be done on #46730 