### PR TITLE
cli: make cockroach demo start in insecure mode by default

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -413,10 +413,10 @@ func Example_demo() {
 		{`demo`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
 		{`demo`, `startrek`, `-e`, `show databases`},
 		{`demo`, `startrek`, `-e`, `show databases`, `--format=table`},
-		// Test that if we start with --insecure we cannot perform
+		// Test that if we start with --insecure=false we can perform
 		// commands that require a secure cluster.
+		{`demo`, `--insecure=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 		{`demo`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
-		{`demo`, `--insecure`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
 		{`demo`, `--geo-partitioned-replicas`, `--disable-demo-license`},
 	}
 	setCLIDefaultsForTests()
@@ -471,9 +471,9 @@ func Example_demo() {
 	//   startrek
 	//   system
 	// (4 rows)
-	// demo -e CREATE USER test WITH PASSWORD 'testpass'
+	// demo --insecure=false -e CREATE USER test WITH PASSWORD 'testpass'
 	// CREATE ROLE
-	// demo --insecure -e CREATE USER test WITH PASSWORD 'testpass'
+	// demo -e CREATE USER test WITH PASSWORD 'testpass'
 	// ERROR: setting or updating a password is not supported in insecure mode
 	// SQLSTATE: 28P01
 	// demo --geo-partitioned-replicas --disable-demo-license

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -165,7 +165,7 @@ func initCLIDefaults() {
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
-	demoCtx.insecure = false
+	demoCtx.insecure = true
 
 	authCtx.validityPeriod = 1 * time.Hour
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -1010,7 +1010,13 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 			fmt.Printf("#\n")
 		}
 
-		if !demoCtx.insecure {
+		if demoCtx.insecure {
+			fmt.Printf(
+				"# Cockroach demo is running in insecure mode.\n" +
+					"# Run with --insecure=false to use security related features.\n" +
+					"# Note: Starting in secure mode will become the default in v20.2.\n#\n",
+			)
+		} else {
 			fmt.Printf(
 				"# The user %q with password %q has been created. Use it to access the Web UI!\n#\n",
 				security.RootUser,

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -10,6 +10,8 @@ eexpect "Welcome"
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
 eexpect "Web UI: http:"
+# See the notice about insecure mode.
+eexpect "Cockroach demo is running in insecure mode."
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
 eexpect "Cluster ID"
@@ -66,12 +68,12 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure
+spawn $argv demo
 # Check that we see our message.
 eexpect "Connect to the cluster on a SQL shell at"
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3
+spawn $argv demo --nodes 3
 
 # Check that we get a message for each node.
 eexpect "Connect to different nodes in the cluster on a SQL shell at"


### PR DESCRIPTION
Release note (cli change): This change makes cockroach demo
start in insecure mode by default.