### PR TITLE
release-20.1: kvserver: disallow timestamp regression with locking scans

### DIFF
--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -97,7 +97,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 	}
 	m.Go(func(ctx context.Context) error {
 		t.Status("installing schema")
-		err = c.RunE(ctx, appNode, fmt.Sprintf("./%s --install_schema "+
+		err := c.RunE(ctx, appNode, fmt.Sprintf("./%s --install_schema "+
 			"--cockroach_ip_addresses_csv='%s' %s", app, addrStr, flags))
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -86,7 +86,7 @@ add-discovered r=<name> k=<key> txn=<name>
 ----
 <error string>
 
- Adds a discovered lock that is disovered by the named request.
+ Adds a discovered lock that is discovered by the named request.
 
 dequeue r=<name>
 ----

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -231,7 +231,7 @@ func tryBumpBatchTimestamp(
 		ts, ba.Txn.ReadTimestamp, ba.Txn.WriteTimestamp)
 	ba.Txn = ba.Txn.Clone()
 	ba.Txn.ReadTimestamp = ts
-	ba.Txn.WriteTimestamp = ba.Timestamp
+	ba.Txn.WriteTimestamp = ts
 	ba.Txn.WriteTooOld = false
 	return true
 }

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -24,10 +24,10 @@ import (
 // retries, it increments its epoch, invalidating all of its previous writes.
 type TxnEpoch int32
 
-// TxnSeq is a zero-indexed sequence number asssigned to a a request performed
-// by a transaction. Writes within a transaction have unique sequences and start
-// at sequence number 1. Reads within a transaction have non-unique sequences
-// and start at sequence number 0.
+// TxnSeq is a zero-indexed sequence number assigned to a request performed by a
+// transaction. Writes within a transaction have unique sequences and start at
+// sequence number 1. Reads within a transaction have non-unique sequences and
+// start at sequence number 0.
 //
 // Writes within a transaction logically take place in sequence number order.
 // Reads within a transaction observe only writes performed by the transaction


### PR DESCRIPTION
Backport 1/1 commits from #46750.

/cc @cockroachdb/release

---

After #46004, locking scans can now hit WriteTooOld errors if they
encounter values at timestamps higher than their read timestamps. The
`ActualTimestamp` recorded is the `encountered ts + 1`. When determining
what the new timestamp for the txn should be, previously we blindly used
the generated `encountered ts + 1`. This was buggy, and could lead to a
timestamp regression in the case where a txn with (read_ts, write_ts) =
(1, 4) finds a value with `ts = 2`. If we try to "bump" the txn to
`ts = 3`, we're regressing the write ts.

Now, when determining what the new timestamp should be, we ensure we use
`max(encountered ts + 1, txn's current write ts)`.

Fixes #43273.

Release note: None
