### PR TITLE
sql: fix IS NULL on tuples

### DIFF
--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -132,6 +132,8 @@ var ComparisonOpReverseMap = map[Operator]tree.ComparisonOperator{
 	NotRegMatchOp:    tree.NotRegMatch,
 	RegIMatchOp:      tree.RegIMatch,
 	NotRegIMatchOp:   tree.NotRegIMatch,
+	IsNullOp:         tree.IsNull,
+	IsNotNullOp:      tree.IsNotNull,
 	IsOp:             tree.IsNotDistinctFrom,
 	IsNotOp:          tree.IsDistinctFrom,
 	ContainsOp:       tree.Contains,
@@ -237,6 +239,8 @@ var NegateOpMap = map[Operator]Operator{
 	NotRegMatchOp:  RegMatchOp,
 	RegIMatchOp:    NotRegIMatchOp,
 	NotRegIMatchOp: RegIMatchOp,
+	IsNullOp:       IsNotNullOp,
+	IsNotNullOp:    IsNullOp,
 	IsOp:           IsNotOp,
 	IsNotOp:        IsOp,
 }

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -411,6 +411,18 @@ define NotRegIMatch {
 }
 
 [Scalar, Bool, Comparison]
+define IsNull {
+   Left  ScalarExpr
+   Right ScalarExpr
+}
+
+[Scalar, Bool, Comparison]
+define IsNotNull {
+   Left  ScalarExpr
+   Right ScalarExpr
+}
+
+[Scalar, Bool, Comparison]
 define Is {
    Left  ScalarExpr
    Right ScalarExpr

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8079,19 +8079,19 @@ a_expr:
   }
 | a_expr IS NULL %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.IsNotDistinctFrom, Left: $1.expr(), Right: tree.DNull}
+    $$.val = &tree.ComparisonExpr{Operator: tree.IsNull, Left: $1.expr(), Right: tree.DNull}
   }
 | a_expr ISNULL %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.IsNotDistinctFrom, Left: $1.expr(), Right: tree.DNull}
+    $$.val = &tree.ComparisonExpr{Operator: tree.IsNull, Left: $1.expr(), Right: tree.DNull}
   }
 | a_expr IS NOT NULL %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.IsDistinctFrom, Left: $1.expr(), Right: tree.DNull}
+    $$.val = &tree.ComparisonExpr{Operator: tree.IsNotNull, Left: $1.expr(), Right: tree.DNull}
   }
 | a_expr NOTNULL %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.IsDistinctFrom, Left: $1.expr(), Right: tree.DNull}
+    $$.val = &tree.ComparisonExpr{Operator: tree.IsNotNull, Left: $1.expr(), Right: tree.DNull}
   }
 | row OVERLAPS row { return unimplemented(sqllex, "overlaps") }
 | a_expr IS TRUE %prec IS

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -317,6 +317,8 @@ const (
 	NotRegMatch
 	RegIMatch
 	NotRegIMatch
+	IsNull
+	IsNotNull
 	IsDistinctFrom
 	IsNotDistinctFrom
 	Contains
@@ -367,6 +369,8 @@ var comparisonOpName = [...]string{
 	NotRegMatch:       "!~",
 	RegIMatch:         "~*",
 	NotRegIMatch:      "!~*",
+	IsNull:            "IS NULL",
+	IsNotNull:         "IS NOT NULL",
 	IsDistinctFrom:    "IS DISTINCT FROM",
 	IsNotDistinctFrom: "IS NOT DISTINCT FROM",
 	Contains:          "@>",

--- a/pkg/sql/sem/tree/testdata/eval/is
+++ b/pkg/sql/sem/tree/testdata/eval/is
@@ -276,3 +276,123 @@ eval
 1 IS NOT OF (BOOL, INT)
 ----
 false
+
+eval
+(1, 1) IS NOT DISTINCT FROM NULL
+----
+false
+
+eval
+(1, 1) IS DISTINCT FROM NULL
+----
+true
+
+eval
+NOT ((1, 1) IS NOT DISTINCT FROM NULL)
+----
+true
+
+eval
+NOT ((1, 1) IS DISTINCT FROM NULL)
+----
+false
+
+eval
+(1, NULL) IS NOT DISTINCT FROM NULL
+----
+false
+
+eval
+(1, NULL) IS DISTINCT FROM NULL
+----
+true
+
+eval
+NOT ((1, NULL) IS NOT DISTINCT FROM NULL)
+----
+true
+
+eval
+NOT ((1, NULL) IS DISTINCT FROM NULL)
+----
+false
+
+eval
+(NULL, NULL) IS NOT DISTINCT FROM NULL
+----
+false
+
+eval
+(NULL, NULL) IS DISTINCT FROM NULL
+----
+true
+
+eval
+NOT ((NULL, NULL) IS NOT DISTINCT FROM NULL)
+----
+true
+
+eval
+NOT ((NULL, NULL) IS DISTINCT FROM NULL)
+----
+false
+
+eval
+(1, 1) IS NULL
+----
+false
+
+eval
+(1, 1) IS NOT NULL
+----
+true
+
+eval
+NOT ((1, 1) IS NULL)
+----
+true
+
+eval
+NOT ((1, 1) IS NOT NULL)
+----
+false
+
+eval
+(1, NULL) IS NULL
+----
+false
+
+eval
+(1, NULL) IS NOT NULL
+----
+false
+
+eval
+NOT ((1, NULL) IS NULL)
+----
+true
+
+eval
+NOT ((1, NULL) IS NOT NULL)
+----
+true
+
+eval
+(NULL, NULL) IS NULL
+----
+true
+
+eval
+(NULL, NULL) IS NOT NULL
+----
+false
+
+eval
+NOT ((NULL, NULL) IS NULL)
+----
+false
+
+eval
+NOT ((NULL, NULL) IS NOT NULL)
+----
+true


### PR DESCRIPTION
As it turns out, `IS NULL` behaves differently from
`IS NOT DISTINCT FROM
NULL` when the argument is a tuple
(https://www.postgresql.org/docs/8.3/functions-comparison.html):
```
Note: If the expression is row-valued, then IS NULL is true when the row
expression itself is null or when all the row's fields are null, while IS
NOT NULL is true when the row expression itself is non-null and all the
row's fields are non-null.
```
However, in our comparison resolution we transform `IS` into `IS NOT 
DISTINCT FROM`
and `IS NOT` into `IS DISTINCT FROM` which is incorrect
for tuples. This is now fixed by introducing separate `IsNullOp` which
reuses all overloads from `IsNotDistinctFromOp` while introducing its
own overload implementation only for tuples.

Here are the distinctions (note that `IS DISTINCT FROM` always
equals `!(IS NOT DISTINCT FROM)`, however, `IS NOT NULL` is not
always the same as `!(IS NULL)`):

| Tuple  | IS NOT DISTINCT FROM | IS NULL  | IS DISTINCT FROM | IS NOT NULL |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| (1, 1)  | false  | false  | true  | true  |
| (1, NULL)  | false  | **false**  | true | **false**  |
| (NULL, NULL)  | false  | true | true | false  |

Fixes: #46675.

Release note (bug fix): CockroachDB previously was incorrectly
evaluating `IS NULL` and `IS NOT NULL` on tuples which has been fixed.