### PR TITLE
release-19.2: sql: add CONCURRENTLY syntax to CREATE INDEX and DROP INDEX

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1643,6 +1643,7 @@ reserved_keyword ::=
 	| 'CHECK'
 	| 'COLLATE'
 	| 'COLUMN'
+	| 'CONCURRENTLY'
 	| 'CONSTRAINT'
 	| 'CREATE'
 	| 'CURRENT_CATALOG'

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3154,6 +3154,9 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`REINDEX TABLE a`, 0, `reindex table`, `CockroachDB does not require reindexing.`},
 		{`REINDEX DATABASE a`, 0, `reindex database`, `CockroachDB does not require reindexing.`},
 		{`REINDEX SYSTEM a`, 0, `reindex system`, `CockroachDB does not require reindexing.`},
+
+		{`CREATE INDEX CONCURRENTLY a ON a(a)`, 0, `concurrently`, `CockroachDB performs this operation concurrently - CONCURRENTLY is not required.`},
+		{`DROP INDEX CONCURRENTLY a@a`, 0, `concurrently`, `CockroachDB performs this operation concurrently - CONCURRENTLY is not required.`},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -504,7 +504,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str> CACHE CANCEL CASCADE CASE CAST CHANGEFEED CHAR
 %token <str> CHARACTER CHARACTERISTICS CHECK
 %token <str> CLUSTER COALESCE COLLATE COLLATION COLUMN COLUMNS COMMENT COMMIT
-%token <str> COMMITTED COMPACT COMPLETE CONCAT CONFIGURATION CONFIGURATIONS CONFIGURE
+%token <str> COMMITTED COMPACT COMPLETE CONCAT CONCURRENTLY CONFIGURATION CONFIGURATIONS CONFIGURE
 %token <str> CONFLICT CONSTRAINT CONSTRAINTS CONTAINS CONVERSION COPY COVERING CREATE
 %token <str> CROSS CUBE CURRENT CURRENT_CATALOG CURRENT_DATE CURRENT_SCHEMA
 %token <str> CURRENT_ROLE CURRENT_TIME CURRENT_TIMESTAMP
@@ -888,7 +888,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.DurationField> opt_interval interval_second interval_qualifier
 %type <tree.Expr> overlay_placing
 
-%type <bool> opt_unique opt_cluster
+%type <bool> opt_unique opt_concurrently opt_cluster
 %type <bool> opt_using_gin_btree
 
 %type <*tree.Limit> limit_clause offset_clause opt_limit_clause
@@ -2533,20 +2533,20 @@ drop_table_stmt:
 // %Text: DROP INDEX [IF EXISTS] <idxname> [, ...] [CASCADE | RESTRICT]
 // %SeeAlso: WEBDOCS/drop-index.html
 drop_index_stmt:
-  DROP INDEX table_index_name_list opt_drop_behavior
+  DROP INDEX opt_concurrently table_index_name_list opt_drop_behavior
   {
     $$.val = &tree.DropIndex{
-      IndexList: $3.newTableIndexNames(),
+      IndexList: $4.newTableIndexNames(),
       IfExists: false,
-      DropBehavior: $4.dropBehavior(),
+      DropBehavior: $5.dropBehavior(),
     }
   }
-| DROP INDEX IF EXISTS table_index_name_list opt_drop_behavior
+| DROP INDEX opt_concurrently IF EXISTS table_index_name_list opt_drop_behavior
   {
     $$.val = &tree.DropIndex{
-      IndexList: $5.newTableIndexNames(),
+      IndexList: $6.newTableIndexNames(),
       IfExists: true,
-      DropBehavior: $6.dropBehavior(),
+      DropBehavior: $7.dropBehavior(),
     }
   }
 | DROP INDEX error // SHOW HELP: DROP INDEX
@@ -5065,62 +5065,62 @@ create_type_stmt:
 // %SeeAlso: CREATE TABLE, SHOW INDEXES, SHOW CREATE,
 // WEBDOCS/create-index.html
 create_index_stmt:
-  CREATE opt_unique INDEX opt_index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
-  {
-    table := $6.unresolvedObjectName().ToTableName()
-    $$.val = &tree.CreateIndex{
-      Name:    tree.Name($4),
-      Table:   table,
-      Unique:  $2.bool(),
-      Columns: $9.idxElems(),
-      Storing: $11.nameList(),
-      Interleave: $12.interleave(),
-      PartitionBy: $13.partitionBy(),
-      Inverted: $7.bool(),
-    }
-  }
-| CREATE opt_unique INDEX IF NOT EXISTS index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
-  {
-    table := $9.unresolvedObjectName().ToTableName()
-    $$.val = &tree.CreateIndex{
-      Name:        tree.Name($7),
-      Table:       table,
-      Unique:      $2.bool(),
-      IfNotExists: true,
-      Columns:     $12.idxElems(),
-      Storing:     $14.nameList(),
-      Interleave:  $15.interleave(),
-      PartitionBy: $16.partitionBy(),
-      Inverted:    $10.bool(),
-    }
-  }
-| CREATE opt_unique INVERTED INDEX opt_index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
+  CREATE opt_unique INDEX opt_concurrently opt_index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
   {
     table := $7.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
-      Name:       tree.Name($5),
-      Table:      table,
-      Unique:     $2.bool(),
-      Inverted:   true,
-      Columns:    $9.idxElems(),
-      Storing:     $11.nameList(),
-      Interleave:  $12.interleave(),
-      PartitionBy: $13.partitionBy(),
+      Name:    tree.Name($5),
+      Table:   table,
+      Unique:  $2.bool(),
+      Columns: $10.idxElems(),
+      Storing: $12.nameList(),
+      Interleave:   $13.interleave(),
+      PartitionBy:  $14.partitionBy(),
+      Inverted:     $8.bool(),
     }
   }
-| CREATE opt_unique INVERTED INDEX IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
+| CREATE opt_unique INDEX opt_concurrently IF NOT EXISTS index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
   {
     table := $10.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
       Name:        tree.Name($8),
       Table:       table,
       Unique:      $2.bool(),
+      IfNotExists: true,
+      Columns:     $13.idxElems(),
+      Storing:     $15.nameList(),
+      Interleave:  $16.interleave(),
+      PartitionBy: $17.partitionBy(),
+      Inverted:    $11.bool(),
+    }
+  }
+| CREATE opt_unique INVERTED INDEX opt_concurrently opt_index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
+  {
+    table := $8.unresolvedObjectName().ToTableName()
+    $$.val = &tree.CreateIndex{
+      Name:       tree.Name($6),
+      Table:      table,
+      Unique:     $2.bool(),
+      Inverted:   true,
+      Columns:    $10.idxElems(),
+      Storing:     $12.nameList(),
+      Interleave:  $13.interleave(),
+      PartitionBy: $14.partitionBy(),
+    }
+  }
+| CREATE opt_unique INVERTED INDEX opt_concurrently IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_idx_where
+  {
+    table := $11.unresolvedObjectName().ToTableName()
+    $$.val = &tree.CreateIndex{
+      Name:        tree.Name($9),
+      Table:       table,
+      Unique:      $2.bool(),
       Inverted:    true,
       IfNotExists: true,
-      Columns:     $12.idxElems(),
-      Storing:     $14.nameList(),
-      Interleave:  $15.interleave(),
-      PartitionBy: $16.partitionBy(),
+      Columns:     $13.idxElems(),
+      Storing:     $15.nameList(),
+      Interleave:  $16.interleave(),
+      PartitionBy: $17.partitionBy(),
     }
   }
 | CREATE opt_unique INDEX error // SHOW HELP: CREATE INDEX
@@ -5144,6 +5144,21 @@ opt_using_gin_btree:
         sqllex.Error("unrecognized access method: " + $2)
         return 1
     }
+  }
+| /* EMPTY */
+  {
+    $$.val = false
+  }
+
+opt_concurrently:
+  CONCURRENTLY
+  {
+    /* SKIP DOC */
+    return purposelyUnimplemented(
+      sqllex,
+      "concurrently",
+      "CockroachDB performs this operation concurrently - CONCURRENTLY is not required.",
+    )
   }
 | /* EMPTY */
   {
@@ -9688,6 +9703,7 @@ reserved_keyword:
 | CHECK
 | COLLATE
 | COLUMN
+| CONCURRENTLY
 | CONSTRAINT
 | CREATE
 | CURRENT_CATALOG


### PR DESCRIPTION
Backport 1/1 commits from #46695.

/cc @cockroachdb/release

---

Resolves #46616
Resolves #46615 

This is different to the master version - we add the syntax with
telemetry, but block it's usage as we cannot send notices.

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): We now parse `CREATE INDEX CONCURRENTLY`
and `DROP INDEX CONCURRENTLY` syntax which errors when used.