### PR TITLE
rowflow: account for some memory in routerOutput

### DIFF
--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -108,6 +108,13 @@ type routerOutput struct {
 
 	// memoryMonitor and diskMonitor are mu.rowContainer's monitors.
 	memoryMonitor, diskMonitor *mon.BytesMonitor
+
+	rowAlloc         rowenc.EncDatumRowAlloc
+	rowBufToPushFrom [routerRowBufSize]rowenc.EncDatumRow
+	// rowBufToPushFromMon and rowBufToPushFromAcc are the memory accounting
+	// infrastructure of rowBufToPushFrom.
+	rowBufToPushFromMon *mon.BytesMonitor
+	rowBufToPushFromAcc *mon.BoundAccount
 }
 
 func (ro *routerOutput) addMetadataLocked(meta *execinfrapb.ProducerMetadata) {
@@ -138,16 +145,14 @@ func (ro *routerOutput) addRowLocked(ctx context.Context, row rowenc.EncDatumRow
 	return nil
 }
 
-func (ro *routerOutput) popRowsLocked(
-	ctx context.Context, rowBuf []rowenc.EncDatumRow,
-) ([]rowenc.EncDatumRow, error) {
+func (ro *routerOutput) popRowsLocked(ctx context.Context) ([]rowenc.EncDatumRow, error) {
 	n := 0
 	// First try to get rows from the row container.
 	if ro.mu.rowContainer.Len() > 0 {
 		if err := func() error {
 			i := ro.mu.rowContainer.NewFinalIterator(ctx)
 			defer i.Close()
-			for i.Rewind(); n < len(rowBuf); i.Next() {
+			for i.Rewind(); n < len(ro.rowBufToPushFrom); i.Next() {
 				if ok, err := i.Valid(); err != nil {
 					return err
 				} else if !ok {
@@ -157,9 +162,18 @@ func (ro *routerOutput) popRowsLocked(
 				if err != nil {
 					return err
 				}
-				// TODO(radu): use an EncDatumRowAlloc?
-				rowBuf[n] = make(rowenc.EncDatumRow, len(row))
-				copy(rowBuf[n], row)
+				// We're reusing the same rowBufToPushFrom slice, so we can
+				// only release the memory under the "old" row once we
+				// overwrite it in rowBufToPushFrom which we're about to do for
+				// rowBufToPushFrom[n].
+				prevSize := uintptr(0)
+				if ro.rowBufToPushFrom[n] != nil {
+					prevSize = ro.rowBufToPushFrom[n].Size()
+				}
+				if err := ro.rowBufToPushFromAcc.Grow(ctx, int64(row.Size()-prevSize)); err != nil {
+					return err
+				}
+				ro.rowBufToPushFrom[n] = ro.rowAlloc.CopyRow(row)
 				n++
 			}
 			return nil
@@ -169,12 +183,12 @@ func (ro *routerOutput) popRowsLocked(
 	}
 
 	// If the row container is empty, get more rows from the row buffer.
-	for ; n < len(rowBuf) && ro.mu.rowBufLen > 0; n++ {
-		rowBuf[n] = ro.mu.rowBuf[ro.mu.rowBufLeft]
+	for ; n < len(ro.rowBufToPushFrom) && ro.mu.rowBufLen > 0; n++ {
+		ro.rowBufToPushFrom[n] = ro.mu.rowBuf[ro.mu.rowBufLeft]
 		ro.mu.rowBufLeft = (ro.mu.rowBufLeft + 1) % routerRowBufSize
 		ro.mu.rowBufLen--
 	}
-	return rowBuf[:n], nil
+	return ro.rowBufToPushFrom[:n], nil
 }
 
 // See the comment for routerBase.semaphoreCount.
@@ -255,6 +269,14 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 			ctx, flowCtx.Cfg.DiskMonitor,
 			fmt.Sprintf("router-disk-%d", rb.outputs[i].streamID),
 		)
+		// Note that the monitor is an unlimited one since we don't know how
+		// to fallback to disk if a memory budget error is encountered when
+		// we're popping rows from the row container into the row buffer.
+		rb.outputs[i].rowBufToPushFromMon = execinfra.NewMonitor(
+			ctx, evalCtx.Mon, fmt.Sprintf("router-unlimited-%d", rb.outputs[i].streamID),
+		)
+		memAcc := rb.outputs[i].rowBufToPushFromMon.MakeBoundAccount()
+		rb.outputs[i].rowBufToPushFromAcc = &memAcc
 
 		rb.outputs[i].mu.rowContainer.Init(
 			nil, /* ordering */
@@ -284,7 +306,6 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 			}
 
 			drain := false
-			rowBuf := make([]rowenc.EncDatumRow, routerRowBufSize)
 			streamStatus := execinfra.NeedMoreRows
 			ro.mu.Lock()
 			for {
@@ -313,8 +334,10 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 				if !drain {
 					// Send any rows that have been buffered. We grab multiple rows at a
 					// time to reduce contention.
-					if rows, err := ro.popRowsLocked(ctx, rowBuf); err != nil {
+					if rows, err := ro.popRowsLocked(ctx); err != nil {
+						ro.mu.Unlock()
 						rb.fwdMetadata(&execinfrapb.ProducerMetadata{Err: err})
+						ro.mu.Lock()
 						atomic.StoreUint32(&rb.aggregatedStatus, uint32(execinfra.DrainRequested))
 						drain = true
 						continue
@@ -343,10 +366,12 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 						tracing.SetSpanStats(span, &ro.stats)
 						tracing.FinishSpan(span)
 						if trace := execinfra.GetTraceData(ctx); trace != nil {
+							ro.mu.Unlock()
 							rb.semaphore <- struct{}{}
 							status := ro.stream.Push(nil, &execinfrapb.ProducerMetadata{TraceData: trace})
 							rb.updateStreamState(&streamStatus, status)
 							<-rb.semaphore
+							ro.mu.Lock()
 						}
 					}
 					ro.stream.ProducerDone()
@@ -359,8 +384,10 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 			ro.mu.rowContainer.Close(ctx)
 			ro.mu.Unlock()
 
+			ro.rowBufToPushFromAcc.Close(ctx)
 			ro.memoryMonitor.Stop(ctx)
 			ro.diskMonitor.Stop(ctx)
+			ro.rowBufToPushFromMon.Stop(ctx)
 
 			wg.Done()
 		}(ctx, rb, &rb.outputs[i], wg)
@@ -408,6 +435,7 @@ func (rb *routerBase) updateStreamState(
 // data. Note that if the metadata record contains an error, it is propagated
 // to all non-closed streams whereas all other types of metadata are propagated
 // only to the first non-closed stream.
+// Note: fwdMetadata should be called without holding the lock.
 func (rb *routerBase) fwdMetadata(meta *execinfrapb.ProducerMetadata) {
 	if meta == nil {
 		log.Fatalf(context.TODO(), "asked to fwd empty metadata")


### PR DESCRIPTION
This commit adds memory accounting for `EncDatumRow`s that we're popping
from the row buffer and/or the row container and making copies of before
pushing them out to the receiver. We have references to these rows until
we overwrite them with the next "batch" of popped rows at which point we
update the memory account accordingly.

Additionally, this commit fixes a few places where holding a lock could
lead to a deadlock (in error propagating cases).

Release note: None