### PR TITLE
Ui telemetry metrics time picker

### DIFF
--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -19,3 +19,4 @@ export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
+export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -20,3 +20,4 @@ export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
 export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";
+export { default as trackTimeFrameChange } from "./trackTimeFrameChange";

--- a/pkg/ui/src/util/analytics/trackTimeFrameChange.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTimeFrameChange.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTimeFrameChange";
+
+const sandbox = createSandbox();
+
+describe("trackPaginate", () => {
+  const direction = "test";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(direction);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Time Frame Change";
+
+    track(spy)(direction);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(direction);
+
+    const sent = spy.getCall(0).args[0];
+    const changeDirection = get(sent, "properties.direction");
+
+    assert.isTrue(changeDirection === direction);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTimeFrameChange.ts
+++ b/pkg/ui/src/util/analytics/trackTimeFrameChange.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (direction: string) => {
+  fn({
+    event: "Time Frame Change",
+    properties: {
+      direction,
+    },
+  });
+};
+
+export default function trackTimeFrameChange(direction: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(direction);
+}

--- a/pkg/ui/src/util/analytics/trackTimeScaleOption.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTimeScaleOption.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTimeScaleSelected";
+
+const sandbox = createSandbox();
+
+describe("trackTimeScaleSelected", () => {
+  const scale = "Last 2 weeks";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(scale);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Time Scale Selected";
+
+    track(spy)(scale);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(scale);
+
+    const sent = spy.getCall(0).args[0];
+    const timeScale = get(sent, "properties.timeScale");
+
+    assert.isTrue(timeScale === scale);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTimeScaleSelected.ts
+++ b/pkg/ui/src/util/analytics/trackTimeScaleSelected.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (scale: string) => {
+  fn({
+    event: "Time Scale Selected",
+    properties: {
+      timeScale: scale,
+    },
+  });
+};
+
+export default function trackTimeScaleSelected(scale: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(scale);
+}

--- a/pkg/ui/src/views/cluster/components/range/index.tsx
+++ b/pkg/ui/src/views/cluster/components/range/index.tsx
@@ -11,6 +11,7 @@
 import { Button, TimePicker, notification, Calendar, Icon } from "antd";
 import moment, { Moment } from "moment";
 import { TimeWindow } from "oss/src/redux/timewindow";
+import { trackTimeScaleSelected } from "src/util/analytics";
 import React from "react";
 import "./range.styl";
 
@@ -127,11 +128,16 @@ class RangeSelect extends React.Component<RangeSelectProps, RangeSelectState> {
 
   toggleDropDown = () => this.setState({ opened: !this.state.opened }, this.toggleCustomPicker(this.state.opened ));
 
+  handleOptionButtonOnClick = (option: RangeOption) => () => {
+    trackTimeScaleSelected(option.label);
+    (option.value === "Custom" ? this.toggleCustomPicker(true) : this.onChangeOption(option))();
+  }
+
   optionButton = (option: RangeOption) => (
     <Button
       type="default"
       className={`_time-button ${this.props.selected.title === option.value && "active" || ""}`}
-      onClick={option.value === "Custom" ? this.toggleCustomPicker(true) : this.onChangeOption(option)}
+      onClick={this.handleOptionButtonOnClick(option)}
       ghost
     >
       <span className="dropdown__range-title">{this.props.selected.title !== "Custom" && option.value === "Custom" ? "--" : option.timeLabel}</span>

--- a/pkg/ui/src/views/cluster/containers/timescale/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/timescale/index.tsx
@@ -18,6 +18,7 @@ import { refreshNodes } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import * as timewindow from "src/redux/timewindow";
 import { INodeStatus } from "src/util/proto";
+import { trackTimeFrameChange } from "src/util/analytics";
 import Dropdown, { ArrowDirection, DropdownOption } from "src/views/shared/components/dropdown";
 import TimeFrameControls from "../../components/controls";
 import RangeSelect, { DateTypes } from "../../components/range";
@@ -82,14 +83,17 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
 
     switch (direction) {
       case ArrowDirection.RIGHT:
+        trackTimeFrameChange("next frame");
         if (windowEnd) {
           windowEnd = windowEnd.add(seconds, "seconds");
         }
         break;
       case ArrowDirection.LEFT:
+        trackTimeFrameChange("previous frame");
         windowEnd = windowEnd.subtract(seconds, "seconds");
         break;
       case ArrowDirection.CENTER:
+        trackTimeFrameChange("now");
         windowEnd = moment.utc();
         break;
       default:


### PR DESCRIPTION
fixes #45632

- [x] time frame selection (including custom)
- [x] next/previous timeframe button clicks
- [x] "now" button clicks

Added tracking events for changes to the time series on the metrics view. The events are,

### Time Scale Selected

This event fires when the user selects a new time scale from the drop down.

![time-scale-select](https://user-images.githubusercontent.com/397448/78309212-61481400-7518-11ea-8d77-df25332344bd.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Time Frame Change',
  properties: {
    direction: 'previous frame',
    pagePath: '/metrics/overview/cluster'
  }
}

{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Time Frame Change',
  properties: {
    direction: 'now',
    pagePath: '/metrics/overview/cluster'
  }
}
```

### Time Frame Change

This event fires when the user changes the time frame using the directional controls or "now".

![time-frame-change](https://user-images.githubusercontent.com/397448/78309238-715ff380-7518-11ea-8452-62ee4adbd334.gif)

```
{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Time Scale Selected',
  properties: {
    pagePath: '/metrics/overview/cluster',
    timeScale: 'Custom'
  }
}

{
  userId: '9553cdfb-5cf3-4430-862c-1a7bd4ec524b',
  event: 'Time Scale Selected',
  properties: {
    pagePath: '/metrics/overview/cluster',
    timeScale: 'Past 3 Days'
  }
}
```