### PR TITLE
release-20.1: kvclient/kvcoord: inhibit parallel commit when retrying EndTxn request

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -234,6 +234,8 @@ func (tc *txnCommitter) SendLocked(
 	// could be a combination of protos from responses, all merged by
 	// DistSender.
 	if pErr := needTxnRetryAfterStaging(br); pErr != nil {
+		log.VEventf(ctx, 2, "parallel commit failed since some writes were pushed. "+
+			"Synthesized err: %s", pErr)
 		return nil, pErr
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -138,8 +138,34 @@ func (tc *txnCommitter) SendLocked(
 	// set. This is the only place where EndTxnRequest.Key is assigned, but we
 	// could be dealing with a re-issued batch after a refresh. Remember, the
 	// committer is below the span refresh on the interceptor stack.
+	var etAttempt endTxnAttempt
 	if et.Key == nil {
 		et.Key = ba.Txn.Key
+		etAttempt = endTxnFirstAttempt
+	} else {
+		// If this is a retry, we'll disable parallel commit. Since the previous
+		// attempt might have partially succeeded (i.e. the batch might have been
+		// split into sub-batches and some of them might have evaluated
+		// successfully), there might be intents laying around. If we'd perform a
+		// parallel commit, and the batch gets split again, and the STAGING txn
+		// record were written before we evaluate some of the other sub-batche. We
+		// could technically enter the "implicitly committed" state before all the
+		// sub-batches are evaluated and this is problematic: there's a race between
+		// evaluating those requests and other pushers coming along and
+		// transitioning the txn to explicitly committed (and cleaning up all the
+		// intents), and the evaluations of the outstanding sub-batches. If the
+		// randos win, then the re-evaluations will fail because we don't have
+		// idempotency of evaluations across a txn commit (for example, the
+		// re-evaluations might notice that their transaction is already committed
+		// and get confused).
+		etAttempt = endTxnRetry
+		if len(et.InFlightWrites) > 0 {
+			// Make a copy of the EndTxn, since we're going to change it below to
+			// disable the parallel commit.
+			etCpy := *et
+			ba.Requests[len(ba.Requests)-1].SetInner(&etCpy)
+			et = &etCpy
+		}
 	}
 
 	// Determine whether the commit request can be run in parallel with the rest
@@ -147,7 +173,7 @@ func (tc *txnCommitter) SendLocked(
 	// attached to the EndTxn request to the LockSpans and clear the in-flight
 	// write set; no writes will be in-flight concurrently with the EndTxn
 	// request.
-	if len(et.InFlightWrites) > 0 && !tc.canCommitInParallel(ctx, ba, et) {
+	if len(et.InFlightWrites) > 0 && !tc.canCommitInParallel(ctx, ba, et, etAttempt) {
 		// NB: when parallel commits is disabled, this is the best place to
 		// detect whether the batch has only distinct spans. We can set this
 		// flag based on whether any of previously declared in-flight writes
@@ -274,14 +300,30 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 	return br, nil
 }
 
+// endTxnAttempt specifies whether it's the first time that we're attempting to
+// evaluate an EndTxn request or whether it's a retry (i.e. after a successful
+// refresh). There are some precautions we need to take when sending out
+// retries.
+type endTxnAttempt int
+
+const (
+	endTxnFirstAttempt endTxnAttempt = iota
+	endTxnRetry
+)
+
 // canCommitInParallel determines whether the batch can issue its committing
 // EndTxn in parallel with the rest of its requests and with any in-flight
 // writes, which all should have corresponding QueryIntent requests in the
 // batch.
 func (tc *txnCommitter) canCommitInParallel(
-	ctx context.Context, ba roachpb.BatchRequest, et *roachpb.EndTxnRequest,
+	ctx context.Context, ba roachpb.BatchRequest, et *roachpb.EndTxnRequest, etAttempt endTxnAttempt,
 ) bool {
 	if !parallelCommitsEnabled.Get(&tc.st.SV) {
+		return false
+	}
+
+	if etAttempt == endTxnRetry {
+		log.VEventf(ctx, 2, "retrying batch not eligible for parallel commit")
 		return false
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -260,17 +260,13 @@ func PushTxn(
 	recoverOnFailedPush := cArgs.EvalCtx.EvalKnobs().RecoverIndeterminateCommitsOnFailedPushes
 	if reply.PusheeTxn.Status == roachpb.STAGING && (pusherWins || recoverOnFailedPush) {
 		err := roachpb.NewIndeterminateCommitError(reply.PusheeTxn)
-		if log.V(1) {
-			log.Infof(ctx, "%v", err)
-		}
+		log.VEventf(ctx, 1, "%v", err)
 		return result.Result{}, err
 	}
 
 	if !pusherWins {
 		err := roachpb.NewTransactionPushError(reply.PusheeTxn)
-		if log.V(1) {
-			log.Infof(ctx, "%v", err)
-		}
+		log.VEventf(ctx, 1, "%v", err)
 		return result.Result{}, err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -142,6 +142,7 @@ func PushTxn(
 	if err != nil {
 		return result.Result{}, err
 	} else if !ok {
+		log.VEventf(ctx, 2, "pushee txn record not found")
 		// There are three cases in which there is no transaction record:
 		//
 		// * the pushee is still active but its transaction record has not

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -165,10 +165,8 @@ func (s *Store) Send(
 		}
 	}
 
-	if log.V(1) {
+	if log.ExpensiveLogEnabled(ctx, 1) {
 		log.Eventf(ctx, "executing %s", ba)
-	} else if log.HasSpanOrEvent(ctx) {
-		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 
 	// Get range and add command to the range for execution.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -917,7 +917,7 @@ func (n *Node) batchInternal(
 		// NB: wrapped to delay br evaluation to its value when returning.
 		defer func() { finishSpan(br) }()
 		if log.HasSpanOrEvent(ctx) {
-			log.Event(ctx, args.Summary())
+			log.Eventf(ctx, "node received request: %s", args.Summary())
 		}
 
 		tStart := timeutil.Now()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1499,21 +1499,6 @@ func (st *SessionTracing) TraceExecEnd(ctx context.Context, err error, count int
 	}
 }
 
-// extractMsgFromRecord extracts the message of the event, which is either in an
-// "event" or "error" field.
-func extractMsgFromRecord(rec tracing.LogRecord) string {
-	for _, f := range rec.Fields {
-		key := f.Key
-		if key == "event" {
-			return f.Value
-		}
-		if key == "error" {
-			return fmt.Sprint("error:", f.Value)
-		}
-	}
-	return "<event missing in trace message>"
-}
-
 const (
 	// span_idx    INT NOT NULL,        -- The span's index.
 	traceSpanIdxCol = iota
@@ -1765,7 +1750,7 @@ func getMessagesForSubtrace(
 			allLogs = append(allLogs,
 				logRecordRow{
 					timestamp: logTime,
-					msg:       extractMsgFromRecord(span.Logs[i]),
+					msg:       span.Logs[i].Msg(),
 					span:      span,
 					// Add 1 to the index to account for the first dummy message in a
 					// span.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -739,6 +739,9 @@ func (opts *MVCCGetOptions) validate() error {
 // Note that transactional gets must be consistent. Put another way, only
 // non-transactional gets may be inconsistent.
 //
+// If the timestamp is specified as hlc.Timestamp{}, the value is expected to be
+// "inlined". See MVCCPut().
+//
 // When reading in "fail on more recent" mode, a WriteTooOldError will be
 // returned if the read observes a version with a timestamp above the read
 // timestamp. Similarly, a WriteIntentError will be returned if the read

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -125,7 +125,7 @@ func eventInternal(ctx context.Context, isErr, withTags bool, format string, arg
 		if sp != nil {
 			// TODO(radu): pass tags directly to sp.LogKV when LightStep supports
 			// that.
-			sp.LogFields(otlog.String("event", msg))
+			sp.LogFields(otlog.String(tracing.LogMessageField, msg))
 			// if isErr {
 			// 	// TODO(radu): figure out a way to signal that this is an error. We
 			// 	// could use a different "error" key (provided it shows up in

--- a/pkg/util/tracing/recorded_span.go
+++ b/pkg/util/tracing/recorded_span.go
@@ -10,7 +10,14 @@
 
 package tracing
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// LogMessageField is the field name used for the opentracing.Span.LogFields()
+// for a log message.
+const LogMessageField = "event"
 
 func (s *RecordedSpan) String() string {
 	sb := strings.Builder{}
@@ -19,4 +26,19 @@ func (s *RecordedSpan) String() string {
 		sb.WriteRune('\n')
 	}
 	return sb.String()
+}
+
+// Msg extracts the message of the LogRecord, which is either in an "event" or
+// "error" field.
+func (l LogRecord) Msg() string {
+	for _, f := range l.Fields {
+		key := f.Key
+		if key == LogMessageField {
+			return f.Value
+		}
+		if key == "error" {
+			return fmt.Sprint("error:", f.Value)
+		}
+	}
+	return ""
 }

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -490,7 +490,7 @@ func (s *span) LogFields(fields ...otlog.Field) {
 		// TODO(radu): when LightStep supports arbitrary fields, we should make
 		// the formatting of the message consistent with that. Until then we treat
 		// legacy events that just have an "event" key specially.
-		if len(fields) == 1 && fields[0].Key() == "event" {
+		if len(fields) == 1 && fields[0].Key() == LogMessageField {
 			s.netTr.LazyPrintf("%s", fields[0].Value())
 		} else {
 			var buf bytes.Buffer
@@ -565,12 +565,12 @@ func (s *span) Tracer() opentracing.Tracer {
 
 // LogEvent is part of the opentracing.Span interface. Deprecated.
 func (s *span) LogEvent(event string) {
-	s.LogFields(otlog.String("event", event))
+	s.LogFields(otlog.String(LogMessageField, event))
 }
 
 // LogEventWithPayload is part of the opentracing.Span interface. Deprecated.
 func (s *span) LogEventWithPayload(event string, payload interface{}) {
-	s.LogFields(otlog.String("event", event), otlog.Object("payload", payload))
+	s.LogFields(otlog.String(LogMessageField, event), otlog.Object("payload", payload))
 }
 
 // Log is part of the opentracing.Span interface. Deprecated.

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -13,6 +13,7 @@ package tracing
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -253,86 +254,42 @@ func GetRecording(os opentracing.Span) Recording {
 type traceLogData struct {
 	opentracing.LogRecord
 	depth int
-}
-
-type traceLogs []traceLogData
-
-func (l traceLogs) Len() int {
-	return len(l)
-}
-
-func (l traceLogs) Less(i, j int) bool {
-	return l[i].Timestamp.Before(l[j].Timestamp)
-}
-
-func (l traceLogs) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
+	// timeSincePrev represents the duration since the previous log line (previous in the
+	// set of log lines that this is part of). This is always computed relative to a log line
+	// from the same span, except for start of span in which case the duration is computed relative
+	// to the last log in the parent occurring before this start. For example:
+	// start span A
+	// log 1           // duration relative to "start span A"
+	//   start span B  // duration relative to "log 1"
+	//   log 2  			 // duration relative to "start span B"
+	// log 3  				 // duration relative to "log 1"
+	timeSincePrev time.Duration
 }
 
 // String formats the given spans for human consumption, showing the
 // relationship using nesting and times as both relative to the previous event
-// and cumulative.
+// and cumulative. The order in which log lines are displayed is similar to the
+// one in generateSessionTraceVTable().
 //
 // TODO(andrei): this should be unified with
 // SessionTracing.GenerateSessionTraceVTable.
 func (r Recording) String() string {
-	m := make(map[uint64]*RecordedSpan)
-	for i, sp := range r {
-		m[sp.SpanID] = &r[i]
-	}
-
-	var depth func(uint64) int
-	depth = func(parentID uint64) int {
-		p := m[parentID]
-		if p == nil {
-			return 0
-		}
-		return depth(p.ParentSpanID) + 1
-	}
-
-	var logs traceLogs
+	var logs []traceLogData
 	var start time.Time
 	for _, sp := range r {
 		if sp.ParentSpanID == 0 {
-			start = sp.StartTime
-		}
-		d := depth(sp.ParentSpanID)
-		// Issue a log with the operation name. Include any tags.
-		lr := opentracing.LogRecord{
-			Timestamp: sp.StartTime,
-			Fields:    []otlog.Field{otlog.String("operation", sp.Operation)},
-		}
-		if len(sp.Tags) > 0 {
-			tags := make([]string, 0, len(sp.Tags))
-			for k := range sp.Tags {
-				tags = append(tags, k)
+			if start == (time.Time{}) {
+				start = sp.StartTime
 			}
-			sort.Strings(tags)
-			for _, k := range tags {
-				lr.Fields = append(lr.Fields, otlog.String(k, sp.Tags[k]))
-			}
-		}
-		logs = append(logs, traceLogData{LogRecord: lr, depth: d})
-		for _, l := range sp.Logs {
-			lr := opentracing.LogRecord{
-				Timestamp: l.Time,
-				Fields:    make([]otlog.Field, len(l.Fields)),
-			}
-			for i, f := range l.Fields {
-				lr.Fields[i] = otlog.String(f.Key, f.Value)
-			}
-
-			logs = append(logs, traceLogData{LogRecord: lr, depth: d})
+			logs = append(logs, r.visitSpan(sp, 0 /* depth */)...)
 		}
 	}
-	sort.Sort(logs)
 
-	var buf bytes.Buffer
-	last := start
+	var buf strings.Builder
 	for _, entry := range logs {
 		fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",
 			1000*entry.Timestamp.Sub(start).Seconds(),
-			1000*entry.Timestamp.Sub(last).Seconds(),
+			1000*entry.timeSincePrev.Seconds(),
 			strings.Repeat("    ", entry.depth+1))
 		for i, f := range entry.Fields {
 			if i != 0 {
@@ -341,9 +298,113 @@ func (r Recording) String() string {
 			fmt.Fprintf(&buf, "%s:%v", f.Key(), f.Value())
 		}
 		buf.WriteByte('\n')
-		last = entry.Timestamp
 	}
 	return buf.String()
+}
+
+// FindLogMessage returns the first log message in the recording that matches
+// the given regexp. The bool return value is true if such a message is found.
+func (r Recording) FindLogMessage(pattern string) (string, bool) {
+	re := regexp.MustCompile(pattern)
+	for _, sp := range r {
+		for _, l := range sp.Logs {
+			msg := l.Msg()
+			if re.MatchString(msg) {
+				return msg, true
+			}
+		}
+	}
+	return "", false
+}
+
+// visitSpan returns the log messages for sp, and all of sp's children.
+func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
+	ownLogs := make([]traceLogData, 0, len(sp.Logs)+1)
+
+	conv := func(l opentracing.LogRecord, ref time.Time) traceLogData {
+		var timeSincePrev time.Duration
+		if ref != (time.Time{}) {
+			timeSincePrev = l.Timestamp.Sub(ref)
+		}
+		return traceLogData{
+			LogRecord:     l,
+			depth:         depth,
+			timeSincePrev: timeSincePrev,
+		}
+	}
+
+	// Add a log line representing the start of the span.
+	lr := opentracing.LogRecord{
+		Timestamp: sp.StartTime,
+		Fields:    []otlog.Field{otlog.String("=== operation", sp.Operation)},
+	}
+	if len(sp.Tags) > 0 {
+		tags := make([]string, 0, len(sp.Tags))
+		for k := range sp.Tags {
+			tags = append(tags, k)
+		}
+		sort.Strings(tags)
+		for _, k := range tags {
+			lr.Fields = append(lr.Fields, otlog.String(k, sp.Tags[k]))
+		}
+	}
+	ownLogs = append(ownLogs, conv(
+		lr,
+		// ref - this entries timeSincePrev will be computed when we merge it into the parent
+		time.Time{}))
+
+	for _, l := range sp.Logs {
+		lr := opentracing.LogRecord{
+			Timestamp: l.Time,
+			Fields:    make([]otlog.Field, len(l.Fields)),
+		}
+		for i, f := range l.Fields {
+			lr.Fields[i] = otlog.String(f.Key, f.Value)
+		}
+		lastLog := ownLogs[len(ownLogs)-1]
+		ownLogs = append(ownLogs, conv(lr, lastLog.Timestamp))
+	}
+
+	childSpans := make([][]traceLogData, 0)
+	for _, osp := range r {
+		if osp.ParentSpanID != sp.SpanID {
+			continue
+		}
+		childSpans = append(childSpans, r.visitSpan(osp, depth+1))
+	}
+
+	// Merge ownLogs with childSpans.
+	mergedLogs := make([]traceLogData, 0, len(ownLogs))
+	timeMax := time.Date(2200, 0, 0, 0, 0, 0, 0, time.UTC)
+	i, j := 0, 0
+	var lastTimestamp time.Time
+	for i < len(ownLogs) || j < len(childSpans) {
+		if len(mergedLogs) > 0 {
+			lastTimestamp = mergedLogs[len(mergedLogs)-1].Timestamp
+		}
+		nextLog, nextChild := timeMax, timeMax
+		if i < len(ownLogs) {
+			nextLog = ownLogs[i].Timestamp
+		}
+		if j < len(childSpans) {
+			nextChild = childSpans[j][0].Timestamp
+		}
+		if nextLog.After(nextChild) {
+			// Fill in timeSincePrev for the first one of the child's entries.
+			if lastTimestamp != (time.Time{}) {
+				childSpans[j][0].timeSincePrev = childSpans[j][0].Timestamp.Sub(lastTimestamp)
+			}
+			mergedLogs = append(mergedLogs, childSpans[j]...)
+			lastTimestamp = childSpans[j][0].Timestamp
+			j++
+		} else {
+			mergedLogs = append(mergedLogs, ownLogs[i])
+			lastTimestamp = ownLogs[i].Timestamp
+			i++
+		}
+	}
+
+	return mergedLogs
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given span;


### PR DESCRIPTION
Backport 6/6 commits from #46596.

/cc @cockroachdb/release

---

The scenario that this patch addresses is the following (from #46431):
1. txn1 sends Put(a) + Put(b) + EndTxn
2. DistSender splits the Put(a) from the rest.
3. Put(a) succeeds, but the rest catches some retriable error.
4. TxnCoordSender gets the retriable error. The fact that a sub-batch
  succeeded is lost. We used to care about that fact, but we've
  successively gotten rid of that tracking across #35140 and #44661.
5. we refresh everything that came before this batch. The refresh
  succeeds.
6. we re-send the batch. It gets split again. The part with the EndTxn
  executes first. The transaction is now STAGING. More than that, the txn
  is in fact implicitly committed - the intent on a is already there since
  the previous attempt and, because it's at a lower timestamp than the txn
  record, it counts as golden for the purposes of verifying the implicit
  commit condition.
7. some other transaction wonders in, sees that txn1 is in its way, and
  transitions it to explicitly committed.
8. the Put(a) now tries to evaluate. It gets really confused. I guess
  that different things can happen; none of them good. One thing that I
  believe we've observed in #46299 is that, if there's another txn's
  intent there already, the Put will try to push it, enter the
  txnWaitQueue, eventually observe that its own txn is committed and
  return an error. The client thus gets an error (and a non-ambiguous one
  to boot) although the txn is committed. Even worse perhaps, I think it's
  possible for a request to return wrong results instead of an error.

This patch fixes it by inhibiting the parallel commit when the EndTxn
batch is retried. This way, there's never a STAGING record.

Release note (bug fix): A rare bug causing errors to be returned for
successfully committed transactions was fixed. The most common error
message was "TransactionStatusError: already committed".

Release justification: serious bug fix

Fixes #46341
