### PR TITLE
kvserver: mitigate unavailability due to backpressure when reducing range size

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -1,0 +1,180 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/jackc/pgx"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that mitigations to backpressure when reducing the range size works.
+func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rRand, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
+
+	const (
+		rowSize  = 32 << 10 // 32 KiB
+		dataSize = 32 << 20 // 32 MiB
+		numRows  = dataSize / rowSize
+	)
+
+	// setup will set up a testcluster with a table filled with data. All splits
+	// will be blocked until the returned closure is called.
+	setup := func(t *testing.T, numServers int) (
+		tc *testcluster.TestCluster, tdb *sqlutils.SQLRunner, tablePrefix roachpb.Key, unblockSplit func(),
+	) {
+		// Add a testing knob to block split transactions which we'll enable before
+		// we return from setup.
+		var allowSplits atomic.Value
+		allowSplits.Store(true)
+		unblockCh := make(chan struct{}, 1)
+		tc = testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+							if ba.Header.Txn != nil && ba.Header.Txn.Name == "split" && !allowSplits.Load().(bool) {
+								select {
+								case <-unblockCh:
+									return roachpb.NewError(errors.Errorf("splits disabled"))
+								case <-ctx.Done():
+									<-ctx.Done()
+								}
+
+							}
+							return nil
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, tc.WaitForFullReplication())
+
+		// Create the table, split it off, and load it up with data.
+		tdb = sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		tdb.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES NOT NULL)")
+
+		var tableID int
+		tdb.QueryRow(t, "SELECT table_id FROM crdb_internal.tables WHERE name = 'foo'").Scan(&tableID)
+		require.NotEqual(t, 0, tableID)
+		tablePrefix = keys.MakeTablePrefix(uint32(tableID))
+		tc.SplitRangeOrFatal(t, tablePrefix)
+		require.NoError(t, tc.WaitForSplitAndInitialization(tablePrefix))
+
+		for i := 0; i < dataSize/rowSize; i++ {
+			tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
+				rRand.Intn(numRows), randutil.RandBytes(rRand, rowSize))
+		}
+
+		// Block splits and return.
+		allowSplits.Store(false)
+		var closeOnce sync.Once
+		return tc, tdb, tablePrefix, func() {
+			closeOnce.Do(func() { close(unblockCh) })
+		}
+	}
+
+	waitForZoneConfig := func(t *testing.T, tc *testcluster.TestCluster, tablePrefix roachpb.Key, exp int64) {
+		testutils.SucceedsSoon(t, func() error {
+			for i := 0; i < tc.NumServers(); i++ {
+				s := tc.Server(i)
+				_, r := getFirstStoreReplica(t, s, tablePrefix)
+				_, zone := r.DescAndZone()
+				if *zone.RangeMaxBytes != exp {
+					return fmt.Errorf("expected %d, got %d", exp, *zone.RangeMaxBytes)
+				}
+			}
+			return nil
+		})
+	}
+
+	t.Run("no backpressure when much larger", func(t *testing.T) {
+		tc, tdb, tablePrefix, unblockSplits := setup(t, 1)
+		defer tc.Stopper().Stop(ctx)
+		defer unblockSplits()
+
+		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
+			"range_max_bytes = $1, range_min_bytes = $2", dataSize/5, dataSize/10)
+		waitForZoneConfig(t, tc, tablePrefix, dataSize/5)
+
+		// Don't observe backpressure.
+		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
+			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+	})
+
+	t.Run("backpressure when near limit", func(t *testing.T) {
+		tc, tdb, tablePrefix, unblockSplits := setup(t, 1)
+		defer tc.Stopper().Stop(ctx)
+		defer unblockSplits()
+		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
+			"range_max_bytes = $1, range_min_bytes = $2", dataSize/5, dataSize/10)
+		waitForZoneConfig(t, tc, tablePrefix, dataSize/5)
+
+		// Don't observe backpressure.
+		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
+			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+
+		// Now we'll change the range_max_bytes to be half the range size less a
+		// bit. This is the range where we expect to observe backpressure.
+		_, repl := getFirstStoreReplica(t, tc.Server(0), roachpb.Key(tablePrefix).Next())
+		newMax := repl.GetMVCCStats().Total()/2 - 32<<10
+		newMin := newMax / 4
+		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
+			"range_max_bytes = $1, range_min_bytes = $2", newMax, newMin)
+		waitForZoneConfig(t, tc, tablePrefix, newMax)
+
+		// Observe backpressure now that the range is just over the limit.
+		// Use pgx so that cancellation does something reasonable.
+		url, cleanup := sqlutils.PGUrl(t, tc.Server(0).ServingSQLAddr(), "", url.User("root"))
+		defer cleanup()
+		conf, err := pgx.ParseConnectionString(url.String())
+		require.NoError(t, err)
+		c, err := pgx.Connect(conf)
+		require.NoError(t, err)
+		ctxWithCancel, cancel := context.WithCancel(ctx)
+		defer cancel()
+		upsertErrCh := make(chan error)
+		go func() {
+			_, err := c.ExecEx(ctxWithCancel, "UPSERT INTO foo VALUES ($1, $2)",
+				nil /* options */, rRand.Intn(numRows), randutil.RandBytes(rRand, rowSize))
+			upsertErrCh <- err
+		}()
+
+		select {
+		case <-time.After(10 * time.Millisecond):
+			cancel()
+		case err := <-upsertErrCh:
+			t.Fatalf("expected no error because the request should hang, got %v", err)
+		}
+		require.Equal(t, context.Canceled, <-upsertErrCh)
+	})
+
+}

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -33,49 +33,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test that mitigations to backpressure when reducing the range size works.
+// Test that mitigations to backpressure when reducing the range size work.
 func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rRand, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 
+	// Some arbitrary data sizes we'll load into a table and then use to derive
+	// range size parameters. We want something not too tiny but also not too big
+	// that it takes a while to load.
 	const (
-		rowSize  = 32 << 10 // 32 KiB
-		dataSize = 32 << 20 // 32 MiB
+		rowSize  = 16 << 10  // 16 KiB
+		dataSize = 512 << 10 // 512 KiB
 		numRows  = dataSize / rowSize
 	)
 
 	// setup will set up a testcluster with a table filled with data. All splits
 	// will be blocked until the returned closure is called.
 	setup := func(t *testing.T, numServers int) (
-		tc *testcluster.TestCluster, tdb *sqlutils.SQLRunner, tablePrefix roachpb.Key, unblockSplit func(),
+		tc *testcluster.TestCluster,
+		args base.TestClusterArgs,
+		tdb *sqlutils.SQLRunner,
+		tablePrefix roachpb.Key,
+		unblockSplit func(),
+		waitForBlockedRange func(id roachpb.RangeID),
 	) {
 		// Add a testing knob to block split transactions which we'll enable before
 		// we return from setup.
 		var allowSplits atomic.Value
 		allowSplits.Store(true)
 		unblockCh := make(chan struct{}, 1)
-		tc = testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+		var rangesBlocked sync.Map
+		args = base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
 						TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
 							if ba.Header.Txn != nil && ba.Header.Txn.Name == "split" && !allowSplits.Load().(bool) {
+								rangesBlocked.Store(ba.Header.RangeID, true)
+								defer rangesBlocked.Delete(ba.Header.RangeID)
 								select {
 								case <-unblockCh:
 									return roachpb.NewError(errors.Errorf("splits disabled"))
 								case <-ctx.Done():
 									<-ctx.Done()
 								}
-
 							}
 							return nil
 						},
 					},
 				},
 			},
-		})
+		}
+		tc = testcluster.StartTestCluster(t, numServers, args)
 		require.NoError(t, tc.WaitForFullReplication())
 
 		// Create the table, split it off, and load it up with data.
@@ -97,9 +108,21 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		// Block splits and return.
 		allowSplits.Store(false)
 		var closeOnce sync.Once
-		return tc, tdb, tablePrefix, func() {
-			closeOnce.Do(func() { close(unblockCh) })
+		unblockSplit = func() {
+			closeOnce.Do(func() {
+				allowSplits.Store(true)
+				close(unblockCh)
+			})
 		}
+		waitForBlockedRange = func(id roachpb.RangeID) {
+			testutils.SucceedsSoon(t, func() error {
+				if _, ok := rangesBlocked.Load(id); !ok {
+					return errors.Errorf("waiting for %v to be blocked", id)
+				}
+				return nil
+			})
+		}
+		return tc, args, tdb, tablePrefix, unblockSplit, waitForBlockedRange
 	}
 
 	waitForZoneConfig := func(t *testing.T, tc *testcluster.TestCluster, tablePrefix roachpb.Key, exp int64) {
@@ -116,8 +139,31 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		})
 	}
 
-	t.Run("no backpressure when much larger", func(t *testing.T) {
-		tc, tdb, tablePrefix, unblockSplits := setup(t, 1)
+	moveTableToNewStore := func(t *testing.T, tc *testcluster.TestCluster, args base.TestClusterArgs, tablePrefix roachpb.Key) {
+		tc.AddServer(t, args.ServerArgs)
+		testutils.SucceedsSoon(t, func() error {
+			desc, err := tc.LookupRange(tablePrefix)
+			require.NoError(t, err)
+			voters := desc.Replicas().Voters()
+			if len(voters) == 1 && voters[0].NodeID == tc.Server(1).NodeID() {
+				return nil
+			}
+			if len(voters) == 1 {
+				desc, err = tc.AddReplicas(tablePrefix, tc.Target(1))
+				if err != nil {
+					return err
+				}
+			}
+			if err = tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
+				return err
+			}
+			_, err = tc.RemoveReplicas(tablePrefix, tc.Target(0))
+			return err
+		})
+	}
+
+	t.Run("no backpressure when much larger on existing node", func(t *testing.T) {
+		tc, _, tdb, tablePrefix, unblockSplits, _ := setup(t, 1)
 		defer tc.Stopper().Stop(ctx)
 		defer unblockSplits()
 
@@ -130,30 +176,101 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
 	})
 
-	t.Run("backpressure when near limit", func(t *testing.T) {
-		tc, tdb, tablePrefix, unblockSplits := setup(t, 1)
+	t.Run("no backpressure when much larger on new node", func(t *testing.T) {
+		tc, args, tdb, tablePrefix, unblockSplits, _ := setup(t, 1)
 		defer tc.Stopper().Stop(ctx)
 		defer unblockSplits()
+
+		// We didn't want to have to load too much data into these ranges because
+		// it makes the testing slower so let's lower the threshold at which we'll
+		// consider the range to be way over the backpressure limit from megabytes
+		// down to kilobytes.
+		tdb.Exec(t, "SET CLUSTER SETTING kv.range.backpressure_byte_tolerance = '1 KiB'")
+
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
 			"range_max_bytes = $1, range_min_bytes = $2", dataSize/5, dataSize/10)
 		waitForZoneConfig(t, tc, tablePrefix, dataSize/5)
 
+		// Then we'll add a new server and move the table there.
+		moveTableToNewStore(t, tc, args, tablePrefix)
+
 		// Don't observe backpressure.
 		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
 			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+	})
 
-		// Now we'll change the range_max_bytes to be half the range size less a
-		// bit. This is the range where we expect to observe backpressure.
-		_, repl := getFirstStoreReplica(t, tc.Server(0), roachpb.Key(tablePrefix).Next())
+	t.Run("no backpressure when near limit on existing node", func(t *testing.T) {
+		tc, _, tdb, tablePrefix, unblockSplits, _ := setup(t, 1)
+		defer tc.Stopper().Stop(ctx)
+		defer unblockSplits()
+
+		// We didn't want to have to load too much data into these ranges because
+		// it makes the testing slower so let's lower the threshold at which we'll
+		// consider the range to be way over the backpressure limit from megabytes
+		// down to kilobytes.
+		tdb.Exec(t, "SET CLUSTER SETTING kv.range.backpressure_byte_tolerance = '128 KiB'")
+
+		// Now we'll change the range_max_bytes to be half the range size less a bit
+		// so that the range size is above the backpressure threshold but within the
+		// backpressureByteTolerance. We won't see backpressure because the range
+		// will remember its previous zone config setting.
+		s, repl := getFirstStoreReplica(t, tc.Server(0), tablePrefix.Next())
 		newMax := repl.GetMVCCStats().Total()/2 - 32<<10
 		newMin := newMax / 4
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
 			"range_max_bytes = $1, range_min_bytes = $2", newMax, newMin)
 		waitForZoneConfig(t, tc, tablePrefix, newMax)
 
+		// Don't observe backpressure because we remember the previous max size on
+		// this node.
+		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
+			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+
+		// Allow one split to occur and make sure that the remembered value is
+		// cleared.
+		unblockSplits()
+
+		testutils.SucceedsSoon(t, func() error {
+			if size := repl.LargestPreviousMaxRangeSizeBytes(); size != 0 {
+				_ = s.ForceSplitScanAndProcess()
+				return errors.Errorf("expected LargestPreviousMaxRangeSizeBytes to be 0, got %d", size)
+			}
+			return nil
+		})
+	})
+	// This case is very similar to the above case but differs in that the range
+	// is moved to a new node after the range size is decreased. This new node
+	// never knew about the old, larger range size, and thus will backpressure
+	// writes. This is the one case that is not mitigated by either
+	// backpressureByteTolerance or largestPreviousMaxRangeSizeBytes.
+	t.Run("backpressure when near limit on new node", func(t *testing.T) {
+		tc, args, tdb, tablePrefix, unblockSplits, waitForBlocked := setup(t, 1)
+		defer tc.Stopper().Stop(ctx)
+		defer unblockSplits()
+
+		// Now we'll change the range_max_bytes to be half the range size less a
+		// bit. This is the range where we expect to observe backpressure.
+		_, repl := getFirstStoreReplica(t, tc.Server(0), tablePrefix.Next())
+		newMax := repl.GetMVCCStats().Total()/2 - 32<<10
+		newMin := newMax / 4
+		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
+			"range_max_bytes = $1, range_min_bytes = $2", newMax, newMin)
+		waitForZoneConfig(t, tc, tablePrefix, newMax)
+
+		// Then we'll add a new server and move the table there.
+		moveTableToNewStore(t, tc, args, tablePrefix)
+
+		s, repl := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
+		s.SetReplicateQueueActive(false)
+		require.Len(t, repl.Desc().Replicas().All(), 1)
+		// We really need to make sure that the split queue has hit this range,
+		// otherwise we'll fail to backpressure.
+		go func() { _ = s.ForceSplitScanAndProcess() }()
+		waitForBlocked(repl.RangeID)
+
 		// Observe backpressure now that the range is just over the limit.
 		// Use pgx so that cancellation does something reasonable.
-		url, cleanup := sqlutils.PGUrl(t, tc.Server(0).ServingSQLAddr(), "", url.User("root"))
+		url, cleanup := sqlutils.PGUrl(t, tc.Server(1).ServingSQLAddr(), "", url.User("root"))
 		defer cleanup()
 		conf, err := pgx.ParseConnectionString(url.String())
 		require.NoError(t, err)
@@ -176,5 +293,4 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		}
 		require.Equal(t, context.Canceled, <-upsertErrCh)
 	})
-
 }

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -380,6 +380,14 @@ func (r *Replica) SideloadedRaftMuLocked() SideloadStorage {
 	return r.raftMu.sideloaded
 }
 
+// LargestPreviousMaxRangeSizeBytes returns the in-memory value used to mitigate
+// backpressure when the zone.RangeMaxSize is decreased.
+func (r *Replica) LargestPreviousMaxRangeSizeBytes() int64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.largestPreviousMaxRangeSizeBytes
+}
+
 func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, storage.MVCCKeyValue) {
 	sstFile := &storage.MemFile{}
 	sst := storage.MakeIngestionSSTWriter(sstFile)

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -245,7 +245,9 @@ func (mq *mergeQueue) process(
 	// in a situation where we keep merging ranges that would be split soon after
 	// by a small increase in load.
 	conservativeLoadBasedSplitThreshold := 0.5 * lhsRepl.SplitByLoadQPSThreshold()
-	if ok, _ := shouldSplitRange(mergedDesc, mergedStats, lhsRepl.GetMaxBytes(), sysCfg); ok || mergedQPS >= conservativeLoadBasedSplitThreshold {
+	shouldSplit, _ := shouldSplitRange(mergedDesc, mergedStats,
+		lhsRepl.GetMaxBytes(), lhsRepl.shouldBackpressureWrites(), sysCfg)
+	if shouldSplit || mergedQPS >= conservativeLoadBasedSplitThreshold {
 		log.VEventf(ctx, 2,
 			"skipping merge to avoid thrashing: merged range %s may split "+
 				"(estimated size, estimated QPS: %d, %v)",

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -835,6 +835,12 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	prevStats := *r.mu.state.Stats
 	*r.mu.state.Stats = *b.state.Stats
 
+	// If the range is now less than its RangeMaxBytes, clear the history of its
+	// largest previous max bytes.
+	if r.mu.largestPreviousMaxRangeSizeBytes > 0 && b.state.Stats.Total() < *r.mu.zone.RangeMaxBytes {
+		r.mu.largestPreviousMaxRangeSizeBytes = 0
+	}
+
 	// Check the queuing conditions while holding the lock.
 	needsSplitBySize := r.needsSplitBySizeRLocked()
 	needsMergeBySize := r.needsMergeBySizeRLocked()

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -42,7 +42,7 @@ var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
 // backpressureByteTolerance exists to deal with the fact that lowering the
 // range size by anything larger than the backpressureRangeSizeMultiplier would
 // immediately mean that all ranges require backpressure. To mitigate this
-// unwanted backpressure we say that any range which is large than the
+// unwanted backpressure we say that any range which is larger than the
 // size where backpressure would kick in by more than this quantity will
 // immediately avoid backpressure. This approach is a bit risky because a
 // command larger than this value would effectively disable backpressure
@@ -50,13 +50,17 @@ var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
 // is reduced by roughly exactly the multiplier then we'd potentially have
 // lots of ranges in this state.
 //
-// TODO(ajwerner): We could mitigate this situation further in two ways:
+// We additionally mitigate this situation further by:
 //
 //  1) We store in-memory on each replica the largest zone configuration range
 //     size (largestPreviousMaxRangeBytes) we've seen and we do not backpressure
 //     if the current range size is less than that. That value is cleared when
 //     a range splits or runs GC such that the range size becomes smaller than
-//     the current max range size.
+//     the current max range size. This mitigation alone is insufficient because
+//     a node may restart before the splitting has concluded, leaving the
+//     cluster in a state of backpressure.
+//
+// TODO(ajwerner): We could mitigate this even further by:
 //
 //  2) We assign a higher priority in the snapshot queue to ranges which are
 //     currently backpressuring than ranges which are larger but are not

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -50,7 +50,7 @@ var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
 // is reduced by roughly exactly the multiplier then we'd potentially have
 // lots of ranges in this state.
 //
-// We additionally mitigate this situation further by:
+// We additionally mitigate this situation further by doing the following:
 //
 //  1) We store in-memory on each replica the largest zone configuration range
 //     size (largestPreviousMaxRangeBytes) we've seen and we do not backpressure
@@ -59,8 +59,6 @@ var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
 //     the current max range size. This mitigation alone is insufficient because
 //     a node may restart before the splitting has concluded, leaving the
 //     cluster in a state of backpressure.
-//
-// TODO(ajwerner): We could mitigate this even further by:
 //
 //  2) We assign a higher priority in the snapshot queue to ranges which are
 //     currently backpressuring than ranges which are larger but are not

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -39,6 +39,36 @@ var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
 	},
 )
 
+// backpressureByteTolerance exists to deal with the fact that lowering the
+// range size by anything larger than the backpressureRangeSizeMultiplier would
+// immediately mean that all ranges require backpressure. To mitigate this
+// unwanted backpressure we say that any range which is large than the
+// size where backpressure would kick in by more than this quantity will
+// immediately avoid backpressure. This approach is a bit risky because a
+// command larger than this value would effectively disable backpressure
+// altogether. Another downside of this approach is that if the range size
+// is reduced by roughly exactly the multiplier then we'd potentially have
+// lots of ranges in this state.
+//
+// TODO(ajwerner): We could mitigate this situation further in two ways:
+//
+//  1) We store in-memory on each replica the largest zone configuration range
+//     size (largestPreviousMaxRangeBytes) we've seen and we do not backpressure
+//     if the current range size is less than that. That value is cleared when
+//     a range splits or runs GC such that the range size becomes smaller than
+//     the current max range size.
+//
+//  2) We assign a higher priority in the snapshot queue to ranges which are
+//     currently backpressuring than ranges which are larger but are not
+//     applying backpressure.
+//
+var backpressureByteTolerance = settings.RegisterByteSizeSetting(
+	"kv.range.backpressure_byte_tolerance",
+	"defines the number of bytes above the product of "+
+		"backpressure_range_size_multiplier and the range_max_size at which "+
+		"backpressure will not apply",
+	2<<20 /* 2 MiB */)
+
 // backpressurableSpans contains spans of keys where write backpressuring
 // is permitted. Writes to any keys within these spans may cause a batch
 // to be backpressured.
@@ -77,7 +107,9 @@ func canBackpressureBatch(ba *roachpb.BatchRequest) bool {
 // shouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure. This is based on the size of the range in
 // relation to the split size. The method returns true if the range is more
-// than backpressureRangeSizeMultiplier times larger than the split size.
+// than backpressureRangeSizeMultiplier times larger than the split size but not
+// larger than that by more than backpressureByteTolerance (see that comment for
+// further explanation).
 func (r *Replica) shouldBackpressureWrites() bool {
 	mult := backpressureRangeSizeMultiplier.Get(&r.store.cfg.Settings.SV)
 	if mult == 0 {
@@ -87,7 +119,14 @@ func (r *Replica) shouldBackpressureWrites() bool {
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.exceedsMultipleOfSplitSizeRLocked(mult)
+	exceeded, bytesOver := r.exceedsMultipleOfSplitSizeRLocked(mult)
+	if !exceeded {
+		return false
+	}
+	if bytesOver > backpressureByteTolerance.Get(&r.store.cfg.Settings.SV) {
+		return false
+	}
+	return true
 }
 
 // maybeBackpressureBatch blocks to apply backpressure if the replica deems

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -57,8 +57,10 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64 << 20, 64 << 20, false, 0},
 		// No intersection, max bytes+1, no load.
 		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64<<20 + 1, 64 << 20, true, 1},
-		// No intersection, max bytes * 2, no load.
-		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64 << 21, 64 << 20, true, 2},
+		// No intersection, max bytes * 2 + 2, no load, should backpressure.
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64<<21 + 2, 64 << 20, true, 52},
+		// No intersection, max bytes * 4, no load, should not backpressure.
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64 << 22, 64 << 20, true, 4},
 		// Intersection, max bytes +1, no load.
 		{keys.MakeTablePrefix(2000), roachpb.RKeyMax, 32<<20 + 1, 32 << 20, true, 2},
 		// Split needed at table boundary, but no zone config, no load.
@@ -92,7 +94,8 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
-		shouldQ, priority := shouldSplitRange(repl.Desc(), repl.GetMVCCStats(), repl.GetMaxBytes(), cfg)
+		shouldQ, priority := shouldSplitRange(repl.Desc(), repl.GetMVCCStats(),
+			repl.GetMaxBytes(), repl.ShouldBackpressureWrites(), cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}


### PR DESCRIPTION
This PR comes in three commits which, taken together, should effectively mitigate the problems caused by reducing the range size.

1) Detect when a range is much larger than the maximum size allowed with the backpressure policy and assume that the range got that big because the maximum range size used to be larger. This "much larger" threshold is controlled by a private cluster setting and defaults to 2MB.

2) Remember, in-memory, previous large range sizes and use that previous range size to decide whether to backpressure.

3) Prioritize splitting ranges which are currently backpressuring writes. 

Fixes #46271

Release note (bug fix): When reducing the `range_max_size` zone configuration, queries will no experience longer experience backpressure based on the new, smaller value until the range size has first been reduced to below that value.