### PR TITLE
backport-20.1: kvserver: improve reporting for an assertion

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -333,7 +334,14 @@ func evaluateBatch(
 		if limit := baHeader.MaxSpanRequestKeys; limit > 0 {
 			retResults := reply.Header().NumKeys
 			if retResults > limit {
-				log.Fatalf(ctx, "received %d results, limit was %d", retResults, limit)
+				index, retResults, limit := index, retResults, limit // don't alloc unless branch taken
+				err := errorutil.UnexpectedWithIssueErrorf(46652,
+					"received %d results, limit was %d (original limit: %d, batch=%s idx=%d)",
+					errors.Safe(retResults), errors.Safe(limit),
+					errors.Safe(ba.Header.MaxSpanRequestKeys),
+					errors.Safe(ba.Summary()), errors.Safe(index))
+				errorutil.SendReport(ctx, &rec.ClusterSettings().SV, err)
+				return nil, mergedResult, roachpb.NewError(err)
 			} else if retResults < limit {
 				baHeader.MaxSpanRequestKeys -= retResults
 			} else {


### PR DESCRIPTION
Backport 2/2 commits from #46720.

/cc @cockroachdb/release

---

Downgrade the assertion to returning an error to the user, asking nicely
for providing their repro on the issue. We keep reporting to sentry
despite not terminating the process.

Touches #46652.

Release justification: low-risk reporting improvement
Release note: None
