### PR TITLE
[20.1 backport] vendor: Bump pebble to e00e62806858f52998d9fb373bdfbb52b4443beb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8582389220996045b3c5e31835635ab607214cbcc075eb3200194bdc699678ef"
+  digest = "1:72cd3a6421449aeb9b90ac2d284695178adb9372f89f82b088dca4c7b9602c31"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "a06c162aa79d8acdafff5609a1c30328457dae04"
+  revision = "e00e62806858f52998d9fb373bdfbb52b4443beb"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Changes pulled in:
 - internal/lint: prohibit usage of "errors" and fmt.Errorf
 - *: remove remaining uses of errors.New and fmt.Errorf
 - *: use errors.Errorf in replace of fmt.Errorf
 - *: use github.com/cockroachdb/errors
 - vendor: add cockroachdb/errors and its dependencies
 - *: add FileNum type
 - db: delete orphaned temporary files in Open
 - version_set: Handle case where RocksDB doesn't bump minUnflushedLogNum
 - db: modify Options.DebugCheck to be a function
 - internal/manifest: Relax SeqNum overlap invariant in L0
 - internal/metamorphic: fix ingest_using_apply implementation
 - *: use Go 1.13 error wrapping
 - internal/metamorphic: randomize MaxConcurrentCompactions
 - internal/metamorphic: enable run comparison by default
 - internal/metamorphic: temporarily disable ingest_using_apply
 - db: document that Close may not be called twice
 - db: use require.* functions for test checks
 - *: use require.NoError everywhere
 - internal/errorfs: move to new package

Release note: None