### PR TITLE
release-19.2: cli: fix windows compilation

### DIFF
--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -16,7 +16,7 @@ import "os"
 var drainSignals = []os.Signal{os.Interrupt}
 
 // quitSignal is the signal to recognize to dump Go stacks.
-var quitSignal os.Signal = -1
+var quitSignal os.Signal = nil
 
 func handleSignalDuringShutdown(os.Signal) {
 	// Windows doesn't indicate whether a process exited due to a signal in the


### PR DESCRIPTION
Backport 1/1 commits from #45927.

/cc @cockroachdb/release

---

`os.Signal` is an interface. We only use quitSignal to match a received
signal, so `nil` works here.

ref https://github.com/cockroachdb/cockroach/pull/36378

Release note: None
