### PR TITLE
sql: Change output of CREATE/ALTER/DROP ROLE to not include rows affected. Add hint for GRANT ROLE.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -472,7 +472,7 @@ func Example_demo() {
 	//   system
 	// (4 rows)
 	// demo -e CREATE USER test WITH PASSWORD 'testpass'
-	// CREATE ROLE 1
+	// CREATE ROLE
 	// demo --insecure -e CREATE USER test WITH PASSWORD 'testpass'
 	// ERROR: setting or updating a password is not supported in insecure mode
 	// SQLSTATE: 28P01

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -31,8 +31,6 @@ type alterRoleNode struct {
 	ifExists    bool
 	isRole      bool
 	roleOptions roleoption.List
-
-	run alterRoleRun
 }
 
 // AlterRole represents a ALTER ROLE statement.
@@ -75,12 +73,6 @@ func (p *planner) AlterRoleNode(
 		isRole:       isRole,
 		roleOptions:  roleOptions,
 	}, nil
-}
-
-// alterRoleRun is the run-time state of
-// alterRoleNode for local execution.
-type alterRoleRun struct {
-	rowsAffected int
 }
 
 func (n *alterRoleNode) startExec(params runParams) error {
@@ -156,7 +148,7 @@ func (n *alterRoleNode) startExec(params runParams) error {
 
 		// Updating PASSWORD is a special case since PASSWORD lives in system.users
 		// while the rest of the role options lives in system.role_options.
-		n.run.rowsAffected, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
+		_, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
 			params.ctx,
 			opName,
 			params.p.txn,
@@ -193,7 +185,7 @@ func (n *alterRoleNode) startExec(params runParams) error {
 			}
 		}
 
-		rowsAffected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
 			params.ctx,
 			opName,
 			params.p.txn,
@@ -204,7 +196,6 @@ func (n *alterRoleNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		n.run.rowsAffected += rowsAffected
 	}
 
 	return nil
@@ -213,7 +204,3 @@ func (n *alterRoleNode) startExec(params runParams) error {
 func (*alterRoleNode) Next(runParams) (bool, error) { return false, nil }
 func (*alterRoleNode) Values() tree.Datums          { return tree.Datums{} }
 func (*alterRoleNode) Close(context.Context)        {}
-
-func (n *alterRoleNode) FastPathResults() (int, bool) {
-	return n.run.rowsAffected, true
-}

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -32,8 +32,6 @@ type CreateRoleNode struct {
 	isRole      bool
 	roleOptions roleoption.List
 	userNameInfo
-
-	run createUserRun
 }
 
 var userTableName = tree.NewTableName("system", "users")
@@ -155,7 +153,7 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 	}
 
 	// TODO(richardjcai): move hashedPassword column to system.role_options.
-	n.run.rowsAffected, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
+	rowsAffected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
 		params.ctx,
 		opName,
 		params.p.txn,
@@ -167,9 +165,9 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 
 	if err != nil {
 		return err
-	} else if n.run.rowsAffected != 1 {
+	} else if rowsAffected != 1 {
 		return errors.AssertionFailedf("%d rows affected by user creation; expected exactly one row affected",
-			n.run.rowsAffected,
+			rowsAffected,
 		)
 	}
 
@@ -197,7 +195,7 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 			}
 		}
 
-		rowsAffected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
 			params.ctx,
 			opName,
 			params.p.txn,
@@ -208,14 +206,9 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		n.run.rowsAffected += rowsAffected
 	}
 
 	return nil
-}
-
-type createUserRun struct {
-	rowsAffected int
 }
 
 // Next implements the planNode interface.
@@ -226,9 +219,6 @@ func (*CreateRoleNode) Values() tree.Datums { return tree.Datums{} }
 
 // Close implements the planNode interface.
 func (*CreateRoleNode) Close(context.Context) {}
-
-// FastPathResults implements the planNodeFastPath interface.
-func (n *CreateRoleNode) FastPathResults() (int, bool) { return n.run.rowsAffected, true }
 
 const usernameHelp = "Usernames are case insensitive, must start with a letter, " +
 	"digit or underscore, may contain letters, digits, dashes, periods, or underscores, and must not exceed 63 characters."

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -225,9 +225,6 @@ var _ planNode = &virtualTableNode{}
 var _ planNode = &windowNode{}
 var _ planNode = &zeroNode{}
 
-var _ planNodeFastPath = &CreateRoleNode{}
-var _ planNodeFastPath = &DropRoleNode{}
-var _ planNodeFastPath = &alterRoleNode{}
 var _ planNodeFastPath = &deleteRangeNode{}
 var _ planNodeFastPath = &rowCountNode{}
 var _ planNodeFastPath = &serializeNode{}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -195,7 +195,7 @@ func (*AlterSequence) StatementType() StatementType { return DDL }
 func (*AlterSequence) StatementTag() string { return "ALTER SEQUENCE" }
 
 // StatementType implements the Statement interface.
-func (*AlterRole) StatementType() StatementType { return RowsAffected }
+func (*AlterRole) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*AlterRole) StatementTag() string { return "ALTER ROLE" }
@@ -333,7 +333,7 @@ func (n *CreateTable) StatementTag() string {
 func (*CreateTable) modifiesSchema() bool { return true }
 
 // StatementType implements the Statement interface.
-func (*CreateRole) StatementType() StatementType { return RowsAffected }
+func (*CreateRole) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateRole) StatementTag() string { return "CREATE ROLE" }
@@ -415,7 +415,7 @@ func (*DropSequence) StatementType() StatementType { return DDL }
 func (*DropSequence) StatementTag() string { return "DROP SEQUENCE" }
 
 // StatementType implements the Statement interface.
-func (*DropRole) StatementType() StatementType { return RowsAffected }
+func (*DropRole) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*DropRole) StatementTag() string { return "DROP ROLE" }


### PR DESCRIPTION
#Fixes 46728, 46698

Change output of CREATE/ALTER/DROP ROLE to not include rows affected. Add hint for GRANT ROLE.

Result from CREATE/ALTER/DROP ROLE no longer include rows affected.

Previous

root@127.0.0.1:63323/defaultdb> create role j with createrole;
CREATE ROLE 3
Now

root@127.0.0.1:63323/defaultdb> create role j with createrole;
CREATE ROLE
Now when trying to GRANT an option to a user directly using the GRANT ROLE syntax, it gives a hint to use ALTER ROLE.

root@127.0.0.1:51231/movr> grant createrole to user1;
ERROR: role/user createrole does not exist
SQLSTATE: 42704
HINT: CREATEROLE is a role option, try using ALTER ROLE to change a role's options.
Release note (sql change): Remove number from CREATE/ALTER/DROP ROLE command
results. The number doesn't make sense to include since rowsAffected includes
system.role_options rows, the number can be greater than 1 which is misleading.
This also matches PG as no number is returned for these commands.

Release note (sql change): Add hint to use ALTER ROLE when trying to
"GRANT" a role option directly to a user (using the GRANT ROLE syntax).

Release justification: Low risk change, command result output changed for
CREATE/ALTER/DROP ROLE. Hint added for GRANT ROLE.