### PR TITLE
release-20.1: demo: display connection urls for nodes in the demo cluster

### DIFF
--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -39,3 +39,28 @@ eexpect root@
 # Ensure db is movr.
 eexpect "movr>"
 end_test
+
+# Test that demo displays connection URLs for nodes in the cluster.
+start_test "Check that node URLs are displayed"
+spawn $argv demo --insecure
+# Check that we see our message.
+eexpect "Connect to the cluster on a SQL shell at"
+
+# Start the test again with a multi node cluster.
+spawn $argv demo --insecure --nodes 3
+
+# Check that we get a message for each node.
+eexpect "Connect to different nodes in the cluster on a SQL shell at"
+eexpect "Node 1"
+eexpect "Node 2"
+eexpect "Node 3"
+
+spawn $argv demo --insecure=false
+eexpect "Connect to the cluster on a SQL shell at"
+# Expect that security related tags are part of the connection URL.
+eexpect "sslcert="
+eexpect "sslkey="
+eexpect "sslrootcert="
+
+end_test
+


### PR DESCRIPTION
Backport 1/1 commits from #46913.

/cc @cockroachdb/release

---

Fixes #46901.

Release note (cli change): cockroach demo now displays a connection
URL to the demo cluster, and in a multi-node cluster it displays
connection strings for all of the nodes in the cluster.
