### PR TITLE
opt: don't mark division with constant as side-effecting

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -247,3 +247,30 @@ group-by
  └── aggregations
       └── sum [as=sum:7, type=decimal, outer=(1)]
            └── variable: x:1 [type=int]
+
+# Verify that we don't mark the division as side-effecting when the right-hand
+# side is a constant.
+build
+SELECT x / 1, x::float / 2.0, x::decimal / 3.0 FROM xy
+----
+project
+ ├── columns: "?column?":3(decimal!null) "?column?":4(float!null) "?column?":5(decimal!null)
+ ├── prune: (3-5)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── projections
+      ├── div [as="?column?":3, type=decimal, outer=(1)]
+      │    ├── variable: x:1 [type=int]
+      │    └── const: 1 [type=int]
+      ├── div [as="?column?":4, type=float, outer=(1)]
+      │    ├── cast: FLOAT8 [type=float]
+      │    │    └── variable: x:1 [type=int]
+      │    └── const: 2.0 [type=float]
+      └── div [as="?column?":5, type=decimal, outer=(1)]
+           ├── cast: DECIMAL [type=decimal]
+           │    └── variable: x:1 [type=int]
+           └── const: 3.0 [type=decimal]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
@@ -43,7 +43,6 @@ project
  ├── save-table-name: q17_project_1
  ├── columns: avg_yearly:45(float)
  ├── cardinality: [1 - 1]
- ├── side-effects
  ├── stats: [rows=1, distinct(45)=1, null(45)=0]
  ├── key: ()
  ├── fd: ()-->(45)
@@ -131,7 +130,7 @@ project
  │         └── sum [as=sum:44, type=float, outer=(6)]
  │              └── l_extendedprice:6 [type=float]
  └── projections
-      └── sum:44 / 7.0 [as=avg_yearly:45, type=float, outer=(44), side-effects]
+      └── sum:44 / 7.0 [as=avg_yearly:45, type=float, outer=(44)]
 
 stats table=q17_project_1
 ----

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -13,7 +13,6 @@ SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 d:6
- ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -24,7 +23,7 @@ select
       ├── k:1 > (i:2 + 1) [outer=(1,2), constraints=(/1: (/NULL - ])]
       ├── i:2 >= (k:1 - 1) [outer=(1,2), constraints=(/2: (/NULL - ])]
       ├── k:1 < (i:2 * i:2) [outer=(1,2), constraints=(/1: (/NULL - ])]
-      └── i:2 <= (k:1 / 2) [outer=(1,2), side-effects, constraints=(/2: (/NULL - ])]
+      └── i:2 <= (k:1 / 2) [outer=(1,2), constraints=(/2: (/NULL - ])]
 
 # --------------------------------------------------
 # CommuteConstInequality

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1031,21 +1031,17 @@ SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
  ├── columns: r:8
- ├── side-effects
  ├── group-by
  │    ├── columns: k:1!null scalar:9 bool_or:11
  │    ├── grouping columns: k:1!null
- │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 y:7 scalar:9 notnull:10
- │    │    ├── side-effects
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null
- │    │    │    ├── side-effects
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(9)
  │    │    │    ├── scan a
@@ -1053,7 +1049,7 @@ project
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2)
  │    │    │    └── projections
- │    │    │         └── (i:2 * i:2) / 5 [as=scalar:9, outer=(2), side-effects]
+ │    │    │         └── (i:2 * i:2) / 5 [as=scalar:9, outer=(2)]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10!null x:6!null y:7
  │    │    │    ├── key: (6)
@@ -1088,15 +1084,12 @@ WHERE EXISTS
 distinct-on
  ├── columns: k:1!null
  ├── grouping columns: k:1!null
- ├── side-effects
  ├── key: (1)
  └── select
       ├── columns: k:1!null x:6!null div:10!null
-      ├── side-effects
       ├── fd: (6)==(10), (10)==(6)
       ├── project
       │    ├── columns: div:10!null k:1!null x:6!null
-      │    ├── side-effects
       │    ├── inner-join (cross)
       │    │    ├── columns: k:1!null i:2!null x:6!null u:8!null
       │    │    ├── key: (1,6,8)
@@ -1123,7 +1116,7 @@ distinct-on
       │    │    │    └── filters (true)
       │    │    └── filters (true)
       │    └── projections
-      │         └── u:8 / 1.1 [as=div:10, outer=(8), side-effects]
+      │         └── u:8 / 1.1 [as=div:10, outer=(8)]
       └── filters
            └── x:6 = div:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
 
@@ -1137,11 +1130,9 @@ WHERE EXISTS
 ----
 project
  ├── columns: k:1!null
- ├── side-effects
  ├── key: (1)
  └── semi-join-apply
       ├── columns: k:1!null i:2
-      ├── side-effects
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan a
@@ -1151,11 +1142,9 @@ project
       ├── left-join (cross)
       │    ├── columns: x:6 div:10!null
       │    ├── outer: (2)
-      │    ├── side-effects
       │    ├── project
       │    │    ├── columns: div:10!null
       │    │    ├── outer: (2)
-      │    │    ├── side-effects
       │    │    ├── select
       │    │    │    ├── columns: u:8!null
       │    │    │    ├── outer: (2)
@@ -1166,7 +1155,7 @@ project
       │    │    │    └── filters
       │    │    │         └── i:2 = 5 [outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    │    └── projections
-      │    │         └── u:8 / 1.1 [as=div:10, outer=(8), side-effects]
+      │    │         └── u:8 / 1.1 [as=div:10, outer=(8)]
       │    ├── scan xy
       │    │    ├── columns: x:6!null
       │    │    └── key: (6)
@@ -3732,21 +3721,17 @@ SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 ----
 project
  ├── columns: r:8 s:4
- ├── side-effects
  ├── group-by
  │    ├── columns: k:1!null s:4 scalar:9 bool_or:11
  │    ├── grouping columns: k:1!null
- │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(4,9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null s:4 x:6 y:7 scalar:9 notnull:10
- │    │    ├── side-effects
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(4,9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null s:4
- │    │    │    ├── side-effects
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(4,9)
  │    │    │    ├── scan a
@@ -3754,7 +3739,7 @@ project
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2,4)
  │    │    │    └── projections
- │    │    │         └── (i:2 * i:2) / 100 [as=scalar:9, outer=(2), side-effects]
+ │    │    │         └── (i:2 * i:2) / 100 [as=scalar:9, outer=(2)]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10!null x:6!null y:7
  │    │    │    ├── key: (6)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -123,7 +123,6 @@ SELECT y1*2, y1/2 FROM (SELECT y+1 AS y1 FROM a)
 ----
 project
  ├── columns: "?column?":6 "?column?":7
- ├── side-effects
  ├── project
  │    ├── columns: y1:5
  │    ├── scan a
@@ -132,7 +131,7 @@ project
  │         └── y:2 + 1 [as=y1:5, outer=(2)]
  └── projections
       ├── y1:5 * 2 [as="?column?":6, outer=(5)]
-      └── y1:5 / 2 [as="?column?":7, outer=(5), side-effects]
+      └── y1:5 / 2 [as="?column?":7, outer=(5)]
 
 # Discard all inner columns.
 norm expect=MergeProjects

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -249,19 +249,16 @@ SELECT i FROM (SELECT k, i, s, f/2.0 f FROM a WHERE k = 5) a2 WHERE i::float = f
 project
  ├── columns: i:2
  ├── cardinality: [0 - 1]
- ├── side-effects
  ├── key: ()
  ├── fd: ()-->(2)
  └── select
       ├── columns: i:2 f:5!null
       ├── cardinality: [0 - 1]
-      ├── side-effects
       ├── key: ()
       ├── fd: ()-->(2,5)
       ├── project
       │    ├── columns: f:5 i:2
       │    ├── cardinality: [0 - 1]
-      │    ├── side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(2,5)
       │    ├── select
@@ -276,7 +273,7 @@ project
       │    │    └── filters
       │    │         └── k:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
       │    └── projections
-      │         └── a.f:3 / 2.0 [as=f:5, outer=(3), side-effects]
+      │         └── a.f:3 / 2.0 [as=f:5, outer=(3)]
       └── filters
            └── f:5 = i:2::FLOAT8 [outer=(2,5), constraints=(/5: (/NULL - ])]
 
@@ -763,7 +760,6 @@ SELECT a.k+1 AS r, a.i/2 AS s, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s
 ----
 project
  ├── columns: r:8!null s:9 x:5!null y:6
- ├── side-effects
  ├── fd: (5)-->(6)
  ├── inner-join (hash)
  │    ├── columns: k:1!null i:2 x:5!null y:6 column7:7!null
@@ -793,7 +789,7 @@ project
  │         └── column7:7 = x:5 [outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
  └── projections
       ├── k:1 + 1 [as=r:8, outer=(1)]
-      └── i:2 / 2 [as=s:9, outer=(2), side-effects]
+      └── i:2 / 2 [as=s:9, outer=(2)]
 
 # Join that is nested in another join.
 norm expect=PruneJoinLeftCols
@@ -1035,7 +1031,6 @@ SELECT xy.*, a.k+1 AS r, a.i/2 AS s FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s
 ----
 project
  ├── columns: x:1!null y:2 r:8!null s:9
- ├── side-effects
  ├── fd: (1)-->(2)
  ├── inner-join (hash)
  │    ├── columns: x:1!null y:2 k:3!null i:4 column7:7!null
@@ -1065,7 +1060,7 @@ project
  │         └── x:1 = column7:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  └── projections
       ├── k:3 + 1 [as=r:8, outer=(3)]
-      └── i:4 / 2 [as=s:9, outer=(4), side-effects]
+      └── i:4 / 2 [as=s:9, outer=(4)]
 
 # Join that is nested in another join.
 norm expect=PruneJoinRightCols

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -475,15 +475,14 @@ SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE div=2
 ----
 select
  ├── columns: i:2 div:6!null f:3
- ├── side-effects
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: div:6 i:2 f:3
- │    ├── side-effects
+ │    ├── fd: (2)-->(6)
  │    ├── scan a
  │    │    └── columns: i:2 f:3
  │    └── projections
- │         └── i:2 / 2 [as=div:6, outer=(2), side-effects]
+ │         └── i:2 / 2 [as=div:6, outer=(2)]
  └── filters
       └── div:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
@@ -493,12 +492,10 @@ SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE 10.0=f AND 2=div AND i=1
 ----
 select
  ├── columns: i:2!null div:6!null f:3!null
- ├── side-effects
  ├── fd: ()-->(2,3,6)
  ├── project
  │    ├── columns: div:6!null i:2!null f:3!null
- │    ├── side-effects
- │    ├── fd: ()-->(2,3)
+ │    ├── fd: ()-->(2,3,6)
  │    ├── select
  │    │    ├── columns: i:2!null f:3!null
  │    │    ├── fd: ()-->(2,3)
@@ -508,7 +505,7 @@ select
  │    │         ├── f:3 = 10.0 [outer=(3), constraints=(/3: [/10.0 - /10.0]; tight), fd=()-->(3)]
  │    │         └── i:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
  │    └── projections
- │         └── i:2 / 2 [as=div:6, outer=(2), side-effects]
+ │         └── i:2 / 2 [as=div:6, outer=(2)]
  └── filters
       └── div:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1789,7 +1789,6 @@ WHERE
 project
  ├── columns: avg_yearly:45
  ├── cardinality: [1 - 1]
- ├── side-effects
  ├── key: ()
  ├── fd: ()-->(45)
  ├── scalar-group-by
@@ -1856,7 +1855,7 @@ project
  │         └── sum [as=sum:44, outer=(6)]
  │              └── l_extendedprice:6
  └── projections
-      └── sum:44 / 7.0 [as=avg_yearly:45, outer=(44), side-effects]
+      └── sum:44 / 7.0 [as=avg_yearly:45, outer=(44)]
 
 # --------------------------------------------------
 # Q18

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1758,7 +1758,6 @@ WHERE
 project
  ├── columns: avg_yearly:45
  ├── cardinality: [1 - 1]
- ├── side-effects
  ├── key: ()
  ├── fd: ()-->(45)
  ├── scalar-group-by
@@ -1825,7 +1824,7 @@ project
  │         └── sum [as=sum:44, outer=(6)]
  │              └── l_extendedprice:6
  └── projections
-      └── sum:44 / 7.0 [as=avg_yearly:45, outer=(44), side-effects]
+      └── sum:44 / 7.0 [as=avg_yearly:45, outer=(44)]
 
 # --------------------------------------------------
 # Q18


### PR DESCRIPTION
We mark division as side-effecting because it can cause the entire
query to error out with a division by zero error. This in turn
disables various optimizations, like inlining a CTE.

In the case of a constant RHS, we can check upfront if it is non-zero
and avoid setting this flag.

Release note (performance improvement): some queries which contain a
division by a constant have improved execution plans.