### PR TITLE
ui: telemetry network matrix

### DIFF
--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -18,3 +18,4 @@ export { default as trackDownloadDiagnosticsBundle } from "./trackDownloadDiagno
 export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
+export { default as trackCollapseNodes } from "./trackCollapseNodes";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -17,3 +17,4 @@ export { default as trackSearch } from "./trackSearch";
 export { default as trackDownloadDiagnosticsBundle } from "./trackDownloadDiagnosticsBundle";
 export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
+export { default as trackNetworkSort } from "./trackNetworkSort";

--- a/pkg/ui/src/util/analytics/trackCollapseNodes.spec.ts
+++ b/pkg/ui/src/util/analytics/trackCollapseNodes.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackCollapseNodes";
+
+const sandbox = createSandbox();
+
+describe("trackCollapseNodes", () => {
+  const testCollapsed = true;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testCollapsed);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Collapse Nodes";
+
+    track(spy)(testCollapsed);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testCollapsed);
+
+    const sent = spy.getCall(0).args[0];
+    const collapsed = get(sent, "properties.collapsed");
+
+    assert.isTrue(collapsed === testCollapsed);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackCollapseNodes.ts
+++ b/pkg/ui/src/util/analytics/trackCollapseNodes.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (collapsed: boolean) => {
+  fn({
+    event: "Collapse Nodes",
+    properties: {
+      collapsed: collapsed,
+    },
+  });
+};
+
+export default function trackCollapseNode (collapsed: boolean) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(collapsed);
+}

--- a/pkg/ui/src/util/analytics/trackNetworkSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackNetworkSort.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackNetworkSort";
+
+const sandbox = createSandbox();
+
+describe("trackNetworkSort", () => {
+  const sortBy = "Test";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(sortBy);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Sort Network Diagnostics";
+
+    track(spy)(sortBy);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(sortBy);
+
+    const sent = spy.getCall(0).args[0];
+    const sortedBy = get(sent, "properties.sortBy");
+
+    assert.isTrue(sortedBy === sortBy);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackNetworkSort.ts
+++ b/pkg/ui/src/util/analytics/trackNetworkSort.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (sortBy: string) => {
+  fn({
+    event: "Sort Network Diagnostics",
+    properties: {
+      sortBy,
+    },
+  });
+};
+
+export default function trackNetworkSort(sortBy: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(sortBy);
+}

--- a/pkg/ui/src/util/analytics/trackPaginate.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.ts
@@ -18,7 +18,7 @@ export const track = (fn: Function) => (page: number) => {
   });
 };
 
-export default function trackSearch(pageNumber: number) {
+export default function trackPaginate(pageNumber: number) {
   const boundTrack = analytics.track.bind(analytics);
   track(boundTrack)(pageNumber);
 }

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { get, isString } from "lodash";
+import { get } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";
 import { track } from "./trackStatementDetailsSubnavSelection";
@@ -37,7 +37,6 @@ describe("trackSubnavSelection", () => {
     const sent = spy.getCall(0).args[0];
     const event = get(sent, "event");
 
-    assert.isTrue(isString(event));
     assert.isTrue(event === expected);
   });
 
@@ -49,7 +48,6 @@ describe("trackSubnavSelection", () => {
     const sent = spy.getCall(0).args[0];
     const selection = get(sent, "properties.selection");
 
-    assert.isTrue(isString(selection));
     assert.isTrue(selection === subNavKey);
   });
 });

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -22,7 +22,7 @@ import { LivenessStatus, NodesSummary, nodesSummarySelector, selectLivenessReque
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment, NanoToMilli } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
-import { trackFilter } from "src/util/analytics";
+import { trackFilter, trackCollapseNodes } from "src/util/analytics";
 import { getFilters, localityToString, NodeFilterList, NodeFilterListProps } from "src/views/reports/components/nodeFilterList";
 import Loading from "src/views/shared/components/loading";
 import { Latency } from "./latency";
@@ -108,7 +108,10 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     }
   }
 
-  onChangeCollapse = (collapsed: boolean) => this.setState({ collapsed });
+  onChangeCollapse = (collapsed: boolean) => {
+    trackCollapseNodes(collapsed);
+    this.setState({ collapsed });
+  }
 
   onChangeFilter = (key: string, value: string) => {
     const { filter } = this.state;

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { deviation as d3Deviation, mean as d3Mean } from "d3";
-import _ from "lodash";
+import _, { capitalize } from "lodash";
 import moment from "moment";
 import React, { Fragment } from "react";
 import { Helmet } from "react-helmet";
@@ -22,6 +22,7 @@ import { LivenessStatus, NodesSummary, nodesSummarySelector, selectLivenessReque
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment, NanoToMilli } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
+import { trackFilter } from "src/util/analytics";
 import { getFilters, localityToString, NodeFilterList, NodeFilterListProps } from "src/views/reports/components/nodeFilterList";
 import Loading from "src/views/shared/components/loading";
 import { Latency } from "./latency";
@@ -114,6 +115,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     const newFilter = filter ? filter : {};
     const data = newFilter[key] || [];
     const values = data.indexOf(value) === -1 ? [...data, value] : data.length === 1 ? null : data.filter((m: string|number) => m !== value);
+    trackFilter(capitalize(key), value);
     this.setState({
       filter: {
         ...newFilter,
@@ -125,6 +127,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
   deselectFilterByKey = (key: string) => {
     const { filter } = this.state;
     const newFilter = filter ? filter : {};
+    trackFilter(capitalize(key), "deselect all");
     this.setState({
       filter: {
         ...newFilter,

--- a/pkg/ui/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/sort/index.tsx
@@ -13,6 +13,7 @@ import Dropdown, { DropdownOption } from "oss/src/views/shared/components/dropdo
 import React from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
+import { trackNetworkSort } from "src/util/analytics";
 import { getMatchParamByName } from "src/util/query";
 import { NetworkFilter, NetworkSort } from "..";
 import { Filter } from "../filter";
@@ -37,6 +38,7 @@ class Sort extends React.Component<ISortProps & RouteComponentProps, {}> {
   }
 
   navigateTo = (selected: DropdownOption) => {
+    trackNetworkSort(selected.label);
     this.props.onChangeCollapse(false);
     this.props.history.push(`/reports/network/${selected.value}`);
   }


### PR DESCRIPTION
depends on  #46927

fixes #45627

- [x] sort by option selection
- [x] filter option drop down clicks
- [x] collapse nodes toggle clicks

### Sort Network Diagnostics

This event fires when the users interacts with the Sort dropdown in Network Diagnostic.

![network-sort](https://user-images.githubusercontent.com/397448/78290481-cb00f780-74f1-11ea-8b7f-466bfc17db63.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Sort Network Diagnostics',
  properties: {
    pagePath: '/reports/network/cloud',
    sortBy: 'Zone'
  }
}
```

## Filtering

Network diagnostics have multiple ways in which to filter the Network Latency Matrix. Reusing the track function created in the [Jobs PR](https://github.com/cockroachdb/cockroach/pull/46927), I am creating a filter event for each of the categories of filtering.

### Cluster Filter

This event is fired when the user filters by Nodes.

![cluster-filtering](https://user-images.githubusercontent.com/397448/78290505-d2280580-74f1-11ea-93b5-ef64e5c0a106.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Cluster Filter',
  properties: {
    pagePath: '/reports/network/region',
    selectedFilter: '2'
  }
}
```

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Cluster Filter',
  properties: {
    pagePath: '/reports/network/region',
    selectedFilter: 'deselect all'
  }
}
```

### Cloud Filter

This event is fired when the user filters by Clouds.

![cloud-filtering](https://user-images.githubusercontent.com/397448/78290519-d81de680-74f1-11ea-9eb4-6f696e035be2.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Cloud Filter',
  properties: {
    pagePath: '/reports/network/region',
    selectedFilter: 'local'
  }
}
```

### Region Filter

This event is fired when the user filters by Regions.

![region-filtering](https://user-images.githubusercontent.com/397448/78290542-dce29a80-74f1-11ea-8e2b-47be1d028313.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Region Filter',
  properties: {
    pagePath: '/reports/network/region',
    selectedFilter: 'deselect all'
  }
}
```

### Zone Filter

This event is fired when the user filters by Zones.

![zone-filtering](https://user-images.githubusercontent.com/397448/78290559-e10eb800-74f1-11ea-967e-d4cc09417002.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Zone Filter',
  properties: {
    pagePath: '/reports/network/region',
    selectedFilter: 'deselect all'
  }
}
```


### Collapse Nodes

This event is fired when the user toggles the collapse nodes checkbox.

![collapse](https://user-images.githubusercontent.com/397448/78290647-07345800-74f2-11ea-88da-4b6f5e60f02d.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Collapse Nodes',
  properties: {
    collapsed: false,
    pagePath: '/reports/network/cloud'
  }
}
```