### PR TITLE
release-20.1: config/zonepb: fix typo in DefaultSystemZoneConfig

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -86,22 +86,22 @@ RANGE default                   ALTER RANGE default CONFIGURE ZONE USING
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE liveness                  ALTER RANGE liveness CONFIGURE ZONE USING
-                                range_min_bytes = 137438953472,
-                                range_max_bytes = 549755813888,
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
                                 gc.ttlseconds = 600,
                                 num_replicas = 5,
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE meta                      ALTER RANGE meta CONFIGURE ZONE USING
-                                range_min_bytes = 137438953472,
-                                range_max_bytes = 549755813888,
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
                                 gc.ttlseconds = 3600,
                                 num_replicas = 5,
                                 constraints = '[]',
                                 lease_preferences = '[]'
 RANGE system                    ALTER RANGE system CONFIGURE ZONE USING
-                                range_min_bytes = 137438953472,
-                                range_max_bytes = 549755813888,
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
                                 gc.ttlseconds = 90000,
                                 num_replicas = 5,
                                 constraints = '[]',

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -213,24 +213,12 @@ func DefaultZoneConfigRef() *ZoneConfig {
 }
 
 // DefaultSystemZoneConfig is the default zone configuration used when no custom
-// config has been specified.
+// config has been specified. The DefaultSystemZoneConfig is like the
+// DefaultZoneConfig but has a replication factor of 5 instead of 3.
 func DefaultSystemZoneConfig() ZoneConfig {
-	return ZoneConfig{
-		NumReplicas:   proto.Int32(5),
-		RangeMinBytes: proto.Int64(128 << 30), // 128 MB
-		RangeMaxBytes: proto.Int64(512 << 30), // 512 MB
-		GC: &GCPolicy{
-			// Use 25 hours instead of the previous 24 to make users successful by
-			// default. Users desiring to take incremental backups every 24h may
-			// incorrectly assume that the previous default 24h was sufficient to do
-			// that. But the equation for incremental backups is:
-			// 	GC TTLSeconds >= (desired backup interval) + (time to perform incremental backup)
-			// We think most new users' incremental backups will complete within an
-			// hour, and larger clusters will have more experienced operators and will
-			// understand how to change these settings if needed.
-			TTLSeconds: 25 * 60 * 60,
-		},
-	}
+	defaultSystemZoneConfig := DefaultZoneConfig()
+	defaultSystemZoneConfig.NumReplicas = proto.Int32(5)
+	return defaultSystemZoneConfig
 }
 
 // DefaultSystemZoneConfigRef is the default zone configuration used when no custom

--- a/pkg/config/zonepb/zone_test.go
+++ b/pkg/config/zonepb/zone_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	proto "github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -908,4 +909,13 @@ func tableSpecifier(
 		},
 		Partition: partition,
 	}
+}
+
+// TestDefaultRangeSizesAreSane is a sanity check test to ensure that the values
+// in the default zone configs are what the author intended.
+func TestDefaultRangeSizesAreSane(t *testing.T) {
+	require.Regexp(t, "range_min_bytes:134217728 range_max_bytes:536870912",
+		DefaultSystemZoneConfigRef().String())
+	require.Regexp(t, "range_min_bytes:134217728 range_max_bytes:536870912",
+		DefaultZoneConfigRef().String())
 }


### PR DESCRIPTION
Backport 1/1 commits from #46953.

/cc @cockroachdb/release

---

This change fixes a typo that made the default system zone config gigabytes
instead of megabytes. Fortunately this was both not released in an official
release and also system ranges aren't generally gigantic.

Nevertheless, this is pretty egregious.

Release note: None
