### PR TITLE
sql: add bit support for bit_and aggregate function

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -43,6 +43,8 @@
 </span></td></tr>
 <tr><td><a name="bit_and"></a><code>bit_and(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise AND of all non-null input values, or null if none.</p>
 </span></td></tr>
+<tr><td><a name="bit_and"></a><code>bit_and(arg1: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates the bitwise AND of all non-null input values, or null if none.</p>
+</span></td></tr>
 <tr><td><a name="bit_or"></a><code>bit_or(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise OR of all non-null input values, or null if none.</p>
 </span></td></tr>
 <tr><td><a name="bool_and"></a><code>bool_and(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Calculates the boolean value of <code>AND</code>ing all selected values.</p>

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2241,3 +2241,107 @@ CREATE TABLE t45453(c INT)
 query I
 SELECT count(*) FROM t45453 GROUP BY 0 + 0
 ----
+
+# Tests for the bit_and aggregate function.
+
+subtest bit_and
+
+statement ok
+DROP TABLE IF EXISTS vals
+
+statement ok
+CREATE TABLE vals (
+  v VARBIT,
+  b BIT(8)
+)
+
+# Testing that bit_and returns NULL if there are no rows.
+
+query T
+SELECT bit_and(v) FROM vals
+----
+NULL
+
+# Testing that bit_and does not trigger aggregation on a constant with a source
+# that has no rows.
+
+query T
+SELECT bit_and('1000'::varbit) FROM vals
+----
+NULL
+
+# Testing that bit_and triggers aggregation and computation on a constant
+# with no source.
+
+query TTT
+SELECT bit_and('1'::varbit), bit_and('1000'::bit(4)), bit_and('1010'::varbit)
+----
+1 1000 1010
+
+# Testing that bit_and returns null given a null.
+
+query T
+SELECT bit_and(NULL::varbit)
+----
+NULL
+
+# Testing a successful bit_and over a sequence of non-nulls.
+
+statement ok
+INSERT INTO vals VALUES
+('11111111'::varbit, '11111111'::bit(8)),
+('01111111'::varbit, '01111111'::bit(8)),
+('10111111'::varbit, '10111111'::bit(8)),
+('11011111'::varbit, '11011111'::bit(8)),
+('11101111'::varbit, '11101111'::bit(8))
+
+query TT
+SELECT bit_and(v), bit_and(b) FROM vals
+----
+00001111 00001111
+
+# Testing bit_and over a sequence with nulls and non-nulls.
+
+statement ok
+INSERT INTO vals VALUES
+(NULL::varbit, NULL::bit),
+(NULL::varbit, NULL::bit)
+
+query TT
+SELECT bit_and(v), bit_and(b) FROM vals
+----
+00001111 00001111
+
+# Testing bit_and over a sequence with all nulls.
+
+statement ok
+DELETE FROM vals
+
+statement ok
+INSERT INTO vals VALUES
+(NULL::varbit),
+(NULL::varbit),
+(NULL::varbit),
+(NULL::varbit)
+
+query T
+SELECT bit_and(v) FROM vals
+----
+NULL
+
+# Testing that bit_and returns an error when given an uncasted null.
+
+statement error ambiguous call: bit_and\(unknown\), candidates are
+SELECT bit_and(NULL)
+
+# Testing that an error is returned when bit_and is called on bit arrays of
+# different sizes.
+
+statement error cannot AND bit strings of different sizes
+SELECT bit_and(x::varbit) FROM (VALUES ('1'), ('11')) t(x)
+
+statement error cannot AND bit strings of different sizes
+SELECT bit_and(x) FROM (VALUES ('100'::bit(3)), ('101010111'::varbit)) t(x)
+
+statement error cannot AND bit strings of different sizes
+SELECT bit_and(x) FROM (VALUES (''::varbit), ('1'::varbit)) t(x)

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -86,13 +86,28 @@ func TestAvgIntervalResultDeepCopy(t *testing.T) {
 func TestBitAndIntResultDeepCopy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Run("all null", func(t *testing.T) {
-		testAggregateResultDeepCopy(t, newBitAndAggregate, makeNullTestDatum(10))
+		testAggregateResultDeepCopy(t, newIntBitAndAggregate, makeNullTestDatum(10))
 	})
 	t.Run("with null", func(t *testing.T) {
-		testAggregateResultDeepCopy(t, newBitAndAggregate, makeTestWithNullDatum(10, makeIntTestDatum))
+		testAggregateResultDeepCopy(t, newIntBitAndAggregate, makeTestWithNullDatum(10, makeIntTestDatum))
 	})
 	t.Run("without null", func(t *testing.T) {
-		testAggregateResultDeepCopy(t, newBitAndAggregate, makeIntTestDatum(10))
+		testAggregateResultDeepCopy(t, newIntBitAndAggregate, makeIntTestDatum(10))
+	})
+}
+
+func TestBitAndBitResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Run("all null", func(t *testing.T) {
+		testAggregateResultDeepCopy(t, newBitBitAndAggregate, makeNullTestDatum(10))
+	})
+	t.Run("with null", func(t *testing.T) {
+		testAggregateResultDeepCopy(t, newBitBitAndAggregate, makeTestWithNullDatum(10, makeBitTestDatum))
+	})
+	t.Run("without null", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			testAggregateResultDeepCopy(t, newBitBitAndAggregate, makeBitTestDatum(10))
+		}
 	})
 }
 
@@ -235,6 +250,19 @@ func makeIntTestDatum(count int) []tree.Datum {
 	vals := make([]tree.Datum, count)
 	for i := range vals {
 		vals[i] = tree.NewDInt(tree.DInt(rng.Int63()))
+	}
+	return vals
+}
+
+func makeBitTestDatum(count int) []tree.Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	// Compute randWidth outside the loop so that all bit arrays are the same
+	// length. Generate widths in the range [0, 64].
+	vals := make([]tree.Datum, count)
+	randWidth := uint(rng.Intn(65))
+	for i := range vals {
+		vals[i], _ = tree.NewDBitArrayFromInt(rng.Int63(), randWidth)
 	}
 	return vals
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -63,6 +63,13 @@ var (
 	big10E10 = big.NewInt(1e10)
 )
 
+// NewCannotMixBitArraySizesError creates an error for the case when a bitwise
+// aggregate function is called on bit arrays with different sizes.
+func NewCannotMixBitArraySizesError(op string) error {
+	return pgerror.Newf(pgcode.StringDataLengthMismatch,
+		"cannot %s bit strings of different sizes", op)
+}
+
 // UnaryOp is a unary operator.
 type UnaryOp struct {
 	Typ        *types.T
@@ -382,11 +389,6 @@ func getJSONPath(j DJSON, ary DArray) (Datum, error) {
 	return &DJSON{result}, nil
 }
 
-func newCannotMixBitArraySizesError(op string) error {
-	return pgerror.Newf(pgcode.StringDataLengthMismatch,
-		"cannot %s bit strings of different sizes", op)
-}
-
 // BinOps contains the binary operations indexed by operation type.
 var BinOps = map[BinaryOperator]binOpOverload{
 	Bitand: {
@@ -406,7 +408,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				lhs := MustBeDBitArray(left)
 				rhs := MustBeDBitArray(right)
 				if lhs.BitLen() != rhs.BitLen() {
-					return nil, newCannotMixBitArraySizesError("AND")
+					return nil, NewCannotMixBitArraySizesError("AND")
 				}
 				return &DBitArray{
 					BitArray: bitarray.And(lhs.BitArray, rhs.BitArray),
@@ -443,7 +445,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				lhs := MustBeDBitArray(left)
 				rhs := MustBeDBitArray(right)
 				if lhs.BitLen() != rhs.BitLen() {
-					return nil, newCannotMixBitArraySizesError("OR")
+					return nil, NewCannotMixBitArraySizesError("OR")
 				}
 				return &DBitArray{
 					BitArray: bitarray.Or(lhs.BitArray, rhs.BitArray),
@@ -480,7 +482,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				lhs := MustBeDBitArray(left)
 				rhs := MustBeDBitArray(right)
 				if lhs.BitLen() != rhs.BitLen() {
-					return nil, newCannotMixBitArraySizesError("XOR")
+					return nil, NewCannotMixBitArraySizesError("XOR")
 				}
 				return &DBitArray{
 					BitArray: bitarray.Xor(lhs.BitArray, rhs.BitArray),


### PR DESCRIPTION
Previously, the bit_and aggregate function only worked with INT
types. This commit adds support for BIT and VARBIT types.

Fixes #45841

Release note (sql change): bit_and aggregate function now supports BIT
and VARBIT data types.