### PR TITLE
hlc: use PTP user space API as HLC clock

### DIFF
--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -39,7 +39,9 @@ case "${1-}" in
       XGOARCH=amd64
       XCMAKE_SYSTEM_NAME=Linux
       TARGET_TRIPLE=x86_64-unknown-linux-gnu
-      LDFLAGS="-static-libgcc -static-libstdc++"
+# -lrt is needed as clock_gettime isn't part of glibc prior to 2.17
+# once we update - the -lrt can be removed
+      LDFLAGS="-static-libgcc -static-libstdc++ -lrt"
       SUFFIX=-linux-2.6.32-gnu-amd64
     ) ;;
 

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -213,6 +213,10 @@ type Config struct {
 	// connections to determine connection health and update the local view
 	// of remote clocks.
 	RPCHeartbeatInterval time.Duration
+
+	// Enables the use of an PTP hardware clock user space API for HLC current time.
+	// This contains the path to the device to be used (i.e. /dev/ptp0)
+	ClockDevicePath string
 }
 
 func wrapError(err error) error {
@@ -243,6 +247,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""
 	cfg.DisableClusterNameVerification = false
+	cfg.ClockDevicePath = ""
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -673,6 +673,20 @@ fields.
 		Description: `Path to the CA key.`,
 	}
 
+	ClockDevice = FlagInfo{
+		Name: "clock-device",
+		Description: `
+Override HLC to use PTP hardware clock user space API when querying for current time.
+The value corresponds to the clock device to be used. This is currently only tested
+and supported on Linux.
+<PRE>
+
+  --clock-device=/dev/ptp0
+
+</PRE>
+`,
+	}
+
 	MaxOffset = FlagInfo{
 		Name: "max-offset",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -358,6 +358,7 @@ func init() {
 		VarFlag(f, &serverCfg.Stores, cliflags.Store)
 		VarFlag(f, &serverCfg.StorageEngine, cliflags.StorageEngine)
 		VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
+		StringFlag(f, &serverCfg.ClockDevicePath, cliflags.ClockDevice, "")
 
 		StringFlag(f, &startCtx.listeningURLFile, cliflags.ListeningURLFile, startCtx.listeningURLFile)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -229,7 +229,16 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		panic(errors.New("no tracer set in AmbientCtx"))
 	}
 
-	clock := hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
+	var clock *hlc.Clock
+	if cfg.ClockDevicePath != "" {
+		clockSrc, err := hlc.MakeClockSource(context.Background(), cfg.ClockDevicePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "instantiating clock source")
+		}
+		clock = hlc.NewClock(clockSrc.UnixNano, time.Duration(cfg.MaxOffset))
+	} else {
+		clock = hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
+	}
 	s := &Server{
 		st:       st,
 		clock:    clock,

--- a/pkg/util/hlc/hlc_clock_device_linux.go
+++ b/pkg/util/hlc/hlc_clock_device_linux.go
@@ -1,0 +1,79 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build linux
+
+package hlc
+
+/*
+#include <time.h>
+*/
+import "C"
+
+import (
+	"context"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// ClockSource contains the handle of the clock device as well as the
+// clock id.
+type ClockSource struct {
+	// clockDevice is not used after the device is open but is here to prevent the GC
+	// from closing the device and invalidating the clockDeviceID.
+	clockDevice   *os.File
+	clockDeviceID uintptr
+}
+
+// MakeClockSource creates a new ClockSource for the given device path.
+func MakeClockSource(ctx context.Context, clockDevicePath string) (ClockSource, error) {
+	var result ClockSource
+	var err error
+	result.clockDevice, err = os.Open(clockDevicePath)
+	if err != nil {
+		return result, errors.Wrapf(err, "cannot open %s", clockDevicePath)
+	}
+
+	clockDeviceFD := result.clockDevice.Fd()
+	// For clarification of how the clock id is computed:
+	// https://lore.kernel.org/patchwork/patch/868609/
+	// https://github.com/torvalds/linux/blob/7e63420847ae5f1036e4f7c42f0b3282e73efbc2/tools/testing/selftests/ptp/testptp.c#L87
+	clockID := (^clockDeviceFD << 3) | 3
+	log.Infof(
+		ctx,
+		"opened clock device %s with fd %d, mod_fd %x",
+		clockDevicePath,
+		clockDeviceFD,
+		clockID,
+	)
+	var ts C.struct_timespec
+	_, err = C.clock_gettime(C.clockid_t(clockID), &ts)
+	if err != nil {
+		return result, errors.Wrap(err, "UseClockDevice: error calling clock_gettime")
+	}
+	result.clockDeviceID = clockID
+
+	return result, nil
+}
+
+// UnixNano returns the clock device's physical nanosecond
+// unix epoch timestamp as a convenience to create a HLC via
+// c := hlc.NewClock(dev.UnixNano, ...).
+func (p ClockSource) UnixNano() int64 {
+	var ts C.struct_timespec
+	_, err := C.clock_gettime(C.clockid_t(p.clockDeviceID), &ts)
+	if err != nil {
+		panic(err)
+	}
+
+	return int64(ts.tv_sec)*1e9 + int64(ts.tv_nsec)
+}

--- a/pkg/util/hlc/hlc_clock_device_stub.go
+++ b/pkg/util/hlc/hlc_clock_device_stub.go
@@ -1,0 +1,34 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !linux
+
+package hlc
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// ClockSource contains the handle of the clock device as well as the
+// clock id.
+type ClockSource struct {
+}
+
+// UnixNano is not used on platforms other than Linux
+func (p ClockSource) UnixNano() int64 {
+	panic(errors.New("clock device not supported on this platform"))
+}
+
+// MakeClockSource us not used on platforms other than Linux
+func MakeClockSource(_ context.Context, _ string) (ClockSource, error) {
+	return ClockSource{}, errors.New("clock device not supported on this platform")
+}


### PR DESCRIPTION
Adds support for Linux for using PTP user space API clock
device for HLC. This is needed in case that the host clock is
prone to large jumps (as is the case when using vMotion).

Release note (cli change): added new start option --clock-device that
allows HLC to use PTP user space API clock