### PR TITLE
release-20.1: opt: reduce allocations in optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -46,7 +46,7 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	emptyScope := &scope{builder: b}
+	emptyScope := b.allocScope()
 	inputScope := b.buildStmt(split.Rows, colTypes, emptyScope)
 	checkInputColumns("SPLIT AT", inputScope, colNames, colTypes, 1)
 
@@ -118,7 +118,7 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) 
 
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	inputScope := b.buildStmt(unsplit.Rows, colTypes, &scope{builder: b})
+	inputScope := b.buildStmt(unsplit.Rows, colTypes, b.allocScope())
 	checkInputColumns("UNSPLIT AT", inputScope, colNames, colTypes, 1)
 	private.Props = inputScope.makePhysicalProps()
 
@@ -169,7 +169,7 @@ func (b *Builder) buildAlterTableRelocate(
 
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	inputScope := b.buildStmt(relocate.Rows, colTypes, &scope{builder: b})
+	inputScope := b.buildStmt(relocate.Rows, colTypes, b.allocScope())
 	checkInputColumns(cmdName, inputScope, colNames, colTypes, 2)
 
 	outScope.expr = b.factory.ConstructAlterTableRelocate(

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -65,7 +65,7 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 
 		b.pushWithFrame()
 		// Build the input query.
-		outScope := b.buildStmt(ct.AsSource, nil /* desiredTypes */, inScope)
+		outScope = b.buildStmt(ct.AsSource, nil /* desiredTypes */, inScope)
 		b.popWithFrame(outScope)
 
 		numColNames := 0
@@ -102,7 +102,8 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 		input = b.factory.ConstructZeroValues()
 	}
 
-	expr := b.factory.ConstructCreateTable(
+	outScope = b.allocScope()
+	outScope.expr = b.factory.ConstructCreateTable(
 		input,
 		&memo.CreateTablePrivate{
 			Schema:    schID,
@@ -110,5 +111,5 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 			Syntax:    ct,
 		},
 	)
-	return &scope{builder: b, expr: expr}
+	return outScope
 }

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -58,7 +58,8 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 		}
 	}
 
-	expr := b.factory.ConstructCreateView(
+	outScope = b.allocScope()
+	outScope.expr = b.factory.ConstructCreateView(
 		&memo.CreateViewPrivate{
 			Schema:      schID,
 			ViewName:    cv.Name.Table(),
@@ -69,5 +70,5 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 			Deps:        b.viewDeps,
 		},
 	)
-	return &scope{builder: b, expr: expr}
+	return outScope
 }

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -25,7 +25,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 
 	// We don't allow the statement under Explain to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	stmtScope := b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */, &scope{builder: b})
+	stmtScope := b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */, b.allocScope())
 
 	b.popWithFrame(stmtScope)
 	outScope = inScope.push()

--- a/pkg/sql/opt/optbuilder/export.go
+++ b/pkg/sql/opt/optbuilder/export.go
@@ -24,7 +24,7 @@ func (b *Builder) buildExport(export *tree.Export, inScope *scope) (outScope *sc
 	}
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	emptyScope := &scope{builder: b}
+	emptyScope := b.allocScope()
 	inputScope := b.buildStmt(export.Query, nil /* desiredTypes */, emptyScope)
 
 	texpr := emptyScope.resolveType(export.File, types.String)

--- a/pkg/sql/opt/optbuilder/misc_statements.go
+++ b/pkg/sql/opt/optbuilder/misc_statements.go
@@ -25,7 +25,7 @@ func (b *Builder) buildControlJobs(n *tree.ControlJobs, inScope *scope) (outScop
 
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	emptyScope := &scope{builder: b}
+	emptyScope := b.allocScope()
 	colTypes := []*types.T{types.Int}
 	inputScope := b.buildStmt(n.Jobs, colTypes, emptyScope)
 
@@ -50,7 +50,7 @@ func (b *Builder) buildControlJobs(n *tree.ControlJobs, inScope *scope) (outScop
 func (b *Builder) buildCancelQueries(n *tree.CancelQueries, inScope *scope) (outScope *scope) {
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	emptyScope := &scope{builder: b}
+	emptyScope := b.allocScope()
 	colTypes := []*types.T{types.String}
 	inputScope := b.buildStmt(n.Queries, colTypes, emptyScope)
 
@@ -75,7 +75,7 @@ func (b *Builder) buildCancelQueries(n *tree.CancelQueries, inScope *scope) (out
 func (b *Builder) buildCancelSessions(n *tree.CancelSessions, inScope *scope) (outScope *scope) {
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	emptyScope := &scope{builder: b}
+	emptyScope := b.allocScope()
 	colTypes := []*types.T{types.String}
 	inputScope := b.buildStmt(n.Sessions, colTypes, emptyScope)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -814,7 +814,9 @@ func (mb *mutationBuilder) mapToReturnScopeOrd(tabOrd int) scopeOrdinal {
 func (mb *mutationBuilder) buildReturning(returning tree.ReturningExprs) {
 	// Handle case of no RETURNING clause.
 	if returning == nil {
-		mb.outScope = &scope{builder: mb.b, expr: mb.outScope.expr}
+		expr := mb.outScope.expr
+		mb.outScope = mb.b.allocScope()
+		mb.outScope.expr = expr
 		return
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #46934.

/cc @cockroachdb/release

---

This commit reduces allocations in the optbuilder by changing all
direct constructions of scope{} to use allocScope() instead.
It also avoids constructing new scopes when not necessary.

The purpose of this commit is to address the performance regressions
that were identified by running the BenchmarkChain set of benchmarks
against master and the 19.2 release branch.

After this commit, there are still some regressions, but they are
relatively small. The remaining regressions are due to essential
changes that we made over the course of the release cycle to fix
correctness issues.

benchdiff results comparing this commit to the point where 19.2
was forked:
```
name                      old time/op    new time/op    delta
Chain/chain-19/Explore-4    5.70ms ±19%    3.22ms ±10%  -43.56%  (p=0.000 n=18+16)
Chain/chain-18/Explore-4    5.01ms ±17%    2.95ms ±10%  -41.04%  (p=0.000 n=19+17)
Chain/chain-17/Explore-4    4.31ms ±15%    2.70ms ±12%  -37.46%  (p=0.000 n=19+18)
Chain/chain-16/Explore-4    3.60ms ±14%    2.50ms ±18%  -30.46%  (p=0.000 n=18+18)
Chain/chain-15/Explore-4    3.15ms ±16%    2.22ms ±14%  -29.71%  (p=0.000 n=18+17)
Chain/chain-14/Explore-4    2.70ms ±14%    2.01ms ±11%  -25.80%  (p=0.000 n=19+20)
Chain/chain-13/Explore-4    2.18ms ±11%    1.71ms ±13%  -21.32%  (p=0.000 n=16+20)
Chain/chain-12/Explore-4    1.89ms ±20%    1.55ms ±13%  -17.77%  (p=0.000 n=18+20)
Chain/chain-11/Explore-4    1.54ms ±20%    1.32ms ± 7%  -14.28%  (p=0.000 n=18+18)
Chain/chain-10/Explore-4    1.27ms ±33%    1.15ms ± 8%   -9.10%  (p=0.000 n=17+18)
Chain/chain-8/Explore-4      820µs ±17%     784µs ± 8%   -4.29%  (p=0.011 n=18+18)
Chain/chain-5/Explore-4      433µs ±33%     439µs ± 9%     ~     (p=0.336 n=20+19)
Chain/chain-7/Explore-4      667µs ±27%     672µs ±19%     ~     (p=0.815 n=18+18)
Chain/chain-9/Explore-4     1.04ms ±12%    1.02ms ±15%     ~     (p=0.116 n=16+20)
Chain/chain-6/Explore-4      529µs ±22%     558µs ±17%   +5.48%  (p=0.017 n=16+18)
Chain/chain-3/Explore-4      216µs ±16%     228µs ±12%   +5.94%  (p=0.017 n=19+18)
Chain/chain-2/Explore-4      109µs ±25%     122µs ±24%  +11.56%  (p=0.002 n=19+19)
Chain/chain-1/Explore-4     19.1µs ±16%    21.4µs ±15%  +12.25%  (p=0.000 n=18+18)
Chain/chain-4/Explore-4      291µs ± 8%     332µs ±12%  +14.34%  (p=0.000 n=17+19)

name                      old alloc/op   new alloc/op   delta
Chain/chain-19/Explore-4    2.08MB ± 0%    0.84MB ± 0%  -59.31%  (p=0.000 n=20+20)
Chain/chain-18/Explore-4    1.75MB ± 0%    0.77MB ± 0%  -55.93%  (p=0.000 n=20+20)
Chain/chain-17/Explore-4    1.47MB ± 0%    0.70MB ± 0%  -52.29%  (p=0.000 n=19+20)
Chain/chain-16/Explore-4    1.23MB ± 0%    0.64MB ± 0%  -48.29%  (p=0.000 n=20+20)
Chain/chain-15/Explore-4    1.01MB ± 0%    0.56MB ± 0%  -44.70%  (p=0.000 n=20+20)
Chain/chain-14/Explore-4     833kB ± 0%     500kB ± 0%  -39.96%  (p=0.000 n=20+20)
Chain/chain-13/Explore-4     634kB ± 0%     396kB ± 0%  -37.57%  (p=0.000 n=20+20)
Chain/chain-12/Explore-4     515kB ± 0%     349kB ± 0%  -32.26%  (p=0.000 n=20+20)
Chain/chain-11/Explore-4     407kB ± 0%     297kB ± 0%  -26.99%  (p=0.000 n=20+20)
Chain/chain-10/Explore-4     327kB ± 0%     259kB ± 0%  -20.81%  (p=0.000 n=20+20)
Chain/chain-9/Explore-4      263kB ± 0%     225kB ± 0%  -14.71%  (p=0.000 n=19+20)
Chain/chain-8/Explore-4      187kB ± 0%     168kB ± 0%  -10.31%  (p=0.000 n=20+20)
Chain/chain-7/Explore-4      148kB ± 0%     141kB ± 0%   -4.75%  (p=0.000 n=20+19)
Chain/chain-1/Explore-4     6.38kB ± 0%    6.29kB ± 0%   -1.49%  (p=0.000 n=20+20)
Chain/chain-6/Explore-4      113kB ± 0%     113kB ± 0%   -0.14%  (p=0.000 n=19+20)
Chain/chain-2/Explore-4     20.9kB ± 0%    21.4kB ± 0%   +2.69%  (p=0.000 n=20+20)
Chain/chain-5/Explore-4     82.6kB ± 0%    85.8kB ± 0%   +3.88%  (p=0.000 n=20+20)
Chain/chain-4/Explore-4     58.1kB ± 0%    61.8kB ± 0%   +6.28%  (p=0.000 n=20+20)
Chain/chain-3/Explore-4     38.6kB ± 0%    41.5kB ± 0%   +7.45%  (p=0.000 n=17+19)

name                      old allocs/op  new allocs/op  delta
Chain/chain-19/Explore-4     4.64k ± 0%     2.73k ± 0%  -41.20%  (p=0.000 n=20+17)
Chain/chain-18/Explore-4     4.16k ± 0%     2.56k ± 0%  -38.44%  (p=0.000 n=20+16)
Chain/chain-17/Explore-4     3.72k ± 0%     2.40k ± 0%  -35.55%  (p=0.000 n=17+20)
Chain/chain-16/Explore-4     3.31k ± 0%     2.23k ± 0%  -32.56%  (p=0.000 n=20+20)
Chain/chain-15/Explore-4     2.93k ± 0%     2.07k ± 0%  -29.44%  (p=0.000 n=20+20)
Chain/chain-14/Explore-4     2.58k ± 0%     1.91k ± 0%  -26.20%  (p=0.000 n=17+17)
Chain/chain-13/Explore-4     2.25k ± 0%     1.73k ± 0%  -23.13%  (p=0.000 n=18+20)
Chain/chain-12/Explore-4     1.96k ± 0%     1.57k ± 0%  -19.71%  (p=0.000 n=19+18)
Chain/chain-11/Explore-4     1.70k ± 0%     1.42k ± 0%  -16.25%  (p=0.000 n=20+20)
Chain/chain-10/Explore-4     1.46k ± 0%     1.27k ± 0%  -12.80%  (p=0.000 n=20+20)
Chain/chain-9/Explore-4      1.25k ± 0%     1.13k ± 0%   -9.38%  (p=0.000 n=20+20)
Chain/chain-8/Explore-4      1.03k ± 0%     0.97k ± 0%   -6.18%  (p=0.000 n=20+20)
Chain/chain-7/Explore-4        858 ± 0%       832 ± 0%   -3.03%  (p=0.000 n=20+20)
Chain/chain-6/Explore-4        695 ± 0%       694 ± 0%   -0.14%  (p=0.000 n=20+20)
Chain/chain-1/Explore-4       38.0 ± 0%      38.0 ± 0%     ~     (all equal)
Chain/chain-5/Explore-4        547 ± 0%       560 ± 0%   +2.38%  (p=0.000 n=20+20)
Chain/chain-2/Explore-4        153 ± 0%       157 ± 0%   +2.61%  (p=0.000 n=20+20)
Chain/chain-4/Explore-4        409 ± 0%       427 ± 0%   +4.50%  (p=0.000 n=20+16)
Chain/chain-3/Explore-4        282 ± 0%       298 ± 0%   +5.67%  (p=0.000 n=20+20)
```
benchdiff results comparing this commit against current master:
```
name                      old time/op    new time/op    delta
Chain/chain-18/Explore-4    2.90ms ±15%    2.74ms ± 8%  -5.61%  (p=0.037 n=17+16)
Chain/chain-11/Explore-4    1.25ms ±20%    1.19ms ±14%  -4.74%  (p=0.029 n=18+17)
Chain/chain-1/Explore-4     20.6µs ±21%    20.5µs ±15%    ~     (p=0.730 n=18+19)
Chain/chain-2/Explore-4      115µs ±17%     112µs ±12%    ~     (p=0.594 n=19+17)
Chain/chain-3/Explore-4      213µs ±23%     217µs ±19%    ~     (p=0.594 n=17+19)
Chain/chain-4/Explore-4      321µs ±21%     311µs ±22%    ~     (p=0.154 n=19+19)
Chain/chain-6/Explore-4      522µs ±16%     535µs ±19%    ~     (p=0.588 n=20+19)
Chain/chain-7/Explore-4      725µs ±62%     654µs ±33%    ~     (p=0.361 n=20+18)
Chain/chain-8/Explore-4      811µs ±47%     766µs ±18%    ~     (p=0.265 n=18+18)
Chain/chain-9/Explore-4      938µs ±17%     969µs ±26%    ~     (p=0.515 n=20+18)
Chain/chain-10/Explore-4    1.07ms ±22%    1.14ms ±30%    ~     (p=0.696 n=18+20)
Chain/chain-12/Explore-4    1.38ms ±22%    1.45ms ±26%    ~     (p=0.181 n=18+18)
Chain/chain-13/Explore-4    1.66ms ±24%    1.62ms ±31%    ~     (p=0.534 n=20+18)
Chain/chain-14/Explore-4    1.85ms ± 7%    1.91ms ±28%    ~     (p=0.851 n=16+18)
Chain/chain-15/Explore-4    2.14ms ±28%    2.14ms ±34%    ~     (p=0.386 n=17+18)
Chain/chain-16/Explore-4    2.28ms ±10%    2.34ms ±21%    ~     (p=0.851 n=16+18)
Chain/chain-17/Explore-4    2.61ms ±16%    2.61ms ±22%    ~     (p=0.832 n=18+17)
Chain/chain-19/Explore-4    3.13ms ±23%    3.04ms ±26%    ~     (p=0.232 n=18+17)
Chain/chain-5/Explore-4      401µs ±14%     419µs ±10%  +4.60%  (p=0.021 n=17+19)

name                      old alloc/op   new alloc/op   delta
Chain/chain-2/Explore-4     23.4kB ± 0%    21.4kB ± 0%  -8.47%  (p=0.000 n=18+20)
Chain/chain-1/Explore-4     6.77kB ± 0%    6.29kB ± 0%  -7.09%  (p=0.000 n=20+20)
Chain/chain-3/Explore-4     43.0kB ± 0%    41.5kB ± 0%  -3.35%  (p=0.000 n=20+19)
Chain/chain-6/Explore-4      117kB ± 0%     113kB ± 0%  -3.33%  (p=0.000 n=20+20)
Chain/chain-4/Explore-4     63.7kB ± 0%    61.8kB ± 0%  -3.01%  (p=0.000 n=20+20)
Chain/chain-5/Explore-4     88.2kB ± 0%    85.8kB ± 0%  -2.72%  (p=0.000 n=20+20)
Chain/chain-7/Explore-4      144kB ± 0%     141kB ± 0%  -2.33%  (p=0.000 n=17+20)
Chain/chain-8/Explore-4      172kB ± 0%     168kB ± 0%  -2.23%  (p=0.000 n=20+19)
Chain/chain-10/Explore-4     265kB ± 0%     259kB ± 0%  -2.20%  (p=0.000 n=20+18)
Chain/chain-9/Explore-4      229kB ± 0%     225kB ± 0%  -1.88%  (p=0.000 n=20+19)
Chain/chain-11/Explore-4     302kB ± 0%     297kB ± 0%  -1.75%  (p=0.000 n=20+20)
Chain/chain-12/Explore-4     354kB ± 0%     349kB ± 0%  -1.62%  (p=0.000 n=20+19)
Chain/chain-13/Explore-4     402kB ± 0%     396kB ± 0%  -1.56%  (p=0.000 n=20+19)
Chain/chain-14/Explore-4     508kB ± 0%     500kB ± 0%  -1.52%  (p=0.000 n=20+19)
Chain/chain-15/Explore-4     563kB ± 0%     556kB ± 0%  -1.28%  (p=0.000 n=20+20)
Chain/chain-18/Explore-4     782kB ± 0%     773kB ± 0%  -1.24%  (p=0.000 n=20+20)
Chain/chain-16/Explore-4     645kB ± 0%     637kB ± 0%  -1.19%  (p=0.000 n=20+20)
Chain/chain-17/Explore-4     711kB ± 0%     703kB ± 0%  -1.14%  (p=0.000 n=20+19)
Chain/chain-19/Explore-4     854kB ± 0%     845kB ± 0%  -1.06%  (p=0.000 n=20+19)

name                      old allocs/op  new allocs/op  delta
Chain/chain-1/Explore-4       40.0 ± 0%      38.0 ± 0%  -5.00%  (p=0.000 n=20+20)
Chain/chain-2/Explore-4        162 ± 0%       157 ± 0%  -3.09%  (p=0.000 n=20+20)
Chain/chain-3/Explore-4        304 ± 0%       298 ± 0%  -1.97%  (p=0.000 n=20+20)
Chain/chain-4/Explore-4        435 ± 0%       427 ± 0%  -1.84%  (p=0.000 n=19+17)
Chain/chain-6/Explore-4        707 ± 0%       694 ± 0%  -1.84%  (p=0.000 n=20+20)
Chain/chain-5/Explore-4        570 ± 0%       560 ± 0%  -1.75%  (p=0.000 n=20+20)
Chain/chain-7/Explore-4        846 ± 0%       832 ± 0%  -1.65%  (p=0.000 n=20+20)
Chain/chain-10/Explore-4     1.30k ± 0%     1.27k ± 0%  -1.63%  (p=0.000 n=20+20)
Chain/chain-8/Explore-4        987 ± 0%       971 ± 0%  -1.62%  (p=0.000 n=20+20)
Chain/chain-9/Explore-4      1.15k ± 0%     1.13k ± 0%  -1.57%  (p=0.000 n=20+20)
Chain/chain-11/Explore-4     1.44k ± 0%     1.42k ± 0%  -1.52%  (p=0.000 n=20+20)
Chain/chain-12/Explore-4     1.60k ± 0%     1.57k ± 0%  -1.50%  (p=0.000 n=20+20)
Chain/chain-14/Explore-4     1.94k ± 0%     1.91k ± 0%  -1.50%  (p=0.000 n=19+16)
Chain/chain-13/Explore-4     1.75k ± 0%     1.73k ± 0%  -1.48%  (p=0.000 n=18+17)
Chain/chain-15/Explore-4     2.10k ± 0%     2.07k ± 0%  -1.44%  (p=0.000 n=20+20)
Chain/chain-18/Explore-4     2.60k ± 0%     2.56k ± 0%  -1.42%  (p=0.000 n=18+20)
Chain/chain-16/Explore-4     2.26k ± 0%     2.23k ± 0%  -1.41%  (p=0.000 n=12+17)
Chain/chain-17/Explore-4     2.43k ± 0%     2.40k ± 0%  -1.40%  (p=0.000 n=20+20)
Chain/chain-19/Explore-4     2.77k ± 0%     2.73k ± 0%  -1.35%  (p=0.000 n=17+16)
```
Release justification: low risk, high benefit change to existing functionality
Release note: None