### PR TITLE
geo/geos: refactor C++ initialization code

### DIFF
--- a/pkg/geo/geos/.clang-format
+++ b/pkg/geo/geos/.clang-format
@@ -1,0 +1,109 @@
+---
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '^".*"$'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        5
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/pkg/geo/geos/geos_unix.cc
+++ b/pkg/geo/geos/geos_unix.cc
@@ -15,6 +15,8 @@
 
 #include "geos_unix.h"
 
+namespace {
+
 // Data Types adapted from `capi/geos_c.h.in` in GEOS.
 typedef void *CR_GEOS_Handle;
 typedef void *CR_GEOS_WKTReader;
@@ -39,126 +41,107 @@ typedef void (*CR_GEOS_WKBWriter_setByteOrder_r)(CR_GEOS_Handle,
                                                  CR_GEOS_WKBWriter, int);
 typedef void (*CR_GEOS_WKBWriter_destroy_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter);
 
-struct CR_GEOS {
-  void *dlHandle;
-
-  CR_GEOS_init_r CR_GEOS_init_r;
-  CR_GEOS_finish_r CR_GEOS_finish_r;
-
-  CR_GEOS_Geom_destroy_r CR_GEOS_Geom_destroy_r;
-
-  CR_GEOS_WKTReader_create_r CR_GEOS_WKTReader_create_r;
-  CR_GEOS_WKTReader_destroy_r CR_GEOS_WKTReader_destroy_r;
-  CR_GEOS_WKTReader_read_r CR_GEOS_WKTReader_read_r;
-
-  CR_GEOS_WKBWriter_create_r CR_GEOS_WKBWriter_create_r;
-  CR_GEOS_WKBWriter_destroy_r CR_GEOS_WKBWriter_destroy_r;
-  CR_GEOS_WKBWriter_setByteOrder_r CR_GEOS_WKBWriter_setByteOrder_r;
-  CR_GEOS_WKBWriter_write_r CR_GEOS_WKBWriter_write_r;
-
-  ~CR_GEOS() {
-    if (dlHandle != NULL) {
-      dlclose(dlHandle);
-    }
-  };
-};
-
-inline std::string CR_GEOS_StringToString(CR_GEOS_String goStr) {
+std::string ToString(CR_GEOS_String goStr) {
   return std::string(goStr.data, goStr.len);
 }
 
 const char *dlopenFailError = "failed to execute dlopen";
 
-char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib) {
-  char *error;
+} // namespace
 
-  auto locStr = CR_GEOS_StringToString(loc);
+struct CR_GEOS {
+  void *dlHandle;
+
+  CR_GEOS_init_r GEOS_init_r;
+  CR_GEOS_finish_r GEOS_finish_r;
+
+  CR_GEOS_Geom_destroy_r GEOSGeom_destroy_r;
+
+  CR_GEOS_WKTReader_create_r GEOSWKTReader_create_r;
+  CR_GEOS_WKTReader_destroy_r GEOSWKTReader_destroy_r;
+  CR_GEOS_WKTReader_read_r GEOSWKTReader_read_r;
+
+  CR_GEOS_WKBWriter_create_r GEOSWKBWriter_create_r;
+  CR_GEOS_WKBWriter_destroy_r GEOSWKBWriter_destroy_r;
+  CR_GEOS_WKBWriter_setByteOrder_r GEOSWKBWriter_setByteOrder_r;
+  CR_GEOS_WKBWriter_write_r GEOSWKBWriter_write_r;
+
+  CR_GEOS(void *h)
+      : dlHandle(h) {
+  }
+
+  ~CR_GEOS() {
+    if (dlHandle != NULL) {
+      dlclose(dlHandle);
+    }
+  }
+
+  char* Init() {
+#define INIT(x)                     \
+    do {                            \
+      auto error = InitSym(&x, #x); \
+      if (error != nullptr) {       \
+        return error;               \
+      }                             \
+    } while (0)
+
+    INIT(GEOS_init_r);
+    INIT(GEOS_finish_r);
+    INIT(GEOSGeom_destroy_r);
+    INIT(GEOSWKTReader_create_r);
+    INIT(GEOSWKTReader_destroy_r);
+    INIT(GEOSWKTReader_read_r);
+    INIT(GEOSWKBWriter_create_r);
+    INIT(GEOSWKBWriter_destroy_r);
+    INIT(GEOSWKBWriter_setByteOrder_r);
+    INIT(GEOSWKBWriter_write_r);
+    return nullptr;
+
+#undef INIT
+  }
+
+  template <typename T>
+  char *InitSym(T *ptr, const char *symbol) {
+    *ptr = reinterpret_cast<T>(dlsym(dlHandle, symbol));
+    return dlerror();
+  }
+};
+
+char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib) {
+  auto locStr = ToString(loc);
   void *dlHandle = dlopen(locStr.c_str(), RTLD_LAZY);
   if (!dlHandle) {
     return (char *)dlopenFailError;
   }
 
-  std::unique_ptr<CR_GEOS> ret(new CR_GEOS());
-  ret->dlHandle = dlHandle;
-
-  // TODO(otan): autogenerate all of this.
-  ret->CR_GEOS_init_r = (CR_GEOS_init_r)dlsym(dlHandle, "GEOS_init_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_finish_r = (CR_GEOS_finish_r)dlsym(dlHandle, "GEOS_finish_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-
-  ret->CR_GEOS_Geom_destroy_r =
-      (CR_GEOS_Geom_destroy_r)dlsym(dlHandle, "GEOSGeom_destroy_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-
-  ret->CR_GEOS_WKTReader_create_r =
-      (CR_GEOS_WKTReader_create_r)dlsym(dlHandle, "GEOSWKTReader_create_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_WKTReader_destroy_r =
-      (CR_GEOS_WKTReader_destroy_r)dlsym(dlHandle, "GEOSWKTReader_destroy_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_WKTReader_read_r =
-      (CR_GEOS_WKTReader_read_r)dlsym(dlHandle, "GEOSWKTReader_read_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-
-  ret->CR_GEOS_WKBWriter_create_r =
-      (CR_GEOS_WKBWriter_create_r)dlsym(dlHandle, "GEOSWKBWriter_create_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_WKBWriter_destroy_r =
-      (CR_GEOS_WKBWriter_destroy_r)dlsym(dlHandle, "GEOSWKBWriter_destroy_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_WKBWriter_setByteOrder_r =
-      (CR_GEOS_WKBWriter_setByteOrder_r)dlsym(dlHandle,
-                                              "GEOSWKBWriter_setByteOrder_r");
-  if ((error = dlerror()) != NULL) {
-    return error;
-  }
-  ret->CR_GEOS_WKBWriter_write_r =
-      (CR_GEOS_WKBWriter_write_r)dlsym(dlHandle, "GEOSWKBWriter_write_r");
-  if ((error = dlerror()) != NULL) {
+  std::unique_ptr<CR_GEOS> ret(new CR_GEOS(dlHandle));
+  auto error = ret->Init();
+  if (error != nullptr) {
     return error;
   }
 
   *lib = ret.release();
-
   return NULL;
 }
 
 CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wktString) {
   CR_GEOS_String result = {.data = NULL, .len = 0};
 
-  CR_GEOS_Handle handle = lib->CR_GEOS_init_r();
-  CR_GEOS_WKTReader wktReader = lib->CR_GEOS_WKTReader_create_r(handle);
-  auto wktStr = CR_GEOS_StringToString(wktString);
-  CR_GEOS_Geometry geom =
-      lib->CR_GEOS_WKTReader_read_r(handle, wktReader, wktStr.c_str());
-  lib->CR_GEOS_WKTReader_destroy_r(handle, wktReader);
+  auto handle = lib->GEOS_init_r();
+  auto wktReader = lib->GEOSWKTReader_create_r(handle);
+  auto wktStr = ToString(wktString);
+  auto geom = lib->GEOSWKTReader_read_r(handle, wktReader, wktStr.c_str());
+  lib->GEOSWKTReader_destroy_r(handle, wktReader);
 
   if (geom != NULL) {
-    CR_GEOS_WKBWriter wkbWriter = lib->CR_GEOS_WKBWriter_create_r(handle);
-    lib->CR_GEOS_WKBWriter_setByteOrder_r(handle, wkbWriter, 1);
+    auto wkbWriter = lib->GEOSWKBWriter_create_r(handle);
+    lib->GEOSWKBWriter_setByteOrder_r(handle, wkbWriter, 1);
     result.data =
-        lib->CR_GEOS_WKBWriter_write_r(handle, wkbWriter, geom, &result.len);
-    lib->CR_GEOS_WKBWriter_destroy_r(handle, wkbWriter);
-    lib->CR_GEOS_Geom_destroy_r(handle, geom);
+        lib->GEOSWKBWriter_write_r(handle, wkbWriter, geom, &result.len);
+    lib->GEOSWKBWriter_destroy_r(handle, wkbWriter);
+    lib->GEOSGeom_destroy_r(handle, geom);
   }
 
-  lib->CR_GEOS_finish_r(handle);
+  lib->GEOS_finish_r(handle);
   return result;
 }

--- a/pkg/geo/geos/geos_unix.cc
+++ b/pkg/geo/geos/geos_unix.cc
@@ -18,9 +18,9 @@
 namespace {
 
 // Data Types adapted from `capi/geos_c.h.in` in GEOS.
-typedef void *CR_GEOS_Handle;
-typedef void *CR_GEOS_WKTReader;
-typedef void *CR_GEOS_WKBWriter;
+typedef void* CR_GEOS_Handle;
+typedef void* CR_GEOS_WKTReader;
+typedef void* CR_GEOS_WKBWriter;
 
 // Function declarations from `capi/geos_c.h.in` in GEOS.
 typedef CR_GEOS_Handle (*CR_GEOS_init_r)();
@@ -29,28 +29,24 @@ typedef void (*CR_GEOS_finish_r)(CR_GEOS_Handle);
 typedef void (*CR_GEOS_Geom_destroy_r)(CR_GEOS_Handle, CR_GEOS_Geometry);
 
 typedef CR_GEOS_WKTReader (*CR_GEOS_WKTReader_create_r)(CR_GEOS_Handle);
-typedef CR_GEOS_Geometry (*CR_GEOS_WKTReader_read_r)(CR_GEOS_Handle,
-                                                     CR_GEOS_WKTReader,
-                                                     const char *);
+typedef CR_GEOS_Geometry (*CR_GEOS_WKTReader_read_r)(CR_GEOS_Handle, CR_GEOS_WKTReader,
+                                                     const char*);
 typedef void (*CR_GEOS_WKTReader_destroy_r)(CR_GEOS_Handle, CR_GEOS_WKTReader);
 
 typedef CR_GEOS_WKBWriter (*CR_GEOS_WKBWriter_create_r)(CR_GEOS_Handle);
-typedef char *(*CR_GEOS_WKBWriter_write_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter,
-                                           CR_GEOS_Geometry, size_t *);
-typedef void (*CR_GEOS_WKBWriter_setByteOrder_r)(CR_GEOS_Handle,
-                                                 CR_GEOS_WKBWriter, int);
+typedef char* (*CR_GEOS_WKBWriter_write_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter, CR_GEOS_Geometry,
+                                           size_t*);
+typedef void (*CR_GEOS_WKBWriter_setByteOrder_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter, int);
 typedef void (*CR_GEOS_WKBWriter_destroy_r)(CR_GEOS_Handle, CR_GEOS_WKBWriter);
 
-std::string ToString(CR_GEOS_String goStr) {
-  return std::string(goStr.data, goStr.len);
-}
+std::string ToString(CR_GEOS_String goStr) { return std::string(goStr.data, goStr.len); }
 
-const char *dlopenFailError = "failed to execute dlopen";
+const char* dlopenFailError = "failed to execute dlopen";
 
-} // namespace
+}  // namespace
 
 struct CR_GEOS {
-  void *dlHandle;
+  void* dlHandle;
 
   CR_GEOS_init_r GEOS_init_r;
   CR_GEOS_finish_r GEOS_finish_r;
@@ -66,9 +62,7 @@ struct CR_GEOS {
   CR_GEOS_WKBWriter_setByteOrder_r GEOSWKBWriter_setByteOrder_r;
   CR_GEOS_WKBWriter_write_r GEOSWKBWriter_write_r;
 
-  CR_GEOS(void *h)
-      : dlHandle(h) {
-  }
+  CR_GEOS(void* h) : dlHandle(h) {}
 
   ~CR_GEOS() {
     if (dlHandle != NULL) {
@@ -77,13 +71,13 @@ struct CR_GEOS {
   }
 
   char* Init() {
-#define INIT(x)                     \
-    do {                            \
-      auto error = InitSym(&x, #x); \
-      if (error != nullptr) {       \
-        return error;               \
-      }                             \
-    } while (0)
+#define INIT(x)                                                                                    \
+  do {                                                                                             \
+    auto error = InitSym(&x, #x);                                                                  \
+    if (error != nullptr) {                                                                        \
+      return error;                                                                                \
+    }                                                                                              \
+  } while (0)
 
     INIT(GEOS_init_r);
     INIT(GEOS_finish_r);
@@ -100,18 +94,17 @@ struct CR_GEOS {
 #undef INIT
   }
 
-  template <typename T>
-  char *InitSym(T *ptr, const char *symbol) {
+  template <typename T> char* InitSym(T* ptr, const char* symbol) {
     *ptr = reinterpret_cast<T>(dlsym(dlHandle, symbol));
     return dlerror();
   }
 };
 
-char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib) {
+char* CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS** lib) {
   auto locStr = ToString(loc);
-  void *dlHandle = dlopen(locStr.c_str(), RTLD_LAZY);
+  void* dlHandle = dlopen(locStr.c_str(), RTLD_LAZY);
   if (!dlHandle) {
-    return (char *)dlopenFailError;
+    return (char*)dlopenFailError;
   }
 
   std::unique_ptr<CR_GEOS> ret(new CR_GEOS(dlHandle));
@@ -124,7 +117,7 @@ char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib) {
   return NULL;
 }
 
-CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wktString) {
+CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS* lib, CR_GEOS_String wktString) {
   CR_GEOS_String result = {.data = NULL, .len = 0};
 
   auto handle = lib->GEOS_init_r();
@@ -136,8 +129,7 @@ CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wktString) {
   if (geom != NULL) {
     auto wkbWriter = lib->GEOSWKBWriter_create_r(handle);
     lib->GEOSWKBWriter_setByteOrder_r(handle, wkbWriter, 1);
-    result.data =
-        lib->GEOSWKBWriter_write_r(handle, wkbWriter, geom, &result.len);
+    result.data = lib->GEOSWKBWriter_write_r(handle, wkbWriter, geom, &result.len);
     lib->GEOSWKBWriter_destroy_r(handle, wkbWriter);
     lib->GEOSGeom_destroy_r(handle, geom);
   }


### PR DESCRIPTION
Refactor the C++ initialization code, and remove the `CR_GEOS_` from
member names. The latter seems to fix a warning that some C++ compilers
complain about.

Release note: None