### PR TITLE
cli/demo: simplify the SQL connection parameters

### DIFF
--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -64,7 +64,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
 		demoCtx.cacheSize = tc.cacheSize
 
-		actual := testServerArgsForTransientCluster(tc.nodeID, tc.joinAddr)
+		actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr)
 
 		assert.Len(t, actual.StoreSpecs, 1)
 		assert.Equal(

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -2,14 +2,15 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-start_test "Check that demo says hello properly"
-spawn $argv demo
+start_test "Check that demo insecure says hello properly"
+spawn $argv demo --insecure=true
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
-eexpect "Web UI: http:"
+eexpect "(console)"
+eexpect "http:"
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
 eexpect "Cluster ID"
@@ -26,17 +27,41 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo
+spawn $argv demo --empty
 eexpect "Welcome"
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root@"
+eexpect "sslmode=disable"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --insecure=true
+spawn $argv demo --insecure=true --empty
 eexpect "Welcome"
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root@"
+eexpect "sslmode=disable"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
@@ -44,21 +69,46 @@ end_test
 
 start_test "Check that demo secure says hello properly"
 
+
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo
+spawn $argv demo --empty
 eexpect "Welcome"
 eexpect "The user \"root\" with password \"admin\" has been created."
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root:admin@"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --insecure=false
+spawn $argv demo --insecure=false --empty
 eexpect "Welcome"
 eexpect "The user \"root\" with password \"admin\" has been created."
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root:admin@"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
@@ -66,25 +116,46 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure
+spawn $argv demo --insecure --empty
 # Check that we see our message.
-eexpect "Connect to the cluster on a SQL shell at"
+eexpect "Connection parameters"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+expect root@
+send_eof
+eexpect eof
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3
+spawn $argv demo --insecure --nodes 3 --empty
 
 # Check that we get a message for each node.
-eexpect "Connect to different nodes in the cluster on a SQL shell at"
-eexpect "Node 1"
-eexpect "Node 2"
-eexpect "Node 3"
+eexpect "Connection parameters"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "defaultdb>"
 
-spawn $argv demo --insecure=false
-eexpect "Connect to the cluster on a SQL shell at"
+send "\\demo ls\r"
+eexpect "node 1"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "node 2"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "node 3"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+spawn $argv demo --insecure=false --empty
 # Expect that security related tags are part of the connection URL.
-eexpect "sslcert="
-eexpect "sslkey="
-eexpect "sslrootcert="
+eexpect "(sql/tcp)"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
 
 end_test
-

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -71,6 +71,7 @@ More documentation about our SQL dialect and the CLI shell is available online:
 
 	demoCommandsHelp = `
 Commands specific to the demo shell (EXPERIMENTAL):
+  \demo ls                     list the demo nodes and their connection URLs.
   \demo shutdown <nodeid>      stop a demo node.
   \demo restart <nodeid>       restart a stopped demo node.
   \demo decommission <nodeid>  decommission a node.
@@ -490,9 +491,16 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 	if demoCtx.transientCluster == nil {
 		return c.invalidSyntax(errState, `\demo can only be run with cockroach demo`)
 	}
+
+	if len(cmd) == 1 && cmd[0] == "ls" {
+		demoCtx.transientCluster.listDemoNodes(os.Stdout, false /* justOne */)
+		return nextState
+	}
+
 	if len(cmd) != 2 {
 		return c.invalidSyntax(errState, `\demo expects 2 parameters`)
 	}
+
 	nodeID, err := strconv.ParseInt(cmd[1], 10, 32)
 	if err != nil {
 		return c.invalidSyntax(
@@ -501,6 +509,7 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 			errors.Wrapf(err, "cannot convert %s to string", cmd[2]).Error(),
 		)
 	}
+
 	switch cmd[0] {
 	case "shutdown":
 		if err := demoCtx.transientCluster.DrainNode(roachpb.NodeID(nodeID)); err != nil {

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -97,3 +97,7 @@ func disableOtherPermissionBits() {
 	mask |= 00007
 	_ = unix.Umask(mask)
 }
+
+func useUnixSocketsInDemo() bool {
+	return true
+}

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -32,3 +32,8 @@ func maybeRerunBackground() (bool, error) {
 func disableOtherPermissionBits() {
 	// No-op on windows, which does not support umask.
 }
+
+func useUnixSocketsInDemo() bool {
+	// No unix sockets on windows.
+	return false
+}


### PR DESCRIPTION
First commit from #46968. 
Requested/recommended by @aaron-crl 

Prior to this patch, the `cockroach demo` shell was advertising SQL
client URLs that were dependent on TLS client certs. This makes it
overly reliant on the client app having access to the cert files,
which in a multi-user system may not be easy to achieve.

This patch improves the situation as follows:

- the generated SQL connection URL, when in secure mode, now requires
  TLS (`sslmode=require`) but uses a password to authenticate the
  client instead of a client cert.

- when running on unix, a unix socket is also configured.
  The socket URL, if available, is also displayed because
  alongside the TCP URL.

Example:

```
   $ ./cockroach demo  --nodes 2
   #
   # Welcome to the CockroachDB demo database!
   #
   ...
   # Connection parameters:
   # node 1:
   #   (console) http://127.0.0.1:36732
   #   (sql)     postgres://root:admin@?host=%2Ftmp%2Fdemo806076655&port=26257
   #   (sql/tcp) postgres://root:admin@127.0.0.1:43251?sslmode=require
   #
   # node 2:
   #   (console) http://127.0.0.1:31261
   #   (sql)     postgres://root:admin@?host=%2Ftmp%2Fdemo806076655&port=26258
   #   (sql/tcp) postgres://root:admin@127.0.0.1:13130?sslmode=require
   #
   # Enter \? for a brief introduction.
   #
   root@127.0.0.1:43251/movr>
```

Additionally, the new client-side command `\demo ls` enables the user
to re-display the connection URLs during an interactive demo.

For example:

```
root@127.0.0.1:43251/movr> \demo ls
node 1:
  (console) http://127.0.0.1:36732
  (sql)     postgres://root:admin@?host=%2Ftmp%2Fdemo806076655&port=26257
  (sql/tcp) postgres://root:admin@127.0.0.1:43251?sslmode=require

node 2:
  (console) http://127.0.0.1:31261
  (sql)     postgres://root:admin@?host=%2Ftmp%2Fdemo806076655&port=26258
  (sql/tcp) postgres://root:admin@127.0.0.1:13130?sslmode=require
```

Release note (cli change): The `cockroach demo` now displays a
connection URL using a unix datagram socket before the TCP-based URL,
as this may deliver better performance in clients running on the same
system.

Release note (cli change): the SQL URL generated by `cockroach demo`,
when running in the secure mode, now embed the password. This way,
a command ran by copy-pasting the URL is able to run without asking
for a password first.

Release note (cli change): the SQL URL generated by `cockroach demo`
is simplified to not require TLS client certificates in particular
directory locations.

Release note (cli change): the new client-side command `\demo
ls` (experimental) can now (re-)display the connection parameters for
every node in the simulated cluster.