### PR TITLE
Ui telemetry statements details

### DIFF
--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -1,0 +1,2 @@
+export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
+export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -13,3 +13,4 @@ export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpe
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
 export { default as trackTableSort } from "./trackTableSort";
 export { default as trackPaginate } from "./trackPaginate";
+export { default as trackSearch } from "./trackSearch";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -12,3 +12,4 @@ export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics"
 export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
 export { default as trackTableSort } from "./trackTableSort";
+export { default as trackPaginate } from "./trackPaginate";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -11,3 +11,4 @@
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
 export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
+export { default as trackTableSort } from "./trackTableSort";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -1,2 +1,12 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -9,4 +9,5 @@
 // licenses/APL.txt.
 
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
+export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -36,7 +36,7 @@ describe("trackActivateDiagnostics", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -49,6 +49,6 @@ describe("trackActivateDiagnostics", () => {
     const fingerprint = get(sent, "properties.fingerprint");
 
     assert.isTrue(isString(fingerprint));
-    assert.isTrue( fingerprint === statement);
+    assert.isTrue(fingerprint === statement);
   });
 });

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -1,0 +1,26 @@
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackActivateDiagnostics";
+
+const sandbox = createSandbox();
+
+describe("trackActivateDiagnostics", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should send a track call given a payload", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(spy.calledOnce);
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue( fingerprint === statement);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -20,7 +20,26 @@ describe("trackActivateDiagnostics", () => {
     sandbox.reset();
   });
 
-  it("should send a track call given a payload", () => {
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Activation";
+
+    track(spy)("whatever");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
     const spy = sandbox.spy();
     const statement = "SELECT blah from blah-blah";
 
@@ -29,7 +48,6 @@ describe("trackActivateDiagnostics", () => {
     const sent = spy.getCall(0).args[0];
     const fingerprint = get(sent, "properties.fingerprint");
 
-    assert.isTrue(spy.calledOnce);
     assert.isTrue(isString(fingerprint));
     assert.isTrue( fingerprint === statement);
   });

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { get, isString } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
@@ -1,0 +1,15 @@
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Activation",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackActivateDiagnostics (statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { analytics } from "src/redux/analytics";
 
 export const track = (fn: Function) => (statement: string) => {

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
@@ -36,10 +36,10 @@ describe("trackDiagnosticsModalOpen", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
-  it("should send a track call with the correct fingerprint", () => {
+  it("send the correct payload", () => {
     const spy = sandbox.spy();
     const statement = "SELECT blah from blah-blah";
 
@@ -49,6 +49,6 @@ describe("trackDiagnosticsModalOpen", () => {
     const fingerprint = get(sent, "properties.fingerprint");
 
     assert.isTrue(isString(fingerprint));
-    assert.isTrue( fingerprint === statement);
+    assert.isTrue(fingerprint === statement);
   });
 });

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackDiagnosticsModalOpen";
+
+const sandbox = createSandbox();
+
+describe("trackDiagnosticsModalOpen", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send a track call with the correct event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Modal Open";
+
+    track(spy)("some statement");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send a track call with the correct fingerprint", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue( fingerprint === statement);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Modal Open",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackDiagnosticsModalOpen (statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/src/util/analytics/trackPaginate.spec.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString, isNumber } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackPaginate";
+
+const sandbox = createSandbox();
+
+describe("trackPaginate", () => {
+  const testPage = 5;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testPage);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Paginate";
+
+    track(spy)(testPage);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testPage);
+
+    const sent = spy.getCall(0).args[0];
+    const selectedPage = get(sent, "properties.selectedPage");
+
+    assert.isTrue(isNumber(selectedPage));
+    assert.isTrue( selectedPage === testPage);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackPaginate.spec.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.spec.ts
@@ -38,7 +38,7 @@ describe("trackPaginate", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -50,6 +50,6 @@ describe("trackPaginate", () => {
     const selectedPage = get(sent, "properties.selectedPage");
 
     assert.isTrue(isNumber(selectedPage));
-    assert.isTrue( selectedPage === testPage);
+    assert.isTrue(selectedPage === testPage);
   });
 });

--- a/pkg/ui/src/util/analytics/trackPaginate.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (page: number) => {
+  fn({
+    event: "Paginate",
+    properties: {
+      selectedPage: page,
+    },
+  });
+};
+
+export default function trackSearch(pageNumber: number) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(pageNumber);
+}

--- a/pkg/ui/src/util/analytics/trackSearch.spec.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.spec.ts
@@ -38,7 +38,7 @@ describe("trackSearch", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -50,6 +50,6 @@ describe("trackSearch", () => {
     const numberOfResults = get(sent, "properties.numberOfResults");
 
     assert.isTrue(isNumber(numberOfResults));
-    assert.isTrue( numberOfResults === testSearchResults);
+    assert.isTrue(numberOfResults === testSearchResults);
   });
 });

--- a/pkg/ui/src/util/analytics/trackSearch.spec.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString, isNumber } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackSearch";
+
+const sandbox = createSandbox();
+
+describe("trackSearch", () => {
+  const testSearchResults = 3;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testSearchResults);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Search";
+
+    track(spy)(testSearchResults);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testSearchResults);
+
+    const sent = spy.getCall(0).args[0];
+    const numberOfResults = get(sent, "properties.numberOfResults");
+
+    assert.isTrue(isNumber(numberOfResults));
+    assert.isTrue( numberOfResults === testSearchResults);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackSearch.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (numberOfResults: number) => {
+  fn({
+      event: "Search",
+      properties: {
+        numberOfResults,
+      },
+  });
+};
+
+export default function trackSearch(numberOfResults: number) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(numberOfResults);
+}

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -16,20 +16,39 @@ import { track } from "./trackStatementDetailsSubnavSelection";
 const sandbox = createSandbox();
 
 describe("trackSubnavSelection", () => {
+  const subNavKey = "subnav-test";
+
   afterEach(() => {
     sandbox.reset();
   });
 
-  it("should send a track call given a selected nav item key", () => {
+  it("should only call track once", () => {
     const spy = sandbox.spy();
-    const subNavKey = "subnav-test";
+    track(spy)(subNavKey);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send a track call with the correct event", () => {
+    const spy = sandbox.spy();
+    const expected = "SubNavigation Selection";
+
+    track(spy)(subNavKey);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue(event === expected);
+  });
+
+  it("send the correct payload", () => {
+    const spy = sandbox.spy();
 
     track(spy)(subNavKey);
 
     const sent = spy.getCall(0).args[0];
     const selection = get(sent, "properties.selection");
 
-    assert.isTrue(spy.calledOnce);
     assert.isTrue(isString(selection));
     assert.isTrue(selection === subNavKey);
   });

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -1,0 +1,26 @@
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackStatementDetailsSubnavSelection";
+
+const sandbox = createSandbox();
+
+describe("trackSubnavSelection", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should send a track call given a selected nav item key", () => {
+    const spy = sandbox.spy();
+    const subNavKey = "subnav-test";
+
+    track(spy)(subNavKey);
+
+    const sent = spy.getCall(0).args[0];
+    const selection = get(sent, "properties.selection");
+
+    assert.isTrue(spy.calledOnce);
+    assert.isTrue(isString(selection));
+    assert.isTrue(selection === subNavKey);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { get, isString } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
@@ -1,0 +1,15 @@
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (selection: string) => {
+  fn({
+    event: "SubNavigation Selection",
+    properties: {
+      selection,
+    },
+  });
+};
+
+export default function trackSubnavSelection (selection: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(selection);
+}

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { analytics } from "src/redux/analytics";
 
 export const track = (fn: Function) => (selection: string) => {

--- a/pkg/ui/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.spec.ts
@@ -36,13 +36,13 @@ describe("trackTableSort", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
     const spy = sandbox.spy();
     const tableName = "Test table";
-    const column = { title: "test", cell: (x: number) => x};
+    const column = { title: "test", cell: (x: number) => x };
     const sortSetting = { sortKey: "whatever", ascending: true };
 
     track(spy)(tableName, column, sortSetting);

--- a/pkg/ui/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.spec.ts
@@ -1,0 +1,67 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTableSort";
+
+const sandbox = createSandbox();
+
+describe("trackTableSort", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)();
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Table Sort";
+
+    track(spy)();
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+    const tableName = "Test table";
+    const column = { title: "test", cell: (x: number) => x};
+    const sortSetting = { sortKey: "whatever", ascending: true };
+
+    track(spy)(tableName, column, sortSetting);
+
+    const sent = spy.getCall(0).args[0];
+    const table = get(sent, "properties.tableName");
+    const columnName = get(sent, "properties.columnName");
+    const direction = get(sent, "properties.sortDirection");
+
+    assert.isTrue(isString(table), "Table name is a string");
+    assert.isTrue(table === tableName, "Table name matches given table name");
+
+    assert.isTrue(isString(columnName), "Column name is a string");
+    assert.isTrue(column.title === columnName, "Column name matches given column name");
+
+    assert.isTrue(isString(direction), "Sort direction is a string");
+    assert.isTrue(
+      direction === "asc",
+      "Sort direction matches the sort setting ascending property",
+    );
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTableSort.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.ts
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+import { SortableColumn, SortSetting } from "oss/src/views/shared/components/sortabletable";
+
+export const track = (fn: Function) => (
+  name?: String,
+  col?: SortableColumn,
+  sortSetting?: SortSetting,
+) => {
+  const tableName = name || "";
+  const columnName = col && col.title || "";
+  const sortDirection = sortSetting && (sortSetting.ascending) ? "asc" : "desc";
+
+  fn({
+    event: "Table Sort",
+    properties: {
+      tableName,
+      columnName,
+      sortDirection,
+    },
+  });
+};
+
+export default function trackTableSort(
+  name?: String,
+  col?: SortableColumn,
+  sortSetting?: SortSetting,
+) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(name, col, sortSetting);
+}

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -16,7 +16,7 @@ import times from "lodash/times";
 
 import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
-import { analytics } from "src/redux/analytics";
+import { trackTableSort } from "src/util/analytics";
 
 import "./sortabletable.styl";
 
@@ -238,23 +238,6 @@ export class SortableTable extends React.Component<TableProps> {
     });
   }
 
-  trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
-    const tableName = name || "";
-    const columnName = col.title || "";
-    const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
-
-    const payload = {
-      event: "Table Sort",
-      properties: {
-        tableName,
-        columnName,
-        sortDirection,
-      },
-    };
-
-    analytics.track(payload);
-  }
-
   render() {
     const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult, className } = this.props;
     const { visible, drawerData } = this.state;
@@ -274,7 +257,7 @@ export class SortableTable extends React.Component<TableProps> {
                 if (!isUndefined(c.sortKey)) {
                   classes.push("sort-table__cell--sortable");
                   onClick = () => {
-                    this.trackTableSort(className, c, sortSetting);
+                    trackTableSort(className, c, sortSetting);
                     this.clickSort(c.sortKey);
                   };
                   if (c.sortKey === sortSetting.sortKey) {

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,18 +17,8 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { analytics } from "src/redux/analytics";
-
+import { trackActivateDiagnostics } from "src/util/analytics";
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
-
-function trackActivateDiagnostics (statement: string) {
-  analytics.track({
-    event: "Diagnostics Activation",
-    properties: {
-      fingerprint: statement,
-    },
-  });
-}
 
 export interface ActivateDiagnosticsModalRef {
   showModalFor: (statement: string) => void;

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,7 +17,7 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { trackActivateDiagnostics } from "src/util/analytics";
+import { trackActivateDiagnostics, trackDiagnosticsModalOpen } from "src/util/analytics";
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
 export interface ActivateDiagnosticsModalRef {
@@ -45,6 +45,7 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
     return {
       showModalFor: (forwardStatement: string) => {
         setStatement(forwardStatement);
+        trackDiagnosticsModalOpen(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -43,6 +43,7 @@ import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnost
 import { getDiagnosticsStatus, sortByCompletedField, sortByRequestedAtField } from "./diagnosticsUtils";
 import { statementDiagnostics } from "src/util/docs";
 import { createStatementDiagnosticsAlertLocalSetting } from "oss/src/redux/alerts";
+import { trackActivateDiagnostics } from "src/util/analytics";
 
 interface DiagnosticsViewOwnProps {
   statementFingerprint?: string;
@@ -126,6 +127,7 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
   onActivateButtonClick = () => {
     const { activate, statementFingerprint } = this.props;
     activate(statementFingerprint);
+    trackActivateDiagnostics(statementFingerprint);
   }
 
   componentWillUnmount() {
@@ -190,6 +192,7 @@ export class EmptyDiagnosticsView extends React.Component<DiagnosticsViewProps> 
   onActivateButtonClick = () => {
     const { activate, statementFingerprint } = this.props;
     activate(statementFingerprint);
+    trackActivateDiagnostics(statementFingerprint);
   }
 
   render() {

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -48,6 +48,7 @@ import {
   selectDiagnosticsReportsCountByStatementFingerprint,
 } from "src/redux/statements/statementsSelectors";
 import { Button, BackIcon } from "oss/src/components/button";
+import { analytics } from "src/redux/analytics";
 
 const { TabPane } = Tabs;
 
@@ -146,6 +147,18 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
     );
   }
 }
+
+const handleTabChange = (key: string) => {
+  // const tabInfo = find(tabPaneIndex, { key: key });
+  const payload = {
+    event: "SubNavigation Selection",
+    properties: {
+      selection: key,
+    },
+  };
+
+  analytics.track(payload);
+};
 
 export class StatementDetails extends React.Component<StatementDetailsProps, StatementDetailsState> {
 
@@ -248,8 +261,8 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     const logicalPlan = stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     return (
-      <Tabs defaultActiveKey="1" className="cockroach--tabs">
-        <TabPane tab="Overview" key="1">
+      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={handleTabChange}>
+        <TabPane tab="Overview" key="overview">
           <Row gutter={16}>
             <Col className="gutter-row" span={16}>
               <SqlBox value={ statement } />
@@ -324,10 +337,10 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
             </Col>
           </Row>
         </TabPane>
-        <TabPane tab={`Diagnostics ${diagnosticsCount > 0 ? `(${diagnosticsCount})` : ""}`} key="2">
+        <TabPane tab={`Diagnostics ${diagnosticsCount > 0 ? `(${diagnosticsCount})` : ""}`} key="diagnostics">
           <DiagnosticsView statementFingerprint={statement} />
         </TabPane>
-        <TabPane tab="Logical Plan" key="3">
+        <TabPane tab="Logical Plan" key="logical-plan">
           <SummaryCard>
             <PlanView
               title="Logical Plan"
@@ -335,7 +348,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
             />
           </SummaryCard>
         </TabPane>
-        <TabPane tab="Execution Stats" key="4">
+        <TabPane tab="Execution Stats" key="execution-stats">
           <SummaryCard>
             <h2 className="base-heading summary--card__title">
               Execution Latency By Phase

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -48,7 +48,7 @@ import {
   selectDiagnosticsReportsCountByStatementFingerprint,
 } from "src/redux/statements/statementsSelectors";
 import { Button, BackIcon } from "oss/src/components/button";
-import { analytics } from "src/redux/analytics";
+import { trackSubnavSelection } from "src/util/analytics";
 
 const { TabPane } = Tabs;
 
@@ -147,18 +147,6 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
     );
   }
 }
-
-const handleTabChange = (key: string) => {
-  // const tabInfo = find(tabPaneIndex, { key: key });
-  const payload = {
-    event: "SubNavigation Selection",
-    properties: {
-      selection: key,
-    },
-  };
-
-  analytics.track(payload);
-};
 
 export class StatementDetails extends React.Component<StatementDetailsProps, StatementDetailsState> {
 
@@ -261,7 +249,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     const logicalPlan = stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     return (
-      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={handleTabChange}>
+      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={trackSubnavSelection}>
         <TabPane tab="Overview" key="overview">
           <Row gutter={16}>
             <Col className="gutter-row" span={16}>

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -43,6 +43,7 @@ import {
 } from "src/redux/statements/statementsSelectors";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
+import { trackPaginate } from "src/util/analytics";
 
 import "./statements.styl";
 
@@ -163,7 +164,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
   onChangePage = (current: number) => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
-    this.trackPaginate(current);
+    trackPaginate(current);
   }
   onSubmitSearchField = (search: string) => {
     this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
@@ -190,15 +191,6 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
       event: "Search",
       properties: {
         numberOfResults,
-      },
-    });
-  }
-
-  trackPaginate = (page: number) => {
-    analytics.track({
-      event: "Paginate",
-      properties: {
-        selectedPage: page,
       },
     });
   }

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -22,7 +22,6 @@ import * as protos from "src/js/protos";
 import { refreshStatementDiagnosticsRequests, refreshStatements } from "src/redux/apiReducers";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
-import { analytics } from "src/redux/analytics";
 import { StatementsResponseMessage } from "src/util/api";
 import { aggregateStatementStats, combineStatementStats, ExecutionStatistics, flattenStatementStats, StatementStatistics } from "src/util/appStats";
 import { appAttr } from "src/util/constants";
@@ -43,7 +42,7 @@ import {
 } from "src/redux/statements/statementsSelectors";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
-import { trackPaginate } from "src/util/analytics";
+import { trackPaginate, trackSearch } from "src/util/analytics";
 
 import "./statements.styl";
 
@@ -151,7 +150,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
 
   componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
     if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.filteredStatementsData().length);
+      trackSearch(this.filteredStatementsData().length);
     }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
@@ -184,15 +183,6 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const { search } = this.state;
     const { statements } = this.props;
     return statements.filter(statement => search.split(" ").every(val => statement.label.toLowerCase().includes(val.toLowerCase())));
-  }
-
-  trackSearch = (numberOfResults: number) => {
-    analytics.track({
-      event: "Search",
-      properties: {
-        numberOfResults,
-      },
-    });
   }
 
   renderPage = (_page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next", originalElement: React.ReactNode) => {


### PR DESCRIPTION
fixes #45625 

- [x] clicks of the sub navigation (logical plans, execution stats, diagnostics)
- [x] clicks of the diagnostics activation
- [x] click to activate modal on statements page

_Author's note_: It may be helpful to view this PR a commit at a time as there is some refactoring work in here, so I have tried to break the commits into logical steps that may tell a better story.

Organizing track functions into a consolidated location (`pkg/ui/src/util/analytics`) and writing them in a form that makes testing less cumbersome. The thrust of this PR is to add tracking for interesting events on the statement details page. This resolves two from issue #45625 and an additional event (identified from feedback) on the statements page. They are as follows,

### SubNavigation Selection

This event is fired when a user clicks on a tab in the sub-navigation.

![subnavigation-selection](https://user-images.githubusercontent.com/397448/78068152-ef2fcd80-7365-11ea-85f8-a7b4b55c68a7.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'SubNavigation Selection',
  properties: {
    pagePath: '/statements/(internal)/true/[some long internal fingerprint]',
    selection: 'logical-plan'
  }
}
```

### Diagnostics Activation

This event is fired when statement diagnostics are activated from the "Diagnostics" section of the details view,

![details-diagnostics-activation](https://user-images.githubusercontent.com/397448/78068320-2f8f4b80-7366-11ea-8852-653608d6fac4.gif)

```
{
  userId: '5f87309b-b68a-4c56-898f-4995e8672991',
  event: 'Diagnostics Activation',
  properties: {
    fingerprint: 'SELECT blah, blah FROM blahhdy-blah WHERE blah = $blah',
    pagePath: '/statement/[statement]'
  }
}
```
_and a backfill on the Statements view_

### Diagnostics Modal Open

This event is fired when the user clicks _"Activate"_ to open the activation modal.

![diagnostics-modal-open](https://user-images.githubusercontent.com/397448/78072603-6583fe00-736d-11ea-978f-dece08eb70e0.gif)
 
This event 
```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Diagnostics Modal Open',
  properties: {
    fingerprint: 'INSERT INTO test VALUES (_)',
    pagePath: '/statements'
  }
}
```