### PR TITLE
server,ui: simplify/sanitize the "ui auth disabled" flag

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -124,7 +124,7 @@ type TestServerArgs struct {
 
 	// If set, web session authentication will be disabled, even if the server
 	// is running in secure mode.
-	DisableWebSessionAuthentication bool
+	InsecureWebAccess bool
 
 	// IF set, the demo login endpoint will be enabled.
 	EnableDemoLoginEndpoint bool

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_kv_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_kv_test.go
@@ -32,7 +32,7 @@ func TestTenantRangeQPSStat(t *testing.T) {
 
 	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DisableWebSessionAuthentication: true,
+			InsecureWebAccess: true,
 			// Must disable test tenant because test below assumes that
 			// it is connecting to the host tenant.
 			DisableDefaultTestTenant: true,

--- a/pkg/obsservice/obslib/httpproxy/reverseproxy.go
+++ b/pkg/obsservice/obslib/httpproxy/reverseproxy.go
@@ -135,8 +135,7 @@ func (p *ReverseHTTPProxy) Start(ctx context.Context, stop *stop.Stopper) {
 	// configured in `obsservice` and not hardcoded into `obslib`. This
 	// gives lib users a chance to do whatever they want with the UI.
 	mux.Handle("/", ui.Handler(ui.Config{
-		ExperimentalUseLogin: false,
-		LoginEnabled:         false,
+		Insecure: true,
 		GetUser: func(ctx context.Context) *string {
 			u := "Observability Service"
 			return &u

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -64,8 +64,8 @@ func TestRotateCerts(t *testing.T) {
 	// authenticate the individual clients being instantiated (session auth has
 	// no effect on what is being tested here).
 	params := base.TestServerArgs{
-		SSLCertsDir:                     certsDir,
-		DisableWebSessionAuthentication: true,
+		SSLCertsDir:       certsDir,
+		InsecureWebAccess: true,
 	}
 	s, _, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -390,8 +390,8 @@ func TestUseCerts(t *testing.T) {
 	// authenticate the individual clients being instantiated (session auth has
 	// no effect on what is being tested here).
 	params := base.TestServerArgs{
-		SSLCertsDir:                     certsDir,
-		DisableWebSessionAuthentication: true,
+		SSLCertsDir:       certsDir,
+		InsecureWebAccess: true,
 	}
 	s, _, db := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
@@ -472,8 +472,8 @@ func TestUseSplitCACerts(t *testing.T) {
 	// authenticate the individual clients being instantiated (session auth has
 	// no effect on what is being tested here).
 	params := base.TestServerArgs{
-		SSLCertsDir:                     certsDir,
-		DisableWebSessionAuthentication: true,
+		SSLCertsDir:       certsDir,
+		InsecureWebAccess: true,
 	}
 	s, _, db := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
@@ -590,8 +590,8 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	// authenticate the individual clients being instantiated (session auth has
 	// no effect on what is being tested here).
 	params := base.TestServerArgs{
-		SSLCertsDir:                     certsDir,
-		DisableWebSessionAuthentication: true,
+		SSLCertsDir:       certsDir,
+		InsecureWebAccess: true,
 	}
 	s, _, db := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -88,7 +88,7 @@ func TestSSLEnforcement(t *testing.T) {
 		// client certificates over HTTP endpoints. Web session authentication
 		// is disabled in order to avoid the need to authenticate the individual
 		// clients being instantiated.
-		DisableWebSessionAuthentication: true,
+		InsecureWebAccess: true,
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -183,9 +183,11 @@ type BaseConfig struct {
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 
-	// EnableWebSessionAuthentication enables session-based authentication for
-	// the Admin API's HTTP endpoints.
-	EnableWebSessionAuthentication bool
+	// TestingInsecureWebAccess enables uses of the HTTP and UI
+	// endpoints without a valid authentication token. This should be
+	// used only in tests what want a secure cluster with RPC
+	// auth but no auth in HTTP.
+	TestingInsecureWebAccess bool
 
 	// EnableDemoLoginEndpoint enables the HTTP GET endpoint for user logins,
 	// which a feature unique to the demo shell.
@@ -250,7 +252,7 @@ func (cfg *BaseConfig) SetDefaults(
 	cfg.MaxOffset = MaxOffsetType(base.DefaultMaxClockOffset)
 	cfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()
 	cfg.StorageEngine = storage.DefaultStorageEngine
-	cfg.EnableWebSessionAuthentication = !disableWebLogin
+	cfg.TestingInsecureWebAccess = disableWebLogin
 	cfg.Stores = base.StoreSpecList{
 		Specs: []base.StoreSpec{storeSpec},
 	}
@@ -865,10 +867,10 @@ func (cfg *Config) FilterGossipBootstrapAddresses(ctx context.Context) []util.Un
 	return filtered
 }
 
-// RequireWebSession indicates whether the server should require authentication
-// sessions when serving admin API requests.
-func (cfg *BaseConfig) RequireWebSession() bool {
-	return !cfg.Insecure && cfg.EnableWebSessionAuthentication
+// InsecureWebAccess indicates whether the server should allow
+// access to the HTTP endpoints without a valid auth cookie.
+func (cfg *BaseConfig) InsecureWebAccess() bool {
+	return cfg.Insecure || cfg.TestingInsecureWebAccess
 }
 
 func (cfg *Config) readSQLEnvironmentVariables() {

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -673,7 +673,7 @@ func makeInMemoryTenantServerConfig(
 
 	baseCfg.MaxOffset = kvServerCfg.BaseConfig.MaxOffset
 	baseCfg.StorageEngine = kvServerCfg.BaseConfig.StorageEngine
-	baseCfg.EnableWebSessionAuthentication = kvServerCfg.BaseConfig.EnableWebSessionAuthentication
+	baseCfg.TestingInsecureWebAccess = kvServerCfg.BaseConfig.TestingInsecureWebAccess
 	baseCfg.Locality = kvServerCfg.BaseConfig.Locality
 	baseCfg.SpanConfigsDisabled = kvServerCfg.BaseConfig.SpanConfigsDisabled
 	baseCfg.EnableDemoLoginEndpoint = kvServerCfg.BaseConfig.EnableDemoLoginEndpoint

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -752,10 +752,6 @@ func TestServeIndexHTML(t *testing.T) {
 	t.Run("Insecure mode", func(t *testing.T) {
 		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 			Insecure: true,
-			// This test server argument has the same effect as setting the environment variable
-			// `COCKROACH_EXPERIMENTAL_REQUIRE_WEB_SESSION` to false, or not setting it.
-			// In test servers, web sessions are required by default.
-			DisableWebSessionAuthentication: true,
 		})
 		defer s.Stopper().Stop(ctx)
 		tsrv := s.(*TestServer)
@@ -804,7 +800,7 @@ Binary built without web UI.
 			respBytes, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			expected := fmt.Sprintf(
-				`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 				build.GetInfo().Tag,
 				build.BinaryVersionPrefix(),
 				1,
@@ -832,7 +828,7 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,
@@ -841,7 +837,7 @@ Binary built without web UI.
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -108,8 +108,6 @@ func makeTestBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 	baseCfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	baseCfg.User = username.NodeUserName()
-	// Enable web session authentication.
-	baseCfg.EnableWebSessionAuthentication = true
 	return baseCfg
 }
 
@@ -230,9 +228,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.HTTPAddr = params.HTTPAddr
 	}
 	cfg.DisableTLSForHTTP = params.DisableTLSForHTTP
-	if params.DisableWebSessionAuthentication {
-		cfg.EnableWebSessionAuthentication = false
-	}
+	cfg.TestingInsecureWebAccess = params.InsecureWebAccess
 	if params.EnableDemoLoginEndpoint {
 		cfg.EnableDemoLoginEndpoint = true
 	}

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -98,8 +98,8 @@ func newRowLevelTTLTestJobTestHelper(
 	testCluster := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
 		ReplicationMode: replicationMode,
 		ServerArgs: base.TestServerArgs{
-			Knobs:                           baseTestingKnobs,
-			DisableWebSessionAuthentication: true,
+			Knobs:             baseTestingKnobs,
+			InsecureWebAccess: true,
 		},
 	})
 	th.testCluster = testCluster

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -59,16 +59,16 @@ var indexHTML = []byte(`<!DOCTYPE html>
 `)
 
 type indexHTMLArgs struct {
-	ExperimentalUseLogin bool
-	LoginEnabled         bool
-	LoggedInUser         *string
-	Tag                  string
-	Version              string
-	NodeID               string
-	OIDCAutoLogin        bool
-	OIDCLoginEnabled     bool
-	OIDCButtonText       string
-	FeatureFlags         serverpb.FeatureFlags
+	// Insecure means disable auth entirely - anyone can use.
+	Insecure         bool
+	LoggedInUser     *string
+	Tag              string
+	Version          string
+	NodeID           string
+	OIDCAutoLogin    bool
+	OIDCLoginEnabled bool
+	OIDCButtonText   string
+	FeatureFlags     serverpb.FeatureFlags
 }
 
 // OIDCUIConf is a variable that stores data required by the
@@ -99,12 +99,11 @@ Binary built without web UI.
 
 // Config contains the configuration parameters for Handler.
 type Config struct {
-	ExperimentalUseLogin bool
-	LoginEnabled         bool
-	NodeID               *base.NodeIDContainer
-	GetUser              func(ctx context.Context) *string
-	OIDC                 OIDCUI
-	Flags                serverpb.FeatureFlags
+	Insecure bool
+	NodeID   *base.NodeIDContainer
+	GetUser  func(ctx context.Context) *string
+	OIDC     OIDCUI
+	Flags    serverpb.FeatureFlags
 }
 
 var uiConfigPath = regexp.MustCompile("^/uiconfig$")
@@ -136,15 +135,14 @@ func Handler(cfg Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		oidcConf := cfg.OIDC.GetOIDCConf()
 		args := indexHTMLArgs{
-			ExperimentalUseLogin: cfg.ExperimentalUseLogin,
-			LoginEnabled:         cfg.LoginEnabled,
-			LoggedInUser:         cfg.GetUser(r.Context()),
-			Tag:                  buildInfo.Tag,
-			Version:              build.BinaryVersionPrefix(),
-			OIDCAutoLogin:        oidcConf.AutoLogin,
-			OIDCLoginEnabled:     oidcConf.Enabled,
-			OIDCButtonText:       oidcConf.ButtonText,
-			FeatureFlags:         cfg.Flags,
+			Insecure:         cfg.Insecure,
+			LoggedInUser:     cfg.GetUser(r.Context()),
+			Tag:              buildInfo.Tag,
+			Version:          build.BinaryVersionPrefix(),
+			OIDCAutoLogin:    oidcConf.AutoLogin,
+			OIDCLoginEnabled: oidcConf.Enabled,
+			OIDCButtonText:   oidcConf.ButtonText,
+			FeatureFlags:     cfg.Flags,
 		}
 		if cfg.NodeID != nil {
 			args.NodeID = cfg.NodeID.String()

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -58,9 +58,8 @@ func TestUIHandlerDevelopment(t *testing.T) {
 	}()()
 
 	cfg := Config{
-		ExperimentalUseLogin: false,
-		LoginEnabled:         false,
-		NodeID:               &base.NodeIDContainer{},
+		Insecure: true,
+		NodeID:   &base.NodeIDContainer{},
 		GetUser: func(ctx context.Context) *string {
 			z := ""
 			return &z
@@ -133,9 +132,8 @@ func TestUIHandler(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	cfg := Config{
-		ExperimentalUseLogin: false,
-		LoginEnabled:         false,
-		NodeID:               &base.NodeIDContainer{},
+		Insecure: true,
+		NodeID:   &base.NodeIDContainer{},
 		GetUser: func(ctx context.Context) *string {
 			z := ""
 			return &z

--- a/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
@@ -12,8 +12,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
 
 export interface DataFromServer {
-  ExperimentalUseLogin: boolean;
-  LoginEnabled: boolean;
+  Insecure: boolean;
   LoggedInUser: string;
   Tag: string;
   Version: string;

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -68,25 +68,7 @@ class LoginEnabledState {
   }
 }
 
-class LoginDisabledState {
-  displayUserMenu(): boolean {
-    return true;
-  }
-
-  secureCluster(): boolean {
-    return false;
-  }
-
-  hideLoginPage(): boolean {
-    return true;
-  }
-
-  loggedInUser(): string {
-    return null;
-  }
-}
-
-class NoLoginState {
+class InsecureState {
   displayUserMenu(): boolean {
     return false;
   }
@@ -100,7 +82,7 @@ class NoLoginState {
   }
 
   loggedInUser(): string {
-    return null;
+    return "";
   }
 }
 
@@ -110,12 +92,8 @@ export const selectLoginState = createSelector(
   (state: AdminUIState) => state.login,
   (login: LoginAPIState) => {
     const dataFromServer = getDataFromServer();
-    if (!dataFromServer.ExperimentalUseLogin) {
-      return new NoLoginState();
-    }
-
-    if (!dataFromServer.LoginEnabled) {
-      return new LoginDisabledState();
+    if (dataFromServer.Insecure) {
+      return new InsecureState();
     }
 
     return new LoginEnabledState(login);

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -52,10 +52,9 @@ export interface AdminUIState {
 }
 
 const emptyDataFromServer: DataFromServer = {
-  ExperimentalUseLogin: false,
+  Insecure: true,
   FeatureFlags: {},
   LoggedInUser: "",
-  LoginEnabled: false,
   NodeID: "",
   OIDCAutoLogin: false,
   OIDCButtonText: "",

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -12,8 +12,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
 
 export interface DataFromServer {
-  ExperimentalUseLogin: boolean;
-  LoginEnabled: boolean;
+  Insecure: boolean;
   LoggedInUser: string;
   Tag: string;
   Version: string;

--- a/pkg/ui/workspaces/db-console/src/views/app/components/loginIndicator/loginIndicator.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/loginIndicator/loginIndicator.tsx
@@ -69,7 +69,7 @@ class LoginIndicator extends React.Component<
 
     const user = loginState.loggedInUser();
 
-    if (user == null) {
+    if (typeof user == "undefined" || user == null) {
       return null;
     }
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/userAvatar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/userAvatar/index.tsx
@@ -25,7 +25,10 @@ export default function UserAvatar(props: UserAvatarProps) {
     "user-avatar--disabled": disabled,
   });
 
-  const nameAbbreviation = userName[0].toUpperCase();
+  const nameAbbreviation =
+    typeof userName[0] == "undefined" || userName[0] == null
+      ? ""
+      : userName[0].toUpperCase();
 
   return (
     <div className={classes}>


### PR DESCRIPTION
For context, whether authentication is enabled for HTTP endpoints and
the web UI is equivalent to whether the cluster is started
securely (i.e. without `--insecure`).
A few *tests* challenge that by requiring a secure cluster but without
HTTP auth, but this behavior is not meant to be exposed to clients.

Prior to this patch, the display of the UI components related
to login and authentication were controlled by 2 variables:

- something called `ExperimentalUseLogin` which, if false,
  would both hide the login page and display
  an "insecure" indicator.
- something called `LoginEnabled` which, if false,
  would both hide the login page and display
  an "insecure" indicator.

(Yes, these variables were redundant.)

This patch removes this redundancy by merging them together
as a single new variable called `Insecure`.

Additionally, these variables were initialized in a rather exotic way:

- inside the server config there was something called
  `EnableWebSessionAuthentication`, directly used to control
  `ExperimentalUseLogin` described above. It was
  the one used by tests.

  This had very dubious semantics: a security-
  minded user could reasonably expect that disabling
  authentication would prevent access, not enable
  access by everyone.

  This variable is now renamed to `TestingInsecureWebAccess` for
  clarity.

- separately, the `LoginEnabled` variable was initialized
  as `!(!cfg.Insecure && cfg.EnableWebSessionAuthentication)`.
  (Note the double negative. Confusing.)

These two things are now simplified by setting the UI's `Insecure`
flag as `cfg.Insecure || cfg.TestingInsecureWebAccess` server-side.

Epic: None
Release note: None