### PR TITLE
ui: bugfix app selection change didn't reset page

### DIFF
--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -141,6 +141,18 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const { history } = this.props;
     history.location.pathname = `/statements/${app.value}`;
     history.replace(history.location);
+    this.resetPagination();
+  }
+
+  resetPagination = () => {
+    this.setState((prevState) => {
+      return {
+        pagination: {
+          current: 1,
+          pageSize: prevState.pagination.pageSize,
+        },
+      };
+    });
   }
 
   componentDidMount() {
@@ -176,7 +188,8 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
   }
 
   onSubmitSearchField = (search: string) => {
-    this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
+    this.setState({ search });
+    this.resetPagination();
     this.syncHistory({
       "q": search,
     });


### PR DESCRIPTION
When selecting a new "app" to filter statements,
the pagination setting wasn't reverted to page 1
anymore due to the change in how history was
managed. This change ensures that we always reset
to page 1 when we change the app.

Release justification: low-impact bugfix

Release note (admin ui change): Fixes a bug on the
statements page that would not reset pagination state
to page 1 after the app selection was changed.