### PR TITLE
ui: fix invalid attr being set on HTML element

### DIFF
--- a/pkg/ui/src/views/app/components/Search/index.tsx
+++ b/pkg/ui/src/views/app/components/Search/index.tsx
@@ -70,28 +70,21 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   }
 
   render() {
+    const { onClear, ...rest } = this.props;
     const { value, submitted } = this.state;
     const className = submitted ? "_submitted" : "";
-
-    /*
-      current antdesign (3.25.3) has Input.d.ts incompatible with latest @types/react
-      temporary fix, remove as soon antd can be updated
-    */
-
-    // tslint:disable-next-line: variable-name
-    const MyInput = Input as any;
 
     return (
       <Form onSubmit={this.onSubmit} className="_search-form">
         <Form.Item>
-          <MyInput
+          <Input
             className={className}
             placeholder="Search Statement"
             onChange={this.onChange}
             prefix={<img className="_prefix-icon" src={SearchIcon} />}
             suffix={this.renderSuffix()}
             value={value}
-            {...this.props}
+            {...rest}
          />
         </Form.Item>
       </Form>


### PR DESCRIPTION
- The `onClear` prop was being passed through to
  the HTML input field that powers the search box.
  It is now removed from the props before they are
  handed down to the `Input` component.

- I believe the `MyInput` alias was created to get
  around this issue so I have removed it.

Release justification: Bug fixes and low-risk updates,
this removes a warning in the browser console and
does not affect any functionality.

Release note: None