### PR TITLE
release-19.1: sql: add CONCURRENTLY syntax to CREATE INDEX and DROP INDEX

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1563,6 +1563,7 @@ reserved_keyword ::=
 	| 'CHECK'
 	| 'COLLATE'
 	| 'COLUMN'
+	| 'CONCURRENTLY'
 	| 'CONSTRAINT'
 	| 'CREATE'
 	| 'CURRENT_CATALOG'

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2991,6 +2991,9 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`REINDEX DATABASE a`, 0, `reindex database`, `CockroachDB does not require reindexing.`},
 		{`REINDEX SYSTEM a`, 0, `reindex system`, `CockroachDB does not require reindexing.`},
 
+		{`CREATE INDEX CONCURRENTLY a ON a(a)`, 0, `concurrently`, `CockroachDB performs this operation concurrently - CONCURRENTLY is not required.`},
+		{`DROP INDEX CONCURRENTLY a@a`, 0, `concurrently`, `CockroachDB performs this operation concurrently - CONCURRENTLY is not required.`},
+
 		{`UPSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``, ``},
 	}
 	for _, d := range testData {


### PR DESCRIPTION
Backport 1/1 commits from #46695.

/cc @cockroachdb/release

---

Resolves #46616
Resolves #46615 

This is different to the master version - we add the syntax with
telemetry, but block it's usage as we cannot send notices.

Release justification: low risk, high benefit changes to existing
functionality

Release note (sql change): We now parse `CREATE INDEX CONCURRENTLY`
and `DROP INDEX CONCURRENTLY` syntax which errors when used.
