### PR TITLE
colexec: optimize buffering operators with Bytes vectors

### DIFF
--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -538,7 +538,7 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				execinfrapb.AggregatorSpec_BOOL_OR,
 			},
 			aggCols:  [][]uint32{{0}, {1}, {}, {1}, {1}, {2}, {2}, {2}, {1}, {3}, {3}},
-			colTypes: []coltypes.T{coltypes.Int64, coltypes.Decimal, coltypes.Int64, coltypes.Bool, coltypes.Bool},
+			colTypes: []coltypes.T{coltypes.Int64, coltypes.Decimal, coltypes.Int64, coltypes.Bool},
 			input: tuples{
 				{nil, 1.1, 4, true},
 				{0, nil, nil, nil},


### PR DESCRIPTION
Previously, buffering operators would call `SetLength` on their buffered
batch when consuming the input. If there are any `Bytes` columns, we would
be updating the offsets. Additionally, our "input consumption pattern" is
appending to the end of the buffered vectors, and all this would result
in quadratic behavior of updating the offsets. This is actually not
necessary at all (since `Vec.Append` maintains the correct offsets), so
this commit introduces a utility wrapper around `coldata.Batch` that
should be used by buffering operators.

This commit also removes some "column schema compression" business from
the constructor of `hashAggregator` since it makes no sense.

Release note: None