### PR TITLE
cli/demo: document the client-side commands

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl.disabled
@@ -4,7 +4,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-start_test "Check \\demo_node commands work as expected"
+start_test "Check \\demo commands work as expected"
 # Start a demo with 5 nodes.
 spawn $argv demo movr --nodes=5
 
@@ -12,29 +12,29 @@ spawn $argv demo movr --nodes=5
 eexpect "movr>"
 
 # Wrong number of args
-send "\\demo_node\r"
+send "\\demo\r"
 eexpect "Usage:"
 
 # Cannot shutdown node 1
-send "\\demo_node shutdown 1\r"
+send "\\demo shutdown 1\r"
 eexpect "cannot shutdown node 1"
 
 # Cannot operate on a node which does not exist.
-send "\\demo_node shutdown 8\r"
+send "\\demo shutdown 8\r"
 eexpect "node 8 does not exist"
-send "\\demo_node restart 8\r"
+send "\\demo restart 8\r"
 eexpect "node 8 does not exist"
-send "\\demo_node decommission 8\r"
+send "\\demo decommission 8\r"
 eexpect "node 8 does not exist"
-send "\\demo_node recommission 8\r"
+send "\\demo recommission 8\r"
 eexpect "node 8 does not exist"
 
 # Cannot restart a node that is not shut down.
-send "\\demo_node restart 2\r"
+send "\\demo restart 2\r"
 eexpect "node 2 is already running"
 
 # Shut down a separate node.
-send "\\demo_node shutdown 3\r"
+send "\\demo shutdown 3\r"
 eexpect "node 3 has been shutdown"
 
 send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
@@ -45,7 +45,7 @@ eexpect "4 |  false   |      false"
 eexpect "5 |  false   |      false"
 
 # Cannot shut it down again.
-send "\\demo_node shutdown 3\r"
+send "\\demo shutdown 3\r"
 eexpect "node 3 is already shut down"
 
 # Expect queries to still work with just one node down.
@@ -54,7 +54,7 @@ eexpect "500"
 eexpect "movr>"
 
 # Now restart the node.
-send "\\demo_node restart 3\r"
+send "\\demo restart 3\r"
 eexpect "node 3 has been restarted"
 
 send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
@@ -65,7 +65,7 @@ eexpect "4 |  false   |      false"
 eexpect "5 |  false   |      false"
 
 # Try commissioning commands
-send "\\demo_node decommission 4\r"
+send "\\demo decommission 4\r"
 eexpect "node 4 has been decommissioned"
 
 send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"
@@ -75,7 +75,7 @@ eexpect "3 |  false   |      false"
 eexpect "4 |  false   |      true"
 eexpect "5 |  false   |      false"
 
-send "\\demo_node recommission 4\r"
+send "\\demo recommission 4\r"
 eexpect "node 4 has been recommissioned"
 
 send "select node_id, draining, decommissioning from crdb_internal.gossip_liveness ORDER BY node_id;\r"

--- a/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
@@ -13,8 +13,8 @@ set client_spawn_id $spawn_id
 eexpect root@
 
 # Ensure the demo command does not work.
-send "\\demo_node shutdown 2\n"
-eexpect "\\demo_node can only be run with cockroach demo"
+send "\\demo shutdown 2\n"
+eexpect "\\demo can only be run with cockroach demo"
 
 # Exit the shell.
 interrupt

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -49,7 +49,6 @@ const (
 # To exit, type: \q.
 #
 `
-	// TODO(#42242): document the \demo_node command.
 	helpMessageFmt = `You are using 'cockroach sql', CockroachDB's lightweight SQL client.
 Type:
   \? or "help"      print this help.
@@ -65,9 +64,18 @@ Type:
   \dt               show the tables of the current schema in the current database.
   \du               list the users for all databases.
   \d [TABLE]        show details about columns in the specified table, or alias for '\dt' if no table is specified.
+%s
 More documentation about our SQL dialect and the CLI shell is available online:
 %s
 %s`
+
+	demoCommandsHelp = `
+Commands specific to the demo shell (EXPERIMENTAL):
+  \demo shutdown <nodeid>      stop a demo node.
+  \demo restart <nodeid>       restart a stopped demo node.
+  \demo decommission <nodeid>  decommission a node.
+  \demo recommission <nodeid>  recommission a node.
+`
 
 	defaultPromptPattern = "%n@%M/%/%x>"
 
@@ -207,8 +215,13 @@ const (
 )
 
 // printCliHelp prints a short inline help about the CLI.
-func printCliHelp() {
+func (c *cliState) printCliHelp() {
+	demoHelpStr := ""
+	if demoCtx.transientCluster != nil {
+		demoHelpStr = demoCommandsHelp
+	}
 	fmt.Printf(helpMessageFmt,
+		demoHelpStr,
 		base.DocsURL("sql-statements.html"),
 		base.DocsURL("use-the-built-in-sql-client.html"),
 	)
@@ -470,18 +483,15 @@ func isEndOfStatement(lastTok int) bool {
 	return lastTok == ';' || lastTok == parser.HELPTOKEN
 }
 
-// handleDemoNode handles operations on \demo_node.
+// handleDemo handles operations on \demo.
 // This can only be done from `cockroach demo`.
-func (c *cliState) handleDemoNode(cmd []string, nextState, errState cliStateEnum) cliStateEnum {
-	usageStr := `Usage: \demo_node <shutdown|restart|recommission|decommission> <node_id>` + "\n"
+func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cliStateEnum {
 	// A transient cluster signifies the presence of `cockroach demo`.
 	if demoCtx.transientCluster == nil {
-		return c.invalidSyntax(errState, `\demo_node can only be run with cockroach demo`)
+		return c.invalidSyntax(errState, `\demo can only be run with cockroach demo`)
 	}
 	if len(cmd) != 2 {
-		fmt.Fprint(stderr, usageStr)
-		c.exitErr = errInvalidSyntax
-		return errState
+		return c.invalidSyntax(errState, `\demo expects 2 parameters`)
 	}
 	nodeID, err := strconv.ParseInt(cmd[1], 10, 32)
 	if err != nil {
@@ -517,9 +527,7 @@ func (c *cliState) handleDemoNode(cmd []string, nextState, errState cliStateEnum
 		fmt.Printf("node %d has been decommissioned\n", nodeID)
 		return nextState
 	}
-	fmt.Fprint(stderr, usageStr)
-	c.exitErr = errInvalidSyntax
-	return errState
+	return c.invalidSyntax(errState, `command not recognized: %s`, cmd[0])
 }
 
 // handleHelp prints SQL help.
@@ -972,7 +980,7 @@ func (c *cliState) doProcessFirstLine(startState, nextState cliStateEnum) cliSta
 		return startState
 
 	case "help":
-		printCliHelp()
+		c.printCliHelp()
 		return startState
 
 	case "exit", "quit":
@@ -1008,7 +1016,7 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return cliStop
 
 	case `\`, `\?`, `\help`:
-		printCliHelp()
+		c.printCliHelp()
 
 	case `\set`:
 		return c.handleSet(cmd[1:], loopState, errState)
@@ -1059,8 +1067,8 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		}
 		return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
 
-	case `\demo_node`:
-		return c.handleDemoNode(cmd[1:], loopState, errState)
+	case `\demo`:
+		return c.handleDemo(cmd[1:], loopState, errState)
 
 	default:
 		if strings.HasPrefix(cmd[0], `\d`) {


### PR DESCRIPTION
Fixes #42242.

This adds the missing documentation, and also shortens the command
prefix from `\demo_node` to `\demo`. This way we can add more
sub-commands besides shutdown/restart/etc.

Release note (cli change): The client-side commands specific to
`cockroach demo`, starting with `\demo`, are now advertised in the
output of `\?`. Note that this feature is currently experimental.