### PR TITLE
release-19.1: sql: fix type checking code for aggregate functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -221,3 +221,10 @@ query I
 SELECT IF(true, NULL, 1) + IF(false, 1, NULL)
 ----
 NULL
+
+# Regression test for #46196.
+query error ambiguous call: max\(unknown\)
+SELECT MAX(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0)
+
+query error ambiguous call: max\(unknown\)
+SELECT MAX(NULL) FROM (VALUES (NULL), (NULL)) t0(c0)

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -223,8 +223,12 @@ SELECT IF(true, NULL, 1) + IF(false, 1, NULL)
 NULL
 
 # Regression test for #46196.
-query error ambiguous call: max\(unknown\)
-SELECT MAX(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0)
+query T
+SELECT max(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0)
+----
+NULL
 
-query error ambiguous call: max\(unknown\)
-SELECT MAX(NULL) FROM (VALUES (NULL), (NULL)) t0(c0)
+query T
+SELECT max(NULL) FROM (VALUES (NULL), (NULL)) t0(c0)
+----
+NULL

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3169,3 +3169,26 @@ group-by
            ├── fd: (1)-->(2,3)
            ├── prune: (1-3)
            └── interesting orderings: (+1,+2) (+3,+2,+1)
+
+# Regression test for #46196.
+build
+SELECT MAX(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0);
+----
+error (42725): ambiguous call: max(unknown), candidates are:
+max(int) -> int
+max(float) -> float
+max(decimal) -> decimal
+max(date) -> date
+max(timestamp) -> timestamp
+max(interval) -> interval
+max(string) -> string
+max(bytes) -> bytes
+max(timestamptz) -> timestamptz
+max(oid) -> oid
+max(uuid) -> uuid
+max(inet) -> inet
+max(time) -> time
+max(timetz) -> timetz
+max(jsonb) -> jsonb
+max(varbit) -> varbit
+max(bool) -> bool

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3170,25 +3170,24 @@ group-by
            ├── prune: (1-3)
            └── interesting orderings: (+1,+2) (+3,+2,+1)
 
-# Regression test for #46196.
+# Regression test for #46196. Don't eliminate the scalar group by, and
+# default to type string.
 build
-SELECT MAX(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0);
+SELECT max(t0.c0) FROM (VALUES (NULL), (NULL)) t0(c0);
 ----
-error (42725): ambiguous call: max(unknown), candidates are:
-max(int) -> int
-max(float) -> float
-max(decimal) -> decimal
-max(date) -> date
-max(timestamp) -> timestamp
-max(interval) -> interval
-max(string) -> string
-max(bytes) -> bytes
-max(timestamptz) -> timestamptz
-max(oid) -> oid
-max(uuid) -> uuid
-max(inet) -> inet
-max(time) -> time
-max(timetz) -> timetz
-max(jsonb) -> jsonb
-max(varbit) -> varbit
-max(bool) -> bool
+scalar-group-by
+ ├── columns: max:3(string)
+ ├── project
+ │    ├── columns: column2:2(string)
+ │    ├── values
+ │    │    ├── columns: column1:1(unknown)
+ │    │    ├── tuple [type=tuple{unknown}]
+ │    │    │    └── null [type=unknown]
+ │    │    └── tuple [type=tuple{unknown}]
+ │    │         └── null [type=unknown]
+ │    └── projections
+ │         └── cast: STRING [type=string]
+ │              └── variable: column1 [type=unknown]
+ └── aggregations
+      └── max [type=string]
+           └── variable: column2 [type=string]

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -803,9 +803,10 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 	}
 
 	// Return NULL if at least one overload is possible, no overload accepts
-	// NULL arguments, the function isn't a generator builtin, and NULL is given
-	// as an argument.
-	if !def.NullableArgs && def.FunctionProperties.Class != GeneratorClass {
+	// NULL arguments, the function isn't a generator or aggregate builtin, and
+	// NULL is given as an argument.
+	if !def.NullableArgs && def.FunctionProperties.Class != GeneratorClass &&
+		def.FunctionProperties.Class != AggregateClass {
 		for _, expr := range typedSubExprs {
 			if expr.ResolvedType() == types.Unknown {
 				return DNull, nil

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -802,6 +802,41 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 		return nil, errors.Wrapf(err, "%s()", def.Name)
 	}
 
+	// If the function is an aggregate that does not accept null arguments and we
+	// have arguments of unknown type, see if we can assign type string instead.
+	// TODO(rytaft): If there are no overloads with string inputs, Postgres
+	// chooses the overload with preferred type for the given category. For
+	// example, float8 is the preferred type for the numeric category in Postgres.
+	// To match Postgres' behavior, we should add that logic here too.
+	if !def.NullableArgs && def.FunctionProperties.Class == AggregateClass {
+		for i := range typedSubExprs {
+			if typedSubExprs[i].ResolvedType() == types.Unknown {
+				var filtered []overloadImpl
+				for j := range fns {
+					if fns[j].params().GetAt(i).Equivalent(types.String) {
+						if filtered == nil {
+							filtered = make([]overloadImpl, 0, len(fns)-j)
+						}
+						filtered = append(filtered, fns[j])
+					}
+				}
+
+				// Only use the filtered list if it's not empty.
+				if filtered != nil {
+					fns = filtered
+
+					// Cast the expression to a string so the execution engine will find
+					// the correct overload.
+					e, err := NewTypedCastExpr(typedSubExprs[i], coltypes.String)
+					if err != nil {
+						return nil, err
+					}
+					typedSubExprs[i] = e
+				}
+			}
+		}
+	}
+
 	// Return NULL if at least one overload is possible, no overload accepts
 	// NULL arguments, the function isn't a generator or aggregate builtin, and
 	// NULL is given as an argument.


### PR DESCRIPTION
Backport 2/2 commits from #46649.

/cc @cockroachdb/release

---

Prior to this commit, any aggregate function that had an argument with
unknown type was replaced with `NULL`. This is incorrect for scalar
aggregates when the input relation has multiple rows, because after
replacement, the query result has the same number of rows as the input
relation. It should instead be reduced to a single row.

This commit fixes the issue by avoiding replacing the aggregate with `NULL`.

Note that for many aggregates, this change results in an ambiguous function
error since the type checking code cannot choose which overload is correct
for the unknown type. This is different behavior than Postgres, which
defaults to type "text".

Fixes #46196

Release justification: this is a low risk, high benefit change to existing
functionality.
Release note (bug fix): fixed an incorrect query result that could occur
when a scalar aggregate was called with a null input.
