### PR TITLE
ui: Statement diagnostics history - empty state

### DIFF
--- a/pkg/ui/src/components/empty/empty.tsx
+++ b/pkg/ui/src/components/empty/empty.tsx
@@ -16,50 +16,53 @@ import styles from "./empty.module.styl";
 
 const cx = classnames.bind(styles);
 
-export interface IEmptyProps {
+interface IMainEmptyProps {
   title?: string;
   description?: string;
   label?: React.ReactNode;
   link?: string;
   anchor?: string;
   backgroundImage?: string;
-  onClick?: () => void;
-  btnType?: "button" | "anchor";
 }
+
+type OnClickXORHref =
+  | {
+      onClick?: () => void;
+      buttonHref?: never;
+    }
+  | {
+      onClick?: never;
+      buttonHref?: string;
+    };
+
+export type EmptyProps = OnClickXORHref & IMainEmptyProps;
 
 export const Empty = ({
   title,
   description,
   anchor,
   label,
-  onClick,
   link,
   backgroundImage,
-}: IEmptyProps) => (
+  onClick,
+  buttonHref,
+}: EmptyProps) => (
   <div
     className={cx("cl-empty-view")}
     style={{ backgroundImage: `url(${backgroundImage})` }}
   >
-    <Text
-      className={cx("cl-empty-view__title")}
-      textType={TextTypes.Heading3}
-    >
+    <Text className={cx("cl-empty-view__title")} textType={TextTypes.Heading3}>
       {title}
     </Text>
-    <div
-      className={cx("cl-empty-view__content")}
-    >
+    <div className={cx("cl-empty-view__content")}>
       <main className={cx("cl-empty-view__main")}>
         <Text
-          className={cx("cl-empty-view__main--text")}
           textType={TextTypes.Body}
+          className={cx("cl-empty-view__main--text")}
         >
           {description}
           {link && (
-            <Anchor
-              href={link}
-              className={cx("cl-empty-view__main--anchor")}
-            >
+            <Anchor href={link} className={cx("cl-empty-view__main--anchor")}>
               {anchor}
             </Anchor>
           )}
@@ -68,7 +71,9 @@ export const Empty = ({
       <footer className={cx("cl-empty-view__footer")}>
         <Button
           type="primary"
-          onClick={onClick}
+          onClick={() =>
+            buttonHref ? window.open(buttonHref) : onClick && onClick()
+          }
         >
           {label}
         </Button>
@@ -78,7 +83,6 @@ export const Empty = ({
 );
 
 Empty.defaultProps = {
-  onClick: () => {},
   backgroundImage: heroBannerLp,
   anchor: "Learn more",
   label: "Learn more",

--- a/pkg/ui/src/redux/statements/statementsSelectors.ts
+++ b/pkg/ui/src/redux/statements/statementsSelectors.ts
@@ -38,6 +38,11 @@ export const selectStatementDiagnosticsReports = createSelector(
   diagnosticsReports => diagnosticsReports,
 );
 
+export const statementDiagnosticsReportsInFlight = createSelector(
+  (state: AdminUIState) => state.cachedData.statementDiagnosticsReports.inFlight,
+  inFlight => inFlight,
+);
+
 type StatementDiagnosticsDictionary = {
   [statementFingerprint: string]: IStatementDiagnosticsReport;
 };

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -159,7 +159,7 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
             title: "There are no jobs to display.",
             description: "The jobs page provides details about backup/restore jobs, schema changes, user-created table statistics, automatic table statistics jobs and changefeeds.",
             label: "Learn more",
-            onClick: () => window.open(jobTable),
+            buttonHref: jobTable,
           }}
           pagination={pagination}
         />

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -21,7 +21,7 @@ import { trackTableSort } from "src/util/analytics";
 import styles from "./sortabletable.module.styl";
 import { Spin, Icon } from "antd";
 import SpinIcon from "src/components/icon/spin";
-import { Empty, IEmptyProps } from "src/components/empty";
+import { Empty, EmptyProps } from "src/components/empty";
 
 const cx = classNames.bind(styles);
 /**
@@ -84,7 +84,7 @@ interface TableProps {
   loadingLabel?: string;
   // empty state for table
   empty?: boolean;
-  emptyProps?: IEmptyProps;
+  emptyProps?: EmptyProps;
 }
 
 export interface ExpandableConfig {

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.stories.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.stories.tsx
@@ -8,17 +8,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require '~src/components/core/index.styl'
+import React from "react";
+import { storiesOf } from "@storybook/react";
 
-.diagnostics-history-view
-  &__table-container
-    background $colors--white
-    padding $spacing-medium-small
+import { SortableTable } from "./";
 
-  & .crl-table-wrapper .sort-table__row:hover .nodes-table__link
-    color $colors--primary-blue-3
-    text-decoration underline
-
-  &__table-header
-    margin-top: $spacing-medium-small
-    margin-bottom $spacing-x-small
+storiesOf("Sortable table", module)
+  .add("Empty state", () => (
+    <SortableTable
+        empty
+    />
+  ));

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -67,6 +67,10 @@
   &__row
     border-top 1px solid transparent
     border-bottom 1px solid $table-border 
+    .cell--show-on-hover
+      visibility hidden
+    &:hover .cell--show-on-hover
+      visibility visible  
     &.drawer-active
       background-color $background-color
       .cl-table-link__tooltip
@@ -117,7 +121,8 @@
   color $colors--neutral-1
   white-space pre-wrap
   margin-bottom 0
-  cursor pointer
+  line-height 22px
+  color $colors--neutral-6
   span
     margin-right 6px
   a
@@ -136,9 +141,3 @@
     line-height 22px
     letter-spacing $letter-spacing--compact
     color $colors--neutral-6
-
-.drawer__content
-  color #f6f6f6
-  font-family RobotoMono-Regular
-  font-size 12px
-  line-height 24px

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -14,7 +14,7 @@ import { Moment } from "moment";
 import React from "react";
 import { createSelector } from "reselect";
 import { ExpandableConfig, SortableColumn, SortableTable, SortSetting } from "src/views/shared/components/sortabletable";
-import { IEmptyProps } from "src/components/empty";
+import { EmptyProps } from "oss/src/components/empty";
 
 export interface ISortedTablePagination {
   current: number;
@@ -85,7 +85,7 @@ interface SortedTableProps<T> {
   loadingLabel?: string;
   // empty state for table
   empty?: boolean;
-  emptyProps?: IEmptyProps;
+  emptyProps?: EmptyProps;
 }
 
 interface SortedTableState {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -286,7 +286,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
               title: "There are no statements since this page was last cleared.",
               description: "Statements help you identify frequently executed or high latency SQL statements. Statements are cleared every hour by default, or according to your configuration.",
               label: "Learn more",
-              onClick: () => window.open(statementsTable),
+              buttonHref: statementsTable,
             }}
             sortSetting={this.state.sortSetting}
             onChangeSortSetting={this.changeSortSetting}


### PR DESCRIPTION
Use `SortableTable` component instead of antd table, this change gives us oportunity to reuse realisation of empty and loading states of table on Statement diagnostics history page.
Minor updates to <Empty/> component props api, to avoid duplicates of window.open calls
Added storybook for SortableTable empty state.

Resolves: #46576

Release note (ui): new design of empty state of Statement diagnostics history page

![Screenshot 2020-04-24 at 16 11 20](https://user-images.githubusercontent.com/12850886/80216182-57f92580-8646-11ea-832e-8584b3c6c69f.png)
