### PR TITLE
geo: add ability to convert from Geography to S2 regions

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -890,7 +890,7 @@ func TestLint(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec)\.Unmarshal\(`),
+			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec|ewkb)\.Unmarshal\(`),
 		), func(s string) {
 			t.Errorf("\n%s <- forbidden; use 'protoutil.Unmarshal' instead", s)
 		}); err != nil {


### PR DESCRIPTION
This PR adds the ability to convert from Geography to S2. We currently
do this via the geom library, to avoid having to parse any EWKB
ourselves. This will be different in future, but is a good stop gap to
unblock feature development.

Release note: None