### PR TITLE
release-19.2: colrpc: reduce Outbox Next error logging verbosity

### DIFF
--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -222,7 +222,9 @@ func (o *Outbox) sendBatches(
 		}
 
 		if err := execerror.CatchVectorizedRuntimeError(nextBatch); err != nil {
-			log.Warningf(ctx, "Outbox Next error: %+v", err)
+			if log.V(1) {
+				log.Warningf(ctx, "Outbox Next error: %+v", err)
+			}
 			return false, err
 		}
 		if o.batch.Length() == 0 {


### PR DESCRIPTION
Backport 1/1 commits from #46724.

/cc @cockroachdb/release

---

Release justification: low risk, high benefit change. Eliminates noisy log
messages in default logging configuration.

We would previously log any error that happened when calling Next on an
Outbox's input tree. This could include expected errors such as context
cancellations, making the resulting log output (including a stack trace) pretty
scary. This commit puts this logging behind a verbosity(1) flag.

Release note (bug fix): benign Outbox Next errors are now only logged when log
verbosity is set to 1 or greater.
