### PR TITLE
sql: add unimplemented error for ADD CONSTRAINT ... EXCLUDE USING

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3120,6 +3120,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 		expected string
 	}{
 		{`ALTER TABLE a ALTER CONSTRAINT foo`, 31632, `alter constraint`},
+		{`ALTER TABLE a ADD CONSTRAINT foo EXCLUDE USING gist (bar WITH =)`, 46657, `add constraint exclude using`},
 
 		{`CREATE AGGREGATE a`, 0, `create aggregate`},
 		{`CREATE CAST a`, 0, `create cast`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4828,6 +4828,10 @@ constraint_elem:
       Actions: $10.referenceActions(),
     }
   }
+| EXCLUDE USING error
+  {
+    return unimplementedWithIssueDetail(sqllex, 46657, "add constraint exclude using")
+  }
 
 
 create_as_opt_col_list:


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/46658.

Release note (sql change): This PR adds a new unimplemented error when
attempting to ADD CONSTRAINT with the EXCLUDE USING syntax.