### PR TITLE
backupccl: handle storage that does not support listing incremental layers

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -443,7 +443,7 @@ func backupPlanHook(
 
 				prev, err := findPriorBackups(ctx, defaultStore)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "determining base for incremental backup")
 				}
 				prevBackups = make([]BackupManifest, 0, len(prev)+1)
 

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -85,6 +85,9 @@ var redactedQueryParams = map[string]struct{}{
 	CredentialsParam:     {},
 }
 
+// ErrListingUnsupported is a marker for indicating listing is unsupported.
+var ErrListingUnsupported = errors.New("listing is not supported")
+
 // ExternalStorageFactory describes a factory function for ExternalStorage.
 type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStorage) (ExternalStorage, error)
 

--- a/pkg/storage/cloud/http_storage.go
+++ b/pkg/storage/cloud/http_storage.go
@@ -266,7 +266,7 @@ func (h *httpStorage) WriteFile(ctx context.Context, basename string, content io
 }
 
 func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
-	return nil, errors.New(`http storage does not support listing files`)
+	return nil, errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
 }
 
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {


### PR DESCRIPTION
The new automatic incremental backup append/discovery UX depends on being able
to list the existing layers of incremental backup that may already be in the
specified storage location.

However HTTP storage -- unlike s3, local files, etc -- does not have a common
and well-defined way of listing files within some path. When backing up to or
restoring from HTTP storage, we can only support explicitly specifying the
locations of each incremental layer.

This changes RESTORE and SHOW BACKUP to ignore listing unsupported errors from
HTTP storage, effectively meaning they will not attempt to find prior backup layers.
BACKUP to a location that already contains a backup via HTTP will fail when it
attempts to find prior incremental layers. SHOW BACKUP will show what RESTORE can
restore, i.e. just the base backup.

Fixes #46878.

Release note (enterprise change): BACKUP and RESTORE to HTTP storage locations requires explicitly specifying incremental storage locations (i.e. cannot use the new automatically appended incremental syntax).