### PR TITLE
release-20.1: sql: fix the telemetry for conn+audit logs

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -378,3 +378,21 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
 		"user %s does not have %s privilege", user, roleOption.String())
 }
+
+// ConnAuditingClusterSettingName is the name of the cluster setting
+// for the cluster setting that enables pgwire-level connection audit
+// logs.
+//
+// This name is defined here because it is needed in the telemetry
+// counts in SetClusterSetting() and importing pgwire here would
+// create a circular dependency.
+const ConnAuditingClusterSettingName = "server.auth_log.sql_connections.enabled"
+
+// AuthAuditingClusterSettingName is the name of the cluster setting
+// for the cluster setting that enables pgwire-level authentication audit
+// logs.
+//
+// This name is defined here because it is needed in the telemetry
+// counts in SetClusterSetting() and importing pgwire here would
+// create a circular dependency.
+const AuthAuditingClusterSettingName = "server.auth_log.sql_sessions.enabled"

--- a/pkg/sql/logictest/testdata/logic_test/feature_counts
+++ b/pkg/sql/logictest/testdata/logic_test/feature_counts
@@ -10,3 +10,21 @@ SELECT feature_name
 ----
 feature_name
 errorcodes.42601
+
+statement ok
+SET CLUSTER SETTING server.auth_log.sql_connections.enabled = true;
+SET CLUSTER SETTING server.auth_log.sql_connections.enabled = false;
+  SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = true;
+  SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = false
+
+query IT colnames
+SELECT usage_count, feature_name
+  FROM crdb_internal.feature_usage
+ WHERE feature_name LIKE 'auditing.%abled'
+ORDER BY 2,1
+----
+usage_count  feature_name
+1            auditing.authentication.disabled
+1            auditing.authentication.enabled
+1            auditing.connection.disabled
+1            auditing.connection.enabled

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -259,9 +258,6 @@ func (c *conn) serveImpl(
 	var sessionAuthLogger *log.SecondaryLogger
 	if !inTestWithoutSQL && c.authLogEnabled() {
 		sessionAuthLogger = authLogger
-		telemetry.Inc(sqltelemetry.LoggedAuthAttempts)
-	} else {
-		telemetry.Inc(sqltelemetry.UnloggedAuthAttempts)
 	}
 
 	// We'll build an authPipe to communicate with the authentication process.

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -65,12 +65,12 @@ var connResultsBufferSize = settings.RegisterPublicByteSizeSetting(
 )
 
 var logConnAuth = settings.RegisterPublicBoolSetting(
-	"server.auth_log.sql_connections.enabled",
+	sql.ConnAuditingClusterSettingName,
 	"if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)",
 	false)
 
 var logSessionAuth = settings.RegisterPublicBoolSetting(
-	"server.auth_log.sql_sessions.enabled",
+	sql.AuthAuditingClusterSettingName,
 	"if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)",
 	false)
 
@@ -468,9 +468,6 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 	connStart := timeutil.Now()
 	if s.connLogEnabled() {
 		s.execCfg.AuthLogger.Logf(ctx, "received connection")
-		telemetry.Inc(sqltelemetry.LoggedConnections)
-	} else {
-		telemetry.Inc(sqltelemetry.UnloggedConnections)
 	}
 	defer func() {
 		// The duration of the session is logged at the end so that the

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -173,6 +173,20 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 			case "false":
 				telemetry.Inc(sqltelemetry.TurnAutoStatsOffUseCounter)
 			}
+		case ConnAuditingClusterSettingName:
+			switch expectedEncodedValue {
+			case "true":
+				telemetry.Inc(sqltelemetry.TurnConnAuditingOnUseCounter)
+			case "false":
+				telemetry.Inc(sqltelemetry.TurnConnAuditingOffUseCounter)
+			}
+		case AuthAuditingClusterSettingName:
+			switch expectedEncodedValue {
+			case "true":
+				telemetry.Inc(sqltelemetry.TurnAuthAuditingOnUseCounter)
+			case "false":
+				telemetry.Inc(sqltelemetry.TurnAuthAuditingOffUseCounter)
+			}
 		case ReorderJoinsLimitClusterSettingName:
 			val, err := strconv.ParseInt(expectedEncodedValue, 10, 64)
 			if err != nil {

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -92,3 +92,15 @@ func IncIAMRevokePrivilegesCounter(on string) {
 	telemetry.Inc(telemetry.GetCounter(
 		fmt.Sprintf("%s.%s.%s.%s", iamRoles, "revoke", "privileges", on)))
 }
+
+// TurnConnAuditingOnUseCounter counts how many time connection audit logs were enabled.
+var TurnConnAuditingOnUseCounter = telemetry.GetCounterOnce("auditing.connection.enabled")
+
+// TurnConnAuditingOffUseCounter counts how many time connection audit logs were disabled.
+var TurnConnAuditingOffUseCounter = telemetry.GetCounterOnce("auditing.connection.disabled")
+
+// TurnAuthAuditingOnUseCounter counts how many time connection audit logs were enabled.
+var TurnAuthAuditingOnUseCounter = telemetry.GetCounterOnce("auditing.authentication.enabled")
+
+// TurnAuthAuditingOffUseCounter counts how many time connection audit logs were disabled.
+var TurnAuthAuditingOffUseCounter = telemetry.GetCounterOnce("auditing.authentication.disabled")

--- a/pkg/sql/sqltelemetry/scalar.go
+++ b/pkg/sql/sqltelemetry/scalar.go
@@ -75,27 +75,3 @@ var LargeLShiftArgumentCounter = telemetry.GetCounterOnce("sql.large_lshift_argu
 // LargeRShiftArgumentCounter is to be incremented upon evaluating a scalar
 // expressions a >> b when b is larger than 64 or negative.
 var LargeRShiftArgumentCounter = telemetry.GetCounterOnce("sql.large_rshift_argument")
-
-// UnloggedConnections tracks the number of SQL client connections for which
-// audit logs were disabled.
-// TODO(knz): The original telemetry request was for a counter of how
-// many times the cluster setting for conn audit logging was
-// customized. However this was not implementable at the time. This
-// can be revisited if/when specific cluster setting changes are
-// brought under telemetry.
-var UnloggedConnections = telemetry.GetCounterOnce("auditing.connection.disabled")
-
-// LoggedConnections tracks the number of connections for which audit logs
-// were enabled.
-// TODO(knz): see TODO above.
-var LoggedConnections = telemetry.GetCounterOnce("auditing.connection.enabled")
-
-// UnloggedAuthAttempts tracks the number of authentication attempts
-// for which audit logs were disabled.
-// TODO(knz): see TODO above.
-var UnloggedAuthAttempts = telemetry.GetCounterOnce("auditing.authentication.disabled")
-
-// LoggedAuthAttempts tracks the number of authentication attempts for
-// which audit logs were enabled.
-// TODO(knz): see TODO above.
-var LoggedAuthAttempts = telemetry.GetCounterOnce("auditing.authentication.enabled")


### PR DESCRIPTION
Backport 1/1 commits from #46840.

/cc @cockroachdb/release

---

The telemetry counters requested by @nstewart in #45028 should
log how many times the cluster setting was toggled, not how many
connections there were in each configuration.

This patch fixes that.


