### PR TITLE
cli/demo: prevent a call to os.Exit in the license goroutine

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -65,10 +65,7 @@ func Main() {
 	defer log.RecoverAndReportPanic(context.Background(), &serverCfg.Settings.SV)
 
 	err := Run(os.Args[1:])
-	exitWithError(cmdName, err)
-}
 
-func exitWithError(cmdName string, err error) {
 	errCode := 0
 	if err != nil {
 		// Display the error and its details/hints.
@@ -85,6 +82,7 @@ func exitWithError(cmdName string, err error) {
 			errCode = cliErr.exitCode
 		}
 	}
+
 	os.Exit(errCode)
 }
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -623,7 +623,7 @@ func setupTransientCluster(
 }
 
 func (c *transientCluster) setupWorkload(
-	ctx context.Context, gen workload.Generator, licenseDone chan struct{},
+	ctx context.Context, gen workload.Generator, licenseDone <-chan error,
 ) error {
 	// If there is a load generator, create its database and load its
 	// fixture.
@@ -652,7 +652,9 @@ func (c *transientCluster) setupWorkload(
 			if cliCtx.isInteractive {
 				fmt.Println("#\n# Waiting for license acquisition to complete...")
 			}
-			<-licenseDone
+			if err := waitForLicense(licenseDone); err != nil {
+				return err
+			}
 			if cliCtx.isInteractive {
 				fmt.Println("#\n# Partitioning the demo database, please wait...")
 			}
@@ -822,8 +824,9 @@ func checkDemoConfiguration(
 		demoCtx.disableTelemetry || (GetAndApplyLicense == nil) || demoCtx.disableLicenseAcquisition
 
 	if demoCtx.geoPartitionedReplicas {
+		geoFlag := "--" + cliflags.DemoGeoPartitionedReplicas.Name
 		if demoCtx.disableLicenseAcquisition {
-			return nil, errors.New("enterprise features are needed for this demo (--geo-partitioned-replicas)")
+			return nil, errors.Newf("enterprise features are needed for this demo (%s)", geoFlag)
 		}
 
 		// Make sure that the user didn't request to have a topology and an empty database.
@@ -833,18 +836,18 @@ func checkDemoConfiguration(
 
 		// Make sure that the Movr database is selected when automatically partitioning.
 		if gen == nil || gen.Meta().Name != "movr" {
-			return nil, errors.New("--geo-partitioned-replicas must be used with the Movr dataset")
+			return nil, errors.Newf("%s must be used with the Movr dataset", geoFlag)
 		}
 
 		// If the geo-partitioned replicas flag was given and the demo localities have changed, throw an error.
 		if demoCtx.localities != nil {
-			return nil, errors.New("--demo-locality cannot be used with --geo-partitioned-replicas")
+			return nil, errors.Newf("--demo-locality cannot be used with %s", geoFlag)
 		}
 
 		// If the geo-partitioned replicas flag was given and the nodes have changed, throw an error.
 		if flagSetForCmd(cmd).Lookup(cliflags.DemoNodes.Name).Changed {
 			if demoCtx.nodes != 9 {
-				return nil, errors.New("--nodes with a value different from 9 cannot be used with --geo-partitioned-replicas")
+				return nil, errors.Newf("--nodes with a value different from 9 cannot be used with %s", geoFlag)
 			}
 		} else {
 			const msg = `#
@@ -872,10 +875,10 @@ func checkDemoConfiguration(
 // temporary demo license from the Cockroach Labs website. It returns
 // a channel that can be waited on if it is needed to wait on the
 // license acquisition.
-func (c *transientCluster) acquireDemoLicense(ctx context.Context) (chan struct{}, error) {
+func (c *transientCluster) acquireDemoLicense(ctx context.Context) (chan error, error) {
 	// Communicate information about license acquisition to services
 	// that depend on it.
-	licenseDone := make(chan struct{})
+	licenseDone := make(chan error)
 	if demoCtx.disableLicenseAcquisition {
 		// If we are not supposed to acquire a license, close the channel
 		// immediately so that future waiters don't hang.
@@ -892,17 +895,17 @@ func (c *transientCluster) acquireDemoLicense(ctx context.Context) (chan struct{
 
 			success, err := GetAndApplyLicense(db, c.s.ClusterID(), demoOrg)
 			if err != nil {
-				exitWithError("demo", err)
+				licenseDone <- err
+				return
 			}
 			if !success {
 				if demoCtx.geoPartitionedReplicas {
-					log.Shout(ctx, log.Severity_ERROR,
-						"license acquisition was unsuccessful.\nNote: enterprise features are needed for --geo-partitioned-replicas.")
-					exitWithError("demo", errors.New("unable to acquire a license for this demo"))
+					licenseDone <- errors.WithDetailf(
+						errors.New("unable to acquire a license for this demo"),
+						"Enterprise features are needed for this demo (--%s).",
+						cliflags.DemoGeoPartitionedReplicas.Name)
+					return
 				}
-
-				const msg = "\nwarning: unable to acquire demo license - enterprise features are not enabled."
-				fmt.Fprintln(stderr, msg)
 			}
 			close(licenseDone)
 		}()
@@ -983,17 +986,35 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 				defaultRootPassword,
 			)
 		}
+		// If we didn't launch a workload, we still need to inform the
+		// user if the license check fails. Do this asynchronously and print
+		// the final error if any.
+		//
+		// It's ok to do this twice (if workload setup already waited) because
+		// then the error return is guaranteed to be nil.
+		go func() {
+			if err := waitForLicense(licenseDone); err != nil {
+				_ = checkAndMaybeShout(err)
+			}
+		}()
 	} else {
 		// If we are not running an interactive shell, we need to wait to ensure
 		// that license acquisition is successful. If license acquisition is
 		// disabled, then a read on this channel will return immediately.
-		<-licenseDone
+		if err := waitForLicense(licenseDone); err != nil {
+			return checkAndMaybeShout(err)
+		}
 	}
 
 	conn := makeSQLConn(c.connURL)
 	defer conn.Close()
 
 	return runClient(cmd, conn)
+}
+
+func waitForLicense(licenseDone <-chan error) error {
+	err := <-licenseDone
+	return err
 }
 
 // sockForServer generates the metadata for a unix socket for the given node.

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -64,7 +64,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
 		demoCtx.cacheSize = tc.cacheSize
 
-		actual := testServerArgsForTransientCluster(tc.nodeID, tc.joinAddr)
+		actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr)
 
 		assert.Len(t, actual.StoreSpecs, 1)
 		assert.Equal(

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -2,14 +2,15 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-start_test "Check that demo says hello properly"
-spawn $argv demo
+start_test "Check that demo insecure says hello properly"
+spawn $argv demo --insecure=true
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
-eexpect "Web UI: http:"
+eexpect "(console)"
+eexpect "http:"
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
 eexpect "Cluster ID"
@@ -26,17 +27,41 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo
+spawn $argv demo --empty
 eexpect "Welcome"
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root@"
+eexpect "sslmode=disable"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --insecure=true
+spawn $argv demo --insecure=true --empty
 eexpect "Welcome"
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root@"
+eexpect "sslmode=disable"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
@@ -44,21 +69,46 @@ end_test
 
 start_test "Check that demo secure says hello properly"
 
+
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo
+spawn $argv demo --empty
 eexpect "Welcome"
 eexpect "The user \"root\" with password \"admin\" has been created."
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root:admin@"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --insecure=false
+spawn $argv demo --insecure=false --empty
 eexpect "Welcome"
 eexpect "The user \"root\" with password \"admin\" has been created."
-eexpect "movr>"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(console)"
+eexpect "http://"
+eexpect "(sql)"
+eexpect "root:admin@"
+eexpect "(sql/tcp)"
+eexpect "root:admin@"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 
@@ -66,25 +116,46 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure
+spawn $argv demo --insecure --empty
 # Check that we see our message.
-eexpect "Connect to the cluster on a SQL shell at"
+eexpect "Connection parameters"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+expect root@
+send_eof
+eexpect eof
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3
+spawn $argv demo --insecure --nodes 3 --empty
 
 # Check that we get a message for each node.
-eexpect "Connect to different nodes in the cluster on a SQL shell at"
-eexpect "Node 1"
-eexpect "Node 2"
-eexpect "Node 3"
+eexpect "Connection parameters"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "defaultdb>"
 
-spawn $argv demo --insecure=false
-eexpect "Connect to the cluster on a SQL shell at"
+send "\\demo ls\r"
+eexpect "node 1"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "node 2"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "node 3"
+eexpect "(sql)"
+eexpect "(sql/tcp)"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+spawn $argv demo --insecure=false --empty
 # Expect that security related tags are part of the connection URL.
-eexpect "sslcert="
-eexpect "sslkey="
-eexpect "sslrootcert="
+eexpect "(sql/tcp)"
+eexpect "sslmode=require"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
 
 end_test
-

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -100,8 +100,7 @@ start_test "Expect an error if geo-partitioning is requested and a license canno
 set env(COCKROACH_DEMO_LICENSE_URL) "https://127.0.0.1:9999/"
 spawn $argv demo --geo-partitioned-replicas
 eexpect "error while contacting licensing server"
-eexpect "dial tcp"
-eexpect "ERROR: license acquisition was unsuccessful"
+eexpect "Enterprise features are needed for this demo"
 eexpect eof
 end_test
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -71,6 +71,7 @@ More documentation about our SQL dialect and the CLI shell is available online:
 
 	demoCommandsHelp = `
 Commands specific to the demo shell (EXPERIMENTAL):
+  \demo ls                     list the demo nodes and their connection URLs.
   \demo shutdown <nodeid>      stop a demo node.
   \demo restart <nodeid>       restart a stopped demo node.
   \demo decommission <nodeid>  decommission a node.
@@ -490,9 +491,16 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 	if demoCtx.transientCluster == nil {
 		return c.invalidSyntax(errState, `\demo can only be run with cockroach demo`)
 	}
+
+	if len(cmd) == 1 && cmd[0] == "ls" {
+		demoCtx.transientCluster.listDemoNodes(os.Stdout, false /* justOne */)
+		return nextState
+	}
+
 	if len(cmd) != 2 {
 		return c.invalidSyntax(errState, `\demo expects 2 parameters`)
 	}
+
 	nodeID, err := strconv.ParseInt(cmd[1], 10, 32)
 	if err != nil {
 		return c.invalidSyntax(
@@ -501,6 +509,7 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 			errors.Wrapf(err, "cannot convert %s to string", cmd[2]).Error(),
 		)
 	}
+
 	switch cmd[0] {
 	case "shutdown":
 		if err := demoCtx.transientCluster.DrainNode(roachpb.NodeID(nodeID)); err != nil {

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -97,3 +97,7 @@ func disableOtherPermissionBits() {
 	mask |= 00007
 	_ = unix.Umask(mask)
 }
+
+func useUnixSocketsInDemo() bool {
+	return true
+}

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -32,3 +32,8 @@ func maybeRerunBackground() (bool, error) {
 func disableOtherPermissionBits() {
 	// No-op on windows, which does not support umask.
 }
+
+func useUnixSocketsInDemo() bool {
+	// No unix sockets on windows.
+	return false
+}


### PR DESCRIPTION
First commit from #46979. 

Prior to this patch, the async goroutine responsible for license
acquisition was also taking over the responsibility to call os.Exit.

This was sad because it meant that in case license acquisition failed,
the temporary files created for the demo cluster were not cleaned up.

This patch repairs that by bringing error handling back into the main
goroutine.

(It's still possible for demo to leave stray files behind - see
#46988 - and that will
need a separate patch.)

Release note (bug fix): `cockroach demo` now properly cleans up its
temporary files if the background license acquisition fails.