### PR TITLE
ui: Link from statement diagnostics to details page

### DIFF
--- a/pkg/ui/src/components/table/table.styl
+++ b/pkg/ui/src/components/table/table.styl
@@ -11,6 +11,9 @@
 @require '~src/components/core/index.styl'
 
 .crl-table-wrapper
+  .ant-table
+    color $colors--primary-text
+
   // Table header
   .ant-table-thead
     background-color $colors--neutral-1

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -108,3 +108,4 @@
   line-height 22px
   color $colors--neutral-1
   white-space pre-wrap
+  margin-bottom 0

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
@@ -53,7 +53,7 @@
     margin-right $spacing-x-small
 
   &__statements-link
-    color $colors--title
+    color $colors--primary-text
     &:hover
       color $colors--link
 

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
@@ -52,6 +52,11 @@
     vertical-align -0.125em
     margin-right $spacing-x-small
 
+  &__statements-link
+    color $colors--title
+    &:hover
+      color $colors--link
+
 .summary--card__empty-sate
   background-color $colors--white
   background-image url("../../../../assets/statementsPage/emptyTracingBackground.svg")


### PR DESCRIPTION
Resolves: #46559

We have Statements diagnostics history page with list
of all requested diagnostics.
Before, statement fingerprint were represented as a
simple text and now it is a links to statement details
page.

One notion, that it is possible to have diagnostics for
statements which is already cleared. In this case
statement is displayed as a text instead of link.

Release note (admin ui change): Add links to statement
details from Statement Diagnostics history page.

Release justification: bug fixes and low-risk updates to new functionality

![out](https://user-images.githubusercontent.com/3106437/78255335-d824e300-74ff-11ea-9203-233ac8ba67fc.gif)
