### PR TITLE
c-deps: bump the rebuild counter for all cmake dependencies

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -191,6 +191,11 @@ RUN git clone git://git.sv.gnu.org/sed \
 
 # xenial installs cmake 3.5.1. We need a newer version. Run this step
 # after the llvm/cross-compile step which is exceedingly slow.
+#
+# NOTE: When upgrading cmake, bump the rebuild counters in
+# c-deps/*-rebuild to force recreating the makefiles. This prevents
+# strange build errors caused by those makefiles depending on the
+# installed version of cmake.
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz -o cmake.tar.gz \
  && echo 'b44685227b9f9be103e305efa2075a8ccf2415807fbcf1fc192da4d36aacc9f5 cmake.tar.gz' | sha256sum -c - \
  && tar --strip-components=1 -C /usr -xzf cmake.tar.gz \

--- a/c-deps/cryptopp-rebuild
+++ b/c-deps/cryptopp-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing cryptopp configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+4

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+5

--- a/c-deps/krb5-rebuild
+++ b/c-deps/krb5-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing krb5 configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+2

--- a/c-deps/libedit-rebuild
+++ b/c-deps/libedit-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libedit configure flags. Search for "BUILD
 ARTIFACT CACHING" in the top-level Makefile for rationale.
 
-1
+2

--- a/c-deps/libroach-rebuild
+++ b/c-deps/libroach-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libroach CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+5

--- a/c-deps/protobuf-rebuild
+++ b/c-deps/protobuf-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing protobuf CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-5
+6

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-14
+15

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-6
+7


### PR DESCRIPTION
We recently bumped the version of cmake in the builder. This caused
strange build errors on CI due to switching back and forth between the
new version of cmake and the old version cmake. The makefiles created by
cmake seem to depend on the installed version of cmake in a way I don't
quite understand.

Rather than trying to add a dependency on the version of cmake, simply
bump the rebuild counter for all cmake dependencies. The one exception
is libgeos which requires the new version of cmake (and landed after the
cmake version bump was performed).

Fixes cockroachdb/dev-inf/issues/66

Release note: None