### PR TITLE
cli/demo: make the secure mode controllable via COCKROACH_INSECURE

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -77,6 +77,10 @@ func (u urlParser) Type() string {
 }
 
 func (u urlParser) Set(v string) error {
+	return u.setInternal(v, true /* warn */)
+}
+
+func (u urlParser) setInternal(v string, warn bool) error {
 	parsedURL, err := url.Parse(v)
 	if err != nil {
 		return err
@@ -110,9 +114,11 @@ func (u urlParser) Set(v string) error {
 			// information. We do not produce an error however, so that a
 			// user can readily copy-paste the URL produced by `cockroach
 			// start` even if the client command does not accept a username.
-			fmt.Fprintf(stderr,
-				"warning: --url specifies user/password, but command %q does not accept user/password details - details ignored\n",
-				u.cmd.Name())
+			if warn {
+				fmt.Fprintf(stderr,
+					"warning: --url specifies user/password, but command %q does not accept user/password details - details ignored\n",
+					u.cmd.Name())
+			}
 		} else {
 			if err := f.Value.Set(parsedURL.User.Username()); err != nil {
 				return errors.Wrapf(err, "extracting user")
@@ -149,9 +155,11 @@ func (u urlParser) Set(v string) error {
 			// not produce an error however, so that a user can readily
 			// copy-paste an URL they picked up from another tool (a GUI
 			// tool for example).
-			fmt.Fprintf(stderr,
-				"warning: --url specifies database %q, but command %q does not accept a database name - database name ignored\n",
-				dbPath, u.cmd.Name())
+			if warn {
+				fmt.Fprintf(stderr,
+					"warning: --url specifies database %q, but command %q does not accept a database name - database name ignored\n",
+					dbPath, u.cmd.Name())
+			}
 		} else {
 			if err := f.Value.Set(dbPath); err != nil {
 				return errors.Wrapf(err, "extracting database name")

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -583,6 +583,20 @@ func init() {
 		if cmd != demoCmd {
 			VarFlag(f, urlParser{cmd, &cliCtx, false /* strictSSL */}, cliflags.URL)
 			StringFlag(f, &cliCtx.sqlConnUser, cliflags.User, cliCtx.sqlConnUser)
+
+			// Even though SQL commands take their connection parameters via
+			// --url / --user (see above), the urlParser{} struct internally
+			// needs the ClientHost and ClientPort flags to be defined -
+			// even if they are invisible - due to the way initialization from
+			// env vars is implemented.
+			//
+			// TODO(knz): if/when env var option initialization is deferred
+			// to parse time, this can be removed.
+			VarFlag(f, addrSetter{&cliCtx.clientConnHost, &cliCtx.clientConnPort}, cliflags.ClientHost)
+			_ = f.MarkHidden(cliflags.ClientHost.Name)
+			StringFlag(f, &cliCtx.clientConnPort, cliflags.ClientPort, cliCtx.clientConnPort)
+			_ = f.MarkHidden(cliflags.ClientPort.Name)
+
 		}
 
 		if cmd == sqlShellCmd {
@@ -675,9 +689,27 @@ func init() {
 // actually parsed. For example, it will inject the value of
 // $COCKROACH_URL into the urlParser object linked to the --url flag.
 func processEnvVarDefaults() error {
-	for envVar, d := range envVarDefaults {
-		if err := d.flagSet.Set(d.flagName, d.envValue); err != nil {
-			return errors.Wrapf(err, "setting --%s from %s", d.flagName, envVar)
+	for _, d := range envVarDefaults {
+		f := d.flagSet.Lookup(d.flagName)
+		if f == nil {
+			panic(errors.AssertionFailedf("unknown flag: %s", d.flagName))
+		}
+		var err error
+		if url, ok := f.Value.(urlParser); ok {
+			// URLs are a special case: they can emit a warning if there's
+			// excess configuration for certain commands.
+			// Since the env-var initialization is ran for all commands
+			// all the time, regardless of which particular command is
+			// currently active, we want to silence this warning here.
+			//
+			// TODO(knz): rework this code to only pull env var values
+			// for the current command.
+			err = url.setInternal(d.envValue, false /* warn */)
+		} else {
+			err = d.flagSet.Set(d.flagName, d.envValue)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "setting --%s from %s", d.flagName, d.envVar)
 		}
 	}
 	return nil
@@ -687,6 +719,7 @@ func processEnvVarDefaults() error {
 // setting covered by a flag from the value of an environment
 // variable.
 type envVarDefault struct {
+	envVar   string
 	envValue string
 	flagName string
 	flagSet  *pflag.FlagSet
@@ -694,7 +727,7 @@ type envVarDefault struct {
 
 // envVarDefaults records the initializations from environment variables
 // for processing at the end of initialization, before flag parsing.
-var envVarDefaults = map[string]envVarDefault{}
+var envVarDefaults []envVarDefault
 
 // registerEnvVarDefault registers a deferred initialization of a flag
 // from an environment variable.
@@ -707,11 +740,12 @@ func registerEnvVarDefault(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
 		// Env var not set. Nothing to do.
 		return
 	}
-	envVarDefaults[flagInfo.EnvVar] = envVarDefault{
+	envVarDefaults = append(envVarDefaults, envVarDefault{
+		envVar:   flagInfo.EnvVar,
 		envValue: value,
 		flagName: flagInfo.Name,
 		flagSet:  f,
-	}
+	})
 }
 
 // extraServerFlagInit configures the server.Config based on the command-line flags.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -641,7 +641,7 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, demoCtx.geoPartitionedReplicas)
 	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
-	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, demoCtx.insecure)
+	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ClientInsecure, demoCtx.insecure)
 	BoolFlag(demoFlags, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense, demoCtx.disableLicenseAcquisition)
 	// Mark the --global flag as hidden until we investigate it more.
 	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, demoCtx.simulateLatency)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -621,20 +621,20 @@ func init() {
 	demoFlags := demoCmd.PersistentFlags()
 	// We add this command as a persistent flag so you can do stuff like
 	// ./cockroach demo movr --nodes=3.
-	IntFlag(demoFlags, &demoCtx.nodes, cliflags.DemoNodes, 1)
-	BoolFlag(demoFlags, &demoCtx.runWorkload, cliflags.RunDemoWorkload, false)
+	IntFlag(demoFlags, &demoCtx.nodes, cliflags.DemoNodes, demoCtx.nodes)
+	BoolFlag(demoFlags, &demoCtx.runWorkload, cliflags.RunDemoWorkload, demoCtx.runWorkload)
 	VarFlag(demoFlags, &demoCtx.localities, cliflags.DemoNodeLocality)
-	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
+	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, demoCtx.geoPartitionedReplicas)
 	VarFlag(demoFlags, demoNodeSQLMemSizeValue, cliflags.DemoNodeSQLMemSize)
 	VarFlag(demoFlags, demoNodeCacheSizeValue, cliflags.DemoNodeCacheSize)
-	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, false)
-	BoolFlag(demoFlags, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense, false)
+	BoolFlag(demoFlags, &demoCtx.insecure, cliflags.ServerInsecure, demoCtx.insecure)
+	BoolFlag(demoFlags, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense, demoCtx.disableLicenseAcquisition)
 	// Mark the --global flag as hidden until we investigate it more.
-	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
+	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, demoCtx.simulateLatency)
 	_ = demoFlags.MarkHidden(cliflags.Global.Name)
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
-	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
+	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, demoCtx.useEmptyDatabase)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -2,25 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-start_test "Check that demo insecure says hello properly"
-spawn $argv demo --insecure
-# Be polite.
-eexpect "Welcome"
-# Warn the user that they won't get persistence.
-eexpect "your changes to data stored in the demo session will not be saved!"
-# Inform the necessary URL.
-eexpect "Web UI: http:"
-# Ensure same messages as cockroach sql.
-eexpect "Server version"
-eexpect "Cluster ID"
-eexpect "brief introduction"
-# Ensure user is root.
-eexpect root@
-# Ensure db is movr.
-eexpect "movr>"
-end_test
-
-start_test "Check that demo secure says hello properly"
+start_test "Check that demo says hello properly"
 spawn $argv demo
 # Be polite.
 eexpect "Welcome"
@@ -28,8 +10,6 @@ eexpect "Welcome"
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
 eexpect "Web UI: http:"
-# Ensure that user login information is present.
-eexpect "The user \"root\" with password \"admin\" has been created."
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
 eexpect "Cluster ID"
@@ -38,4 +18,48 @@ eexpect "brief introduction"
 eexpect root@
 # Ensure db is movr.
 eexpect "movr>"
+interrupt
+eexpect eof
+end_test
+
+start_test "Check that demo insecure says hello properly"
+
+# With env var.
+set ::env(COCKROACH_INSECURE) "true"
+spawn $argv demo
+eexpect "Welcome"
+eexpect "movr>"
+interrupt
+eexpect eof
+
+# With command-line override.
+set ::env(COCKROACH_INSECURE) "false"
+spawn $argv demo --insecure=true
+eexpect "Welcome"
+eexpect "movr>"
+interrupt
+eexpect eof
+
+end_test
+
+start_test "Check that demo secure says hello properly"
+
+# With env var.
+set ::env(COCKROACH_INSECURE) "false"
+spawn $argv demo
+eexpect "Welcome"
+eexpect "The user \"root\" with password \"admin\" has been created."
+eexpect "movr>"
+interrupt
+eexpect eof
+
+# With command-line override.
+set ::env(COCKROACH_INSECURE) "true"
+spawn $argv demo --insecure=false
+eexpect "Welcome"
+eexpect "The user \"root\" with password \"admin\" has been created."
+eexpect "movr>"
+interrupt
+eexpect eof
+
 end_test


### PR DESCRIPTION
(Note that this is useful regardless of where we settle as to what the default should be.)

Release note (cli change): It is now possible to pre-configure
the secure mode of `cockroach demo` using the environment
variable `COCKROACH_INSECURE` like other client commands.
