### PR TITLE
sql: wait to start index GC job until schema changer is done

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -34,12 +34,8 @@ postgres
 system
 test
 
-# The "updating privileges" clause in the SELECT statement is for excluding jobs
-# run by an unrelated startup migration.
-# TODO (lucy): Update this if/when we decide to change how these jobs queued by
-# the startup migration are handled.
 query TT
-SELECT job_type, status FROM [SHOW JOBS] WHERE description != 'updating privileges'
+SELECT job_type, status FROM [SHOW JOBS]
 ----
 SCHEMA CHANGE       succeeded
 SCHEMA CHANGE GC    running
@@ -251,3 +247,15 @@ DROP DATABASE defaultdb; DROP DATABASE postgres
 
 statement ok
 CREATE DATABASE defaultdb; CREATE DATABASE postgres
+
+# Test that an empty database doesn't get a GC job.
+statement ok
+CREATE DATABASE empty
+
+statement ok
+DROP DATABASE empty
+
+query TT
+SELECT job_type, status FROM [SHOW JOBS] WHERE description LIKE '%empty%'
+----
+SCHEMA CHANGE       succeeded

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -373,22 +373,8 @@ func startGCJob(
 	details jobspb.SchemaChangeGCDetails,
 ) error {
 	var sj *jobs.StartableJob
-	descriptorIDs := make([]sqlbase.ID, 0)
-	if len(details.Indexes) > 0 {
-		if len(descriptorIDs) == 0 {
-			descriptorIDs = []sqlbase.ID{details.ParentID}
-		}
-	} else if len(details.Tables) > 0 {
-		for _, table := range details.Tables {
-			descriptorIDs = append(descriptorIDs, table.ID)
-		}
-	} else {
-		// Nothing to GC.
-		return nil
-	}
-
+	jobRecord := CreateGCJobRecord(schemaChangeDescription, username, details)
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		jobRecord := CreateGCJobRecord(schemaChangeDescription, username, descriptorIDs, details)
 		var err error
 		if sj, err = jobRegistry.CreateStartableJobWithTxn(ctx, jobRecord, txn, nil /* resultCh */); err != nil {
 			return err
@@ -401,16 +387,6 @@ func startGCJob(
 		return err
 	}
 	return nil
-}
-
-func (sc *SchemaChanger) startGCJob(
-	ctx context.Context, details jobspb.SchemaChangeGCDetails, isRollback bool,
-) error {
-	description := sc.job.Payload().Description
-	if isRollback {
-		description = "ROLLBACK of " + description
-	}
-	return startGCJob(ctx, sc.db, sc.jobRegistry, sc.job.Payload().Username, description, details)
 }
 
 // Execute the entire schema change in steps.
@@ -464,7 +440,9 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 				},
 			},
 		}
-		if err := sc.startGCJob(ctx, gcDetails, false /* isRollback */); err != nil {
+		if err := startGCJob(
+			ctx, sc.db, sc.jobRegistry, sc.job.Payload().Username, sc.job.Payload().Description, gcDetails,
+		); err != nil {
 			return err
 		}
 	}
@@ -799,9 +777,11 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 		}
 	}
 
+	var indexGCJobs []*jobs.StartableJob
 	update := func(txn *kv.Txn, descs map[sqlbase.ID]*sqlbase.MutableTableDescriptor) error {
 		// Reset vars here because update function can be called multiple times in a retry.
 		isRollback = false
+		indexGCJobs = nil
 
 		i := 0
 		scDesc, ok := descs[sc.tableID]
@@ -837,9 +817,18 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 						},
 						ParentID: sc.tableID,
 					}
-					if err := sc.startGCJob(ctx, indexGCDetails, isRollback); err != nil {
+
+					description := sc.job.Payload().Description
+					if isRollback {
+						description = "ROLLBACK of " + description
+					}
+					gcJobRecord := CreateGCJobRecord(description, sc.job.Payload().Username, indexGCDetails)
+					indexGCJob, err := sc.jobRegistry.CreateStartableJobWithTxn(ctx, gcJobRecord, txn, nil /* resultsCh */)
+					if err != nil {
 						return err
 					}
+					log.VEventf(ctx, 2, "created index GC job %d", *indexGCJob.ID())
+					indexGCJobs = append(indexGCJobs, indexGCJob)
 				}
 			}
 			if constraint := mutation.GetConstraint(); constraint != nil &&
@@ -921,10 +910,15 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 						Progress:      jobspb.SchemaChangeProgress{},
 						NonCancelable: true,
 					}
+					// TODO (lucy): We should be able to create a StartableJob and start
+					// it after calling PublishMultiple() to finalize the mutations,
+					// as with the indexGCJob. That will allow us to start the job
+					// immediately without having to wait for the registry to adopt it.
 					job, err := sc.jobRegistry.CreateJobWithTxn(ctx, jobRecord, txn)
 					if err != nil {
 						return err
 					}
+					log.VEventf(ctx, 2, "created job %d to drop previous indexes", *job.ID())
 					scDesc.MutationJobs = append(scDesc.MutationJobs, sqlbase.TableDescriptor_MutationJob{
 						MutationID: mutationID,
 						JobID:      *job.ID(),
@@ -973,7 +967,18 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 		)
 	})
 	if err != nil {
+		for _, job := range indexGCJobs {
+			if rollbackErr := job.CleanupOnRollback(ctx); rollbackErr != nil {
+				log.Warningf(ctx, "failed to cleanup job: %v", rollbackErr)
+			}
+		}
 		return nil, err
+	}
+	for _, job := range indexGCJobs {
+		if _, err := job.Start(ctx); err != nil {
+			log.Warningf(ctx, "starting GC job %d failed with error: %v", *job.ID(), err)
+		}
+		log.VEventf(ctx, 2, "started GC job %d", *job.ID())
 	}
 	return descs[sc.tableID], nil
 }
@@ -1373,14 +1378,21 @@ func (sc *SchemaChanger) reverseMutation(
 	return mutation, columns
 }
 
-// CreateGCJobRecord creates the job record for a GC job setting some properties
-// which are common for all GC job.
+// CreateGCJobRecord creates the job record for a GC job, setting some
+// properties which are common for all GC jobs.
 func CreateGCJobRecord(
-	originalDescription string,
-	username string,
-	descriptorIDs sqlbase.IDs,
-	details jobspb.SchemaChangeGCDetails,
+	originalDescription string, username string, details jobspb.SchemaChangeGCDetails,
 ) jobs.Record {
+	descriptorIDs := make([]sqlbase.ID, 0)
+	if len(details.Indexes) > 0 {
+		if len(descriptorIDs) == 0 {
+			descriptorIDs = []sqlbase.ID{details.ParentID}
+		}
+	} else {
+		for _, table := range details.Tables {
+			descriptorIDs = append(descriptorIDs, table.ID)
+		}
+	}
 	return jobs.Record{
 		Description:   fmt.Sprintf("GC for %s", originalDescription),
 		Username:      username,
@@ -1596,6 +1608,12 @@ func (r schemaChangeResumer) Resume(
 				return err
 			}
 		}
+		return nil
+	}
+
+	// For an empty database, the zone config for it was already GC'ed and there's
+	// nothing left to do.
+	if details.DroppedDatabaseID != sqlbase.InvalidID && len(details.DroppedTables) == 0 {
 		return nil
 	}
 

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -918,7 +918,6 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		record := sql.CreateGCJobRecord(
 			fmt.Sprintf("table %d", desc.ID),
 			security.NodeUser,
-			sqlbase.IDs{desc.ID},
 			jobspb.SchemaChangeGCDetails{
 				Tables: []jobspb.SchemaChangeGCDetails_DroppedID{{ID: desc.ID, DropTime: desc.DropTime}},
 			})
@@ -1079,7 +1078,6 @@ func migrateMutationJobForTable(
 		indexGCJobRecord := sql.CreateGCJobRecord(
 			job.Payload().Description,
 			job.Payload().Username,
-			sqlbase.IDs{tableDesc.ID},
 			jobspb.SchemaChangeGCDetails{
 				Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
 					{
@@ -1181,7 +1179,6 @@ func migrateDropTablesOrDatabaseJob(
 	gcJobRecord := sql.CreateGCJobRecord(
 		job.Payload().Description,
 		job.Payload().Username,
-		job.Payload().DescriptorIDs,
 		jobspb.SchemaChangeGCDetails{
 			Tables:   tablesToDrop,
 			ParentID: details.DroppedDatabaseID,


### PR DESCRIPTION
Previously, we were creating and starting the index GC job in a separate
transaction from the one used in `PublishMultiple()` in
`SchemaChanger.done()`, meaning that the index GC job could be run
before the original transaction to finalize all schema changes on the
table descriptor had been committed. This led to unpredictable behavior
while testing. It could also potentially cause multiple GC jobs to be
created if the `PublishMultiple()` closure were retried.

In this PR, the GC job is now created as a `StartableJob` that is
started only after the table descriptor in the finalized state has been
published.

Release justification: Bug fix for new feature.

Release note (bug fix): Fixed a bug introduced in beta.3 that could
cause multiple index GC jobs to be created for the same schema change in
rare cases.