### PR TITLE
release-20.1: ui: vertical scroll bug, default stmt sort, tooltip size

### DIFF
--- a/pkg/ui/src/components/tooltip/tooltip.styl
+++ b/pkg/ui/src/components/tooltip/tooltip.styl
@@ -11,7 +11,9 @@
 @require '~src/components/core/index.styl'
 
 .tooltip-overlay
+  max-width max-content
   .ant-tooltip-content
+    width 500px
     .ant-tooltip-inner
       @extend $text--body
       line-height $line-height--small

--- a/pkg/ui/src/components/tooltip/tooltip.tsx
+++ b/pkg/ui/src/components/tooltip/tooltip.tsx
@@ -16,21 +16,18 @@ import "antd/es/tooltip/style/css";
 import "./tooltip.styl";
 
 export interface TooltipProps {
-  title: React.ReactNode;
-  placement?: "top" | "bottom";
   children: React.ReactNode;
   theme?: "default" | "blue";
 }
 
 export function Tooltip(props: TooltipProps & AntTooltipProps) {
-  const { title, children, theme, placement } = props;
+  const { children, theme } = props;
   const classes = cn("tooltip-overlay", `crl-tooltip--theme-${theme}`);
   return (
     <AntTooltip
-      title={title}
       mouseEnterDelay={0.5}
       overlayClassName={classes}
-      placement={placement}
+      {...props}
     >
       {children}
     </AntTooltip>

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -28,7 +28,7 @@
   height 100%
   display flex
   flex-direction column
-  overflow hidden
+  overflow auto
 
 .cluster-overview
   .cluster-summary
@@ -257,4 +257,3 @@
   max-width $max-window-width
   position relative
   padding $spacing-smaller $spacing-medium
-  overflow hidden

--- a/pkg/ui/src/views/jobs/jobDescriptionCell.tsx
+++ b/pkg/ui/src/views/jobs/jobDescriptionCell.tsx
@@ -21,11 +21,12 @@ export class JobDescriptionCell extends React.PureComponent<{ job: Job }> {
     // statement.
     const job = this.props.job;
     const additionalStyle = (job.statement ? "" : " jobs-table__cell--sql");
+    const description = job.description && job.description.length > 425 ? `${job.description.slice(0, 425)}...` : job.description;
     return (
       <Link className={`${additionalStyle}`} to={`jobs/${String(job.id)}`}>
         <div className="cl-table-link__tooltip">
-          <Tooltip overlayClassName="preset-black" placement="bottom" title={
-            <pre style={{whiteSpace: "pre-wrap"}}>{job.description}</pre>
+          <Tooltip arrowPointAtCenter placement="bottom" title={
+            <pre style={{whiteSpace: "pre-wrap"}} className="cl-table-link__description">{description}</pre>
           }>
             <div className="jobs-table__cell--description">{job.statement || job.description}</div>
           </Tooltip>

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -102,3 +102,9 @@
     line-height 1.57
     letter-spacing 0.1px
     color $colors--primary-blue-3
+
+.cl-table-link__description
+  font-size $font-size--small
+  line-height 22px
+  color $colors--neutral-1
+  white-space pre-wrap

--- a/pkg/ui/src/views/statements/statementsPage.spec.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.spec.tsx
@@ -1,0 +1,34 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { assert } from "chai";
+import { ReactWrapper } from "enzyme";
+
+import { connectedMount } from "src/test-utils";
+import StatementsPageConnected, {
+  StatementsPage,
+  StatementsPageProps,
+  StatementsPageState,
+} from "src/views/statements/statementsPage";
+
+describe("StatementsPage", () => {
+  describe("Statements table", () => {
+    it("sorts data by Execution Count DESC as default option", () => {
+      const rootWrapper = connectedMount(() => <StatementsPageConnected />);
+
+      const statementsPageWrapper: ReactWrapper<StatementsPageProps, StatementsPageState> = rootWrapper.find(StatementsPage).first();
+      const statementsPageInstance = statementsPageWrapper.instance();
+
+      assert.equal(statementsPageInstance.state.sortSetting.sortKey, 3);
+      assert.equal(statementsPageInstance.state.sortSetting.ascending, false);
+    });
+  });
+});

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -47,7 +47,7 @@ import "./statements.styl";
 
 type ICollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
-interface StatementsPageProps {
+interface OwnProps {
   statements: AggregateStatistics[];
   statementsError: Error | null;
   apps: string[];
@@ -62,20 +62,22 @@ type PaginationSettings = {
   current: number;
 };
 
-interface StatementsPageState {
+export interface StatementsPageState {
   sortSetting: SortSetting;
   pagination: PaginationSettings;
   search?: string;
 }
 
-export class StatementsPage extends React.Component<StatementsPageProps & RouteComponentProps<any>, StatementsPageState> {
+export type StatementsPageProps = OwnProps & RouteComponentProps<any>;
+
+export class StatementsPage extends React.Component<StatementsPageProps, StatementsPageState> {
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
 
-  constructor(props: StatementsPageProps & RouteComponentProps<any>) {
+  constructor(props: StatementsPageProps) {
     super(props);
     const defaultState = {
       sortSetting: {
-        sortKey: 6, // Latency column is default for sorting
+        sortKey: 3, // Sort by Execution Count column as default option
         ascending: false,
       },
       pagination: {

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Tooltip } from "antd";
 import getHighlightedText from "oss/src/util/highlightedText";
 import React from "react";
 import { Link } from "react-router-dom";
@@ -18,7 +17,7 @@ import { FixLong } from "src/util/fixLong";
 import { StatementSummary, summarize } from "src/util/sql/summarize";
 import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
 import { countBarChart, latencyBarChart, retryBarChart, rowsBarChart } from "./barCharts";
-import { Anchor } from "src/components";
+import { Anchor, Tooltip } from "src/components";
 import "./statements.styl";
 import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { cockroach } from "src/js/protos";
@@ -45,8 +44,8 @@ function StatementLink(props: { statement: string, app: string, implicitTxn: boo
   return (
     <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
       <div className="cl-table-link__tooltip">
-        <Tooltip overlayClassName="preset-black" placement="bottom" title={
-          <pre style={{ whiteSpace: "pre-wrap" }}>{ getHighlightedText(props.statement, props.search) }</pre>
+        <Tooltip placement="bottom" title={
+          <pre className="cl-table-link__description">{ getHighlightedText(props.statement, props.search) }</pre>
         }>
           <div className="cl-table-link__tooltip-hover-area">
             { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: (fix) Enable vertical scrolling for Node map page" (#46741)
  * 1/1 commits from "ui: Default sort by Execution Count column for Statements" (#46780)
  * 1/1 commits from "ui: Jobs / Statements description tooltip" (#46557)

Please see individual PRs for details.

/cc @cockroachdb/release
