### PR TITLE
jobs: fix order of `error.Is` arguments

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -868,7 +868,7 @@ func (r *Registry) stepThroughStateMachine(
 			// If the job has failed with any error different than canceled we
 			// mark it as Failed.
 			nextStatus := StatusFailed
-			if errors.Is(errJobCanceled, jobErr) {
+			if errors.Is(jobErr, errJobCanceled) {
 				nextStatus = StatusCanceled
 			}
 			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, nextStatus, jobErr)


### PR DESCRIPTION
The order of the `error.Is` arguments has been reversed.
Fortunately this has not caused a bug yet since the
errors compared are actually identical but may cause error
in the future.

Release justification: no-op change that prevents future bugs from
occurring.

Release note (bug fix): this is actually just a potential and this
change prevents it from becoming a bug if the error is extended in
the future.