### PR TITLE
sql/stmtdiagnostics: include a more readable trace in the bundle

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -228,10 +228,10 @@ func (ex *connExecutor) execStmtInOpenState(
 			trace := tracing.GetRecording(sp)
 			ie := p.extendedEvalCtx.InternalExecutor.(*InternalExecutor)
 			if finishCollectionDiagnostics != nil {
-				traceJSON, bundle, collectionErr := getTraceAndBundle(
-					origCtx, ex.server.cfg.DB, ie, trace, &p.curPlan,
+				bundle, collectionErr := buildStatementBundle(
+					origCtx, ex.server.cfg.DB, ie, &p.curPlan, trace,
 				)
-				finishCollectionDiagnostics(origCtx, traceJSON, bundle, collectionErr)
+				finishCollectionDiagnostics(origCtx, bundle.trace, bundle.zip, collectionErr)
 			} else {
 				// Handle EXPLAIN ANALYZE (DEBUG).
 				// If there was a communication error, no point in setting any results.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -624,14 +624,14 @@ type StmtDiagnosticsRecorder interface {
 		stmtFingerprint string,
 		stmt string,
 		traceJSON tree.Datum,
-		bundle *bytes.Buffer,
+		bundleZip []byte,
 	) (id int64, err error)
 }
 
 // StmtDiagnosticsTraceFinishFunc is the type of function returned from
 // ShouldCollectDiagnostics to report the outcome of a trace.
 type StmtDiagnosticsTraceFinishFunc = func(
-	ctx context.Context, traceJSON tree.Datum, bundle *bytes.Buffer, collectionErr error,
+	ctx context.Context, traceJSON tree.Datum, bundle []byte, collectionErr error,
 )
 
 var _ base.ModuleTestingKnobs = &ExecutorTestingKnobs{}

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -39,7 +39,7 @@ func TestExplainAnalyzeDebug(t *testing.T) {
 	r := sqlutils.MakeSQLRunner(godb)
 	r.Exec(t, "CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT UNIQUE)")
 
-	base := "statement.txt trace.json env.sql"
+	base := "statement.txt trace.json trace.txt env.sql"
 	plans := "schema.sql opt.txt opt-v.txt opt-vv.txt plan.txt"
 
 	t.Run("basic", func(t *testing.T) {


### PR DESCRIPTION
Before this patch, the bundle had the trace as a JSON file. That file is
not very human-readable because the fields are not order as you'd want,
the logs are not compacted properly, etc.
This patch adds another file to the bundle, besides the JSON, which is
the recording.String() representation.

Release note: None
Release justification: usability improvement; low risk

A simple trace looks like this:

```
     0.000ms      0.000ms    operation:traced statement client:127.0.0.1:60233 hostssl: node:1 sb:1 user:root
     0.038ms      0.038ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] added table 'movr.public.t' to table collection
     1.511ms      1.473ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] found table in table collection for table 'movr.public.t'
     1.549ms      0.038ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] query cache hit but needed update
     1.561ms      0.012ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] planning ends
     1.566ms      0.005ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] checking distributability
     1.573ms      0.006ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] will distribute plan: true
     1.575ms      0.002ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] execution starts: distributed engine
     1.582ms      0.007ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] creating DistSQL plan with isLocal=false
     1.602ms      0.020ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] querying next range at /Table/59/1
     1.629ms      0.026ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] creating plan diagram
     1.664ms      0.036ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] running DistSQL plan
     1.666ms      0.002ms        operation:flow client:127.0.0.1:60233 hostssl: n:1 user:root
     1.682ms      0.015ms        event:[n1,client=127.0.0.1:60233,hostssl,user=root] starting (0 processors, 0 startables)
     1.683ms      0.001ms            operation:table reader client:127.0.0.1:60233 cockroach.flowid:7fb1c168-156b-444b-be54-ca2ca233170e cockroach.processorid:0 cockroach.stat.tablereader.bytes.read:0 B cockroach.stat.tablereader.input.rows:0 cockroach.stat.tablereader.stalltime:144µs hostssl: n:1 user:root
     1.687ms      0.004ms            event:[n1,client=127.0.0.1:60233,hostssl,user=root] starting scan with limitBatches true
     1.695ms      0.009ms            event:[n1,client=127.0.0.1:60233,hostssl,user=root] Scan /Table/59/{1-2}
     1.698ms      0.002ms                operation:txn coordinator send client:127.0.0.1:60233 hostssl: n:1 txnID:d418b6f6-5b58-4717-b888-e57d84a26228 user:root
     1.705ms      0.007ms                    operation:dist sender send client:127.0.0.1:60233 hostssl: n:1 txn:d418b6f6 user:root
     1.716ms      0.012ms                    event:[n1,client=127.0.0.1:60233,hostssl,user=root,txn=d418b6f6] querying next range at /Table/59/1
     1.732ms      0.016ms                    event:[n1,client=127.0.0.1:60233,hostssl,user=root,txn=d418b6f6] r63: sending batch 1 Scan to (n1,s1):1
     1.735ms      0.003ms                    event:[n1,client=127.0.0.1:60233,hostssl,user=root,txn=d418b6f6] sending request to local client
     1.737ms      0.002ms                        operation:/cockroach.roachpb.Internal/Batch n:1
     1.739ms      0.002ms                        event:[n1] 1 Scan
     1.744ms      0.005ms                        event:[n1,s1] executing 1 requests
     1.751ms      0.007ms                        event:[n1,s1,r63/1:/{Table/59-Max}] read-only path
     1.761ms      0.010ms                        event:[n1,s1,r63/1:/{Table/59-Max}] read has no clock uncertainty
     1.763ms      0.002ms                        event:[n1,s1,r63/1:/{Table/59-Max}] sequencing request
     1.767ms      0.004ms                        event:[n1,s1,r63/1:/{Table/59-Max}] acquiring latches
     1.772ms      0.005ms                        event:[n1,s1,r63/1:/{Table/59-Max}] scanning lock table for conflicting locks
     1.776ms      0.004ms                        event:[n1,s1,r63/1:/{Table/59-Max}] waiting for read lock
     1.805ms      0.029ms                        event:[n1,s1,r63/1:/{Table/59-Max}] read completed
     1.829ms      0.024ms                event:[n1,client=127.0.0.1:60233,hostssl,user=root,txn=d418b6f6] recording span to refresh: /Table/59/{1-2}
     1.925ms      0.095ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] execution ends
     1.926ms      0.002ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] rows affected: 0
     1.950ms      0.023ms    event:[n1,client=127.0.0.1:60233,hostssl,user=root] AutoCommit. err: <nil>
```