### PR TITLE
storage/metamorphic: Set MaxKeys, TargetBytes, handle Open-time errors

### DIFF
--- a/pkg/storage/metamorphic/operands.go
+++ b/pkg/storage/metamorphic/operands.go
@@ -30,6 +30,7 @@ const (
 	operandNextTS
 	operandValue
 	operandIterator
+	operandFloat
 )
 
 const (
@@ -457,4 +458,37 @@ func (i *iteratorGenerator) closeAll() {
 	i.liveIters = nil
 	i.iterInfo = make(map[iteratorID]iteratorInfo)
 	i.readerToIter = make(map[readWriterID][]iteratorID)
+}
+
+type floatGenerator struct {
+	rng *rand.Rand
+}
+
+func (f *floatGenerator) get() string {
+	return fmt.Sprintf("%.4f", f.rng.Float32())
+}
+
+func (f *floatGenerator) getNew() string {
+	return f.get()
+}
+
+func (f *floatGenerator) parse(input string) float32 {
+	var result float32
+	if _, err := fmt.Sscanf(input, "%f", &result); err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func (f *floatGenerator) opener() string {
+	// Not applicable, because count() is always nonzero.
+	return ""
+}
+
+func (f *floatGenerator) count() int {
+	return 1
+}
+
+func (f *floatGenerator) closeAll() {
+	// No-op.
 }

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -122,6 +122,8 @@ func generateMVCCScan(
 	} else {
 		txn = txnID(args[2])
 	}
+	maxKeys := int64(m.floatGenerator.parse(args[3]) * 32)
+	targetBytes := int64(m.floatGenerator.parse(args[4]) * (1 << 20))
 	return &mvccScanOp{
 		m:            m,
 		key:          key.Key,
@@ -130,6 +132,8 @@ func generateMVCCScan(
 		txn:          txn,
 		inconsistent: inconsistent,
 		reverse:      reverse,
+		maxKeys:      maxKeys,
+		targetBytes:  targetBytes,
 	}
 }
 
@@ -343,6 +347,8 @@ type mvccScanOp struct {
 	txn          txnID
 	inconsistent bool
 	reverse      bool
+	maxKeys      int64
+	targetBytes  int64
 }
 
 func (m mvccScanOp) run(ctx context.Context) string {
@@ -361,11 +367,14 @@ func (m mvccScanOp) run(ctx context.Context) string {
 		Tombstones:   true,
 		Reverse:      m.reverse,
 		Txn:          txn,
+		MaxKeys:      m.maxKeys,
+		TargetBytes:  m.targetBytes,
 	})
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
-	return fmt.Sprintf("kvs = %v, intents = %v", result.KVs, result.Intents)
+	return fmt.Sprintf("kvs = %v, intents = %v, resumeSpan = %v, numBytes = %d, numKeys = %d",
+		result.KVs, result.Intents, result.ResumeSpan, result.NumBytes, result.NumKeys)
 }
 
 type txnOpenOp struct {
@@ -903,6 +912,8 @@ var opGenerators = []opGenerator{
 			operandMVCCKey,
 			operandMVCCKey,
 			operandTransaction,
+			operandFloat,
+			operandFloat,
 		},
 		weight: 100,
 	},
@@ -915,6 +926,8 @@ var opGenerators = []opGenerator{
 			operandMVCCKey,
 			operandMVCCKey,
 			operandPastTS,
+			operandFloat,
+			operandFloat,
 		},
 		weight: 100,
 	},
@@ -927,6 +940,8 @@ var opGenerators = []opGenerator{
 			operandMVCCKey,
 			operandMVCCKey,
 			operandTransaction,
+			operandFloat,
+			operandFloat,
 		},
 		weight: 100,
 	},


### PR DESCRIPTION
Sets the TargetBytes and MaxKeys options in MVCCScan to some resonable
non-zero defaults. Also sets the engine handle to nil if there's an
Open-time error, so we don't double-panic when the defer CloseAll
runs.

Release note: None.