### PR TITLE
release-20.1: sql: deal with retriable errors when using a new txn

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -652,6 +652,10 @@ type ExecutorTestingKnobs struct {
 	// statement has been executed.
 	StatementFilter StatementFilter
 
+	// BeforePrepare can be used to trap execution of SQL statement preparation.
+	// If a nil error is returned, planning continues as usual.
+	BeforePrepare func(ctx context.Context, stmt string, txn *kv.Txn) error
+
 	// BeforeExecute is called by the Executor before plan execution. It is useful
 	// for synchronizing statement execution.
 	BeforeExecute func(ctx context.Context, stmt string)


### PR DESCRIPTION
Backport 1/1 commits from #46829.

Fixes #46827

/cc @cockroachdb/release

---

In #46588 a bug was introduced when a retriable error was encountered while
using a new transaction for preparing. Prior to that commit, all error were
treated as not retriable. This was sort of a bummer. Retriable errors can
occur due to read within uncertainty. Before this PR, those retriable errors
would make their way to the client. Now we'll handle those retry errors
internally underneath `connExecutor.prepare`

Fixes #43251

Release note: None
