### PR TITLE
backport-20.1: kvserver: make sure an error makes it to the logs

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -344,6 +344,7 @@ func evaluateBatch(
 					errors.Safe(ba.Header.MaxSpanRequestKeys),
 					errors.Safe(ba.Summary()), errors.Safe(index))
 				if sentryIssue46720Limiter.Allow() {
+					log.Error(ctx, err)
 					errorutil.SendReport(ctx, &rec.ClusterSettings().SV, err)
 				}
 				return nil, mergedResult, roachpb.NewError(err)


### PR DESCRIPTION
Backport 1/1 commits from #46983.

/cc @cockroachdb/release

---

We were reporting this error, but not necessarily printing it. It is
helpful to have it in the logs.

Release note: None
