### PR TITLE
geo: initial framework to parse WKT from GEOS

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -8,9 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package geo contains the base types for spatial data type operations.
 package geo
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	// Force these into vendor until they're used.
 	_ "github.com/golang/geo/s2"
 	_ "github.com/twpayne/go-geom"
@@ -22,3 +25,49 @@ import (
 	_ "github.com/twpayne/go-geom/encoding/wkbhex"
 	_ "github.com/twpayne/go-geom/encoding/wkt"
 )
+
+// spatialObjectBase is the base for spatial objects.
+type spatialObjectBase struct {
+	ewkb geopb.EWKB
+	// TODO: denormalize SRID from EWKB.
+}
+
+// Geometry is planar spatial object.
+type Geometry struct {
+	spatialObjectBase
+}
+
+// NewGeometry returns a new Geometry.
+func NewGeometry(ewkb geopb.EWKB) *Geometry {
+	return &Geometry{spatialObjectBase{ewkb: ewkb}}
+}
+
+// ParseGeometry parses a Geometry from a given text.
+func ParseGeometry(str geopb.WKT) (*Geometry, error) {
+	wkb, err := geos.WKTToWKB(str)
+	if err != nil {
+		return nil, err
+	}
+	return NewGeometry(geopb.EWKB(wkb)), nil
+}
+
+// Geography is a spherical spatial object.
+type Geography struct {
+	spatialObjectBase
+}
+
+// NewGeography returns a new Geography.
+func NewGeography(ewkb geopb.EWKB) *Geography {
+	return &Geography{spatialObjectBase{ewkb: ewkb}}
+}
+
+// ParseGeography parses a Geography from a given text.
+// TODO(otan): when we have our own WKT parser, move this to geo.
+func ParseGeography(str geopb.WKT) (*Geography, error) {
+	// TODO(otan): set SRID of EWKB to 4326.
+	wkb, err := geos.WKTToWKB(str)
+	if err != nil {
+		return nil, err
+	}
+	return NewGeography(geopb.EWKB(wkb)), nil
+}

--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGeometry(t *testing.T) {
+	testCases := []struct {
+		wkt         geopb.WKT
+		expected    *Geometry
+		expectedErr bool
+	}{
+		{
+			"POINT(1.0 1.0)",
+			NewGeometry(geopb.EWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
+			false,
+		},
+		{
+			"invalid",
+			nil,
+			true,
+		},
+		{
+			"",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.wkt), func(t *testing.T) {
+			g, err := ParseGeometry(tc.wkt)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, g)
+			}
+		})
+	}
+}
+
+func TestParseGeography(t *testing.T) {
+	testCases := []struct {
+		wkt         geopb.WKT
+		expected    *Geography
+		expectedErr bool
+	}{
+		{
+			"POINT(1.0 1.0)",
+			NewGeography(geopb.EWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
+			false,
+		},
+		{
+			"invalid",
+			nil,
+			true,
+		},
+		{
+			"",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.wkt), func(t *testing.T) {
+			g, err := ParseGeography(tc.wkt)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, g)
+			}
+		})
+	}
+}

--- a/pkg/geo/geopb/types.go
+++ b/pkg/geo/geopb/types.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geopb
+
+// WKT is the Well Known Text form of a spatial object.
+type WKT string
+
+// WKB is the Well Known Bytes form of a spatial object.
+type WKB []byte
+
+// EWKB is the Extended Well Known Bytes form of a spatial object.
+type EWKB []byte

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package geos is a wrapper around the spatial data types between the geo
+// package and the GEOS C library. The GEOS library is dynamically loaded
+// at init time.
+// Operations will error if the GEOS library was not found.
+package geos

--- a/pkg/geo/geos/geos_unix.cc
+++ b/pkg/geo/geos/geos_unix.cc
@@ -1,0 +1,164 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <dlfcn.h>
+#include <memory>
+#include <stdlib.h>
+#include <string>
+
+#include "geos_unix.h"
+
+// Data Types adapted from `capi/geos_c.h.in` in GEOS.
+typedef void *CR_GEOS_Handle;
+typedef void *CR_GEOS_WKTReader;
+typedef void *CR_GEOS_WKBWriter;
+
+// Function declarations from `capi/geos_c.h.in` in GEOS.
+typedef CR_GEOS_Handle (*CR_GEOS_init_r)();
+typedef void (*CR_GEOS_finish_r)(CR_GEOS_Handle);
+
+typedef void (*CR_GEOS_Geom_destroy_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
+
+typedef CR_GEOS_WKTReader (*CR_GEOS_WKTReader_create_r)(CR_GEOS_Handle);
+typedef CR_GEOS_Geometry (*CR_GEOS_WKTReader_read_r)(CR_GEOS_Handle,
+                                                     CR_GEOS_WKTReader,
+                                                     const char *);
+typedef void (*CR_GEOS_WKTReader_destroy_r)(CR_GEOS_Handle, CR_GEOS_WKTReader);
+
+typedef CR_GEOS_WKBWriter (*CR_GEOS_WKBWriter_create_r)(CR_GEOS_Handle);
+typedef char *(*CR_GEOS_WKBWriter_write_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter,
+                                           CR_GEOS_Geometry, size_t *);
+typedef void (*CR_GEOS_WKBWriter_setByteOrder_r)(CR_GEOS_Handle,
+                                                 CR_GEOS_WKBWriter, int);
+typedef void (*CR_GEOS_WKBWriter_destroy_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter);
+
+struct CR_GEOS {
+  void *dlHandle;
+
+  CR_GEOS_init_r CR_GEOS_init_r;
+  CR_GEOS_finish_r CR_GEOS_finish_r;
+
+  CR_GEOS_Geom_destroy_r CR_GEOS_Geom_destroy_r;
+
+  CR_GEOS_WKTReader_create_r CR_GEOS_WKTReader_create_r;
+  CR_GEOS_WKTReader_destroy_r CR_GEOS_WKTReader_destroy_r;
+  CR_GEOS_WKTReader_read_r CR_GEOS_WKTReader_read_r;
+
+  CR_GEOS_WKBWriter_create_r CR_GEOS_WKBWriter_create_r;
+  CR_GEOS_WKBWriter_destroy_r CR_GEOS_WKBWriter_destroy_r;
+  CR_GEOS_WKBWriter_setByteOrder_r CR_GEOS_WKBWriter_setByteOrder_r;
+  CR_GEOS_WKBWriter_write_r CR_GEOS_WKBWriter_write_r;
+
+  ~CR_GEOS() {
+    if (dlHandle != NULL) {
+      dlclose(dlHandle);
+    }
+  };
+};
+
+inline std::string CR_GEOS_StringToString(CR_GEOS_String goStr) {
+  return std::string(goStr.data, goStr.len);
+}
+
+const char *dlopenFailError = "failed to execute dlopen";
+
+char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib) {
+  char *error;
+
+  auto locStr = CR_GEOS_StringToString(loc);
+  void *dlHandle = dlopen(locStr.c_str(), RTLD_LAZY);
+  if (!dlHandle) {
+    return (char *)dlopenFailError;
+  }
+
+  std::unique_ptr<CR_GEOS> ret(new CR_GEOS());
+  ret->dlHandle = dlHandle;
+
+  // TODO(otan): autogenerate all of this.
+  ret->CR_GEOS_init_r = (CR_GEOS_init_r)dlsym(dlHandle, "GEOS_init_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_finish_r = (CR_GEOS_finish_r)dlsym(dlHandle, "GEOS_finish_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+
+  ret->CR_GEOS_Geom_destroy_r =
+      (CR_GEOS_Geom_destroy_r)dlsym(dlHandle, "GEOSGeom_destroy_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+
+  ret->CR_GEOS_WKTReader_create_r =
+      (CR_GEOS_WKTReader_create_r)dlsym(dlHandle, "GEOSWKTReader_create_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_WKTReader_destroy_r =
+      (CR_GEOS_WKTReader_destroy_r)dlsym(dlHandle, "GEOSWKTReader_destroy_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_WKTReader_read_r =
+      (CR_GEOS_WKTReader_read_r)dlsym(dlHandle, "GEOSWKTReader_read_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+
+  ret->CR_GEOS_WKBWriter_create_r =
+      (CR_GEOS_WKBWriter_create_r)dlsym(dlHandle, "GEOSWKBWriter_create_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_WKBWriter_destroy_r =
+      (CR_GEOS_WKBWriter_destroy_r)dlsym(dlHandle, "GEOSWKBWriter_destroy_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_WKBWriter_setByteOrder_r =
+      (CR_GEOS_WKBWriter_setByteOrder_r)dlsym(dlHandle,
+                                              "GEOSWKBWriter_setByteOrder_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+  ret->CR_GEOS_WKBWriter_write_r =
+      (CR_GEOS_WKBWriter_write_r)dlsym(dlHandle, "GEOSWKBWriter_write_r");
+  if ((error = dlerror()) != NULL) {
+    return error;
+  }
+
+  *lib = ret.release();
+
+  return NULL;
+}
+
+CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wktString) {
+  CR_GEOS_String result = {.data = NULL, .len = 0};
+
+  CR_GEOS_Handle handle = lib->CR_GEOS_init_r();
+  CR_GEOS_WKTReader wktReader = lib->CR_GEOS_WKTReader_create_r(handle);
+  auto wktStr = CR_GEOS_StringToString(wktString);
+  CR_GEOS_Geometry geom =
+      lib->CR_GEOS_WKTReader_read_r(handle, wktReader, wktStr.c_str());
+  lib->CR_GEOS_WKTReader_destroy_r(handle, wktReader);
+
+  if (geom != NULL) {
+    CR_GEOS_WKBWriter wkbWriter = lib->CR_GEOS_WKBWriter_create_r(handle);
+    lib->CR_GEOS_WKBWriter_setByteOrder_r(handle, wkbWriter, 1);
+    result.data =
+        lib->CR_GEOS_WKBWriter_write_r(handle, wkbWriter, geom, &result.len);
+    lib->CR_GEOS_WKBWriter_destroy_r(handle, wkbWriter);
+    lib->CR_GEOS_Geom_destroy_r(handle, geom);
+  }
+
+  lib->CR_GEOS_finish_r(handle);
+  return result;
+}

--- a/pkg/geo/geos/geos_unix.go
+++ b/pkg/geo/geos/geos_unix.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !windows
+
+package geos
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/errors"
+)
+
+// #cgo CXXFLAGS: -std=c++14
+// #cgo LDFLAGS: -ldl
+//
+// #include "geos_unix.h"
+import "C"
+
+// maxArrayLen is the maximum safe length for this architecture.
+const maxArrayLen = 1<<31 - 1
+
+// validOrError returns an error if the CR_GEOS  is not valid.
+func validOrError(c *C.CR_GEOS) error {
+	if c == nil {
+		// TODO(otan): be more helpful in this error message.
+		return errors.Newf("could not load GEOS library")
+	}
+	return nil
+}
+
+// defaultGEOSLocations contains a list of locations where GEOS is expected to exist.
+// TODO(otan): make this configurable by flags.
+// TODO(otan): put mac / linux locations
+var defaultGEOSLocations []string
+
+// crGEOS contains the global instance of CR_GEOS, to be initialized
+// during init time.
+var crGEOS *C.CR_GEOS
+
+func init() {
+	// Add the CI path by trying to find all parenting paths and appending
+	// `lib/lib_geos.<ext>`.
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		var nextPath string
+		if runtime.GOOS == "darwin" {
+			nextPath = filepath.Join(cwd, "lib", "libgeos_c.dylib")
+		} else {
+			nextPath = filepath.Join(cwd, "lib", "libgeos_c.so")
+		}
+		if _, err := os.Stat(nextPath); err == nil {
+			defaultGEOSLocations = append(defaultGEOSLocations, nextPath)
+		}
+		nextCWD := filepath.Dir(cwd)
+		if nextCWD == cwd {
+			break
+		}
+		cwd = nextCWD
+	}
+	crGEOS = initCRGEOS(defaultGEOSLocations)
+}
+
+// initCRGEOS initializes the CR_GEOS by attempting to dlopen all
+// the paths as parsed in by locs.
+func initCRGEOS(locs []string) *C.CR_GEOS {
+	for _, loc := range locs {
+		var ret *C.CR_GEOS
+		errStr := C.CR_GEOS_Init(goToCString(loc), &ret)
+		if errStr == nil {
+			return ret
+		}
+		// TODO(otan): thread the error message somewhere.
+	}
+	return nil
+}
+
+// goToCString returns a CR_GEOS_Slice from a given Go string.
+func goToCString(str string) C.CR_GEOS_String {
+	if len(str) == 0 {
+		return C.CR_GEOS_Slice{data: nil, len: 0}
+	}
+	b := []byte(str)
+	return C.CR_GEOS_Slice{
+		data: (*C.char)(unsafe.Pointer(&b[0])),
+		len:  C.size_t(len(b)),
+	}
+}
+
+// cSliceToGo converts a CR_GEOS_Slice to go bytes.
+func cSliceToUnsafeGoBytes(s C.CR_GEOS_Slice) []byte {
+	if s.data == nil {
+		return nil
+	}
+	// Interpret the C pointer as a pointer to a Go array, then slice.
+	return (*[maxArrayLen]byte)(unsafe.Pointer(s.data))[:s.len:s.len]
+}
+
+// WKTToWKB parses a WKT into WKB using the GEOS library.
+func WKTToWKB(wkt geopb.WKT) (geopb.WKB, error) {
+	if err := validOrError(crGEOS); err != nil {
+		return nil, err
+	}
+	cWKB := C.CR_GEOS_WKTToWKB(
+		crGEOS,
+		goToCString(string(wkt)),
+	)
+	if cWKB.data == nil {
+		return nil, errors.Newf("error decoding WKT: %s", wkt)
+	}
+	unsafeWKB := cSliceToUnsafeGoBytes(cWKB)
+	wkb := make([]byte, len(unsafeWKB))
+	copy(wkb, unsafeWKB)
+	defer C.free(unsafe.Pointer(cWKB.data))
+	return wkb, nil
+}

--- a/pkg/geo/geos/geos_unix.h
+++ b/pkg/geo/geos/geos_unix.h
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Data Types adapted from `capi/geos_c.h.in` in GEOS.
+typedef void *CR_GEOS_Geometry;
+
+// CR_GEOS_Slice is a wrapper around a Go slice.
+typedef struct {
+  char *data;
+  size_t len;
+} CR_GEOS_Slice;
+
+// CR_GEOS_String is a wrapper around a Go string.
+typedef struct {
+  char *data;
+  size_t len;
+} CR_GEOS_String;
+
+// CR_GEOS contains all the functions loaded by GEOS.
+typedef struct CR_GEOS CR_GEOS;
+
+// CR_GEOS_Init initializes the provided GEOSLib with GEOS using dlopen/dlsym.
+// Returns a string containing an error if an error was found.
+// The CR_GEOS object will be stored in lib.
+// The error returned does not need to be freed.
+char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib);
+
+// CR_GEOS_WKTToWKB converts a given WKT into it's WKB form.
+CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wkt);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/pkg/geo/geos/geos_unix_test.go
+++ b/pkg/geo/geos/geos_unix_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package geos is a wrapper around the spatial data types in the geo package
+// and the GEOS C library. The GEOS library is dynamically loaded at init time.
+// Operations will error if the GEOS library was not found.
+package geos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCockroachGEOSLib(t *testing.T) {
+	t.Run("test invalid initCRGEOS paths", func(t *testing.T) {
+		ret := initCRGEOS([]string{"/invalid/path"})
+		assert.Error(t, validOrError(ret))
+	})
+
+	t.Run("test valid initCRGEOS paths", func(t *testing.T) {
+		ret := initCRGEOS(defaultGEOSLocations)
+		assert.NoError(t, validOrError(ret))
+	})
+}

--- a/pkg/geo/geos/geos_windows.go
+++ b/pkg/geo/geos/geos_windows.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build windows
+
+package geos
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+func WKTToWKB(wkt geopb.WKT) (geopb.WKB, error) {
+	return nil, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}


### PR DESCRIPTION
This PR introduces the ability to parse WKT using the GEOS library. It
is the only library I can tell that can decode WKT, so everything will
have to go through that (for now). We're planning to store everything in
EWKB, and everything can be parsed off WKB which is why I've made
that the base type for now.

In future, the geos package will take in WKBs in a new package `geomfn`,
and transform into GEOSGeometry for operations without ever returning
*GEOSGeometry back to the user. This is necessary as we have no control
on the lifetime of a Geometry object.

Release note: None