### PR TITLE
roachtest: subdue weekly/tpcc-max

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -285,14 +285,14 @@ func registerTPCC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       "weekly/tpcc-max",
+		Name:       "weekly/tpcc/headroom",
 		Owner:      OwnerKV,
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Tags:       []string{`weekly`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Timeout:    time.Duration(6*24)*time.Hour + time.Duration(10)*time.Minute,
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			warehouses := 1350
+			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				Duration:   6 * 24 * time.Hour,


### PR DESCRIPTION
The existing version of weekly/tpcc-max times-out as
the response times increase with the database growth.
This reduces the number of warehouses to 1000 to provide
headroom for the slowdown towards the end of the test and
renames the test to weekly/tpcc/headroom

Fixes #41163

Release note: None