### PR TITLE
release-20.1: sql: fix execution of non-scalar count(*)

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -640,11 +640,7 @@ func NewColOperator(
 				result.ColumnTypes = make([]types.T, 0)
 				break
 			}
-			if len(aggSpec.GroupCols) == 0 &&
-				len(aggSpec.Aggregations) == 1 &&
-				aggSpec.Aggregations[0].FilterColIdx == nil &&
-				aggSpec.Aggregations[0].Func == execinfrapb.AggregatorSpec_COUNT_ROWS &&
-				!aggSpec.Aggregations[0].Distinct {
+			if aggSpec.IsRowCount() {
 				result.Op, result.IsStreaming, err = NewCountOp(NewAllocator(ctx, streamingMemAccount), inputs[0]), true, nil
 				result.ColumnTypes = []types.T{*types.Int}
 				break
@@ -713,7 +709,7 @@ func NewColOperator(
 			} else {
 				result.Op, err = NewOrderedAggregator(
 					NewAllocator(ctx, streamingMemAccount), inputs[0], typs, aggFns,
-					aggSpec.GroupCols, aggCols, execinfrapb.IsScalarAggregate(aggSpec),
+					aggSpec.GroupCols, aggCols, aggSpec.IsScalar(),
 				)
 				result.IsStreaming = true
 			}

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -102,9 +102,8 @@ func (a AggregatorSpec_Aggregation) Equals(b AggregatorSpec_Aggregation) bool {
 	return true
 }
 
-// IsScalarAggregate returns whether the aggregate function is in scalar
-// context.
-func IsScalarAggregate(spec *AggregatorSpec) bool {
+// IsScalar returns whether the aggregate function is in scalar context.
+func (spec *AggregatorSpec) IsScalar() bool {
 	switch spec.Type {
 	case AggregatorSpec_SCALAR:
 		return true
@@ -114,6 +113,16 @@ func IsScalarAggregate(spec *AggregatorSpec) bool {
 		// This case exists for backward compatibility.
 		return (len(spec.GroupCols) == 0)
 	}
+}
+
+// IsRowCount returns true if the aggregator spec is scalar and has a single
+// COUNT_ROWS aggregation with no FILTER or DISTINCT.
+func (spec *AggregatorSpec) IsRowCount() bool {
+	return len(spec.Aggregations) == 1 &&
+		spec.Aggregations[0].FilterColIdx == nil &&
+		spec.Aggregations[0].Func == AggregatorSpec_COUNT_ROWS &&
+		!spec.Aggregations[0].Distinct &&
+		spec.IsScalar()
 }
 
 // GetWindowFunctionInfo returns windowFunc constructor and the return type

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2232,3 +2232,12 @@ INSERT INTO t46423(c0) VALUES(0)
 query T
 SELECT c0 FROM t46423 GROUP BY c0 HAVING NOT (variance(0) IS NULL);
 ----
+
+# Regression test for #45453 - make sure that we don't incorrectly treat the
+# aggregation as scalar.
+statement ok
+CREATE TABLE t45453(c INT)
+
+query I
+SELECT count(*) FROM t45453 GROUP BY 0 + 0
+----

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -100,7 +100,7 @@ func (ag *aggregatorBase) init(
 		ag.FinishTrace = ag.outputStatsToTrace
 	}
 	ag.input = input
-	ag.isScalar = execinfrapb.IsScalarAggregate(spec)
+	ag.isScalar = spec.IsScalar()
 	ag.groupCols = spec.GroupCols
 	ag.orderedGroupCols = spec.OrderedGroupCols
 	ag.aggregations = spec.Aggregations
@@ -309,11 +309,7 @@ func newAggregator(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-	if len(spec.GroupCols) == 0 &&
-		len(spec.Aggregations) == 1 &&
-		spec.Aggregations[0].FilterColIdx == nil &&
-		spec.Aggregations[0].Func == execinfrapb.AggregatorSpec_COUNT_ROWS &&
-		!spec.Aggregations[0].Distinct {
+	if spec.IsRowCount() {
 		return newCountAggregator(flowCtx, processorID, input, post, output)
 	}
 	if len(spec.OrderedGroupCols) == len(spec.GroupCols) {


### PR DESCRIPTION
Backport 1/1 commits from #46879.

/cc @cockroachdb/release

---

It is possible to have non-scalar aggregations with no grouping columns - this
happens when the grouping columns are constant and reduced by the optimizer. In
this case, we must not produce a row if the input is empty. We plumbed a scalar
flag and type through execution, but there is a special fast path for `count(*)`
which still relies on just checking if there are no grouping columns.

This change fixes this issue and moves this logic into a helper so that the code
is not duplicated between the row and col exec.

Fixes #45453.

Release note (bug fix): fixed incorrect result with count(*) when grouping on
constant columns.
