### PR TITLE
ui: Enable sorting for Statements table (Databases page)

### DIFF
--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -38,6 +38,10 @@ const databaseTableGrantsSortSetting = new LocalSetting<AdminUIState, SortSettin
   "tableDetails/sort_setting/grants", (s) => s.localSettings,
 );
 
+const databaseTableStatementsSortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "tableDetails/sort_setting/statements", (s) => s.localSettings,
+);
+
 /**
  * TableMainData are the data properties which should be passed to the TableMain
  * container.
@@ -45,6 +49,7 @@ const databaseTableGrantsSortSetting = new LocalSetting<AdminUIState, SortSettin
 interface TableMainData {
   tableInfo: TableInfo;
   grantsSortSetting: SortSetting;
+  statementsSortSetting: SortSetting;
   statements: AggregateStatistics[];
 }
 
@@ -59,6 +64,7 @@ interface TableMainActions {
   refreshStatements: typeof refreshStatements;
   refreshDatabaseDetails: typeof refreshDatabaseDetails;
   setSort: typeof databaseTableGrantsSortSetting.set;
+  setStatementsTableSort: typeof databaseTableStatementsSortSetting.set;
   dbResponse: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
 }
 
@@ -103,7 +109,15 @@ export class TableMain extends React.Component<TableMainProps, {}> {
   }
 
   render() {
-    const { tableInfo, grantsSortSetting, statements, match, dbResponse } = this.props;
+    const {
+      tableInfo,
+      grantsSortSetting,
+      statements,
+      match,
+      dbResponse,
+      statementsSortSetting,
+      setStatementsTableSort,
+    } = this.props;
     const database = getMatchParamByName(match, databaseNameAttr);
     const table = getMatchParamByName(match, tableNameAttr);
     const selectedApp = getMatchParamByName(match, appAttr);
@@ -164,6 +178,8 @@ export class TableMain extends React.Component<TableMainProps, {}> {
               <TabPane tab="Statements" key="2">
                 <SummaryCard>
                   <StatementsSortedTable
+                    sortSetting={statementsSortSetting}
+                    onChangeSortSetting={(setting) => setStatementsTableSort(setting) }
                     data={this.getStatementsTableData()}
                     columns={statements && makeStatementsColumns(statements, selectedApp)}
                   />
@@ -213,12 +229,14 @@ export function selectTableInfo(state: AdminUIState, props: RouteComponentProps)
 const mapStateToProps = (state: AdminUIState, ownProps: RouteComponentProps) => ({
   tableInfo: selectTableInfo(state, ownProps),
   grantsSortSetting: databaseTableGrantsSortSetting.selector(state),
+  statementsSortSetting: databaseTableStatementsSortSetting.selector(state),
   statements: selectStatements(state, ownProps),
   dbResponse: databaseDetails(state)[getMatchParamByName(ownProps.match, databaseNameAttr)] && databaseDetails(state)[getMatchParamByName(ownProps.match, databaseNameAttr)].data,
 });
 
 const mapDispatchToProps = {
   setSort: databaseTableGrantsSortSetting.set,
+  setStatementsTableSort: databaseTableStatementsSortSetting.set,
   refreshTableDetails,
   refreshTableStats,
   refreshStatements,


### PR DESCRIPTION
Prior, sorting functionality wasn't applied on Statements
table in Databases > Table details page.

Now sorting functionality is added with the same
configuration as on Statements page (with default
sorting for Execution count column).
Also sorting selection is preserved across page
reloads in local storage.

Release note (admin ui change): Add sorting for
Statements table in Databases > Table details view.

Release justification: bug fixes and low-risk updates to new functionality

![out](https://user-images.githubusercontent.com/3106437/78043485-11344a80-737c-11ea-832f-73fd722981e9.gif)
