### PR TITLE
cli: make the SQL client commands work with unix sockets

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -24,7 +24,7 @@ end_test
 
 proc start_secure_server {argv certs_dir extra} {
     report "BEGIN START SECURE SERVER"
-    system "$argv start-single-node --host=localhost --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
+    system "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
             $argv sql --certs-dir=$certs_dir -e 'select 1'"
     report "END START SECURE SERVER"
 }
@@ -97,6 +97,24 @@ start_test "Check that an auth cookie cannot be created for a user that does not
 send "$argv auth-session login nonexistent --certs-dir=$certs_dir\r"
 eexpect "user \"nonexistent\" does not exist"
 eexpect $prompt
+end_test
+
+set mywd [pwd]
+
+start_test "Check that socket-based login works."
+
+send "$argv sql --url 'postgres://eisen@?host=$mywd&port=26257&sslmode=require'\r"
+eexpect "Enter password:"
+send "hunter2\r"
+eexpect "eisen@"
+interrupt
+eexpect $prompt
+
+send "$argv sql --url 'postgres://eisen:hunter2@?host=$mywd&port=26257&sslmode=require'\r"
+eexpect "eisen@"
+interrupt
+eexpect $prompt
+
 end_test
 
 start_test "Check that the auth cookie creation works and reports useful output."

--- a/pkg/cli/interactive_tests/test_url_login.tcl
+++ b/pkg/cli/interactive_tests/test_url_login.tcl
@@ -10,9 +10,28 @@ start_test "Check that the client can start when no username is specified."
 # also exercised by the test.
 spawn $argv sql --url "postgresql://localhost:26257?sslmode=disable"
 eexpect @localhost
+send_eof
+eexpect eof
+
 end_test
 
+stop_server $argv
+
+start_test "Check that the unix socket can be used simply."
+
+# Start a server with a socket listener.
+set mywd [pwd]
+
+system "$argv start-single-node --insecure --pid-file=server_pid --socket-dir=. --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
+        $argv sql --insecure -e 'select 1'"
+
+spawn $argv sql --url "postgresql://?host=$mywd&port=26257"
+eexpect "Enter password"
+send "insecure\r"
+eexpect root@
 send_eof
 eexpect eof
 
 stop_server $argv
+
+end_test


### PR DESCRIPTION
Prior to this patch crdb's own CLI commands did not know how to use a
unix socket, even though that's the standard facility offered by
PostgreSQL and is also supported by CockroachDB servers.

This patch fixes it.

Release note (cli change): The `cockroach` CLI commands that
internally use SQL, including `cockroach sql`, now can connect
to a server using a unix datagram socket. The syntax for this
is `--url 'postgres://user@?host=/path/to/directory?port=NNNN'`.