### PR TITLE
lint/passes/nakedreturn: add a linter to disallow naked returns

### DIFF
--- a/pkg/cmd/roachvet/main.go
+++ b/pkg/cmd/roachvet/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nakedreturn"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nocopy"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
@@ -55,6 +56,7 @@ func main() {
 		returnerrcheck.Analyzer,
 		timer.Analyzer,
 		unconvert.Analyzer,
+		nakedreturn.Analyzer,
 
 		// Standard go vet analyzers:
 		asmdecl.Analyzer,

--- a/pkg/testutils/lint/passes/nakedreturn/naked_return.go
+++ b/pkg/testutils/lint/passes/nakedreturn/naked_return.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package nakedreturn defines an Analyzer that detects naked returns.
+package nakedreturn
+
+import (
+	"go/ast"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Doc documents this pass.
+const Doc = `check for naked returns`
+
+// Analyzer defines this pass.
+var Analyzer = &analysis.Analyzer{
+	Name:     "nakedreturn",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	inspect.Preorder([]ast.Node{
+		(*ast.ReturnStmt)(nil),
+	}, func(n ast.Node) {
+		ret := n.(*ast.ReturnStmt)
+
+		fSig := passes.FindContainingFuncSig(pass, ret)
+		if fSig.Results().Len() > 0 && len(ret.Results) == 0 {
+			pass.Reportf(ret.Pos(), "illegal naked return")
+		}
+	})
+	return nil, nil
+}

--- a/pkg/testutils/lint/passes/nakedreturn/naked_return_test.go
+++ b/pkg/testutils/lint/passes/nakedreturn/naked_return_test.go
@@ -1,0 +1,17 @@
+package nakedreturn_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nakedreturn"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, nakedreturn.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/nakedreturn/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/nakedreturn/testdata/src/a/a.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+func F() (b int) {
+	return // want `illegal naked return`
+}
+
+func G() {
+	f := func() (b int) {
+		return // want `illegal naked return`
+	}
+	f()
+	return
+}
+
+func H() (b int) {
+	return b
+}

--- a/pkg/testutils/lint/passes/util.go
+++ b/pkg/testutils/lint/passes/util.go
@@ -1,0 +1,53 @@
+package passes
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// FindContainingFile find the file in the pass's Fset which contains the given
+// ast node.
+func FindContainingFile(pass *analysis.Pass, n ast.Node) *ast.File {
+	fPos := pass.Fset.File(n.Pos())
+	for _, f := range pass.Files {
+		if pass.Fset.File(f.Pos()) == fPos {
+			return f
+		}
+	}
+	panic(fmt.Errorf("cannot file file for %v", n))
+}
+
+// FindContainingFunc returns the deepest parent function of the given ast node.
+// If the ast node is not a child of a function, nil will be returned.
+func FindContainingFunc(pass *analysis.Pass, n ast.Node) *types.Func {
+	stack, _ := astutil.PathEnclosingInterval(FindContainingFile(pass, n), n.Pos(), n.End())
+	for i := len(stack) - 1; i >= 0; i-- {
+		// If we stumble upon a func decl or func lit then we're in an interesting spot
+		funcDecl, ok := stack[i].(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
+	}
+	return nil
+}
+
+// FindContainingFuncSig returns the signature of the deepest parent closure or
+// function of the given ast node. If the ast node is not a child of a function
+// or closure, nil will be returned.
+func FindContainingFuncSig(pass *analysis.Pass, n ast.Node) *types.Signature {
+	stack, _ := astutil.PathEnclosingInterval(FindContainingFile(pass, n), n.Pos(), n.End())
+	for _, n := range stack {
+		if funcDecl, ok := n.(*ast.FuncDecl); ok {
+			return pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func).Type().(*types.Signature)
+		}
+		if funcLit, ok := n.(*ast.FuncLit); ok {
+			return pass.TypesInfo.Types[funcLit].Type.(*types.Signature)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Naked returns can be buggy and make IDEs harder to use to detect
variable usage. Let's not use them.

Release note: None