### PR TITLE
release-20.1: rowexec: make noopProcessor implement execinfra.OpNode

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -118,3 +118,19 @@ EXPLAIN (VEC) SELECT t46122_0.c0 FROM t46122_0, t46122_1
 └ *rowexec.hashJoiner
   ├ *colexec.colBatchScan
   └ *colexec.colBatchScan
+
+# Regression test for #46404 (rowexec.noopProcessor not implementing
+# execinfra.OpNode interface).
+statement ok
+CREATE TABLE t46404_0(c0 INT); CREATE TABLE t46404_1(c0 INT)
+
+query T
+EXPLAIN (VEC) SELECT stddev((t46404_1.c0 > ANY (0, 0))::INT) FROM t46404_0, t46404_1 GROUP BY t46404_0.rowid
+----
+│
+└ Node 1
+└ *rowexec.hashAggregator
+  └ *rowexec.noopProcessor
+    └ *colexec.hashJoiner
+      ├ *colexec.colBatchScan
+      └ *colexec.colBatchScan

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -217,7 +217,10 @@ func (ag *aggregatorBase) outputStatsToTrace() {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (ag *aggregatorBase) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := ag.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -383,7 +383,10 @@ func (d *distinct) outputStatsToTrace() {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (d *distinct) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := d.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -855,7 +855,12 @@ func shouldShortCircuit(storedSide joinSide, joinType sqlbase.JoinType) bool {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (h *hashJoiner) ChildCount(verbose bool) int {
-	return 2
+	if _, ok := h.leftSource.(execinfra.OpNode); ok {
+		if _, ok := h.rightSource.(execinfra.OpNode); ok {
+			return 2
+		}
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/indexjoiner.go
+++ b/pkg/sql/rowexec/indexjoiner.go
@@ -251,7 +251,10 @@ func (ij *indexJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (ij *indexJoiner) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := ij.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -696,7 +696,10 @@ func (jr *joinReader) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetad
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (jr *joinReader) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := jr.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -307,7 +307,12 @@ func (m *mergeJoiner) outputStatsToTrace() {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (m *mergeJoiner) ChildCount(verbose bool) int {
-	return 2
+	if _, ok := m.leftSource.(execinfra.OpNode); ok {
+		if _, ok := m.rightSource.(execinfra.OpNode); ok {
+			return 2
+		}
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -290,7 +290,10 @@ func (ps *projectSetProcessor) ConsumerClosed() {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (ps *projectSetProcessor) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := ps.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -43,7 +43,10 @@ func newInputStatCollector(input execinfra.RowSource) *inputStatCollector {
 
 // ChildCount is part of the OpNode interface.
 func (isc *inputStatCollector) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := isc.RowSource.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the OpNode interface.

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -878,7 +878,10 @@ func (w *windower) outputStatsToTrace() {
 
 // ChildCount is part of the execinfra.OpNode interface.
 func (w *windower) ChildCount(verbose bool) int {
-	return 1
+	if _, ok := w.input.(execinfra.OpNode); ok {
+		return 1
+	}
+	return 0
 }
 
 // Child is part of the execinfra.OpNode interface.


### PR DESCRIPTION
Backport 1/1 commits from #46439.

/cc @cockroachdb/release

---

Release justification: bug fixes and low-risk updates to new
functionality.

This commit makes `noopProcessor` implement `execinfra.OpNode`
interface. It also changes the way we handle processors when traversing
`execinfra.OpNode` tree - we will now check whether the inputs to
a processor implement the interface and return different number of
children based on that check. This is done so that the user doesn't see
an internal error and, instead, sees a "truncated" output of `EXPLAIN
(VEC)`.

Fixes: #46404.

Release note: None (no stable release with this behavior)
