### PR TITLE
ui: fix the insecure cluster indicator

### DIFF
--- a/pkg/ui/src/redux/login.ts
+++ b/pkg/ui/src/redux/login.ts
@@ -26,9 +26,28 @@ const dataFromServer = getDataFromServer();
 // State for application use.
 
 export interface LoginState {
+  // useLogin() indicates whether the login drop-down menu should be
+  // displayed at the top right.
+  //
+  // Despite its name, it does not indicate whether the login
+  // page should be displayed or not. It merely controls the
+  // display of the drop-down menu.
   useLogin(): boolean;
+  // loginEnabled() indicates whether the connection is secure. If
+  // false, an "insecure" indicator is displayed at the top right.
+  //
+  // Note that an "insecure" indicator should be displayed at the
+  // top right even when useLogin() is false.
+  //
+  // Despite its name, it does not indicate whether users can
+  // log in or not; it merely controls the display of the indicator.
   loginEnabled(): boolean;
+  // hasAccess() indicates whether the login page can be displayed
+  // at all.
+  // Despite its name, it does not constrain whether a user
+  // can log in or not.
   hasAccess(): boolean;
+  // loggedInUser() returns the name of the user logged in.
   loggedInUser(): string;
 }
 

--- a/pkg/ui/src/redux/login.ts
+++ b/pkg/ui/src/redux/login.ts
@@ -26,27 +26,16 @@ const dataFromServer = getDataFromServer();
 // State for application use.
 
 export interface LoginState {
-  // useLogin() indicates whether the login drop-down menu should be
+  // displayUserMenu() indicates whether the login drop-down menu should be
   // displayed at the top right.
-  //
-  // Despite its name, it does not indicate whether the login
-  // page should be displayed or not. It merely controls the
-  // display of the drop-down menu.
-  useLogin(): boolean;
-  // loginEnabled() indicates whether the connection is secure. If
+  displayUserMenu(): boolean;
+  // secureCluster() indicates whether the connection is secure. If
   // false, an "insecure" indicator is displayed at the top right.
-  //
-  // Note that an "insecure" indicator should be displayed at the
-  // top right even when useLogin() is false.
-  //
-  // Despite its name, it does not indicate whether users can
-  // log in or not; it merely controls the display of the indicator.
-  loginEnabled(): boolean;
-  // hasAccess() indicates whether the login page can be displayed
-  // at all.
-  // Despite its name, it does not constrain whether a user
-  // can log in or not.
-  hasAccess(): boolean;
+  secureCluster(): boolean;
+  // hideLoginPage() indicates whether the login page can be
+  // displayed at all. The login page is hidden e.g.
+  // after a user has logged in.
+  hideLoginPage(): boolean;
   // loggedInUser() returns the name of the user logged in.
   loggedInUser(): string;
 }
@@ -58,15 +47,15 @@ class LoginEnabledState {
     this.apiState = state;
   }
 
-  useLogin(): boolean {
+  displayUserMenu(): boolean {
     return true;
   }
 
-  loginEnabled(): boolean {
+  secureCluster(): boolean {
     return true;
   }
 
-  hasAccess(): boolean {
+  hideLoginPage(): boolean {
     return this.apiState.loggedInUser != null;
   }
 
@@ -76,15 +65,15 @@ class LoginEnabledState {
 }
 
 class LoginDisabledState {
-  useLogin(): boolean {
+  displayUserMenu(): boolean {
     return true;
   }
 
-  loginEnabled(): boolean {
+  secureCluster(): boolean {
     return false;
   }
 
-  hasAccess(): boolean {
+  hideLoginPage(): boolean {
     return true;
   }
 
@@ -94,15 +83,15 @@ class LoginDisabledState {
 }
 
 class NoLoginState {
-  useLogin(): boolean {
+  displayUserMenu(): boolean {
     return false;
   }
 
-  loginEnabled(): boolean {
+  secureCluster(): boolean {
     return false;
   }
 
-  hasAccess(): boolean {
+  hideLoginPage(): boolean {
     return true;
   }
 

--- a/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
+++ b/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
@@ -47,7 +47,7 @@ class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicator
   render() {
     const { loginState, handleLogout } = this.props;
     const { isOpenMenu } = this.state;
-    if (!loginState.loginEnabled()) {
+    if (!loginState.secureCluster()) {
       return (
         <div className="login-indicator login-indicator--insecure">
           <div
@@ -60,7 +60,7 @@ class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicator
       );
     }
 
-    if (!loginState.useLogin()) {
+    if (!loginState.displayUserMenu()) {
       return null;
     }
 

--- a/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
+++ b/pkg/ui/src/views/app/components/loginIndicator/loginIndicator.tsx
@@ -47,10 +47,6 @@ class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicator
   render() {
     const { loginState, handleLogout } = this.props;
     const { isOpenMenu } = this.state;
-    if (!loginState.useLogin()) {
-      return null;
-    }
-
     if (!loginState.loginEnabled()) {
       return (
         <div className="login-indicator login-indicator--insecure">
@@ -62,6 +58,10 @@ class LoginIndicator extends React.Component<LoginIndicatorProps, LoginIndicator
           <div className="login-indicator__title">Insecure mode</div>
         </div>
       );
+    }
+
+    if (!loginState.useLogin()) {
+      return null;
     }
 
     const user = loginState.loggedInUser();

--- a/pkg/ui/src/views/login/requireLogin.tsx
+++ b/pkg/ui/src/views/login/requireLogin.tsx
@@ -31,17 +31,17 @@ class RequireLogin extends React.Component<RouteComponentProps & RequireLoginPro
   checkLogin() {
     const { location, history } = this.props;
 
-    if (!this.hasAccess()) {
+    if (!this.hideLoginPage()) {
       history.push(getLoginPage(location));
     }
   }
 
-  hasAccess() {
-    return this.props.loginState.hasAccess();
+  hideLoginPage() {
+    return this.props.loginState.hideLoginPage();
   }
 
   render() {
-    if (!this.hasAccess()) {
+    if (!this.hideLoginPage()) {
       return null;
     }
 


### PR DESCRIPTION
Somewhere in the UI redesign the insecure cluster indicator was
lost. This was due to a mixup in the order of the checks - if login
was disabled (e.g. because of insecure mode) neither the drop-down
user menu *nor* the insecure indicator were displayed.

This patch repairs this by restoring the insecure indicator even when
login is disabled.

Release note (bug fix): The "insecure cluster" indicator is now
displayed again at the top right of the screen for insecure clusters.