### PR TITLE
ui: improve wording in storage tooltips

### DIFF
--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -31,7 +31,9 @@ export const enableNodeMap = docsURL("enable-node-map.html");
 export const configureReplicationZones = docsURL("configure-replication-zones.html");
 export const transactionalPipelining = docsURL("architecture/transaction-layer.html#transaction-pipelining");
 export const adminUIAccess = docsURL("admin-ui-overview.html#admin-ui-access");
-export const statementDiagnostics = docsURLNoVersion("admin-ui-statements-page.html#diagnostics");
+export const statementDiagnostics = docsURL("admin-ui-statements-page.html#diagnostics");
+export const howAreCapacityMetricsCalculated = docsURL("admin-ui-storage-dashboard.html#capacity-metrics");
+export const keyValuePairs = docsURL("architecture/distribution-layer.html#table-data");
 
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+
+import * as docsURL from "src/util/docs";
+import {Anchor} from "src/components";
+import {ReactNode} from "react";
+
+export const CapacityGraphTooltip: React.FunctionComponent<{tooltipSelection: ReactNode}> =
+  ({tooltipSelection}) => (<div>
+    <dl>
+      <dt>Capacity</dt>
+      <dd>
+        <p>
+          Usage of disk space {tooltipSelection}.
+        </p>
+        <p>
+          <Anchor href={docsURL.howAreCapacityMetricsCalculated}>
+            How are these metrics calculated?
+          </Anchor>
+        </p>
+      </dd>
+    </dl>
+  </div>);
+
+export const LogicalBytesGraphTooltip: React.FunctionComponent =
+  () => (<div>
+    <dl>
+      <dt>Logical Bytes per Store</dt>
+      <dd>
+        <p>
+          Number of logical bytes stored in
+          {" "}
+          <Anchor href={docsURL.keyValuePairs}>
+            key-value pairs
+          </Anchor>
+          {" "}
+          on each node.
+        </p>
+        <p>
+          This includes historical and deleted data.
+        </p>
+      </dd>
+    </dl>
+  </div>);

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -11,11 +11,11 @@
 import React from "react";
 import _ from "lodash";
 
-import * as docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+import { CapacityGraphTooltip } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;
@@ -88,32 +88,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Capacity"
       sources={storeSources}
-      tooltip={(
-        <div>
-          <dl>
-            <dt>Capacity</dt>
-            <dd>
-              Total disk space available {tooltipSelection} to CockroachDB.
-              {" "}
-              <em>
-                Control this value per node with the
-                {" "}
-                <code>
-                  <a href={docsURL.startFlags} target="_blank">
-                    --store
-                  </a>
-                </code>
-                {" "}
-                flag.
-              </em>
-            </dd>
-            <dt>Available</dt>
-            <dd>Free disk space available {tooltipSelection} to CockroachDB.</dd>
-            <dt>Used</dt>
-            <dd>Disk space used {tooltipSelection} by CockroachDB.</dd>
-          </dl>
-        </div>
-      )}
+      tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection}/>}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         <Metric name="cr.store.capacity" title="Capacity" />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -15,6 +15,9 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+import {
+  LogicalBytesGraphTooltip,
+} from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, storeSources } = props;
@@ -83,7 +86,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Logical Bytes per Store" tooltip={`The number of logical bytes of data on each store.`}>
+    <LineGraph title="Logical Bytes per Store" tooltip={<LogicalBytesGraphTooltip />}>
       <Axis units={AxisUnits.Bytes} label="logical store size">
         {
           _.map(nodeIDs, (nid) => (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -15,6 +15,7 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+import { CapacityGraphTooltip } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;
@@ -23,7 +24,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Capacity"
       sources={storeSources}
-      tooltip={`Summary of total and available capacity ${tooltipSelection}.`}
+      tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         <Metric name="cr.store.capacity" title="Capacity" />
@@ -36,8 +37,7 @@ export default function (props: GraphDashboardProps) {
       title="Live Bytes"
       sources={storeSources}
       tooltip={
-        `The amount of Live data used by both applications and the
-           CockroachDB system ${tooltipSelection}. This excludes historical and deleted data.`
+        `Amount of data that can be read by applications and CockroachDB ${tooltipSelection}`
       }
     >
       <Axis units={AxisUnits.Bytes} label="live bytes">

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -147,7 +147,7 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
               <SummaryBar>
                 <SummaryHeadlineStat
                   title="Database Size"
-                  tooltip="Approximate total disk size of this database across all replicas."
+                  tooltip="Approximate total disk size of this database across all table replicas."
                   value={this.totalSize()}
                   format={Bytes} />
                 <SummaryHeadlineStat


### PR DESCRIPTION
Some existing tooltips discussion storage metrics
needed adjustment to improve accuracy.

Changes affect:

### Metrics
* Overview page: Capacity graph
* Replication page: Logical Bytes per Store
* Storage page: Capacity and Live Bytes

### Databases
* Database summary box: "Database Size"

Some tooltips now include links to documentation
where database operators can get much more detail
on how these metrics are calculated and how to
use them.

Resolves #46726

Release justification: low risk documentation edit

Release note (admin ui change): improved tooltips
for existing capacity and storage metrics.