### PR TITLE
release-20.1: ui: telemetry tracking calls

### DIFF
--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -189,8 +189,8 @@ export class AnalyticsSync {
     /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
     track(msg: TrackMessage) {
       const cluster = this.getCluster();
-      const { cluster_id } = cluster;
-      const message = Object.assign({ userId: cluster_id }, msg);
+      const clusterId = cluster ? cluster.cluster_id : "null";
+      const message = { userId: clusterId, ...msg };
       this.analyticsService.track(message);
     }
 

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -189,8 +189,27 @@ export class AnalyticsSync {
     /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
     track(msg: TrackMessage) {
       const cluster = this.getCluster();
-      const clusterId = cluster ? cluster.cluster_id : "null";
-      const message = { userId: clusterId, ...msg };
+      if (cluster === null) {
+        return;
+      }
+
+      // get cluster_id to id the event
+      const { cluster_id } = cluster;
+      const pagePath = this.redact(history.location.pathname);
+
+      // break down properties from message
+      const { properties, ...rest } = msg;
+      const props = {
+        pagePath,
+        ...properties,
+      }
+
+      const message = { 
+        userId: cluster_id,
+        properties: { ...props },
+        ...rest,
+      };
+
       this.analyticsService.track(message);
     }
 

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -20,6 +20,12 @@ import { COCKROACHLABS_ADDR } from "src/util/cockroachlabsAPI";
 
 type ClusterResponse = protos.cockroach.server.serverpb.IClusterResponse;
 
+interface TrackMessage {
+    event: string;
+    properties?: Object;
+    timestamp?: Date;
+    context?: Object;
+}
 /**
  * List of current redactions needed for pages tracked by the Admin UI.
  * TODO(mrtracy): It this list becomes more extensive, it might benefit from a
@@ -178,6 +184,14 @@ export class AnalyticsSync {
             },
         });
         this.identifyEventSent = true;
+    }
+
+    /** Analytics Track for Segment: https://segment.com/docs/connections/spec/track/ */
+    track(msg: TrackMessage) {
+      const cluster = this.getCluster();
+      const { cluster_id } = cluster;
+      const message = Object.assign({ userId: cluster_id }, msg);
+      this.analyticsService.track(message);
     }
 
     /**

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -202,9 +202,9 @@ export class AnalyticsSync {
       const props = {
         pagePath,
         ...properties,
-      }
+      };
 
-      const message = { 
+      const message = {
         userId: cluster_id,
         properties: { ...props },
         ...rest,

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -1,0 +1,2 @@
+export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
+export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -17,3 +17,4 @@ export { default as trackSearch } from "./trackSearch";
 export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
+export { default as trackCollapseNodes } from "./trackCollapseNodes";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -13,3 +13,4 @@ export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpe
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
 export { default as trackTableSort } from "./trackTableSort";
 export { default as trackPaginate } from "./trackPaginate";
+export { default as trackSearch } from "./trackSearch";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -16,3 +16,4 @@ export { default as trackPaginate } from "./trackPaginate";
 export { default as trackSearch } from "./trackSearch";
 export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
+export { default as trackNetworkSort } from "./trackNetworkSort";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -19,3 +19,4 @@ export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
 export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";
+export { default as trackTimeFrameChange } from "./trackTimeFrameChange";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -14,3 +14,4 @@ export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSe
 export { default as trackTableSort } from "./trackTableSort";
 export { default as trackPaginate } from "./trackPaginate";
 export { default as trackSearch } from "./trackSearch";
+export { default as trackDocsLink} from "./trackDocsLink";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -18,3 +18,4 @@ export { default as trackDocsLink} from "./trackDocsLink";
 export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
+export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -12,3 +12,4 @@ export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics"
 export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
 export { default as trackTableSort } from "./trackTableSort";
+export { default as trackPaginate } from "./trackPaginate";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -11,3 +11,4 @@
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
 export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";
+export { default as trackTableSort } from "./trackTableSort";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -1,2 +1,12 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -9,4 +9,5 @@
 // licenses/APL.txt.
 
 export { default as trackActivateDiagnostics } from "./trackActivateDiagnostics";
+export { default as trackDiagnosticsModalOpen } from "./trackDiagnosticsModalOpen";
 export { default as trackSubnavSelection } from "./trackStatementDetailsSubnavSelection";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -15,4 +15,4 @@ export { default as trackTableSort } from "./trackTableSort";
 export { default as trackPaginate } from "./trackPaginate";
 export { default as trackSearch } from "./trackSearch";
 export { default as trackDocsLink} from "./trackDocsLink";
-export { default as trackStatusFilter } from "./trackStatusFilter";
+export { default as trackFilter } from "./trackFilter";

--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -15,3 +15,4 @@ export { default as trackTableSort } from "./trackTableSort";
 export { default as trackPaginate } from "./trackPaginate";
 export { default as trackSearch } from "./trackSearch";
 export { default as trackDocsLink} from "./trackDocsLink";
+export { default as trackStatusFilter } from "./trackStatusFilter";

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -36,7 +36,7 @@ describe("trackActivateDiagnostics", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -49,6 +49,6 @@ describe("trackActivateDiagnostics", () => {
     const fingerprint = get(sent, "properties.fingerprint");
 
     assert.isTrue(isString(fingerprint));
-    assert.isTrue( fingerprint === statement);
+    assert.isTrue(fingerprint === statement);
   });
 });

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -1,0 +1,26 @@
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackActivateDiagnostics";
+
+const sandbox = createSandbox();
+
+describe("trackActivateDiagnostics", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should send a track call given a payload", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(spy.calledOnce);
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue( fingerprint === statement);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -20,7 +20,26 @@ describe("trackActivateDiagnostics", () => {
     sandbox.reset();
   });
 
-  it("should send a track call given a payload", () => {
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Activation";
+
+    track(spy)("whatever");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
     const spy = sandbox.spy();
     const statement = "SELECT blah from blah-blah";
 
@@ -29,7 +48,6 @@ describe("trackActivateDiagnostics", () => {
     const sent = spy.getCall(0).args[0];
     const fingerprint = get(sent, "properties.fingerprint");
 
-    assert.isTrue(spy.calledOnce);
     assert.isTrue(isString(fingerprint));
     assert.isTrue( fingerprint === statement);
   });

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { get, isString } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
@@ -1,0 +1,15 @@
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Activation",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackActivateDiagnostics (statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
+++ b/pkg/ui/src/util/analytics/trackActivateDiagnostics.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { analytics } from "src/redux/analytics";
 
 export const track = (fn: Function) => (statement: string) => {

--- a/pkg/ui/src/util/analytics/trackCollapseNodes.spec.ts
+++ b/pkg/ui/src/util/analytics/trackCollapseNodes.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackCollapseNodes";
+
+const sandbox = createSandbox();
+
+describe("trackCollapseNodes", () => {
+  const testCollapsed = true;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testCollapsed);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Collapse Nodes";
+
+    track(spy)(testCollapsed);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testCollapsed);
+
+    const sent = spy.getCall(0).args[0];
+    const collapsed = get(sent, "properties.collapsed");
+
+    assert.isTrue(collapsed === testCollapsed);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackCollapseNodes.ts
+++ b/pkg/ui/src/util/analytics/trackCollapseNodes.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (collapsed: boolean) => {
+  fn({
+    event: "Collapse Nodes",
+    properties: {
+      collapsed: collapsed,
+    },
+  });
+};
+
+export default function trackCollapseNode (collapsed: boolean) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(collapsed);
+}

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
@@ -36,10 +36,10 @@ describe("trackDiagnosticsModalOpen", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
-  it("should send a track call with the correct fingerprint", () => {
+  it("send the correct payload", () => {
     const spy = sandbox.spy();
     const statement = "SELECT blah from blah-blah";
 
@@ -49,6 +49,6 @@ describe("trackDiagnosticsModalOpen", () => {
     const fingerprint = get(sent, "properties.fingerprint");
 
     assert.isTrue(isString(fingerprint));
-    assert.isTrue( fingerprint === statement);
+    assert.isTrue(fingerprint === statement);
   });
 });

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackDiagnosticsModalOpen";
+
+const sandbox = createSandbox();
+
+describe("trackDiagnosticsModalOpen", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send a track call with the correct event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Modal Open";
+
+    track(spy)("some statement");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send a track call with the correct fingerprint", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue( fingerprint === statement);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.ts
+++ b/pkg/ui/src/util/analytics/trackDiagnosticsModalOpen.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Modal Open",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackDiagnosticsModalOpen (statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/src/util/analytics/trackDocsLink.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDocsLink.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackDocsLink";
+
+const sandbox = createSandbox();
+
+describe("trackDocsLink", () => {
+  const targetText = "Test target";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(targetText);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Link to Docs";
+
+    track(spy)(targetText);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(targetText);
+
+    const sent = spy.getCall(0).args[0];
+    const linkText = get(sent, "properties.linkText");
+
+    assert.isTrue(linkText === targetText);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackDocsLink.ts
+++ b/pkg/ui/src/util/analytics/trackDocsLink.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (targetText: string) => {
+  fn({
+    event: "Link to Docs",
+    properties: {
+      linkText: targetText,
+    },
+  });
+};
+
+export default function trackDocsLink(targetText: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(targetText);
+}

--- a/pkg/ui/src/util/analytics/trackFilter.spec.ts
+++ b/pkg/ui/src/util/analytics/trackFilter.spec.ts
@@ -8,15 +8,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { get, isString } from "lodash";
+import { get } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";
-import { track } from "./trackStatusFilter";
+import { track } from "./trackFilter";
 
 const sandbox = createSandbox();
 
-describe("trackSubnavSelection", () => {
-  const filter = "test filter";
+describe("trackFilter", () => {
+  const filter = "Test";
+  const filterValue = "test-value";
 
   afterEach(() => {
     sandbox.reset();
@@ -24,32 +25,30 @@ describe("trackSubnavSelection", () => {
 
   it("should only call track once", () => {
     const spy = sandbox.spy();
-    track(spy)(filter);
+    track(spy)(filter, filterValue);
     assert.isTrue(spy.calledOnce);
   });
 
   it("should send a track call with the correct event", () => {
     const spy = sandbox.spy();
-    const expected = "Status Filter";
+    const expected = "Test Filter";
 
-    track(spy)(filter);
+    track(spy)(filter, filterValue);
 
     const sent = spy.getCall(0).args[0];
     const event = get(sent, "event");
 
-    assert.isTrue(isString(event));
     assert.isTrue(event === expected);
   });
 
   it("send the correct payload", () => {
     const spy = sandbox.spy();
 
-    track(spy)(filter);
+    track(spy)(filter, filterValue);
 
     const sent = spy.getCall(0).args[0];
     const selectedFilter = get(sent, "properties.selectedFilter");
 
-    assert.isTrue(isString(selectedFilter));
-    assert.isTrue(selectedFilter === filter);
+    assert.isTrue(selectedFilter === filterValue);
   });
 });

--- a/pkg/ui/src/util/analytics/trackFilter.ts
+++ b/pkg/ui/src/util/analytics/trackFilter.ts
@@ -9,16 +9,16 @@
 // licenses/APL.txt.
 import { analytics } from "src/redux/analytics";
 
-export const track = (fn: Function) => (filter: string) => {
+export const track = (fn: Function) => (filter: string, value: string) => {
   fn({
-    event: "Status Filter",
+    event: `${filter} Filter`,
     properties: {
-      selectedFilter: filter,
+      selectedFilter: value,
     },
   });
 };
 
-export default function trackStatusFilter (filter: string) {
+export default function trackFilter (filter: string, value: string) {
   const boundTrack = analytics.track.bind(analytics);
-  track(boundTrack)(filter);
+  track(boundTrack)(filter, value);
 }

--- a/pkg/ui/src/util/analytics/trackNetworkSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackNetworkSort.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackNetworkSort";
+
+const sandbox = createSandbox();
+
+describe("trackNetworkSort", () => {
+  const sortBy = "Test";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(sortBy);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Sort Network Diagnostics";
+
+    track(spy)(sortBy);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(sortBy);
+
+    const sent = spy.getCall(0).args[0];
+    const sortedBy = get(sent, "properties.sortBy");
+
+    assert.isTrue(sortedBy === sortBy);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackNetworkSort.ts
+++ b/pkg/ui/src/util/analytics/trackNetworkSort.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (sortBy: string) => {
+  fn({
+    event: "Sort Network Diagnostics",
+    properties: {
+      sortBy,
+    },
+  });
+};
+
+export default function trackNetworkSort(sortBy: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(sortBy);
+}

--- a/pkg/ui/src/util/analytics/trackPaginate.spec.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString, isNumber } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackPaginate";
+
+const sandbox = createSandbox();
+
+describe("trackPaginate", () => {
+  const testPage = 5;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testPage);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Paginate";
+
+    track(spy)(testPage);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testPage);
+
+    const sent = spy.getCall(0).args[0];
+    const selectedPage = get(sent, "properties.selectedPage");
+
+    assert.isTrue(isNumber(selectedPage));
+    assert.isTrue( selectedPage === testPage);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackPaginate.spec.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.spec.ts
@@ -38,7 +38,7 @@ describe("trackPaginate", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -50,6 +50,6 @@ describe("trackPaginate", () => {
     const selectedPage = get(sent, "properties.selectedPage");
 
     assert.isTrue(isNumber(selectedPage));
-    assert.isTrue( selectedPage === testPage);
+    assert.isTrue(selectedPage === testPage);
   });
 });

--- a/pkg/ui/src/util/analytics/trackPaginate.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.ts
@@ -18,7 +18,7 @@ export const track = (fn: Function) => (page: number) => {
   });
 };
 
-export default function trackSearch(pageNumber: number) {
+export default function trackPaginate(pageNumber: number) {
   const boundTrack = analytics.track.bind(analytics);
   track(boundTrack)(pageNumber);
 }

--- a/pkg/ui/src/util/analytics/trackPaginate.ts
+++ b/pkg/ui/src/util/analytics/trackPaginate.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (page: number) => {
+  fn({
+    event: "Paginate",
+    properties: {
+      selectedPage: page,
+    },
+  });
+};
+
+export default function trackSearch(pageNumber: number) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(pageNumber);
+}

--- a/pkg/ui/src/util/analytics/trackSearch.spec.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.spec.ts
@@ -38,7 +38,7 @@ describe("trackSearch", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
@@ -50,6 +50,6 @@ describe("trackSearch", () => {
     const numberOfResults = get(sent, "properties.numberOfResults");
 
     assert.isTrue(isNumber(numberOfResults));
-    assert.isTrue( numberOfResults === testSearchResults);
+    assert.isTrue(numberOfResults === testSearchResults);
   });
 });

--- a/pkg/ui/src/util/analytics/trackSearch.spec.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString, isNumber } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackSearch";
+
+const sandbox = createSandbox();
+
+describe("trackSearch", () => {
+  const testSearchResults = 3;
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(testSearchResults);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Search";
+
+    track(spy)(testSearchResults);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(testSearchResults);
+
+    const sent = spy.getCall(0).args[0];
+    const numberOfResults = get(sent, "properties.numberOfResults");
+
+    assert.isTrue(isNumber(numberOfResults));
+    assert.isTrue( numberOfResults === testSearchResults);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackSearch.ts
+++ b/pkg/ui/src/util/analytics/trackSearch.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (numberOfResults: number) => {
+  fn({
+      event: "Search",
+      properties: {
+        numberOfResults,
+      },
+  });
+};
+
+export default function trackSearch(numberOfResults: number) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(numberOfResults);
+}

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { get, isString } from "lodash";
+import { get } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";
 import { track } from "./trackStatementDetailsSubnavSelection";
@@ -37,7 +37,6 @@ describe("trackSubnavSelection", () => {
     const sent = spy.getCall(0).args[0];
     const event = get(sent, "event");
 
-    assert.isTrue(isString(event));
     assert.isTrue(event === expected);
   });
 
@@ -49,7 +48,6 @@ describe("trackSubnavSelection", () => {
     const sent = spy.getCall(0).args[0];
     const selection = get(sent, "properties.selection");
 
-    assert.isTrue(isString(selection));
     assert.isTrue(selection === subNavKey);
   });
 });

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -16,20 +16,39 @@ import { track } from "./trackStatementDetailsSubnavSelection";
 const sandbox = createSandbox();
 
 describe("trackSubnavSelection", () => {
+  const subNavKey = "subnav-test";
+
   afterEach(() => {
     sandbox.reset();
   });
 
-  it("should send a track call given a selected nav item key", () => {
+  it("should only call track once", () => {
     const spy = sandbox.spy();
-    const subNavKey = "subnav-test";
+    track(spy)(subNavKey);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send a track call with the correct event", () => {
+    const spy = sandbox.spy();
+    const expected = "SubNavigation Selection";
+
+    track(spy)(subNavKey);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue(event === expected);
+  });
+
+  it("send the correct payload", () => {
+    const spy = sandbox.spy();
 
     track(spy)(subNavKey);
 
     const sent = spy.getCall(0).args[0];
     const selection = get(sent, "properties.selection");
 
-    assert.isTrue(spy.calledOnce);
     assert.isTrue(isString(selection));
     assert.isTrue(selection === subNavKey);
   });

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -1,0 +1,26 @@
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackStatementDetailsSubnavSelection";
+
+const sandbox = createSandbox();
+
+describe("trackSubnavSelection", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should send a track call given a selected nav item key", () => {
+    const spy = sandbox.spy();
+    const subNavKey = "subnav-test";
+
+    track(spy)(subNavKey);
+
+    const sent = spy.getCall(0).args[0];
+    const selection = get(sent, "properties.selection");
+
+    assert.isTrue(spy.calledOnce);
+    assert.isTrue(isString(selection));
+    assert.isTrue(selection === subNavKey);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { get, isString } from "lodash";
 import { assert } from "chai";
 import { createSandbox } from "sinon";

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
@@ -1,0 +1,15 @@
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (selection: string) => {
+  fn({
+    event: "SubNavigation Selection",
+    properties: {
+      selection,
+    },
+  });
+};
+
+export default function trackSubnavSelection (selection: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(selection);
+}

--- a/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
+++ b/pkg/ui/src/util/analytics/trackStatementDetailsSubnavSelection.ts
@@ -1,3 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 import { analytics } from "src/redux/analytics";
 
 export const track = (fn: Function) => (selection: string) => {

--- a/pkg/ui/src/util/analytics/trackStatusFilter.spec.ts
+++ b/pkg/ui/src/util/analytics/trackStatusFilter.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackStatusFilter";
+
+const sandbox = createSandbox();
+
+describe("trackSubnavSelection", () => {
+  const filter = "test filter";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(filter);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send a track call with the correct event", () => {
+    const spy = sandbox.spy();
+    const expected = "Status Filter";
+
+    track(spy)(filter);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue(event === expected);
+  });
+
+  it("send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(filter);
+
+    const sent = spy.getCall(0).args[0];
+    const selectedFilter = get(sent, "properties.selectedFilter");
+
+    assert.isTrue(isString(selectedFilter));
+    assert.isTrue(selectedFilter === filter);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackStatusFilter.ts
+++ b/pkg/ui/src/util/analytics/trackStatusFilter.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (filter: string) => {
+  fn({
+    event: "Status Filter",
+    properties: {
+      selectedFilter: filter,
+    },
+  });
+};
+
+export default function trackStatusFilter (filter: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(filter);
+}

--- a/pkg/ui/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.spec.ts
@@ -36,13 +36,13 @@ describe("trackTableSort", () => {
     const event = get(sent, "event");
 
     assert.isTrue(isString(event));
-    assert.isTrue( event === expected);
+    assert.isTrue(event === expected);
   });
 
   it("should send the correct payload", () => {
     const spy = sandbox.spy();
     const tableName = "Test table";
-    const column = { title: "test", cell: (x: number) => x};
+    const column = { title: "test", cell: (x: number) => x };
     const sortSetting = { sortKey: "whatever", ascending: true };
 
     track(spy)(tableName, column, sortSetting);

--- a/pkg/ui/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.spec.ts
@@ -1,0 +1,67 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTableSort";
+
+const sandbox = createSandbox();
+
+describe("trackTableSort", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)();
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Table Sort";
+
+    track(spy)();
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue( event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+    const tableName = "Test table";
+    const column = { title: "test", cell: (x: number) => x};
+    const sortSetting = { sortKey: "whatever", ascending: true };
+
+    track(spy)(tableName, column, sortSetting);
+
+    const sent = spy.getCall(0).args[0];
+    const table = get(sent, "properties.tableName");
+    const columnName = get(sent, "properties.columnName");
+    const direction = get(sent, "properties.sortDirection");
+
+    assert.isTrue(isString(table), "Table name is a string");
+    assert.isTrue(table === tableName, "Table name matches given table name");
+
+    assert.isTrue(isString(columnName), "Column name is a string");
+    assert.isTrue(column.title === columnName, "Column name matches given column name");
+
+    assert.isTrue(isString(direction), "Sort direction is a string");
+    assert.isTrue(
+      direction === "asc",
+      "Sort direction matches the sort setting ascending property",
+    );
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTableSort.ts
+++ b/pkg/ui/src/util/analytics/trackTableSort.ts
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+import { SortableColumn, SortSetting } from "oss/src/views/shared/components/sortabletable";
+
+export const track = (fn: Function) => (
+  name?: String,
+  col?: SortableColumn,
+  sortSetting?: SortSetting,
+) => {
+  const tableName = name || "";
+  const columnName = col && col.title || "";
+  const sortDirection = sortSetting && (sortSetting.ascending) ? "asc" : "desc";
+
+  fn({
+    event: "Table Sort",
+    properties: {
+      tableName,
+      columnName,
+      sortDirection,
+    },
+  });
+};
+
+export default function trackTableSort(
+  name?: String,
+  col?: SortableColumn,
+  sortSetting?: SortSetting,
+) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(name, col, sortSetting);
+}

--- a/pkg/ui/src/util/analytics/trackTimeFrameChange.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTimeFrameChange.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTimeFrameChange";
+
+const sandbox = createSandbox();
+
+describe("trackPaginate", () => {
+  const direction = "test";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(direction);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Time Frame Change";
+
+    track(spy)(direction);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(direction);
+
+    const sent = spy.getCall(0).args[0];
+    const changeDirection = get(sent, "properties.direction");
+
+    assert.isTrue(changeDirection === direction);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTimeFrameChange.ts
+++ b/pkg/ui/src/util/analytics/trackTimeFrameChange.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (direction: string) => {
+  fn({
+    event: "Time Frame Change",
+    properties: {
+      direction,
+    },
+  });
+};
+
+export default function trackTimeFrameChange(direction: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(direction);
+}

--- a/pkg/ui/src/util/analytics/trackTimeScaleOption.spec.ts
+++ b/pkg/ui/src/util/analytics/trackTimeScaleOption.spec.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackTimeScaleSelected";
+
+const sandbox = createSandbox();
+
+describe("trackTimeScaleSelected", () => {
+  const scale = "Last 2 weeks";
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)(scale);
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Time Scale Selected";
+
+    track(spy)(scale);
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+
+    track(spy)(scale);
+
+    const sent = spy.getCall(0).args[0];
+    const timeScale = get(sent, "properties.timeScale");
+
+    assert.isTrue(timeScale === scale);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackTimeScaleSelected.ts
+++ b/pkg/ui/src/util/analytics/trackTimeScaleSelected.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (scale: string) => {
+  fn({
+    event: "Time Scale Selected",
+    properties: {
+      timeScale: scale,
+    },
+  });
+};
+
+export default function trackTimeScaleSelected(scale: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(scale);
+}

--- a/pkg/ui/src/views/cluster/components/range/index.tsx
+++ b/pkg/ui/src/views/cluster/components/range/index.tsx
@@ -11,6 +11,7 @@
 import { Button, TimePicker, notification, Calendar, Icon } from "antd";
 import moment, { Moment } from "moment";
 import { TimeWindow } from "oss/src/redux/timewindow";
+import { trackTimeScaleSelected } from "src/util/analytics";
 import React from "react";
 import "./range.styl";
 
@@ -127,11 +128,16 @@ class RangeSelect extends React.Component<RangeSelectProps, RangeSelectState> {
 
   toggleDropDown = () => this.setState({ opened: !this.state.opened }, this.toggleCustomPicker(this.state.opened ));
 
+  handleOptionButtonOnClick = (option: RangeOption) => () => {
+    trackTimeScaleSelected(option.label);
+    (option.value === "Custom" ? this.toggleCustomPicker(true) : this.onChangeOption(option))();
+  }
+
   optionButton = (option: RangeOption) => (
     <Button
       type="default"
       className={`_time-button ${this.props.selected.title === option.value && "active" || ""}`}
-      onClick={option.value === "Custom" ? this.toggleCustomPicker(true) : this.onChangeOption(option)}
+      onClick={this.handleOptionButtonOnClick(option)}
       ghost
     >
       <span className="dropdown__range-title">{this.props.selected.title !== "Custom" && option.value === "Custom" ? "--" : option.timeLabel}</span>

--- a/pkg/ui/src/views/cluster/containers/timescale/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/timescale/index.tsx
@@ -18,6 +18,7 @@ import { refreshNodes } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import * as timewindow from "src/redux/timewindow";
 import { INodeStatus } from "src/util/proto";
+import { trackTimeFrameChange } from "src/util/analytics";
 import Dropdown, { ArrowDirection, DropdownOption } from "src/views/shared/components/dropdown";
 import TimeFrameControls from "../../components/controls";
 import RangeSelect, { DateTypes } from "../../components/range";
@@ -82,14 +83,17 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
 
     switch (direction) {
       case ArrowDirection.RIGHT:
+        trackTimeFrameChange("next frame");
         if (windowEnd) {
           windowEnd = windowEnd.add(seconds, "seconds");
         }
         break;
       case ArrowDirection.LEFT:
+        trackTimeFrameChange("previous frame");
         windowEnd = windowEnd.subtract(seconds, "seconds");
         break;
       case ArrowDirection.CENTER:
+        trackTimeFrameChange("now");
         windowEnd = moment.utc();
         break;
       default:

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -26,7 +26,7 @@ import { SortSetting} from "src/views/shared/components/sortabletable";
 import "./index.styl";
 import { statusOptions } from "./jobStatusOptions";
 import { JobTable} from "oss/src/views/jobs/jobTable";
-import { trackStatusFilter } from "src/util/analytics";
+import { trackFilter } from "src/util/analytics";
 import JobType = cockroach.sql.jobs.jobspb.Type;
 import JobsRequest = cockroach.server.serverpb.JobsRequest;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
@@ -103,13 +103,15 @@ export class JobsTable extends React.Component<JobsTableProps> {
 
   onStatusSelected = (selected: DropdownOption) => {
     const filter = (selected.value === "") ? "all" : selected.value;
-    trackStatusFilter(filter);
+    trackFilter("Status", filter);
     this.props.setStatus(selected.value);
   }
 
   onTypeSelected = (selected: DropdownOption) => {
-    // track here
-    this.props.setType(parseInt(selected.value, 10));
+    const type = parseInt(selected.value, 10);
+    const typeLabel = typeOptions[type].label;
+    trackFilter("Type", typeLabel);
+    this.props.setType(type);
   }
 
   onShowSelected = (selected: DropdownOption) => {

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -10,22 +10,23 @@
 
 import moment from "moment";
 import React from "react";
-import {Helmet} from "react-helmet";
-import {connect} from "react-redux";
-import {withRouter} from "react-router-dom";
+import { Helmet } from "react-helmet";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
 
-import {cockroach} from "src/js/protos";
-import {jobsKey, refreshJobs} from "src/redux/apiReducers";
-import {CachedDataReducerState} from "src/redux/cachedDataReducer";
-import {LocalSetting} from "src/redux/localsettings";
-import {AdminUIState} from "src/redux/state";
-import Dropdown, {DropdownOption} from "src/views/shared/components/dropdown";
+import { cockroach } from "src/js/protos";
+import { jobsKey, refreshJobs } from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import Loading from "src/views/shared/components/loading";
-import {PageConfig, PageConfigItem} from "src/views/shared/components/pageconfig";
-import {SortSetting} from "src/views/shared/components/sortabletable";
+import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
+import { SortSetting} from "src/views/shared/components/sortabletable";
 import "./index.styl";
-import {statusOptions} from "./jobStatusOptions";
-import {JobTable} from "oss/src/views/jobs/jobTable";
+import { statusOptions } from "./jobStatusOptions";
+import { JobTable} from "oss/src/views/jobs/jobTable";
+import { trackStatusFilter } from "src/util/analytics";
 import JobType = cockroach.sql.jobs.jobspb.Type;
 import JobsRequest = cockroach.server.serverpb.JobsRequest;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
@@ -101,10 +102,13 @@ export class JobsTable extends React.Component<JobsTableProps> {
   }
 
   onStatusSelected = (selected: DropdownOption) => {
+    const filter = (selected.value === "") ? "all" : selected.value;
+    trackStatusFilter(filter);
     this.props.setStatus(selected.value);
   }
 
   onTypeSelected = (selected: DropdownOption) => {
+    // track here
     this.props.setType(parseInt(selected.value, 10));
   }
 

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -8,18 +8,19 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
-import {ColumnDescriptor, SortedTable} from "src/views/shared/components/sortedtable";
-import {cockroach} from "src/js/protos";
-import {TimestampToMoment} from "src/util/convert";
-import {DATE_FORMAT} from "src/util/format";
-import {JobStatusCell} from "oss/src/views/jobs/jobStatusCell";
-import {Icon, Pagination} from "antd";
+import React, { MouseEvent } from "react";
+import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
+import { cockroach } from "src/js/protos";
+import { TimestampToMoment } from "src/util/convert";
+import { DATE_FORMAT } from "src/util/format";
+import { JobStatusCell } from "oss/src/views/jobs/jobStatusCell";
+import { Icon, Pagination } from "antd";
 import Empty from "src/views/app/components/empty";
-import {SortSetting} from "oss/src/views/shared/components/sortabletable";
-import {CachedDataReducerState} from "oss/src/redux/cachedDataReducer";
-import _ from "lodash";
-import {JobDescriptionCell} from "oss/src/views/jobs/jobDescriptionCell";
+import { SortSetting } from "oss/src/views/shared/components/sortabletable";
+import { CachedDataReducerState } from "oss/src/redux/cachedDataReducer";
+import { isEmpty, isEqual, map } from "lodash";
+import { JobDescriptionCell } from "oss/src/views/jobs/jobDescriptionCell";
+import { trackDocsLink } from "src/util/analytics";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
 
@@ -121,17 +122,26 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
     return `${count} of ${total} jobs`;
   }
 
+  redirectToLearnMore = (e: MouseEvent<HTMLAnchorElement>) => {
+    trackDocsLink(e.currentTarget.text);
+  }
+
   noJobResult = () => (
     <>
       <p>There are no jobs that match your search in filter.</p>
-      <a href="https://www.cockroachlabs.com/docs/stable/admin-ui-jobs-page.html" target="_blank">Learn more about jobs</a>
+      <a
+        href="https://www.cockroachlabs.com/docs/stable/admin-ui-jobs-page.html"
+        target="_blank"
+        onClick={this.redirectToLearnMore}>
+        Learn more about jobs
+      </a>
     </>
   )
 
   render() {
     const jobs = this.props.jobs.data.jobs;
     const { pagination } = this.state;
-    if (_.isEmpty(jobs) && !this.props.isUsedFilter) {
+    if (isEmpty(jobs) && !this.props.isUsedFilter) {
       return (
         <Empty
           title="There are no jobs to display."
@@ -173,11 +183,11 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
   }
 
   private setCurrentPageToOneIfJobsChanged(prevProps: Readonly<JobTableProps>) {
-    if (!_.isEqual(
-      _.map(prevProps.jobs.data.jobs, (j) => {
+    if (!isEqual(
+      map(prevProps.jobs.data.jobs, (j) => {
         return j.id;
       }),
-      _.map(this.props.jobs.data.jobs, (j) => {
+      map(this.props.jobs.data.jobs, (j) => {
         return j.id;
       }),
     )) {

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -22,7 +22,7 @@ import { LivenessStatus, NodesSummary, nodesSummarySelector, selectLivenessReque
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment, NanoToMilli } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
-import { trackFilter } from "src/util/analytics";
+import { trackFilter, trackCollapseNodes } from "src/util/analytics";
 import { getFilters, localityToString, NodeFilterList, NodeFilterListProps } from "src/views/reports/components/nodeFilterList";
 import Loading from "src/views/shared/components/loading";
 import { Latency } from "./latency";
@@ -108,7 +108,10 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     }
   }
 
-  onChangeCollapse = (collapsed: boolean) => this.setState({ collapsed });
+  onChangeCollapse = (collapsed: boolean) => {
+    trackCollapseNodes(collapsed);
+    this.setState({ collapsed });
+  }
 
   onChangeFilter = (key: string, value: string) => {
     const { filter } = this.state;

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { deviation as d3Deviation, mean as d3Mean } from "d3";
-import _ from "lodash";
+import _, { capitalize } from "lodash";
 import moment from "moment";
 import React, { Fragment } from "react";
 import { Helmet } from "react-helmet";
@@ -22,6 +22,7 @@ import { LivenessStatus, NodesSummary, nodesSummarySelector, selectLivenessReque
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment, NanoToMilli } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
+import { trackFilter } from "src/util/analytics";
 import { getFilters, localityToString, NodeFilterList, NodeFilterListProps } from "src/views/reports/components/nodeFilterList";
 import Loading from "src/views/shared/components/loading";
 import { Latency } from "./latency";
@@ -114,6 +115,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     const newFilter = filter ? filter : {};
     const data = newFilter[key] || [];
     const values = data.indexOf(value) === -1 ? [...data, value] : data.length === 1 ? null : data.filter((m: string|number) => m !== value);
+    trackFilter(capitalize(key), value);
     this.setState({
       filter: {
         ...newFilter,
@@ -125,6 +127,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
   deselectFilterByKey = (key: string) => {
     const { filter } = this.state;
     const newFilter = filter ? filter : {};
+    trackFilter(capitalize(key), "deselect all");
     this.setState({
       filter: {
         ...newFilter,

--- a/pkg/ui/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/sort/index.tsx
@@ -13,6 +13,7 @@ import Dropdown, { DropdownOption } from "oss/src/views/shared/components/dropdo
 import React from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
+import { trackNetworkSort } from "src/util/analytics";
 import { getMatchParamByName } from "src/util/query";
 import { NetworkFilter, NetworkSort } from "..";
 import { Filter } from "../filter";
@@ -37,6 +38,7 @@ class Sort extends React.Component<ISortProps & RouteComponentProps, {}> {
   }
 
   navigateTo = (selected: DropdownOption) => {
+    trackNetworkSort(selected.label);
     this.props.onChangeCollapse(false);
     this.props.history.push(`/reports/network/${selected.value}`);
   }

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -16,7 +16,7 @@ import times from "lodash/times";
 
 import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
-import { analytics } from "src/redux/analytics";
+import { trackTableSort } from "src/util/analytics";
 
 import "./sortabletable.styl";
 
@@ -238,23 +238,6 @@ export class SortableTable extends React.Component<TableProps> {
     });
   }
 
-  trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
-    const tableName = name || "";
-    const columnName = col.title || "";
-    const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
-
-    const payload = {
-      event: "Table Sort",
-      properties: {
-        tableName,
-        columnName,
-        sortDirection,
-      },
-    };
-
-    analytics.track(payload);
-  }
-
   render() {
     const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult, className } = this.props;
     const { visible, drawerData } = this.state;
@@ -274,7 +257,7 @@ export class SortableTable extends React.Component<TableProps> {
                 if (!isUndefined(c.sortKey)) {
                   classes.push("sort-table__cell--sortable");
                   onClick = () => {
-                    this.trackTableSort(className, c, sortSetting);
+                    trackTableSort(className, c, sortSetting);
                     this.clickSort(c.sortKey);
                   };
                   if (c.sortKey === sortSetting.sortKey) {

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -10,13 +10,13 @@
 
 import React from "react";
 import classNames from "classnames";
-import map from 'lodash/map';
-import isUndefined from 'lodash/isUndefined';
-import times from 'lodash/times';
+import map from "lodash/map";
+import isUndefined from "lodash/isUndefined";
+import times from "lodash/times";
 
 import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
-import { analytics } from '../../../../redux/analytics';
+import { analytics } from "src/redux/analytics";
 
 import "./sortabletable.styl";
 
@@ -242,7 +242,7 @@ export class SortableTable extends React.Component<TableProps> {
     const path = window.location.pathname + window.location.hash;
     const tableName = name || "";
     const columnName = col.title || "";
-    const sortDirection = (sortSetting.ascending) ? 'asc' : 'desc';
+    const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
 
     const payload = {
       event: "Table Sort",

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -239,7 +239,6 @@ export class SortableTable extends React.Component<TableProps> {
   }
 
   trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
-    const path = window.location.pathname + window.location.hash;
     const tableName = name || "";
     const columnName = col.title || "";
     const sortDirection = (sortSetting.ascending) ? "asc" : "desc";
@@ -247,7 +246,6 @@ export class SortableTable extends React.Component<TableProps> {
     const payload = {
       event: "Table Sort",
       properties: {
-        pagePath: path,
         tableName,
         columnName,
         sortDirection,

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -8,11 +8,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import classNames from "classnames";
-import _ from "lodash";
-import getHighlightedText from "oss/src/util/highlightedText";
 import React from "react";
+import classNames from "classnames";
+import map from 'lodash/map';
+import isUndefined from 'lodash/isUndefined';
+import times from 'lodash/times';
+
+import getHighlightedText from "oss/src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
+import { analytics } from '../../../../redux/analytics';
+
 import "./sortabletable.styl";
 
 /**
@@ -172,7 +177,7 @@ export class SortableTable extends React.Component<TableProps> {
         }}
       >
         {expandableConfig ? this.expansionControl(expanded) : null}
-        {_.map(columns, (c: SortableColumn, colIndex: number) => {
+        {map(columns, (c: SortableColumn, colIndex: number) => {
           return (
             <td className={classNames("sort-table__cell", { "sort-table__cell--header": firstCellBordered && colIndex === 0 }, c.className)} key={colIndex}>
               {c.cell(rowIndex)}
@@ -233,25 +238,45 @@ export class SortableTable extends React.Component<TableProps> {
     });
   }
 
+  trackTableSort = (name?: String, col?: SortableColumn, sortSetting?: SortSetting) => {
+    const path = window.location.pathname + window.location.hash;
+    const tableName = name || "";
+    const columnName = col.title || "";
+    const sortDirection = (sortSetting.ascending) ? 'asc' : 'desc';
+
+    const payload = {
+      event: "Table Sort",
+      properties: {
+        pagePath: path,
+        tableName,
+        columnName,
+        sortDirection,
+      },
+    };
+
+    analytics.track(payload);
+  }
+
   render() {
-    const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult } = this.props;
+    const { sortSetting, columns, expandableConfig, drawer, firstCellBordered, count, renderNoResult, className } = this.props;
     const { visible, drawerData } = this.state;
     return (
       <React.Fragment>
-        <table className={classNames("sort-table", this.props.className)}>
+        <table className={classNames("sort-table", className)}>
           <thead>
             <tr className="sort-table__row sort-table__row--header">
               {expandableConfig ? <th className="sort-table__cell" /> : null}
-              {_.map(columns, (c: SortableColumn, colIndex: number) => {
+              {map(columns, (c: SortableColumn, colIndex: number) => {
                 const classes = ["sort-table__cell"];
                 const style = {
                   textAlign: c.titleAlign,
                 };
                 let onClick: (e: any) => void = undefined;
 
-                if (!_.isUndefined(c.sortKey)) {
+                if (!isUndefined(c.sortKey)) {
                   classes.push("sort-table__cell--sortable");
                   onClick = () => {
+                    this.trackTableSort(className, c, sortSetting);
                     this.clickSort(c.sortKey);
                   };
                   if (c.sortKey === sortSetting.sortKey) {
@@ -268,14 +293,14 @@ export class SortableTable extends React.Component<TableProps> {
                 return (
                   <th className={classNames(classes)} key={colIndex} onClick={onClick} style={style}>
                     {c.title}
-                    {!_.isUndefined(c.sortKey) && <span className="sortable__actions" />}
+                    {!isUndefined(c.sortKey) && <span className="sortable__actions" />}
                   </th>
                 );
               })}
             </tr>
           </thead>
           <tbody>
-            {_.times(this.props.count, this.renderRow)}
+            {times(this.props.count, this.renderRow)}
           </tbody>
         </table>
         {drawer && (

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,18 +17,29 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
+import { AggregateStatistics } from "../statementsTable";
+import { analytics } from "src/redux/analytics";
 
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
+function trackActivateDiagnostics (statement: AggregateStatistics) {
+  analytics.track({
+    event: "Diagnostics Activation",
+    properties: {
+      fingerprint: statement.label,
+    },
+  });
+}
+
 export interface ActivateDiagnosticsModalRef {
-  showModalFor: (statement: string) => void;
+  showModalFor: (statement: AggregateStatistics) => void;
 }
 
 // tslint:disable-next-line:variable-name
 const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: React.RefObject<ActivateDiagnosticsModalRef>) => {
   const {activate} = props;
   const [visible, setVisible] = useState(false);
-  const [statement, setStatement] = useState();
+  const [statement, setStatement] = useState<string>();
 
   const onOkHandler = useCallback(
     () => {
@@ -42,8 +53,9 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
 
   useImperativeHandle(ref, () => {
     return {
-      showModalFor: (forwardStatement: string) => {
-        setStatement(forwardStatement);
+      showModalFor: (forwardStatement: AggregateStatistics) => {
+        setStatement(forwardStatement.label);
+        trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,18 +17,8 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { analytics } from "src/redux/analytics";
-
+import { trackActivateDiagnostics } from "src/util/analytics";
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
-
-function trackActivateDiagnostics (statement: string) {
-  analytics.track({
-    event: "Diagnostics Activation",
-    properties: {
-      fingerprint: statement,
-    },
-  });
-}
 
 export interface ActivateDiagnosticsModalRef {
   showModalFor: (statement: string) => void;

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,22 +17,21 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { AggregateStatistics } from "../statementsTable";
 import { analytics } from "src/redux/analytics";
 
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
-function trackActivateDiagnostics (statement: AggregateStatistics) {
+function trackActivateDiagnostics (statement: string) {
   analytics.track({
     event: "Diagnostics Activation",
     properties: {
-      fingerprint: statement.label,
+      fingerprint: statement,
     },
   });
 }
 
 export interface ActivateDiagnosticsModalRef {
-  showModalFor: (statement: AggregateStatistics) => void;
+  showModalFor: (statement: string) => void;
 }
 
 // tslint:disable-next-line:variable-name
@@ -53,8 +52,8 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
 
   useImperativeHandle(ref, () => {
     return {
-      showModalFor: (forwardStatement: AggregateStatistics) => {
-        setStatement(forwardStatement.label);
+      showModalFor: (forwardStatement: string) => {
+        setStatement(forwardStatement);
         trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -43,6 +43,7 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
   const onOkHandler = useCallback(
     () => {
       activate(statement);
+      trackActivateDiagnostics(statement);
       setVisible(false);
     },
     [statement],
@@ -54,7 +55,6 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
     return {
       showModalFor: (forwardStatement: string) => {
         setStatement(forwardStatement);
-        trackActivateDiagnostics(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/activateDiagnosticsModal.tsx
@@ -17,7 +17,7 @@ import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { AdminUIState } from "src/redux/state";
 import { invalidateStatementDiagnosticsRequests, refreshStatementDiagnosticsRequests } from "src/redux/apiReducers";
 import { statementDiagnostics } from "src/util/docs";
-import { trackActivateDiagnostics } from "src/util/analytics";
+import { trackActivateDiagnostics, trackDiagnosticsModalOpen } from "src/util/analytics";
 export type ActivateDiagnosticsModalProps = MapDispatchToProps;
 
 export interface ActivateDiagnosticsModalRef {
@@ -45,6 +45,7 @@ const ActivateDiagnosticsModal = (props: ActivateDiagnosticsModalProps, ref: Rea
     return {
       showModalFor: (forwardStatement: string) => {
         setStatement(forwardStatement);
+        trackDiagnosticsModalOpen(forwardStatement);
         setVisible(true);
       },
     };

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -43,6 +43,7 @@ import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnost
 import { getDiagnosticsStatus, sortByCompletedField, sortByRequestedAtField } from "./diagnosticsUtils";
 import { statementDiagnostics } from "src/util/docs";
 import { createStatementDiagnosticsAlertLocalSetting } from "oss/src/redux/alerts";
+import { trackActivateDiagnostics } from "src/util/analytics";
 
 interface DiagnosticsViewOwnProps {
   statementFingerprint?: string;
@@ -126,6 +127,7 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
   onActivateButtonClick = () => {
     const { activate, statementFingerprint } = this.props;
     activate(statementFingerprint);
+    trackActivateDiagnostics(statementFingerprint);
   }
 
   componentWillUnmount() {
@@ -190,6 +192,7 @@ export class EmptyDiagnosticsView extends React.Component<DiagnosticsViewProps> 
   onActivateButtonClick = () => {
     const { activate, statementFingerprint } = this.props;
     activate(statementFingerprint);
+    trackActivateDiagnostics(statementFingerprint);
   }
 
   render() {

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -48,6 +48,7 @@ import {
   selectDiagnosticsReportsCountByStatementFingerprint,
 } from "src/redux/statements/statementsSelectors";
 import { Button, BackIcon } from "oss/src/components/button";
+import { analytics } from "src/redux/analytics";
 
 const { TabPane } = Tabs;
 
@@ -146,6 +147,18 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
     );
   }
 }
+
+const handleTabChange = (key: string) => {
+  // const tabInfo = find(tabPaneIndex, { key: key });
+  const payload = {
+    event: "SubNavigation Selection",
+    properties: {
+      selection: key,
+    },
+  };
+
+  analytics.track(payload);
+};
 
 export class StatementDetails extends React.Component<StatementDetailsProps, StatementDetailsState> {
 
@@ -248,8 +261,8 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     const logicalPlan = stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     return (
-      <Tabs defaultActiveKey="1" className="cockroach--tabs">
-        <TabPane tab="Overview" key="1">
+      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={handleTabChange}>
+        <TabPane tab="Overview" key="overview">
           <Row gutter={16}>
             <Col className="gutter-row" span={16}>
               <SqlBox value={ statement } />
@@ -324,10 +337,10 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
             </Col>
           </Row>
         </TabPane>
-        <TabPane tab={`Diagnostics ${diagnosticsCount > 0 ? `(${diagnosticsCount})` : ""}`} key="2">
+        <TabPane tab={`Diagnostics ${diagnosticsCount > 0 ? `(${diagnosticsCount})` : ""}`} key="diagnostics">
           <DiagnosticsView statementFingerprint={statement} />
         </TabPane>
-        <TabPane tab="Logical Plan" key="3">
+        <TabPane tab="Logical Plan" key="logical-plan">
           <SummaryCard>
             <PlanView
               title="Logical Plan"
@@ -335,7 +348,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
             />
           </SummaryCard>
         </TabPane>
-        <TabPane tab="Execution Stats" key="4">
+        <TabPane tab="Execution Stats" key="execution-stats">
           <SummaryCard>
             <h2 className="base-heading summary--card__title">
               Execution Latency By Phase

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -48,7 +48,7 @@ import {
   selectDiagnosticsReportsCountByStatementFingerprint,
 } from "src/redux/statements/statementsSelectors";
 import { Button, BackIcon } from "oss/src/components/button";
-import { analytics } from "src/redux/analytics";
+import { trackSubnavSelection } from "src/util/analytics";
 
 const { TabPane } = Tabs;
 
@@ -147,18 +147,6 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
     );
   }
 }
-
-const handleTabChange = (key: string) => {
-  // const tabInfo = find(tabPaneIndex, { key: key });
-  const payload = {
-    event: "SubNavigation Selection",
-    properties: {
-      selection: key,
-    },
-  };
-
-  analytics.track(payload);
-};
 
 export class StatementDetails extends React.Component<StatementDetailsProps, StatementDetailsState> {
 
@@ -261,7 +249,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     const logicalPlan = stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     return (
-      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={handleTabChange}>
+      <Tabs defaultActiveKey="1" className="cockroach--tabs" onChange={trackSubnavSelection}>
         <TabPane tab="Overview" key="overview">
           <Row gutter={16}>
             <Col className="gutter-row" span={16}>

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { Icon, Pagination } from "antd";
-import isNil from "lodash/isNil";
+import { isNil, merge, forIn } from "lodash";
 import moment from "moment";
 import { DATE_FORMAT } from "src/util/format";
 import React from "react";
@@ -89,7 +89,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     };
 
     const stateFromHistory = this.getStateFromHistory();
-    this.state = _.merge(defaultState, stateFromHistory);
+    this.state = merge(defaultState, stateFromHistory);
     this.activateDiagnosticsRef = React.createRef();
   }
 
@@ -114,7 +114,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const currentSearchParams = new URLSearchParams(history.location.search);
     // const nextSearchParams = new URLSearchParams(params);
 
-    _.forIn(params, (value, key) => {
+    forIn(params, (value, key) => {
       if (!value) {
         currentSearchParams.delete(key);
       } else {
@@ -148,19 +148,16 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     this.props.refreshStatementDiagnosticsRequests();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
+    if (this.state.search && this.state.search !== prevState.search) {
+      this.trackSearch(this.state.search, this.filteredStatementsData().length);
+    }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
   }
 
   componentWillUnmount() {
     this.props.dismissAlertMessage();
-  }
-
-  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
-    if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.state.search, this.filteredStatementsData().length);
-    }
   }
 
   onChangePage = (current: number) => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { Icon, Pagination } from "antd";
-import _ from "lodash";
+import isNil from "lodash/isNil";
 import moment from "moment";
 import { DATE_FORMAT } from "src/util/format";
 import React from "react";
@@ -22,6 +22,7 @@ import * as protos from "src/js/protos";
 import { refreshStatementDiagnosticsRequests, refreshStatements } from "src/redux/apiReducers";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
+import { analytics } from "src/redux/analytics";
 import { StatementsResponseMessage } from "src/util/api";
 import { aggregateStatementStats, combineStatementStats, ExecutionStatistics, flattenStatementStats, StatementStatistics } from "src/util/appStats";
 import { appAttr } from "src/util/constants";
@@ -156,9 +157,15 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     this.props.dismissAlertMessage();
   }
 
+  componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
+    if (this.state.search && this.state.search !== prevState.search) {
+      this.trackSearch(this.state.search, this.filteredStatementsData().length);
+    }
+  }
+
   onChangePage = (current: number) => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current }});
+    this.setState({ pagination: { ...pagination, current } });
   }
   onSubmitSearchField = (search: string) => {
     this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
@@ -178,6 +185,21 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const { search } = this.state;
     const { statements } = this.props;
     return statements.filter(statement => search.split(" ").every(val => statement.label.toLowerCase().includes(val.toLowerCase())));
+  }
+
+  trackSearch = (searchTerm: string, numberOfResults: number) => {
+    const pagePath = window.location.pathname + window.location.hash;
+
+    const payload = {
+      event: "Search",
+      properties: {
+        searchTerm,
+        numberOfResults,
+        pagePath,
+      },
+    };
+
+    analytics.track(payload);
   }
 
   renderPage = (_page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next", originalElement: React.ReactNode) => {
@@ -313,14 +335,14 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const app = getMatchParamByName(match, appAttr);
     return (
       <React.Fragment>
-        <Helmet title={ app ? `${app} App | Statements` : "Statements"} />
+        <Helmet title={app ? `${app} App | Statements` : "Statements"} />
 
         <section className="section">
           <h1 className="base-heading">Statements</h1>
         </section>
 
         <Loading
-          loading={_.isNil(this.props.statements)}
+          loading={isNil(this.props.statements)}
           error={this.props.statementsError}
           render={this.renderStatements}
         />

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -43,6 +43,7 @@ import {
 } from "src/redux/statements/statementsSelectors";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
+import { trackPaginate } from "src/util/analytics";
 
 import "./statements.styl";
 
@@ -163,7 +164,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
   onChangePage = (current: number) => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
-    this.trackPaginate(current);
+    trackPaginate(current);
   }
   onSubmitSearchField = (search: string) => {
     this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
@@ -190,15 +191,6 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
       event: "Search",
       properties: {
         numberOfResults,
-      },
-    });
-  }
-
-  trackPaginate = (page: number) => {
-    analytics.track({
-      event: "Paginate",
-      properties: {
-        selectedPage: page,
       },
     });
   }

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -22,7 +22,6 @@ import * as protos from "src/js/protos";
 import { refreshStatementDiagnosticsRequests, refreshStatements } from "src/redux/apiReducers";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
-import { analytics } from "src/redux/analytics";
 import { StatementsResponseMessage } from "src/util/api";
 import { aggregateStatementStats, combineStatementStats, ExecutionStatistics, flattenStatementStats, StatementStatistics } from "src/util/appStats";
 import { appAttr } from "src/util/constants";
@@ -43,7 +42,7 @@ import {
 } from "src/redux/statements/statementsSelectors";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
-import { trackPaginate } from "src/util/analytics";
+import { trackPaginate, trackSearch } from "src/util/analytics";
 
 import "./statements.styl";
 
@@ -151,7 +150,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
 
   componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
     if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.filteredStatementsData().length);
+      trackSearch(this.filteredStatementsData().length);
     }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
@@ -184,15 +183,6 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const { search } = this.state;
     const { statements } = this.props;
     return statements.filter(statement => search.split(" ").every(val => statement.label.toLowerCase().includes(val.toLowerCase())));
-  }
-
-  trackSearch = (numberOfResults: number) => {
-    analytics.track({
-      event: "Search",
-      properties: {
-        numberOfResults,
-      },
-    });
   }
 
   renderPage = (_page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next", originalElement: React.ReactNode) => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -166,6 +166,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
   onChangePage = (current: number) => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
+    this.trackPaginate(current);
   }
   onSubmitSearchField = (search: string) => {
     this.setState({ pagination: { ...this.state.pagination, current: 1 }, search });
@@ -188,18 +189,22 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
   }
 
   trackSearch = (searchTerm: string, numberOfResults: number) => {
-    const pagePath = window.location.pathname + window.location.hash;
-
-    const payload = {
+    analytics.track({
       event: "Search",
       properties: {
         searchTerm,
         numberOfResults,
-        pagePath,
       },
-    };
+    });
+  }
 
-    analytics.track(payload);
+  trackPaginate = (page: number) => {
+    analytics.track({
+      event: "Paginate",
+      properties: {
+        selectedPage: page,
+      },
+    });
   }
 
   renderPage = (_page: number, type: "page" | "prev" | "next" | "jump-prev" | "jump-next", originalElement: React.ReactNode) => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -150,7 +150,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
 
   componentDidUpdate = (__: StatementsPageProps, prevState: StatementsPageState) => {
     if (this.state.search && this.state.search !== prevState.search) {
-      this.trackSearch(this.state.search, this.filteredStatementsData().length);
+      this.trackSearch(this.filteredStatementsData().length);
     }
     this.props.refreshStatements();
     this.props.refreshStatementDiagnosticsRequests();
@@ -185,11 +185,10 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     return statements.filter(statement => search.split(" ").every(val => statement.label.toLowerCase().includes(val.toLowerCase())));
   }
 
-  trackSearch = (searchTerm: string, numberOfResults: number) => {
+  trackSearch = (numberOfResults: number) => {
     analytics.track({
       event: "Search",
       properties: {
-        searchTerm,
         numberOfResults,
       },
     });

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -36,19 +36,19 @@ export interface AggregateStatistics {
   diagnosticsReport?: IStatementDiagnosticsReport;
 }
 
-export class StatementsSortedTable extends SortedTable<AggregateStatistics> { }
+export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
 
 function StatementLink(props: { statement: string, app: string, implicitTxn: boolean, search: string }) {
   const summary = summarize(props.statement);
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
-    <Link to={`${base}/${encodeURIComponent(props.statement)}`}>
+    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
       <div className="cl-table-link__tooltip">
         <Tooltip placement="bottom" title={
           <pre className="cl-table-link__description">{ getHighlightedText(props.statement, props.search) }</pre>
         }>
           <div className="cl-table-link__tooltip-hover-area">
-            {getHighlightedText(shortStatement(summary, props.statement), props.search, true)}
+            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
           </div>
         </Tooltip>
       </div>
@@ -80,10 +80,10 @@ export function makeStatementsColumns(
       className: "cl-table__col-query-text",
       cell: (stmt) => (
         <StatementLink
-          statement={stmt.label}
-          implicitTxn={stmt.implicitTxn}
+          statement={ stmt.label }
+          implicitTxn={ stmt.implicitTxn }
           search={search}
-          app={selectedApp}
+          app={ selectedApp }
         />
       ),
       sort: (stmt) => stmt.label,
@@ -126,18 +126,18 @@ export function makeStatementsColumns(
 
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
   return (
-    <Link to={`/node/${props.nodeId}`}>
+    <Link to={ `/node/${props.nodeId}` }>
       <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
     </Link>
   );
 }
 
 export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: { [nodeId: string]: string })
-  : ColumnDescriptor<AggregateStatistics>[] {
+    : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: null,
-      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={nodeNames} />,
+      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
       // sort: (stmt) => stmt.label,
     },
   ];
@@ -146,7 +146,7 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
 }
 
 function makeCommonColumns(statements: AggregateStatistics[])
-  : ColumnDescriptor<AggregateStatistics>[] {
+    : ColumnDescriptor<AggregateStatistics>[] {
   const countBar = countBarChart(statements);
   const retryBar = retryBarChart(statements);
   const rowsBar = rowsBarChart(statements);

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -36,19 +36,19 @@ export interface AggregateStatistics {
   diagnosticsReport?: IStatementDiagnosticsReport;
 }
 
-export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
+export class StatementsSortedTable extends SortedTable<AggregateStatistics> { }
 
 function StatementLink(props: { statement: string, app: string, implicitTxn: boolean, search: string }) {
   const summary = summarize(props.statement);
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
-    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
+    <Link to={`${base}/${encodeURIComponent(props.statement)}`}>
       <div className="cl-table-link__tooltip">
         <Tooltip placement="bottom" title={
           <pre className="cl-table-link__description">{ getHighlightedText(props.statement, props.search) }</pre>
         }>
           <div className="cl-table-link__tooltip-hover-area">
-            { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }
+            {getHighlightedText(shortStatement(summary, props.statement), props.search, true)}
           </div>
         </Tooltip>
       </div>
@@ -80,10 +80,10 @@ export function makeStatementsColumns(
       className: "cl-table__col-query-text",
       cell: (stmt) => (
         <StatementLink
-          statement={ stmt.label }
-          implicitTxn={ stmt.implicitTxn }
+          statement={stmt.label}
+          implicitTxn={stmt.implicitTxn}
           search={search}
-          app={ selectedApp }
+          app={selectedApp}
         />
       ),
       sort: (stmt) => stmt.label,
@@ -126,18 +126,18 @@ export function makeStatementsColumns(
 
 function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string } }) {
   return (
-    <Link to={ `/node/${props.nodeId}` }>
+    <Link to={`/node/${props.nodeId}`}>
       <div className="node-name-tooltip__info-icon">{props.nodeNames[props.nodeId]}</div>
     </Link>
   );
 }
 
 export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: { [nodeId: string]: string })
-    : ColumnDescriptor<AggregateStatistics>[] {
+  : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: null,
-      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={ nodeNames } />,
+      cell: (stmt) => <NodeLink nodeId={stmt.label} nodeNames={nodeNames} />,
       // sort: (stmt) => stmt.label,
     },
   ];
@@ -146,7 +146,7 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
 }
 
 function makeCommonColumns(statements: AggregateStatistics[])
-    : ColumnDescriptor<AggregateStatistics>[] {
+  : ColumnDescriptor<AggregateStatistics>[] {
   const countBar = countBarChart(statements);
   const retryBar = retryBarChart(statements);
   const rowsBar = rowsBarChart(statements);


### PR DESCRIPTION
Backport:
  * 11/11 commits from "UI Telemetry for Statements" (#45920)
  * 11/11 commits from "Ui telemetry statements details" (#46789)
  * 3/3 commits from "ui: telemetry jobs" (#46927)
  * 4/4 commits from "ui: telemetry network matrix" (#46939)
  * 2/2 commits from "Ui telemetry metrics time picker" (#46943)

Please see individual PRs for details.

/cc @cockroachdb/release
