### PR TITLE
kv: batch ranged intent resolution

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -108,6 +109,13 @@ type Config struct {
 	// MaxMsgsPerBatch is the maximum number of messages.
 	// If MaxMsgsPerBatch <= 0 then no limit is enforced.
 	MaxMsgsPerBatch int
+
+	// MaxKeysPerBatchReq is the maximum number of keys that each batch is
+	// allowed to touch during one of its requests. If the limit is exceeded,
+	// the batch is paginated over a series of individual requests. This limit
+	// corresponds to the MaxSpanRequestKeys assigned to the Header of each
+	// request. If MaxKeysPerBatchReq <= 0 then no limit is enforced.
+	MaxKeysPerBatchReq int
 
 	// MaxWait is the maximum amount of time a message should wait in a batch
 	// before being sent. If MaxWait is <= 0 then no wait timeout is enforced.
@@ -264,7 +272,7 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 		var br *roachpb.BatchResponse
 		send := func(ctx context.Context) error {
 			var pErr *roachpb.Error
-			if br, pErr = b.cfg.Sender.Send(ctx, ba.batchRequest()); pErr != nil {
+			if br, pErr = b.cfg.Sender.Send(ctx, ba.batchRequest(&b.cfg)); pErr != nil {
 				return pErr.GoError()
 			}
 			return nil
@@ -276,16 +284,61 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 					ctx, b.sendBatchOpName, timeutil.Until(ba.sendDeadline), actualSend)
 			}
 		}
-		err := send(ctx)
-		for i, r := range ba.reqs {
-			res := Response{}
-			if br != nil && i < len(br.Responses) {
-				res.Resp = br.Responses[i].GetInner()
+		// Send requests in a loop to support pagination, which may be necessary
+		// if MaxKeysPerBatchReq is set. If so, partial responses with resume
+		// spans may be returned for requests, indicating that the limit was hit
+		// before they could complete and that they should be resumed over the
+		// specified key span. Requests in the batch are neither guaranteed to
+		// be ordered nor guaranteed to be non-overlapping, so we can make no
+		// assumptions about the requests that will result in full responses
+		// (with no resume spans) vs. partial responses vs. empty responses (see
+		// the comment on roachpb.Header.MaxSpanRequestKeys).
+		//
+		// To accommodate this, we keep track of all partial responses from
+		// previous iterations. After receiving a batch of responses during an
+		// iteration, the responses are each combined with the previous response
+		// for their corresponding requests. From there, responses that have no
+		// resume spans are removed. Responses that have resume spans are
+		// updated appropriately and sent again in the next iteration. The loop
+		// proceeds until all requests have been run to completion.
+		var prevResps []roachpb.Response
+		for len(ba.reqs) > 0 {
+			err := send(ctx)
+			nextReqs, nextPrevResps := ba.reqs[:0], prevResps[:0]
+			for i, r := range ba.reqs {
+				var res Response
+				if br != nil {
+					resp := br.Responses[i].GetInner()
+					if prevResps != nil {
+						prevResp := prevResps[i]
+						if cErr := roachpb.CombineResponses(prevResp, resp); cErr != nil {
+							log.Fatal(ctx, cErr)
+						}
+						resp = prevResp
+					}
+					if resume := resp.Header().ResumeSpan; resume != nil {
+						// Add a trimmed request to the next batch.
+						h := r.req.Header()
+						h.SetSpan(*resume)
+						r.req = r.req.ShallowCopy()
+						r.req.SetHeader(h)
+						nextReqs = append(nextReqs, r)
+						// Strip resume span from previous response and record.
+						prevH := resp.Header()
+						prevH.ResumeSpan = nil
+						prevResp := resp
+						prevResp.SetHeader(prevH)
+						nextPrevResps = append(nextPrevResps, prevResp)
+						continue
+					}
+					res.Resp = resp
+				}
+				if err != nil {
+					res.Err = err
+				}
+				b.sendResponse(r, res)
 			}
-			if err != nil {
-				res.Err = err
-			}
-			b.sendResponse(r, res)
+			ba.reqs, prevResps = nextReqs, nextPrevResps
 		}
 	})
 }
@@ -462,13 +515,16 @@ func (b *batch) rangeID() roachpb.RangeID {
 	return b.reqs[0].rangeID
 }
 
-func (b *batch) batchRequest() roachpb.BatchRequest {
+func (b *batch) batchRequest(cfg *Config) roachpb.BatchRequest {
 	req := roachpb.BatchRequest{
 		// Preallocate the Requests slice.
 		Requests: make([]roachpb.RequestUnion, 0, len(b.reqs)),
 	}
 	for _, r := range b.reqs {
 		req.Add(r.req)
+	}
+	if cfg.MaxKeysPerBatchReq > 0 {
+		req.MaxSpanRequestKeys = int64(cfg.MaxKeysPerBatchReq)
 	}
 	return req
 }

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -44,35 +44,34 @@ import (
 // testUser has valid client certs.
 var testUser = server.TestUser
 
-var errInfo = testutils.MakeCaller(3, 2)
-
 // checkKVs verifies that a KeyValue slice contains the expected keys and
 // values. The values can be either integers or strings; the expected results
 // are passed as alternating keys and values, e.g:
 //   checkScanResult(t, result, key1, val1, key2, val2)
 func checkKVs(t *testing.T, kvs []kv.KeyValue, expected ...interface{}) {
+	t.Helper()
 	expLen := len(expected) / 2
 	if expLen != len(kvs) {
-		t.Errorf("%s: expected %d scan results, got %d", errInfo(), expLen, len(kvs))
+		t.Errorf("expected %d scan results, got %d", expLen, len(kvs))
 		return
 	}
 	for i := 0; i < expLen; i++ {
 		expKey := expected[2*i].(roachpb.Key)
 		if key := kvs[i].Key; !key.Equal(expKey) {
-			t.Errorf("%s: expected scan key %d to be %q; got %q", errInfo(), i, expKey, key)
+			t.Errorf("expected scan key %d to be %q; got %q", i, expKey, key)
 		}
 		switch expValue := expected[2*i+1].(type) {
 		case int:
 			if value, err := kvs[i].Value.GetInt(); err != nil {
-				t.Errorf("%s: non-integer scan value %d: %q", errInfo(), i, kvs[i].Value)
+				t.Errorf("non-integer scan value %d: %q", i, kvs[i].Value)
 			} else if value != int64(expValue) {
-				t.Errorf("%s: expected scan value %d to be %d; got %d",
-					errInfo(), i, expValue, value)
+				t.Errorf("expected scan value %d to be %d; got %d",
+					i, expValue, value)
 			}
 		case string:
 			if value := kvs[i].Value.String(); value != expValue {
-				t.Errorf("%s: expected scan value %d to be %s; got %s",
-					errInfo(), i, expValue, value)
+				t.Errorf("expected scan value %d to be %s; got %s",
+					i, expValue, value)
 			}
 		default:
 			t.Fatalf("unsupported type %T", expValue)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -513,10 +513,10 @@ func TestMultiRangeBoundedBatchScan(t *testing.T) {
 	}
 }
 
-// TestMultiRangeBoundedBatchScanUnsortedOrder runs two non-overlapping
-// scan requests out of order and shows how the batch response can
-// contain two partial responses.
-func TestMultiRangeBoundedBatchScanUnsortedOrder(t *testing.T) {
+// TestMultiRangeBoundedBatchScanPartialResponses runs multiple scan requests
+// either out-of-order or over overlapping key spans and shows how the batch
+// responses can contain partial responses.
+func TestMultiRangeBoundedBatchScanPartialResponses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := startNoSplitMergeServer(t)
 	ctx := context.TODO()
@@ -527,104 +527,239 @@ func TestMultiRangeBoundedBatchScanUnsortedOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "b4", "b5", "c1", "c2", "d1", "f1", "f2", "f3"} {
+	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"} {
 		if err := db.Put(ctx, key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	bound := 6
-	b := &kv.Batch{}
-	b.Header.MaxSpanRequestKeys = int64(bound)
-	// Two non-overlapping requests out of order.
-	spans := [][]string{{"b3", "c2"}, {"a", "b3"}}
-	for _, span := range spans {
-		b.Scan(span[0], span[1])
+	for _, tc := range []struct {
+		name         string
+		bound        int64
+		spans        [][]string
+		expResults   [][]string
+		expSatisfied []int
+	}{
+		{
+			name:  "unsorted, non-overlapping, neither satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "d"}, {"a", "b1"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+		},
+		{
+			name:  "unsorted, non-overlapping, first satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "c"}, {"a", "b1"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "unsorted, non-overlapping, second satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "d"}, {"a", "b"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "unsorted, non-overlapping, both satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "c"}, {"a", "b"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			name:  "sorted, overlapping, neither satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "d"}, {"b", "g"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"b1"},
+			},
+		},
+		{
+			name:  "sorted, overlapping, first satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "c"}, {"b", "g"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"b1"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "sorted, overlapping, second satisfied",
+			bound: 9,
+			spans: [][]string{
+				{"a", "d"}, {"b", "c"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"b1", "b2", "b3"},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "sorted, overlapping, both satisfied",
+			bound: 9,
+			spans: [][]string{
+				{"a", "c"}, {"b", "c"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"b1", "b2", "b3"},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			name:  "unsorted, overlapping, neither satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "g"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "b1"},
+			},
+		},
+		{
+			name:  "unsorted, overlapping, first satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "c"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "b1"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "unsorted, overlapping, second satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "g"}, {"a", "b2"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "b1"},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "unsorted, overlapping, both satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "c"}, {"a", "b2"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "b1"},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			name:  "unsorted, overlapping, unreached",
+			bound: 7,
+			spans: [][]string{
+				{"b", "g"}, {"c", "f"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {}, {"a1", "a2", "a3", "b1"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &kv.Batch{}
+			b.Header.MaxSpanRequestKeys = tc.bound
+			for _, span := range tc.spans {
+				b.Scan(span[0], span[1])
+			}
+			if err := db.Run(ctx, b); err != nil {
+				t.Fatal(err)
+			}
+
+			expSatisfied := make(map[int]struct{})
+			for _, exp := range tc.expSatisfied {
+				expSatisfied[exp] = struct{}{}
+			}
+			opts := checkOptions{mode: Strict}
+			checkScanResults(t, tc.spans, b.Results, tc.expResults, expSatisfied, opts)
+		})
 	}
-	if err := db.Run(ctx, b); err != nil {
-		t.Fatal(err)
-	}
-	// See incomplete results for the two requests.
-	expResults := [][]string{
-		{"b3", "b4", "b5"},
-		{"a1", "a2", "a3"},
-	}
-	checkScanResults(t, spans, b.Results, expResults, nil /* satisfied */, checkOptions{mode: Strict})
 }
 
-// TestMultiRangeBoundedBatchScanSortedOverlapping runs two overlapping
-// ordered (by start key) scan requests, and shows how the batch response can
-// contain two partial responses.
-func TestMultiRangeBoundedBatchScanSortedOverlapping(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, _ := startNoSplitMergeServer(t)
-	ctx := context.TODO()
-	defer s.Stopper().Stop(ctx)
+// checks the results of a DelRange.
+func checkDelRangeResults(
+	t *testing.T,
+	spans [][]string,
+	results []kv.Result,
+	expResults [][]string,
+	expSatisfied map[int]struct{},
+) {
+	checkDelRangeSpanResults(t, results, expResults)
+	checkResumeSpanDelRangeResults(t, spans, results, expResults, expSatisfied)
+}
 
-	db := s.DB()
-	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f"); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3"} {
-		if err := db.Put(ctx, key, "value"); err != nil {
-			t.Fatal(err)
+// checks the keys returned from a DelRange.
+func checkDelRangeSpanResults(t *testing.T, results []kv.Result, expResults [][]string) {
+	t.Helper()
+	require.Equal(t, len(expResults), len(results))
+	for i, res := range results {
+		require.Equal(t, len(expResults[i]), len(res.Keys))
+		for j, key := range res.Keys {
+			require.Equal(t, expResults[i][j], string(key))
 		}
 	}
-
-	bound := 6
-	b := &kv.Batch{}
-	b.Header.MaxSpanRequestKeys = int64(bound)
-	// Two ordered overlapping requests.
-	spans := [][]string{{"a", "d"}, {"b", "g"}}
-	for _, span := range spans {
-		b.Scan(span[0], span[1])
-	}
-	if err := db.Run(ctx, b); err != nil {
-		t.Fatal(err)
-	}
-	// See incomplete results for the two requests.
-	expResults := [][]string{
-		{"a1", "a2", "a3", "b1", "b2"},
-		{"b1"},
-	}
-	checkScanResults(t, spans, b.Results, expResults, nil /* satisfied */, checkOptions{mode: Strict})
 }
 
-// check ResumeSpan in the DelRange results.
+// checks the ResumeSpan in the DelRange results.
 func checkResumeSpanDelRangeResults(
-	t *testing.T, spans [][]string, results []kv.Result, expResults [][]string, expCount int,
+	t *testing.T,
+	spans [][]string,
+	results []kv.Result,
+	expResults [][]string,
+	expSatisfied map[int]struct{},
 ) {
 	t.Helper()
 	for i, res := range results {
+		keyLen := len(res.Keys)
+		// Check that satisfied requests don't have resume spans.
+		if _, satisfied := expSatisfied[i]; satisfied {
+			require.Nil(t, res.ResumeSpan)
+			continue
+		}
+
 		// Check ResumeSpan when request has been processed.
-		rowLen := len(res.Keys)
-		if rowLen > 0 {
-			// The key can be empty once the entire span has been deleted.
-			if rowLen == len(expResults[i]) {
-				if res.ResumeSpan == nil {
-					// Done.
-					continue
-				}
-			}
-			// The next start key is always greater than the last key seen.
-			if key, expKey := string(res.ResumeSpan.Key), expResults[i][rowLen-1]; key <= expKey {
-				t.Errorf("expected resume key %d, %d to be %q; got %q", i, expCount, expKey, key)
-			}
+		require.NotNil(t, res.ResumeSpan)
+		require.Equal(t, roachpb.RESUME_KEY_LIMIT, res.ResumeReason)
+
+		// The key can be empty once the entire span has been deleted.
+		if keyLen == 0 {
+			// The request was not processed; the resume span key >= first seen key.
+			require.LessOrEqual(t, spans[i][0], string(res.ResumeSpan.Key), "ResumeSpan.Key")
 		} else {
-			// The request was not processed; the resume span key <= first seen key.
-			if key, expKey := string(res.ResumeSpan.Key), expResults[i][0]; key > expKey {
-				t.Errorf("expected resume key %d, %d to be %q; got %q", i, expCount, expKey, key)
-			}
+			// The next start key is always greater than the last key seen.
+			lastRes := expResults[i][keyLen-1]
+			require.Less(t, lastRes, string(res.ResumeSpan.Key), "ResumeSpan.Key")
 		}
 		// The EndKey is untouched.
-		if key, expKey := string(res.ResumeSpan.EndKey), spans[i][1]; key != expKey {
-			t.Errorf("expected resume endkey %d, %d to be %q; got %q", i, expCount, expKey, key)
-		}
+		require.Equal(t, spans[i][1], string(res.ResumeSpan.EndKey), "ResumeSpan.EndKey")
 	}
 }
 
-// Tests a batch of bounded DelRange() requests.
+// Tests multiple delete range requests across many ranges with multiple bounds.
 func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := startNoSplitMergeServer(t)
@@ -636,63 +771,244 @@ func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// These are the expected results if there is no bound.
-	expResults := [][]string{
+	expResultsWithoutBound := [][]string{
 		{"a1", "a2", "a3", "b1", "b2"},
 		{"c1", "c2", "d1"},
 		{"g1", "g2"},
 	}
-	maxExpCount := 0
-	for _, res := range expResults {
-		maxExpCount += len(res)
-	}
 
 	for bound := 1; bound <= 20; bound++ {
-		// Initialize all keys.
-		for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3", "g1", "g2", "h1"} {
-			if err := db.Put(ctx, key, "value"); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		b := &kv.Batch{}
-		b.Header.MaxSpanRequestKeys = int64(bound)
-		spans := [][]string{{"a", "c"}, {"c", "f"}, {"g", "h"}}
-		for _, span := range spans {
-			b.DelRange(span[0], span[1], true /* returnKeys */)
-		}
-		if err := db.Run(ctx, b); err != nil {
-			t.Fatal(err)
-		}
-
-		if len(expResults) != len(b.Results) {
-			t.Fatalf("bound: %d, only got %d results, wanted %d", bound, len(expResults), len(b.Results))
-		}
-		expCount := maxExpCount
-		if bound < maxExpCount {
-			expCount = bound
-		}
-		rem := expCount
-		for i, res := range b.Results {
-			// Verify that the KeyValue slice contains the given keys.
-			rem -= len(res.Keys)
-			for j, key := range res.Keys {
-				if expKey := expResults[i][j]; string(key) != expKey {
-					t.Errorf("expected scan key %d, %d to be %q; got %q", i, j, expKey, key)
+		t.Run(fmt.Sprintf("bound=%d", bound), func(t *testing.T) {
+			for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3", "g1", "g2", "h1"} {
+				if err := db.Put(ctx, key, "value"); err != nil {
+					t.Fatal(err)
 				}
 			}
-		}
-		if rem != 0 {
-			t.Errorf("expected %d keys, got %d", bound, expCount-rem)
-		}
-		checkResumeSpanDelRangeResults(t, spans, b.Results, expResults, expCount)
-	}
 
+			b := &kv.Batch{}
+			b.Header.MaxSpanRequestKeys = int64(bound)
+			spans := [][]string{{"a", "c"}, {"c", "e"}, {"g", "h"}}
+			for _, span := range spans {
+				b.DelRange(span[0], span[1], true /* returnKeys */)
+			}
+			if err := db.Run(ctx, b); err != nil {
+				t.Fatal(err)
+			}
+
+			require.Equal(t, len(expResultsWithoutBound), len(b.Results))
+
+			expResults := make([][]string, len(expResultsWithoutBound))
+			expSatisfied := make(map[int]struct{})
+			var count int
+		Loop:
+			for i, expRes := range expResultsWithoutBound {
+				for _, key := range expRes {
+					if count == bound {
+						break Loop
+					}
+					expResults[i] = append(expResults[i], key)
+					count++
+				}
+				// NB: only works because requests are sorted and non-overlapping.
+				expSatisfied[i] = struct{}{}
+			}
+
+			checkDelRangeResults(t, spans, b.Results, expResults, expSatisfied)
+		})
+	}
 }
 
-// Test that a bounded DelRange() request that gets terminated at a range
-// boundary uses the range boundary as the start key in the response
-// ResumeSpan.
+// TestMultiRangeBoundedBatchScanPartialResponses runs multiple delete range
+// requests either out-of-order or over overlapping key spans and shows how the
+// batch responses can contain partial responses.
+func TestMultiRangeBoundedBatchDelRangePartialResponses(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _ := startNoSplitMergeServer(t)
+	ctx := context.TODO()
+	defer s.Stopper().Stop(ctx)
+
+	db := s.DB()
+	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		bound        int64
+		spans        [][]string
+		expResults   [][]string
+		expSatisfied []int
+	}{
+		{
+			name:  "unsorted, non-overlapping, neither satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "d"}, {"a", "b1"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+		},
+		{
+			name:  "unsorted, non-overlapping, first satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "c"}, {"a", "b1"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "unsorted, non-overlapping, second satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "d"}, {"a", "b"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "unsorted, non-overlapping, both satisfied",
+			bound: 6,
+			spans: [][]string{
+				{"b1", "c"}, {"a", "b"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			// NOTE: the first request will have already deleted the keys, so
+			// the second request has no keys to delete.
+			name:  "sorted, overlapping, neither satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "d"}, {"b", "g"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3", "c1"}, {},
+			},
+		},
+		{
+			name:  "sorted, overlapping, first satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "c"}, {"b", "g"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"c1"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "sorted, overlapping, second satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "d"}, {"b", "c"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3", "c1"}, {},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "sorted, overlapping, both satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"a", "c"}, {"b", "c"},
+			},
+			expResults: [][]string{
+				{"a1", "a2", "a3", "b1", "b2", "b3"}, {},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			name:  "unsorted, overlapping, neither satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "g"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3", "c1"}, {"a1", "a2", "a3"},
+			},
+		},
+		{
+			name:  "unsorted, overlapping, first satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "c"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "c1"},
+			},
+			expSatisfied: []int{0},
+		},
+		{
+			name:  "unsorted, overlapping, second satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "g"}, {"a", "b2"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3", "c1"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{1},
+		},
+		{
+			name:  "unsorted, overlapping, both satisfied",
+			bound: 7,
+			spans: [][]string{
+				{"b", "c"}, {"a", "b2"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
+			},
+			expSatisfied: []int{0, 1},
+		},
+		{
+			name:  "unsorted, overlapping, unreached",
+			bound: 6,
+			spans: [][]string{
+				{"b", "g"}, {"c", "f"}, {"a", "d"},
+			},
+			expResults: [][]string{
+				{"b1", "b2", "b3"}, {}, {"a1", "a2", "a3"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Re-write all keys before each subtest.
+			for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3", "d1", "d2", "d3"} {
+				if err := db.Put(ctx, key, "value"); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			b := &kv.Batch{}
+			b.Header.MaxSpanRequestKeys = tc.bound
+			for _, span := range tc.spans {
+				b.DelRange(span[0], span[1], true /* returnKeys */)
+			}
+			if err := db.Run(ctx, b); err != nil {
+				t.Fatal(err)
+			}
+
+			expSatisfied := make(map[int]struct{})
+			for _, exp := range tc.expSatisfied {
+				expSatisfied[exp] = struct{}{}
+			}
+			checkDelRangeResults(t, tc.spans, b.Results, tc.expResults, expSatisfied)
+		})
+	}
+}
+
+// Test that a bounded range delete request that gets terminated at a range
+// boundary uses the range boundary as the start key in the response ResumeSpan.
 func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := startNoSplitMergeServer(t)
@@ -703,7 +1019,6 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 	if err := setupMultipleRanges(ctx, db, "a", "b"); err != nil {
 		t.Fatal(err)
 	}
-	// Check that a
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2"} {
 		if err := db.Put(ctx, key, "value"); err != nil {
 			t.Fatal(err)
@@ -734,71 +1049,6 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 	}
 	if string(b.Results[0].ResumeSpan.Key) != "b2" || string(b.Results[0].ResumeSpan.EndKey) != "c" {
 		t.Fatalf("received ResumeSpan %+v", b.Results[0].ResumeSpan)
-	}
-}
-
-// Tests a batch of bounded DelRange() requests deleting key ranges that
-// overlap.
-func TestMultiRangeBoundedBatchDelRangeOverlappingKeys(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, _ := startNoSplitMergeServer(t)
-	ctx := context.TODO()
-	defer s.Stopper().Stop(ctx)
-
-	db := s.DB()
-	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f"); err != nil {
-		t.Fatal(err)
-	}
-
-	expResults := [][]string{
-		{"a1", "a2", "a3", "b1", "b2"},
-		{"b3", "c1", "c2"},
-		{"d1", "f1", "f2"},
-		{"f3"},
-	}
-	maxExpCount := 0
-	for _, res := range expResults {
-		maxExpCount += len(res)
-	}
-
-	for bound := 1; bound <= 20; bound++ {
-		for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "d1", "f1", "f2", "f3"} {
-			if err := db.Put(ctx, key, "value"); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		b := &kv.Batch{}
-		b.Header.MaxSpanRequestKeys = int64(bound)
-		spans := [][]string{{"a", "b3"}, {"b", "d"}, {"c", "f2a"}, {"f1a", "g"}}
-		for _, span := range spans {
-			b.DelRange(span[0], span[1], true /* returnKeys */)
-		}
-		if err := db.Run(ctx, b); err != nil {
-			t.Fatal(err)
-		}
-
-		if len(expResults) != len(b.Results) {
-			t.Fatalf("bound: %d, only got %d results, wanted %d", bound, len(expResults), len(b.Results))
-		}
-		expCount := maxExpCount
-		if bound < maxExpCount {
-			expCount = bound
-		}
-		rem := expCount
-		for i, res := range b.Results {
-			// Verify that the KeyValue slice contains the given keys.
-			rem -= len(res.Keys)
-			for j, key := range res.Keys {
-				if expKey := expResults[i][j]; string(key) != expKey {
-					t.Errorf("expected scan key %d, %d to be %q; got %q", i, j, expKey, key)
-				}
-			}
-		}
-		if rem != 0 {
-			t.Errorf("expected %d keys, got %d", bound, expCount-rem)
-		}
-		checkResumeSpanDelRangeResults(t, spans, b.Results, expResults, expCount)
 	}
 }
 

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -249,6 +249,21 @@ type combinable interface {
 	combine(combinable) error
 }
 
+// CombineResponses attempts to combine the two provided responses. If both of
+// the responses are combinable, they will be combined. If neither are
+// combinable, the function is a no-op and returns a nil error. If one of the
+// responses is combinable and the other isn't, the function returns an error.
+func CombineResponses(left, right Response) error {
+	cLeft, lOK := left.(combinable)
+	cRight, rOK := right.(combinable)
+	if lOK && rOK {
+		return cLeft.combine(cRight)
+	} else if lOK != rOK {
+		return errors.Errorf("can not combine %T and %T", left, right)
+	}
+	return nil
+}
+
 // combine is used by range-spanning Response types (e.g. Scan or DeleteRange)
 // to merge their headers.
 func (rh *ResponseHeader) combine(otherRH ResponseHeader) error {

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -72,7 +72,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -100,7 +100,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{1}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{1}
 }
 
 type ChecksumMode int32
@@ -147,7 +147,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{2}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -178,7 +178,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{3}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{3}
 }
 
 type ExternalStorageProvider int32
@@ -216,7 +216,7 @@ func (x ExternalStorageProvider) String() string {
 	return proto.EnumName(ExternalStorageProvider_name, int32(x))
 }
 func (ExternalStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{4}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{4}
 }
 
 type MVCCFilter int32
@@ -239,7 +239,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{5}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -265,7 +265,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{2, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{2, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -307,7 +307,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{26, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{26, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -321,7 +321,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -364,7 +364,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{1}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -431,7 +431,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{2}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -465,7 +465,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{3}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -503,7 +503,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{4}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -546,7 +546,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{5}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -580,7 +580,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{6}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -634,7 +634,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{7}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -669,7 +669,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{8}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -715,7 +715,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{9}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -749,7 +749,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{10}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -789,7 +789,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{11}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -826,7 +826,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{12}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -860,7 +860,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{13}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -894,7 +894,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{14}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -946,7 +946,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{15}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -983,7 +983,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{16}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1030,7 +1030,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{17}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1064,7 +1064,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{18}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1105,7 +1105,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{19}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{19}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1139,7 +1139,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{20}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{20}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1190,7 +1190,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{21}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{21}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1237,7 +1237,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{22}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{22}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1288,7 +1288,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{23}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{23}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1335,7 +1335,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{24}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{24}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1388,7 +1388,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{25}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{25}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1425,7 +1425,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{26}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{26}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1469,7 +1469,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{26, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{26, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1517,7 +1517,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{27}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{27}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1553,7 +1553,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{28}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{28}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1650,7 +1650,7 @@ func (m *EndTxnRequest) Reset()         { *m = EndTxnRequest{} }
 func (m *EndTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTxnRequest) ProtoMessage()    {}
 func (*EndTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{29}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{29}
 }
 func (m *EndTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1696,7 +1696,7 @@ func (m *EndTxnResponse) Reset()         { *m = EndTxnResponse{} }
 func (m *EndTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTxnResponse) ProtoMessage()    {}
 func (*EndTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{30}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{30}
 }
 func (m *EndTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1757,7 +1757,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{31}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{31}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1792,7 +1792,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{32}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{32}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1831,7 +1831,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{33}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{33}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1866,7 +1866,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{34}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{34}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1909,7 +1909,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{35}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{35}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1944,7 +1944,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{36}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{36}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1982,7 +1982,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{37}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{37}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2015,7 +2015,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{38}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{38}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2050,7 +2050,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{39}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{39}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2108,7 +2108,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{40}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{40}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2143,7 +2143,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{41}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{41}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2180,7 +2180,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{42}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{42}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2213,7 +2213,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{43}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{43}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2252,7 +2252,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{44}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{44}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2289,7 +2289,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{45}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{45}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2327,7 +2327,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{46}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{46}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2361,7 +2361,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{46, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{46, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2395,7 +2395,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{47}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{47}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2464,7 +2464,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{48}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{48}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2507,7 +2507,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{49}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{49}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2554,7 +2554,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{50}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{50}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2590,7 +2590,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{51}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{51}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2634,7 +2634,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{52}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{52}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2673,7 +2673,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{53}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{53}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2733,7 +2733,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{54}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{54}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2769,7 +2769,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{55}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{55}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2815,7 +2815,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{56}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{56}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2850,7 +2850,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{57}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{57}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2900,7 +2900,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{58}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{58}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2935,7 +2935,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{59}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{59}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2972,7 +2972,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{60}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{60}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3006,7 +3006,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{61}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{61}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3051,7 +3051,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{62}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{62}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3085,7 +3085,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{63}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{63}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3129,7 +3129,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{64}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{64}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3178,7 +3178,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{65}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{65}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3215,7 +3215,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{66}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{66}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3252,7 +3252,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{67}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{67}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3287,7 +3287,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{68}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{68}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3342,7 +3342,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{69}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{69}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3379,7 +3379,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{70}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{70}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3418,7 +3418,7 @@ func (m *ExternalStorage) Reset()         { *m = ExternalStorage{} }
 func (m *ExternalStorage) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage) ProtoMessage()    {}
 func (*ExternalStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71}
 }
 func (m *ExternalStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3452,7 +3452,7 @@ func (m *ExternalStorage_LocalFilePath) Reset()         { *m = ExternalStorage_L
 func (m *ExternalStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExternalStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 0}
 }
 func (m *ExternalStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3485,7 +3485,7 @@ func (m *ExternalStorage_Http) Reset()         { *m = ExternalStorage_Http{} }
 func (m *ExternalStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Http) ProtoMessage()    {}
 func (*ExternalStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 1}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 1}
 }
 func (m *ExternalStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3525,7 +3525,7 @@ func (m *ExternalStorage_S3) Reset()         { *m = ExternalStorage_S3{} }
 func (m *ExternalStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_S3) ProtoMessage()    {}
 func (*ExternalStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 2}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 2}
 }
 func (m *ExternalStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3564,7 +3564,7 @@ func (m *ExternalStorage_GCS) Reset()         { *m = ExternalStorage_GCS{} }
 func (m *ExternalStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_GCS) ProtoMessage()    {}
 func (*ExternalStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 3}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 3}
 }
 func (m *ExternalStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3600,7 +3600,7 @@ func (m *ExternalStorage_Azure) Reset()         { *m = ExternalStorage_Azure{} }
 func (m *ExternalStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Azure) ProtoMessage()    {}
 func (*ExternalStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 4}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 4}
 }
 func (m *ExternalStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3639,7 +3639,7 @@ func (m *ExternalStorage_Workload) Reset()         { *m = ExternalStorage_Worklo
 func (m *ExternalStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Workload) ProtoMessage()    {}
 func (*ExternalStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{71, 5}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 5}
 }
 func (m *ExternalStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3679,7 +3679,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{72}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{72}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3713,7 +3713,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{73}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{73}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3747,7 +3747,7 @@ func (m *FileEncryptionOptions) Reset()         { *m = FileEncryptionOptions{} }
 func (m *FileEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*FileEncryptionOptions) ProtoMessage()    {}
 func (*FileEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{74}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{74}
 }
 func (m *FileEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3817,7 +3817,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{75}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{75}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3869,7 +3869,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{76}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{76}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3905,7 +3905,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{77}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{77}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3945,7 +3945,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{77, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{77, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3996,7 +3996,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{78}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{78}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4031,7 +4031,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{78, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{78, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4067,7 +4067,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{78, 1}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{78, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4102,7 +4102,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{79}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{79}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4140,7 +4140,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{80}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{80}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4175,7 +4175,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{81}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{81}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4208,7 +4208,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{81, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{81, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4253,7 +4253,7 @@ func (m *AdminVerifyProtectedTimestampRequest) Reset()         { *m = AdminVerif
 func (m *AdminVerifyProtectedTimestampRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampRequest) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{82}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{82}
 }
 func (m *AdminVerifyProtectedTimestampRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4291,7 +4291,7 @@ func (m *AdminVerifyProtectedTimestampResponse) Reset()         { *m = AdminVeri
 func (m *AdminVerifyProtectedTimestampResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampResponse) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{83}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{83}
 }
 func (m *AdminVerifyProtectedTimestampResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4344,7 +4344,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{84}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{84}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4378,7 +4378,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{85}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{85}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4422,7 +4422,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{86}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{86}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4456,7 +4456,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{87}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{87}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4495,7 +4495,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{88}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{88}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4529,7 +4529,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{89}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{89}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4578,7 +4578,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{90}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{90}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4627,7 +4627,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{91}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{91}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4662,7 +4662,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{92}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{92}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4701,7 +4701,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{93}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{93}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4784,7 +4784,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{94}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{94}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6234,7 +6234,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{95}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{95}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7638,22 +7638,79 @@ type Header struct {
 	// operations. The default is CONSISTENT. This value is ignored for
 	// write operations.
 	ReadConsistency ReadConsistencyType `protobuf:"varint,6,opt,name=read_consistency,json=readConsistency,proto3,enum=cockroach.roachpb.ReadConsistencyType" json:"read_consistency,omitempty"`
-	// If set to a non-zero value, it limits the total number of keys touched
-	// by span requests in the batch. Span requests are requests like
-	// Scan, ReverseScan, and DelRange. If two requests touch the
-	// same key it is double counted.
+	// If set to a non-zero value, the total number of keys touched by requests in
+	// the batch is limited. A resume span will be provided on the response of the
+	// requests that were not able to run to completion before the limit was
+	// reached.
 	//
-	// If a batch limit is used with Scan requests, the spans for the requests
-	// must be non-overlapping and in increasing order.
+	// Overlapping requests
 	//
-	// If a batch limit is used with ReverseScan requests, the spans for the
-	// requests must be non-overlapping and in decreasing order.
+	// The spans accessed by the requests are allowed to overlap. However, if any
+	// requests overlap, the caller must be prepared to handle *multiple* partial
+	// responses in the corresponding BatchResponse. If no requests overlap, then
+	// only up to one request will return a partial result. Additionally, if two
+	// requests touch the same key, it is double counted towards the key limit.
+	//
+	// Unordered requests
+	//
+	// The spans accessed by requests do not need to be in sorted order. However,
+	// if the requests are not in sorted order (e.g. increasing key order for
+	// Scans and other forward requests, decreasing key order for ReverseScans),
+	// the caller must be prepared to handle empty responses interleaved with full
+	// responses and one (or more, see "Overlapping requests") partial response
+	// in the corresponding BatchResponse. If the requests are in sorted order,
+	// the caller can expect to receive a group of full responses, one (or more)
+	// partial responses, and a group of empty responses.
+	//
+	// Pagination of requests
+	//
+	// As discussed above, overlapping requests or unordered requests in batches
+	// with a limit can lead to response batches with multiple partial responses.
+	// In practice, this is because DistSender paginates request evaluation over
+	// ranges in increasing key order (decreasing for reverse batches). As ranges
+	// are iterated over in order, all requests that target a given range are sent
+	// to it, regardless of their position in the batch. Once split and delivered
+	// to a range, the applicable requests are executed in-full according to their
+	// order in the batch.
+	//
+	// This behavior makes it difficult to make assumptions about the resume spans
+	// of individual responses in batches that contain either overlapping requests
+	// or unordered requests. As such, clients should not make assumptions about
+	// resume spans and should instead inspect the result for every request in the
+	// batch if if cannot guarantee that the batch is ordered with no overlapping
+	// requests.
+	//
+	// Supported requests
+	//
+	// If a limit is provided, the batch can contain only the following range
+	// request types:
+	// - ScanRequest
+	// - ReverseScanRequest
+	// - DeleteRangeRequest
+	// - RevertRangeRequest
+	// - ResolveIntentRangeRequest
+	//
+	// The following two requests types are also allowed in the batch, although
+	// the limit has no effect on them:
+	// - QueryIntentRequest
+	// - EndTxnRequest
+	//
+	// Forward requests and reverse requests cannot be mixed in the same batch if
+	// a limit is set. There doesn't seem to be a fundemental reason for this
+	// restriction, but a batch that mixed forward and reverse requests would be
+	// impossible to order, so it would unavoidably have to deal with the added
+	// complications discussed in "Unordered requests". For now, that's a good
+	// enough reason to disallow such batches.
 	MaxSpanRequestKeys int64 `protobuf:"varint,8,opt,name=max_span_request_keys,json=maxSpanRequestKeys,proto3" json:"max_span_request_keys,omitempty"`
 	// If set to a non-zero value, sets a target (in bytes) for how large the
 	// response may grow. This is only supported for (forward and reverse) scans
 	// and limits the number of rows scanned (and returned). The target will be
 	// overshot; in particular, at least one row will always be returned (assuming
 	// one exists). A suitable resume span will be returned.
+	//
+	// The semantics around overlapping requests, unordered requests, and
+	// supported requests from max_span_request_keys apply to the target_bytes
+	// option as well.
 	TargetBytes int64 `protobuf:"varint,15,opt,name=target_bytes,json=targetBytes,proto3" json:"target_bytes,omitempty"`
 	// If set, all of the spans in the batch are distinct. Note that the
 	// calculation of distinct spans does not include intents in an
@@ -7692,7 +7749,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{96}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{96}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7728,7 +7785,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{97}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{97}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7765,7 +7822,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{98}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{98}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7823,7 +7880,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{98, 0}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{98, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7862,7 +7919,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{99}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{99}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7903,7 +7960,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{100}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{100}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7944,7 +8001,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{101}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{101}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7981,7 +8038,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{102}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{102}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8018,7 +8075,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_1c19b4ddaf602363, []int{103}
+	return fileDescriptor_api_c072a2b9f1c6804f, []int{103}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -37432,9 +37489,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_1c19b4ddaf602363) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_c072a2b9f1c6804f) }
 
-var fileDescriptor_api_1c19b4ddaf602363 = []byte{
+var fileDescriptor_api_c072a2b9f1c6804f = []byte{
 	// 7362 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x7d, 0x5d, 0x6c, 0x23, 0xc9,
 	0x75, 0xae, 0x9a, 0xa4, 0x24, 0xf2, 0x90, 0xa2, 0x5a, 0xa5, 0xf9, 0xe1, 0x68, 0x66, 0x25, 0x0d,

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -72,7 +72,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -100,7 +100,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{1}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{1}
 }
 
 type ChecksumMode int32
@@ -147,7 +147,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{2}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -178,7 +178,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{3}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{3}
 }
 
 type ExternalStorageProvider int32
@@ -216,7 +216,7 @@ func (x ExternalStorageProvider) String() string {
 	return proto.EnumName(ExternalStorageProvider_name, int32(x))
 }
 func (ExternalStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{4}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{4}
 }
 
 type MVCCFilter int32
@@ -239,7 +239,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{5}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -265,7 +265,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{2, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{2, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -307,7 +307,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{26, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{26, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -321,7 +321,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -364,7 +364,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{1}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -431,7 +431,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{2}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -465,7 +465,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{3}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -503,7 +503,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{4}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -546,7 +546,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{5}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -580,7 +580,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{6}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -634,7 +634,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{7}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -669,7 +669,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{8}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -715,7 +715,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{9}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -749,7 +749,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{10}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -789,7 +789,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{11}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -826,7 +826,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{12}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -860,7 +860,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{13}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -894,7 +894,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{14}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -946,7 +946,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{15}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -983,7 +983,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{16}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1030,7 +1030,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{17}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1064,7 +1064,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{18}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1105,7 +1105,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{19}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{19}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1139,7 +1139,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{20}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{20}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1190,7 +1190,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{21}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{21}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1237,7 +1237,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{22}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{22}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1288,7 +1288,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{23}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{23}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1335,7 +1335,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{24}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{24}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1388,7 +1388,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{25}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{25}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1425,7 +1425,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{26}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{26}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1469,7 +1469,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{26, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{26, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1517,7 +1517,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{27}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{27}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1553,7 +1553,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{28}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{28}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1650,7 +1650,7 @@ func (m *EndTxnRequest) Reset()         { *m = EndTxnRequest{} }
 func (m *EndTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTxnRequest) ProtoMessage()    {}
 func (*EndTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{29}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{29}
 }
 func (m *EndTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1696,7 +1696,7 @@ func (m *EndTxnResponse) Reset()         { *m = EndTxnResponse{} }
 func (m *EndTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTxnResponse) ProtoMessage()    {}
 func (*EndTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{30}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{30}
 }
 func (m *EndTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1757,7 +1757,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{31}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{31}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1792,7 +1792,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{32}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{32}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1831,7 +1831,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{33}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{33}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1866,7 +1866,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{34}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{34}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1909,7 +1909,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{35}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{35}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1944,7 +1944,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{36}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{36}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1982,7 +1982,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{37}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{37}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2015,7 +2015,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{38}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{38}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2050,7 +2050,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{39}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{39}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2108,7 +2108,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{40}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{40}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2143,7 +2143,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{41}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{41}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2180,7 +2180,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{42}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{42}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2213,7 +2213,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{43}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{43}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2252,7 +2252,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{44}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{44}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2289,7 +2289,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{45}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{45}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2327,7 +2327,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{46}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{46}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2361,7 +2361,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{46, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{46, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2395,7 +2395,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{47}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{47}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2464,7 +2464,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{48}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{48}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2507,7 +2507,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{49}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{49}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2554,7 +2554,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{50}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{50}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2590,7 +2590,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{51}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{51}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2634,7 +2634,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{52}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{52}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2673,7 +2673,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{53}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{53}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2733,7 +2733,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{54}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{54}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2769,7 +2769,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{55}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{55}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2815,7 +2815,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{56}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{56}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2850,7 +2850,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{57}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{57}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2900,7 +2900,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{58}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{58}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2935,7 +2935,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{59}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{59}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2972,7 +2972,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{60}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{60}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3006,7 +3006,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{61}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{61}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3051,7 +3051,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{62}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{62}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3085,7 +3085,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{63}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{63}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3129,7 +3129,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{64}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{64}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3178,7 +3178,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{65}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{65}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3215,7 +3215,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{66}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{66}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3252,7 +3252,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{67}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{67}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3287,7 +3287,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{68}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{68}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3342,7 +3342,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{69}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{69}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3379,7 +3379,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{70}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{70}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3418,7 +3418,7 @@ func (m *ExternalStorage) Reset()         { *m = ExternalStorage{} }
 func (m *ExternalStorage) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage) ProtoMessage()    {}
 func (*ExternalStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71}
 }
 func (m *ExternalStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3452,7 +3452,7 @@ func (m *ExternalStorage_LocalFilePath) Reset()         { *m = ExternalStorage_L
 func (m *ExternalStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExternalStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 0}
 }
 func (m *ExternalStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3485,7 +3485,7 @@ func (m *ExternalStorage_Http) Reset()         { *m = ExternalStorage_Http{} }
 func (m *ExternalStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Http) ProtoMessage()    {}
 func (*ExternalStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 1}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 1}
 }
 func (m *ExternalStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3525,7 +3525,7 @@ func (m *ExternalStorage_S3) Reset()         { *m = ExternalStorage_S3{} }
 func (m *ExternalStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_S3) ProtoMessage()    {}
 func (*ExternalStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 2}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 2}
 }
 func (m *ExternalStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3564,7 +3564,7 @@ func (m *ExternalStorage_GCS) Reset()         { *m = ExternalStorage_GCS{} }
 func (m *ExternalStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_GCS) ProtoMessage()    {}
 func (*ExternalStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 3}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 3}
 }
 func (m *ExternalStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3600,7 +3600,7 @@ func (m *ExternalStorage_Azure) Reset()         { *m = ExternalStorage_Azure{} }
 func (m *ExternalStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Azure) ProtoMessage()    {}
 func (*ExternalStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 4}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 4}
 }
 func (m *ExternalStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3639,7 +3639,7 @@ func (m *ExternalStorage_Workload) Reset()         { *m = ExternalStorage_Worklo
 func (m *ExternalStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Workload) ProtoMessage()    {}
 func (*ExternalStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{71, 5}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{71, 5}
 }
 func (m *ExternalStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3679,7 +3679,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{72}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{72}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3713,7 +3713,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{73}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{73}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3747,7 +3747,7 @@ func (m *FileEncryptionOptions) Reset()         { *m = FileEncryptionOptions{} }
 func (m *FileEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*FileEncryptionOptions) ProtoMessage()    {}
 func (*FileEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{74}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{74}
 }
 func (m *FileEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3817,7 +3817,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{75}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{75}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3869,7 +3869,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{76}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{76}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3905,7 +3905,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{77}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{77}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3945,7 +3945,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{77, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{77, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3996,7 +3996,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{78}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{78}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4031,7 +4031,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{78, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{78, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4067,7 +4067,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{78, 1}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{78, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4102,7 +4102,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{79}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{79}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4140,7 +4140,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{80}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{80}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4175,7 +4175,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{81}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{81}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4208,7 +4208,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{81, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{81, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4253,7 +4253,7 @@ func (m *AdminVerifyProtectedTimestampRequest) Reset()         { *m = AdminVerif
 func (m *AdminVerifyProtectedTimestampRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampRequest) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{82}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{82}
 }
 func (m *AdminVerifyProtectedTimestampRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4291,7 +4291,7 @@ func (m *AdminVerifyProtectedTimestampResponse) Reset()         { *m = AdminVeri
 func (m *AdminVerifyProtectedTimestampResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampResponse) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{83}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{83}
 }
 func (m *AdminVerifyProtectedTimestampResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4344,7 +4344,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{84}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{84}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4378,7 +4378,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{85}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{85}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4422,7 +4422,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{86}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{86}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4456,7 +4456,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{87}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{87}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4495,7 +4495,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{88}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{88}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4529,7 +4529,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{89}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{89}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4578,7 +4578,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{90}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{90}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4627,7 +4627,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{91}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{91}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4662,7 +4662,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{92}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{92}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4701,7 +4701,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{93}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{93}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4784,7 +4784,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{94}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{94}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6234,7 +6234,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{95}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{95}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7696,7 +7696,7 @@ type Header struct {
 	// - EndTxnRequest
 	//
 	// Forward requests and reverse requests cannot be mixed in the same batch if
-	// a limit is set. There doesn't seem to be a fundemental reason for this
+	// a limit is set. There doesn't seem to be a fundamental reason for this
 	// restriction, but a batch that mixed forward and reverse requests would be
 	// impossible to order, so it would unavoidably have to deal with the added
 	// complications discussed in "Unordered requests". For now, that's a good
@@ -7749,7 +7749,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{96}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{96}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7785,7 +7785,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{97}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{97}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7822,7 +7822,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{98}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{98}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7880,7 +7880,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{98, 0}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{98, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7919,7 +7919,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{99}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{99}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7960,7 +7960,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{100}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{100}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8001,7 +8001,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{101}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{101}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8038,7 +8038,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{102}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{102}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8075,7 +8075,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_c072a2b9f1c6804f, []int{103}
+	return fileDescriptor_api_a9d9e49af26caba8, []int{103}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -37489,9 +37489,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_c072a2b9f1c6804f) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_a9d9e49af26caba8) }
 
-var fileDescriptor_api_c072a2b9f1c6804f = []byte{
+var fileDescriptor_api_a9d9e49af26caba8 = []byte{
 	// 7362 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x7d, 0x5d, 0x6c, 0x23, 0xc9,
 	0x75, 0xae, 0x9a, 0xa4, 0x24, 0xf2, 0x90, 0xa2, 0x5a, 0xa5, 0xf9, 0xe1, 0x68, 0x66, 0x25, 0x0d,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1823,22 +1823,79 @@ message Header {
   // operations. The default is CONSISTENT. This value is ignored for
   // write operations.
   ReadConsistencyType read_consistency = 6;
-  // If set to a non-zero value, it limits the total number of keys touched
-  // by span requests in the batch. Span requests are requests like
-  // Scan, ReverseScan, and DelRange. If two requests touch the
-  // same key it is double counted.
+  // If set to a non-zero value, the total number of keys touched by requests in
+  // the batch is limited. A resume span will be provided on the response of the
+  // requests that were not able to run to completion before the limit was
+  // reached.
   //
-  // If a batch limit is used with Scan requests, the spans for the requests
-  // must be non-overlapping and in increasing order.
+  // Overlapping requests
   //
-  // If a batch limit is used with ReverseScan requests, the spans for the
-  // requests must be non-overlapping and in decreasing order.
+  // The spans accessed by the requests are allowed to overlap. However, if any
+  // requests overlap, the caller must be prepared to handle *multiple* partial
+  // responses in the corresponding BatchResponse. If no requests overlap, then
+  // only up to one request will return a partial result. Additionally, if two
+  // requests touch the same key, it is double counted towards the key limit.
+  //
+  // Unordered requests
+  //
+  // The spans accessed by requests do not need to be in sorted order. However,
+  // if the requests are not in sorted order (e.g. increasing key order for
+  // Scans and other forward requests, decreasing key order for ReverseScans),
+  // the caller must be prepared to handle empty responses interleaved with full
+  // responses and one (or more, see "Overlapping requests") partial response
+  // in the corresponding BatchResponse. If the requests are in sorted order,
+  // the caller can expect to receive a group of full responses, one (or more)
+  // partial responses, and a group of empty responses.
+  //
+  // Pagination of requests
+  //
+  // As discussed above, overlapping requests or unordered requests in batches
+  // with a limit can lead to response batches with multiple partial responses.
+  // In practice, this is because DistSender paginates request evaluation over
+  // ranges in increasing key order (decreasing for reverse batches). As ranges
+  // are iterated over in order, all requests that target a given range are sent
+  // to it, regardless of their position in the batch. Once split and delivered
+  // to a range, the applicable requests are executed in-full according to their
+  // order in the batch.
+  //
+  // This behavior makes it difficult to make assumptions about the resume spans
+  // of individual responses in batches that contain either overlapping requests
+  // or unordered requests. As such, clients should not make assumptions about
+  // resume spans and should instead inspect the result for every request in the
+  // batch if if cannot guarantee that the batch is ordered with no overlapping
+  // requests.
+  //
+  // Supported requests
+  //
+  // If a limit is provided, the batch can contain only the following range
+  // request types:
+  // - ScanRequest
+  // - ReverseScanRequest
+  // - DeleteRangeRequest
+  // - RevertRangeRequest
+  // - ResolveIntentRangeRequest
+  //
+  // The following two requests types are also allowed in the batch, although
+  // the limit has no effect on them:
+  // - QueryIntentRequest
+  // - EndTxnRequest
+  //
+  // Forward requests and reverse requests cannot be mixed in the same batch if
+  // a limit is set. There doesn't seem to be a fundemental reason for this
+  // restriction, but a batch that mixed forward and reverse requests would be
+  // impossible to order, so it would unavoidably have to deal with the added
+  // complications discussed in "Unordered requests". For now, that's a good
+  // enough reason to disallow such batches.
   int64 max_span_request_keys = 8;
   // If set to a non-zero value, sets a target (in bytes) for how large the
   // response may grow. This is only supported for (forward and reverse) scans
   // and limits the number of rows scanned (and returned). The target will be
   // overshot; in particular, at least one row will always be returned (assuming
   // one exists). A suitable resume span will be returned.
+  //
+  // The semantics around overlapping requests, unordered requests, and
+  // supported requests from max_span_request_keys apply to the target_bytes
+  // option as well.
   int64 target_bytes = 15;
   // If set, all of the spans in the batch are distinct. Note that the
   // calculation of distinct spans does not include intents in an

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1881,7 +1881,7 @@ message Header {
   // - EndTxnRequest
   //
   // Forward requests and reverse requests cannot be mixed in the same batch if
-  // a limit is set. There doesn't seem to be a fundemental reason for this
+  // a limit is set. There doesn't seem to be a fundamental reason for this
   // restriction, but a batch that mixed forward and reverse requests would be
   // impossible to order, so it would unavoidably have to deal with the added
   // complications discussed in "Unordered requests". For now, that's a good

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -430,15 +430,8 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse, positions []int) err
 		}
 		valLeft := br.Responses[pos].GetInner()
 		valRight := otherBatch.Responses[i].GetInner()
-		cValLeft, lOK := valLeft.(combinable)
-		cValRight, rOK := valRight.(combinable)
-		if lOK && rOK {
-			if err := cValLeft.combine(cValRight); err != nil {
-				return err
-			}
-			continue
-		} else if lOK != rOK {
-			return errors.Errorf("can not combine %T and %T", valLeft, valRight)
+		if err := CombineResponses(valLeft, valRight); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -17,33 +17,35 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func assertStmt(t *testing.T, cmd Command, exp string) {
+	t.Helper()
 	stmt, ok := cmd.(ExecStmt)
 	if !ok {
-		t.Fatalf("%s: expected ExecStmt, got %T", testutils.Caller(1), cmd)
+		t.Fatalf("expected ExecStmt, got %T", cmd)
 	}
 	if stmt.AST.String() != exp {
-		t.Fatalf("%s: expected statement %s, got %s", testutils.Caller(1), exp, stmt)
+		t.Fatalf("expected statement %s, got %s", exp, stmt)
 	}
 }
 
 func assertPrepareStmt(t *testing.T, cmd Command, expName string) {
+	t.Helper()
 	ps, ok := cmd.(PrepareStmt)
 	if !ok {
-		t.Fatalf("%s: expected PrepareStmt, got %T", testutils.Caller(1), cmd)
+		t.Fatalf("expected PrepareStmt, got %T", cmd)
 	}
 	if ps.Name != expName {
-		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, ps.Name)
+		t.Fatalf("expected name %s, got %s", expName, ps.Name)
 	}
 }
 
 func mustPush(ctx context.Context, t *testing.T, buf *StmtBuf, cmd Command) {
+	t.Helper()
 	if err := buf.Push(ctx, cmd); err != nil {
-		t.Fatalf("%s: %s", testutils.Caller(1), err)
+		t.Fatalf("%s", err)
 	}
 }
 

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -385,6 +385,7 @@ const (
 func expectExecStmt(
 	ctx context.Context, t *testing.T, expSQL string, rd *sql.StmtBufReader, c *conn, typ executeType,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -393,18 +394,18 @@ func expectExecStmt(
 
 	es, ok := cmd.(sql.ExecStmt)
 	if !ok {
-		t.Fatalf("%s: expected command ExecStmt, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command ExecStmt, got: %T (%+v)", cmd, cmd)
 	}
 
 	if es.AST.String() != expSQL {
-		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, es.AST.String())
+		t.Fatalf("expected %s, got %s", expSQL, es.AST.String())
 	}
 
 	if es.ParseStart == (time.Time{}) {
-		t.Fatalf("%s: ParseStart not filled in", testutils.Caller(1))
+		t.Fatalf("ParseStart not filled in")
 	}
 	if es.ParseEnd == (time.Time{}) {
-		t.Fatalf("%s: ParseEnd not filled in", testutils.Caller(1))
+		t.Fatalf("ParseEnd not filled in")
 	}
 	if typ == queryStringComplete {
 		if err := finishQuery(execute, c); err != nil {
@@ -420,6 +421,7 @@ func expectExecStmt(
 func expectPrepareStmt(
 	ctx context.Context, t *testing.T, expName string, expSQL string, rd *sql.StmtBufReader, c *conn,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -428,15 +430,15 @@ func expectPrepareStmt(
 
 	pr, ok := cmd.(sql.PrepareStmt)
 	if !ok {
-		t.Fatalf("%s: expected command PrepareStmt, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command PrepareStmt, got: %T (%+v)", cmd, cmd)
 	}
 
 	if pr.Name != expName {
-		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, pr.Name)
+		t.Fatalf("expected name %s, got %s", expName, pr.Name)
 	}
 
 	if pr.AST.String() != expSQL {
-		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, pr.AST.String())
+		t.Fatalf("expected %s, got %s", expSQL, pr.AST.String())
 	}
 
 	if err := finishQuery(prepare, c); err != nil {
@@ -452,6 +454,7 @@ func expectDescribeStmt(
 	rd *sql.StmtBufReader,
 	c *conn,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -460,15 +463,15 @@ func expectDescribeStmt(
 
 	desc, ok := cmd.(sql.DescribeStmt)
 	if !ok {
-		t.Fatalf("%s: expected command DescribeStmt, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command DescribeStmt, got: %T (%+v)", cmd, cmd)
 	}
 
 	if desc.Name != expName {
-		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, desc.Name)
+		t.Fatalf("expected name %s, got %s", expName, desc.Name)
 	}
 
 	if desc.Type != expType {
-		t.Fatalf("%s: expected type %s, got %s", testutils.Caller(1), expType, desc.Type)
+		t.Fatalf("expected type %s, got %s", expType, desc.Type)
 	}
 
 	if err := finishQuery(describe, c); err != nil {
@@ -479,6 +482,7 @@ func expectDescribeStmt(
 func expectBindStmt(
 	ctx context.Context, t *testing.T, expName string, rd *sql.StmtBufReader, c *conn,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -487,11 +491,11 @@ func expectBindStmt(
 
 	bd, ok := cmd.(sql.BindStmt)
 	if !ok {
-		t.Fatalf("%s: expected command BindStmt, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command BindStmt, got: %T (%+v)", cmd, cmd)
 	}
 
 	if bd.PreparedStatementName != expName {
-		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, bd.PreparedStatementName)
+		t.Fatalf("expected name %s, got %s", expName, bd.PreparedStatementName)
 	}
 
 	if err := finishQuery(bind, c); err != nil {
@@ -500,6 +504,7 @@ func expectBindStmt(
 }
 
 func expectSync(ctx context.Context, t *testing.T, rd *sql.StmtBufReader) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -508,13 +513,14 @@ func expectSync(ctx context.Context, t *testing.T, rd *sql.StmtBufReader) {
 
 	_, ok := cmd.(sql.Sync)
 	if !ok {
-		t.Fatalf("%s: expected command Sync, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command Sync, got: %T (%+v)", cmd, cmd)
 	}
 }
 
 func expectExecPortal(
 	ctx context.Context, t *testing.T, expName string, rd *sql.StmtBufReader, c *conn,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -523,11 +529,11 @@ func expectExecPortal(
 
 	ep, ok := cmd.(sql.ExecPortal)
 	if !ok {
-		t.Fatalf("%s: expected command ExecPortal, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command ExecPortal, got: %T (%+v)", cmd, cmd)
 	}
 
 	if ep.Name != expName {
-		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, ep.Name)
+		t.Fatalf("expected name %s, got %s", expName, ep.Name)
 	}
 
 	if err := finishQuery(execPortal, c); err != nil {
@@ -538,6 +544,7 @@ func expectExecPortal(
 func expectSendError(
 	ctx context.Context, t *testing.T, pgErrCode string, rd *sql.StmtBufReader, c *conn,
 ) {
+	t.Helper()
 	cmd, err := rd.CurCmd()
 	if err != nil {
 		t.Fatal(err)
@@ -546,7 +553,7 @@ func expectSendError(
 
 	se, ok := cmd.(sql.SendError)
 	if !ok {
-		t.Fatalf("%s: expected command SendError, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
+		t.Fatalf("expected command SendError, got: %T (%+v)", cmd, cmd)
 	}
 
 	if code := pgerror.GetPGCode(se.Err); code != pgErrCode {

--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -66,11 +66,3 @@ func Caller(depth ...int) string {
 	}
 	return buf.String()
 }
-
-// MakeCaller returns a function which will invoke Caller with the specified
-// arguments.
-func MakeCaller(depth ...int) func() string {
-	return func() string {
-		return Caller(depth...)
-	}
-}

--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -11,13 +11,10 @@
 package testutils
 
 import (
-	"bytes"
-	"fmt"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 )
 
 // IsError returns true if the error string matches the supplied regex.
@@ -51,18 +48,4 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 		return false
 	}
 	return matched
-}
-
-// Caller returns filename and line number info for the specified stack
-// depths. The info is formated as <file>:<line> and each entry is separated
-// for a space.
-func Caller(depth ...int) string {
-	var sep string
-	var buf bytes.Buffer
-	for _, d := range depth {
-		file, line, _ := caller.Lookup(d + 1)
-		fmt.Fprintf(&buf, "%s%s:%d", sep, file, line)
-		sep = " "
-	}
-	return buf.String()
 }


### PR DESCRIPTION
Fixes #46752.
Resolves the recent perf regression on TPC-C.

This commit follows in the footsteps of #34803 and introduces batching for ranged intent resolution, where previously only point intent resolution was batched. As we found in #46752, this is more important than it has been in the past, because implicit SELECT FOR UPDATE acquires a ranged lock on each row that it updates instead of a single-key lock.

The change addresses this by adding a third request batcher to IntentResolver. ResolveIntent requests and ResolveIntentRange requests are batched separately, which is necessary for the use of MaxSpanRequestKeys to work properly (in fact, to be accepted by DistSender at all).

To accommodate the ranged nature of ResolveIntentRange request, the notion of pagination is introduced into RequestBatcher. A MaxKeysPerBatchReq option is added to the configuration of a RequestBatcher, which corresponds to the MaxSpanRequestKeys value set on each BatchRequest header. The RequestBatcher is then taught about request pagination and how to work with partial responses. The semantics at play here are clarified in an earlier commit in the PR.

Release justification: important fix to avoid a performance regression when implicit SELECT FOR UPDATE is enabled. All commits except the last are testing-only. The last commit is subtle but small and well-tested.

@andreimatei: I assigned you because I think you know the most about `MaxSpanRequestKeys`. I'm mostly interested to get your input on the "rationalize Header.MaxSpanRequestKeys" commit (testing + comments only).