### PR TITLE
server: first pass at splitting up NewServer

### DIFF
--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -870,7 +870,7 @@ func (m *multiTestContext) addStore(idx int) {
 	m.populateDB(idx, cfg.Settings, stopper)
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 	m.nodeLivenesses[idx] = kvserver.NewNodeLiveness(
-		ambient, m.clocks[idx], m.dbs[idx], m.engines, m.gossips[idx],
+		ambient, m.clocks[idx], m.dbs[idx], m.gossips[idx],
 		nlActive, nlRenewal, cfg.Settings, metric.TestSampleInterval,
 	)
 	m.populateStorePool(idx, cfg, m.nodeLivenesses[idx])
@@ -980,7 +980,7 @@ func (m *multiTestContext) addStore(idx int) {
 		ran.Do(func() {
 			close(ran.ch)
 		})
-	})
+	}, []storage.Engine{m.engines[idx]})
 
 	store.WaitForInit()
 
@@ -1050,7 +1050,7 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 	m.populateDB(i, m.storeConfig.Settings, stopper)
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 	m.nodeLivenesses[i] = kvserver.NewNodeLiveness(
-		log.AmbientContext{Tracer: m.storeConfig.Settings.Tracer}, m.clocks[i], m.dbs[i], m.engines,
+		log.AmbientContext{Tracer: m.storeConfig.Settings.Tracer}, m.clocks[i], m.dbs[i],
 		m.gossips[i], nlActive, nlRenewal, cfg.Settings, metric.TestSampleInterval,
 	)
 	m.populateStorePool(i, cfg, m.nodeLivenesses[i])
@@ -1074,7 +1074,7 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 		if err := store.WriteLastUpTimestamp(ctx, now); err != nil {
 			log.Warning(ctx, err)
 		}
-	})
+	}, []storage.Engine{m.engines[i]})
 }
 
 // restartStore restarts a store previously stopped with StopStore.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -81,7 +81,6 @@ var errAdminAPIError = status.Errorf(codes.Internal, "An internal server error "
 type adminServer struct {
 	server     *Server
 	memMonitor mon.BytesMonitor
-	memMetrics *sql.MemoryMetrics
 }
 
 // noteworthyAdminMemoryUsageBytes is the minimum size tracked by the
@@ -92,7 +91,7 @@ var noteworthyAdminMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEW
 // newAdminServer allocates and returns a new REST server for
 // administrative APIs.
 func newAdminServer(s *Server) *adminServer {
-	server := &adminServer{server: s, memMetrics: &s.adminMemMetrics}
+	server := &adminServer{server: s}
 	// TODO(knz): We do not limit memory usage by admin operations
 	// yet. Is this wise?
 	server.memMonitor = mon.MakeUnlimitedMonitor(
@@ -218,7 +217,7 @@ func (s *adminServer) Databases(
 		return nil, err
 	}
 
-	rows, err := s.server.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-show-dbs", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 		"SHOW DATABASES",
@@ -258,7 +257,7 @@ func (s *adminServer) DatabaseDetails(
 	// TODO(cdo): Use placeholders when they're supported by SHOW.
 
 	// Marshal grants.
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-show-grants", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON DATABASE %s", escDBName),
@@ -303,7 +302,7 @@ func (s *adminServer) DatabaseDetails(
 	}
 
 	// Marshal table names.
-	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-show-tables", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW TABLES FROM %s", escDBName),
@@ -380,7 +379,7 @@ func (s *adminServer) TableDetails(
 	var resp serverpb.TableDetailsResponse
 
 	// Marshal SHOW COLUMNS result.
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-show-columns",
 		nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
@@ -443,7 +442,7 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW INDEX result.
-	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-showindex", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW INDEX FROM %s", escQualTable),
@@ -496,7 +495,7 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW GRANTS result.
-	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-show-grants", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON TABLE %s", escQualTable),
@@ -529,7 +528,7 @@ func (s *adminServer) TableDetails(
 	}
 
 	// Marshal SHOW CREATE result.
-	rows, cols, err = s.server.internalExecutor.QueryWithCols(
+	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-show-create", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW CREATE %s", escQualTable),
@@ -839,7 +838,7 @@ func (s *adminServer) Users(
 		return nil, err
 	}
 	query := `SELECT username FROM system.users WHERE "isRole" = false`
-	rows, err := s.server.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-users", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		query,
@@ -898,7 +897,7 @@ func (s *adminServer) Events(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-events", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...)
@@ -990,7 +989,7 @@ func (s *adminServer) RangeLog(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-range-log", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...,
@@ -1103,7 +1102,7 @@ func (s *adminServer) getUIData(
 	if err := query.Errors(); err != nil {
 		return nil, s.serverErrorf("error constructing query: %v", err)
 	}
-	rows, err := s.server.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-getUIData", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		query.String(), query.QueryArguments()...,
@@ -1174,7 +1173,7 @@ func (s *adminServer) SetUIData(
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
 		query := `UPSERT INTO system.ui (key, value, "lastUpdated") VALUES ($1, $2, now())`
-		rowsAffected, err := s.server.internalExecutor.ExecEx(
+		rowsAffected, err := s.server.sqlServer.internalExecutor.ExecEx(
 			ctx, "admin-set-ui-data", nil, /* txn */
 			sqlbase.InternalExecutorSessionDataOverride{
 				User: security.RootUser,
@@ -1423,7 +1422,7 @@ func (s *adminServer) Jobs(
 	if req.Limit > 0 {
 		q.Append(" LIMIT $", tree.DInt(req.Limit))
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-jobs", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...,
@@ -1493,7 +1492,7 @@ func (s *adminServer) Locations(
 
 	q := makeSQLQuery()
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-locations", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(),
@@ -1549,7 +1548,7 @@ func (s *adminServer) QueryPlan(
 	explain := fmt.Sprintf(
 		"SELECT json FROM [EXPLAIN (DISTSQL) %s]",
 		strings.Trim(req.Query, ";"))
-	rows, err := s.server.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-query-plan", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		explain,
@@ -1577,7 +1576,7 @@ func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.R
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	row, err := s.server.internalExecutor.QueryRowEx(
+	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "admin-stmt-bundle", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 		"SELECT bundle_chunks FROM system.statement_diagnostics WHERE id=$1 AND bundle_chunks IS NOT NULL",
@@ -1596,7 +1595,7 @@ func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.R
 	var bundle bytes.Buffer
 	chunkIDs := row[0].(*tree.DArray).Array
 	for _, chunkID := range chunkIDs {
-		chunkRow, err := s.server.internalExecutor.QueryRowEx(
+		chunkRow, err := s.server.sqlServer.internalExecutor.QueryRowEx(
 			ctx, "admin-stmt-bundle", nil, /* txn */
 			sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 			"SELECT data FROM system.statement_bundle_chunks WHERE id=$1",
@@ -1741,7 +1740,7 @@ func (s *adminServer) DataDistribution(
 	// and deleted tables (as opposed to e.g. information_schema) because we are interested
 	// in the data for all ranges, not just ranges for visible tables.
 	tablesQuery := `SELECT name, table_id, database_name, drop_time FROM "".crdb_internal.tables WHERE schema_name = 'public'`
-	rows1, err := s.server.internalExecutor.QueryEx(
+	rows1, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-replica-matrix", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		tablesQuery,
@@ -1783,7 +1782,7 @@ func (s *adminServer) DataDistribution(
 				`SELECT zone_id FROM [SHOW ZONE CONFIGURATION FOR TABLE %s.%s]`,
 				(*tree.Name)(dbName), (*tree.Name)(tableName),
 			)
-			rows, err := s.server.internalExecutor.QueryEx(
+			rows, err := s.server.sqlServer.internalExecutor.QueryEx(
 				ctx, "admin-replica-matrix", nil, /* txn */
 				sqlbase.InternalExecutorSessionDataOverride{User: userName},
 				zoneConfigQuery,
@@ -1860,7 +1859,7 @@ func (s *adminServer) DataDistribution(
 		FROM crdb_internal.zones
 		WHERE target IS NOT NULL
 	`
-	rows2, err := s.server.internalExecutor.QueryEx(
+	rows2, err := s.server.sqlServer.internalExecutor.QueryEx(
 		ctx, "admin-replica-matrix", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		zoneConfigsQuery)
@@ -2273,7 +2272,7 @@ func (s *adminServer) queryZone(
 	ctx context.Context, userName string, id sqlbase.ID,
 ) (zonepb.ZoneConfig, bool, error) {
 	const query = `SELECT crdb_internal.get_zone_config($1)`
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx,
 		"admin-query-zone",
 		nil, /* txn */
@@ -2330,7 +2329,7 @@ func (s *adminServer) queryNamespaceID(
 	ctx context.Context, userName string, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
 	const query = `SELECT crdb_internal.get_namespace_id($1, $2)`
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "admin-query-namespace-ID", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		query, parentID, name,
@@ -2419,7 +2418,7 @@ func (s *adminServer) hasAdminRole(ctx context.Context, sessionUser string) (boo
 		// Shortcut.
 		return true, nil
 	}
-	rows, cols, err := s.server.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
 		ctx, "check-is-admin", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 		"SELECT crdb_internal.is_admin()")

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -261,7 +261,10 @@ type Config struct {
 	//
 	// The bool parameter is true if the server is not bootstrapped yet, will not
 	// bootstrap itself and will be waiting for an `init` command or accept
-	// bootstrapping from a joined node. Must not block.
+	// bootstrapping from a joined node.
+	//
+	// This method is invoked from the main start goroutine, so it should not
+	// do nontrivial work.
 	ReadyFn func(waitForInit bool)
 
 	// DelayedBootstrapFn is called if the boostrap process does not complete

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -24,46 +24,73 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors"
 )
 
 // ErrClusterInitialized is reported when the Boostrap RPC is ran on
 // a node already part of an initialized cluster.
 var ErrClusterInitialized = fmt.Errorf("cluster has already been initialized")
 
-// initServer manages the temporary init server used during
-// bootstrapping.
+// initServer handles the bootstrapping process. It is instantiated early in the
+// server startup sequence to determine whether a NodeID and ClusterID are
+// available (true if and only if an initialized store is present). If all
+// engines are empty, either a new cluster needs to be started (via incoming
+// Bootstrap RPC) or an existing one joined. Either way, the goal is to learn a
+// ClusterID and NodeID (and initialize at least one store). All of this
+// subtlety is encapsulated by the initServer, which offers a primitive
+// ServeAndWait() after which point the startup code can assume that the
+// Node/ClusterIDs are known.
+//
+// TODO(tbg): at the time of writing, when joining an existing cluster for the
+// first time, the initServer provides only the clusterID. Fix this by giving
+// the initServer a *kv.DB that it can use to assign a NodeID and StoreID, and
+// later by switching to the connect RPC (#32574).
 type initServer struct {
 	mu struct {
 		syncutil.Mutex
 		// If set, a Bootstrap() call is rejected with this error.
 		rejectErr error
 	}
-	bootstrapBlockCh chan struct{} // blocks Bootstrap() until ServeAndWait() is invoked
-	bootstrapReqCh   chan *initState
-
-	engs []storage.Engine // late-bound in ServeAndWait
-
-	binaryVersion, binaryMinSupportedVersion       roachpb.Version
-	bootstrapVersion                               clusterversion.ClusterVersion
+	// The version at which to bootstrap the cluster in Bootstrap().
+	bootstrapVersion roachpb.Version
+	// The zone configs to bootstrap with.
 	bootstrapZoneConfig, bootstrapSystemZoneConfig *zonepb.ZoneConfig
+	// The state of the engines. This tells us whether the node is already
+	// bootstrapped. The goal of the initServer is to complete this by the
+	// time ServeAndWait returns.
+	inspectState *initDiskState
+
+	// If Bootstrap() succeeds, resulting initState will go here (to be consumed
+	// by ServeAndWait).
+	bootstrapReqCh chan *initState
 }
 
-func newInitServer(
+func setupInitServer(
+	ctx context.Context,
 	binaryVersion, binaryMinSupportedVersion roachpb.Version,
-	bootstrapVersion clusterversion.ClusterVersion,
+	bootstrapVersion roachpb.Version,
 	bootstrapZoneConfig, bootstrapSystemZoneConfig *zonepb.ZoneConfig,
-) *initServer {
-	return &initServer{
-		bootstrapReqCh:   make(chan *initState, 1),
-		bootstrapBlockCh: make(chan struct{}),
+	engines []storage.Engine,
+) (*initServer, error) {
+	inspectState, err := inspectEngines(ctx, engines, binaryVersion, binaryMinSupportedVersion)
+	if err != nil {
+		return nil, err
+	}
 
-		binaryVersion:             binaryVersion,
-		binaryMinSupportedVersion: binaryMinSupportedVersion,
+	s := &initServer{
+		bootstrapReqCh: make(chan *initState, 1),
+
+		inspectState:              inspectState,
 		bootstrapVersion:          bootstrapVersion,
 		bootstrapZoneConfig:       bootstrapZoneConfig,
 		bootstrapSystemZoneConfig: bootstrapSystemZoneConfig,
 	}
+
+	if len(inspectState.initializedEngines) > 0 {
+		// We have a NodeID/ClusterID, so don't allow bootstrap.
+		s.mu.rejectErr = ErrClusterInitialized
+	}
+
+	return s, nil
 }
 
 // initDiskState contains the part of initState that is read from stable
@@ -109,51 +136,32 @@ type initState struct {
 	bootstrapped bool
 }
 
-// ServeAndWait sets up the initServer to accept Bootstrap requests (which will
-// block until then). It uses the provided engines and gossip to block until
-// either a new cluster was bootstrapped or Gossip connected to an existing
-// cluster.
+// ServeAndWait waits until the server is ready to bootstrap. In the common case
+// of restarting an existing node, this immediately returns. When starting with
+// a blank slate (i.e. only empty engines), it waits for incoming Bootstrap
+// request or for Gossip to connect (whichever happens earlier).
+//
+// The returned initState may not reflect a bootstrapped cluster yet, but it
+// is guaranteed to have a ClusterID set.
 //
 // This method must be called only once.
+//
+// TODO(tbg): give this a KV client and thus initialize at least one store in
+// all cases.
 func (s *initServer) ServeAndWait(
-	ctx context.Context, stopper *stop.Stopper, engs []storage.Engine, g *gossip.Gossip,
+	ctx context.Context, stopper *stop.Stopper, g *gossip.Gossip,
 ) (*initState, error) {
-	if s.engs != nil {
-		return nil, errors.New("cannot call ServeAndWait twice")
-	}
-
-	s.engs = engs // Bootstrap() is still blocked, so no data race here
-
-	inspectState, err := inspectEngines(ctx, engs, s.binaryVersion, s.binaryMinSupportedVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(inspectState.initializedEngines) != 0 {
-		// We have a NodeID/ClusterID, so don't allow bootstrap.
-		if err := s.testOrSetRejectErr(ErrClusterInitialized); err != nil {
-			return nil, errors.Wrap(err, "error unexpectedly set previously")
-		}
-		// If anyone mistakenly tried to bootstrap, unblock them so they can get
-		// the above error.
-		close(s.bootstrapBlockCh)
-
-		// In fact, it's crucial that we return early. This is because Gossip
-		// won't necessarily connect until a leaseholder for range 1 gossips the
-		// cluster ID, and all nodes in the cluster might be starting up right
-		// now. Without this return, we could have all nodes in the cluster
-		// deadlocked on g.Connected below. For similar reasons, we can't ever
-		// hope to initialize the newEngines below, for which we would need to
-		// increment a KV counter.
+	if len(s.inspectState.initializedEngines) != 0 {
+		// If already bootstrapped, return early.
 		return &initState{
-			initDiskState: *inspectState,
+			initDiskState: *s.inspectState,
 			joined:        false,
 			bootstrapped:  false,
 		}, nil
 	}
 
-	log.Info(ctx, "no stores bootstrapped and --join flag specified, awaiting init command or join with an already initialized node.")
-	close(s.bootstrapBlockCh)
+	log.Info(ctx, "no stores bootstrapped and --join flag specified, awaiting "+
+		"init command or join with an already initialized node.")
 
 	select {
 	case <-stopper.ShouldQuiesce():
@@ -175,31 +183,27 @@ func (s *initServer) ServeAndWait(
 		// (It's also so much simpler to think about). The RPC will also tell us
 		// a cluster version to use instead of the lowest possible one (reducing
 		// the short amount of time until the Gossip hook bumps the version);
-		// this doesn't fix anything but again, is simpler to think about.
+		// this doesn't fix anything but again, is simpler to think about. A
+		// gotcha that may not immediately be obvious is that we can never hope
+		// to have all stores initialized by the time ServeAndWait returns. This
+		// is because *if this server is already bootstrapped*, it might hold a
+		// replica of the range backing the StoreID allocating counter, and
+		// letting this server start may be necessary to restore quorum to that
+		// range. So in general, after this TODO, we will always leave this
+		// method with *at least one* store initialized, but not necessarily
+		// all. This is fine, since initializing additional stores later is
+		// easy.
 		clusterID, err := g.GetClusterID()
 		if err != nil {
 			return nil, err
 		}
-		inspectState.clusterID = clusterID
+		s.inspectState.clusterID = clusterID
 		return &initState{
-			initDiskState: *inspectState,
+			initDiskState: *s.inspectState,
 			joined:        true,
 			bootstrapped:  false,
 		}, nil
 	}
-}
-
-// testOrSetRejectErr set the reject error unless a reject error was already
-// set, in which case it returns the one that was already set. If no error had
-// previously been set, returns nil.
-func (s *initServer) testOrSetRejectErr(err error) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.mu.rejectErr != nil {
-		return s.mu.rejectErr
-	}
-	s.mu.rejectErr = err
-	return nil
 }
 
 // Bootstrap implements the serverpb.Init service. Users set up a new
@@ -213,17 +217,26 @@ func (s *initServer) testOrSetRejectErr(err error) error {
 // panicking or refusing to connect to each other.
 func (s *initServer) Bootstrap(
 	ctx context.Context, request *serverpb.BootstrapRequest,
-) (response *serverpb.BootstrapResponse, err error) {
-	<-s.bootstrapBlockCh // block until ServeAndWait() is active
+) (*serverpb.BootstrapResponse, error) {
+	s.mu.Lock()
+	err := s.mu.rejectErr
+	s.mu.rejectErr = ErrClusterInitialized
+	s.mu.Unlock()
+
 	// NB: this isn't necessary since bootstrapCluster would fail, but this is
 	// cleaner.
-	if err := s.testOrSetRejectErr(ErrClusterInitialized); err != nil {
-		return nil, err
-	}
-	state, err := bootstrapCluster(ctx, s.engs, s.bootstrapVersion, s.bootstrapZoneConfig, s.bootstrapSystemZoneConfig)
 	if err != nil {
 		return nil, err
 	}
+
+	cv := clusterversion.ClusterVersion{Version: s.bootstrapVersion}
+	state, err := bootstrapCluster(
+		ctx, s.inspectState.newEngines, cv, s.bootstrapZoneConfig, s.bootstrapSystemZoneConfig,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	s.bootstrapReqCh <- state
 	return &serverpb.BootstrapResponse{}, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,14 +148,14 @@ func (mux *safeServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Server is the cockroach server node.
 type Server struct {
-	nodeIDContainer *base.NodeIDContainer
+	// The following fields are populated in NewServer.
 
-	cfg        Config
-	st         *cluster.Settings
-	mux        safeServeMux
-	clock      *hlc.Clock
-	startTime  time.Time
-	rpcContext *rpc.Context
+	nodeIDContainer *base.NodeIDContainer
+	cfg             Config
+	st              *cluster.Settings
+	mux             safeServeMux
+	clock           *hlc.Clock
+	rpcContext      *rpc.Context
 	// The gRPC server on which the different RPC handlers will be registered.
 	grpc         *grpcServer
 	gossip       *gossip.Gossip
@@ -185,11 +185,15 @@ type Server struct {
 	debug *debug.Server
 
 	replicationReporter   *reports.Reporter
-	engines               Engines
 	protectedtsProvider   protectedts.Provider
 	protectedtsReconciler *ptreconcile.Reconciler
 
 	sqlServer *sqlServer
+
+	// The fields below are populated at start time, i.e. in `(*Server).Start`.
+
+	startTime time.Time
+	engines   Engines
 }
 
 type sqlServer struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,7 +148,7 @@ func (mux *safeServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Server is the cockroach server node.
 type Server struct {
-	nodeIDContainer base.NodeIDContainer
+	nodeIDContainer *base.NodeIDContainer
 
 	cfg        Config
 	st         *cluster.Settings
@@ -178,7 +178,7 @@ type Server struct {
 	// stores is already initialized.
 	initServer    *initServer
 	tsDB          *ts.DB
-	tsServer      ts.Server
+	tsServer      *ts.Server
 	raftTransport *kvserver.RaftTransport
 	stopper       *stop.Stopper
 
@@ -235,14 +235,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	} else {
 		clock = hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
 	}
-	s := &Server{
-		st:       st,
-		clock:    clock,
-		stopper:  stopper,
-		cfg:      cfg,
-		registry: metric.NewRegistry(),
-	}
-
+	registry := metric.NewRegistry()
 	// If the tracer has a Close function, call it after the server stops.
 	if tr, ok := cfg.AmbientCtx.Tracer.(stop.Closer); ok {
 		stopper.AddCloser(tr)
@@ -253,7 +246,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		return nil, err
 	} else if certMgr != nil {
 		// The certificate manager is non-nil in secure mode.
-		s.registry.AddMetricStruct(certMgr.Metrics())
+		registry.AddMetricStruct(certMgr.Metrics())
 	}
 
 	// Add a dynamic log tag value for the node ID.
@@ -268,48 +261,50 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// regular tag since it's just doing an (atomic) load when a log/trace message
 	// is constructed. The node ID is set by the Store if this host was
 	// bootstrapped; otherwise a new one is allocated in Node.
-	s.cfg.AmbientCtx.AddLogTag("n", &s.nodeIDContainer)
+	nodeIDContainer := &base.NodeIDContainer{}
+	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
 
-	ctx := s.AnnotateCtx(context.Background())
+	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 
 	// Check the compatibility between the configured addresses and that
 	// provided in certificates. This also logs the certificate
 	// addresses in all cases to aid troubleshooting.
 	// This must be called after the certificate manager was initialized
 	// and after ValidateAddrs().
-	s.cfg.CheckCertificateAddrs(ctx)
+	cfg.CheckCertificateAddrs(ctx)
 
-	if knobs := s.cfg.TestingKnobs.Server; knobs != nil {
+	var rpcContext *rpc.Context
+	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		serverKnobs := knobs.(*TestingKnobs)
-		s.rpcContext = rpc.NewContextWithTestingKnobs(
-			s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper, cfg.Settings,
+		rpcContext = rpc.NewContextWithTestingKnobs(
+			cfg.AmbientCtx, cfg.Config, clock, stopper, cfg.Settings,
 			serverKnobs.ContextTestingKnobs,
 		)
 	} else {
-		s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper,
+		rpcContext = rpc.NewContext(cfg.AmbientCtx, cfg.Config, clock, stopper,
 			cfg.Settings)
 	}
-	s.rpcContext.HeartbeatCB = func() {
-		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(ctx); err != nil {
+	rpcContext.HeartbeatCB = func() {
+		if err := rpcContext.RemoteClocks.VerifyClockOffset(ctx); err != nil {
 			log.Fatal(ctx, err)
 		}
 	}
-	s.registry.AddMetricStruct(s.rpcContext.Metrics())
+	registry.AddMetricStruct(rpcContext.Metrics())
 
-	s.grpc = newGRPCServer(s.rpcContext)
+	grpcServer := newGRPCServer(rpcContext)
 
-	s.gossip = gossip.New(
-		s.cfg.AmbientCtx,
-		&s.rpcContext.ClusterID,
-		&s.nodeIDContainer,
-		s.rpcContext,
-		s.grpc.Server,
-		s.stopper,
-		s.registry,
-		s.cfg.Locality,
-		&s.cfg.DefaultZoneConfig,
+	g := gossip.New(
+		cfg.AmbientCtx,
+		&rpcContext.ClusterID,
+		nodeIDContainer,
+		rpcContext,
+		grpcServer.Server,
+		stopper,
+		registry,
+		cfg.Locality,
+		&cfg.DefaultZoneConfig,
 	)
-	s.nodeDialer = nodedialer.New(s.rpcContext, gossip.AddressResolver(s.gossip))
+	nodeDialer := nodedialer.New(rpcContext, gossip.AddressResolver(g))
 
 	bootstrapVersion := cfg.Settings.Version.BinaryVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
@@ -318,17 +313,17 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 
-	s.initServer = newInitServer(
+	initServer := newInitServer(
 		cfg.Settings.Version.BinaryVersion(),
 		cfg.Settings.Version.BinaryMinSupportedVersion(),
 		clusterversion.ClusterVersion{Version: bootstrapVersion},
 		&cfg.DefaultZoneConfig,
 		&cfg.DefaultSystemZoneConfig,
 	)
-	serverpb.RegisterInitServer(s.grpc.Server, s.initServer)
+	serverpb.RegisterInitServer(grpcServer.Server, initServer)
 
-	s.runtime = status.NewRuntimeStatSampler(context.TODO(), s.clock)
-	s.registry.AddMetricStruct(s.runtime)
+	runtimeSampler := status.NewRuntimeStatSampler(context.TODO(), clock)
+	registry.AddMetricStruct(runtimeSampler)
 
 	// A custom RetryOptions is created which uses stopper.ShouldQuiesce() as
 	// the Closer. This prevents infinite retry loops from occurring during
@@ -342,79 +337,81 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// succeed because the only server has been shut down; thus, the
 	// DistSender needs to know that it should not retry in this situation.
 	var clientTestingKnobs kvcoord.ClientTestingKnobs
-	if kvKnobs := s.cfg.TestingKnobs.KVClient; kvKnobs != nil {
+	if kvKnobs := cfg.TestingKnobs.KVClient; kvKnobs != nil {
 		clientTestingKnobs = *kvKnobs.(*kvcoord.ClientTestingKnobs)
 	}
-	retryOpts := s.cfg.RetryOptions
+	retryOpts := cfg.RetryOptions
 	if retryOpts == (retry.Options{}) {
 		retryOpts = base.DefaultRetryOptions()
 	}
-	retryOpts.Closer = s.stopper.ShouldQuiesce()
+	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSenderCfg := kvcoord.DistSenderConfig{
-		AmbientCtx:      s.cfg.AmbientCtx,
+		AmbientCtx:      cfg.AmbientCtx,
 		Settings:        st,
-		Clock:           s.clock,
-		RPCContext:      s.rpcContext,
+		Clock:           clock,
+		RPCContext:      rpcContext,
 		RPCRetryOptions: &retryOpts,
 		TestingKnobs:    clientTestingKnobs,
-		NodeDialer:      s.nodeDialer,
+		NodeDialer:      nodeDialer,
 	}
-	s.distSender = kvcoord.NewDistSender(distSenderCfg, s.gossip)
-	s.registry.AddMetricStruct(s.distSender.Metrics())
+	distSender := kvcoord.NewDistSender(distSenderCfg, g)
+	registry.AddMetricStruct(distSender.Metrics())
 
-	txnMetrics := kvcoord.MakeTxnMetrics(s.cfg.HistogramWindowInterval())
-	s.registry.AddMetricStruct(txnMetrics)
+	txnMetrics := kvcoord.MakeTxnMetrics(cfg.HistogramWindowInterval())
+	registry.AddMetricStruct(txnMetrics)
 	txnCoordSenderFactoryCfg := kvcoord.TxnCoordSenderFactoryConfig{
-		AmbientCtx:   s.cfg.AmbientCtx,
+		AmbientCtx:   cfg.AmbientCtx,
 		Settings:     st,
-		Clock:        s.clock,
-		Stopper:      s.stopper,
-		Linearizable: s.cfg.Linearizable,
+		Clock:        clock,
+		Stopper:      stopper,
+		Linearizable: cfg.Linearizable,
 		Metrics:      txnMetrics,
 		TestingKnobs: clientTestingKnobs,
 	}
-	s.tcsFactory = kvcoord.NewTxnCoordSenderFactory(txnCoordSenderFactoryCfg, s.distSender)
+	tcsFactory := kvcoord.NewTxnCoordSenderFactory(txnCoordSenderFactoryCfg, distSender)
 
 	dbCtx := kv.DefaultDBContext()
-	dbCtx.NodeID = &s.nodeIDContainer
-	dbCtx.Stopper = s.stopper
-	s.db = kv.NewDBWithContext(s.cfg.AmbientCtx, s.tcsFactory, s.clock, dbCtx)
+	dbCtx.NodeID = nodeIDContainer
+	dbCtx.Stopper = stopper
+	db := kv.NewDBWithContext(cfg.AmbientCtx, tcsFactory, clock, dbCtx)
 
-	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()
+	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 
-	s.nodeLiveness = kvserver.NewNodeLiveness(
-		s.cfg.AmbientCtx,
-		s.clock,
-		s.db,
-		s.engines,
-		s.gossip,
+	nodeLiveness := kvserver.NewNodeLiveness(
+		cfg.AmbientCtx,
+		clock,
+		db,
+		// TODO(tbg): this is supposed to get the engines slice, which is only
+		// available at start time.
+		nil,
+		g,
 		nlActive,
 		nlRenewal,
-		s.st,
-		s.cfg.HistogramWindowInterval(),
+		st,
+		cfg.HistogramWindowInterval(),
 	)
-	s.registry.AddMetricStruct(s.nodeLiveness.Metrics())
+	registry.AddMetricStruct(nodeLiveness.Metrics())
 
-	s.storePool = kvserver.NewStorePool(
-		s.cfg.AmbientCtx,
-		s.st,
-		s.gossip,
-		s.clock,
-		s.nodeLiveness.GetNodeCount,
-		kvserver.MakeStorePoolNodeLivenessFunc(s.nodeLiveness),
+	storePool := kvserver.NewStorePool(
+		cfg.AmbientCtx,
+		st,
+		g,
+		clock,
+		nodeLiveness.GetNodeCount,
+		kvserver.MakeStorePoolNodeLivenessFunc(nodeLiveness),
 		/* deterministic */ false,
 	)
 
-	s.raftTransport = kvserver.NewRaftTransport(
-		s.cfg.AmbientCtx, st, s.nodeDialer, s.grpc.Server, s.stopper,
+	raftTransport := kvserver.NewRaftTransport(
+		cfg.AmbientCtx, st, nodeDialer, grpcServer.Server, stopper,
 	)
 
-	s.tsDB = ts.NewDB(s.db, s.cfg.Settings)
-	s.registry.AddMetricStruct(s.tsDB.Metrics())
+	tsDB := ts.NewDB(db, cfg.Settings)
+	registry.AddMetricStruct(tsDB.Metrics())
 	nodeCountFn := func() int64 {
-		return s.nodeLiveness.Metrics().LiveNodes.Value()
+		return nodeLiveness.Metrics().LiveNodes.Value()
 	}
-	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB, nodeCountFn, s.cfg.TimeSeriesServerConfig, s.stopper)
+	tsServer := ts.MakeServer(cfg.AmbientCtx, tsDB, nodeCountFn, cfg.TimeSeriesServerConfig, stopper)
 
 	// The InternalExecutor will be further initialized later, as we create more
 	// of the server's components. There's a circular dependency - many things
@@ -427,171 +424,211 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// This function defines how ExternalStorage objects are created.
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		return cloud.MakeExternalStorage(
-			ctx, dest, s.cfg.ExternalIOConfig, st,
+			ctx, dest, cfg.ExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
-				s.nodeIDContainer.Get(),
-				s.nodeDialer,
+				nodeIDContainer.Get(),
+				nodeDialer,
 				st.ExternalIODir,
 			),
 		)
 	}
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
 		return cloud.ExternalStorageFromURI(
-			ctx, uri, s.cfg.ExternalIOConfig, st,
+			ctx, uri, cfg.ExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
-				s.nodeIDContainer.Get(),
-				s.nodeDialer,
+				nodeIDContainer.Get(),
+				nodeDialer,
 				st.ExternalIODir,
 			),
 		)
 	}
 
-	var err error
-	if s.protectedtsProvider, err = ptprovider.New(ptprovider.Config{
-		DB:               s.db,
+	protectedtsProvider, err := ptprovider.New(ptprovider.Config{
+		DB:               db,
 		InternalExecutor: internalExecutor,
 		Settings:         st,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	// TODO(bdarnell): make StoreConfig configurable.
+	// Break a circular dependency: we need a Node to make a StoreConfig (for
+	// ClosedTimestamp), but the Node needs a StoreConfig to be made.
+	var lateBoundNode *Node
+
 	storeCfg := kvserver.StoreConfig{
-		DefaultZoneConfig:       &s.cfg.DefaultZoneConfig,
+		DefaultZoneConfig:       &cfg.DefaultZoneConfig,
 		Settings:                st,
-		AmbientCtx:              s.cfg.AmbientCtx,
-		RaftConfig:              s.cfg.RaftConfig,
-		Clock:                   s.clock,
-		DB:                      s.db,
-		Gossip:                  s.gossip,
-		NodeLiveness:            s.nodeLiveness,
-		Transport:               s.raftTransport,
-		NodeDialer:              s.nodeDialer,
-		RPCContext:              s.rpcContext,
-		ScanInterval:            s.cfg.ScanInterval,
-		ScanMinIdleTime:         s.cfg.ScanMinIdleTime,
-		ScanMaxIdleTime:         s.cfg.ScanMaxIdleTime,
-		TimestampCachePageSize:  s.cfg.TimestampCachePageSize,
-		HistogramWindowInterval: s.cfg.HistogramWindowInterval(),
-		StorePool:               s.storePool,
+		AmbientCtx:              cfg.AmbientCtx,
+		RaftConfig:              cfg.RaftConfig,
+		Clock:                   clock,
+		DB:                      db,
+		Gossip:                  g,
+		NodeLiveness:            nodeLiveness,
+		Transport:               raftTransport,
+		NodeDialer:              nodeDialer,
+		RPCContext:              rpcContext,
+		ScanInterval:            cfg.ScanInterval,
+		ScanMinIdleTime:         cfg.ScanMinIdleTime,
+		ScanMaxIdleTime:         cfg.ScanMaxIdleTime,
+		TimestampCachePageSize:  cfg.TimestampCachePageSize,
+		HistogramWindowInterval: cfg.HistogramWindowInterval(),
+		StorePool:               storePool,
 		SQLExecutor:             internalExecutor,
-		LogRangeEvents:          s.cfg.EventLogEnabled,
-		RangeDescriptorCache:    s.distSender.RangeDescriptorCache(),
-		TimeSeriesDataStore:     s.tsDB,
+		LogRangeEvents:          cfg.EventLogEnabled,
+		RangeDescriptorCache:    distSender.RangeDescriptorCache(),
+		TimeSeriesDataStore:     tsDB,
 
 		// Initialize the closed timestamp subsystem. Note that it won't
 		// be ready until it is .Start()ed, but the grpc server can be
 		// registered early.
 		ClosedTimestamp: container.NewContainer(container.Config{
 			Settings: st,
-			Stopper:  s.stopper,
-			Clock:    s.nodeLiveness.AsLiveClock(),
+			Stopper:  stopper,
+			Clock:    nodeLiveness.AsLiveClock(),
 			// NB: s.node is not defined at this point, but it will be
 			// before this is ever called.
 			Refresh: func(rangeIDs ...roachpb.RangeID) {
 				for _, rangeID := range rangeIDs {
-					repl, _, err := s.node.stores.GetReplicaForRangeID(rangeID)
+					repl, _, err := lateBoundNode.stores.GetReplicaForRangeID(rangeID)
 					if err != nil || repl == nil {
 						continue
 					}
 					repl.EmitMLAI()
 				}
 			},
-			Dialer: s.nodeDialer.CTDialer(),
+			Dialer: nodeDialer.CTDialer(),
 		}),
 
 		EnableEpochRangeLeases:  true,
 		ExternalStorage:         externalStorage,
 		ExternalStorageFromURI:  externalStorageFromURI,
-		ProtectedTimestampCache: s.protectedtsProvider,
+		ProtectedTimestampCache: protectedtsProvider,
 	}
-	if storeTestingKnobs := s.cfg.TestingKnobs.Store; storeTestingKnobs != nil {
+	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
 		storeCfg.TestingKnobs = *storeTestingKnobs.(*kvserver.StoreTestingKnobs)
 	}
 
-	s.recorder = status.NewMetricsRecorder(s.clock, s.nodeLiveness, s.rpcContext, s.gossip, st)
-	s.registry.AddMetricStruct(s.rpcContext.RemoteClocks.Metrics())
+	recorder := status.NewMetricsRecorder(clock, nodeLiveness, rpcContext, g, st)
+	registry.AddMetricStruct(rpcContext.RemoteClocks.Metrics())
 
-	s.node = NewNode(
-		storeCfg, s.recorder, s.registry, s.stopper,
-		txnMetrics, nil /* execCfg */, &s.rpcContext.ClusterID)
-	roachpb.RegisterInternalServer(s.grpc.Server, s.node)
-	kvserver.RegisterPerReplicaServer(s.grpc.Server, s.node.perReplicaServer)
-	s.node.storeCfg.ClosedTimestamp.RegisterClosedTimestampServer(s.grpc.Server)
-	s.replicationReporter = reports.NewReporter(
-		s.db, s.node.stores, s.storePool,
-		s.ClusterSettings(), s.nodeLiveness, internalExecutor)
+	node := NewNode(
+		storeCfg, recorder, registry, stopper,
+		txnMetrics, nil /* execCfg */, &rpcContext.ClusterID)
+	lateBoundNode = node
+	roachpb.RegisterInternalServer(grpcServer.Server, node)
+	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)
+	node.storeCfg.ClosedTimestamp.RegisterClosedTimestampServer(grpcServer.Server)
+	replicationReporter := reports.NewReporter(
+		db, node.stores, storePool, st, nodeLiveness, internalExecutor)
 
-	s.protectedtsReconciler = ptreconcile.NewReconciler(ptreconcile.Config{
-		Settings: s.st,
-		Stores:   s.node.stores,
-		DB:       s.db,
-		Storage:  s.protectedtsProvider,
-		Cache:    s.protectedtsProvider,
+	protectedtsReconciler := ptreconcile.NewReconciler(ptreconcile.Config{
+		Settings: st,
+		Stores:   node.stores,
+		DB:       db,
+		Storage:  protectedtsProvider,
+		Cache:    protectedtsProvider,
 		StatusFuncs: ptreconcile.StatusFuncs{
 			jobsprotectedts.MetaType: jobsprotectedts.MakeStatusFunc(jobRegistry),
 		},
 	})
-	s.registry.AddMetricStruct(s.protectedtsReconciler.Metrics())
+	registry.AddMetricStruct(protectedtsReconciler.Metrics())
 
-	s.admin = newAdminServer(s)
+	lateBoundServer := &Server{}
+	// TODO(tbg): don't pass the whole Server into lateBoundServer to avoid this
+	// hack.
+	adminServer := newAdminServer(lateBoundServer)
 	sessionRegistry := sql.NewSessionRegistry()
 
-	s.status = newStatusServer(
-		s.cfg.AmbientCtx,
+	statusServer := newStatusServer(
+		cfg.AmbientCtx,
 		st,
-		s.cfg.Config,
-		s.admin,
-		s.db,
-		s.gossip,
-		s.recorder,
-		s.nodeLiveness,
-		s.storePool,
-		s.rpcContext,
-		s.node.stores,
-		s.stopper,
+		cfg.Config,
+		adminServer,
+		db,
+		g,
+		recorder,
+		nodeLiveness,
+		storePool,
+		rpcContext,
+		node.stores,
+		stopper,
 		sessionRegistry,
 		internalExecutor,
 	)
-	s.authentication = newAuthenticationServer(s)
-	for i, gw := range []grpcGatewayServer{s.admin, s.status, s.authentication, &s.tsServer} {
+	// TODO(tbg): don't pass all of Server into this to avoid this hack.
+	authenticationServer := newAuthenticationServer(lateBoundServer)
+	for i, gw := range []grpcGatewayServer{adminServer, statusServer, authenticationServer, &tsServer} {
 		if reflect.ValueOf(gw).IsNil() {
 			return nil, errors.Errorf("%d: nil", i)
 		}
-		gw.RegisterService(s.grpc.Server)
+		gw.RegisterService(grpcServer.Server)
 	}
 
-	flowDB := kv.NewDB(cfg.AmbientCtx, s.tcsFactory, s.clock)
-	s.sqlServer, err = newSQLServer(sqlServerArgs{
-		Config:                 &s.cfg, // NB: s.cfg has a populated AmbientContext.
+	flowDB := kv.NewDB(cfg.AmbientCtx, tcsFactory, clock)
+	sqlServer, err := newSQLServer(sqlServerArgs{
+		Config:                 &cfg, // NB: s.cfg has a populated AmbientContext.
 		stopper:                stopper,
 		clock:                  clock,
-		rpcContext:             s.rpcContext,
-		distSender:             s.distSender,
-		status:                 s.status,
-		nodeLiveness:           s.nodeLiveness,
-		protectedtsProvider:    s.protectedtsProvider,
-		gossip:                 s.gossip,
-		nodeDialer:             s.nodeDialer,
-		grpcServer:             s.grpc.Server,
-		recorder:               s.recorder,
-		runtime:                s.runtime,
-		db:                     s.db,
-		registry:               s.registry,
+		rpcContext:             rpcContext,
+		distSender:             distSender,
+		status:                 statusServer,
+		nodeLiveness:           nodeLiveness,
+		protectedtsProvider:    protectedtsProvider,
+		gossip:                 g,
+		nodeDialer:             nodeDialer,
+		grpcServer:             grpcServer.Server,
+		recorder:               recorder,
+		runtime:                runtimeSampler,
+		db:                     db,
+		registry:               registry,
 		internalExecutor:       internalExecutor,
-		nodeIDContainer:        &s.nodeIDContainer,
+		nodeIDContainer:        nodeIDContainer,
 		flowDB:                 flowDB,
 		externalStorage:        externalStorage,
 		externalStorageFromURI: externalStorageFromURI,
 		jobRegistry:            jobRegistry,
-		isMeta1Leaseholder:     s.node.stores.IsMeta1Leaseholder,
+		isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,
 	})
 	if err != nil {
 		return nil, err
 	}
-	s.debug = debug.NewServer(s.ClusterSettings(), s.sqlServer.pgServer.HBADebugFn())
-	s.node.InitLogger(s.sqlServer.execCfg)
-	return s, err
+	debugServer := debug.NewServer(st, sqlServer.pgServer.HBADebugFn())
+	node.InitLogger(sqlServer.execCfg)
+
+	*lateBoundServer = Server{
+		nodeIDContainer:       nodeIDContainer,
+		cfg:                   cfg,
+		st:                    st,
+		clock:                 clock,
+		rpcContext:            rpcContext,
+		grpc:                  grpcServer,
+		gossip:                g,
+		nodeDialer:            nodeDialer,
+		nodeLiveness:          nodeLiveness,
+		storePool:             storePool,
+		tcsFactory:            tcsFactory,
+		distSender:            distSender,
+		db:                    db,
+		node:                  node,
+		registry:              registry,
+		recorder:              recorder,
+		runtime:               runtimeSampler,
+		admin:                 adminServer,
+		status:                statusServer,
+		authentication:        authenticationServer,
+		initServer:            initServer,
+		tsDB:                  tsDB,
+		tsServer:              &tsServer,
+		raftTransport:         raftTransport,
+		stopper:               stopper,
+		debug:                 debugServer,
+		replicationReporter:   replicationReporter,
+		protectedtsProvider:   protectedtsProvider,
+		protectedtsReconciler: protectedtsReconciler,
+		sqlServer:             sqlServer,
+	}
+	return lateBoundServer, err
 }
 
 type sqlServerArgs struct {
@@ -1521,7 +1558,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	})
 
-	for _, gw := range []grpcGatewayServer{s.admin, s.status, s.authentication, &s.tsServer} {
+	for _, gw := range []grpcGatewayServer{s.admin, s.status, s.authentication, s.tsServer} {
 		if err := gw.RegisterGateway(gwCtx, gwMux, conn); err != nil {
 			return err
 		}
@@ -1881,7 +1918,7 @@ func (s *Server) Start(ctx context.Context) error {
 		ui.Handler(ui.Config{
 			ExperimentalUseLogin: s.cfg.EnableWebSessionAuthentication,
 			LoginEnabled:         s.cfg.RequireWebSession(),
-			NodeID:               &s.nodeIDContainer,
+			NodeID:               s.nodeIDContainer,
 			GetUser: func(ctx context.Context) *string {
 				if u, ok := ctx.Value(webSessionUserKey{}).(string); ok {
 					return &u

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -381,9 +381,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		cfg.AmbientCtx,
 		clock,
 		db,
-		// TODO(tbg): this is supposed to get the engines slice, which is only
-		// available at start time.
-		nil,
 		g,
 		nlActive,
 		nlRenewal,
@@ -1852,7 +1849,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}); err != nil {
 			log.Warning(ctx, errors.Wrap(err, "writing last up timestamp"))
 		}
-	})
+	}, s.engines)
 
 	// Begin recording status summaries.
 	s.node.startWriteNodeStatus(DefaultMetricsSampleInterval)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -660,8 +660,8 @@ type sqlServerArgs struct {
 	circularInternalExecutor *sql.InternalExecutor // empty initially
 	// DistSQL, lease management, and others want to know the node they're on.
 	//
-	// TODO(tbg): reasonable ask, but a SQL tenant process has no NodeID.
-	// Replace this with a method that can refuse to return a result.
+	// TODO(tbg): replace this with a method that can refuse to return a result
+	// because once we have multi-tenancy, a NodeID will not be available.
 	nodeIDContainer *base.NodeIDContainer
 
 	// Used by backup/restore.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1588,8 +1588,8 @@ func (s *Server) Start(ctx context.Context) error {
 		if storeSpec.InMemory {
 			continue
 		}
-		for base, val := range listenerFiles {
-			file := filepath.Join(storeSpec.Path, base)
+		for name, val := range listenerFiles {
+			file := filepath.Join(storeSpec.Path, name)
 			if err := ioutil.WriteFile(file, []byte(val), 0644); err != nil {
 				return errors.Wrapf(err, "failed to write %s", file)
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -575,7 +575,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		nodeDialer:             s.nodeDialer,
 		grpcServer:             s.grpc.Server,
 		recorder:               s.recorder,
-		node:                   s.node,
 		runtime:                s.runtime,
 		db:                     s.db,
 		registry:               s.registry,
@@ -585,38 +584,73 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		externalStorage:        externalStorage,
 		externalStorageFromURI: externalStorageFromURI,
 		jobRegistry:            jobRegistry,
+		isMeta1Leaseholder:     s.node.stores.IsMeta1Leaseholder,
 	})
 	if err != nil {
 		return nil, err
 	}
 	s.debug = debug.NewServer(s.ClusterSettings(), s.sqlServer.pgServer.HBADebugFn())
+	s.node.InitLogger(s.sqlServer.execCfg)
 	return s, err
 }
 
 type sqlServerArgs struct {
 	*Config
-	stopper             *stop.Stopper
-	clock               *hlc.Clock
-	rpcContext          *rpc.Context
-	distSender          *kvcoord.DistSender
-	status              *statusServer
-	nodeLiveness        *kvserver.NodeLiveness
-	protectedtsProvider protectedts.Provider
-	gossip              *gossip.Gossip
-	nodeDialer          *nodedialer.Dialer
-	grpcServer          *grpc.Server
-	recorder            *status.MetricsRecorder
-	node                *Node
-	runtime             *status.RuntimeStatSampler
+	stopper    *stop.Stopper
+	clock      *hlc.Clock
+	rpcContext *rpc.Context
 
-	db                     *kv.DB
-	registry               *metric.Registry
-	internalExecutor       *sql.InternalExecutor // empty initially
-	nodeIDContainer        *base.NodeIDContainer
-	flowDB                 *kv.DB // for DistSQL
+	// SQL mostly uses the DistSender "wrapped" under a *kv.DB, but SQL also
+	// uses range descriptors and leaseholders, which DistSender maintains,
+	// for debugging and DistSQL planning purposes.
+	distSender *kvcoord.DistSender
+	// The executorConfig depends on the status server.
+	// The status server is handed the stmtDiagnosticsRegistry.
+	status *statusServer
+	// The DistSQLPlanner uses node liveness.
+	nodeLiveness *kvserver.NodeLiveness
+	// The executorConfig uses the provider.
+	protectedtsProvider protectedts.Provider
+	// Gossip is relied upon by distSQLCfg (execinfra.ServerConfig), the executor
+	// config, the DistSQL planner, the table statistics cache, the statements
+	// diagnostics registry, and the lease manager.
+	gossip *gossip.Gossip
+	// Used by DistSQLConfig and DistSQLPlanner.
+	nodeDialer *nodedialer.Dialer
+	// To register blob and DistSQL servers.
+	grpcServer *grpc.Server
+	// Used by executorConfig.
+	recorder *status.MetricsRecorder
+	// For the temporaryObjectCleaner.
+	isMeta1Leaseholder func(hlc.Timestamp) (bool, error)
+	// DistSQLCfg holds on to this to check for node CPU utilization in
+	// samplerProcessor.
+	runtime *status.RuntimeStatSampler
+
+	// SQL needs to use KV. There's one regular DB and one for DistSQL.
+	//
+	// TODO(tbg): why can't it be the same?
+	db     *kv.DB
+	flowDB *kv.DB // for DistSQL
+
+	// Various components want to register themselves with metrics.
+	registry *metric.Registry
+
+	// KV depends on the internal executor, so it is early bound but only filled
+	// in newSQLServer.
+	internalExecutor *sql.InternalExecutor // empty initially
+	// DistSQL, lease management, and others want to know the node they're on.
+	//
+	// TODO(tbg): reasonable ask, but a SQL tenant process has no NodeID.
+	// Replace this with a method that can refuse to return a result.
+	nodeIDContainer *base.NodeIDContainer
+
+	// Used by backup/restore.
 	externalStorage        cloud.ExternalStorageFactory
 	externalStorageFromURI cloud.ExternalStorageFromURIFactory
 
+	// The protected timestamps KV subsystem depends on this, so it is bound
+	// early but only gets filled in newSQLServer.
 	jobRegistry *jobs.Registry
 }
 
@@ -984,15 +1018,13 @@ func newSQLServer(cfg sqlServerArgs) (*sqlServer, error) {
 	s.leaseMgr.RefreshLeases(cfg.stopper, cfg.db, cfg.gossip)
 	s.leaseMgr.PeriodicallyRefreshSomeLeases()
 
-	cfg.node.InitLogger(execCfg)
-
 	s.temporaryObjectCleaner = sql.NewTemporaryObjectCleaner(
 		cfg.Settings,
 		cfg.db,
 		cfg.registry,
 		s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory,
 		cfg.status,
-		cfg.node.stores.IsMeta1Leaseholder,
+		cfg.isMeta1Leaseholder,
 		sqlExecutorTestingKnobs,
 	)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1475,6 +1475,9 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
+	// Set up the init server. We have to do this relatively early because we
+	// can't call RegisterInitServer() after `grpc.Serve`, which is called in
+	// startRPCServer (and for the loopback grpc-gw connection).
 	initServer, err := setupInitServer(
 		ctx,
 		s.cfg.Settings.Version.BinaryVersion(),
@@ -1488,9 +1491,6 @@ func (s *Server) Start(ctx context.Context) error {
 		return err
 	}
 
-	// We cannot register a server after grpc.Serve has been called (it will
-	// panic otherwise). This will happen when startRPCServer is called or when
-	// we serve the UI, both of which happen relatively early.
 	serverpb.RegisterInitServer(s.grpc.Server, initServer)
 
 	s.node.startAssertEngineHealth(ctx, s.engines)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1659,16 +1659,14 @@ func (s *Server) Start(ctx context.Context) error {
 		// If the node is started without join flags, attempt self-bootstrap.
 		// Note that we're not checking whether the node is already bootstrapped;
 		// if this is the case, Bootstrap will simply fail.
-		_ = s.stopper.RunAsyncTask(ctx, "bootstrap", func(ctx context.Context) {
-			_, err := initServer.Bootstrap(ctx, &serverpb.BootstrapRequest{})
-			switch err {
-			case nil:
-				log.Infof(ctx, "**** add additional nodes by specifying --join=%s", s.cfg.AdvertiseAddr)
-			case ErrClusterInitialized:
-			default:
-				// Process is shutting down.
-			}
-		})
+		_, err := initServer.Bootstrap(ctx, &serverpb.BootstrapRequest{})
+		switch err {
+		case nil:
+			log.Infof(ctx, "**** add additional nodes by specifying --join=%s", s.cfg.AdvertiseAddr)
+		case ErrClusterInitialized:
+		default:
+			// Process is shutting down.
+		}
 	}
 
 	state, err := initServer.ServeAndWait(ctx, s.stopper, s.gossip)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1652,9 +1652,6 @@ func (s *Server) Start(ctx context.Context) error {
 		})
 	}
 
-	// This opens the main listener.
-	startRPCServer(workersCtx)
-
 	if len(s.cfg.GossipBootstrapResolvers) == 0 {
 		// If the node is started without join flags, attempt self-bootstrap.
 		// Note that we're not checking whether the node is already bootstrapped;
@@ -1668,6 +1665,9 @@ func (s *Server) Start(ctx context.Context) error {
 			// Process is shutting down.
 		}
 	}
+
+	// This opens the main listener.
+	startRPCServer(workersCtx)
 
 	state, err := initServer.ServeAndWait(ctx, s.stopper, s.gossip)
 	if err != nil {

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -92,7 +92,7 @@ func (s *Server) gcSystemLog(
 		var rowsAffected int64
 		err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			var err error
-			row, err := s.internalExecutor.QueryRowEx(
+			row, err := s.sqlServer.internalExecutor.QueryRowEx(
 				ctx,
 				table+"-gc",
 				txn,

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -67,7 +67,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 			// `cluster.preserve_downgrade_option` statement in a transaction until
 			// success.
 			for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
-				if _, err := s.internalExecutor.ExecEx(
+				if _, err := s.sqlServer.internalExecutor.ExecEx(
 					ctx, "set-version", nil, /* txn */
 					sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 					"SET CLUSTER SETTING version = crdb_internal.node_executable_version();",
@@ -130,7 +130,7 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 	// Check if auto upgrade is enabled at current version. This is read from
 	// the KV store so that it's in effect on all nodes immediately following a
 	// SET CLUSTER SETTING.
-	datums, err := s.internalExecutor.QueryEx(
+	datums, err := s.sqlServer.internalExecutor.QueryEx(
 		ctx, "read-downgrade", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"SELECT value FROM system.settings WHERE name = 'cluster.preserve_downgrade_option';",
@@ -155,7 +155,7 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 // (which returns the version from the KV store as opposed to the possibly
 // lagging settings subsystem).
 func (s *Server) clusterVersion(ctx context.Context) (string, error) {
-	datums, err := s.internalExecutor.QueryEx(
+	datums, err := s.sqlServer.internalExecutor.QueryEx(
 		ctx, "show-version", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"SHOW CLUSTER SETTING version;",

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -87,8 +87,8 @@ func (s *statusServer) Statements(
 }
 
 func (s *statusServer) StatementsLocal(ctx context.Context) (*serverpb.StatementsResponse, error) {
-	stmtStats := s.admin.server.pgServer.SQLServer.GetUnscrubbedStmtStats()
-	lastReset := s.admin.server.pgServer.SQLServer.GetStmtStatsLastReset()
+	stmtStats := s.admin.server.sqlServer.pgServer.SQLServer.GetUnscrubbedStmtStats()
+	lastReset := s.admin.server.sqlServer.pgServer.SQLServer.GetStmtStatsLastReset()
 
 	resp := &serverpb.StatementsResponse{
 		Statements:            make([]serverpb.StatementsResponse_CollectedStatementStatistics, len(stmtStats)),

--- a/pkg/server/stats_test.go
+++ b/pkg/server/stats_test.go
@@ -37,7 +37,7 @@ CREATE TABLE t.test (x INT PRIMARY KEY);
 		t.Fatal(err)
 	}
 
-	sqlServer := s.(*TestServer).Server.pgServer.SQLServer
+	sqlServer := s.(*TestServer).Server.sqlServer.pgServer.SQLServer
 
 	// Flush stats at the beginning of the test.
 	sqlServer.ResetSQLStats(ctx)
@@ -78,7 +78,7 @@ func TestSQLStatCollection(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
-	sqlServer := s.(*TestServer).Server.pgServer.SQLServer
+	sqlServer := s.(*TestServer).Server.sqlServer.pgServer.SQLServer
 
 	// Flush stats at the beginning of the test.
 	sqlServer.ResetSQLStats(ctx)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2041,7 +2041,7 @@ func (s *statusServer) JobRegistryStatus(
 	resp := &serverpb.JobRegistryStatusResponse{
 		NodeID: remoteNodeID,
 	}
-	for _, jID := range s.admin.server.jobRegistry.CurrentlyRunningJobs() {
+	for _, jID := range s.admin.server.sqlServer.jobRegistry.CurrentlyRunningJobs() {
 		job := serverpb.JobRegistryStatusResponse_Job{
 			Id: jID,
 		}
@@ -2061,7 +2061,7 @@ func (s *statusServer) JobStatus(
 
 	ctx = s.AnnotateCtx(propagateGatewayMetadata(ctx))
 
-	j, err := s.admin.server.jobRegistry.LoadJob(ctx, req.JobId)
+	j, err := s.admin.server.sqlServer.jobRegistry.LoadJob(ctx, req.JobId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -301,7 +301,7 @@ func (ts *TestServer) Clock() *hlc.Clock {
 // JobRegistry returns the *jobs.Registry as an interface{}.
 func (ts *TestServer) JobRegistry() interface{} {
 	if ts != nil {
-		return ts.jobRegistry
+		return ts.sqlServer.jobRegistry
 	}
 	return nil
 }
@@ -309,7 +309,7 @@ func (ts *TestServer) JobRegistry() interface{} {
 // MigrationManager returns the *sqlmigrations.Manager as an interface{}.
 func (ts *TestServer) MigrationManager() interface{} {
 	if ts != nil {
-		return ts.migMgr
+		return ts.sqlServer.migMgr
 	}
 	return nil
 }
@@ -341,7 +341,7 @@ func (ts *TestServer) DB() *kv.DB {
 // PGServer returns the pgwire.Server used by the TestServer.
 func (ts *TestServer) PGServer() *pgwire.Server {
 	if ts != nil {
-		return ts.pgServer
+		return ts.sqlServer.pgServer
 	}
 	return nil
 }
@@ -571,7 +571,7 @@ func (ts *TestServer) getAuthenticatedHTTPClientAndCookie(
 }
 
 func (ts *TestServer) createAuthUser(userName string, isAdmin bool) error {
-	if _, err := ts.Server.internalExecutor.ExecEx(context.TODO(),
+	if _, err := ts.Server.sqlServer.internalExecutor.ExecEx(context.TODO(),
 		"create-auth-user", nil,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"CREATE USER $1", userName,
@@ -581,7 +581,7 @@ func (ts *TestServer) createAuthUser(userName string, isAdmin bool) error {
 	if isAdmin {
 		// We can't use the GRANT statement here because we don't want
 		// to rely on CCL code.
-		if _, err := ts.Server.internalExecutor.ExecEx(context.TODO(),
+		if _, err := ts.Server.sqlServer.internalExecutor.ExecEx(context.TODO(),
 			"grant-admin", nil,
 			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"INSERT INTO system.role_members (role, member, \"isAdmin\") VALUES ('admin', $1, true)", userName,
@@ -621,7 +621,7 @@ func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 	var found bool
 
 	reg := metric.NewRegistry()
-	for _, m := range ts.pgServer.Metrics() {
+	for _, m := range ts.sqlServer.pgServer.Metrics() {
 		reg.AddMetricStruct(m)
 	}
 	reg.Each(func(n string, v interface{}) {
@@ -644,12 +644,12 @@ func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 
 // LeaseManager is part of TestServerInterface.
 func (ts *TestServer) LeaseManager() interface{} {
-	return ts.leaseMgr
+	return ts.sqlServer.leaseMgr
 }
 
 // InternalExecutor is part of TestServerInterface.
 func (ts *TestServer) InternalExecutor() interface{} {
-	return ts.internalExecutor
+	return ts.sqlServer.internalExecutor
 }
 
 // GetNode exposes the Server's Node.
@@ -675,12 +675,12 @@ func (ts *TestServer) SQLServer() interface{} {
 
 // DistSQLServer is part of TestServerInterface.
 func (ts *TestServer) DistSQLServer() interface{} {
-	return ts.distSQLServer
+	return ts.sqlServer.distSQLServer
 }
 
 // SetDistSQLSpanResolver is part of TestServerInterface.
 func (s *Server) SetDistSQLSpanResolver(spanResolver interface{}) {
-	s.execCfg.DistSQLPlanner.SetSpanResolver(spanResolver.(physicalplan.SpanResolver))
+	s.sqlServer.execCfg.DistSQLPlanner.SetSpanResolver(spanResolver.(physicalplan.SpanResolver))
 }
 
 // GetFirstStoreID is part of TestServerInterface.
@@ -853,7 +853,7 @@ func (ts *TestServer) GetRangeLease(
 
 // ExecutorConfig is part of the TestServerInterface.
 func (ts *TestServer) ExecutorConfig() interface{} {
-	return *ts.execCfg
+	return *ts.sqlServer.execCfg
 }
 
 // GCSystemLog deletes entries in the given system log table between
@@ -879,7 +879,7 @@ func (ts *TestServer) ForceTableGC(
    JOIN system.namespace dbs ON dbs.id = tables."parentID"
    WHERE dbs.name = $1 AND tables.name = $2
  `
-	row, err := ts.internalExecutor.QueryRowEx(
+	row, err := ts.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "resolve-table-id", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		tableIDQuery, database, table)

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -283,7 +283,7 @@ func (s *Server) maybeReportDiagnostics(
 	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
 		s.reportDiagnostics(ctx)
 	}
-	s.pgServer.SQLServer.ResetReportedStats(ctx)
+	s.sqlServer.pgServer.SQLServer.ResetReportedStats(ctx)
 
 	return scheduled.Add(diagnosticReportFrequency.Get(&s.st.SV))
 }
@@ -351,7 +351,7 @@ func (s *Server) getReportingInfo(
 	// Read the system.settings table to determine the settings for which we have
 	// explicitly set values -- the in-memory SV has the set and default values
 	// flattened for quick reads, but we'd rather only report the non-defaults.
-	if datums, err := s.internalExecutor.QueryEx(
+	if datums, err := s.sqlServer.internalExecutor.QueryEx(
 		ctx, "read-setting", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"SELECT name FROM system.settings",
@@ -365,7 +365,7 @@ func (s *Server) getReportingInfo(
 		}
 	}
 
-	if datums, err := s.internalExecutor.QueryEx(
+	if datums, err := s.sqlServer.internalExecutor.QueryEx(
 		ctx,
 		"read-zone-configs",
 		nil, /* txn */
@@ -392,7 +392,7 @@ func (s *Server) getReportingInfo(
 		}
 	}
 
-	info.SqlStats = s.pgServer.SQLServer.GetScrubbedReportingStats()
+	info.SqlStats = s.sqlServer.pgServer.SQLServer.GetScrubbedReportingStats()
 	return &info
 }
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -145,7 +145,7 @@ func TestUsageQuantization(t *testing.T) {
 	}
 
 	// Flush the SQL stat pool.
-	ts.Server.pgServer.SQLServer.ResetSQLStats(ctx)
+	ts.Server.sqlServer.pgServer.SQLServer.ResetSQLStats(ctx)
 
 	// Collect a round of statistics.
 	ts.reportDiagnostics(ctx)
@@ -565,7 +565,7 @@ func TestReportUsage(t *testing.T) {
 
 		node := ts.node.recorder.GenerateNodeStatus(ctx)
 		// Clear the SQL stat pool before getting diagnostics.
-		ts.pgServer.SQLServer.ResetSQLStats(ctx)
+		ts.sqlServer.pgServer.SQLServer.ResetSQLStats(ctx)
 		ts.reportDiagnostics(ctx)
 
 		keyCounts := make(map[roachpb.StoreID]int64)

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1463,11 +1463,6 @@ func NewLeaseManager(
 	return lm
 }
 
-// SetInternalExecutor has to be called if a nil execCfg was passed to NewLeaseManager.
-func (m *LeaseManager) SetInternalExecutor(executor sqlutil.InternalExecutor) {
-	m.internalExecutor = executor
-}
-
 func nameMatchesTable(
 	table *sqlbase.TableDescriptor, dbID sqlbase.ID, schemaID sqlbase.ID, tableName string,
 ) bool {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -150,7 +150,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		cfg.AmbientCtx,
 		cfg.Clock,
 		cfg.DB,
-		[]storage.Engine{ltc.Eng},
 		cfg.Gossip,
 		active,
 		renewal,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -204,7 +204,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	}
 
 	if !ltc.DisableLivenessHeartbeat {
-		cfg.NodeLiveness.StartHeartbeat(ctx, ltc.Stopper, nil /* alive */)
+		cfg.NodeLiveness.StartHeartbeat(ctx, ltc.Stopper, nil /* alive */, []storage.Engine{ltc.Eng})
 	}
 
 	if err := ltc.Store.Start(ctx, ltc.Stopper); err != nil {


### PR DESCRIPTION
First four commits from #46843.

----

Ultimately we want to separate the SQL and KV startup paths.
This is difficult because of various cyclic dependencies;
for example, the KV subsystem relies on being able to run
simple SQL queries, and the SQL subsystem in turn relies
on node liveness, Gossip, and others that in a multi-tenant
future it won't have access to.

This won't be untangled in one commit, but here is a modest start: We
split out a `newSQLServer` method which we call in `NewServer` and which
populates the `(Server).sqlServer` field, which now houses all that was
formerly in `Server` but really ought to be owned by SQL.

A few of these PRs in, you can imagine a structure emerging in which,
modulo the cross-dependencies which will then clearly be visible,

```
type Server struct
  // ...
  kvServer  *kv.Server
  sqlServer *sql.Server
}
```

Release note: None

