### PR TITLE
backupccl: prevent automatically narrowing full backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -453,6 +453,11 @@ func backupPlanHook(
 				}
 				prevBackups = append(prevBackups, m)
 
+				if m.DescriptorCoverage == tree.AllDescriptors &&
+					backupStmt.DescriptorCoverage != tree.AllDescriptors {
+					return errors.Errorf("cannot append a backup of specific tables or databases to a full-cluster backup")
+				}
+
 				for _, inc := range prev {
 					m, err := readBackupManifest(ctx, defaultStore, inc, encryption)
 					if err != nil {


### PR DESCRIPTION
The new backup UX that allows appending incrementals by re-specifying paths
makes it easy to accidentally 'narrow' a backup, by backing up a single table
or database to a location that contains a existing backup of a additional
tables, databases or a full-cluster. In such a case, it would then base that
original backup impossible to appended to covering its original scope, i.e.
to do an incremental full-cluster backup, since the single table/db incremental
layer would be the most recent layer from which new layers would be based, but
would not contain the rest of the cluster/dbs that were in the base.

Narrowing or backing up different things at different cadences to different
places falls under what we are considering 'advanced' usage and can continue
using the existing syntax, as it is flexible enough to support such cases.
However 'basic' usage -- just backup my cluster somewhere -- with the new
syntax should reject narrowing as it is an easy way to mess up your backup
routine.

Fixes #46737.

Release note (enterprise change): the new appended incremental backup syntax does not allow converting a full cluster backup to a specific table or database backup.