### PR TITLE
release-19.2: sql: make iteration over all databases take fewer round trips

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -652,17 +652,57 @@ func (tc *TableCollection) getAllDatabaseDescriptors(
 		if err != nil {
 			return nil, err
 		}
-		dbDescs := make([]*sqlbase.DatabaseDescriptor, 0, len(dbDescIDs))
-		for _, dbDescID := range dbDescIDs {
-			dbDesc, err := MustGetDatabaseDescByID(ctx, txn, dbDescID)
-			if err != nil {
-				return nil, err
-			}
-			dbDescs = append(dbDescs, dbDesc)
+		dbDescs, err := getDatabaseDescriptorsFromIDs(ctx, txn, dbDescIDs)
+		if err != nil {
+			return nil, err
 		}
 		tc.allDatabaseDescriptors = dbDescs
 	}
 	return tc.allDatabaseDescriptors, nil
+}
+
+// getDatabaseDesciptorsFromIDs returns the database descriptors from an input
+// set of database IDs. It will return an error if any one of the IDs is not a
+// database. It attempts to perform this operation in a single request,
+// rather than making a round trip for each ID.
+func getDatabaseDescriptorsFromIDs(
+	ctx context.Context, txn *client.Txn, ids []sqlbase.ID,
+) ([]*sqlbase.DatabaseDescriptor, error) {
+	b := txn.NewBatch()
+	for _, id := range ids {
+		key := sqlbase.MakeDescMetadataKey(id)
+		b.Get(key)
+	}
+	if err := txn.Run(ctx, b); err != nil {
+		return nil, err
+	}
+	results := make([]*sqlbase.DatabaseDescriptor, 0, len(ids))
+	for i := range b.Results {
+		result := &b.Results[i]
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		if len(result.Rows) != 1 {
+			return nil, errors.AssertionFailedf(
+				"expected one result for key %s but found %d",
+				result.Keys[0],
+				len(result.Rows),
+			)
+		}
+		desc := &sqlbase.Descriptor{}
+		if err := result.Rows[0].ValueProto(desc); err != nil {
+			return nil, err
+		}
+		db := desc.GetDatabase()
+		if db == nil {
+			return nil, errors.AssertionFailedf(
+				"%q is not a database",
+				desc.String(),
+			)
+		}
+		results = append(results, db)
+	}
+	return results, nil
 }
 
 // releaseAllDescriptors releases the cached slice of all descriptors


### PR DESCRIPTION
Backport 1/1 commits from #46872.

/cc @cockroachdb/release

---

Fixes #46870.

This PR fixes a perfomance regression where virtual tables
that needed to iterate over all databases would perform
a lookup for each one, rather than batchimg all of
the requests. This led to slow performance of some
virtual tables when round trip latency is high.
Release note (performance improvement): This PR makes virtual
tables that access all table descriptors make fewer round trips.
